### PR TITLE
CORE-1978: Remove dependency from `permission-storage-writer-impl` on reader

### DIFF
--- a/libs/permissions/permission-storage-writer-impl/build.gradle
+++ b/libs/permissions/permission-storage-writer-impl/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation project(':libs:permissions:permission-datamodel')
     implementation project(':libs:permissions:permission-storage-common')
     implementation project(':libs:permissions:permission-storage-writer')
-    implementation project(':libs:permissions:permission-storage-reader')
 
     implementation "javax.persistence:javax.persistence-api"
 


### PR DESCRIPTION
Since we now have `:libs:permissions:permission-storage-common` module, this dependency is redundant.