### PR TITLE
CORE-950: Refactor OSGi conventions into build scripts. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,8 @@ TODO
 # gradle-dependx plugin
 .dependx/
 
+# Directory generated during Resolve and TestOSGi gradle tasks
+bnd/
+
 # Ignore Gradle build output directory
 build

--- a/build.gradle
+++ b/build.gradle
@@ -87,10 +87,6 @@ subprojects {
 
     dependencies {
         detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion"
-
-        api "org.osgi:osgi.annotation:$osgiVersion"
-        api "org.osgi:osgi.cmpn:$osgiVersion"
-        api "org.osgi:osgi.core:$osgiVersion"
     }
 }
 
@@ -141,6 +137,11 @@ allprojects {
                 srcDirs = [ 'src/integration-test/resources' ]
             }
         }
+    }
+
+    // Added to support junit5 tests
+    tasks.named('test').configure {
+        useJUnitPlatform()
     }
 
     configurations {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}
+
+dependencies {
+    implementation "biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0"
+    implementation "biz.aQute.bnd:biz.aQute.bndlib:5.3.0"
+}
+
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/groovy/corda.osgi-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-conventions.gradle
@@ -1,0 +1,70 @@
+import aQute.bnd.gradle.Bundle
+import aQute.bnd.gradle.Resolve
+import aQute.bnd.gradle.TestOSGi
+
+plugins {
+    id 'biz.aQute.bnd.builder'
+}
+
+configurations {
+    integrationTestApi.extendsFrom testApi
+    integrationTestCompileOnly.extendsFrom testCompileOnly
+    integrationTestImplementation.extendsFrom testImplementation
+}
+
+dependencies {
+    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
+    compileOnly "org.osgi:osgi.core:$osgiVersion"
+
+    integrationTestRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
+    integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
+    integrationTestRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
+    integrationTestRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
+    integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+}
+
+def testingBundle = tasks.register('testingBundle', Bundle) {
+    archiveClassifier = 'tests'
+    from sourceSets.integrationTest.output
+    sourceSet = sourceSets.integrationTest
+
+    bnd """\
+Bundle-SymbolicName: \${task.archiveBaseName}-\${task.archiveClassifier}
+Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}
+"""
+}
+
+def resolve = tasks.register('resolve', Resolve) {
+    dependsOn jar, testingBundle
+    bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
+    bndrun = 'test.bndrun'
+    //  bnd attempts to use ~/ for caching if this is unavailable the build will fail.
+    System.setProperty("bnd.home.dir", "$rootDir/bnd/")
+}
+
+def testOSGi = tasks.register('testOSGi', TestOSGi) {
+    description = "Runs OSGi integration tests."
+    group = "verification"
+    dependsOn resolve
+    bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
+    bndrun = 'test.bndrun'
+}
+
+tasks.named('check') {
+    dependsOn testOSGi
+}
+
+tasks.register('integrationTest', Test) {
+    description = "Runs integration tests."
+    group = "verification"
+    dependsOn testOSGi
+
+    testClassesDirs = project.sourceSets["integrationTest"].output.classesDirs
+    classpath = project.sourceSets["integrationTest"].runtimeClasspath
+}
+
+artifacts {
+    archives testingBundle
+}
+

--- a/goodbyeworld/build.gradle
+++ b/goodbyeworld/build.gradle
@@ -2,35 +2,18 @@ plugins {
     id 'biz.aQute.bnd.builder'
 }
 
