### PR TITLE
NOTICK: Fix warnings relating to OSGi bundles, and a few compiler warnings too.

### DIFF
--- a/components/install/file-based-install-service/build.gradle
+++ b/components/install/file-based-install-service/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'corda.osgi-test-conventions'
 }
 
+description 'File-Based CorDapp Installer'
+
 configurations {
     cpis {
         canBeConsumed = false

--- a/components/install/file-based-install-service/src/main/kotlin/net/corda/install/local/file/impl/LocalPackageCache.kt
+++ b/components/install/file-based-install-service/src/main/kotlin/net/corda/install/local/file/impl/LocalPackageCache.kt
@@ -38,6 +38,7 @@ import kotlin.concurrent.write
 
 class UpdatedCPIList(val delta: NavigableSet<CPI.Identifier>) : LifecycleEvent
 
+@Suppress("unused")
 @Component(service = [InstallService::class], scope = ServiceScope.SINGLETON)
 class LocalPackageCache @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
@@ -127,15 +128,15 @@ class LocalPackageCache @Activate constructor(
         }
     }
 
-    override fun get(id: CPI.Identifier) = packageCacheLock.read {
+    override fun get(id: CPI.Identifier): CompletableFuture<CPI?> = packageCacheLock.read {
         CompletableFuture.completedFuture(packageCache.cpiByIdMap[id])
     }
 
-    override fun get(id: CPK.Identifier) = packageCacheLock.read {
+    override fun get(id: CPK.Identifier): CompletableFuture<CPK?> = packageCacheLock.read {
         CompletableFuture.completedFuture(packageCache.cpkByIdMap[id])
     }
 
-    override fun getCPKByHash(hash: SecureHash) = packageCacheLock.read {
+    override fun getCPKByHash(hash: SecureHash): CompletableFuture<CPK?> = packageCacheLock.read {
         CompletableFuture.completedFuture(packageCache.cpkByHashMap[hash])
     }
 

--- a/components/install/install/build.gradle
+++ b/components/install/install/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'corda.common-library'
 }
 
+description 'Corda CorDapp Installer'
+
 dependencies {
     implementation platform(group: "net.corda", name: "corda-api", version: cordaApiVersion)
     compileOnly group: "org.osgi", name: "osgi.annotation"

--- a/libs/serialization/checkpoint-serialization-api/build.gradle
+++ b/libs/serialization/checkpoint-serialization-api/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'corda.common-library'
 }
 
+description 'Corda Checkpoint Serialization API'
+
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'

--- a/testing/membership-testkit/build.gradle
+++ b/testing/membership-testkit/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'corda.common-library'
 }
 
+description 'Membership Internal TestKit'
+
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly 'org.osgi:org.osgi.service.component.annotations'


### PR DESCRIPTION
Add missing project descriptions, which are used as `Bundle-Name` values, and resolve warnings about functions returning Java platform types.