### PR TITLE
CORE-2617 Remove remaining usages of `RPCOps` from `corda-api`

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/rpc/proxies/RpcAuthHelper.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/rpc/proxies/RpcAuthHelper.kt
@@ -2,7 +2,7 @@
 
 package net.corda.httprpc.rpc.proxies
 
-import net.corda.v5.application.messaging.RPCOps
+import net.corda.v5.httprpc.api.RpcOps
 import java.lang.reflect.Method
 
 
@@ -13,7 +13,7 @@ object RpcAuthHelper {
 
     fun methodFullName(clazz: Class<*>, methodName: String): String {
         require(clazz.isInterface) { "Must be an interface: $clazz" }
-        require(RPCOps::class.java.isAssignableFrom(clazz)) { "Must be assignable from RPCOps: $clazz" }
+        require(RpcOps::class.java.isAssignableFrom(clazz)) { "Must be assignable from RPCOps: $clazz" }
         return clazz.name + INTERFACE_SEPARATOR + methodName
     }
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/rpc/proxies/ThreadContextAdjustingRpcOpsProxy.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/rpc/proxies/ThreadContextAdjustingRpcOpsProxy.kt
@@ -1,7 +1,7 @@
 package net.corda.httprpc.rpc.proxies
 
 import net.corda.httprpc.server.utils.executeWithThreadContextClassLoader
-import net.corda.v5.application.messaging.RPCOps
+import net.corda.v5.httprpc.api.RpcOps
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 
@@ -15,7 +15,7 @@ import java.lang.reflect.Proxy
  * that any provided classes from these libraries will be available during RPC calls.
  */
 internal object ThreadContextAdjustingRpcOpsProxy {
-    fun <T : RPCOps> proxy(delegate: T, clazz: Class<out T>, classLoader: ClassLoader): T {
+    fun <T : RpcOps> proxy(delegate: T, clazz: Class<out T>, classLoader: ClassLoader): T {
         require(clazz.isInterface) { "Interface is expected instead of $clazz" }
         val handler = ThreadContextAdjustingInvocationHandler(delegate, classLoader)
         @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
`RPCOps` has been removed and an internal version `RpcOps` is defined in
`:http-rpc`.