### PR TITLE
NOTICK: Force specific kafka broker version

### DIFF
--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/KafkaBroker.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/KafkaBroker.kt
@@ -46,7 +46,7 @@ class KafkaBroker(
         }
     }
     override val app = "kafka-broker-$index"
-    override val image = "wurstmeister/kafka:latest"
+    override val image = "wurstmeister/kafka:2.13-2.8.1"
     override val labels = mapOf("type" to "kafka-broker")
 
     override val ports = listOf(


### PR DESCRIPTION
It looks like AWS is not using the same `latest` every time you create a Kafka broker pod. This should use `2.13-2.8.1` which is the actual [latest](https://hub.docker.com/r/wurstmeister/kafka/tags)