### PR TITLE
NOTICK - changed key serialiser to get encoder on each call 

### DIFF
--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/serializer/PublicKeySerializer.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/serializer/PublicKeySerializer.kt
@@ -1,7 +1,6 @@
 package net.corda.crypto.impl.serializer
 
 import net.corda.crypto.CryptoLibraryFactory
-import net.corda.v5.cipher.suite.KeyEncodingService
 import net.corda.v5.serialization.SerializationCustomSerializer
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -17,8 +16,9 @@ class PublicKeySerializer @Activate constructor(
     private val cryptoLibraryFactory: CryptoLibraryFactory
 ) : SerializationCustomSerializer<PublicKey, ByteArray> {
 
-    private val keyEncodingService: KeyEncodingService by lazy { cryptoLibraryFactory.getKeyEncodingService() }
+    override fun toProxy(obj: PublicKey): ByteArray =
+        cryptoLibraryFactory.getKeyEncodingService().encodeAsByteArray(obj)
 
-    override fun toProxy(obj: PublicKey): ByteArray = obj.encoded
-    override fun fromProxy(proxy: ByteArray): PublicKey = keyEncodingService.decodePublicKey(proxy)
+    override fun fromProxy(proxy: ByteArray): PublicKey =
+        cryptoLibraryFactory.getKeyEncodingService().decodePublicKey(proxy)
 }

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CryptoLibraryFactoryTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CryptoLibraryFactoryTests.kt
@@ -4,10 +4,15 @@ import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.cipher.suite.CipherSuiteFactory
 import net.corda.v5.crypto.DigestService
 import net.corda.v5.crypto.SignatureVerificationService
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.security.KeyPairGenerator
+import java.security.PublicKey
+import java.time.Duration
 import kotlin.test.assertSame
+import kotlin.test.fail
 
 class CryptoLibraryFactoryTests {
     @Test
@@ -29,5 +34,51 @@ class CryptoLibraryFactoryTests {
         assertSame(digest, factory.getDigestService())
         assertSame(verifier, factory.getSignatureVerificationService())
         assertSame(metadata, factory.getCipherSchemeMetadata())
+    }
+
+    @Disabled("Use only to evaluate the factory performance.")
+    @Test
+    fun `Should perform well`() {
+        val cipherSuiteFactory = CipherSuiteFactoryImpl(
+            listOf(
+                CipherSchemeMetadataProviderImpl()
+            ),
+            listOf(
+                SignatureVerificationServiceProviderImpl()
+            ),
+            listOf(
+                DigestServiceProviderImpl()
+            )
+        )
+        val factory = CryptoLibraryFactoryImpl(cipherSuiteFactory)
+        val publicKey: PublicKey = KeyPairGenerator.getInstance("RSA").genKeyPair().public
+        val encoded = factory.getKeyEncodingService().encodeAsByteArray(publicKey)
+        val encodingMessage = elapsed{
+            for (i in 1..1_000_000) {
+                val encoder = factory.getKeyEncodingService()
+                encoder.encodeAsByteArray(publicKey)
+            }
+        }.second
+        val decodingMessage = elapsed{
+            for (i in 1..1_000_000) {
+                val encoder = factory.getKeyEncodingService()
+                encoder.decodePublicKey(encoded)
+            }
+        }.second
+        fail("Encoding: $encodingMessage, ${System.lineSeparator()}Decoding: $decodingMessage")
+        // Approximately (so we can always get the service from factory):
+        // getKeyEncodingService = 6M/second
+        // getKeyEncodingService + encode = 3M/second (occasionally as high as 10M/second)
+        // getKeyEncodingService + decode = 1M/minute
+    }
+
+    private fun elapsed(block: () -> Unit): Pair<Duration, String> {
+        val start = System.nanoTime()
+        block()
+        val duration = Duration.ofNanos(System.nanoTime() - start)
+        return Pair(
+            duration,
+            "Executed in $duration (${duration.toMillis()} ms.)."
+        )
     }
 }

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/serializer/PrivateKeySerializationTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/serializer/PrivateKeySerializationTests.kt
@@ -6,14 +6,19 @@ import org.junit.jupiter.api.Timeout
 import org.mockito.Mockito.mock
 import java.security.PrivateKey
 
-@Timeout(30)
 class PrivateKeySerializationTests {
-
     @Test
-    fun `check throws when serializing a private key`() {
+    @Timeout(5)
+    fun `Should throw IllegalStateException when serializing a private key`() {
         val privateKey = mock(PrivateKey::class.java)
         assertThatThrownBy { PrivateKeySerializer().toProxy(privateKey) }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Attempt to serialise private key")
+    }
+
+    @Test
+    @Timeout(5)
+    fun `Should throw IllegalStateException when deserializing a private key`() {
+        assertThatThrownBy { PrivateKeySerializer().fromProxy("mock") }
+            .isInstanceOf(IllegalStateException::class.java)
     }
 }

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/serializer/PublicKeySerializationTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/serializer/PublicKeySerializationTests.kt
@@ -3,22 +3,22 @@ package net.corda.crypto.impl.serializer
 import net.corda.crypto.CryptoLibraryFactory
 import net.corda.v5.cipher.suite.KeyEncodingService
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 import org.mockito.kotlin.mock
-import java.security.KeyPairGenerator
 import java.security.PublicKey
 import kotlin.test.assertEquals
 
 class PublicKeySerializationTests {
-
     @Test
-    fun `test custom serializers on public key`() {
-        val algorithm = "RSA"
-
-        // Generate new key for testing
-        val publicKey: PublicKey = KeyPairGenerator.getInstance(algorithm).genKeyPair().public
-
+    @Timeout(5)
+    fun `Should serialize and then deserialize public key`() {
+        val encodedPublicKey = ByteArray(1)
+        val publicKey = mock<PublicKey> {
+            on { it.encoded }.thenReturn(encodedPublicKey)
+        }
         val keyEncodingService = mock<KeyEncodingService> {
-            on { it.decodePublicKey(publicKey.encoded) }.thenReturn(publicKey)
+            on { it.decodePublicKey(encodedPublicKey) }.thenReturn(publicKey)
+            on { it.encodeAsByteArray(publicKey) }.thenReturn(encodedPublicKey)
         }
         val cryptoLibraryFactory = mock<CryptoLibraryFactory> {
             on { it.getKeyEncodingService() }.thenReturn(keyEncodingService)


### PR DESCRIPTION
It has negligible performance implications - from ~6M/sec down to ~3M/sec, see the performance notes in the performance test. 

It's simpler than to track the factory lifecycle whenever the cached instance of the key encoder should be recreated.