### PR TITLE
CORE-968: system_packages_extra bug fix.

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -107,6 +107,19 @@ private def addSystemPackagesExtra(
             }
         }
     }
+    final jdkExtraPackages = [
+            "net.corda.osgi.framework.api",
+            "sun.net.www.protocol.jar",
+            "sun.nio.ch",
+            "sun.security.x509",
+            "sun.security.ssl",
+            "javax.servlet",
+            "javax.transaction.xa;version=1.1.0",
+            "javax.xml.stream;version=1.0",
+            "javax.xml.stream.events;version=1.0",
+            "javax.xml.stream.util;version=1.0"
+    ]
+    jdkExtraPackages.each { export -> systemBundleExtraSet.add(export) }
 }
 
 def cordaAssembleBundlesTask = tasks.register("cordaAssembleBundles") {

--- a/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
+++ b/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
@@ -114,7 +114,7 @@ class OSGiFrameworkWrap(
             val configurationMap = mapOf(
                 Constants.FRAMEWORK_STORAGE to frameworkStorageDir.toString(),
                 Constants.FRAMEWORK_STORAGE_CLEAN to Constants.FRAMEWORK_STORAGE_CLEAN_ONFIRSTINIT,
-                Constants.FRAMEWORK_SYSTEMCAPABILITIES_EXTRA to systemPackagesExtra
+                Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA to systemPackagesExtra
             )
             if (logger.isDebugEnabled) {
                 configurationMap.forEach { (key, value) -> logger.debug("OSGi property $key = $value.") }


### PR DESCRIPTION
pac`OSGiFrameworkWrap.getFrameworkFrom` method load `system_packages_extra` dependencies in `Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA` now but was `Constants.FRAMEWORK_SYSTEMCAPABILITIES_EXTRA` before!
jdkExtraPackages exported.