### PR TITLE
NOTICK: Update the internal publish plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ avroGradlePluginVersion=1.1.0
 bndVersion=6.0.0
 cordaGradlePluginsVersion=6.0.0-BETA09
 detektPluginVersion=1.18.1
-internalPublishVersion=0.1.1626968102251-beta
+internalPublishVersion=1.+
 
 # Implementation dependency versions
 activationVersion = 1.2.0


### PR DESCRIPTION
* start using released versions (first one is 1.0.0)
* use Gradle mechanism to find the newest version for the plugin