### PR TITLE
CORE-2885 Remove `classInfoService` from `SerializationContext`

### DIFF
--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -56,9 +56,6 @@ class AMQPwithOSGiSerializationTests {
         lateinit var installService: InstallService
 
         @InjectService
-        lateinit var sandboxContextService: SandboxContextService
-
-        @InjectService
         lateinit var sandboxCreationService: SandboxCreationService
 
         private val cordappVersion = System.getProperty("test.cordapp.version") ?: fail("Version number missing")
@@ -159,7 +156,6 @@ class AMQPwithOSGiSerializationTests {
                 objectReferencesEnabled = false,
                 useCase = SerializationContext.UseCase.Testing,
                 encoding = null,
-                classInfoService = sandboxContextService,
                 sandboxGroup = sandboxGroup
             )
 
@@ -229,7 +225,6 @@ class AMQPwithOSGiSerializationTests {
             objectReferencesEnabled = false,
             useCase = SerializationContext.UseCase.Testing,
             encoding = null,
-            classInfoService = sandboxContextService,
             sandboxGroup = sandboxGroup
         )
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationScheme.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationScheme.kt
@@ -38,12 +38,9 @@ data class SerializationContextImpl @JvmOverloads constructor(
     override val encodingWhitelist: EncodingWhitelist = SnappyEncodingWhitelist,
     override val preventDataLoss: Boolean = false,
     override val customSerializers: Set<SerializationCustomSerializer<*, *>>? = null,
-    // TODO this needs chaning in corda-api repo
-    override val classInfoService: Any? = null,
     override val sandboxGroup: Any? = null
 ) : SerializationContext {
 
-    override fun withClassInfoService(classInfoService: Any): SerializationContext = copy(classInfoService = classInfoService)
     override fun withClassLoader(classLoader: ClassLoader): SerializationContext {
         TODO("Not yet implemented")
     }

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/SerializationAPIJavaApiTest.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/SerializationAPIJavaApiTest.java
@@ -153,30 +153,12 @@ public class SerializationAPIJavaApiTest {
         }
 
         @Test
-        public void getClassInfoService() {
-            when(serializationContext.getClassInfoService()).thenReturn(proxy);
-            var result = serializationContext.getClassInfoService();
-
-            assertThat(result).isNotNull();
-            assertThat(result).isEqualTo(proxy);
-        }
-
-        @Test
         public void getSandboxGroup() {
             when(serializationContext.getSandboxGroup()).thenReturn(obj);
             var result = serializationContext.getSandboxGroup();
 
             assertThat(result).isNotNull();
             assertThat(result).isEqualTo(obj);
-        }
-
-        @Test
-        public void withClassInfoService() {
-            when(serializationContext.withClassInfoService(obj)).thenReturn(serializationContext);
-            var result = serializationContext.withClassInfoService(obj);
-
-            assertThat(result).isNotNull();
-            assertThat(result).isEqualTo(serializationContext);
         }
 
         @Test

--- a/libs/serialization/serialization-internal/src/main/kotlin/net/corda/serialization/SerializationContext.kt
+++ b/libs/serialization/serialization-internal/src/main/kotlin/net/corda/serialization/SerializationContext.kt
@@ -10,28 +10,34 @@ interface SerializationContext {
      * When serializing, use the format this header sequence represents.
      */
     val preferredSerializationVersion: SerializationMagic
+
     /**
      * If non-null, apply this encoding (typically compression) when serializing.
      */
     val encoding: SerializationEncoding?
+
     /**
      * A whitelist that contains (mostly for security purposes) which classes can be serialized and deserialized.
      */
     val whitelist: ClassWhitelist
+
     /**
      * A whitelist that determines (mostly for security purposes)
      * whether a particular encoding may be used when deserializing.
      */
     val encodingWhitelist: EncodingWhitelist
+
     /**
      * A map of any addition properties specific to the particular use case.
      */
     val properties: Map<Any, Any>
+
     /**
      * Duplicate references to the same object preserved in the wire format and when
      * deserialized when this is true, otherwise they appear as new copies of the object.
      */
     val objectReferencesEnabled: Boolean
+
     /**
      * If true the serialization evolver will fail if the binary to be deserialized
      * contains more fields then the current object from the classpath.
@@ -39,19 +45,18 @@ interface SerializationContext {
      * The default is false.
      */
     val preventDataLoss: Boolean
+
     /**
      * The use case we are serializing or deserializing for.  See [UseCase].
      */
     val useCase: UseCase
+
     /**
      * Custom serializers that will be made available during (de)serialization.
      * If this is null then the default Custom Serializers will be used.
      */
     val customSerializers: Set<SerializationCustomSerializer<*, *>>?
-    /**
-     * Service used to retrieve information about CPKs from the context of the current sandbox.
-     */
-    val classInfoService: Any?
+
     /**
      * The set of CorDapp sandboxes for the node's CPB.
      *
@@ -59,11 +64,6 @@ interface SerializationContext {
      * to support multiple sandbox groups.
      */
     val sandboxGroup: Any?
-
-    /**
-     * Helper method to set the ClassInfoService
-     */
-    fun withClassInfoService(classInfoService: Any): SerializationContext
 
     /**
      * Helper method to set the SandboxGroup


### PR DESCRIPTION
Removes `classInfoService` from `SerializationContext` as it is not being used in AMQP serialization.