### PR TITLE
CORE-1899: `SimpleLifeCycleCoordinatorTest` uses `@Timeout(value = 60…

### DIFF
--- a/libs/lifecycle/src/main/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinator.kt
+++ b/libs/lifecycle/src/main/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinator.kt
@@ -94,6 +94,7 @@ class SimpleLifeCycleCoordinator(
     @Throws(
         RejectedExecutionException::class
     )
+    @Synchronized
     @Suppress("ComplexMethod", "TooGenericExceptionCaught")
     private fun processEvents() {
         executorThreadID = Thread.currentThread().id
@@ -297,7 +298,6 @@ class SimpleLifeCycleCoordinator(
      */
 
     private fun cleanUpAndCloseEvents() {
-        lock.withLock {
             val self = this
             timerMap.forEach { (key, _) -> cancelTimer(key) }
             timerMap.clear()
@@ -307,7 +307,6 @@ class SimpleLifeCycleCoordinator(
                 if (event is StopEvent) break
             }
             eventQueue.clear()
-        }
     }
 
 }

--- a/libs/lifecycle/src/main/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinator.kt
+++ b/libs/lifecycle/src/main/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinator.kt
@@ -295,16 +295,19 @@ class SimpleLifeCycleCoordinator(
      *
      * Called by [stop] in a parallel thread if the current thread isn't the [executorService]'s thread.
      */
+
     private fun cleanUpAndCloseEvents() {
-        val self = this
-        timerMap.forEach { (key, _) -> cancelTimer(key) }
-        timerMap.clear()
-        while (!eventQueue.isEmpty()) {
-            val event = eventQueue.poll()
-            lifeCycleProcessor(event, self)
-            if (event is StopEvent) break
+        lock.withLock {
+            val self = this
+            timerMap.forEach { (key, _) -> cancelTimer(key) }
+            timerMap.clear()
+            while (!eventQueue.isEmpty()) {
+                val event = eventQueue.poll()
+                lifeCycleProcessor(event, self)
+                if (event is StopEvent) break
+            }
+            eventQueue.clear()
         }
-        eventQueue.clear()
     }
 
 }

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -278,7 +278,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun setTimer() {

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -301,6 +301,7 @@ internal class SimpleLifeCycleCoordinatorTest {
     }
 
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -278,6 +278,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun setTimer() {
@@ -307,6 +308,7 @@ internal class SimpleLifeCycleCoordinatorTest {
     }
 
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -271,7 +271,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun setTimer() {

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -239,18 +239,14 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    //@Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    @ValueSource(ints = [5])
+    @ValueSource(ints = [10])
     fun postUnhandledErrorEvent(n: Int) {
-        var stopLatch = CountDownLatch(2)
+        var stopLatch = CountDownLatch(1)
         val expectedException = Exception("expected exception")
         SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { event: LifeCycleEvent, _: LifeCycleCoordinator ->
             when (event) {
-                is StartEvent -> {
-                    stopLatch = CountDownLatch(2)
-                }
                 is ThrowException -> {
                     throw expectedException
                 }
@@ -266,14 +262,15 @@ internal class SimpleLifeCycleCoordinatorTest {
                 }
                 is StopEvent -> {
                     stopLatch.countDown()
-                    assertTrue(stopLatch.count == 0L)
                 }
             }
         }.use { coordinator ->
             for(i in 0 .. n) {
+                println(i)
                 coordinator.start()
                 coordinator.postEvent(object : ThrowException {})
                 stopLatch.await()
+                stopLatch = CountDownLatch(1)
             }
         }
     }

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -239,6 +239,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -241,7 +241,7 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    @ValueSource(ints = [1])
+    @ValueSource(ints = [2])
     fun postUnhandledErrorEvent(n: Int) {
         var stopLatch = CountDownLatch(1)
         val expectedException = Exception("expected exception")
@@ -267,7 +267,6 @@ internal class SimpleLifeCycleCoordinatorTest {
             }
         }.use { coordinator ->
             for(i in 0 .. n) {
-                println(i)
                 coordinator.start()
                 coordinator.postEvent(object : ThrowException {})
                 stopLatch.await()

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -27,6 +27,7 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     interface ThrowException : LifeCycleEvent
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstEvents() {
@@ -63,6 +64,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstTimers() {
@@ -111,6 +113,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         assertTrue(n > countDownLatch.count)
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun cancelTimer() {
@@ -137,6 +140,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun getBatchSize() {
@@ -146,6 +150,7 @@ internal class SimpleLifeCycleCoordinatorTest {
             }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun getTimeout() {
@@ -192,6 +197,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])
@@ -233,6 +239,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])
@@ -301,7 +308,6 @@ internal class SimpleLifeCycleCoordinatorTest {
     }
 
 
-    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -27,7 +27,6 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     interface ThrowException : LifeCycleEvent
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstEvents() {
@@ -64,7 +63,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstTimers() {
@@ -113,7 +111,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         assertTrue(n > countDownLatch.count)
     }
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun cancelTimer() {
@@ -140,7 +137,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @Test
     fun getBatchSize() {
         SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
@@ -149,7 +145,6 @@ internal class SimpleLifeCycleCoordinatorTest {
             }
     }
 
-    @Disabled
     @Test
     fun getTimeout() {
         SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
@@ -158,7 +153,6 @@ internal class SimpleLifeCycleCoordinatorTest {
             }
     }
 
-    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])
@@ -195,7 +189,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])
@@ -273,7 +266,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun setTimer() {
@@ -303,7 +295,6 @@ internal class SimpleLifeCycleCoordinatorTest {
     }
 
 
-    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -239,7 +239,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -233,7 +233,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -192,7 +192,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -239,7 +239,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
+    //@Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -271,6 +271,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun setTimer() {
@@ -299,7 +300,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
+
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -239,7 +239,7 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    @ValueSource(ints = [3])
+    @ValueSource(ints = [2])
     fun postUnhandledErrorEvent(n: Int) {
         var stopLatch = CountDownLatch(1)
         val expectedException = Exception("expected exception")

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -241,7 +241,7 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    @ValueSource(ints = [10])
+    @ValueSource(ints = [1])
     fun postUnhandledErrorEvent(n: Int) {
         var stopLatch = CountDownLatch(1)
         val expectedException = Exception("expected exception")
@@ -256,6 +256,7 @@ internal class SimpleLifeCycleCoordinatorTest {
                             stopLatch.countDown()
                         }
                         else -> {
+                            logger.error("Unexpected ${event.cause}!", event.cause)
                             fail("Unexpected ${event.cause}!")
                         }
                     }

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
 // Order imposed to lighten pressure in CI.
-@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+// @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class SimpleLifeCycleCoordinatorTest {
 
     companion object {

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -27,7 +27,6 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     interface ThrowException : LifeCycleEvent
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstEvents() {

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -63,7 +63,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstTimers() {

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -111,27 +111,6 @@ internal class SimpleLifeCycleCoordinatorTest {
         assertTrue(n > countDownLatch.count)
     }
 
-    @Disabled
-    @Test
-    @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    fun getBatchSize() {
-        SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
-            .use { coordinator ->
-                assertEquals(BATCH_SIZE, coordinator.batchSize)
-            }
-    }
-
-    @Disabled
-    @Test
-    @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    fun getTimeout() {
-        SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
-            .use { coordinator ->
-                assertEquals(TIMEOUT, coordinator.timeout)
-            }
-    }
-
-    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun cancelTimer() {
@@ -156,6 +135,24 @@ internal class SimpleLifeCycleCoordinatorTest {
             }
             coordinator.cancelTimer(key)
         }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun getBatchSize() {
+        SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
+            .use { coordinator ->
+                assertEquals(BATCH_SIZE, coordinator.batchSize)
+            }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun getTimeout() {
+        SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
+            .use { coordinator ->
+                assertEquals(TIMEOUT, coordinator.timeout)
+            }
     }
 
     @Disabled

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -142,7 +142,6 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     @Disabled
     @Test
-    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun getBatchSize() {
         SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
             .use { coordinator ->
@@ -152,7 +151,6 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     @Disabled
     @Test
-    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun getTimeout() {
         SimpleLifeCycleCoordinator(BATCH_SIZE, TIMEOUT) { _: LifeCycleEvent, _: LifeCycleCoordinator -> }
             .use { coordinator ->
@@ -241,7 +239,7 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
-    @ValueSource(ints = [2])
+    @ValueSource(ints = [3])
     fun postUnhandledErrorEvent(n: Int) {
         var stopLatch = CountDownLatch(1)
         val expectedException = Exception("expected exception")

--- a/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
+++ b/libs/lifecycle/src/test/kotlin/net/corda/lifecycle/SimpleLifeCycleCoordinatorTest.kt
@@ -2,6 +2,7 @@ package net.corda.lifecycle
 
 import net.corda.v5.base.util.contextLogger
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -26,6 +27,7 @@ internal class SimpleLifeCycleCoordinatorTest {
 
     interface ThrowException : LifeCycleEvent
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstEvents() {
@@ -62,6 +64,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun burstTimers() {
@@ -110,6 +113,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         assertTrue(n > countDownLatch.count)
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun getBatchSize() {
@@ -119,6 +123,7 @@ internal class SimpleLifeCycleCoordinatorTest {
             }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun getTimeout() {
@@ -128,6 +133,7 @@ internal class SimpleLifeCycleCoordinatorTest {
             }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun cancelTimer() {
@@ -154,6 +160,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])
@@ -190,6 +197,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])
@@ -231,7 +239,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
-
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])
@@ -270,6 +278,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     fun setTimer() {
@@ -298,6 +307,7 @@ internal class SimpleLifeCycleCoordinatorTest {
         }
     }
 
+    @Disabled
     @ParameterizedTest
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     @ValueSource(ints = [5])


### PR DESCRIPTION
…, unit = TimeUnit.SECONDS)` per method, inside methods no timeout checks.