### PR TITLE
remove tech writers from .md files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-# All documentation should be reviewed by the technical writers
-*.md	@corda/technical-writers
 
 # Build scripts should be audited by BLT
 *.gradle        @corda/blt


### PR DESCRIPTION
removed as this is a bottle neck when runtime-os repo is in a state of flux and .md files may be changing often