### PR TITLE
No-Ticket: Fix concurrency issue that caused flaky test

### DIFF
--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -32,6 +32,7 @@
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
 	javassist;version='[3.27.0,3.27.1)',\
+	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
 	javax.persistence-api;version='[2.2.0,2.2.1)',\
 	jaxb-api;version='[2.3.1,2.3.2)',\

--- a/libs/messaging/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/topic/model/ConsumerGroupTest.kt
+++ b/libs/messaging/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/topic/model/ConsumerGroupTest.kt
@@ -238,10 +238,19 @@ class ConsumerGroupTest {
     }
 
     @Test
-    fun `waitForData will wait for a signal`() {
-        group.waitForData()
+    fun `waitForPhaseChange will wait for phase if not the same`() {
+        val phase = group.currentPhase()
+        group.waitForPhaseChange(phase)
 
         verify(sleeper).await(any(), any())
+    }
+
+    @Test
+    fun `waitForPhaseChange will not wait if phase changed`() {
+        val phase = group.currentPhase()
+        group.waitForPhaseChange(phase - 1)
+
+        verify(sleeper, never()).await(any(), any())
     }
 
     @Test
@@ -249,6 +258,15 @@ class ConsumerGroupTest {
         group.wakeUp()
 
         verify(sleeper).signalAll()
+    }
+
+    @Test
+    fun `wakeUp will change the phase`() {
+        val phase = group.currentPhase()
+
+        group.wakeUp()
+
+        assertThat(group.currentPhase()).isNotEqualTo(phase)
     }
 
     @Test

--- a/libs/messaging/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/topic/model/ConsumptionLoopTest.kt
+++ b/libs/messaging/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/topic/model/ConsumptionLoopTest.kt
@@ -231,4 +231,20 @@ class ConsumptionLoopTest {
 
         verify(partitionOne, times(1)).getRecordsFrom(16, 10)
     }
+
+    @Test
+    fun `run will wait for phase change is there are no records`() {
+        whenever(group.currentPhase())
+            .thenReturn(5)
+            .thenReturn(6)
+        whenever(group.isConsuming(consumer))
+            .thenReturn(true)
+            .thenReturn(true)
+            .thenReturn(false)
+
+        loop.run()
+
+        verify(group).waitForPhaseChange(5)
+        verify(group).waitForPhaseChange(6)
+    }
 }


### PR DESCRIPTION
The issue was caused if we added another record before we checked that the list is empty.

Now we have a phase that changes on every addition and we will wait only if the phase had not changed since we started reading the record.

