### PR TITLE
NOTICK: Remove unwanted dependencies from serialization examples.

### DIFF
--- a/applications/examples/serialization-amqp/custom-serializer-poc/build.gradle
+++ b/applications/examples/serialization-amqp/custom-serializer-poc/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
+    compileOnly "org.osgi:org.osgi.service.cm:$osgiCmVersion"
     compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
@@ -39,7 +40,6 @@ dependencies {
     implementation project(":osgi-framework-api")
 
     implementation project(':libs:serialization:serialization-amqp')
-    implementation project(':components:install:install-legacy')
 
     cpks project(path: ':applications:examples:serialization-amqp:custom-serializer-poc:custom-serializer-poc-example-cpk-a', configuration: 'cordaCPK')
     cpks project(path: ':applications:examples:serialization-amqp:custom-serializer-poc:custom-serializer-poc-example-cpk-b', configuration: 'cordaCPK')
@@ -47,9 +47,6 @@ dependencies {
     runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
 
-    runtimeOnly "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadataVersion"
-    implementation "org.osgi:org.osgi.service.cm:$osgiCmVersion"
-    runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
     runtimeOnly "org.ow2.asm:asm:$asmVersion"

--- a/applications/examples/serialization-amqp/type-evolution-poc/build.gradle
+++ b/applications/examples/serialization-amqp/type-evolution-poc/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
+    compileOnly "org.osgi:org.osgi.service.cm:$osgiCmVersion"
     compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
@@ -24,6 +25,7 @@ dependencies {
 
     implementation "net.corda:corda-packaging"
     implementation "net.corda:corda-serialization"
+    implementation project(':libs:serialization:serialization-amqp')
     implementation project(':libs:serialization:serialization-internal')
     implementation project(":components:install:install-legacy")
     implementation project(path: ':libs:kotlin-reflection', configuration: 'bundle')
@@ -38,17 +40,11 @@ dependencies {
 
     implementation project(":osgi-framework-api")
 
-    implementation project(':libs:serialization:serialization-amqp')
-    implementation project(':components:install:install-legacy')
-
     cpks project(path: ':applications:examples:serialization-amqp:type-evolution-poc:evolution-example-cpk', configuration: 'cordaCPK')
 
     runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
 
-    runtimeOnly "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadataVersion"
-    implementation "org.osgi:org.osgi.service.cm:$osgiCmVersion"
-    runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
     runtimeOnly "org.ow2.asm:asm:$asmVersion"


### PR DESCRIPTION
These dependencies only contain interfaces, and are only used at compile time:
- `org.osgi:org.osgi.service.cm`
- `org.osgi:org.osgi.service.component`

These corresponding Felix artifacts will provide both interfaces and implementations at runtime:
- `org.apache.felix:org.apache.felix.configadmin`
- `org.apache.felix:org.apache.felix.scr`

The `org.jetbrains.kotlinx:kotlinx-metadata-jvm` artifact has already been included into the `kotlin-reflection` library, and so does not need to be included again explicitly.

Also remove duplicate `install-legacy` dependencies.