### PR TITLE
NOTICK Rename `TREQ` and `TRESP` generic types

### DIFF
--- a/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/rpc/FreshKeySigningServiceClient.kt
+++ b/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/rpc/FreshKeySigningServiceClient.kt
@@ -134,9 +134,9 @@ class FreshKeySigningServiceClient(
     )
 
     @Suppress("ThrowsCount", "UNCHECKED_CAST", "ComplexMethod", "TooGenericExceptionCaught")
-    private fun <TRESP> WireFreshKeysRequest.executeWithTimeoutRetry(
-        respClazz: Class<TRESP>
-    ): TRESP {
+    private fun <RESPONSE> WireFreshKeysRequest.executeWithTimeoutRetry(
+        respClazz: Class<RESPONSE>
+    ): RESPONSE {
         var retry = clientRetries
         while (true) {
             try {
@@ -152,7 +152,7 @@ class FreshKeySigningServiceClient(
                             "received ${response.response::class.java.name} with ${response.context.memberId} member"
                 }
                 logger.debug("Received response {} for member {}", respClazz.name, context.memberId)
-                return response.response as TRESP
+                return response.response as RESPONSE
             } catch (e: TimeoutException) {
                 retry--
                 if (retry < 0) {

--- a/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/rpc/SigningServiceClient.kt
+++ b/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/rpc/SigningServiceClient.kt
@@ -162,10 +162,10 @@ class SigningServiceClient(
     )
 
     @Suppress("ThrowsCount", "UNCHECKED_CAST", "ComplexMethod")
-    private fun <TRESP> WireSigningRequest.executeWithTimeoutRetry(
-        respClazz: Class<TRESP>,
+    private fun <RESPONSE> WireSigningRequest.executeWithTimeoutRetry(
+        respClazz: Class<RESPONSE>,
         allowNoContentValue: Boolean = false
-    ): TRESP? {
+    ): RESPONSE? {
         var retry = clientRetries
         while (true) {
             try {
@@ -195,7 +195,7 @@ class SigningServiceClient(
                             "received ${response.response::class.java.name} with ${response.context.memberId} member"
                 }
                 logger.debug("Received response {} for member {}", respClazz.name, context.memberId)
-                return response.response as TRESP
+                return response.response as RESPONSE
             } catch (e: TimeoutException) {
                 retry--
                 if (retry < 0) {

--- a/components/crypto/crypto-service/src/main/kotlin/net/corda/crypto/service/rpc/AbstractCryptoRpcSub.kt
+++ b/components/crypto/crypto-service/src/main/kotlin/net/corda/crypto/service/rpc/AbstractCryptoRpcSub.kt
@@ -7,13 +7,13 @@ import net.corda.v5.cipher.suite.lifecycle.CryptoLifecycleComponent
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-abstract class AbstractCryptoRpcSub<TREQ: Any, TRESP: Any> : Lifecycle, CryptoLifecycleComponent {
+abstract class AbstractCryptoRpcSub<REQUEST: Any, RESPONSE: Any> : Lifecycle, CryptoLifecycleComponent {
 
     protected val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    private var subscription: RPCSubscription<TREQ, TRESP>? = null
+    private var subscription: RPCSubscription<REQUEST, RESPONSE>? = null
 
-    abstract fun createSubscription(libraryConfig: CryptoLibraryConfig): RPCSubscription<TREQ, TRESP>
+    abstract fun createSubscription(libraryConfig: CryptoLibraryConfig): RPCSubscription<REQUEST, RESPONSE>
 
     override var isRunning: Boolean = false
 

--- a/components/crypto/crypto-service/src/main/kotlin/net/corda/crypto/service/rpc/CryptoRpcHandler.kt
+++ b/components/crypto/crypto-service/src/main/kotlin/net/corda/crypto/service/rpc/CryptoRpcHandler.kt
@@ -1,5 +1,5 @@
 package net.corda.crypto.service.rpc
 
-interface CryptoRpcHandler<TCTX, TREQ> {
-    fun handle(context: TCTX, request: TREQ): Any?
+interface CryptoRpcHandler<CTX, REQUEST> {
+    fun handle(context: CTX, request: REQUEST): Any?
 }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
@@ -94,10 +94,10 @@ class InMemorySessionReplayerTest {
                 return publisher
             }
 
-            override fun <TREQ : Any, TRESP : Any> createRPCSender(
-                rpcConfig: RPCConfig<TREQ, TRESP>,
+            override fun <REQUEST : Any, RESPONSE : Any> createRPCSender(
+                rpcConfig: RPCConfig<REQUEST, RESPONSE>,
                 nodeConfig: Config
-            ): RPCSender<TREQ, TRESP> {
+            ): RPCSender<REQUEST, RESPONSE> {
                 fail("createRPCSender should not be used in this test.")
             }
         }
@@ -181,10 +181,10 @@ class InMemorySessionReplayerTest {
                 return publisher
             }
 
-            override fun <TREQ : Any, TRESP : Any> createRPCSender(
-                rpcConfig: RPCConfig<TREQ, TRESP>,
+            override fun <REQUEST : Any, RESPONSE : Any> createRPCSender(
+                rpcConfig: RPCConfig<REQUEST, RESPONSE>,
                 nodeConfig: Config
-            ): RPCSender<TREQ, TRESP> {
+            ): RPCSender<REQUEST, RESPONSE> {
                 fail("createRPCSender should not be used in this test.")
             }
         }
@@ -250,10 +250,10 @@ class InMemorySessionReplayerTest {
                 return publisher
             }
 
-            override fun <TREQ : Any, TRESP : Any> createRPCSender(
-                rpcConfig: RPCConfig<TREQ, TRESP>,
+            override fun <REQUEST : Any, RESPONSE : Any> createRPCSender(
+                rpcConfig: RPCConfig<REQUEST, RESPONSE>,
                 nodeConfig: Config
-            ): RPCSender<TREQ, TRESP> {
+            ): RPCSender<REQUEST, RESPONSE> {
                 fail("createRPCSender should not be used in this test.")
             }
         }
@@ -297,10 +297,10 @@ class InMemorySessionReplayerTest {
                 return publisher
             }
 
-            override fun <TREQ : Any, TRESP : Any> createRPCSender(
-                rpcConfig: RPCConfig<TREQ, TRESP>,
+            override fun <REQUEST : Any, RESPONSE : Any> createRPCSender(
+                rpcConfig: RPCConfig<REQUEST, RESPONSE>,
                 nodeConfig: Config
-            ): RPCSender<TREQ, TRESP> {
+            ): RPCSender<REQUEST, RESPONSE> {
                 fail("createRPCSender should not be used in this test.")
             }
         }
@@ -343,10 +343,10 @@ class InMemorySessionReplayerTest {
                 return publisher
             }
 
-            override fun <TREQ : Any, TRESP : Any> createRPCSender(
-                rpcConfig: RPCConfig<TREQ, TRESP>,
+            override fun <REQUEST : Any, RESPONSE : Any> createRPCSender(
+                rpcConfig: RPCConfig<REQUEST, RESPONSE>,
                 nodeConfig: Config
-            ): RPCSender<TREQ, TRESP> {
+            ): RPCSender<REQUEST, RESPONSE> {
                 fail("createRPCSender should not be used in this test.")
             }
         }

--- a/libs/messaging/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/factory/CordaPublisherFactory.kt
+++ b/libs/messaging/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/factory/CordaPublisherFactory.kt
@@ -44,10 +44,10 @@ class CordaPublisherFactory @Activate constructor(
         return CordaPublisher(config, topicService)
     }
 
-    override fun <TREQ : Any, TRESP : Any> createRPCSender(
-        rpcConfig: RPCConfig<TREQ, TRESP>,
+    override fun <REQUEST : Any, RESPONSE : Any> createRPCSender(
+        rpcConfig: RPCConfig<REQUEST, RESPONSE>,
         nodeConfig: Config
-    ): RPCSender<TREQ, TRESP> {
+    ): RPCSender<REQUEST, RESPONSE> {
         TODO("Not yet implemented")
     }
 }

--- a/libs/messaging/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/factory/InMemSubscriptionFactory.kt
+++ b/libs/messaging/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/factory/InMemSubscriptionFactory.kt
@@ -109,11 +109,11 @@ class InMemSubscriptionFactory @Activate constructor(
         TODO("Not yet implemented")
     }
 
-    override fun <TREQ : Any, TRESP : Any> createRPCSubscription(
-        rpcConfig: RPCConfig<TREQ, TRESP>,
+    override fun <REQUEST : Any, RESPONSE : Any> createRPCSubscription(
+        rpcConfig: RPCConfig<REQUEST, RESPONSE>,
         nodeConfig: Config,
-        responderProcessor: RPCResponderProcessor<TREQ, TRESP>
-    ): RPCSubscription<TREQ, TRESP> {
+        responderProcessor: RPCResponderProcessor<REQUEST, RESPONSE>
+    ): RPCSubscription<REQUEST, RESPONSE> {
         TODO("Not yet implemented")
     }
 }

--- a/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/publisher/CordaKafkaRPCSenderImpl.kt
+++ b/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/publisher/CordaKafkaRPCSenderImpl.kt
@@ -40,13 +40,13 @@ import kotlin.concurrent.withLock
 
 @Suppress("LongParameterList")
 @Component
-class CordaKafkaRPCSenderImpl<TREQ : Any, TRESP : Any>(
+class CordaKafkaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
     private val config: Config,
     private val publisher: Publisher,
     private val consumerBuilder: ConsumerBuilder<String, RPCResponse>,
-    private val serializer: CordaAvroSerializer<TREQ>,
-    private val deserializer: CordaAvroDeserializer<TRESP>
-) : RPCSender<TREQ, TRESP>, RPCSubscription<TREQ, TRESP> {
+    private val serializer: CordaAvroSerializer<REQUEST>,
+    private val deserializer: CordaAvroDeserializer<RESPONSE>
+) : RPCSender<REQUEST, RESPONSE>, RPCSubscription<REQUEST, RESPONSE> {
 
     private companion object {
         private val log: Logger = contextLogger()
@@ -56,7 +56,7 @@ class CordaKafkaRPCSenderImpl<TREQ : Any, TRESP : Any>(
     private var stopped = false
     private val lock = ReentrantLock()
     private var consumeLoopThread: Thread? = null
-    private val futureTracker = FutureTracker<TRESP>()
+    private val futureTracker = FutureTracker<RESPONSE>()
 
     override val isRunning: Boolean
         get() = !stopped
@@ -202,9 +202,9 @@ class CordaKafkaRPCSenderImpl<TREQ : Any, TRESP : Any>(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    override fun sendRequest(req: TREQ): CompletableFuture<TRESP> {
+    override fun sendRequest(req: REQUEST): CompletableFuture<RESPONSE> {
         val correlationId = UUID.randomUUID().toString()
-        val future = CompletableFuture<TRESP>()
+        val future = CompletableFuture<RESPONSE>()
         val partitions = partitionListener.getPartitions()
         var reqBytes: ByteArray? = null
         try {

--- a/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/publisher/factory/CordaKafkaPublisherFactory.kt
+++ b/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/publisher/factory/CordaKafkaPublisherFactory.kt
@@ -55,10 +55,10 @@ class CordaKafkaPublisherFactory @Activate constructor(
         return CordaKafkaPublisherImpl(config, producer)
     }
 
-    override fun <TREQ : Any, TRESP : Any> createRPCSender(
-        rpcConfig: RPCConfig<TREQ, TRESP>,
+    override fun <REQUEST : Any, RESPONSE : Any> createRPCSender(
+        rpcConfig: RPCConfig<REQUEST, RESPONSE>,
         nodeConfig: Config
-    ): RPCSender<TREQ, TRESP> {
+    ): RPCSender<REQUEST, RESPONSE> {
 
         val publisherConfiguration = ConfigFactory.empty()
             .withValue(GROUP, ConfigValueFactory.fromAnyRef(rpcConfig.groupName))
@@ -75,7 +75,7 @@ class CordaKafkaPublisherFactory @Activate constructor(
         val publisher = createPublisher(PublisherConfig(rpcConfig.clientName), nodeConfig)
 
         val consumerBuilder = CordaKafkaConsumerBuilderImpl<String, RPCResponse>(avroSchemaRegistry)
-        val serializer = CordaAvroSerializer<TREQ>(avroSchemaRegistry)
+        val serializer = CordaAvroSerializer<REQUEST>(avroSchemaRegistry)
         val deserializer = CordaAvroDeserializer(avroSchemaRegistry, { _, _ -> }, rpcConfig.responseType)
 
         return CordaKafkaRPCSenderImpl(

--- a/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/subscription/KafkaRPCSubscriptionImpl.kt
+++ b/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/subscription/KafkaRPCSubscriptionImpl.kt
@@ -31,14 +31,14 @@ import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
 
 @Suppress("LongParameterList")
-class KafkaRPCSubscriptionImpl<TREQ : Any, TRESP : Any>(
+class KafkaRPCSubscriptionImpl<REQUEST : Any, RESPONSE : Any>(
     private val config: Config,
     private val publisher: Publisher,
     private val consumerBuilder: ConsumerBuilder<String, RPCRequest>,
-    private val responderProcessor: RPCResponderProcessor<TREQ, TRESP>,
-    private val serializer: CordaAvroSerializer<TRESP>,
-    private val deserializer: CordaAvroDeserializer<TREQ>
-) : RPCSubscription<TREQ, TRESP> {
+    private val responderProcessor: RPCResponderProcessor<REQUEST, RESPONSE>,
+    private val serializer: CordaAvroSerializer<RESPONSE>,
+    private val deserializer: CordaAvroDeserializer<REQUEST>
+) : RPCSubscription<REQUEST, RESPONSE> {
 
     private val log = LoggerFactory.getLogger(
         config.getString(CONSUMER_GROUP_ID)
@@ -148,7 +148,7 @@ class KafkaRPCSubscriptionImpl<TREQ : Any, TRESP : Any>(
             val rpcRequest = it.record.value()
             val requestBytes = rpcRequest.payload
             val request = deserializer.deserialize(topic, requestBytes.array())
-            val future = CompletableFuture<TRESP>()
+            val future = CompletableFuture<RESPONSE>()
 
             future.whenComplete { response, error ->
                 val record: Record<String, RPCResponse>?

--- a/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/subscription/consumer/listener/RPCConsumerRebalanceListener.kt
+++ b/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/subscription/consumer/listener/RPCConsumerRebalanceListener.kt
@@ -7,10 +7,10 @@ import org.apache.kafka.common.TopicPartition
 import org.slf4j.Logger
 import java.util.*
 
-class RPCConsumerRebalanceListener<TRESP>(
+class RPCConsumerRebalanceListener<RESPONSE>(
     private val topic: String,
     private val groupName: String,
-    private val tracker: FutureTracker<TRESP>
+    private val tracker: FutureTracker<RESPONSE>
 ) : ConsumerRebalanceListener {
 
     private val partitions = mutableListOf<TopicPartition>()

--- a/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/subscription/factory/KafkaSubscriptionFactory.kt
+++ b/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/subscription/factory/KafkaSubscriptionFactory.kt
@@ -237,11 +237,11 @@ class KafkaSubscriptionFactory @Activate constructor(
         return KafkaRandomAccessSubscriptionImpl(config, consumerBuilder, keyClass, valueClass)
     }
 
-    override fun <TREQ : Any, TRESP : Any> createRPCSubscription(
-        rpcConfig: RPCConfig<TREQ, TRESP>,
+    override fun <REQUEST : Any, RESPONSE : Any> createRPCSubscription(
+        rpcConfig: RPCConfig<REQUEST, RESPONSE>,
         nodeConfig: Config,
-        responderProcessor: RPCResponderProcessor<TREQ, TRESP>
-    ): RPCSubscription<TREQ, TRESP> {
+        responderProcessor: RPCResponderProcessor<REQUEST, RESPONSE>
+    ): RPCSubscription<REQUEST, RESPONSE> {
 
         val rpcConfiguration = ConfigFactory.empty()
             .withValue(GROUP, ConfigValueFactory.fromAnyRef(rpcConfig.groupName))
@@ -256,7 +256,7 @@ class KafkaSubscriptionFactory @Activate constructor(
         )
         val consumerBuilder = CordaKafkaConsumerBuilderImpl<String, RPCRequest>(avroSchemaRegistry)
 
-        val cordaAvroSerializer = CordaAvroSerializer<TRESP>(avroSchemaRegistry)
+        val cordaAvroSerializer = CordaAvroSerializer<RESPONSE>(avroSchemaRegistry)
         val cordaAvroDeserializer = CordaAvroDeserializer(avroSchemaRegistry, { _, _ -> }, rpcConfig.requestType)
         val publisherFactory = CordaKafkaPublisherFactory(avroSchemaRegistry)
         val publisher = publisherFactory.createPublisher(PublisherConfig(rpcConfig.clientName), nodeConfig)

--- a/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/utils/FutureTracker.kt
+++ b/libs/messaging/kafka-messaging-impl/src/main/kotlin/net/corda/messaging/kafka/utils/FutureTracker.kt
@@ -12,11 +12,11 @@ import java.util.concurrent.ConcurrentHashMap
  * [futuresInPartitionMap] is a map where the key is the partition number we listen for responses on for the futures we
  * hold in the value part of this map
  */
-class FutureTracker<TRESP> {
+class FutureTracker<RESPONSE> {
 
-    private val futuresInPartitionMap = ConcurrentHashMap<Int, WeakValueHashMap<String, CompletableFuture<TRESP>>>()
+    private val futuresInPartitionMap = ConcurrentHashMap<Int, WeakValueHashMap<String, CompletableFuture<RESPONSE>>>()
 
-    fun addFuture(correlationId: String, future: CompletableFuture<TRESP>, partition: Int) {
+    fun addFuture(correlationId: String, future: CompletableFuture<RESPONSE>, partition: Int) {
         if (futuresInPartitionMap[partition] == null) {
             future.completeExceptionally(
                 CordaRPCAPISenderException(
@@ -28,7 +28,7 @@ class FutureTracker<TRESP> {
         }
     }
 
-    fun getFuture(correlationId: String, partition: Int): CompletableFuture<TRESP>? {
+    fun getFuture(correlationId: String, partition: Int): CompletableFuture<RESPONSE>? {
         return futuresInPartitionMap[partition]?.get(correlationId)
     }
 

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/processor/RPCResponderProcessor.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/processor/RPCResponderProcessor.kt
@@ -4,8 +4,8 @@ import java.util.concurrent.CompletableFuture
 
 
 /**
- * This interface defines a processor of events from a rpc subscription on a feed with with requests of type [TREQ] and
- * responses of type [TRESP]
+ * This interface defines a processor of events from a rpc subscription on a feed with with requests of type [REQUEST] and
+ * responses of type [RESPONSE]
  *
  * If you want to receive events from a from [RPCSubscription] you should implement this interface.
  *
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture
  *
  * There can be multiple workers servicing RPC request messages
  */
-interface RPCResponderProcessor<TREQ, TRESP> {
+interface RPCResponderProcessor<REQUEST, RESPONSE> {
 
     /**
      * The implementation of this functional class will be used to notify you of any requests that need processing
@@ -26,5 +26,5 @@ interface RPCResponderProcessor<TREQ, TRESP> {
      * [onNext] is meant to be asynchronous. As such, it's safe to make external services - provided that when the
      * result of that call is ready, the future is set
      */
-    fun onNext(request: TREQ, respFuture: CompletableFuture<TRESP>)
+    fun onNext(request: REQUEST, respFuture: CompletableFuture<RESPONSE>)
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/publisher/RPCSender.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/publisher/RPCSender.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture
 
 
 /**
- * Interface for posting requests of type [TREQ] and receiving responses of type [TRESP]
+ * Interface for posting requests of type [REQUEST] and receiving responses of type [RESPONSE]
  * RPCSender instances can be created via the [PublisherFactory].
  *
  * The sender contains a subscription for reading back responses. Depending on the response status, the future will be
@@ -14,12 +14,12 @@ import java.util.concurrent.CompletableFuture
  * CancellationException if it was cancelled when calling get()/getOrThrow() on future
  *
  */
-interface RPCSender<TREQ, TRESP>: Lifecycle {
+interface RPCSender<REQUEST, RESPONSE> : Lifecycle {
 
     /**
      * Send request via RPC
-     * @param req of type [TREQ]
-     * @return completable future of type [TRESP]
+     * @param req of type [REQUEST]
+     * @return completable future of type [RESPONSE]
      *
      * The future represents the promise of a response and is completed when said response is received
      * It may error if the response fails or if the request times out
@@ -29,6 +29,6 @@ interface RPCSender<TREQ, TRESP>: Lifecycle {
      *
      * The client is responsible for retries in the event of a failure or timeout
      */
-    fun sendRequest(req: TREQ): CompletableFuture<TRESP>
+    fun sendRequest(req: REQUEST): CompletableFuture<RESPONSE>
 
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/publisher/factory/PublisherFactory.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/publisher/factory/PublisherFactory.kt
@@ -38,10 +38,10 @@ interface PublisherFactory {
      * @param rpcConfig configuration object used to initialize the subscription
      * @param nodeConfig other configuration settings if needed
      */
-    fun <TREQ: Any, TRESP: Any> createRPCSender(
-        rpcConfig: RPCConfig<TREQ, TRESP>,
+    fun <REQUEST: Any, RESPONSE: Any> createRPCSender(
+        rpcConfig: RPCConfig<REQUEST, RESPONSE>,
         nodeConfig: Config = ConfigFactory.empty(),
-    ): RPCSender<TREQ, TRESP>
+    ): RPCSender<REQUEST, RESPONSE>
 
 
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/Subscription.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/Subscription.kt
@@ -31,7 +31,7 @@ interface Subscription<K, V> : Lifecycle {
 }
 
 /**
- * A subscription that handles requests of type [TREQ], processes the request and publishes the response in type [TRESP]
+ * A subscription that handles requests of type [REQUEST], processes the request and publishes the response in type [RESPONSE]
  *
  * RPC requests are processed asynchronously. Input messages are consume as soon as they have been posted to the
  * user event handler. RPC responses are unreliable so do not use this pattern if reliable response are required.
@@ -49,7 +49,7 @@ interface Subscription<K, V> : Lifecycle {
  *
  * A subscription will stop consuming events and close the connection upon close()/stop()
  */
-interface RPCSubscription<TREQ, TRESP> : Lifecycle
+interface RPCSubscription<REQUEST, RESPONSE> : Lifecycle
 
 /**
  * A subscription that can be used to manage the life cycle of consumption of both state and event records from a

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/factory/SubscriptionFactory.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/factory/SubscriptionFactory.kt
@@ -148,8 +148,8 @@ interface SubscriptionFactory {
 
     /**
      * Create an instance of the [RPCSubscription]
-     * This subscription is used to pick up requests of type [TREQ] posted by [RPCSender]
-     * The request is then processed and a response of type [TRESP] is posted back to the sender
+     * This subscription is used to pick up requests of type [REQUEST] posted by [RPCSender]
+     * The request is then processed and a response of type [RESPONSE] is posted back to the sender
      *
      * RPC requests are handled asynchronously. Input messages are consumes as soon as they are posted to the user
      * event handler. RPC responses are unreliable so do not use this pattern if you require reliable responses for
@@ -163,9 +163,9 @@ interface SubscriptionFactory {
      * @param nodeConfig Map of properties to override the default settings for the connection to the source of events
      * @param responderProcessor processor in charge of handling incoming requests
      */
-    fun <TREQ : Any, TRESP : Any> createRPCSubscription(
-        rpcConfig: RPCConfig<TREQ, TRESP>,
+    fun <REQUEST : Any, RESPONSE : Any> createRPCSubscription(
+        rpcConfig: RPCConfig<REQUEST, RESPONSE>,
         nodeConfig: Config = ConfigFactory.empty(),
-        responderProcessor: RPCResponderProcessor<TREQ, TRESP>
-    ): RPCSubscription<TREQ, TRESP>
+        responderProcessor: RPCResponderProcessor<REQUEST, RESPONSE>
+    ): RPCSubscription<REQUEST, RESPONSE>
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/factory/config/RPCConfig.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/factory/config/RPCConfig.kt
@@ -12,14 +12,14 @@ package net.corda.messaging.api.subscription.factory.config
  * The response topic is not present due to the pattern making use of the convention where the response topic
  * is called requestTopic.resp by default
  */
-data class RPCConfig<TREQ, TRESP>(
+data class RPCConfig<REQUEST, RESPONSE>(
     val groupName: String,
     val clientName: String,
     val requestTopic: String,
-    val requestType: Class<TREQ>,
-    val responseType: Class<TRESP>
+    val requestType: Class<REQUEST>,
+    val responseType: Class<RESPONSE>
 )
 
-inline fun <reified TREQ, TRESP> RPCConfig<TREQ, TRESP>.requestType(): Class<out Class<TREQ>> { return requestType::class.java }
+inline fun <reified REQUEST, RESPONSE> RPCConfig<REQUEST, RESPONSE>.requestType(): Class<out Class<REQUEST>> = requestType::class.java
 
-inline fun <reified TREQ, TRESP> RPCConfig<TREQ, TRESP>.responseType(): Class<out Class<TRESP>> { return responseType::class.java }
+inline fun <reified REQUEST, RESPONSE> RPCConfig<REQUEST, RESPONSE>.responseType(): Class<out Class<RESPONSE>> = responseType::class.java


### PR DESCRIPTION
Rename to make them easier to understand.

- `TREQ` -> `REQUEST`
- `TRESP` -> `RESPONSE`