### PR TITLE
CORE-3227: Upgrade Swagger UI to 4.1.3

### DIFF
--- a/.run/Build HTTP RPC.run.xml
+++ b/.run/Build HTTP RPC.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build HTTP RPC" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value=":applications:http-rpc-gateway:publishOSGiImage :applications:examples:db-worker-prototype:publishOSGiImage" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list />
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ testContainersVersion=1.15.3
 javalinVersion = 3.13.12
 swaggerVersion = 2.1.5
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
-swaggeruiVersion = 3.44.0
+swaggeruiVersion = 4.1.3
 nimbusVersion = 9.8
 unirestVersion = 3.11.00
 jettyVersion = 9.4.43.v20210629

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/OptionalDependency.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/OptionalDependency.kt
@@ -13,7 +13,7 @@ enum class OptionalDependency(
     /**
      * Note: [version] must be aligned with [swaggeruiVersion] in Gradle properties
      */
-    SWAGGERUI("Swagger UI", "STATIC-FILES", "org.webjars", "swagger-ui", "3.44.0");
+    SWAGGERUI("Swagger UI", "STATIC-FILES", "org.webjars", "swagger-ui", "4.1.3");
 
     val symbolicName: String = "$groupId.$artifactId"
 }


### PR DESCRIPTION
Tested by:
1. Integration test:
`:libs:http-rpc:http-rpc-server-impl:integrationTest --tests "net.corda.httprpc.server.impl.HttpRpcServerOpenApiTest.GET swagger UI dependencies should return non empty result"`

2. Manually by starting HTTP RPC Gateway
With BasicAuth as well as AzureAD SSO authentication.
For the latter to work the redirect URL had to be changed to: `https://localhost/webjars/swagger-ui/4.1.3/oauth2-redirect.html`