### PR TITLE
CORE-2250: Use corda-api Gradle platform.

### DIFF
--- a/applications/examples/demo-app/build.gradle
+++ b/applications/examples/demo-app/build.gradle
@@ -5,12 +5,13 @@ plugins {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
     implementation project(":osgi-framework-api")
 
     implementation project(":libs:messaging:messaging")

--- a/applications/examples/demo-publisher/build.gradle
+++ b/applications/examples/demo-publisher/build.gradle
@@ -5,12 +5,13 @@ plugins {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
     implementation project(":osgi-framework-api")
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle")

--- a/applications/examples/goodbyeworld/build.gradle
+++ b/applications/examples/goodbyeworld/build.gradle
@@ -5,9 +5,10 @@ plugins {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
     implementation project(":libs:examples:helloworld")
     implementation project(":osgi-framework-api")
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"

--- a/applications/tools/kafka-reader/build.gradle
+++ b/applications/tools/kafka-reader/build.gradle
@@ -7,12 +7,13 @@ description "Configuration Reader"
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
 
     implementation project(':components:kafka-config-read')
     implementation project(":libs:configuration:configuration-read")

--- a/applications/tools/kafka-setup/build.gradle
+++ b/applications/tools/kafka-setup/build.gradle
@@ -7,12 +7,13 @@ description "Bootstrapping Tools"
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
 
     implementation project(':components:kafka-topic-admin')
     implementation project(':components:kafka-config-write')

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,16 @@
 import static org.gradle.api.JavaVersion.VERSION_11
-import io.gitlab.arturbosch.detekt.DetektPlugin
 
 buildscript {
-    repositories {
-        maven {
-            url "$artifactoryContextUrl/corda-releases"
+    configurations.classpath {
+        resolutionStrategy {
+            // FORCE Gradle to use latest dynamic-version plugins.
+            cacheDynamicVersionsFor 0, 'seconds'
         }
+    }
+
+    ext {
+        // Create another Quasar property in this repository's chosen format.
+        quasarVersion = quasar_version
     }
 }
 
@@ -16,13 +21,14 @@ plugins {
     id 'io.gitlab.arturbosch.detekt' apply false
     id 'idea'
     id 'application'
-    id 'com.r3.internal.gradle.plugins.r3Publish' apply false
+    id 'net.corda.cordapp.cordapp-configuration'
+    id 'com.r3.internal.gradle.plugins.r3ArtifactoryPublish'
     id 'maven-publish'
     id 'jacoco'
 }
 
 wrapper {
-    gradleVersion = '6.8.3'
+    gradleVersion = '7.1.1'
     distributionType = Wrapper.DistributionType.BIN
     distributionUrl="https://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-$gradleVersion-bin.zip"
 }
@@ -40,14 +46,14 @@ allprojects {
 
     apply plugin: 'org.jetbrains.kotlin.jvm'
 
-    tasks.withType(JavaCompile) {
+    tasks.withType(JavaCompile).configureEach {
         sourceCompatibility = javaVersion
         targetCompatibility = javaVersion
         options.encoding = 'UTF-8'
         options.compilerArgs += '-XDenableSunApiLintControl'
     }
 
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
             allWarningsAsErrors = true
             languageVersion = '1.4'
@@ -61,6 +67,17 @@ allprojects {
                     "-Xjvm-default=all"
             ]
         }
+    }
+
+    tasks.withType(Test).configureEach {
+        useJUnitPlatform()
+    }
+
+    tasks.register('compileAll') { task ->
+        description = "Compiles all the Kotlin and Java classes, including all of the test classes."
+        group = "verification"
+
+        task.dependsOn tasks.withType(AbstractCompile)
     }
 
     repositories {
@@ -133,10 +150,6 @@ allprojects {
         testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
     }
-
-    tasks.named("test", Test).configure {
-        useJUnitPlatform()
-    }
 }
 
 logger.quiet("********************** CORDA FLOW WORKER BUILD **********************")
@@ -168,7 +181,7 @@ subprojects {
     apply plugin: 'idea'
     apply plugin: 'kotlin-allopen'
     apply plugin: 'kotlin-noarg'
-    apply plugin: DetektPlugin
+    apply plugin: 'io.gitlab.arturbosch.detekt'
     apply plugin: 'jacoco'
 
     version rootProject.version

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -28,8 +28,8 @@ dependencies {
 def jarTask = tasks.named("jar", Jar) {
     archiveBaseName = project.name
     bnd """
-Bundle-Name: $project.description
-Bundle-SymbolicName: ${project.group}.${project.name}
+Bundle-Name: \${project.description}
+Bundle-SymbolicName: \${project.group}.\${project.name}
 """
 }
 
@@ -178,18 +178,28 @@ def cordaAssembleSystemPackagesExtraTask = tasks.register("cordaAssembleSystemPa
 
 def appJarBaseName = "corda-" + project.name
 
-task appJar(type: Jar) {
+def appJar = tasks.register('appJar', Jar) {
     dependsOn cordaAssembleSystemPackagesExtraTask
     archivesBaseName = appJarBaseName
-    destinationDirectory = new File(project.buildDir, "bin")
+    destinationDirectory = layout.buildDirectory.dir("bin")
     from(
             configurations.bootstrapClasspath.collect { it.isDirectory() ? it : zipTree(it) },
             configurations.systemPackages.collect { it.isDirectory() ? it : zipTree(it) },
             new File(project.buildDir, "resources/main")
     )
+    exclude "META-INF/*.SF"
+    exclude "META-INF/*.DSA"
+    exclude "META-INF/*.RSA"
+    exclude "META-INF/*.EC"
+    exclude "**/module-info.class"
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     manifest {
         attributes 'Main-Class': 'net.corda.osgi.framework.OSGiFrameworkMain'
     }
+}
+
+artifacts {
+    archives appJar
 }
 
 publishing {

--- a/buildSrc/src/main/groovy/corda.common-flask.gradle
+++ b/buildSrc/src/main/groovy/corda.common-flask.gradle
@@ -7,9 +7,7 @@ plugins {
 
 quasar {
     // Global configuration for our quasar-utils Gradle plugin.
-    suspendableAnnotation = "net.corda.v5.base.annotations.Suspendable"
     group = 'co.paralleluniverse'
-    version = "0.8.6_r3"
     excludePackages = [
             'co.paralleluniverse**',
             'com.esotericsoftware.**',
@@ -32,9 +30,9 @@ quasar {
     ]
 }
 
-project.tasks.register("appFlask", net.corda.gradle.flask.FlaskJarTask) {
+def appFlask = project.tasks.register("appFlask", net.corda.gradle.flask.FlaskJarTask) {
     archiveBaseName = "corda-flask-" + project.name
-    destinationDirectory = new File(project.buildDir, "bin")
+    destinationDirectory = layout.buildDirectory.dir("bin")
     Provider<RegularFile> quasarAgent = layout.file(provider { configurations.quasarAgent.singleFile })
     includeLibraries(project.tasks.named("appJar").map { it.outputs }, quasarAgent)
     javaAgents {
@@ -44,4 +42,8 @@ project.tasks.register("appFlask", net.corda.gradle.flask.FlaskJarTask) {
         }
     }
     mainClassName = "net.corda.osgi.framework.OSGiFrameworkMain"
+}
+
+artifacts {
+    archives appFlask
 }

--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -17,14 +17,19 @@ configurations {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
+    integrationTestImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
+    integrationTestImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
+    integrationTestImplementation "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
     integrationTestRuntimeOnly "org.junit.platform:junit-platform-launcher:$junitPlatformVersion"
     integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
     integrationTestRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
     integrationTestRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
-    integrationTestRuntimeOnly "org.apache.logging.log4j:log4j-api:$log4jVersion"
+    integrationTestRuntimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
+    integrationTestRuntimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
+    integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 
 def testingBundle = tasks.register('testingBundle', Bundle) {
@@ -41,7 +46,7 @@ Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons
 def resolve = tasks.register('resolve', Resolve) {
     dependsOn jar, testingBundle
     bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
-    bndrun = 'test.bndrun'
+    bndrun = file('test.bndrun')
     //  bnd attempts to use ~/ for caching if this is unavailable the build will fail.
     System.setProperty("bnd.home.dir", "$rootDir/bnd/")
 }
@@ -50,8 +55,9 @@ def testOSGi = tasks.register('testOSGi', TestOSGi) {
     description = "Runs OSGi integration tests."
     group = "verification"
     dependsOn resolve
+    resultsDirectory = file("$testResultsDir/integrationTest")
     bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
-    bndrun = 'test.bndrun'
+    bndrun = file('test.bndrun')
 }
 
 tasks.named('check') {
@@ -62,12 +68,9 @@ tasks.register('integrationTest', Test) {
     description = "Runs integration tests."
     group = "verification"
     dependsOn testOSGi
-
-    testClassesDirs = project.sourceSets["integrationTest"].output.classesDirs
-    classpath = project.sourceSets["integrationTest"].runtimeClasspath
+    enabled = false
 }
 
 artifacts {
     archives testingBundle
 }
-

--- a/components/examples/config-reader/build.gradle
+++ b/components/examples/config-reader/build.gradle
@@ -6,12 +6,13 @@ plugins {
 dependencies {
 
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
     implementation project(':libs:configuration:configuration-read')
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle")

--- a/components/examples/durable-sub/build.gradle
+++ b/components/examples/durable-sub/build.gradle
@@ -4,9 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle")
 }

--- a/components/examples/publisher/build.gradle
+++ b/components/examples/publisher/build.gradle
@@ -4,9 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle")
 }

--- a/components/examples/pubsub-sub/build.gradle
+++ b/components/examples/pubsub-sub/build.gradle
@@ -4,9 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
 
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle")

--- a/components/examples/state-plus-event-sub/build.gradle
+++ b/components/examples/state-plus-event-sub/build.gradle
@@ -4,9 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle")
 }

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -6,9 +6,10 @@ plugins {
 description 'P2P gateway component'
 
 dependencies {
-    implementation "net.corda:corda-base:$cordaVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
-    implementation "net.corda:topic-schema:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
+    implementation "net.corda:topic-schema"
     implementation project(":libs:p2p-crypto")
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle")
@@ -19,12 +20,12 @@ dependencies {
     implementation "io.netty:netty-codec-http:$nettyVersion"
 
     // Log4J: logging framework (with SLF4J bindings) - TEMPORARY UNTIL I FIGURE OUT LOGGING IN THIS PROJECT
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-    compile "org.apache.logging.log4j:log4j-core:$log4jVersion"
-    compile "org.slf4j:jul-to-slf4j:$slf4jVersion"
-    compile "org.slf4j:jcl-over-slf4j:$slf4jVersion"
+    runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    implementation "org.slf4j:jul-to-slf4j:$slf4jVersion"
+    implementation "org.slf4j:jcl-over-slf4j:$slf4jVersion"
     // For async logging
-    compile "com.lmax:disruptor:$disruptorVersion"
+    implementation "com.lmax:disruptor:$disruptorVersion"
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion") {
@@ -46,8 +47,4 @@ tasks.register('integrationTest', Test) {
 
     testClassesDirs = project.sourceSets["integrationTest"].output.classesDirs
     classpath = project.sourceSets["integrationTest"].runtimeClasspath
-}
-
-tasks.named("integrationTest", Test).configure {
-    useJUnitPlatform()
 }

--- a/components/kafka-config-read/build.gradle
+++ b/components/kafka-config-read/build.gradle
@@ -6,9 +6,10 @@ plugins {
 description "Kafka Config Read Component"
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
     implementation project(':libs:configuration:configuration-read')
     implementation project(":libs:lifecycle")
     implementation project(":libs:messaging:messaging")

--- a/components/kafka-config-write/build.gradle
+++ b/components/kafka-config-write/build.gradle
@@ -6,8 +6,9 @@ plugins {
 description "Kafka Config Write Component"
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
     implementation project(':libs:configuration:configuration-write')
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -7,8 +7,8 @@ description 'LinkManager for p2p communication'
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
     implementation project(":libs:p2p-crypto")
     implementation project(":libs:messaging:messaging")
@@ -18,14 +18,15 @@ dependencies {
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
 
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
-    implementation "net.corda:topic-schema:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
+    implementation "net.corda:topic-schema"
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
-    testCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-    testCompile "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    testImplementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ cordaRuntimeRevision=0
 # Plugin dependency versions
 avroGradlePluginVersion=1.1.0
 bndVersion=5.3.0
-cordaGradlePluginsVersion=6.0.0-DevPreview-RC02
+cordaGradlePluginsVersion=6.0.0-DevPreview-RC03
 detektPluginVersion=1.14.0
 internalPublishVersion=0.1.1626968102251-beta
 
@@ -26,8 +26,8 @@ disruptorVersion=3.4.2
 cordaApiVersion=5.0.0.1-beta+
 # If the Corda version is updated here, the corresponding version must also be updated in the Jenkinsfile under .ci.
 cordaVersion=5.0.0-1626712413904-beta
-felixVersion=7.0.0
-felixScrVersion=2.1.20
+felixVersion=7.0.1
+felixScrVersion=2.1.28
 guavaVersion=23.0
 hikariCpVersion=4.0.3
 kafkaClientVersion=2.7.0_2
@@ -35,23 +35,27 @@ kryoVersion = 4.0.2
 kryoSerializerVersion = 0.43
 log4jVersion = 2.14.1
 nettyVersion = 4.1.65.Final
-osgiVersion = 7.0.0
+osgiVersion = 8.0.0
+osgiScrAnnotationVersion=1.4.0
 osgiUtilFunctionVersion=1.1.0
 osgiUtilPromiseVersion=1.1.1
 rxjavaVersion = 1.3.8
 slf4jVersion=1.7.30
 picocliVersion = 4.5.2
 typeSafeConfigVersion=1.4.1
-quasarVersion = 0.8.6_r3
+
+# !!! VERY IMPORTANT !!! Required by quasar-utils plugin !!!
+quasar_suspendable_annotation = net.corda.v5.base.annotations.Suspendable
+quasar_version = 0.8.7_r3
 
 # Test dependency versions
 assertjVersion=3.12.2
 dropwizardMetricsVersion=4.2.2
 h2Version=1.4.200
 jimfsVersion = 1.2
-junit5Version=5.7.1
-junitPlatformVersion=1.7.1
-osgiTestJunit5Version=0.9.0
+junit5Version=5.7.2
+junitPlatformVersion=1.7.2
+osgiTestJunit5Version=1.0.0
 mockitoInlineVersion=3.11.0
 mockitoKotlinVersion=3.2.0
 mockitoVersion=2.28.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-6.8.3-bin.zip
+distributionUrl=https\://gradleproxy\:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/configuration/kafka-configuration-read-impl/build.gradle
+++ b/libs/configuration/kafka-configuration-read-impl/build.gradle
@@ -6,10 +6,10 @@ plugins {
 description 'Kafka Configuration Read API Impl'
 
 dependencies {
-
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
     implementation project(':libs:configuration:configuration-read')
     implementation project(":libs:lifecycle")
     implementation project(":libs:messaging:messaging")

--- a/libs/configuration/kafka-configuration-write-impl/build.gradle
+++ b/libs/configuration/kafka-configuration-write-impl/build.gradle
@@ -7,11 +7,11 @@ description 'Kafka Configuration Write API Impl'
 
 
 dependencies {
-
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
 
     implementation project(":libs:configuration:configuration-write")
     implementation project(":libs:messaging:messaging")

--- a/libs/examples/helloworld-impl/build.gradle
+++ b/libs/examples/helloworld-impl/build.gradle
@@ -7,6 +7,7 @@ plugins {
 description 'Hello World Implementation'
 
 dependencies {
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
     implementation project(":libs:examples:helloworld")
 }

--- a/libs/examples/helloworld-impl/test.bndrun
+++ b/libs/examples/helloworld-impl/test.bndrun
@@ -21,6 +21,7 @@
     bnd.identity;id='net.corda.helloworld-impl',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='slf4j.simple',\
     bnd.identity;id='${project.archivesBaseName}-tests'
 
 # This will help us keep -runbundles sorted
@@ -34,6 +35,7 @@
 	helloworld-impl-tests;version='[5.0.0,5.0.1)',\
 	junit-jupiter-api;version='[5.7.2,5.7.3)',\
 	junit-jupiter-engine;version='[5.7.2,5.7.3)',\
+	junit-jupiter-params;version='[5.7.2,5.7.3)',\
 	junit-platform-commons;version='[1.7.2,1.7.3)',\
 	junit-platform-engine;version='[1.7.2,1.7.3)',\
 	junit-platform-launcher;version='[1.7.2,1.7.3)',\
@@ -42,12 +44,12 @@
 	net.corda.helloworld-impl;version='[5.0.0,5.0.1)',\
 	org.apache.felix.scr;version='[2.1.20,2.1.21)',\
 	org.apache.logging.log4j.api;version='[2.14.1,2.14.2)',\
-	org.apache.logging.log4j.slf4j-impl;version='[2.14.1,2.14.2)',\
 	org.assertj.core;version='[3.12.2,3.12.3)',\
 	org.jetbrains.kotlin.osgi-bundle;version='[1.4.21,1.4.22)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.osgi.test.common;version='[0.9.0,0.9.1)',\
-	org.osgi.test.junit5;version='[0.9.0,0.9.1)',\
-	org.osgi.util.function;version='[1.0.0,1.0.1)',\
-	org.osgi.util.promise;version='[1.0.0,1.0.1)',\
-	slf4j.api;version='[1.7.30,1.7.31)'
+	org.osgi.test.common;version='[1.0.0,1.0.1)',\
+	org.osgi.test.junit5;version='[1.0.0,1.0.1)',\
+	org.osgi.util.function;version='[1.1.0,1.1.1)',\
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	slf4j.api;version='[1.7.30,1.7.31)',\
+	slf4j.simple;version='[1.7.30,1.7.31)'

--- a/libs/flows/flow-manager-impl/build.gradle
+++ b/libs/flows/flow-manager-impl/build.gradle
@@ -6,15 +6,16 @@ plugins {
 description "Flow Manager Implemenation"
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
     implementation "com.esotericsoftware:kryo:$kryoVersion"
-    implementation "net.corda:corda-application:$cordaApiVersion"
+    implementation "net.corda:corda-application"
     implementation "net.corda:corda-base-internal:$cordaVersion"
     implementation "net.corda:corda-install:$cordaVersion"
     implementation "net.corda:corda-packaging:$cordaVersion"
     implementation "net.corda:corda-sandbox:$cordaVersion"
     implementation "net.corda:corda-flow-dependency-injection-internal:$cordaVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
 
     implementation project(':libs:flows:flow-manager')
     implementation project(':libs:flows:statemachine')

--- a/libs/flows/flow-manager/build.gradle
+++ b/libs/flows/flow-manager/build.gradle
@@ -6,9 +6,10 @@ plugins {
 description "Flow Manager"
 
 dependencies {
-    implementation "net.corda:corda-application:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-application"
     implementation "net.corda:corda-base-internal:$cordaVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
 
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"

--- a/libs/flows/statemachine-impl/build.gradle
+++ b/libs/flows/statemachine-impl/build.gradle
@@ -9,10 +9,11 @@ dependencies {
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
     implementation("com.esotericsoftware:kryo:$kryoVersion")
 
-    implementation "net.corda:corda-application:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-application"
     implementation "net.corda:corda-flow-dependency-injection-internal:$cordaVersion"
     implementation "net.corda:corda-base-internal:$cordaVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
 
     implementation project(':libs:flows:statemachine')
 }

--- a/libs/flows/statemachine/build.gradle
+++ b/libs/flows/statemachine/build.gradle
@@ -9,8 +9,9 @@ dependencies {
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
     implementation("com.esotericsoftware:kryo:$kryoVersion")
 
-    implementation "net.corda:corda-application:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-application"
     implementation "net.corda:corda-base-internal:$cordaVersion"
     implementation "net.corda:corda-flow-dependency-injection-internal:$cordaVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
 }

--- a/libs/kafka-utils/topic-admin-impl/build.gradle
+++ b/libs/kafka-utils/topic-admin-impl/build.gradle
@@ -4,9 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
     implementation project(":libs:kafka-utils:topic-admin")
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/libs/lifecycle/build.gradle
+++ b/libs/lifecycle/build.gradle
@@ -6,7 +6,8 @@ plugins {
 description "LifeCycle API"
 
 dependencies {
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/libs/messaging/db-messaging-impl/build.gradle
+++ b/libs/messaging/db-messaging-impl/build.gradle
@@ -6,8 +6,9 @@ plugins {
 description 'Database Messaging API Implementation'
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
     implementation "com.zaxxer:HikariCP:$hikariCpVersion"
     implementation "com.google.guava:guava:$guavaVersion"
     implementation project(":libs:lifecycle")
@@ -48,8 +49,4 @@ tasks.register('integrationTest', Test) {
 
     testClassesDirs = project.sourceSets["integrationTest"].output.classesDirs
     classpath = project.sourceSets["integrationTest"].runtimeClasspath
-}
-
-tasks.named("integrationTest", Test).configure {
-    useJUnitPlatform()
 }

--- a/libs/messaging/inmemory-messaging-impl/build.gradle
+++ b/libs/messaging/inmemory-messaging-impl/build.gradle
@@ -6,8 +6,9 @@ plugins {
 description 'In-Memory Messaging API Impl'
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
     implementation project(":libs:lifecycle")
     implementation project(":libs:messaging:messaging")
 

--- a/libs/messaging/kafka-messaging-impl/build.gradle
+++ b/libs/messaging/kafka-messaging-impl/build.gradle
@@ -32,14 +32,15 @@ dependencies {
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:schema-registry:schema-registry")
 
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation project(":libs:lifecycle")
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
-    testImplementation "net.corda:avro-schema:$cordaApiVersion"
+    testImplementation "net.corda:avro-schema"
 
     testRuntimeOnly "org.osgi:osgi.core:$osgiVersion"
 
@@ -60,7 +61,7 @@ tasks.register('kafkaIntegrationTest', TestOSGi) {
     group = "verification"
     dependsOn resolve
     bundles = files(sourceSets.kafkaIntegrationTest.runtimeClasspath, configurations.archives.artifacts.files)
-    bndrun = 'test.bndrun'
+    bndrun = file('test.bndrun')
 }
 
 def kafkaTestingBundle = tasks.register('kafkaTestingBundle', Bundle) {
@@ -77,7 +78,7 @@ Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons
 def resolve = tasks.register('resolve', Resolve) {
     dependsOn jar, kafkaTestingBundle
     bundles = files(sourceSets.kafkaIntegrationTest.runtimeClasspath, configurations.archives.artifacts.files)
-    bndrun = 'test.bndrun'
+    bndrun = file('test.bndrun')
     //  bnd attempts to use ~/ for caching if this is unavailable the build will fail.
     System.setProperty("bnd.home.dir", "$rootDir/bnd/")
 }

--- a/libs/messaging/messaging/build.gradle
+++ b/libs/messaging/messaging/build.gradle
@@ -4,8 +4,9 @@ plugins {
 }
 
 dependencies {
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation "net.corda:corda-base"
     implementation project(":libs:lifecycle")
 }
 

--- a/libs/p2p-crypto/build.gradle
+++ b/libs/p2p-crypto/build.gradle
@@ -1,8 +1,8 @@
 description 'P2P cryptographic library for session authentication'
 
 dependencies {
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
+    implementation "net.corda:avro-schema"
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
 }

--- a/libs/sandbox/sandbox-cache-impl/build.gradle
+++ b/libs/sandbox/sandbox-cache-impl/build.gradle
@@ -6,12 +6,13 @@ plugins {
 description "Sandbox Cache Implementation"
 
 dependencies {
-    implementation "net.corda:corda-application:$cordaApiVersion"
-    implementation "net.corda:corda-base:$cordaVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-application"
+    implementation "net.corda:corda-base"
     implementation "net.corda:corda-install:$cordaVersion"
     implementation "net.corda:corda-packaging:$cordaVersion"
     implementation "net.corda:corda-sandbox:$cordaVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
 
     implementation project(":libs:sandbox:sandbox-cache")
 

--- a/libs/sandbox/sandbox-cache/build.gradle
+++ b/libs/sandbox/sandbox-cache/build.gradle
@@ -6,10 +6,11 @@ plugins {
 description "Sandbox Cache Interface"
 
 dependencies {
-    implementation "net.corda:corda-application:$cordaApiVersion"
-    implementation "net.corda:corda-base:$cordaVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-application"
+    implementation "net.corda:corda-base"
     implementation "net.corda:corda-install:$cordaVersion"
     implementation "net.corda:corda-packaging:$cordaVersion"
     implementation "net.corda:corda-sandbox:$cordaVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
 }

--- a/libs/schema-registry/schema-registry-impl/build.gradle
+++ b/libs/schema-registry/schema-registry-impl/build.gradle
@@ -4,9 +4,10 @@ plugins {
 }
 
 dependencies {
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
     implementation "org.apache.avro:avro:$avroVersion"
-    implementation "net.corda:avro-schema:$cordaApiVersion"
+    implementation "net.corda:avro-schema"
     implementation project(":libs:schema-registry:schema-registry")
 
     testRuntimeOnly "org.osgi:osgi.core:$osgiVersion"

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -8,8 +8,9 @@ dependencies {
     compileOnly "org.osgi:osgi.core:$osgiVersion"
     compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
 
-    implementation "net.corda:corda-application:$cordaApiVersion"
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-application"
+    implementation "net.corda:corda-base"
     implementation "net.corda:corda-base-internal:$cordaVersion"
     implementation "net.corda:corda-crypto-api:$cordaVersion"
     implementation "net.corda:corda-crypto-impl:$cordaVersion"

--- a/osgi-framework-api/build.gradle
+++ b/osgi-framework-api/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'org.jetbrains.kotlin.jvm'
 }
 
@@ -9,8 +8,8 @@ repositories {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
 }

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -4,7 +4,8 @@ import java.util.jar.JarFile
 description("OSGi Framework Bootstrap")
 
 dependencies {
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
     implementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
     implementation project(":osgi-framework-api")
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,6 @@
 pluginManagement {
     repositories {
         maven {
-            url "$artifactoryContextUrl/corda-dev"
-            content {
-                includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
-            }
-        }
-        maven {
             url "$artifactoryContextUrl/corda-releases"
             content {
                 includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
@@ -15,7 +9,11 @@ pluginManagement {
         maven {
             url "$artifactoryContextUrl/corda-os-maven"
             content {
-                includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
+                includeGroupByRegex 'net\\.corda\\.cordapp(\\..*)?'
+            }
+            credentials {
+                username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
             }
         }
         gradlePluginPortal()
@@ -37,11 +35,13 @@ pluginManagement {
         }
     }
     plugins {
+        id 'net.corda.cordapp.cordapp-configuration' version cordaApiVersion
         id 'org.jetbrains.kotlin.jvm' version kotlinVersion
         id 'org.jetbrains.kotlin.plugin.allopen' version kotlinVersion
         id 'org.jetbrains.kotlin.plugin.noarg' version kotlinVersion
         id 'net.corda.plugins.cordapp-cpk' version cordaGradlePluginsVersion
         id 'net.corda.plugins.quasar-utils' version cordaGradlePluginsVersion
+        id 'com.r3.internal.gradle.plugins.r3ArtifactoryPublish' version internalPublishVersion
         id 'com.r3.internal.gradle.plugins.r3Publish' version internalPublishVersion
         id 'io.gitlab.arturbosch.detekt' version detektPluginVersion
         id 'corda.common-library' version internalPublishVersion

--- a/testing/apps/test-app/build.gradle
+++ b/testing/apps/test-app/build.gradle
@@ -11,10 +11,11 @@ repositories {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.cmpn:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
 
-    implementation "net.corda:corda-base:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-base"
 
     implementation project(":libs:lifecycle")
     implementation project(":osgi-framework-api")


### PR DESCRIPTION
Use the Corda API's shiny new Gradle platform to define all API dependencies. This has also required the following updates:
- Gradle 7.1.1, because only Gradle 7+ supports dynamic Gradle plugin versions.
- OSGi 8.0.0, which is what Felix 7.x actually uses.
- `osgi.cmpn` -> `org.osgi.service.component.annotations` for OSGi 8.0.0.
- Apply `cordapp-configuration` plugin, to support `cordapp-cpk` plugin.
- Fixed OSGi convention plugin, which (to be blunt) was _not_ doing what it was supposed to (and actually _works_ now).
- Replaced several lingering occurrences of `net.corda:corda-base:$cordaVersion` with API version.
- Upgraded Corda Gradle plugins to 6.0.0-DevPreview-RC03.
- Upgraded Quasar to 0.8.7_r3.