### PR TITLE
CORE-2373 Remove singletons

### DIFF
--- a/applications/examples/serialization-amqp/custom-serializer-poc/src/main/kotlin/net/corda/applications/examples/amqp/customserializer/Main.kt
+++ b/applications/examples/serialization-amqp/custom-serializer-poc/src/main/kotlin/net/corda/applications/examples/amqp/customserializer/Main.kt
@@ -120,7 +120,7 @@ class Main @Activate constructor(
 
     private fun configureSerialization(sandboxAndSerializers: SandboxAndSerializers): SerializerFactory {
         // Create SerializerFactory
-        val factory = SerializerFactoryBuilder.build(sandboxAndSerializers.sandboxGroup)
+        val factory = SerializerFactoryBuilder().build(sandboxAndSerializers.sandboxGroup)
         // Register platform serializers
         for (customSerializer in internalCustomSerializers) {
             consoleLogger.info("Registering internal serializer {}", customSerializer.javaClass.name)
@@ -212,7 +212,7 @@ class Main @Activate constructor(
         consoleLogger.info("Attempt to override platform serialiser:")
 
         // Create SerializerFactory
-        val factory = SerializerFactoryBuilder.build(sandboxA.sandboxGroup)
+        val factory = SerializerFactoryBuilder().build(sandboxA.sandboxGroup)
 
         // Build serializers
         val constructor = sandboxA

--- a/applications/examples/serialization-amqp/type-evolution-poc/src/main/kotlin/net/corda/applications/examples/amqp/typeevolutionprogram/Main.kt
+++ b/applications/examples/serialization-amqp/type-evolution-poc/src/main/kotlin/net/corda/applications/examples/amqp/typeevolutionprogram/Main.kt
@@ -59,7 +59,7 @@ class Main @Activate constructor(
         val loadCpb: CPI = installService.loadCpb(ByteArrayInputStream(outputStream.toByteArray()))
         val sandboxGroup = sandboxCreationService.createSandboxGroup(loadCpb.cpks)
 
-        val factory = SerializerFactoryBuilder.build(sandboxGroup)
+        val factory = SerializerFactoryBuilder().build(sandboxGroup)
 
         // Save output
 //        val output = SerializationOutput(factory)

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -112,7 +112,7 @@ class AMQPwithOSGiSerializationTests {
     @JvmOverloads
     fun testDefaultFactoryNoEvolution(sandboxGroup: SandboxGroup, descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry =
                                               DefaultDescriptorBasedSerializerRegistry()): SerializerFactory =
-            SerializerFactoryBuilder.build(
+            SerializerFactoryBuilder().build(
                     sandboxGroup,
                     descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry,
                     allowEvolution = false)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializerFactories.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializerFactories.kt
@@ -15,7 +15,7 @@ fun createSerializerFactoryFactory(): SerializerFactoryFactory = SerializerFacto
 
 open class SerializerFactoryFactoryImpl : SerializerFactoryFactory {
     override fun make(context: SerializationContext): SerializerFactory {
-        return SerializerFactoryBuilder.build(
+        return SerializerFactoryBuilder().build(
             context.currentSandboxGroup(),
             mustPreserveDataWhenEvolving = context.preventDataLoss
         )

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer
 import java.util.Arrays
 import kotlin.math.min
 
+// TODO: this static is subject to leaking between CPKs and needs to be issued
 internal val serializeOutputStreamPool = LazyPool(
         clear = ByteBufferOutputStream::reset,
         shouldReturnToPool = { it.size() < 256 * 1024 }, // Discard if it grew too large

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer
 import java.util.Arrays
 import kotlin.math.min
 
+@Suppress("ForbiddenComment")
 // TODO: this static is subject to leaking between CPKs and needs to be issued
 internal val serializeOutputStreamPool = LazyPool(
         clear = ByteBufferOutputStream::reset,

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
@@ -11,7 +11,7 @@ import java.util.Arrays
 import kotlin.math.min
 
 @Suppress("ForbiddenComment")
-// TODO: this static is subject to leaking between CPKs and needs to be issued
+// TODO: this static is subject to leaking between CPKs and will be issued with https://r3-cev.atlassian.net/browse/CORE-3344.
 internal val serializeOutputStreamPool = LazyPool(
         clear = ByteBufferOutputStream::reset,
         shouldReturnToPool = { it.size() < 256 * 1024 }, // Discard if it grew too large

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
@@ -31,7 +31,7 @@ enum class SectionId : OrdinalWriter {
     ENCODING;
 
     companion object {
-        val reader = OrdinalReader(values())
+        val reader get() = OrdinalReader(values())
     }
 
     override val bits = OrdinalBits(ordinal)
@@ -43,16 +43,16 @@ enum class CordaSerializationEncoding(private val encoderType: EncoderType) : Se
 
     @ServiceConsumer(EncoderService::class)
     companion object {
-        val reader = OrdinalReader(values())
+        val reader get() = OrdinalReader(values())
 
         /**
          * Gets the [EncoderService] via jvm [ServiceLoader]
          */
-        private val encoderService: EncoderService by lazy {
-            // This has to be lazy initialized or a function rather than a value due to initialization order.
-            ServiceLoader.load(EncoderService::class.java).toList().firstOrNull()
+        private val encoderService: EncoderService
+            get() =
+                // This has to be lazy initialized or a function rather than a value due to initialization order.
+                ServiceLoader.load(EncoderService::class.java).toList().firstOrNull()
                     ?: throw NullPointerException("Could not get serialization encoder service")
-        }
 
         /**
          * Get an [Encoder] of the specified type

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
@@ -14,11 +14,12 @@ import net.corda.serialization.SerializationContext
  * MUST be kept separate!
  */
 
-val AMQP_STORAGE_CONTEXT = SerializationContextImpl(
-        amqpMagic,
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.Storage,
-        null,
-        AlwaysAcceptEncodingWhitelist
-)
+val AMQP_STORAGE_CONTEXT
+        get() = SerializationContextImpl(
+                amqpMagic,
+                emptyMap(),
+                true,
+                SerializationContext.UseCase.Storage,
+                null,
+                AlwaysAcceptEncodingWhitelist
+        )

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
@@ -6,13 +6,14 @@ import net.corda.serialization.EncodingWhitelist
 import net.corda.serialization.SerializationContext
 import net.corda.serialization.SerializationEncoding
 
-val AMQP_P2P_CONTEXT = SerializationContextImpl(
-        amqpMagic,
-        emptyMap(),
-        true,
-        SerializationContext.UseCase.P2P,
-        null
-)
+val AMQP_P2P_CONTEXT
+        get() = SerializationContextImpl(
+                amqpMagic,
+                emptyMap(),
+                true,
+                SerializationContext.UseCase.P2P,
+                null
+        )
 
 object AlwaysAcceptEncodingWhitelist : EncodingWhitelist {
     override fun acceptEncoding(encoding: SerializationEncoding) = true

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
@@ -88,6 +88,33 @@ object AMQPTypeIdentifierParser {
          * We are parsing a raw type name, either at the top level or as part of a list of type parameters.
          */
         data class ParsingRawType(override val parent: ParsingParameterList?, val buffer: StringBuilder = StringBuilder()) : ParseState() {
+
+            // This was made an instance var (used to be a static var) to avoid leaking it among CPKs.
+            private val simplified = mapOf(
+                "string" to String::class,
+                "boolean" to Boolean::class,
+                "byte" to Byte::class,
+                "char" to Char::class,
+                "int" to Int::class,
+                "short" to Short::class,
+                "long" to Long::class,
+                "double" to Double::class,
+                "float" to Float::class,
+                "ubyte" to UnsignedByte::class,
+                "uint" to UnsignedInteger::class,
+                "ushort" to UnsignedShort::class,
+                "ulong" to UnsignedLong::class,
+                "decimal32" to Decimal32::class,
+                "decimal64" to Decimal64::class,
+                "decimal128" to Decimal128::class,
+                "binary" to ByteArray::class,
+                "timestamp" to Date::class,
+                "uuid" to UUID::class,
+                "symbol" to Symbol::class
+            ).mapValues { (_, v) ->
+                TypeIdentifier.forClass(v.javaObjectType)
+            }
+
             override fun accept(c: Char, sandboxGroup: SandboxGroup) = when (c) {
                 ',' ->
                     if (parent == null) notInParameterList(c)
@@ -171,30 +198,5 @@ object AMQPTypeIdentifierParser {
 
             override fun getTypeIdentifier() = identifier
         }
-    }
-
-    private val simplified
-        get() = mapOf(
-            "string" to String::class,
-            "boolean" to Boolean::class,
-            "byte" to Byte::class,
-            "char" to Char::class,
-            "int" to Int::class,
-            "short" to Short::class,
-            "long" to Long::class,
-            "double" to Double::class,
-            "float" to Float::class,
-            "ubyte" to UnsignedByte::class,
-            "uint" to UnsignedInteger::class,
-            "ushort" to UnsignedShort::class,
-            "ulong" to UnsignedLong::class,
-            "decimal32" to Decimal32::class,
-            "decimal64" to Decimal64::class,
-            "decimal128" to Decimal128::class,
-            "binary" to ByteArray::class,
-            "timestamp" to Date::class,
-            "uuid" to UUID::class,
-            "symbol" to Symbol::class).mapValues { (_, v) ->
-        TypeIdentifier.forClass(v.javaObjectType)
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
@@ -86,33 +86,6 @@ object AMQPTypeIdentifierParser {
          * We are parsing a raw type name, either at the top level or as part of a list of type parameters.
          */
         data class ParsingRawType(override val parent: ParsingParameterList?, val buffer: StringBuilder = StringBuilder()) : ParseState() {
-
-            // This was made an instance var (used to be a static var) to avoid leaking it among CPKs.
-            private val simplified = mapOf(
-                "string" to String::class,
-                "boolean" to Boolean::class,
-                "byte" to Byte::class,
-                "char" to Char::class,
-                "int" to Int::class,
-                "short" to Short::class,
-                "long" to Long::class,
-                "double" to Double::class,
-                "float" to Float::class,
-                "ubyte" to UnsignedByte::class,
-                "uint" to UnsignedInteger::class,
-                "ushort" to UnsignedShort::class,
-                "ulong" to UnsignedLong::class,
-                "decimal32" to Decimal32::class,
-                "decimal64" to Decimal64::class,
-                "decimal128" to Decimal128::class,
-                "binary" to ByteArray::class,
-                "timestamp" to Date::class,
-                "uuid" to UUID::class,
-                "symbol" to Symbol::class
-            ).mapValues { (_, v) ->
-                TypeIdentifier.forClass(v.javaObjectType)
-            }
-
             override fun accept(c: Char, sandboxGroup: SandboxGroup) = when (c) {
                 ',' ->
                     if (parent == null) notInParameterList(c)
@@ -196,5 +169,30 @@ object AMQPTypeIdentifierParser {
 
             override fun getTypeIdentifier() = identifier
         }
+    }
+
+    private val simplified
+        get() = mapOf(
+            "string" to String::class,
+            "boolean" to Boolean::class,
+            "byte" to Byte::class,
+            "char" to Char::class,
+            "int" to Int::class,
+            "short" to Short::class,
+            "long" to Long::class,
+            "double" to Double::class,
+            "float" to Float::class,
+            "ubyte" to UnsignedByte::class,
+            "uint" to UnsignedInteger::class,
+            "ushort" to UnsignedShort::class,
+            "ulong" to UnsignedLong::class,
+            "decimal32" to Decimal32::class,
+            "decimal64" to Decimal64::class,
+            "decimal128" to Decimal128::class,
+            "binary" to ByteArray::class,
+            "timestamp" to Date::class,
+            "uuid" to UUID::class,
+            "symbol" to Symbol::class).mapValues { (_, v) ->
+        TypeIdentifier.forClass(v.javaObjectType)
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
@@ -25,8 +25,10 @@ class IllegalTypeNameParserStateException(message: String): NotSerializableExcep
  */
 object AMQPTypeIdentifierParser {
 
-    internal const val MAX_TYPE_PARAM_DEPTH = 32
-    private const val MAX_ARRAY_DEPTH = 32
+    internal val MAX_TYPE_PARAM_DEPTH
+        get() = 32
+    private val MAX_ARRAY_DEPTH
+        get() = 32
 
     /**
      * Given a string representing a serialized AMQP type, construct a TypeIdentifier for that string.
@@ -171,7 +173,8 @@ object AMQPTypeIdentifierParser {
         }
     }
 
-    private val simplified = mapOf(
+    private val simplified
+        get() = mapOf(
             "string" to String::class,
             "boolean" to Boolean::class,
             "byte" to Byte::class,

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
@@ -105,6 +105,7 @@ object AMQPTypeIdentifierParser {
             }
 
             override fun getTypeIdentifier(): TypeIdentifier {
+                val simplified = simplified
                 return when (val typeName = getTypeName()) {
                     "*" -> TypeIdentifier.TopType
                     "?" -> TypeIdentifier.UnknownType

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParser.kt
@@ -25,10 +25,8 @@ class IllegalTypeNameParserStateException(message: String): NotSerializableExcep
  */
 object AMQPTypeIdentifierParser {
 
-    internal val MAX_TYPE_PARAM_DEPTH
-        get() = 32
-    private val MAX_ARRAY_DEPTH
-        get() = 32
+    internal const val MAX_TYPE_PARAM_DEPTH = 32
+    private const val MAX_ARRAY_DEPTH = 32
 
     /**
      * Given a string representing a serialized AMQP type, construct a TypeIdentifier for that string.

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifiers.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifiers.kt
@@ -22,7 +22,8 @@ object AMQPTypeIdentifiers {
             primitiveTypeNamesByName[TypeIdentifier.forGenericType(type)] ?:
                     throw NotSerializableException("Primitive type name requested for non-primitive type $type")
 
-    private val primitiveTypeNamesByName = sequenceOf(
+    private val primitiveTypeNamesByName
+        get() = sequenceOf(
             Character::class to "char",
             Char::class to "char",
             Boolean::class to "boolean",
@@ -67,7 +68,8 @@ object AMQPTypeIdentifiers {
         }
     }
 
-    private val primitiveByteArrayType = TypeIdentifier.ArrayOf(TypeIdentifier.forClass(Byte::class.javaPrimitiveType!!))
+    private val primitiveByteArrayType
+        get() = TypeIdentifier.ArrayOf(TypeIdentifier.forClass(Byte::class.javaPrimitiveType!!))
 
     fun nameForType(type: Type): String = nameForType(TypeIdentifier.forGenericType(type))
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
@@ -10,6 +10,7 @@ import net.corda.serialization.EncodingWhitelist
 import net.corda.serialization.SerializationContext
 import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.types.ByteSequence
+import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.serialization.SerializedBytes
@@ -37,9 +38,10 @@ class DeserializationInput constructor(
     private val serializerFactory: SerializerFactory
 ) {
     private val objectHistory: MutableList<Any> = mutableListOf()
-    private val logger = loggerFor<DeserializationInput>()
 
     companion object {
+        private val logger = contextLogger()
+
         @VisibleForTesting
         @Throws(AMQPNoTypeNotSerializableException::class)
         fun <T> withDataBytes(

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
@@ -11,7 +11,6 @@ import net.corda.serialization.SerializationContext
 import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.types.ByteSequence
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.serialization.SerializedBytes
 import org.apache.qpid.proton.amqp.Binary

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Envelope.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Envelope.kt
@@ -14,6 +14,7 @@ import org.apache.qpid.proton.codec.DescribedTypeConstructor
 data class Envelope(val obj: Any?, val schema: Schema, val transformsSchema: TransformsSchema, val metadata: Metadata) : DescribedType {
     companion object : DescribedTypeConstructor<Envelope> {
 
+        @JvmStatic
         val DESCRIPTOR get() = AMQPDescriptorRegistry.ENVELOPE.amqpDescriptor
 
         val DESCRIPTOR_OBJECT get() = Descriptor(null, DESCRIPTOR)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Envelope.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Envelope.kt
@@ -14,20 +14,18 @@ import org.apache.qpid.proton.codec.DescribedTypeConstructor
 data class Envelope(val obj: Any?, val schema: Schema, val transformsSchema: TransformsSchema, val metadata: Metadata) : DescribedType {
     companion object : DescribedTypeConstructor<Envelope> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.ENVELOPE.amqpDescriptor
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.ENVELOPE.amqpDescriptor
 
-        @JvmField
-        val DESCRIPTOR_OBJECT = Descriptor(null, DESCRIPTOR)
+        val DESCRIPTOR_OBJECT get() = Descriptor(null, DESCRIPTOR)
 
-        private const val ENVELOPE_SIMPLE = 2
-        private const val ENVELOPE_WITH_TRANSFORMS = 3
-        private const val ENVELOPE_WITH_METADATA = 4
+        private val ENVELOPE_SIMPLE get() = 2
+        private val ENVELOPE_WITH_TRANSFORMS get() = 3
+        private val ENVELOPE_WITH_METADATA get() = 4
 
-        private const val BLOB_IDX = 0
-        private const val SCHEMA_IDX = 1
-        private const val TRANSFORMS_SCHEMA_IDX = 2
-        private const val METADATA_IDX = 3
+        private val BLOB_IDX get() = 0
+        private val SCHEMA_IDX get() = 1
+        private val TRANSFORMS_SCHEMA_IDX get() = 2
+        private val METADATA_IDX get() = 3
 
         @Suppress("ThrowsCount")
         fun get(data: Data): Envelope {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Envelope.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Envelope.kt
@@ -19,14 +19,14 @@ data class Envelope(val obj: Any?, val schema: Schema, val transformsSchema: Tra
 
         val DESCRIPTOR_OBJECT get() = Descriptor(null, DESCRIPTOR)
 
-        private val ENVELOPE_SIMPLE get() = 2
-        private val ENVELOPE_WITH_TRANSFORMS get() = 3
-        private val ENVELOPE_WITH_METADATA get() = 4
+        private const val ENVELOPE_SIMPLE = 2
+        private const val ENVELOPE_WITH_TRANSFORMS = 3
+        private const val ENVELOPE_WITH_METADATA = 4
 
-        private val BLOB_IDX get() = 0
-        private val SCHEMA_IDX get() = 1
-        private val TRANSFORMS_SCHEMA_IDX get() = 2
-        private val METADATA_IDX get() = 3
+        private const val BLOB_IDX = 0
+        private const val SCHEMA_IDX = 1
+        private const val TRANSFORMS_SCHEMA_IDX = 2
+        private const val METADATA_IDX = 3
 
         @Suppress("ThrowsCount")
         fun get(data: Data): Envelope {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalTypeModelConfigurationImpl.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalTypeModelConfigurationImpl.kt
@@ -29,7 +29,8 @@ class LocalTypeModelConfigurationImpl(
 }
 
 // Copied from SerializerFactory so that we can have equivalent behaviour, for now.
-private val opaqueTypes = setOf(
+private val opaqueTypes
+    get() = setOf(
         Character::class.java,
         Char::class.java,
         Boolean::class.java,
@@ -51,18 +52,19 @@ private val opaqueTypes = setOf(
         ByteArray::class.java,
         String::class.java,
         Symbol::class.java
-)
+    )
 
 @Suppress("unchecked_cast")
-private val DEFAULT_BASE_TYPES = BaseLocalTypes(
-    collectionClass = Collection::class.java,
-    enumSetClass = EnumSet::class.java,
-    exceptionClass = Exception::class.java,
-    mapClass = Map::class.java,
-    stringClass = String::class.java,
-    isEnum = Class<*>::isEnum,
-    enumConstants = Class<*>::getEnumConstants,
-    enumConstantNames = { clazz ->
-        (clazz as Class<out Enum<*>>).enumConstants.map(Enum<*>::name)
-    }
-)
+private val DEFAULT_BASE_TYPES
+    get() = BaseLocalTypes(
+        collectionClass = Collection::class.java,
+        enumSetClass = EnumSet::class.java,
+        exceptionClass = Exception::class.java,
+        mapClass = Map::class.java,
+        stringClass = String::class.java,
+        isEnum = Class<*>::isEnum,
+        enumConstants = Class<*>::getEnumConstants,
+        enumConstantNames = { clazz ->
+            (clazz as Class<out Enum<*>>).enumConstants.map(Enum<*>::name)
+        }
+    )

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Metadata.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Metadata.kt
@@ -18,7 +18,7 @@ data class Metadata(val values: MutableMap<String, Any> = mutableMapOf()) : Desc
         @JvmStatic
         val DESCRIPTOR get() = AMQPDescriptorRegistry.METADATA.amqpDescriptor
 
-        private val VALUES_IDX get() = 0
+        private const val VALUES_IDX = 0
 
         fun get(obj: Any): Metadata {
             val describedType = obj as DescribedType

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Metadata.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Metadata.kt
@@ -15,10 +15,10 @@ import java.io.NotSerializableException
 data class Metadata(val values: MutableMap<String, Any> = mutableMapOf()) : DescribedType {
     companion object : DescribedTypeConstructor<Metadata> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.METADATA.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.METADATA.amqpDescriptor
 
-        private const val VALUES_IDX = 0
+        private val VALUES_IDX get() = 0
 
         fun get(obj: Any): Metadata {
             val describedType = obj as DescribedType

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ObjectBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ObjectBuilder.kt
@@ -10,7 +10,7 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
-private val IGNORE_COMPUTED get() = -1
+private const val IGNORE_COMPUTED = -1
 
 /**
  * Creates a new [ObjectBuilder] ready to be populated with deserialized values so that it can create an object instance.
@@ -259,7 +259,7 @@ class EvolutionObjectBuilder(
 
     companion object {
 
-        val DISCARDED get() = -1
+        const val DISCARDED: Int = -1
 
         /**
          * Construct an [EvolutionObjectBuilder] for the specified type, constructor and properties, mapping the list of

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ObjectBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ObjectBuilder.kt
@@ -10,7 +10,7 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
-private const val IGNORE_COMPUTED = -1
+private val IGNORE_COMPUTED get() = -1
 
 /**
  * Creates a new [ObjectBuilder] ready to be populated with deserialized values so that it can create an object instance.
@@ -259,7 +259,7 @@ class EvolutionObjectBuilder(
 
     companion object {
 
-        const val DISCARDED: Int = -1
+        val DISCARDED get() = -1
 
         /**
          * Construct an [EvolutionObjectBuilder] for the specified type, constructor and properties, mapping the list of

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/PropertyDescriptor.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/PropertyDescriptor.kt
@@ -69,7 +69,7 @@ private fun Class<*>.boxesOrIsAssignableFrom(other: Class<*>) =
 private fun Type.isSupertypeOf(that: Type) = TypeToken.of(this).isSupertypeOf(that)
 
 // match an uppercase letter that also has a corresponding lower case equivalent
-private val propertyMethodRegex = Regex("(?<type>get|set|is)(?<var>\\p{Lu}.*)")
+private val propertyMethodRegex get() = Regex("(?<type>get|set|is)(?<var>\\p{Lu}.*)")
 
 /**
  * Collate the properties of a class and match them with their getter and setter

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Schema.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Schema.kt
@@ -15,9 +15,9 @@ import org.apache.qpid.proton.codec.DescribedTypeConstructor
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 
-const val DESCRIPTOR_DOMAIN: String = "net.corda"
-@JvmField
-val amqpMagic = CordaSerializationMagic("corda".toByteArray() + byteArrayOf(3, 0))
+val DESCRIPTOR_DOMAIN get() = "net.corda"
+
+val amqpMagic get() = CordaSerializationMagic("corda".toByteArray() + byteArrayOf(3, 0))
 
 fun typeDescriptorFor(typeId: TypeIdentifier): Symbol = Symbol.valueOf("$DESCRIPTOR_DOMAIN:${AMQPTypeIdentifiers.nameForType(typeId)}")
 fun typeDescriptorFor(type: Type): Symbol = typeDescriptorFor(forGenericType(type))
@@ -54,8 +54,8 @@ private class RedescribedType(
 data class Schema(val types: List<TypeNotation>) : DescribedType {
     companion object : DescribedTypeConstructor<Schema> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.SCHEMA.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.SCHEMA.amqpDescriptor
 
         fun get(obj: Any): Schema {
             val describedType = obj as DescribedType
@@ -86,8 +86,8 @@ data class Descriptor(val name: Symbol?, val code: UnsignedLong? = null) : Descr
 
     companion object : DescribedTypeConstructor<Descriptor> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.OBJECT_DESCRIPTOR.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.OBJECT_DESCRIPTOR.amqpDescriptor
 
         fun get(obj: Any): Descriptor {
             val describedType = obj as DescribedType
@@ -133,8 +133,8 @@ data class Field(
         val multiple: Boolean) : DescribedType {
     companion object : DescribedTypeConstructor<Field> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.FIELD.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.FIELD.amqpDescriptor
 
         fun get(obj: Any): Field {
             val describedType = obj as DescribedType
@@ -201,8 +201,8 @@ data class CompositeType(
 ) : TypeNotation() {
     companion object : DescribedTypeConstructor<CompositeType> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.COMPOSITE_TYPE.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.COMPOSITE_TYPE.amqpDescriptor
 
         fun get(describedType: DescribedType): CompositeType {
             if (describedType.descriptor != DESCRIPTOR) {
@@ -252,8 +252,8 @@ data class RestrictedType(override val name: String,
                           val choices: List<Choice>) : TypeNotation() {
     companion object : DescribedTypeConstructor<RestrictedType> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.RESTRICTED_TYPE.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.RESTRICTED_TYPE.amqpDescriptor
 
         fun get(describedType: DescribedType): RestrictedType {
             if (describedType.descriptor != DESCRIPTOR) {
@@ -299,8 +299,8 @@ data class RestrictedType(override val name: String,
 data class Choice(val name: String, val value: String) : DescribedType {
     companion object : DescribedTypeConstructor<Choice> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.CHOICE.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.CHOICE.amqpDescriptor
 
         fun get(obj: Any): Choice {
             val describedType = obj as DescribedType
@@ -330,8 +330,8 @@ data class Choice(val name: String, val value: String) : DescribedType {
 data class ReferencedObject(private val refCounter: Int) : DescribedType {
     companion object : DescribedTypeConstructor<ReferencedObject> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.REFERENCED_OBJECT.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.REFERENCED_OBJECT.amqpDescriptor
 
         fun get(obj: Any): ReferencedObject {
             val describedType = obj as DescribedType

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Schema.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/Schema.kt
@@ -15,7 +15,7 @@ import org.apache.qpid.proton.codec.DescribedTypeConstructor
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 
-val DESCRIPTOR_DOMAIN get() = "net.corda"
+const val DESCRIPTOR_DOMAIN: String = "net.corda"
 
 val amqpMagic get() = CordaSerializationMagic("corda".toByteArray() + byteArrayOf(3, 0))
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
@@ -20,9 +20,9 @@ class SerializerFactoryBuilder {
     private val getBundles: Method?
 
     companion object {
-        private val FRAMEWORK_UTIL_CLASS_NAME get() = "org.osgi.framework.FrameworkUtil"
-        private val BUNDLE_CONTEXT_CLASS_NAME get() = "org.osgi.framework.BundleContext"
-        private val BUNDLE_CLASS_NAME get() = "org.osgi.framework.Bundle"
+        private const val FRAMEWORK_UTIL_CLASS_NAME = "org.osgi.framework.FrameworkUtil"
+        private const val BUNDLE_CONTEXT_CLASS_NAME = "org.osgi.framework.BundleContext"
+        private const val BUNDLE_CLASS_NAME = "org.osgi.framework.Bundle"
 
         /**
          * The standard mapping of Java object types to Java primitive types.

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
@@ -50,6 +50,7 @@ class SerializerFactoryBuilder {
         var getBundlesMethod: Method?
 
         try {
+            // TODO - Maybe we should be passing a Classloader as a property to be used in function below?
             val frameworkUtilClass = Class.forName(FRAMEWORK_UTIL_CLASS_NAME, false, this::class.java.classLoader)
             val bundleContextClass = Class.forName(BUNDLE_CONTEXT_CLASS_NAME, false, frameworkUtilClass.classLoader)
             val bundleClass = Class.forName(BUNDLE_CLASS_NAME, false, frameworkUtilClass.classLoader)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
@@ -12,16 +12,37 @@ import net.corda.internal.serialization.model.TypeModellingFingerPrinter
 import net.corda.sandbox.SandboxGroup
 import java.io.NotSerializableException
 import java.lang.reflect.Method
-import java.util.Collections.unmodifiableMap
 
-object SerializerFactoryBuilder {
-    private const val FRAMEWORK_UTIL_CLASS_NAME = "org.osgi.framework.FrameworkUtil"
-    private const val BUNDLE_CONTEXT_CLASS_NAME = "org.osgi.framework.BundleContext"
-    private const val BUNDLE_CLASS_NAME = "org.osgi.framework.Bundle"
+class SerializerFactoryBuilder {
 
     private val getBundle: Method?
     private val getBundleContext: Method?
     private val getBundles: Method?
+
+    companion object {
+        private val FRAMEWORK_UTIL_CLASS_NAME get() = "org.osgi.framework.FrameworkUtil"
+        private val BUNDLE_CONTEXT_CLASS_NAME get() = "org.osgi.framework.BundleContext"
+        private val BUNDLE_CLASS_NAME get() = "org.osgi.framework.Bundle"
+
+        /**
+         * The standard mapping of Java object types to Java primitive types.
+         */
+        @Suppress("unchecked_cast")
+        private val javaPrimitiveTypes: Map<Class<*>, Class<*>>
+            get() = listOf(
+                Boolean::class,
+                Byte::class,
+                Char::class,
+                Double::class,
+                Float::class,
+                Int::class,
+                Long::class,
+                Short::class,
+                Void::class
+            ).associate { klazz ->
+                klazz.javaObjectType to klazz.javaPrimitiveType
+            } as Map<Class<*>, Class<*>>
+    }
 
     init {
         var getBundleMethod: Method?
@@ -70,25 +91,6 @@ object SerializerFactoryBuilder {
         return (bundles as Array<Any>).toList()
     }
 
-    /**
-     * The standard mapping of Java object types to Java primitive types.
-     */
-    @Suppress("unchecked_cast")
-    private val javaPrimitiveTypes: Map<Class<*>, Class<*>> = unmodifiableMap(listOf(
-        Boolean::class,
-        Byte::class,
-        Char::class,
-        Double::class,
-        Float::class,
-        Int::class,
-        Long::class,
-        Short::class,
-        Void::class
-    ).associate {
-        klazz -> klazz.javaObjectType to klazz.javaPrimitiveType
-    }) as Map<Class<*>, Class<*>>
-
-    @JvmStatic
     fun build(sandboxGroup: SandboxGroup): SerializerFactory {
         return makeFactory(
             sandboxGroup,
@@ -101,7 +103,6 @@ object SerializerFactoryBuilder {
     }
 
     @Suppress("LongParameterList")
-    @JvmStatic
     fun build(
             sandboxGroup: SandboxGroup,
             descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry =

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SupportedTransforms.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SupportedTransforms.kt
@@ -26,15 +26,17 @@ data class SupportedTransform(
  * outer annotation
  */
 @Suppress("UNCHECKED_CAST")
-private val wrapperExtract = { x: Annotation ->
-    (x::class.java.getDeclaredMethod("value").invoke(x) as Array<Annotation>).toList()
-}
+private val wrapperExtract
+        get() = { x: Annotation ->
+                (x::class.java.getDeclaredMethod("value").invoke(x) as Array<Annotation>).toList()
+        }
 
 /**
  * Extract from an annotated class the list of annotations that refer to a particular
  * transformation type when that class has a single decorator applied
  */
-private val singleExtract = { x: Annotation -> listOf(x) }
+private val singleExtract
+        get() = { x: Annotation -> listOf(x) }
 
 // Transform annotation used to test the handling of transforms the de-serialising node doesn't understand. At
 // some point test cases will have been created with this transform applied.
@@ -48,29 +50,30 @@ private val singleExtract = { x: Annotation -> listOf(x) }
  * NOTE: We have to support single instances of the transform annotations as well as the wrapping annotation
  * when many instances are repeated.
  */
-val supportedTransforms = listOf(
-        SupportedTransform(
-                CordaSerializationTransformEnumDefaults::class.java,
-                TransformTypes.EnumDefault,
-                wrapperExtract
-        ),
-        SupportedTransform(
-                CordaSerializationTransformEnumDefault::class.java,
-                TransformTypes.EnumDefault,
-                singleExtract
-        ),
-        SupportedTransform(
-                CordaSerializationTransformRenames::class.java,
-                TransformTypes.Rename,
-                wrapperExtract
-        ),
-        SupportedTransform(
-                CordaSerializationTransformRename::class.java,
-                TransformTypes.Rename,
-                singleExtract
+val supportedTransforms
+        get() = listOf(
+                SupportedTransform(
+                        CordaSerializationTransformEnumDefaults::class.java,
+                        TransformTypes.EnumDefault,
+                        wrapperExtract
+                ),
+                SupportedTransform(
+                        CordaSerializationTransformEnumDefault::class.java,
+                        TransformTypes.EnumDefault,
+                        singleExtract
+                ),
+                SupportedTransform(
+                        CordaSerializationTransformRenames::class.java,
+                        TransformTypes.Rename,
+                        wrapperExtract
+                ),
+                SupportedTransform(
+                        CordaSerializationTransformRename::class.java,
+                        TransformTypes.Rename,
+                        singleExtract
+                )
+                //,SupportedTransform(
+                //        UnknownTransformAnnotation::class.java,
+                //        TransformTypes.UnknownTest,
+                //        singleExtract)
         )
-        //,SupportedTransform(
-        //        UnknownTransformAnnotation::class.java,
-        //        TransformTypes.UnknownTest,
-        //        singleExtract)
-)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformsSchema.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformsSchema.kt
@@ -18,8 +18,9 @@ import java.util.EnumMap
 abstract class Transform : DescribedType {
     companion object : DescribedTypeConstructor<Transform> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.TRANSFORM_ELEMENT.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR
+            get() = AMQPDescriptorRegistry.TRANSFORM_ELEMENT.amqpDescriptor
 
         /**
          * @param obj: a serialized instance of a described type, should be one of the
@@ -75,7 +76,7 @@ abstract class Transform : DescribedType {
  */
 class UnknownTransform : Transform() {
     companion object : DescribedTypeConstructor<UnknownTransform> {
-        const val typeName = "UnknownTransform"
+        val typeName get() = "UnknownTransform"
 
         override fun newInstance(obj: Any?) = UnknownTransform()
 
@@ -93,7 +94,7 @@ class UnknownTransform : Transform() {
  */
 class UnknownTestTransform(val a: Int, val b: Int, val c: Int) : Transform() {
     companion object : DescribedTypeConstructor<UnknownTestTransform> {
-        const val typeName = "UnknownTest"
+        val typeName get() = "UnknownTest"
 
         override fun newInstance(obj: Any?): UnknownTestTransform {
             val described = obj as List<*>
@@ -120,7 +121,7 @@ class EnumDefaultSchemaTransform(val old: String, val new: String) : Transform()
         /**
          * Value encoded into the schema that identifies a transform as this type
          */
-        const val typeName = "EnumDefault"
+        val typeName get() = "EnumDefault"
 
         override fun newInstance(obj: Any?): EnumDefaultSchemaTransform {
             val described = obj as List<*>
@@ -157,7 +158,7 @@ class RenameSchemaTransform(val from: String, val to: String) : Transform() {
         /**
          * Value encoded into the schema that identifies a transform as this type
          */
-        const val typeName = "Rename"
+        val typeName get() = "Rename"
 
         override fun newInstance(obj: Any?): RenameSchemaTransform {
             val described = obj as List<*>
@@ -249,8 +250,8 @@ object TransformsAnnotationProcessor {
 data class TransformsSchema(val types: Map<String, EnumMap<TransformTypes, MutableList<Transform>>>) : DescribedType {
     companion object : DescribedTypeConstructor<TransformsSchema> {
 
-        @JvmField
-        val DESCRIPTOR = AMQPDescriptorRegistry.TRANSFORM_SCHEMA.amqpDescriptor
+        @JvmStatic
+        val DESCRIPTOR get() = AMQPDescriptorRegistry.TRANSFORM_SCHEMA.amqpDescriptor
 
         /**
          * Prepare a schema for encoding, takes all of the types being transmitted and inspects each

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformsSchema.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformsSchema.kt
@@ -76,7 +76,7 @@ abstract class Transform : DescribedType {
  */
 class UnknownTransform : Transform() {
     companion object : DescribedTypeConstructor<UnknownTransform> {
-        val typeName get() = "UnknownTransform"
+        const val typeName = "UnknownTransform"
 
         override fun newInstance(obj: Any?) = UnknownTransform()
 
@@ -94,7 +94,7 @@ class UnknownTransform : Transform() {
  */
 class UnknownTestTransform(val a: Int, val b: Int, val c: Int) : Transform() {
     companion object : DescribedTypeConstructor<UnknownTestTransform> {
-        val typeName get() = "UnknownTest"
+        const val typeName = "UnknownTest"
 
         override fun newInstance(obj: Any?): UnknownTestTransform {
             val described = obj as List<*>
@@ -121,7 +121,7 @@ class EnumDefaultSchemaTransform(val old: String, val new: String) : Transform()
         /**
          * Value encoded into the schema that identifies a transform as this type
          */
-        val typeName get() = "EnumDefault"
+        const val typeName = "EnumDefault"
 
         override fun newInstance(obj: Any?): EnumDefaultSchemaTransform {
             val described = obj as List<*>
@@ -158,7 +158,7 @@ class RenameSchemaTransform(val from: String, val to: String) : Transform() {
         /**
          * Value encoded into the schema that identifies a transform as this type
          */
-        val typeName get() = "Rename"
+        const val typeName = "Rename"
 
         override fun newInstance(obj: Any?): RenameSchemaTransform {
             val described = obj as List<*>

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TypeNotationGenerator.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TypeNotationGenerator.kt
@@ -59,7 +59,8 @@ object TypeNotationGenerator {
         return Field(name, typeName, requires, defaultValue, null, isMandatory, false)
     }
 
-    private val defaultValues = sequenceOf(
+    private val defaultValues
+        get() = sequenceOf(
             Boolean::class to "false",
             Byte::class to "0",
             Int::class to "0",
@@ -67,7 +68,8 @@ object TypeNotationGenerator {
             Short::class to "0",
             Long::class to "0",
             Float::class to "0",
-            Double::class to "0").associate { (type, value) ->
-        TypeIdentifier.forClass(type.javaPrimitiveType!!) to value
-    }
+            Double::class to "0"
+        ).associate { (type, value) ->
+            TypeIdentifier.forClass(type.javaPrimitiveType!!) to value
+        }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -139,7 +139,7 @@ abstract class PrimArraySerializer(type: Type, factory: LocalSerializerFactory) 
         // We don't need to handle the unboxed byte type as that is coercible to a byte array, but
         // the other 7 primitive types we do
         fun make(type: Type, factory: LocalSerializerFactory) =
-            when(type) {
+            when (type) {
                 IntArray::class.java -> PrimIntArraySerializer(factory)
                 CharArray::class.java -> PrimCharArraySerializer(factory)
                 BooleanArray::class.java -> PrimBooleanArraySerializer(factory)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -31,17 +31,18 @@ import java.lang.reflect.Type
  * Serialization / deserialization of arrays.
  */
 open class ArraySerializer(override val type: Type, factory: LocalSerializerFactory) : AMQPSerializer<Any> {
+
     companion object {
+        private val logger = contextLogger()
+
         fun make(type: Type, factory: LocalSerializerFactory) : AMQPSerializer<Any> {
-            contextLogger().debug { "Making array serializer, typename=${type.typeName}" }
+            logger.debug { "Making array serializer, typename=${type.typeName}" }
             return when (type) {
                 Array<Char>::class.java -> CharArraySerializer(factory)
                 else -> ArraySerializer(type, factory)
             }
         }
     }
-
-    private val logger = loggerFor<ArraySerializer>()
 
     // because this might be an array of array of primitives (to any recursive depth) and
     // because we care that the lowest type is unboxed we can't rely on the inbuilt type

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -21,10 +21,10 @@ import net.corda.internal.serialization.amqp.AMQPNotSerializableException
 import net.corda.serialization.SerializationContext
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
+import java.lang.IllegalArgumentException
 import java.lang.reflect.Type
 
 /**
@@ -138,18 +138,18 @@ abstract class PrimArraySerializer(type: Type, factory: LocalSerializerFactory) 
     companion object {
         // We don't need to handle the unboxed byte type as that is coercible to a byte array, but
         // the other 7 primitive types we do
-        private val primTypes: Map<Type, (LocalSerializerFactory) -> PrimArraySerializer> = mapOf(
-                IntArray::class.java to { f -> PrimIntArraySerializer(f) },
-                CharArray::class.java to { f -> PrimCharArraySerializer(f) },
-                BooleanArray::class.java to { f -> PrimBooleanArraySerializer(f) },
-                FloatArray::class.java to { f -> PrimFloatArraySerializer(f) },
-                ShortArray::class.java to { f -> PrimShortArraySerializer(f) },
-                DoubleArray::class.java to { f -> PrimDoubleArraySerializer(f) },
-                LongArray::class.java to { f -> PrimLongArraySerializer(f) }
+        fun make(type: Type, factory: LocalSerializerFactory) =
+            when(type) {
+                IntArray::class.java -> PrimIntArraySerializer(factory)
+                CharArray::class.java -> PrimCharArraySerializer(factory)
+                BooleanArray::class.java -> PrimBooleanArraySerializer(factory)
+                FloatArray::class.java -> PrimFloatArraySerializer(factory)
+                ShortArray::class.java -> PrimShortArraySerializer(factory)
+                DoubleArray::class.java -> PrimDoubleArraySerializer(factory)
+                LongArray::class.java -> PrimLongArraySerializer(factory)
                 // ByteArray::class.java <-> NOT NEEDED HERE (see comment above)
-        )
-
-        fun make(type: Type, factory: LocalSerializerFactory) = primTypes[type]!!(factory)
+                else -> throw IllegalArgumentException("Type $type is not a primitive array type")
+            }
     }
 
     fun localWriteObject(data: Data, func: () -> Unit) {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -148,7 +148,7 @@ abstract class PrimArraySerializer(type: Type, factory: LocalSerializerFactory) 
                 DoubleArray::class.java -> PrimDoubleArraySerializer(factory)
                 LongArray::class.java -> PrimLongArraySerializer(factory)
                 // ByteArray::class.java <-> NOT NEEDED HERE (see comment above)
-                else -> throw IllegalArgumentException("Type $type is not a primitive array type")
+                else -> throw IllegalArgumentException("Type $type is not a supported primitive array type")
             }
     }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
@@ -42,17 +42,19 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
 
     companion object {
         // NB: Order matters in this map, the most specific classes should be listed at the end
-        private val supportedTypes: Map<Class<out Collection<*>>, (List<*>) -> Collection<*>> = Collections.unmodifiableMap(
-            linkedMapOf(
-                Collection::class.java to Collections::unmodifiableCollection,
-                List::class.java to Collections::unmodifiableList,
-                Set::class.java to { list -> Collections.unmodifiableSet(LinkedHashSet(list)) },
-                SortedSet::class.java to { list -> Collections.unmodifiableSortedSet(TreeSet(list)) },
-                NavigableSet::class.java to { list -> Collections.unmodifiableNavigableSet(TreeSet(list)) }
+        private val supportedTypes: Map<Class<out Collection<*>>, (List<*>) -> Collection<*>>
+            get() = Collections.unmodifiableMap(
+                linkedMapOf(
+                    Collection::class.java to Collections::unmodifiableCollection,
+                    List::class.java to Collections::unmodifiableList,
+                    Set::class.java to { list -> Collections.unmodifiableSet(LinkedHashSet(list)) },
+                    SortedSet::class.java to { list -> Collections.unmodifiableSortedSet(TreeSet(list)) },
+                    NavigableSet::class.java to { list -> Collections.unmodifiableNavigableSet(TreeSet(list)) }
+                )
             )
-        )
 
-        private val supportedTypeIdentifiers = supportedTypes.keys.mapTo(LinkedHashSet(), TypeIdentifier::forClass)
+        private val supportedTypeIdentifiers
+            get() = supportedTypes.keys.mapTo(LinkedHashSet(), TypeIdentifier::forClass)
 
         /**
          * Replace erased collection types with parameterised types with wildcard type parameters, so that they are represented

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
@@ -43,14 +43,12 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
     companion object {
         // NB: Order matters in this map, the most specific classes should be listed at the end
         private val supportedTypes: Map<Class<out Collection<*>>, (List<*>) -> Collection<*>>
-            get() = Collections.unmodifiableMap(
-                linkedMapOf(
-                    Collection::class.java to Collections::unmodifiableCollection,
-                    List::class.java to Collections::unmodifiableList,
-                    Set::class.java to { list -> Collections.unmodifiableSet(LinkedHashSet(list)) },
-                    SortedSet::class.java to { list -> Collections.unmodifiableSortedSet(TreeSet(list)) },
-                    NavigableSet::class.java to { list -> Collections.unmodifiableNavigableSet(TreeSet(list)) }
-                )
+            get() = linkedMapOf(
+                Collection::class.java to Collections::unmodifiableCollection,
+                List::class.java to Collections::unmodifiableList,
+                Set::class.java to { list -> Collections.unmodifiableSet(LinkedHashSet(list)) },
+                SortedSet::class.java to { list -> Collections.unmodifiableSortedSet(TreeSet(list)) },
+                NavigableSet::class.java to { list -> Collections.unmodifiableNavigableSet(TreeSet(list)) }
             )
 
         private val supportedTypeIdentifiers

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
@@ -51,7 +51,7 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
                 NavigableSet::class.java to { list -> Collections.unmodifiableNavigableSet(TreeSet(list)) }
             )
 
-        private val supportedTypeIdentifiers
+        private val supportedTypeIdentifiers: Set<TypeIdentifier>
             get() = supportedTypes.keys.mapTo(LinkedHashSet(), TypeIdentifier::forClass)
 
         /**

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
@@ -24,13 +24,13 @@ import java.lang.reflect.ParameterizedType
  * Index into the types list of the parent type of the serializer object, should be the
  * type that this object proxies for
  */
-private val CORDAPP_TYPE get() = 0
+private const val CORDAPP_TYPE = 0
 
 /**
  * Index into the types list of the parent type of the serializer object, should be the
  * type of the proxy object that we're using to represent the object we're proxying for
  */
-private val PROXY_TYPE get() = 1
+private const val PROXY_TYPE = 1
 
 /**
  * Wrapper class for user provided serializers

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
@@ -24,13 +24,13 @@ import java.lang.reflect.ParameterizedType
  * Index into the types list of the parent type of the serializer object, should be the
  * type that this object proxies for
  */
-private const val CORDAPP_TYPE = 0
+private val CORDAPP_TYPE get() = 0
 
 /**
  * Index into the types list of the parent type of the serializer object, should be the
  * type of the proxy object that we're using to represent the object we're proxying for
  */
-private const val PROXY_TYPE = 1
+private val PROXY_TYPE get() = 1
 
 /**
  * Wrapper class for user provided serializers

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/MapSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/MapSerializer.kt
@@ -46,7 +46,8 @@ class MapSerializer(private val declaredType: ParameterizedType, factory: LocalS
 
     companion object {
         // NB: Order matters in this map, the most specific classes should be listed at the end
-        private val supportedTypes: Map<Class<out Map<*, *>>, MapCreationFunction> = Collections.unmodifiableMap(linkedMapOf(
+        private val supportedTypes: Map<Class<out Map<*, *>>, MapCreationFunction>
+            get() = linkedMapOf(
                 // Interfaces
                 Map::class.java to { map -> Collections.unmodifiableMap(map) },
                 SortedMap::class.java to { map -> Collections.unmodifiableSortedMap(TreeMap(map)) },
@@ -54,13 +55,11 @@ class MapSerializer(private val declaredType: ParameterizedType, factory: LocalS
                 // concrete classes for user convenience
                 LinkedHashMap::class.java to { map -> LinkedHashMap(map) },
                 TreeMap::class.java to { map -> TreeMap(map) },
-                EnumMap::class.java to { map ->
-                    EnumMap(uncheckedCast<Map<*, *>, Map<EnumJustUsedForCasting, Any>>(map))
-                }
-        ))
+                EnumMap::class.java to { map -> EnumMap(uncheckedCast<Map<*, *>, Map<EnumJustUsedForCasting, Any>>(map)) }
+            )
 
-        private val supportedTypeIdentifiers = supportedTypes.keys.asSequence()
-                .map { TypeIdentifier.forGenericType(it) }.toSet()
+        private val supportedTypeIdentifiers
+            get() = supportedTypes.keys.asSequence().map { TypeIdentifier.forGenericType(it) }.toSet()
 
         private fun findConcreteType(clazz: Class<*>): MapCreationFunction {
             return supportedTypes[clazz] ?: throw AMQPNotSerializableException(clazz, "Unsupported map type $clazz.")

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/EnumTransforms.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/EnumTransforms.kt
@@ -49,7 +49,7 @@ data class EnumTransforms(
             return EnumTransforms(defaults, renames, source).validate(constants)
         }
 
-        val empty = EnumTransforms(emptyMap(), emptyMap(), TransformsMap(TransformTypes::class.java))
+        val empty get() = EnumTransforms(emptyMap(), emptyMap(), TransformsMap(TransformTypes::class.java))
     }
 
     private fun validate(constants: Map<String, Int>): EnumTransforms {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/RemoteTypeInformation.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/RemoteTypeInformation.kt
@@ -66,16 +66,16 @@ sealed class RemoteTypeInformation {
      * The [RemoteTypeInformation] corresponding to an unbounded wildcard ([TypeIdentifier.UnknownType])
      */
     object Unknown : RemoteTypeInformation() {
-        override val typeDescriptor = "?"
-        override val typeIdentifier = TypeIdentifier.UnknownType
+        override val typeDescriptor get() = "?"
+        override val typeIdentifier get() = TypeIdentifier.UnknownType
     }
 
     /**
      * The [RemoteTypeInformation] corresponding to [java.lang.Object] / [Any] ([TypeIdentifier.TopType])
      */
     object Top : RemoteTypeInformation() {
-        override val typeDescriptor = "*"
-        override val typeIdentifier = TypeIdentifier.TopType
+        override val typeDescriptor get() = "*"
+        override val typeIdentifier get() = TypeIdentifier.TopType
     }
 
     /**

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/RemoteTypeInformation.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/RemoteTypeInformation.kt
@@ -66,7 +66,7 @@ sealed class RemoteTypeInformation {
      * The [RemoteTypeInformation] corresponding to an unbounded wildcard ([TypeIdentifier.UnknownType])
      */
     object Unknown : RemoteTypeInformation() {
-        override val typeDescriptor get() = "?"
+        override val typeDescriptor = "?"
         override val typeIdentifier get() = TypeIdentifier.UnknownType
     }
 
@@ -74,7 +74,7 @@ sealed class RemoteTypeInformation {
      * The [RemoteTypeInformation] corresponding to [java.lang.Object] / [Any] ([TypeIdentifier.TopType])
      */
     object Top : RemoteTypeInformation() {
-        override val typeDescriptor get() = "*"
+        override val typeDescriptor = "*"
         override val typeIdentifier get() = TypeIdentifier.TopType
     }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeIdentifier.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeIdentifier.kt
@@ -153,17 +153,19 @@ sealed class TypeIdentifier {
     data class Unparameterised(override val name: String) : TypeIdentifier() {
 
         companion object {
-            private val primitives = listOf(
+            private val primitives
+                get() = listOf(
                     Byte::class,
-                    Boolean:: class,
+                    Boolean::class,
                     Char::class,
                     Int::class,
                     Short::class,
                     Long::class,
                     Float::class,
-                    Double::class).associate {
-                it.javaPrimitiveType!!.name to it.javaPrimitiveType
-            }
+                    Double::class
+                ).associate {
+                    it.javaPrimitiveType!!.name to it.javaPrimitiveType
+                }
         }
         val isPrimitive get() = name in primitives
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
@@ -59,12 +59,12 @@ class TypeModellingFingerPrinter(
 internal class FingerprintWriter(debugEnabled: Boolean = false) {
 
     companion object {
-        private val ARRAY_HASH get() = "Array = true"
-        private val ENUM_HASH get() = "Enum = true"
-        private val ALREADY_SEEN_HASH get() = "Already seen = true"
-        private val NULLABLE_HASH get() = "Nullable = true"
-        private val NOT_NULLABLE_HASH get() = "Nullable = false"
-        private val ANY_TYPE_HASH get() = "Any type = true"
+        private const val ARRAY_HASH: String = "Array = true"
+        private const val ENUM_HASH: String = "Enum = true"
+        private const val ALREADY_SEEN_HASH: String = "Already seen = true"
+        private const val NULLABLE_HASH: String = "Nullable = true"
+        private const val NOT_NULLABLE_HASH: String = "Nullable = false"
+        private const val ANY_TYPE_HASH: String = "Any type = true"
 
         private val logger = contextLogger()
     }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
@@ -59,12 +59,12 @@ class TypeModellingFingerPrinter(
 internal class FingerprintWriter(debugEnabled: Boolean = false) {
 
     companion object {
-        private const val ARRAY_HASH: String = "Array = true"
-        private const val ENUM_HASH: String = "Enum = true"
-        private const val ALREADY_SEEN_HASH: String = "Already seen = true"
-        private const val NULLABLE_HASH: String = "Nullable = true"
-        private const val NOT_NULLABLE_HASH: String = "Nullable = false"
-        private const val ANY_TYPE_HASH: String = "Any type = true"
+        private val ARRAY_HASH get() = "Array = true"
+        private val ENUM_HASH get() = "Enum = true"
+        private val ALREADY_SEEN_HASH get() = "Already seen = true"
+        private val NULLABLE_HASH get() = "Nullable = true"
+        private val NOT_NULLABLE_HASH get() = "Nullable = false"
+        private val ANY_TYPE_HASH get() = "Any type = true"
 
         private val logger = contextLogger()
     }
@@ -104,7 +104,7 @@ private class FingerPrintingState(
         private val writer: FingerprintWriter) {
 
     companion object {
-        private var CHARACTER_TYPE = LocalTypeInformation.Atomic(
+        private val CHARACTER_TYPE get() = LocalTypeInformation.Atomic(
                 Character::class.java,
                 TypeIdentifier.forClass(Character::class.java))
     }

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
@@ -193,15 +193,15 @@ public class JavaSerializationOutputTests {
         DecoderImpl decoder = new DecoderImpl();
 
         decoder.register(Envelope.getDESCRIPTOR(), Envelope.Companion);
-        decoder.register(Schema.DESCRIPTOR, Schema.Companion);
-        decoder.register(Descriptor.DESCRIPTOR, Descriptor.Companion);
-        decoder.register(Field.DESCRIPTOR, Field.Companion);
-        decoder.register(CompositeType.DESCRIPTOR, CompositeType.Companion);
-        decoder.register(Choice.DESCRIPTOR, Choice.Companion);
-        decoder.register(RestrictedType.DESCRIPTOR, RestrictedType.Companion);
+        decoder.register(Schema.getDESCRIPTOR(), Schema.Companion);
+        decoder.register(Descriptor.getDESCRIPTOR(), Descriptor.Companion);
+        decoder.register(Field.getDESCRIPTOR(), Field.Companion);
+        decoder.register(CompositeType.getDESCRIPTOR(), CompositeType.Companion);
+        decoder.register(Choice.getDESCRIPTOR(), Choice.Companion);
+        decoder.register(RestrictedType.getDESCRIPTOR(), RestrictedType.Companion);
         decoder.register(Transform.DESCRIPTOR, Transform.Companion);
         decoder.register(TransformsSchema.DESCRIPTOR, TransformsSchema.Companion);
-        decoder.register(Metadata.DESCRIPTOR, Metadata.Companion);
+        decoder.register(Metadata.getDESCRIPTOR(), Metadata.Companion);
 
         new EncoderImpl(decoder);
         decoder.setByteBuffer(ByteBuffer.wrap(bytes.getBytes(), 8, bytes.getSize() - 8));

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
@@ -192,7 +192,7 @@ public class JavaSerializationOutputTests {
 
         DecoderImpl decoder = new DecoderImpl();
 
-        decoder.register(Envelope.DESCRIPTOR, Envelope.Companion);
+        decoder.register(Envelope.getDESCRIPTOR(), Envelope.Companion);
         decoder.register(Schema.DESCRIPTOR, Schema.Companion);
         decoder.register(Descriptor.DESCRIPTOR, Descriptor.Companion);
         decoder.register(Field.DESCRIPTOR, Field.Companion);

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
@@ -199,8 +199,8 @@ public class JavaSerializationOutputTests {
         decoder.register(CompositeType.getDESCRIPTOR(), CompositeType.Companion);
         decoder.register(Choice.getDESCRIPTOR(), Choice.Companion);
         decoder.register(RestrictedType.getDESCRIPTOR(), RestrictedType.Companion);
-        decoder.register(Transform.DESCRIPTOR, Transform.Companion);
-        decoder.register(TransformsSchema.DESCRIPTOR, TransformsSchema.Companion);
+        decoder.register(Transform.getDESCRIPTOR(), Transform.Companion);
+        decoder.register(TransformsSchema.getDESCRIPTOR(), TransformsSchema.Companion);
         decoder.register(Metadata.getDESCRIPTOR(), Metadata.Companion);
 
         new EncoderImpl(decoder);

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/testutils/AMQPTestUtils.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/testutils/AMQPTestUtils.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 public class AMQPTestUtils {
 
     public static SerializerFactory testDefaultFactory() {
-        return SerializerFactoryBuilder.build(
+        return new SerializerFactoryBuilder().build(
                 (SandboxGroup) Objects.requireNonNull(TestSerializationContext.testSerializationContext.getSandboxGroup()));
     }
 }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/InternalAccessTestHelpers.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/InternalAccessTestHelpers.kt
@@ -10,7 +10,7 @@ import java.lang.reflect.Type
  * A set of functions in serialization:test that allows testing of serialization internal classes in the serialization-tests project.
  */
 
-const val MAX_TYPE_PARAM_DEPTH = AMQPTypeIdentifierParser.MAX_TYPE_PARAM_DEPTH
+val MAX_TYPE_PARAM_DEPTH = AMQPTypeIdentifierParser.MAX_TYPE_PARAM_DEPTH
 
 fun Class<out Any?>.accessPropertyDescriptors(validateProperties: Boolean = true):
     Map<String, PropertyDescriptor> = propertyDescriptors(validateProperties)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/InternalAccessTestHelpers.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/InternalAccessTestHelpers.kt
@@ -10,7 +10,7 @@ import java.lang.reflect.Type
  * A set of functions in serialization:test that allows testing of serialization internal classes in the serialization-tests project.
  */
 
-val MAX_TYPE_PARAM_DEPTH = AMQPTypeIdentifierParser.MAX_TYPE_PARAM_DEPTH
+const val MAX_TYPE_PARAM_DEPTH = AMQPTypeIdentifierParser.MAX_TYPE_PARAM_DEPTH
 
 fun Class<out Any?>.accessPropertyDescriptors(validateProperties: Boolean = true):
     Map<String, PropertyDescriptor> = propertyDescriptors(validateProperties)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/CorDappSerializerTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/CorDappSerializerTests.kt
@@ -18,11 +18,14 @@ import kotlin.test.assertEquals
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 class CorDappSerializerTests {
+
+    val serializerFactoryBuilder = SerializerFactoryBuilder()
+
     data class NeedsProxy(val a: String)
 
     private fun proxyFactory(
             serializers: List<SerializationCustomSerializer<*, *>>
-    ) = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()).apply {
+    ) = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()).apply {
         serializers.forEach {
             registerExternal(it, this)
         }
@@ -97,7 +100,7 @@ class CorDappSerializerTests {
 	fun testWithWhitelistNotAllowed() {
         data class A(val a: Int, val b: NeedsProxy)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.registerExternal(NeedsProxyProxySerializer(), factory)
 
         val tv1 = 100

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTests.kt
@@ -220,7 +220,7 @@ class EnumTests {
     fun enumNotWhitelistedFails() {
         data class C(val c: Bras)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder().build(testSerializationContext.currentSandboxGroup())
 
         Assertions.assertThatThrownBy {
             TestSerializationOutput(VERBOSE, factory).serialize(C(Bras.UNDERWIRE))
@@ -231,7 +231,7 @@ class EnumTests {
     fun enumAnnotated() {
         @CordaSerializable data class C(val c: AnnotatedBras)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder().build(testSerializationContext.currentSandboxGroup())
 
         // if it all works, this won't explode
         TestSerializationOutput(VERBOSE, factory).serialize(C(AnnotatedBras.UNDERWIRE))
@@ -240,10 +240,10 @@ class EnumTests {
     @Test
     fun deserializeCustomisedEnum() {
         val input = CustomEnumWrapper(CustomEnum.ONE)
-        val factory1 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory1 = SerializerFactoryBuilder().build(testSerializationContext.currentSandboxGroup())
         val serialized = TestSerializationOutput(VERBOSE, factory1).serialize(input)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder().build(testSerializationContext.currentSandboxGroup())
         val output = DeserializationInput(factory2).deserialize(serialized)
 
         assertEquals(input, output)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactoryTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactoryTests.kt
@@ -16,13 +16,15 @@ import kotlin.test.assertTrue
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 class EvolutionSerializerFactoryTests {
 
-    private val nonStrictFactory = SerializerFactoryBuilder.build(
+    private val serializerFactoryBuilder = SerializerFactoryBuilder()
+
+    private val nonStrictFactory = serializerFactoryBuilder.build(
             testSerializationContext.currentSandboxGroup(),
             descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry(),
             mustPreserveDataWhenEvolving = false
     )
 
-    private val strictFactory = SerializerFactoryBuilder.build(
+    private val strictFactory = serializerFactoryBuilder.build(
             testSerializationContext.currentSandboxGroup(),
             descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry(),
             mustPreserveDataWhenEvolving = true

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/FingerPrinterTesting.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/FingerPrinterTesting.kt
@@ -50,7 +50,7 @@ class FingerPrinterTestingTests {
         @CordaSerializable
         data class C(val a: Int, val b: Long)
 
-        val factory = SerializerFactoryBuilder.build(
+        val factory = SerializerFactoryBuilder().build(
                 testSerializationContext.currentSandboxGroup(),
                 overrideFingerPrinter = FingerPrinterTesting())
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/GenericsTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/GenericsTests.kt
@@ -69,6 +69,8 @@ class GenericsTests {
         )
     }
 
+    val serializerFactoryBuilder = SerializerFactoryBuilder()
+
     private fun printSeparator() = if (VERBOSE) println("\n\n-------------------------------------------\n\n") else Unit
 
     private fun <T : Any> BytesAndSchemas<T>.printSchema() = if (VERBOSE) println("${this.schema}\n") else Unit
@@ -145,8 +147,8 @@ class GenericsTests {
         @CordaSerializable
         data class Wrapper<T : Any>(val a: Int, val b: SerializedBytes<T>)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val ser = SerializationOutput(factory)
 
         val gBytes = ser.serialize(G(1))
@@ -176,8 +178,8 @@ class GenericsTests {
         @CordaSerializable
         data class Wrapper<T : Any>(val c: Container<T>)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factories = listOf(factory, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factories = listOf(factory, serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
         val ser = SerializationOutput(factory)
 
         ser.serialize(Wrapper(Container(InnerA(1)))).apply {
@@ -209,8 +211,8 @@ class GenericsTests {
         data class Wrapper<T : Any>(val c: Container<T>)
 
         val factorys = listOf(
-            SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()),
-            SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+            serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()),
+            serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         )
 
         val ser = SerializationOutput(factorys[0])
@@ -233,7 +235,7 @@ class GenericsTests {
 
     private fun forceWildcardSerialize(
         a: ForceWildcard<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
     ): SerializedBytes<*> {
         val bytes = SerializationOutput(factory).serializeAndReturnSchema(a)
         bytes.printSchema()
@@ -243,7 +245,7 @@ class GenericsTests {
     @Suppress("UNCHECKED_CAST")
     private fun forceWildcardDeserializeString(
         bytes: SerializedBytes<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
     ) {
         DeserializationInput(factory).deserialize(bytes as SerializedBytes<ForceWildcard<String>>)
     }
@@ -251,7 +253,7 @@ class GenericsTests {
     @Suppress("UNCHECKED_CAST")
     private fun forceWildcardDeserializeDouble(
         bytes: SerializedBytes<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
     ) {
         DeserializationInput(factory).deserialize(bytes as SerializedBytes<ForceWildcard<Double>>)
     }
@@ -259,7 +261,7 @@ class GenericsTests {
     @Suppress("UNCHECKED_CAST")
     private fun forceWildcardDeserialize(
         bytes: SerializedBytes<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
     ) {
         DeserializationInput(factory).deserialize(bytes as SerializedBytes<ForceWildcard<*>>)
     }
@@ -272,7 +274,7 @@ class GenericsTests {
 
     @Test
     fun forceWildcardSharedFactory() {
-        val f = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val f = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         forceWildcardDeserializeString(forceWildcardSerialize(ForceWildcard("hello"), f), f)
         forceWildcardDeserializeDouble(forceWildcardSerialize(ForceWildcard(3.0), f), f)
     }
@@ -286,7 +288,7 @@ class GenericsTests {
 
     @Test
     fun forceWildcardDeserializeSharedFactory() {
-        val f = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val f = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         forceWildcardDeserialize(forceWildcardSerialize(ForceWildcard("hello"), f), f)
         forceWildcardDeserialize(forceWildcardSerialize(ForceWildcard(10), f), f)
         forceWildcardDeserialize(forceWildcardSerialize(ForceWildcard(20.0), f), f)
@@ -330,14 +332,14 @@ class GenericsTests {
         // attempt at having a class loader without some of the derived non core types loaded and thus
         // possibly altering how we serialise things
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val ser2 = TestSerializationOutput(VERBOSE, factory2).serializeAndReturnSchema(state)
 
         //  now deserialise those objects
         val factory3 = testDefaultFactory()
         DeserializationInput(factory3).deserializeAndReturnEnvelope(ser1.obj)
 
-        val factory4 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory4 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         DeserializationInput(factory4).deserializeAndReturnEnvelope(ser2.obj)
     }
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/OptionalSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/OptionalSerializationTests.kt
@@ -17,7 +17,7 @@ class OptionalSerializationTests {
     @Test
     fun setupEnclosedSerializationTest() {
         fun `java optionals should serialize`() {
-            val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+            val factory = SerializerFactoryBuilder().build(testSerializationContext.currentSandboxGroup())
             factory.register(OptionalSerializer(), factory)
             val obj = Optional.ofNullable("YES")
             val bytes = TestSerializationOutput(true, factory).serialize(obj)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -226,6 +226,8 @@ class SerializationOutputTests {
         }
     }
 
+    private val serializerFactoryBuilder = SerializerFactoryBuilder()
+
     private val encodingWhitelist = SnappyEncodingWhitelist
 
     @SuppressWarnings("LongParameterList")
@@ -390,7 +392,7 @@ class SerializationOutputTests {
     @Test
     fun `test annotation whitelisting`() {
         val obj = AnnotatedWoo(5)
-        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        serdes(obj, serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
     }
 
     @Test
@@ -489,7 +491,7 @@ class SerializationOutputTests {
 
     @Test
     fun `class constructor is invoked on deserialisation`() {
-        val serializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val serializerFactory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val ser = SerializationOutput(serializerFactory)
         val des = DeserializationInput(serializerFactory)
         val serialisedOne = ser.serialize(NonZeroByte(1)).bytes
@@ -517,22 +519,22 @@ class SerializationOutputTests {
     @Test
     fun `test annotation is inherited`() {
         val obj = InheritAnnotation("blah")
-        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        serdes(obj, serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
     }
 
     @Test
     fun `generics from java are supported`() {
         val obj = DummyOptional("YES")
-        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        serdes(obj, serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
     }
 
     @Test
     fun `test throwables serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory2)
 
@@ -544,11 +546,11 @@ class SerializationOutputTests {
 
     @Test
     fun `test complex throwables serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory2)
 
@@ -574,11 +576,11 @@ class SerializationOutputTests {
 
     @Test
     fun `test suppressed throwables serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory)
 
@@ -598,11 +600,11 @@ class SerializationOutputTests {
 
     @Test
     fun `test flow corda exception subclasses serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory2)
 
@@ -705,8 +707,8 @@ class SerializationOutputTests {
         val b = ByteArray(2)
         val obj = Bob(listOf(a, b, a))
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val obj2 = serdes(obj, factory, factory2, expectedEqual = false, expectDeserializedEqual = false)
 
         assertNotSame(obj2.byteArrays[0], obj2.byteArrays[2])
@@ -720,8 +722,8 @@ class SerializationOutputTests {
         val a = listOf("a", "b")
         val obj = Vic(a, a)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val objCopy = serdes(obj, factory, factory2)
         assertSame(objCopy.a, objCopy.b)
     }
@@ -737,8 +739,8 @@ class SerializationOutputTests {
     fun `test private constructor`() {
         val obj = Spike()
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         assertThrows<NotSerializableException> { serdes(obj, factory, factory2) }
     }
 
@@ -747,10 +749,10 @@ class SerializationOutputTests {
 
     @Test
     fun `test toString custom serializer`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.register(BigDecimalSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory2.register(BigDecimalSerializer(), factory2)
 
         val obj = BigDecimals(BigDecimal.TEN, BigDecimal.TEN)
@@ -763,10 +765,10 @@ class SerializationOutputTests {
 
     @Test
     fun `test byte arrays not reference counted`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.register(BigDecimalSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory2.register(BigDecimalSerializer(), factory2)
 
         val bytes = ByteArray(1)
@@ -791,10 +793,10 @@ class SerializationOutputTests {
 
     @Test
     fun `test InputStream serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory.register(InputStreamSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         factory2.register(InputStreamSerializer(), factory2)
         val bytes = ByteArray(10) { it.toByte() }
         val obj = bytes.inputStream()
@@ -1004,7 +1006,7 @@ class SerializationOutputTests {
 
     @Test
     fun `compression reduces number of bytes significantly`() {
-        val ser = SerializationOutput(SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        val ser = SerializationOutput(serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
         val obj = ByteArray(20000)
         val uncompressedSize = ser.serialize(obj).bytes.size
         val compressedSize = ser.serialize(obj, CordaSerializationEncoding.SNAPPY).bytes.size

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/StaticInitialisationOfSerializedObjectTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/StaticInitialisationOfSerializedObjectTest.kt
@@ -40,6 +40,9 @@ class C2(var b: Int) {
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 class StaticInitialisationOfSerializedObjectTest {
+
+    val serializerFactoryBuilder = SerializerFactoryBuilder()
+
     @Test
     fun itBlowsUp() {
         assertThrows<ExceptionInInitializerError> { C() }
@@ -50,7 +53,7 @@ class StaticInitialisationOfSerializedObjectTest {
 	fun kotlinObjectWithCompanionObject() {
         data class D(val c: C)
 
-        val sf = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val sf = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
 
         val typeMap = sf::class.java.getDeclaredField("serializersByType")
         typeMap.isAccessible = true
@@ -79,11 +82,11 @@ class StaticInitialisationOfSerializedObjectTest {
 
         // Original version of the class for the serialised version of this class
         //
-//        val sf1 = SerializerFactoryBuilder.build(ClassLoader.getSystemClassLoader())
+//        val sf1 = serializerFactoryBuilder.build(ClassLoader.getSystemClassLoader())
 //        val sc = SerializationOutput(sf1).serialize(D(C2(20)))
 //        File(URI("$localPath/$resource")).writeBytes(sc.bytes)
 
-        val sf2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val sf2 = serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val bytes = url.readBytes()
 
         assertThatThrownBy {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/testutils/AMQPTestUtils.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/testutils/AMQPTestUtils.kt
@@ -46,17 +46,17 @@ class TestDescriptorBasedSerializerRegistry : DescriptorBasedSerializerRegistry 
 
 @JvmOverloads
 fun testDefaultFactory(
-    descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry =
-        DefaultDescriptorBasedSerializerRegistry()
+    descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry(),
+    serializerFactoryBuilder: SerializerFactoryBuilder = SerializerFactoryBuilder()
 ) =
-    SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup(), descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry)
+    serializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup(), descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry)
 
 @JvmOverloads
 fun testDefaultFactoryNoEvolution(
-    descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry =
-        DefaultDescriptorBasedSerializerRegistry()
+    descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry(),
+    serializerFactoryBuilder: SerializerFactoryBuilder = SerializerFactoryBuilder()
 ): SerializerFactory =
-    SerializerFactoryBuilder.build(
+    serializerFactoryBuilder.build(
         testSerializationContext.currentSandboxGroup(),
         descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry,
         allowEvolution = false


### PR DESCRIPTION
Removes singletons or state from existing `object`s/ `companion object`s that could be leaked between different `CPK`s (multi-tenancy), all sharing the same statics in case of `serialization-amqp` module since, as a Corda platform module, it is going to be loaded into a single `Bundle` per JVM.

- Converted `object`s into `class`es.
- Removed static states from the remaining `object`s/ `companion object`s. 

Please note that because static fields have now been converted into static functions, these ex static fields are now being recalculated every time accessed which makes things more expensive now. Maybe some of those could be made `class`es to be shared across their usages in order to save some recalculations. However, this pollutes APIs as extra parameters for those needs to be added. 