### PR TITLE
NOTICK - Add logging for expired sessions

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -592,13 +592,7 @@ open class SessionManagerImpl(
                 return
             }
 
-            val timeSinceLastAck = timeStamp() - sessionInfo.lastAckTimestamp
             val timeSinceLastSend = timeStamp() - sessionInfo.lastSendTimestamp
-
-            if (timeSinceLastAck >= sessionTimeout.toMillis()) {
-                logger.info("Stopped sending heartbeats for session (${session.sessionId}), which expired.")
-                return
-            }
             if (timeSinceLastSend >= heartbeatPeriod.toMillis()) {
                 logger.trace("Sending heartbeat message between ${sessionKey.ourId} (our Identity) and ${sessionKey.responderId}.")
                 sendHeartbeatMessage(


### PR DESCRIPTION
Adding some logging for the case, where a session is torn down and heartbeating is stopped. This might also be useful to give us clues for a test that's sporadically flaky on CI (see [here](https://ci02.dev.r3.com/job/Corda5/view/Corda%205%20build%20Health/job/corda-runtime-os/job/release%252Fent%252F5.0/302/)).