### PR TITLE
NOTICK - Update warning log and missing parameter in simulator docs

### DIFF
--- a/applications/tools/p2p-test/app-simulator/README.md
+++ b/applications/tools/p2p-test/app-simulator/README.md
@@ -50,7 +50,8 @@ In the sender mode, the configuration file should have the following form:
         peerGroupId: "group-1",
         ourX500Name: "O=Bob,L=London,C=GB",
         ourGroupId: "group-1",
-        loadGenerationType: "CONTINUOUS", 
+        loadGenerationType: "CONTINUOUS",  
+        // totalNumberOfMessages: 1000 - only required when loadGenerationType = ONE_OFF
         batchSize: 10,
         interBatchDelay: 0ms,
         messageSizeBytes: 10000

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/BaseHttpChannelHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/BaseHttpChannelHandler.kt
@@ -89,8 +89,7 @@ abstract class BaseHttpChannelHandler(private val eventListener: HttpConnectionL
     }
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        logger.warn("Closing channel due to unrecoverable exception ${cause.message}")
-        logger.debug(cause.stackTraceToString())
+        logger.warn("Closing channel due to unrecoverable exception ${cause.message}", cause)
         ctx.close()
     }
 


### PR DESCRIPTION
* Adding the `totalNumberOfMessages` parameter of the simulator in the docs example, since it's being mentioned but not shown where it should be added so it was a bit ambiguous
* Including the stack trace on a warning log, when connection is closed on the gateway. I noticed it failing once, but I couldn't reproduce it later. Adding the stacktrace so that we can easily tell where it's coming from next it comes up, but it's also a useful thing to have generally.