### PR TITLE
NOTICK: Fix Windows deployment issues

### DIFF
--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/ConfigureAll.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/ConfigureAll.kt
@@ -38,21 +38,14 @@ class ConfigureAll : Runnable {
 
     @Suppress("UNCHECKED_CAST")
     private val namespaces by lazy {
-        ProcessRunner.execute(
-            "kubectl",
-            "get",
+        ProcessRunner.kubeCtlGet(
             "namespace",
-            "-l",
-            "namespace-type=p2p-deployment,creator=${MyUserName.userName}",
-            "-o",
-            "jsonpath={range .items[*]}{.metadata.name}{\"|\"}{.metadata.annotations}{\"\\n\"}{end}",
-        ).lines()
-            .filter {
-                it.contains('|')
-            }
+            listOf("-l", "namespace-type=p2p-deployment,creator=${MyUserName.userName}"),
+            listOf("metadata.name", "metadata.annotations")
+        )
             .associate { line ->
-                val name = line.substringBefore('|')
-                val annotations = line.substringAfter('|')
+                val name = line[0]
+                val annotations = line[1]
                 name to jsonReader.readValue(annotations, Map::class.java)
             }
     }

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/Log.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/Log.kt
@@ -69,21 +69,12 @@ class Log : Runnable {
 
     @Suppress("UNCHECKED_CAST", "ThrowsCount")
     private fun getAllPods(): Map<String, String> {
-        val pods = ProcessRunner.execute(
-            "kubectl",
-            "get",
+        return ProcessRunner.kubeCtlGet(
             "pod",
-            "-n", namespaceName,
-            "--output",
-            "jsonpath={range .items[*]}{.metadata.name}{\",\"}{.spec.containers[].name}{\"\\n\"}{end}"
-        )
-        return pods
-            .lines()
-            .filter { it.contains(',') }
-            .map {
-                it.split(",")
-            }.associate {
-                it[1] to it[0]
-            }
+            listOf("-n", namespaceName),
+            listOf("metadata.name", "spec.containers[].name")
+        ).associate {
+            it[1] to it[0]
+        }
     }
 }

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/UpdateIps.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/UpdateIps.kt
@@ -61,22 +61,19 @@ class UpdateIps : Runnable {
 
     @Suppress("UNCHECKED_CAST")
     private fun namespaces(): Collection<Namespace> {
-        return ProcessRunner.execute(
-            "kubectl",
-            "get",
+        return ProcessRunner.kubeCtlGet(
             "namespace",
-            "-l",
-            "namespace-type=p2p-deployment,creator=${MyUserName.userName}",
-            "-o",
-            "jsonpath={range .items[*]}{.metadata.name}{\",\"}{.metadata.annotations.host}{\"\\n\"}{end}",
-        ).lines()
-            .filter {
-                it.contains(",")
-            }
-            .map { line ->
-                val split = line.split(",")
-                Namespace(split[0], split[1])
-            }
+            listOf(
+                "-l",
+                "namespace-type=p2p-deployment,creator=${MyUserName.userName}",
+            ),
+            listOf(
+                "metadata.name",
+                "metadata.annotations.host",
+            )
+        ).map { split ->
+            Namespace(split[0], split[1])
+        }
     }
 
     override fun run() {

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/resources/sql/create_table.sql
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/resources/sql/create_table.sql
@@ -1,1 +1,14 @@
-../../../../../../p2p-test/app-simulator/src/test/resources/postgres-docker/docker-postgresql-init-scripts/create_table.sql
+CREATE TABLE sent_messages (
+    sender_id varchar(512) NOT NULL,
+    message_id varchar(512) NOT NULL,
+    PRIMARY KEY(sender_id, message_id)
+);
+
+CREATE TABLE received_messages (
+    sender_id varchar(512) NOT NULL,
+    message_id varchar(512) NOT NULL,
+    sent_timestamp timestamp,
+    received_timestamp timestamp,
+    delivery_latency_ms bigint,
+    PRIMARY KEY(sender_id, message_id)
+);


### PR DESCRIPTION
There are two issues:
1. KubeCtl has issues with double-quote in the `jsonpath`. It has to be escaped while Linux won't accept escaped double quotes.
2. Windows can't handle soft links (?!) so I had to copy the content of the SQL file.