### PR TITLE
CORE-3166  Better reporting for OSGi errors.

### DIFF
--- a/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
+++ b/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
@@ -528,7 +528,13 @@ class OSGiFrameworkWrap(
         val applicationServiceReference: ServiceReference<Application>? =
             framework.bundleContext.getServiceReference(Application::class.java)
         if (applicationServiceReference != null) {
-            framework.bundleContext.getService(applicationServiceReference)?.startup(args)
+            val application = framework.bundleContext.getService(applicationServiceReference)
+            if (application != null) {
+                application.startup(args)
+            } else {
+                logger.error("Your Application could not be instantiated - check your constructor @Reference parameters\n" +
+                        "Remove all parameters and add them back one at a time to locate the problem.")
+            }
         } else {
             throw ClassNotFoundException(
                 "No class implementing ${Application::class.java} found to start the application.\n" +


### PR DESCRIPTION
We have introduced bundle validation via bnd tools, so I've reduced this PR to just explicitly handling a "null instance" of an `Application` and reporting it rather than silently ignoring it via the `?.` operator.
