### PR TITLE
INFRA-1589 Consume source Jars and javaDoc for developer productivity when working with corda-api + runtime os

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,13 @@ subprojects {
     version rootProject.version
     group 'net.corda'
 
+    idea{
+        module {
+            downloadJavadoc = true
+            downloadSources = true
+        }
+    }
+
     detekt {
         baseline = file("$projectDir/detekt-baseline.xml")
         config.setFrom(files("$rootDir/detekt-config.yml"))


### PR DESCRIPTION

Related PRs for context:  

SourceJArs will be published for internal development use for non GA/RC branches

**publishing plugin:** https://github.com/corda/corda-internal-gradle-plugins/pull/33
**Corda-API:** https://github.com/corda/corda-api/pull/93