### PR TITLE
CORE-2816 Fixed open file descriptor leakage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ commonsVersion = 1.7
 caffeineVersion = 3.0.2
 commonsLangVersion = 3.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
-cordaApiVersion=5.0.0.16-beta+
+cordaApiVersion=5.0.0.17-beta+
 disruptorVersion=3.4.2
 eddsaVersion = 0.3.0
 felixConfigAdminVersion=1.9.20

--- a/libs/install/src/test/kotlin/net/corda/install/internal/verification/VerifierTests.kt
+++ b/libs/install/src/test/kotlin/net/corda/install/internal/verification/VerifierTests.kt
@@ -17,6 +17,7 @@ import net.corda.v5.crypto.sha256Bytes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
@@ -46,6 +47,15 @@ class VerifierTests {
         contractCpk = cpk("test.cpk.contract", junitTestDir)
         split1Cpk = cpk("test.cpk.split1", junitTestDir)
         split2Cpk = cpk("test.cpk.split2", junitTestDir)
+    }
+
+    @AfterEach
+    fun teardown() {
+        flowsCpk.close()
+        workflowCpk.close()
+        contractCpk.close()
+        split1Cpk.close()
+        split2Cpk.close()
     }
 
     private fun cpk(propertyName: String, rootDir: Path): CPK {

--- a/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -636,5 +636,6 @@ private data class CpkAndContents(
         }
 
         override fun getResourceAsStream(resourceName: String) = ByteArrayInputStream(ByteArray(0))
+        override fun close() {}
     }
 }


### PR DESCRIPTION
Amended `CordaPackageFileBasedPersistenceImpl` to close all the CPK and CPI it has in cache before deleting the cache folder upon process termination