### PR TITLE
NOTICK: add image caching for worker base image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,10 @@ subprojects {
             if (project.hasProperty('isPreTest')) {
                 preTest = isPreTest.toBoolean()
             }
+
+            if (project.hasProperty('baseImage')) {
+                baseImageName = baseImage
+            }
         }
     }
 }

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -94,7 +94,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageName =
-            getObjects().property(String).convention('docker-remotes.software.r3.com/azul/zulu-openjdk-alpine')
+            getObjects().property(String).convention('azul/zulu-openjdk-alpine')
 
     @Input
     final Property<String> baseImageTag =
@@ -132,8 +132,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         Files.copy(Paths.get(overrideFile.getAsFile().get().getPath()), Paths.get(jarLocation), StandardCopyOption.REPLACE_EXISTING)
 
         RegistryImage baseImage = RegistryImage.named("${baseImageName.get()}:${baseImageTag.get()}")
-                .addCredential(registryUsername.get(), registryPassword.get())
 
+        if(baseImageName.get().contains("docker-remotes.software.r3.com")){
+            baseImage.addCredential(registryUsername.get(), registryPassword.get())
+        }
 
         JibContainerBuilder builder = Jib.from(baseImage)
                 .setCreationTime(Instant.now())


### PR DESCRIPTION
Ensure we use JIB cache for base image if it has been pulled before, this should help prevent docker hub rate limits  by setting 
setAlwaysCachebaseImage to true.

add ability to override base image, Update to jenkisn file to follow to pass in using docker-remotes.software.r3 when pulling base image via jenkins so local use will always pull from docker hub

also fix minor logging typo

