### PR TITLE
NOTICK - Include stacktrace in log when connection fails

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpClient.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpClient.kt
@@ -81,7 +81,7 @@ class HttpClient(
 
     private val connectListener = ChannelFutureListener { future ->
         if (!future.isSuccess) {
-            logger.warn("Failed to connect to ${destinationInfo.uri}: ${future.cause().message}")
+            logger.warn("Failed to connect to ${destinationInfo.uri}: ${future.cause().message}", future.cause())
             onClose(HttpConnectionEvent(future.channel()))
         } else {
             logger.info("Connected to ${destinationInfo.uri}")


### PR DESCRIPTION
While investigating some flaky integration test failures of the gateway, I realised we are not including the stacktrace of the connection error. Including it for now to see if that gives us more information.