-apply from: "$rootDir/gradle/publish.gradle"
-
-configurations {
-    testArtifacts
+dependencies {
+    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
+    compileOnly "org.osgi:osgi.core:$osgiVersion"
 }
+
+apply from: "$rootDir/gradle/publish.gradle"
 
 dependencies {
     api project(":helloworld")
 
     api "org.junit.jupiter:junit-jupiter-api:$junit5Version"
-
-    testImplementation "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
-
-    testImplementation "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
-
-    testRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.metatype:$felixMetatypeVersion"
-    testRuntimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
-    testRuntimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-
-    // OSGi Logging Service, implemented by Felix and consumed by Logback.
-    testRuntimeOnly "org.osgi:org.osgi.util.pushstream:$osgiUtilPushstreamVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigadminVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.log:$felixLogVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.logback:$felixLogbackVersion"
-    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 description 'Goodbye World Library'

--- a/helloworld-impl/build.gradle
+++ b/helloworld-impl/build.gradle
@@ -1,9 +1,5 @@
-import aQute.bnd.gradle.Bundle
-import aQute.bnd.gradle.Resolve
-import aQute.bnd.gradle.TestOSGi
-
 plugins {
-    id 'biz.aQute.bnd.builder'
+    id 'corda.osgi-conventions'
 }
 
 apply from: "$rootDir/gradle/publish.gradle"
@@ -14,9 +10,6 @@ description 'Hello World Implementation'
 configurations {
     testArtifacts
     testCompileOnly.extendsFrom compileOnly
-    integrationTestApi.extendsFrom testApi
-    integrationTestCompileOnly.extendsFrom testCompileOnly
-    integrationTestImplementation.extendsFrom testImplementation
 }
 
 dependencies {
@@ -28,29 +21,6 @@ dependencies {
     testImplementation "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
-//    testRuntimeOnly "org.junit.platform:junit-platform-launcher:$junit5Version"
-
-    testRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.metatype:$felixMetatypeVersion"
-    testRuntimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
-    testRuntimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-
-    // OSGi Logging Service, implemented by Felix and consumed by Logback.
-    testRuntimeOnly "org.osgi:org.osgi.util.pushstream:$osgiUtilPushstreamVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigadminVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.log:$felixLogVersion"
-    testRuntimeOnly "org.apache.felix:org.apache.felix.logback:$felixLogbackVersion"
-    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
-
-    integrationTestImplementation "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
-    integrationTestRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
-    integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
-    integrationTestRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
-    integrationTestRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
-    integrationTestRuntimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
-    integrationTestRuntimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-    integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 
 tasks.named('jar', Jar) {
@@ -60,38 +30,3 @@ Bundle-Name: Hello world impl
 Bundle-SymbolicName: ${project.group}.${bundleName}
 """
 }
-
-def testingBundle = tasks.register('testingBundle', Bundle) {
-    archiveClassifier = 'tests'
-    from sourceSets.integrationTest.output
-    sourceSet = sourceSets.integrationTest
-
-    bnd """\
-Bundle-SymbolicName: \${task.archiveBaseName}-\${task.archiveClassifier}
-Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}
-"""
-}
-
-def resolve = tasks.register('resolve', Resolve) {
-    dependsOn jar, testingBundle
-    bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
-    bndrun = 'test.bndrun'
-    //  bnd attempts to use ~/ for caching if this is unavailable the build will fail.
-    System.setProperty("bnd.home.dir", "${System.getProperty("java.io.tmpdir")}/bnd/")
-}
-
-def testOSGi = tasks.register('testOSGi', TestOSGi) {
-    dependsOn resolve
-    bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
-    bndrun = 'test.bndrun'
-}
-
-tasks.named('check') {
-    dependsOn testOSGi
-}
-
-artifacts {
-    archives testingBundle
-    testArtifacts testingBundle
-}
-

--- a/helloworld-impl/src/integration-test/kotlin/net/corda/sample/hello/test/HelloWorldTest.kt
+++ b/helloworld-impl/src/integration-test/kotlin/net/corda/sample/hello/test/HelloWorldTest.kt
@@ -1,6 +1,7 @@
 package net.corda.sample.hello.test
 
 import net.corda.sample.api.hello.HelloWorld
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
@@ -14,7 +15,7 @@ class HelloWorldTest {
 
     @Test
     fun callHelloWorld() {
-        helloWorld.sayHello()
+        assertThat(helloWorld.sayHello()).isEqualTo("Hello world!")
     }
 
 }

--- a/helloworld-impl/src/main/kotlin/net/corda/sample/hello/impl/HelloWorldImpl.kt
+++ b/helloworld-impl/src/main/kotlin/net/corda/sample/hello/impl/HelloWorldImpl.kt
@@ -5,8 +5,10 @@ import org.osgi.service.component.annotations.Component
 
 @Component
 class HelloWorldImpl: HelloWorld {
-    override fun sayHello() {
-        println("Hello world!")
+    override fun sayHello(): String {
+        val hi = "Hello world!"
+        println(hi)
+        return hi
     }
 }
 

--- a/helloworld-impl/src/test/kotlin/net/corda/sample/hello/impl/HelloWorldImplTest.kt
+++ b/helloworld-impl/src/test/kotlin/net/corda/sample/hello/impl/HelloWorldImplTest.kt
@@ -6,6 +6,6 @@ import org.junit.jupiter.api.Test
 internal class HelloWorldImplTest {
     @Test
     fun `prints HelloWorld`() {
-        assertThat(HelloWorldImpl().sayHello()).isEqualTo("Hello World!")
+        assertThat(HelloWorldImpl().sayHello()).isEqualTo("Hello world!")
     }
 }

--- a/helloworld-impl/test.bndrun
+++ b/helloworld-impl/test.bndrun
@@ -38,11 +38,12 @@
 	junit-platform-engine;version='[1.7.1,1.7.2)',\
 	junit-platform-launcher;version='[1.7.1,1.7.2)',\
 	org.apache.felix.scr;version='[2.1.20,2.1.21)',\
+	org.assertj.core;version='[3.12.2,3.12.3)',\
 	org.jetbrains.kotlin.osgi-bundle;version='[1.4.21,1.4.22)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.test.common;version='[0.9.0,0.9.1)',\
 	org.osgi.test.junit5;version='[0.9.0,0.9.1)',\
-	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	org.osgi.util.function;version='[1.0.0,1.0.1)',\
+	org.osgi.util.promise;version='[1.0.0,1.0.1)',\
 	slf4j.api;version='[1.7.30,1.7.31)',\
 	slf4j.simple;version='[1.7.30,1.7.31)'

--- a/helloworld/build.gradle
+++ b/helloworld/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'biz.aQute.bnd.builder'
 }
 
+dependencies {
+    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
+    compileOnly "org.osgi:osgi.core:$osgiVersion"
+}
+
 apply from: "$rootDir/gradle/publish.gradle"
 
 description 'Hello World Library'

--- a/helloworld/src/main/kotlin/net/corda/sample/api/hello/HelloWorld.kt
+++ b/helloworld/src/main/kotlin/net/corda/sample/api/hello/HelloWorld.kt
@@ -1,6 +1,6 @@
 package net.corda.sample.api.hello
 
 interface HelloWorld {
-    fun sayHello()
+    fun sayHello(): String
 }
 


### PR DESCRIPTION
 And update integration-test to work correctly as PoC.

Still to fix:
- the version numbers for `bnd` are hard coded.  I need to figure out how to make `gradle.properties` availble to the builds in `buildSrc`.  I tried making them system properties but that didn't quite work.  Will give it another go.