### PR TITLE
NOTICK Allow gradle plugins to be picked up from mavenLocal

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,7 @@ pluginManagement {
                 }
             }
         }
+        mavenLocal()
     }
     plugins {
         id 'net.corda.cordapp.cordapp-configuration' version cordaApiVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        mavenLocal()
         maven {
             url "$artifactoryContextUrl/corda-releases"
             content {
@@ -33,7 +34,6 @@ pluginManagement {
                 }
             }
         }
-        mavenLocal()
     }
     plugins {
         id 'net.corda.cordapp.cordapp-configuration' version cordaApiVersion


### PR DESCRIPTION
Often I want to update something inside corda-api and publish it to mavenLocal.
Then update the version corda-api used by corda-runtime-os (to use the mavenLocal version). Doing this means I can test locally without pushing anything to artefactory.

At the moment if I try and do this I get:

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/williamvigor/workspace/corda-runtime-os/build.gradle' line: 24

* What went wrong:
Plugin [id: 'net.corda.cordapp.cordapp-configuration', version: '5.0.0.2-SNAPSHOT'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (could not resolve plugin artifact 'net.corda.cordapp.cordapp-configuration:net.corda.cordapp.cordapp-configuration.gradle.plugin:5.0.0.2-SNAPSHOT')
  Searched in the following repositories:
    maven(https://software.r3.com/artifactory/corda-releases)
    maven2(https://software.r3.com/artifactory/corda-os-maven)
    Gradle Central Plugin Repository
    maven3(https://software.r3.com/artifactory/engineering-tools-maven)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 6s
9 actionable tasks: 9 executed

To fix this I have added mavenLocal to the list of repositories for plugins. In corda-api there are some gradle plugins used by corda-runtime-os (which use the same versioning).