### PR TITLE
CORE-2481: Private key AMQP serialization tests

### DIFF
--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivateKeySerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivateKeySerializationTests.kt
@@ -1,0 +1,20 @@
+package net.corda.internal.serialization.amqp
+
+import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.serializeDeserializeAssert
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.mockito.Mockito.mock
+import java.security.PrivateKey
+
+@Timeout(30)
+class PrivateKeySerializationTests {
+
+    @Test
+    fun `check throws when serializing a private key`() {
+        val privateKey = mock(PrivateKey::class.java)
+        assertThatThrownBy { serializeDeserializeAssert(privateKey) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Attempt to serialise private key")
+    }
+}


### PR DESCRIPTION
Check that the serialiser will throw an exception on a private key.