### PR TITLE
NOTICK Add lock to http client in gateway

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpClient.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpClient.kt
@@ -56,7 +56,7 @@ class HttpClient(
 
     private val lock = ReentrantLock()
 
-    private val channelLock = ReentrantLock()
+    private val channelLock = ReentrantLock(true)
 
     /**
      * Queue containing messages that will be sent once the connection is established.


### PR DESCRIPTION
 There is some evidence from the logs that concurrency issues in the HTTPClient is causing failures.

```
p2p-gateway-1: 13:59:30.116 [nioEventLoopGroup-4-1] WARN  net.corda.p2p.gateway.messaging.http.HttpClient - Closing channel due to unrecoverable exception null
p2p-gateway-1: java.util.NoSuchElementException: null
p2p-gateway-1:  at java.util.LinkedList.removeFirst(LinkedList.java:274) ~[?:?]
p2p-gateway-1:  at net.corda.p2p.gateway.messaging.http.HttpClient.onResponse(HttpClient.kt:188) ~[?:?]
p2p-gateway-1:  at net.corda.p2p.gateway.messaging.http.HttpClientChannelHandler.channelRead0(HttpClientChannelHandler.kt:49) ~[?:?]
p2p-gateway-1:  at net.corda.p2p.gateway.messaging.http.HttpClientChannelHandler.channelRead0(HttpClientChannelHandler.kt:14) ~[?:?]
p2p-gateway-1:  at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99) ~[netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) [netty-codec-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) [netty-codec-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372) [netty-handler-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1235) [netty-handler-4.1.68.Final.jar:4.1.68.Final]
p2p-gateway-1:  at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1284) [netty-handler-4.1.68.Final.jar:4.1.68.Final]
```

The concurrency issue might be difficult to reproduce (I saw it twice testing before this change). I have tested this version extensively in EKS and haven't seen the issue.