### PR TITLE
NOTICK: Remove unconfigured quasar-utils plugin.

### DIFF
--- a/testing/cpbs/helloworld/build.gradle
+++ b/testing/cpbs/helloworld/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'com.r3.internal.gradle.plugins.r3Publish'
-    id 'net.corda.plugins.cordapp-cpk'
     id 'net.corda.plugins.cordapp-cpb'
-    id 'net.corda.plugins.quasar-utils'
 }
 
 cordapp {
@@ -20,6 +18,6 @@ dependencies {
     cordaProvided group: 'net.corda', name: 'corda-application'
 }
 
-jar {
+tasks.named('jar', Jar) {
     archiveBaseName = 'corda-helloworld-cpb'
 }


### PR DESCRIPTION
All the `quasar-utils` plugin does is apply the Quasar agent to the project's `Test` and `JavaExec` tasks, so we don't need it here. Not only that, but the plugin would need to be configured for Corda 5 anyway.

Just remove it.

Also remove the `cordapp-cpk` plugin too, because the `cordapp-cpb` plugin applies it automatically.