### PR TITLE
NOTICK: Upgrade libraries to eliminate critical Nexus violations (#636)

### DIFF
--- a/components/crypto/crypto-service/src/main/kotlin/net/corda/crypto/service/CryptoFactoryImpl.kt
+++ b/components/crypto/crypto-service/src/main/kotlin/net/corda/crypto/service/CryptoFactoryImpl.kt
@@ -2,7 +2,7 @@ package net.corda.crypto.service
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.MapperFeature
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import net.corda.crypto.impl.config.CryptoPersistenceConfig
@@ -119,10 +119,10 @@ class CryptoFactoryImpl @Activate constructor(
         private val freshKeyServices = ConcurrentHashMap<String, FreshKeySigningService>()
         private val signingServices = ConcurrentHashMap<String, SigningService>()
 
-        private val objectMapper = ObjectMapper()
+        private val jsonMapper = JsonMapper.builder().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build()
+        private val objectMapper = jsonMapper
             .registerModule(JavaTimeModule())
-            .registerModule(KotlinModule())
-            .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+            .registerModule(KotlinModule.Builder().build())
             .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ activationVersion = 1.2.0
 ariesDynamicBundleVersion = 1.3.2
 antlrVersion=2.7.7
 asmVersion=9.2
-avroVersion=1.10.1
+avroVersion=1.11.0
 bouncyCastleVersion=1.69
 commonsVersion = 1.7
 caffeineVersion = 3.0.2
@@ -50,7 +50,7 @@ felixSecurityVersion=2.8.0
 guavaVersion=30.1.1-jre
 hibernateVersion = 5.6.2.Final
 hikariCpVersion=5.0.0
-jacksonVersion = 2.12.5
+jacksonVersion = 2.13.1
 jaxbVersion = 2.3.1
 jbossTransactionApiSpecVersion=1.1.1.Final
 kafkaClientVersion=2.8.1_1
@@ -64,7 +64,7 @@ kryoSerializerVersion = 0.43
 # This will need to be swapped out when the patch has been applied to an official release.
 # https://r3-cev.atlassian.net/browse/CORE-2723
 liquibaseVersion = 4.5.0-SNAPSHOT
-log4jVersion = 2.17.0
+log4jVersion = 2.17.1
 nettyVersion = 4.1.68.Final
 osgiCmVersion = 1.6.0
 osgiServiceComponentVersion = 1.4.0
@@ -106,7 +106,7 @@ testContainersVersion=1.15.3
 
 # HTTP RPC dependency versions
 javalinVersion = 3.13.12
-swaggerVersion = 2.1.5
+swaggerVersion = 2.1.12
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.1.3
 nimbusVersion = 9.8

--- a/libs/http-rpc/http-rpc-server-impl/build.gradle
+++ b/libs/http-rpc/http-rpc-server-impl/build.gradle
@@ -31,6 +31,13 @@ dependencies {
     implementation "org.eclipse.jetty.websocket:websocket-server:$jettyVersion"
     implementation "org.eclipse.jetty.http2:http2-server:$jettyVersion"
     implementation "io.swagger.core.v3:swagger-core:$swaggerVersion"
+    // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
+    // Constraints block can be removed when Swagger is upgraded to the next version
+    constraints {
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.13+') {
+            because 'sonatype-2021-4682'
+        }
+    }
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation project(":libs:http-rpc:http-rpc-common")
 

--- a/libs/http-rpc/json-serialization/src/main/kotlin/net/corda/common/json/serialization/JsonSerialization.kt
+++ b/libs/http-rpc/json-serialization/src/main/kotlin/net/corda/common/json/serialization/JsonSerialization.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
@@ -13,14 +14,15 @@ import net.corda.v5.application.utilities.JsonRepresentable
 import net.corda.v5.base.annotations.CordaInternal
 import java.util.TimeZone
 
+private val jsonMapper = JsonMapper.builder().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build()
+
 /**
  * General purpose Jackson Mapper which has sensible security default applied to it.
  */
 @CordaInternal
-fun jacksonObjectMapper() = ObjectMapper().apply {
-    registerModule(KotlinModule())
+fun jacksonObjectMapper(): JsonMapper = jsonMapper.apply {
+    registerModule(KotlinModule.Builder().build())
     registerModule(JavaTimeModule())
-    enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
     enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
     setTimeZone(TimeZone.getTimeZone("UTC"))
     disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/libs/schema-registry/schema-registry-impl/build.gradle
+++ b/libs/schema-registry/schema-registry-impl/build.gradle
@@ -12,11 +12,10 @@ dependencies {
 
     implementation "org.apache.avro:avro:$avroVersion"
     // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
-    // Constains block can be removed when Avro is upgraded to v1.11
-    // For more details, please see: https://issues.apache.org/jira/browse/AVRO-3215
+    // Constraints block can be removed when Avro is upgraded to the next version
     constraints {
-        implementation('org.apache.commons:commons-compress:1.21+') {
-            because 'CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090'
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.13+') {
+            because 'sonatype-2021-4682'
         }
     }
 

--- a/libs/schema-registry/schema-registry/build.gradle
+++ b/libs/schema-registry/schema-registry/build.gradle
@@ -11,11 +11,10 @@ dependencies {
 
     api "org.apache.avro:avro:$avroVersion"
     // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
-    // Constains block can be removed when Avro is upgraded to v1.11
-    // For more details, please see: https://issues.apache.org/jira/browse/AVRO-3215
+    // Constraints block can be removed when Avro is upgraded to the next version
     constraints {
-        implementation('org.apache.commons:commons-compress:1.21+') {
-            because 'CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090'
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.13+') {
+            because 'sonatype-2021-4682'
         }
     }
 }


### PR DESCRIPTION
Porting https://github.com/corda/corda-runtime-os/pull/636 to resolve nexus IQ policy violations.