### PR TITLE
Catch unset properties during retrieval of CPK directory.

### DIFF
--- a/libs/install/src/main/kotlin/net/corda/install/internal/persistence/CordaPackageFileBasedPersistenceImpl.kt
+++ b/libs/install/src/main/kotlin/net/corda/install/internal/persistence/CordaPackageFileBasedPersistenceImpl.kt
@@ -122,8 +122,9 @@ internal class CordaPackageFileBasedPersistenceImpl @Activate constructor(
 
     /** Returns the [Path] representing the node's CPK directory. */
     private fun getCpkDirectoryInternal(): Path {
-        val couldNotEstablishBaseDirErr =
+        val couldNotEstablishBaseDirErr by lazy {
             CpkInstallationException("Node's base directory could not be established for storing CPK files.")
+        }
 
         val properties = configAdmin
             .getConfiguration(ConfigurationAdmin::class.java.name, null)


### PR DESCRIPTION
`ConfigurationAdmin.properties` can be null. This change avoids an uninformative NPE in that case.