### PR TITLE
NOTICK: Configure Kotlin for JPA classes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'org.jetbrains.kotlin.plugin.allopen' apply false
-    id 'org.jetbrains.kotlin.plugin.noarg' apply false
+    id 'org.jetbrains.kotlin.plugin.jpa' apply false
     id 'io.gitlab.arturbosch.detekt' apply false
     id 'idea'
     id 'application'
@@ -235,7 +235,7 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'idea'
     apply plugin: 'kotlin-allopen'
-    apply plugin: 'kotlin-noarg'
+    apply plugin: 'kotlin-jpa'
     apply plugin: 'io.gitlab.arturbosch.detekt'
     apply plugin: 'jacoco'
 
@@ -276,5 +276,12 @@ subprojects {
             }
         }
     }
-}
 
+    allOpen {
+        annotations(
+            "javax.persistence.Entity",
+            "javax.persistence.Embeddable",
+            "javax.persistence.MappedSuperclass"
+        )
+    }
+}

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -31,6 +31,7 @@ java: ${project.javaExecutable}
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
 	javassist;version='[3.27.0,3.27.1)',\
+	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
 	javax.persistence-api;version='[2.2.0,2.2.1)',\
 	jaxb-api;version='[2.3.1,2.3.2)',\

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,7 @@ pluginManagement {
         id 'net.corda.cordapp.cordapp-configuration' version cordaApiVersion
         id 'org.jetbrains.kotlin.jvm' version kotlinVersion
         id 'org.jetbrains.kotlin.plugin.allopen' version kotlinVersion
-        id 'org.jetbrains.kotlin.plugin.noarg' version kotlinVersion
+        id 'org.jetbrains.kotlin.plugin.jpa' version kotlinVersion
         id 'net.corda.plugins.cordapp-cpk' version cordaGradlePluginsVersion
         id 'net.corda.plugins.quasar-utils' version cordaGradlePluginsVersion
         id 'com.r3.internal.gradle.plugins.r3ArtifactoryPublish' version internalPublishVersion

--- a/testing/bundles/cats/build.gradle
+++ b/testing/bundles/cats/build.gradle
@@ -12,3 +12,9 @@ dependencies {
 
     api 'javax.persistence:javax.persistence-api'
 }
+
+tasks.named('jar', Jar) {
+    bnd '''\
+DynamicImport-Package: org.hibernate.proxy
+'''
+}

--- a/testing/bundles/dogs/build.gradle
+++ b/testing/bundles/dogs/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.r3.internal.gradle.plugins.r3Publish'
 }
 
-description 'Dogs test bunddle'
+description 'Dogs test bundle'
 
 dependencies {
     api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
@@ -11,4 +11,10 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     api 'javax.persistence:javax.persistence-api'
+}
+
+tasks.named('jar', Jar) {
+    bnd '''\
+DynamicImport-Package: org.hibernate.proxy
+'''
 }


### PR DESCRIPTION
- Replace Kotlin `noarg` plugin with [Kotlin `jpa` plugin](https://kotlinlang.org/docs/no-arg-plugin.html#jpa-support), which applies `noarg` and then configures it for JPA.
- Configure Kotlin `allopen` plugin for JPA.
- Test that we can create lazy JPA proxies.
- Close all `EntityManager` and `EntityManagerFactory` instances after use.