### PR TITLE
CORE-3146: CpkSandbox.loadClassFromMainBundle should only return exported classes.

### DIFF
--- a/applications/examples/serialization-amqp/custom-serializer-poc/src/main/kotlin/net/corda/applications/examples/amqp/customserializer/Main.kt
+++ b/applications/examples/serialization-amqp/custom-serializer-poc/src/main/kotlin/net/corda/applications/examples/amqp/customserializer/Main.kt
@@ -159,7 +159,7 @@ class Main @Activate constructor(
         val inputB = DeserializationInput(serializationB)
 
         consoleLogger.info("Check custom serialisers work in environment A")
-        val objA = sandboxA.sandboxGroup.loadClassFromMainBundles("net.corda.applications.examples.amqp.customserializer.examplea.NeedsCustomSerializerExampleA", Any::class.java).getConstructor(Integer.TYPE).newInstance(1)
+        val objA = sandboxA.sandboxGroup.loadClassFromMainBundles("net.corda.applications.examples.amqp.customserializer.examplea.NeedsCustomSerializerExampleA").getConstructor(Integer.TYPE).newInstance(1)
         val contextA = AMQP_STORAGE_CONTEXT.withSandboxGroup(sandboxA)
         val serializedBytesA = outputA.serialize(objA, contextA)
         consoleLogger.info("SUCCESS - Serialise successful in environment A")
@@ -170,7 +170,7 @@ class Main @Activate constructor(
 
 
         consoleLogger.info("Check custom serialisers work in environment B")
-        val objB = sandboxB.sandboxGroup.loadClassFromMainBundles("net.corda.applications.examples.amqp.customserializer.exampleb.NeedsCustomSerializerExampleB", Any::class.java).getConstructor(Int::class.java).newInstance(2)
+        val objB = sandboxB.sandboxGroup.loadClassFromMainBundles("net.corda.applications.examples.amqp.customserializer.exampleb.NeedsCustomSerializerExampleB").getConstructor(Int::class.java).newInstance(2)
         val contextB = AMQP_STORAGE_CONTEXT.withSandboxGroup(sandboxB)
         val serializedBytesB = outputB.serialize(objB, contextB)
         consoleLogger.info("SUCCESS - Serialise successful in environment B")
@@ -229,8 +229,7 @@ class Main @Activate constructor(
 
         // Build test object
         val obj = sandboxA.sandboxGroup.loadClassFromMainBundles(
-            "net.corda.applications.examples.amqp.customserializer.examplea.NeedsCustomSerializerExampleA",
-            Any::class.java
+            "net.corda.applications.examples.amqp.customserializer.examplea.NeedsCustomSerializerExampleA"
         ).getConstructor(Integer.TYPE).newInstance(5)
 
         // Run object through serialization

--- a/libs/flows/flow-manager-impl/src/main/kotlin/net/corda/flow/manager/impl/FlowManagerImpl.kt
+++ b/libs/flows/flow-manager-impl/src/main/kotlin/net/corda/flow/manager/impl/FlowManagerImpl.kt
@@ -22,7 +22,6 @@ import net.corda.serialization.CheckpointSerializer
 import net.corda.serialization.factory.CheckpointSerializerBuilderFactory
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.util.uncheckedCast
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -112,8 +111,8 @@ class FlowManagerImpl @Activate constructor(
 
     @Suppress("SpreadOperator")
     private fun getOrCreate(sandboxGroup: SandboxGroup, flowName: String, jsonArg: String?): Flow<*> {
-        val flowClazz: Class<Flow<*>> =
-            uncheckedCast(sandboxGroup.loadClassFromMainBundles(flowName, Flow::class.java))
+        val flowClazz: Class<out Flow<*>> =
+            sandboxGroup.loadClassFromMainBundles(flowName, Flow::class.java)
         val constructor = flowClazz.getDeclaredConstructor(String::class.java)
         return constructor.newInstance(jsonArg)
     }

--- a/libs/sandbox/build.gradle
+++ b/libs/sandbox/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:osgi.core"
+    compileOnly "biz.aQute.bnd:biz.aQute.bndlib:$bndVersion"
     api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-packaging'
@@ -30,6 +31,7 @@ dependencies {
     testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
+    testRuntimeOnly "biz.aQute.bnd:biz.aQute.bndlib:$bndVersion"
 
     cpks project(path: 'sandbox-cpk-one', configuration: 'cordaCPK')
     cpks project(path: 'sandbox-cpk-two', configuration: 'cordaCPK')
@@ -43,6 +45,14 @@ dependencies {
     integrationTestImplementation 'net.corda:corda-packaging'
     integrationTestRuntimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
     integrationTestRuntimeOnly project(":libs:sandbox-hooks")
+}
+
+tasks.named('jar', Jar) {
+    bundle {
+        bnd '''\
+-conditionalpackage: aQute.*
+'''
+    }
 }
 
 def integrationTestResources = tasks.named('processIntegrationTestResources', ProcessResources) {

--- a/libs/sandbox/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
+++ b/libs/sandbox/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
@@ -51,7 +51,7 @@ class SandboxClassTagTests {
 
     @Test
     fun `can create class tags for a CPK main bundle class and use them to retrieve the class`() {
-        val cpkClass = sandboxLoader.group1.loadClassFromMainBundles(SERVICES_FLOW_CPK_1, Any::class.java)
+        val cpkClass = sandboxLoader.group1.loadClassFromMainBundles(SERVICES_FLOW_CPK_1)
         val staticTag = sandboxLoader.group1.getStaticTag(cpkClass)
         val evolvableTag = sandboxLoader.group1.getEvolvableTag(cpkClass)
 
@@ -61,7 +61,8 @@ class SandboxClassTagTests {
 
     @Test
     fun `can create static tag for a CPK library class and use it to retrieve the class`() {
-        val cpkLibClass = sandboxLoader.group1.loadClassFromMainBundles(LIBRARY_QUERY_CLASS, Any::class.java)
+        val cpkFlowClass = sandboxLoader.group1.loadClassFromMainBundles(SERVICES_FLOW_CPK_1)
+        val cpkLibClass = FrameworkUtil.getBundle(cpkFlowClass).loadClass(LIBRARY_QUERY_CLASS)
         val staticTag = sandboxLoader.group1.getStaticTag(cpkLibClass)
 
         assertEquals(cpkLibClass, sandboxLoader.group1.getClass(cpkLibClass.name, staticTag))
@@ -69,10 +70,11 @@ class SandboxClassTagTests {
 
     @Test
     fun `throws if attempted to create evolvable tag for a CPK library class`() {
-        val cpkClass = sandboxLoader.group1.loadClassFromMainBundles(LIBRARY_QUERY_CLASS, Any::class.java)
+        val cpkFlowClass = sandboxLoader.group1.loadClassFromMainBundles(SERVICES_FLOW_CPK_1)
+        val cpkLibClass = FrameworkUtil.getBundle(cpkFlowClass).loadClass(LIBRARY_QUERY_CLASS)
 
         assertThrows<SandboxException> {
-            sandboxLoader.group1.getEvolvableTag(cpkClass)
+            sandboxLoader.group1.getEvolvableTag(cpkLibClass)
         }
     }
 

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxGroup.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxGroup.kt
@@ -11,11 +11,20 @@ interface SandboxGroup {
     val cpks: Collection<CPK>
 
     /**
-     * Attempts to load the [Class] with [className] from the main bundle of each sandbox in the sandbox group in
-     * turn. Casts the first match to type [T] and returns it.
+     * Attempts to load the [Class] with [className] from the main bundle of each sandbox in the
+     * sandbox group in turn. Can only find classes belonging to exported packages.
      *
-     * @throws [SandboxException] if no sandbox contains the named class, if any of the sandboxes' main bundles are
-     * uninstalled, or if the named class is not of the correct type.
+     * @throws [SandboxException] if no sandbox contains the named class, multiple sandboxes contain the named class,
+     * or if any of the sandboxes' main bundles are uninstalled.
+     */
+    fun loadClassFromMainBundles(className: String): Class<*>
+
+    /**
+     * Attempts to load the [Class] with [className] from the main bundle of each sandbox in the sandbox group in
+     * turn. Casts the first match to type [T] and returns it. Can only find classes belonging to exported packages.
+     *
+     * @throws [SandboxException] if no sandbox contains the named class, multiple sandboxes contain the named class,
+     * if any of the sandboxes' main bundles are uninstalled, or if the named class is not of the correct type.
      */
     fun <T : Any> loadClassFromMainBundles(className: String, type: Class<T>): Class<out T>
 

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -27,16 +27,19 @@ internal class SandboxGroupImpl(
 
     override val cpks = cpkSandboxes.map(CpkSandbox::cpk)
 
-    override fun <T : Any> loadClassFromMainBundles(className: String, type: Class<T>): Class<out T> {
-        val klass = cpkSandboxes.mapNotNull { sandbox ->
+    override fun loadClassFromMainBundles(className: String): Class<*> {
+        return cpkSandboxes.mapNotNullTo(HashSet()) { sandbox ->
             try {
                 sandbox.loadClassFromMainBundle(className)
             } catch (e: SandboxException) {
                 null
             }
-        }.firstOrNull()
+        }.singleOrNull()
             ?: throw SandboxException("Class $className was not found in any sandbox in the sandbox group.")
+    }
 
+    override fun <T : Any> loadClassFromMainBundles(className: String, type: Class<T>): Class<out T> {
+        val klass = loadClassFromMainBundles(className)
         return try {
             klass.asSubclass(type)
         } catch (e: ClassCastException) {

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/sandbox/CpkSandbox.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/sandbox/CpkSandbox.kt
@@ -15,10 +15,10 @@ internal interface CpkSandbox : Sandbox {
     val privateBundles: Set<Bundle>
 
     /**
-     * Loads the [Class] with [className] from the sandbox's main bundle. Returns null if the bundle does not
-     * contain the named class.
+     * Loads the [Class] with [className] from the sandbox's main bundle.
      *
-     * Throws `SandboxException` if the main bundle does not contain the named class, or is uninstalled.
+     * @throws `SandboxException` if the main bundle does not contain the named class,
+     * or the class belongs to a private package, or the bundle is uninstalled.
      */
     fun loadClassFromMainBundle(className: String): Class<*>
 }

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/sandbox/CpkSandboxImpl.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/internal/sandbox/CpkSandboxImpl.kt
@@ -1,8 +1,11 @@
 package net.corda.sandbox.internal.sandbox
 
+import aQute.bnd.header.OSGiHeader.parseHeader
 import net.corda.packaging.CPK
 import net.corda.sandbox.SandboxException
 import org.osgi.framework.Bundle
+import org.osgi.framework.Constants.EXPORT_PACKAGE
+import java.util.Collections.unmodifiableSet
 import java.util.UUID
 
 /** Extends [SandboxImpl] to implement [CpkSandbox]. */
@@ -13,8 +16,16 @@ internal class CpkSandboxImpl(
     privateBundles: Set<Bundle>
 ) : SandboxImpl(id, setOf(mainBundle), privateBundles), CpkSandbox {
 
+    private val exportedPackages = mainBundle.headers[EXPORT_PACKAGE]?.let { exports ->
+        unmodifiableSet(parseHeader(exports).keys)
+    } ?: emptySet()
+
     override fun loadClassFromMainBundle(className: String): Class<*> = try {
-        mainBundle.loadClass(className)
+        mainBundle.loadClass(className).also { clazz ->
+            if (clazz.packageName !in exportedPackages) {
+                throw SandboxException("The class $className cannot be found in bundle $mainBundle in sandbox $id.")
+            }
+        }
     } catch (e: ClassNotFoundException) {
         throw SandboxException("The class $className cannot be found in bundle $mainBundle in sandbox $id.", e)
     } catch (e: IllegalStateException) {

--- a/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
+++ b/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.osgi.framework.Bundle
+import java.util.Hashtable
 import java.util.UUID.randomUUID
 
 // Various dummy serialised class tags.
@@ -48,7 +49,9 @@ class SandboxGroupImplTests {
     private val nonSandboxClass = Float::class.java
     private val nonBundleClass = Boolean::class.java
 
-    private val mockCpkMainBundle = mockBundle(CPK_MAIN_BUNDLE_NAME, cpkClass)
+    private val mockCpkMainBundle = mockBundle(CPK_MAIN_BUNDLE_NAME, cpkClass).apply {
+        whenever(headers).thenReturn(Hashtable())
+    }
     private val mockCpkLibraryBundle = mockBundle(CPK_LIBRARY_BUNDLE_NAME, cpkLibraryClass)
     private val mockPublicBundle = mockBundle(PUBLIC_BUNDLE_NAME, publicClass)
     private val mockPublicLibraryBundle = mockBundle(PUBLIC_LIBRARY_BUNDLE_NAME, publicLibraryClass)

--- a/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream
 import java.nio.file.Paths
 import java.security.cert.Certificate
 import java.util.Collections.emptyNavigableSet
+import java.util.Hashtable
 import java.util.NavigableSet
 import kotlin.random.Random.Default.nextBytes
 
@@ -90,6 +91,9 @@ class SandboxServiceImplTests {
                 whenever(bundle.uninstall()).then {
                     if (bundleName in notUninstallableBundles) throw IllegalStateException()
                     uninstalledBundles.add(bundle)
+                }
+                whenever(bundle.headers).then {
+                    Hashtable<String, String>()
                 }
 
                 bundle
@@ -260,7 +264,7 @@ class SandboxServiceImplTests {
 
         val sandboxOneBundles = startedBundles.filter { bundle -> sandboxOne.containsBundle(bundle) }
         val sandboxTwoBundles = startedBundles.filter { bundle -> sandboxTwo.containsBundle(bundle) }
-        val sandboxTwoPublicBundles = sandboxTwoBundles.filter { bundle -> bundle in sandboxTwo.publicBundles }
+        val sandboxTwoPublicBundles = sandboxTwoBundles.filterTo(HashSet()) { bundle -> bundle in sandboxTwo.publicBundles }
         val sandboxTwoPrivateBundles = sandboxTwoBundles - sandboxTwoPublicBundles
 
         sandboxOneBundles.forEach { sandboxOneBundle ->
@@ -439,7 +443,7 @@ class SandboxServiceImplTests {
     @Test
     fun `correctly indicates that two bundles in different sandboxes are not in the same sandbox`() {
         sandboxService.createSandboxGroup(setOf(cpkOne))
-        val bundlesFromSandboxGroupOne = startedBundles.toList()
+        val bundlesFromSandboxGroupOne = startedBundles.toSet()
 
         sandboxService.createSandboxGroup(setOf(cpkOne))
         val bundlesFromSandboxGroupTwo = startedBundles - bundlesFromSandboxGroupOne

--- a/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
+++ b/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
+import java.util.Hashtable
 import java.util.UUID.randomUUID
+import org.mockito.kotlin.whenever
 
 const val MOCK_BUNDLE_NAME = "mock_bundle_symbolic_name"
 
@@ -28,7 +30,9 @@ class ClassTagFactoryImplTests {
     private val classTagFactory = ClassTagFactoryImpl()
 
     private val mockBundle = mockBundle(MOCK_BUNDLE_NAME)
-    private val mockCpkMainBundle = mockBundle(CPK_MAIN_BUNDLE_NAME)
+    private val mockCpkMainBundle = mockBundle(CPK_MAIN_BUNDLE_NAME).apply {
+        whenever(headers).thenReturn(Hashtable())
+    }
     private val mockCpk = mockCpk()
     private val mockSandbox = CpkSandboxImpl(randomUUID(), mockCpk, mockCpkMainBundle, emptySet())
 

--- a/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/sandbox/CpkSandboxImplTests.kt
+++ b/libs/sandbox/src/test/kotlin/net/corda/sandbox/internal/sandbox/CpkSandboxImplTests.kt
@@ -9,12 +9,19 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.osgi.framework.Bundle
+import org.osgi.framework.Constants.EXPORT_PACKAGE
+import java.util.Hashtable
 import java.util.UUID.randomUUID
 
 class CpkSandboxImplTests {
     @Test
     fun `can load class from main bundles in CPK sandbox`() {
-        val mainBundle = mockBundle(klass = String::class.java)
+        val exportedPackages = Hashtable<String, String>().apply {
+            put(EXPORT_PACKAGE, String::class.java.packageName)
+        }
+        val mainBundle = mockBundle(klass = String::class.java).apply {
+            whenever(headers).thenReturn(exportedPackages)
+        }
         val sandbox = CpkSandboxImpl(randomUUID(), mock(), mainBundle, emptySet())
 
         assertEquals(String::class.java, sandbox.loadClassFromMainBundle(String::class.java.name))
@@ -22,7 +29,9 @@ class CpkSandboxImplTests {
 
     @Test
     fun `cannot load class from other bundles in CPK sandbox`() {
-        val mainBundle = mockBundle()
+        val mainBundle = mockBundle().apply {
+            whenever(headers).thenReturn(Hashtable())
+        }
         val otherBundle = mockBundle(klass = Int::class.java)
         val sandbox = CpkSandboxImpl(randomUUID(), mock(), mainBundle, setOf(otherBundle))
 
@@ -35,6 +44,7 @@ class CpkSandboxImplTests {
     fun `throws if loading class from CPK sandbox with an uninstalled bundle`() {
         val mainBundle = mock<Bundle>().apply {
             whenever(loadClass(any())).thenThrow(IllegalStateException::class.java)
+            whenever(headers).thenReturn(Hashtable())
         }
         val sandbox = CpkSandboxImpl(randomUUID(), mock(), mainBundle, emptySet())
 

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -162,24 +162,24 @@ class AMQPwithOSGiSerializationTests {
             )
 
             // Serialise our object
-            val cashClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle1.Cash", Any::class.java)
+            val cashClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle1.Cash")
             val cashInstance = cashClass.getConstructor(Int::class.java).newInstance(100)
 
-            val obligationClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle3.Obligation", Any::class.java)
+            val obligationClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle3.Obligation")
 
             val obligationInstance = obligationClass.getConstructor(
                 cashInstance.javaClass
             ).newInstance(cashInstance)
 
-            val documentClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle2.Document", Any::class.java)
+            val documentClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle2.Document")
             val content = "This is a transfer document"
             val documentInstance = documentClass.getConstructor(String::class.java).newInstance(content)
 
             // Container is used to test amqp serialization works for OSGi bundled generic types.
-            val containerClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle5.Container", Any::class.java)
+            val containerClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle5.Container")
             val containerInstance = containerClass.getConstructor(Object::class.java).newInstance(5)
 
-            val transferClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle4.Transfer", Any::class.java)
+            val transferClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle4.Transfer")
 
             val transferInstance = transferClass.getConstructor(
                 obligationInstance.javaClass, documentInstance.javaClass, containerInstance.javaClass
@@ -231,7 +231,7 @@ class AMQPwithOSGiSerializationTests {
             sandboxGroup = sandboxGroup
         )
 
-        val mainBundleItemClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle.MainBundleItem", Any::class.java)
+        val mainBundleItemClass = sandboxGroup.loadClassFromMainBundles("net.corda.bundle.MainBundleItem")
         val mainBundleItemInstance = mainBundleItemClass.getMethod("newInstance").invoke(null)
 
         assertThrows<SandboxException>(

--- a/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/KryoCheckpointTest.kt
+++ b/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/KryoCheckpointTest.kt
@@ -92,7 +92,7 @@ class KryoCheckpointTest {
             .build()
 
         val cash = sandboxManagementService.group1
-            .loadClassFromMainBundles("net.corda.bundle1.Cash", Any::class.java)
+            .loadClassFromMainBundles("net.corda.bundle1.Cash")
             .constructors.first().newInstance(1)
 
         // Serialize with serializerSandbox1


### PR DESCRIPTION
`Bundle.loadClass()` can also return classes which do not belong to this bundle, provided they belong to a package with a bundle wiring to this bundle instead. This is not the intention, particularly for AMQP serialisation where we will only serialise classes that belong to a CPK's "main" bundle.

Restrict `CpkSandbox.loadClassFromMainBundle()` to behave as advertised. This also means that `SandboxGroup.loadClassFromMainBundles()` will now behave as advertised.