### PR TITLE
NOTICK: bump to 2.17 (DoS issue in 2.16)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -64,7 +64,7 @@ kryoSerializerVersion = 0.43
 # This will need to be swapped out when the patch has been applied to an official release.
 # https://r3-cev.atlassian.net/browse/CORE-2723
 liquibaseVersion = 4.5.0-SNAPSHOT
-log4jVersion = 2.16.0
+log4jVersion = 2.17.0
 nettyVersion = 4.1.68.Final
 osgiCmVersion = 1.6.0
 osgiServiceComponentVersion = 1.4.0


### PR DESCRIPTION
issue in 2.16 where you can trigger Infinite recursion with specific string and crash app