### PR TITLE
NOTICK - fix flaky tests

### DIFF
--- a/components/gateway/src/integration-test/kotlin/net/corda/p2p/gateway/messaging/http/HttpTest.kt
+++ b/components/gateway/src/integration-test/kotlin/net/corda/p2p/gateway/messaging/http/HttpTest.kt
@@ -15,6 +15,7 @@ import net.corda.p2p.gateway.LoggingInterceptor
 import net.corda.p2p.gateway.TestBase
 import net.corda.p2p.gateway.messaging.GatewayConfiguration
 import net.corda.p2p.gateway.messaging.SslConfiguration
+import net.corda.test.util.eventually
 import net.corda.v5.base.util.seconds
 import org.apache.logging.log4j.Level
 import org.assertj.core.api.Assertions.assertThat
@@ -309,8 +310,11 @@ class HttpTest : TestBase() {
 
                 // Check HandshakeException is thrown and logged
                 val expectedMessage = "Bad certificate identity or path. " +
-                    "No subject alternative DNS name matching ${serverAddress.host} found"
-                loggingInterceptor.assertMessageExists(expectedMessage, Level.ERROR)
+                        "No subject alternative DNS name matching ${serverAddress.host} found"
+                eventually {
+                    loggingInterceptor.assertMessageExists(expectedMessage, Level.ERROR)
+                }
+
             }
         }
     }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/ConnectionManagerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/ConnectionManagerTest.kt
@@ -9,6 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mockConstruction
+import org.mockito.Mockito.timeout
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -134,7 +135,7 @@ class ConnectionManagerTest {
             )
 
         connectionManager.close()
-        verify(mockedClient.constructed().first(), times(1)).stop()
+        verify(mockedClient.constructed().first(), timeout(1_000).times(1)).stop()
     }
 
     @Test


### PR DESCRIPTION
Fixing a couple of tests that seemed to be failing transiently recently (see [here](https://ci02.dev.r3.com/job/Corda5/view/Corda%205%20build%20Health/job/corda-runtime-os/job/release%252Fent%252F5.0/330/) and [here](https://ci02.dev.r3.com/job/Corda5/view/Corda%205%20build%20Health/job/corda-runtime-os/job/release%252Fent%252F5.0/329/)). 

`HttpTest` must be because of async logging and `ConnectionManagerTest` because the cache calls the removal listener of entries asynchronously.