### PR TITLE
NOTICK - Make some config params required for gateway

### DIFF
--- a/applications/tools/p2p-test/configuration-publisher/README.md
+++ b/applications/tools/p2p-test/configuration-publisher/README.md
@@ -36,7 +36,9 @@ To run the application use:
                             before closing it in seconds
                             Default: 60
   -h, --help              display this help message
-      --host=<hostname>   The name of the HTTP host
+      --hostAddress=<hostAddress>   The host name or IP address where the HTTP server will
+                            bind
+                            Default: 0.0.0.0
       --keyStore=<keyStoreFile>
                           The path to the key store file
       --keyStorePassword=<keyStorePassword>
@@ -102,9 +104,10 @@ java \
 -jar ./applications/tools/p2p-test/configuration-publisher/build/bin/corda-configuration-publisher-5.0.0.0-SNAPSHOT.jar \
 gateway \
 --keyStore ./components/gateway/src/integration-test/resources/sslkeystore_alice.jks \
+--keyStorePassword password \
 --trustStore ./components/gateway/src/integration-test/resources/truststore.jks \
---port 3123 \
---host www.alice.net
+--trustStorePassword password \
+--port 3123
 ```
 The `keyStore` and `trustStore` are valid stores used in the integration tests.
 
@@ -159,14 +162,16 @@ docker run \
  --rm \
  -e KAFKA_SERVERS="broker1:9093" \
  --network kafka-docker_default \
- --hostname www.alice.net \
  -v "$(pwd)/components/gateway/src/integration-test/resources/sslkeystore_alice.jks:/keystore.jks" \
  -v "$(pwd)/components/gateway/src/integration-test/resources/truststore.jks:/truststore.jks" \
  corda-os-docker-dev.software.r3.com/corda-os-configuration-publisher:5.0.0.0-SNAPSHOT \
  gateway \
+ --keyStore /keystore.jks \
+ --keyStorePassword password \
+ --trustStore /truststore.jks \
+ --trustStorePassword password \
  --port 24123
 ```
 Please note:
 * The image need to be able to talk with the kafka broker, hence the network and `KAFKA_SERVERS` environment variable.
-* Using the `--hostname` set the default hostname
 *  Since the keystore and truststore are getting mounted to the correct name, there is no need to add them to the arguments.

--- a/applications/tools/p2p-test/configuration-publisher/docker-args-example.txt
+++ b/applications/tools/p2p-test/configuration-publisher/docker-args-example.txt
@@ -1,4 +1,7 @@
 # An example of an arguments file that can be used to configure the gateway from docker
 gateway
+--keyStore /keystore.jks
+--keyStorePassword password
+--trustStore /truststore.jks
+--trustStorePassword password
 --port 3123
---host www.alice.net

--- a/applications/tools/p2p-test/configuration-publisher/gateway-args-example.txt
+++ b/applications/tools/p2p-test/configuration-publisher/gateway-args-example.txt
@@ -1,6 +1,7 @@
 # An example of an arguments file that can be used to configure the gateway
 gateway
 --keyStore ./components/gateway/src/integration-test/resources/sslkeystore_alice.jks
+--keyStorePassword password
 --trustStore ./components/gateway/src/integration-test/resources/truststore.jks
+--trustStorePassword password
 --port 3123
---host www.alice.net

--- a/applications/tools/p2p-test/configuration-publisher/src/main/kotlin/net/corda/p2p/config/publisher/GatewayConfiguration.kt
+++ b/applications/tools/p2p-test/configuration-publisher/src/main/kotlin/net/corda/p2p/config/publisher/GatewayConfiguration.kt
@@ -19,11 +19,10 @@ import java.time.Duration
 )
 class GatewayConfiguration : ConfigProducer() {
     @Option(
-        names = ["--host"],
-        description = ["The name of the HTTP host"],
-        required = true
+        names = ["--hostAddress"],
+        description = ["The host name or IP address where the HTTP server will bind"]
     )
-    lateinit var hostname: String
+    var hostAddress: String = "0.0.0.0"
 
     @Option(
         names = ["--port"],
@@ -100,7 +99,7 @@ class GatewayConfiguration : ConfigProducer() {
         ConfigFactory.empty()
             .withValue(
                 "hostAddress",
-                ConfigValueFactory.fromAnyRef(hostname)
+                ConfigValueFactory.fromAnyRef(hostAddress)
             )
             .withValue(
                 "hostPort",


### PR DESCRIPTION
Converting some parameters that do not have sensible defaults and could trip people up mandatory, so that the user is forced to think about them early on. For example, the default values for host/port are very likely to be published successfully, but then not work when read from the gateway (e.g. due to binding issues). Similarly, for keystores/truststores/passwords etc., if they use a different password and end up using the default one, they could end up down a troubleshooting rabbit hole.