### PR TITLE
CORE-968: Fix log conflict between slf4j and log4j-slf4j-impl, include the module `appJar` is applied as bundle of bootable JAR. 

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -23,7 +23,6 @@ dependencies {
 
     systemPackages "org.apache.logging.log4j:log4j-api:$log4jVersion"
     systemPackages "org.apache.logging.log4j:log4j-core:$log4jVersion"
-    systemPackages "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
     systemPackages project(":osgi-framework-bootstrap:framework-api")
 }
 
@@ -137,6 +136,9 @@ def cordaAssembleBundlesTask = tasks.register("cordaAssembleBundles") {
             !configurations.systemPackages.contains(resolvableDependencies)
         }.each { resolvableDependencies ->
             addBundles(resolvableDependencies.artifacts as ArtifactCollection, bundlesDir, systemBundleSet)
+        }
+        new File(project.buildDir, "libs").listFiles().findAll { file -> isJar(file) }.each { jar ->
+            addBundle(jar, new File(bundlesDir, jar.name), systemBundleSet)
         }
         final systemBundlesFile = new File(project.buildDir, "resources/main/system_bundles")
         systemBundlesFile.withWriter { writer ->


### PR DESCRIPTION
log bug fix:
Felix can't live with `log4j-slf4j-impl` in the same class-path.
`corda.common-app` plugin failed to zip in bootable JAR the bundle of the module where the plugin is applied.
