### PR TITLE
CORE-2521: Correct version of `javax.transaction` necessary for Infinispan

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -117,7 +117,7 @@ private def addSystemPackagesExtra(
             "sun.security.x509",
             "sun.security.ssl",
             "javax.servlet",
-            "javax.transaction.xa;version=1.1.0",
+            "javax.transaction;version=1.2.0",
             "javax.xml.stream;version=1.0",
             "javax.xml.stream.events;version=1.0",
             "javax.xml.stream.util;version=1.0"


### PR DESCRIPTION
Or else when application is started the following error is observed:
```
13:34:38.188 [main] ERROR net.corda.osgi.framework.OSGiFrameworkMain - Error: Unable to resolve net.corda.kafka-messaging-impl [31](R 31.0): missing requirement [net.corda.kafka-messaging-impl [31](R 31.0)] osgi.wiring.package; (&(osgi.wiring.package=org.infinispan.commons.util)(version>=9.4.0)(!(version>=10.0.0))) [caused by: Unable to resolve org.infinispan.commons [48](R 48.0): missing requirement [org.infinispan.commons [48](R 48.0)] osgi.wiring.package; (&(osgi.wiring.package=javax.transaction)(version>=1.2.0)(!(version>=2.0.0)))] Unresolved requirements: [[net.corda.kafka-messaging-impl [31](R 31.0)] osgi.wiring.package; (&(osgi.wiring.package=org.infinispan.commons.util)(version>=9.4.0)(!(version>=10.0.0)))]!
```

The main bit: `(&(osgi.wiring.package=javax.transaction)(version>=1.2.0)`.

Related to changes made in #221 