### PR TITLE
CORE-1662: Fix client ids for state/event consumers and add a bit of testing

### DIFF
--- a/libs/messaging/kafka-messaging-impl/src/main/resources/messaging-defaults.conf
+++ b/libs/messaging/kafka-messaging-impl/src/main/resources/messaging-defaults.conf
@@ -28,8 +28,8 @@ messaging {
         }
 
         consumer = ${messaging.kafka.common} {
-            group.id = ${topic}-${group}
-            client.id = ${topic}-${group}-consumer-${clientIdCounter}
+            group.id = ${messaging.topic.name}-${group}
+            client.id = ${messaging.topic.name}-${group}-consumer-${clientIdCounter}
             max.poll.records = 100
             max.poll.interval.ms = 100000
             session.timeout.ms = 6000
@@ -91,6 +91,7 @@ messaging {
             subscriptionType = stateAndEvent
             stateConsumer = ${messaging.kafka.consumer} ${messaging.subscription.consumer} {
                 topic.name = ${messaging.topic.name}.state
+                client.id = ${messaging.topic.name}.state-${group}-consumer-${clientIdCounter}
             }
             eventConsumer = ${messaging.kafka.consumer} ${messaging.subscription.consumer}
             producer = ${messaging.kafka.producer} ${messaging.subscription.producer}

--- a/libs/messaging/kafka-messaging-impl/src/test/kotlin/net/corda/messaging/kafka/ConfigTestTemp.kt
+++ b/libs/messaging/kafka-messaging-impl/src/test/kotlin/net/corda/messaging/kafka/ConfigTestTemp.kt
@@ -1,0 +1,75 @@
+package net.corda.messaging.kafka.subscription.net.corda.messaging.kafka
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
+import net.corda.messaging.api.publisher.config.PublisherConfig
+import net.corda.messaging.api.subscription.factory.config.SubscriptionConfig
+import net.corda.messaging.kafka.properties.KafkaProperties.Companion.CONSUMER_GROUP_ID
+import net.corda.messaging.kafka.properties.KafkaProperties.Companion.PATTERN_PUBLISHER
+import net.corda.messaging.kafka.properties.KafkaProperties.Companion.PATTERN_PUBSUB
+import net.corda.messaging.kafka.properties.KafkaProperties.Companion.PATTERN_STATEANDEVENT
+import net.corda.messaging.kafka.properties.KafkaProperties.Companion.PRODUCER_TRANSACTIONAL_ID
+import net.corda.messaging.kafka.resolvePublisherConfiguration
+import net.corda.messaging.kafka.resolveSubscriptionConfiguration
+import net.corda.messaging.kafka.toConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfigTestTemp {
+
+    @Test
+    fun `check resolved publisher configuration`() {
+        val nodeConfig = ConfigFactory.empty()
+            .withValue("messaging.topic.prefix", ConfigValueFactory.fromAnyRef("demo"))
+        val publisherConfig = resolvePublisherConfiguration(
+            PublisherConfig("clientId", 1).toConfig(),
+            nodeConfig,
+            1,
+            PATTERN_PUBLISHER
+        )
+        assertThat(publisherConfig.getString(PRODUCER_TRANSACTIONAL_ID)).isEqualTo("clientId-1")
+    }
+
+    @Test
+    fun `check resolved publisher configuration without instance id doesn't have transactional id`() {
+        val nodeConfig = ConfigFactory.empty()
+            .withValue("messaging.topic.prefix", ConfigValueFactory.fromAnyRef("demo"))
+        val publisherConfig = resolvePublisherConfiguration(
+            PublisherConfig("clientId").toConfig(),
+            nodeConfig,
+            1,
+            PATTERN_PUBLISHER
+        )
+        assertThat(!publisherConfig.hasPath(PRODUCER_TRANSACTIONAL_ID))
+    }
+
+    @Test
+    fun `check resolved subscription configuration`() {
+        val subscriptionConfig = resolveSubscriptionConfiguration(
+            SubscriptionConfig("group", "topic", 1).toConfig(),
+            ConfigFactory.empty(),
+            1,
+            PATTERN_PUBSUB
+        )
+
+        assertThat(subscriptionConfig.getString(CONSUMER_GROUP_ID)).isEqualTo("topic-group")
+        assertThat(subscriptionConfig.getString("consumer.client.id")).isEqualTo("topic-group-consumer-1")
+    }
+
+    @Test
+    fun `check state and event config`() {
+        val config = resolveSubscriptionConfiguration(
+            SubscriptionConfig("group", "topic", 1).toConfig(),
+            ConfigFactory.empty(),
+            1,
+            PATTERN_STATEANDEVENT
+        )
+
+        assertThat(config.getString("producer.client.id")).isEqualTo("group-producer-1")
+        assertThat(config.getString("eventConsumer.client.id")).isEqualTo("topic-group-consumer-1")
+        assertThat(config.getString("stateConsumer.client.id")).isEqualTo("topic.state-group-consumer-1")
+
+        assertThat(config.getString("eventConsumer.group.id")).isEqualTo("topic-group")
+        assertThat(config.getString("stateConsumer.group.id")).isEqualTo("topic-group")
+    }
+}


### PR DESCRIPTION
I'm pretty sure we could add more tests but this should at least be a basic cover.  It will cause resolution of the conf files so we'll at least get a warning of breakage and does a couple of additional checks as well.