### PR TITLE
NOTICK Fix Shutdown of Crypto Service Key Creator

### DIFF
--- a/applications/tools/p2p-test/cryptoservice-key-creator/README.md
+++ b/applications/tools/p2p-test/cryptoservice-key-creator/README.md
@@ -22,7 +22,7 @@ bootstrap.servers=localhost:9092
 The file provided on the `--keys-config` CLI parameter should have the following structure:
 ```json
 {
-    "entries": [
+    "keys": [
         {
           "alias": "key1",
           "keystoreFile": "<path_to_the_keystore_file>",


### PR DESCRIPTION
If key algorithms was incorrect inside the keys-config file. Then we get an OSGi error on shutdown. This is because we are creating the publisher even though the config was invalid. Also fixed a typo in the README.