### PR TITLE
NOTICK: Bnd WARNING for exported private references is now ERROR.

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda.common-library.gradle
@@ -40,6 +40,7 @@ tasks.named('jar', Jar) {
     archiveBaseName = "corda-${project.name}"
     bundle {
         bnd '''\
+-fixupmessages "Export [^,]++,\\\\s++has (\\\\d++),\\\\s++private references "; restrict:=warning; is:=error
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.\${project.name}
 '''


### PR DESCRIPTION
Promote Bnd's warning about private package references being exported from bundles to an error.