### PR TITLE
NOTICK: Fix build by testing with latest Corda5 CPKs.

### DIFF
--- a/libs/install/build.gradle
+++ b/libs/install/build.gradle
@@ -8,7 +8,7 @@ plugins {
 description "Corda CorDapp Installer"
 
 ext {
-    cordaDevPreviewVersion = '5.0.0-DevPreview--beta-1631256347020'
+    cordaDevPreviewVersion = '5.0.0-DevPreview-1.0'
 }
 
 configurations {


### PR DESCRIPTION
The test CPKs from `5.0.0-DevPreview--beta-1631256347020` have now been purged from Artifactory, so use a dynamic version instead.