### PR TITLE
NOTICK Fix Flakey Session Manager Test in LinkManager

### DIFF
--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -864,7 +864,6 @@ class SessionManagerTest {
             publishLatch.countDown()
         }
 
-        //First time we throw an exception so nothing gets published.
         val publisher = CallbackPublisher(::callback)
         whenever(publisherFactory.createPublisher(anyOrNull(), anyOrNull())).thenReturn(publisher)
         sessionManager = SessionManagerImpl(


### PR DESCRIPTION
The test was using the wrong instance of the SessionManager 🤦‍♂️ .