### PR TITLE
CORE-3346 - Populate instance ID properly for simulator receiver/sink mode

### DIFF
--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
@@ -15,7 +15,6 @@ import net.corda.messaging.api.subscription.factory.config.SubscriptionConfig
 import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.p2p.app.simulator.AppSimulator.Companion.KAFKA_BOOTSTRAP_SERVER_KEY
-import net.corda.p2p.app.simulator.AppSimulator.Companion.PRODUCER_CLIENT_ID
 import net.corda.v5.base.util.contextLogger
 import java.io.Closeable
 import java.time.Duration

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
@@ -12,7 +12,6 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.messaging.api.subscription.factory.config.SubscriptionConfig
 import net.corda.p2p.app.simulator.AppSimulator.Companion.KAFKA_BOOTSTRAP_SERVER_KEY
-import net.corda.p2p.app.simulator.AppSimulator.Companion.PRODUCER_CLIENT_ID
 import net.corda.v5.base.util.contextLogger
 import java.io.Closeable
 import java.sql.Timestamp
@@ -33,7 +32,8 @@ class Sink(private val subscriptionFactory: SubscriptionFactory,
 
     fun start() {
         (1..clients).forEach { client ->
-            val subscriptionConfig = SubscriptionConfig("app-simulator-sink", AppSimulator.DELIVERED_MSG_TOPIC, "$instanceId-$client".hashCode())
+            val subscriptionConfig = SubscriptionConfig("app-simulator-sink",
+                AppSimulator.DELIVERED_MSG_TOPIC, "$instanceId-$client".hashCode())
             val kafkaConfig = SmartConfigImpl.empty()
                 .withValue(KAFKA_BOOTSTRAP_SERVER_KEY, ConfigValueFactory.fromAnyRef(kafkaServers))
             val processor = DBSinkProcessor()


### PR DESCRIPTION
## Changes
The subscriptions used by the simulator in receiver/sink mode the number of clients as an instance ID, which was leading to conflicts. For instance, in a k8s deployment this led to one instance being fenced from the other (`ProducerFencedException`), which was resulting in very high latencies for the initial messages. Eventually that got resolved and the latencies seemed to go down to normal levels. Most likely the reason is some of the subscriptions eventually gave up and stopped due to crossing the threshold of acceptable errors. For, instance in the simulator logs one could see the following (with producer fenced exception in the stacktrace below):
```
simulator-receiver--725473759: 12:58:48.578 [durable processing thread p2p.in-app-simulator-receiver-p2p.in] ERROR p2p.in-app-simulator-receiver.app-simulator-receiver-1 - Failed to read and process records from topic p2p.in, group p2p.in-app-simulator-receiver, producerClientId app-simulator-receiver-1. Attempts: 1. Closing subscription.
simulator-receiver--725473759: net.corda.messaging.api.exception.CordaMessageAPIFatalException: Fatal error occurred aborting transaction for CordaKafkaProducer with clientId app-simulator-receiver-1
```

Some notes:
* I also removed the producer ID, since it's not needed for subscriptions
* For instance IDs, I chose to use the hashcode of the (instance ID, client ID) string concatenation for simplicity. Given the small number of simulators that will be commonly run, collisions are not likely (and the system would still function properly in the unlikely scenario).

## Testing
I re-run [this scenario](https://r3-cev.atlassian.net/wiki/spaces/CCD/pages/3773497530/Happy+path+scenario) in k8s with the fix (tag `5.0.0.0-alpha-1640853260339` produced by CI) and noticed the following changes:
* the first messages were delivered much more quickly compared to the version without the fix (1-4 seconds vs ~60 seconds).
* no errors in the simulator logs anymore
* the results in terms of throughput / latency were comparable to the original run with some small improvements (e.g. latencies were slightly lower and more stable / without very big spikes). The improvements are most likely due
 to the fact that all the simulators were now able to run and none of them was stopping due to being fenced. Test results available [here](https://github.com/corda/corda-runtime-os/files/7792641/detailed_data.xls).