### PR TITLE
INFRA-1581: use Artifactory as a cache for Gradle plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,8 +124,8 @@ allprojects {
                     basic(BasicAuthentication)
                 }
                 credentials {
-                    username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: cordaArtifactoryUsername
-                    password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: cordaArtifactoryPassword
+                    username = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
                 }
             }
         } else {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,8 +28,8 @@ repositories {
                 basic(BasicAuthentication)
             }
             credentials {
-                username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: cordaArtifactoryUsername
-                password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: cordaArtifactoryPassword
+                username = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                password = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
             }
         }
     } else {

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,8 +9,8 @@ pluginManagement {
                     basic(BasicAuthentication)
                 }
                 credentials {
-                    username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: settings.ext.find('cordaArtifactoryUsername')
-                    password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: settings.ext.find('cordaArtifactoryPassword')
+                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
                 }
             }
         } else {
@@ -29,8 +29,8 @@ pluginManagement {
                     basic(BasicAuthentication)
                 }
                 credentials {
-                    username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: settings.ext.find('cordaArtifactoryUsername')
-                    password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: settings.ext.find('cordaArtifactoryPassword')
+                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
                 }
             }
             gradlePluginPortal()
@@ -40,8 +40,8 @@ pluginManagement {
                     basic(BasicAuthentication)
                 }
                 credentials {
-                    username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: settings.ext.find('cordaArtifactoryUsername')
-                    password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: settings.ext.find('cordaArtifactoryPassword')
+                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
                 }
             }
         }


### PR DESCRIPTION
* search for plugin in Artifactory if CORDA_USE_CACHE is set
* added explicit `BasicAuthentication` for each Maven repository hosted
  by Artifactory which needs authentication in `pluginManagement`
* replaced `if`s with elvis operator for `engineering-tools-maven` in
  `pluginManagement`
* `buildSrc` configured to search for dependencies if CORDA_USE_CACHE is
   set
* prefer environment variables over Gradle properties, inline with
  current use in the root Gradle project