### PR TITLE
CORE-2750: Tidy-up around `@RPCSinceVersion`

### DIFF
--- a/libs/http-rpc/http-rpc-client/src/integration-test/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integration-test/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
@@ -295,7 +295,9 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
                 assertEquals(""""Pong for str = value"""", this.ping(TestHealthCheckAPI.PingPongData("value")))
                 assertEquals(listOf(2.0, 3.0, 4.0), this.plusOne(listOf("1", "2", "3")))
                 assertEquals(2L, this.plus(1L))
-                assertThatThrownBy { this.laterAddedCall() }.isInstanceOf(UnsupportedOperationException::class.java)
+                assertThatThrownBy {
+                    this.laterAddedCall()
+                }.isInstanceOf(UnsupportedOperationException::class.java)
             }
         }
     }

--- a/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/connect/HttpRpcClientProxyHandler.kt
+++ b/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/connect/HttpRpcClientProxyHandler.kt
@@ -56,7 +56,8 @@ internal class HttpRpcClientProxyHandler<I : RpcOps>(
             val sinceVersion = method.getAnnotation(RPCSinceVersion::class.java)?.version ?: 0
             if (sinceVersion > serverProtocolVersion) {
                 throw UnsupportedOperationException(
-                    "Method $method was added in RPC protocol version $sinceVersion but the server is running $serverProtocolVersion"
+                    "Method $method was added in RPC protocol version '$sinceVersion' " +
+                            "but the server is running '$serverProtocolVersion'."
                 )
             }
         }

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/RPCSinceVersion.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/RPCSinceVersion.kt
@@ -1,6 +1,11 @@
 package net.corda.httprpc.annotations
 
-/** Records the protocol version in which this RPC was added. */
+/**
+ * Records the protocol version in which this RPC method was added.
+ *
+ * In particular [net.corda.httprpc.client.HttpRpcClient] makes use of this annotation to guard against scenario when
+ * HTTP RPC Client's [net.corda.httprpc.RpcOps] interface been updated ahead of server side implementation.
+ */
 @Target(AnnotationTarget.FUNCTION)
 @MustBeDocumented
 annotation class RPCSinceVersion(val version: Int)


### PR DESCRIPTION
I could not reproduce the problem reported in the Jira, but I made sure that we have an adequate unit and integration test coverage.