### PR TITLE
use deferred evaluation for resolution, issue with composite build

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -270,7 +270,7 @@ def appJar = tasks.register('appJar', Jar) {
     into("META-INF/") {
         from(javaAgentFileTask)
     }
-    from(configurations.bootstrapClasspath.collect { it.isDirectory() ? it : zipTree(it) })
+    from{ configurations.bootstrapClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     from(createSystemBundlesFile)
     from(cordaAssembleSystemPackagesExtraTask)
     from(writeFrameworkPropertyFile)


### PR DESCRIPTION
Further details on this teams [chat ](https://teams.microsoft.com/l/message/19:e6e24061f66f40c8b0a909382293f568@thread.tacv2/1633958535965?tenantId=a4be1f2e-2d10-4195-87cd-736aca9b672c&groupId=8a439305-65b8-45ca-afd3-7ee0226bb0a7&parentMessageId=1633958535965&teamName=Engineering&channelName=Eng%20Infra%20Group&createdTime=1633958535965)

But to summarize, when using the Gradle composite build feature triggering builds from subprojects e.g. :subProject:assemble rather than from the root (:assemble) was causing the following failure 

  Project#beforeEvaluate(Action) on project ':corda-api' cannot be executed in the current context.

Root cause of this some logic in the appJar task which resolves some bootstrapClasspath dependencies. using deferred evaluation ( {} rather than () ) resolves this issue.

