### PR TITLE
CORE-2965: Upgrade to Corda Gradle plugins 6.0.0-BETA10.

### DIFF
--- a/components/install/file-based-install-service/build.gradle
+++ b/components/install/file-based-install-service/build.gradle
@@ -4,8 +4,11 @@ plugins {
     id 'corda.osgi-test-conventions'
 }
 
-evaluationDependsOn(':components:install:test-resources:contract-cpk')
-evaluationDependsOn(':components:install:test-resources:workflow-cpk')
+configurations {
+    cpis {
+        canBeConsumed = false
+    }
+}
 
 dependencies {
     compileOnly group: "org.osgi", name: "osgi.annotation"
@@ -26,13 +29,16 @@ dependencies {
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")
     integrationTestRuntimeOnly project(":libs:messaging:inmemory-messaging-impl")
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+
+    cpis project(path: ':components:install:test-resources:workflow-cpk', configuration: 'cordaCPB')
 }
 
-Provider<Task> cpkTaskProvider = project(':components:install:test-resources:workflow-cpk').tasks.named('cpb')
-ext {
-    cpiPath = cpkTaskProvider.get().outputs.files.asPath
-}
+tasks.named('testOSGi') {
+    inputs.files configurations.cpis
 
-testOSGi {
-    inputs.files(cpkTaskProvider)
+    ext {
+        cpiPath = provider {
+            configurations.cpis.singleFile
+        }
+    }
 }

--- a/components/install/file-based-install-service/test.bndrun
+++ b/components/install/file-based-install-service/test.bndrun
@@ -4,7 +4,7 @@
 -resolve.effective: active
 #-runtrace: true
 
--runproperties: cpi.path=${project.cpiPath}
+-runproperties: cpi.path=${task.cpiPath}
 
 -runvm: \
     --add-opens, 'java.base/java.net=ALL-UNNAMED'

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ cordaRuntimeRevision=0
 # Plugin dependency versions
 avroGradlePluginVersion=1.1.0
 bndVersion=6.0.0
-cordaGradlePluginsVersion=6.0.0-BETA09
+cordaGradlePluginsVersion=6.0.0-BETA10
 detektPluginVersion=1.18.1
 internalPublishVersion=1.+
 

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -31,6 +31,7 @@
 	com.fasterxml.classmate;version='[1.5.1,1.5.2)',\
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
+	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
 	javax.persistence-api;version='[2.2.0,2.2.1)',\
 	jaxb-api;version='[2.3.1,2.3.2)',\

--- a/libs/sandbox/test.bndrun
+++ b/libs/sandbox/test.bndrun
@@ -48,6 +48,7 @@
 	net.corda.kotlin-stdlib-jdk7.osgi-bundle;version='[1.4.32,1.4.33)',\
 	net.corda.kotlin-stdlib-jdk8.osgi-bundle;version='[1.4.32,1.4.33)',\
 	net.corda.membership;version='[5.0.0,5.0.1)',\
+	net.corda.membership-conversion;version='[5.0.0,5.0.1)',\
 	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox;version='[5.0.0,5.0.1)',\

--- a/libs/serialization/serialization-amqp/test.bndrun
+++ b/libs/serialization/serialization-amqp/test.bndrun
@@ -52,6 +52,7 @@
 	net.corda.kotlin-stdlib-jdk8.osgi-bundle;version='[1.4.32,1.4.33)',\
 	net.corda.lifecycle;version='[5.0.0,5.0.1)',\
 	net.corda.membership;version='[5.0.0,5.0.1)',\
+	net.corda.membership-conversion;version='[5.0.0,5.0.1)',\
 	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox;version='[5.0.0,5.0.1)',\


### PR DESCRIPTION
Upgrade to Corda Gradle plugins 6.0.0-BETA10, which provides easier access to the `cordapp-cpb` plugin's CPB artifact.