### PR TITLE
NOTICK: Bump version of `commons-compress`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,9 +30,6 @@ ariesDynamicBundleVersion = 1.3.2
 antlrVersion=2.7.7
 asmVersion=9.2
 avroVersion=1.10.1
-# Commons Compress version can be removed when Avro is upgraded to v1.11
-# For more details, please see: https://issues.apache.org/jira/browse/AVRO-3215
-commonsCompressVersion=1.21
 bouncyCastleVersion=1.69
 commonsVersion = 1.7
 caffeineVersion = 3.0.2

--- a/libs/schema-registry/schema-registry-impl/build.gradle
+++ b/libs/schema-registry/schema-registry-impl/build.gradle
@@ -9,8 +9,17 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "net.corda:corda-base"
+
     implementation "org.apache.avro:avro:$avroVersion"
-    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
+    // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
+    // Constains block can be removed when Avro is upgraded to v1.11
+    // For more details, please see: https://issues.apache.org/jira/browse/AVRO-3215
+    constraints {
+        implementation('org.apache.commons:commons-compress:1.21+') {
+            because 'CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090'
+        }
+    }
+
     implementation "net.corda:corda-avro-schema"
     implementation project(":libs:schema-registry:schema-registry")
 

--- a/libs/schema-registry/schema-registry/build.gradle
+++ b/libs/schema-registry/schema-registry/build.gradle
@@ -8,8 +8,16 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+
     api "org.apache.avro:avro:$avroVersion"
-    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
+    // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
+    // Constains block can be removed when Avro is upgraded to v1.11
+    // For more details, please see: https://issues.apache.org/jira/browse/AVRO-3215
+    constraints {
+        implementation('org.apache.commons:commons-compress:1.21+') {
+            because 'CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090'
+        }
+    }
 }
 
 description 'Schema Registry Library API'


### PR DESCRIPTION
This is to eliminate critical vulnerability that comes with version bundled with Avro v1.10.1

New [NexusIQ report](https://nexusiq.dev.r3.com/assets/index.html#/applicationReport/flow-worker-5.0/7c8171a210dc4e43b5cf67b3f18daa81/policy) is available which no longer has critical vulnerabilities.