### PR TITLE
Changes how state is stored to avoid unperformant scans across all sandboxes

### DIFF
--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -68,14 +68,13 @@ internal class SandboxServiceImpl @Activate constructor(
     override fun unloadSandboxGroup(sandboxGroup: SandboxGroup) {
         val sandboxGroupInternal = sandboxGroup as SandboxGroupInternal
 
-        bundleIdToSandboxGroup.forEach { entry ->
-            if (entry.value == sandboxGroup) bundleIdToSandboxGroup.remove(entry.key)
-        }
+        val sandboxGroupsToRemove = bundleIdToSandboxGroup.filter { entry -> entry.value === sandboxGroup }
+        sandboxGroupsToRemove.forEach { entry -> bundleIdToSandboxGroup.remove(entry.key) }
 
         sandboxGroupInternal.cpkSandboxes.forEach { sandbox ->
-            bundleIdToSandbox.forEach { entry ->
-                if (entry.value == sandbox) bundleIdToSandbox.remove(entry.key)
-            }
+            val sandboxesToRemove = bundleIdToSandbox.filter { entry -> entry.value === sandbox }
+            sandboxesToRemove.forEach { entry -> bundleIdToSandbox.remove(entry.key) }
+
             zombieBundles.addAll((sandbox as Sandbox).unload())
         }
     }


### PR DESCRIPTION
Also improves how visibility of public sandboxes is handled (previously, if a public sandbox was created after some sandbox groups had already been created, the existing sandbox groups wouldn't have visibility of the new public sandbox).