### PR TITLE
NOTICK: Upgrade dependency for TypeSafeConfig to `api`

### DIFF
--- a/libs/configuration/configuration-core/build.gradle
+++ b/libs/configuration/configuration-core/build.gradle
@@ -9,10 +9,10 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
+    api "com.typesafe:config:$typeSafeConfigVersion"
+
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
-
-    implementation "com.typesafe:config:$typeSafeConfigVersion"
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"


### PR DESCRIPTION
Since exported class `SmartConfig` extends from `com.typesafe.config.Config`