### PR TITLE
NOTICK - Small fixes for p2p after an initial dryrun of e2e test with Kafka

### DIFF
--- a/applications/tools/p2p-test/configuration-publisher/README.md
+++ b/applications/tools/p2p-test/configuration-publisher/README.md
@@ -79,11 +79,11 @@ To run the application use:
                          Local hosted identity (in the form of <x500Name>:
                            <groupId>)
       --maxMessageSize=<maxMessageSize>
-                         The maximal message size
-                           Default: 500
-      --messageReplayPeriodSecs=<messageReplayPeriodSecs>
-                         message replay period in seconds
-                           Default: 2
+                         The maximal message size in bytes
+                           Default: 1_000_000
+      --messageReplayPeriodMilliSecs=<messageReplayPeriodMilliSecs>
+                         message replay period in milliseconds
+                           Default: 2000
       --protocolMode=<protocolModes>
                          Supported protocol mode (out of: AUTHENTICATION_ONLY,
                            AUTHENTICATED_ENCRYPTION)

--- a/applications/tools/p2p-test/configuration-publisher/src/main/kotlin/net/corda/p2p/config/publisher/LinkManagerConfiguration.kt
+++ b/applications/tools/p2p-test/configuration-publisher/src/main/kotlin/net/corda/p2p/config/publisher/LinkManagerConfiguration.kt
@@ -26,9 +26,9 @@ class LinkManagerConfiguration : ConfigProducer() {
 
     @Option(
         names = ["--maxMessageSize"],
-        description = ["The maximal message size"]
+        description = ["The maximal message size in bytes"]
     )
-    var maxMessageSize = 500
+    var maxMessageSize = 1_000_000
 
     @Option(
         names = ["--protocolMode"],
@@ -37,10 +37,10 @@ class LinkManagerConfiguration : ConfigProducer() {
     var protocolModes: List<ProtocolMode> = listOf(ProtocolMode.AUTHENTICATED_ENCRYPTION)
 
     @Option(
-        names = ["--messageReplayPeriodSecs"],
-        description = ["message replay period in seconds"]
+        names = ["--messageReplayPeriodMilliSecs"],
+        description = ["message replay period in milliseconds"]
     )
-    var messageReplayPeriodSecs = 2L
+    var messageReplayPeriodMilliSecs = 2_000L
 
     @Option(
         names = ["--heartbeatMessagePeriodMilliSecs"],
@@ -84,7 +84,7 @@ class LinkManagerConfiguration : ConfigProducer() {
             )
             .withValue(
                 "messageReplayPeriod",
-                ConfigValueFactory.fromAnyRef(messageReplayPeriodSecs)
+                ConfigValueFactory.fromAnyRef(messageReplayPeriodMilliSecs)
             )
             .withValue(
                 "heartbeatMessagePeriod",

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
@@ -53,8 +53,6 @@ class Gateway(
     override val dominoTile = DominoTile(this::class.java.simpleName, lifecycleCoordinatorFactory, children = children)
 
     companion object {
-        const val CONSUMER_GROUP_ID = "gateway"
-        const val PUBLISHER_ID = "gateway"
         const val CONFIG_KEY = "p2p.gateway"
     }
 }

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -21,7 +21,6 @@ import net.corda.p2p.crypto.InitiatorHandshakeMessage
 import net.corda.p2p.crypto.InitiatorHelloMessage
 import net.corda.p2p.crypto.ResponderHandshakeMessage
 import net.corda.p2p.crypto.ResponderHelloMessage
-import net.corda.p2p.gateway.Gateway.Companion.PUBLISHER_ID
 import net.corda.p2p.gateway.messaging.http.HttpRequest
 import net.corda.p2p.gateway.messaging.http.HttpServerListener
 import net.corda.p2p.gateway.messaging.http.ReconfigurableHttpServer
@@ -51,7 +50,7 @@ internal class InboundMessageHandler(
     private var p2pInPublisher = PublisherWithDominoLogic(
         publisherFactory,
         lifecycleCoordinatorFactory,
-        PublisherConfig(PUBLISHER_ID, instanceId),
+        PublisherConfig("inbound-message-handler", instanceId),
         nodeConfiguration
     )
     private val sessionPartitionMapper = SessionPartitionMapperImpl(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
@@ -14,7 +14,6 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.messaging.api.subscription.factory.config.SubscriptionConfig
 import net.corda.p2p.LinkOutMessage
 import net.corda.p2p.NetworkType
-import net.corda.p2p.gateway.Gateway.Companion.CONSUMER_GROUP_ID
 import net.corda.data.p2p.gateway.GatewayMessage
 import net.corda.p2p.gateway.messaging.ReconfigurableConnectionManager
 import net.corda.p2p.gateway.messaging.http.DestinationInfo
@@ -59,7 +58,7 @@ internal class OutboundMessageHandler(
     )
 
     private val p2pMessageSubscription = subscriptionFactory.createEventLogSubscription(
-        SubscriptionConfig(CONSUMER_GROUP_ID, Schema.LINK_OUT_TOPIC, instanceId),
+        SubscriptionConfig("outbound-message-handler", Schema.LINK_OUT_TOPIC, instanceId),
         this,
         nodeConfiguration,
         null

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -74,6 +74,7 @@ class DeliveryTracker(
             configuration,
             messageTracker.listener
         )
+        messageTrackerSubscription.start()
         resources.keep(messageTrackerSubscription)
         val future = CompletableFuture<Unit>()
         future.complete(Unit)


### PR DESCRIPTION
Fixes for a few issues I identified while trying the first e2e test for p2p:
* Switching default max message size to 1MB. Previous one was 500 bytes, which is below the min packet size (10KB) established so that handshake messages are always possible to transfer.
* The message replay period setting is in milliseconds, instead of seconds. So, renamed the variable and adjusted the default to be 2 seconds (instead of 2 milliseconds).
* Adjusted consumer groups / client IDs for subscriptions/producers in gateway to be unique. Otherwise, the worker ended up creating multiple producers with the same name, which led to producers being fenced (`ProducerFencedException`).
* Added a `start` for the delivery tracker's subscription, which was missing and was preventing the link manager from keeping the state topic up-to-date for replay logic.