### PR TITLE
NOTICK - Rename e2e test build name.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@
 cordaPipeline(
     nexusAppId: 'flow-worker-5.0',
     runIntegrationTests: true,
-    publishRepoPrefix: 'corda-ent-maven',
-    runE2eTests: true
+    publishRepoPrefix: 'corda-ent-maven'
     )
 


### PR DESCRIPTION
Renamed the e2e test reference. However, not sure if there is much value in having this now that we have the version check builds and while there aren't E2E tests yet.