### PR TITLE
NOTICK: Try to prevent Gradle caching dynamic versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,8 +251,8 @@ if ("${compositeBuild}".toBoolean() && file("${cordaApiLocation}").exists()) {
 
 subprojects {
     buildscript {
-        configurations.all {
-            // FORCE Gradle to use latest dynamic versions.
+        configurations.classpath {
+            // FORCE Gradle to use latest dynamic-version plugins.
             resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
         }
     }
@@ -301,6 +301,9 @@ subprojects {
     configurations {
         all {
             resolutionStrategy {
+                // FORCE Gradle to use latest dynamic versions.
+                cacheDynamicVersionsFor 0, 'seconds'
+
                 dependencySubstitution {
                     substitute module("antlr:antlr") using module("antlr:antlr.osgi:$antlrVersion")
                     substitute module("org.dom4j:dom4j") using module("org.apache.servicemix.bundles:org.apache.servicemix.bundles.dom4j:$dom4jOsgiVersion")


### PR DESCRIPTION
Try to force Gradle to update its dynamic versions each time, instead of caching them for an hour. This is an attempt to fix the existing configuration which was trying to do this.