### PR TITLE
CORE-2535: Reacquire privileges to build LocalTypeInformation.

### DIFF
--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
@@ -30,6 +30,9 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+import java.security.AccessController.doPrivileged
+import java.security.PrivilegedActionException
+import java.security.PrivilegedExceptionAction
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
@@ -77,7 +80,9 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                 val previous = visited
                 try {
                     visited = visited + typeIdentifier
-                    buildIfNotFound(type, typeIdentifier, isOpaque)
+                    doPrivileged(PrivilegedExceptionAction { buildIfNotFound(type, typeIdentifier, isOpaque) })
+                } catch (e: PrivilegedActionException) {
+                    throw e.exception
                 } finally {
                     visited = previous
                 }


### PR DESCRIPTION
Corda's security manager forbids Java reflection inside a contract-verification sandbox. Allow Corda serialisation to continue working in this case.