### PR TITLE
CORE-2816 Fixed open file descriptor leakage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ commonsVersion = 1.7
 caffeineVersion = 3.0.2
 commonsLangVersion = 3.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
-cordaApiVersion=5.0.0.16-beta+
+cordaApiVersion=5.0.0.17-beta+
 disruptorVersion=3.4.2
 eddsaVersion = 0.3.0
 felixConfigAdminVersion=1.9.20


### PR DESCRIPTION
Amended `CordaPackageFileBasedPersistenceImpl` to close all the CPK and CPI it has in cache before deleting the cache folder upon process termination