### PR TITLE
CORE-2663: Add delegates to key store and signing services (without verifying)

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/SslConfiguration.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/SslConfiguration.kt
@@ -1,6 +1,8 @@
 package net.corda.p2p.gateway.messaging
 
 import com.typesafe.config.Config
+import net.corda.p2p.gateway.security.delegates.JksSigningService
+import net.corda.p2p.gateway.security.delegates.SecurityDelegateProvider
 import net.corda.v5.base.util.base64ToByteArray
 import java.io.ByteArrayInputStream
 import java.security.KeyStore
@@ -35,7 +37,7 @@ data class SslConfiguration(
      * The key store used for TLS connections
      */
     val keyStore: KeyStore by lazy {
-        readKeyStore(rawKeyStore, keyStorePassword)
+        SecurityDelegateProvider.createKeyStore(JksSigningService(rawKeyStore, keyStorePassword))
     }
     /**
      * The trust root key store used to validate the peer certificate

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/DelegateKeyStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/DelegateKeyStore.kt
@@ -1,0 +1,105 @@
+package net.corda.p2p.gateway.security.delegates
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.Key
+import java.security.KeyStore
+import java.security.KeyStoreSpi
+import java.security.cert.Certificate
+import java.util.Collections
+import java.util.Date
+import java.util.Enumeration
+
+@Suppress("TooManyFunctions")
+internal class DelegateKeyStore : KeyStoreSpi() {
+
+    private var service: SigningService? = null
+
+    internal class LoadParameter(val service: SigningService) : KeyStore.LoadStoreParameter {
+        override fun getProtectionParameter() = null
+    }
+
+    override fun engineLoad(param: KeyStore.LoadStoreParameter?) {
+        if (param is LoadParameter) {
+            service = param.service
+        }
+    }
+
+    private fun getAlias(name: String?): SigningService.Alias? {
+        return service?.aliases?.firstOrNull {
+            it.name == name
+        }
+    }
+    private fun getCertificates(name: String?): Collection<Certificate>? {
+        return getAlias(name)?.certificates
+    }
+
+    override fun engineGetCertificateChain(alias: String?): Array<Certificate> {
+        return getCertificates(alias)?.toTypedArray() ?: emptyArray()
+    }
+
+    override fun engineGetCertificate(alias: String?): Certificate? {
+        return getCertificates(alias)?.firstOrNull()
+    }
+
+    override fun engineAliases(): Enumeration<String> {
+        return service?.aliases?.map { it.name }?.let {
+            Collections.enumeration(it)
+        } ?: Collections.emptyEnumeration()
+    }
+
+    override fun engineContainsAlias(alias: String?): Boolean {
+        return service?.aliases?.any { it.name == alias } ?: false
+    }
+
+    override fun engineSize(): Int {
+        return service?.aliases?.size ?: 0
+    }
+
+    override fun engineIsKeyEntry(alias: String?): Boolean {
+        return engineContainsAlias(alias)
+    }
+
+    override fun engineGetKey(alias: String, password: CharArray?): Key? {
+        val aliasService = getAlias(alias) ?: return null
+        return aliasService.certificates.firstOrNull()?.publicKey?.let {
+            DelegatedPrivateKey(it.format, it.algorithm, aliasService)
+        }
+    }
+
+    override fun engineIsCertificateEntry(alias: String?): Boolean {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineGetCertificateAlias(cert: Certificate?): String {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineGetCreationDate(alias: String?): Date {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineSetKeyEntry(alias: String?, key: Key?, password: CharArray?, chain: Array<out Certificate>?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineSetKeyEntry(alias: String?, key: ByteArray?, chain: Array<out Certificate>?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineSetCertificateEntry(alias: String?, cert: Certificate?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineDeleteEntry(alias: String?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineStore(stream: OutputStream?, password: CharArray?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineLoad(stream: InputStream?, password: CharArray?) {
+        throw UnsupportedOperationException()
+    }
+}

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/DelegatedPrivateKey.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/DelegatedPrivateKey.kt
@@ -1,0 +1,35 @@
+package net.corda.p2p.gateway.security.delegates
+
+import java.math.BigInteger
+import java.security.interfaces.RSAPrivateKey
+
+internal class DelegatedPrivateKey(
+    private val format: String,
+    private val algorithm: String,
+    val aliasService: SigningService.Alias
+) : RSAPrivateKey {
+    companion object {
+        private val KEY_SIZE = BigInteger.valueOf(1L).shiftLeft(527)
+        private val EXPONENT = BigInteger.valueOf(1L)
+    }
+
+    override fun getAlgorithm(): String {
+        return algorithm
+    }
+
+    override fun getFormat(): String {
+        return format
+    }
+
+    override fun getEncoded(): ByteArray {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getModulus(): BigInteger {
+        return KEY_SIZE
+    }
+
+    override fun getPrivateExponent(): BigInteger {
+        return EXPONENT
+    }
+}

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/DelegatedSignature.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/DelegatedSignature.kt
@@ -1,0 +1,74 @@
+package net.corda.p2p.gateway.security.delegates
+
+import java.io.ByteArrayOutputStream
+import java.security.AlgorithmParameters
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.SignatureSpi
+import java.security.spec.AlgorithmParameterSpec
+import java.security.spec.PSSParameterSpec
+
+internal class DelegatedSignature(
+    defaultHash: SigningService.Hash?,
+) : SignatureSpi() {
+    private var alias: SigningService.Alias? = null
+    private var hash: SigningService.Hash? = defaultHash
+    private val data = ByteArrayOutputStream()
+
+    override fun engineInitSign(privateKey: PrivateKey?) {
+        if (privateKey is DelegatedPrivateKey) {
+            alias = privateKey.aliasService
+        } else {
+            throw UnsupportedOperationException()
+        }
+    }
+
+    override fun engineSign(): ByteArray {
+        return alias?.sign(
+            hash ?: throw UnsupportedOperationException(),
+            data.toByteArray()
+        ) ?: throw UnsupportedOperationException()
+    }
+
+    override fun engineUpdate(b: Byte) {
+        data.write(b.toInt())
+    }
+
+    override fun engineUpdate(b: ByteArray, off: Int, len: Int) {
+        data.write(b, off, len)
+    }
+
+    override fun engineSetParameter(params: AlgorithmParameterSpec?) {
+        if (params is PSSParameterSpec) {
+            hash = SigningService.Hash
+                .values()
+                .firstOrNull {
+                    it.hashName == params.digestAlgorithm
+                }
+        }
+    }
+
+    override fun engineGetParameters(): AlgorithmParameters? {
+        return hash?.let { hash ->
+            AlgorithmParameters.getInstance(SecurityDelegateProvider.RSA_SINGING_ALGORITHM).also {
+                it.init(hash.rsaParameter)
+            }
+        }
+    }
+
+    override fun engineInitVerify(publicKey: PublicKey?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineVerify(sigBytes: ByteArray?): Boolean {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineSetParameter(param: String?, value: Any?) {
+        throw UnsupportedOperationException()
+    }
+
+    override fun engineGetParameter(param: String?): Any {
+        throw UnsupportedOperationException()
+    }
+}

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/SecurityDelegateProvider.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/SecurityDelegateProvider.kt
@@ -1,0 +1,61 @@
+package net.corda.p2p.gateway.security.delegates
+
+import java.security.KeyStore
+import java.security.Provider
+import java.security.Security
+
+object SecurityDelegateProvider : Provider(
+    SecurityDelegateProvider::class.simpleName,
+    "0.2",
+    "A delegate keystore provider"
+) {
+    const val RSA_SINGING_ALGORITHM = "RSASSA-PSS"
+    init {
+        putService(DelegateKeyStoreService)
+        putService(DelegateSignatureService(RSA_SINGING_ALGORITHM, null))
+        SigningService.Hash.values().forEach {
+            putService(DelegateSignatureService(it.ecName, it))
+        }
+        this["AlgorithmParameters.EC"] = "sun.security.util.ECParameters"
+        Security.insertProviderAt(SecurityDelegateProvider, 1)
+    }
+
+    fun createKeyStore(
+        service: SigningService
+    ): KeyStore {
+        return KeyStore.getInstance("CordaDelegateKeyStore").also {
+            it.load(DelegateKeyStore.LoadParameter(service))
+        }
+    }
+
+    private object DelegateKeyStoreService : Service(
+        this,
+        "KeyStore",
+        "CordaDelegateKeyStore",
+        DelegateKeyStore::class.qualifiedName,
+        null,
+        mapOf("SupportedKeyClasses" to DelegatedPrivateKey::class.java.name)
+    ) {
+
+        override fun newInstance(constructorParameter: Any?): Any {
+            return DelegateKeyStore()
+        }
+    }
+
+    private class DelegateSignatureService(
+        algorithm: String,
+        private val defaultHash: SigningService.Hash?
+    ) : Service(
+        this,
+        "Signature",
+        algorithm,
+        DelegatedSignature::class.java.name,
+        null,
+        null,
+    ) {
+        override fun newInstance(constructorParameter: Any?): Any {
+            return DelegatedSignature(defaultHash)
+        }
+    }
+}
+

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/SigningService.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/security/delegates/SigningService.kt
@@ -1,0 +1,33 @@
+package net.corda.p2p.gateway.security.delegates
+
+import java.security.cert.Certificate
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.PSSParameterSpec
+
+interface SigningService {
+    val aliases: Collection<Alias>
+    enum class Hash(val hashName: String, private val saltLength: Int) {
+        SHA256("SHA-256", 32),
+        SHA384("SHA-384", 48),
+        SHA512("SHA-512", 64);
+
+        val rsaParameter by lazy {
+            PSSParameterSpec(
+                hashName,
+                "MGF1",
+                MGF1ParameterSpec(hashName),
+                saltLength,
+                1
+            )
+        }
+
+        val ecName = "${name}withECDSA"
+    }
+
+    interface Alias {
+        val name: String
+        val certificates: Collection<Certificate>
+
+        fun sign(hash: Hash, data: ByteArray): ByteArray
+    }
+}

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/DelegateKeyStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/DelegateKeyStoreTest.kt
@@ -1,0 +1,247 @@
+package net.corda.p2p.gateway.security.delegates
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.security.PublicKey
+import java.security.cert.Certificate
+
+class DelegateKeyStoreTest {
+    private val onePublicKey = mock<PublicKey> {
+        on { format } doReturn "format"
+        on { algorithm } doReturn "algorithm"
+    }
+    private val certificateOne = mock<Certificate> {
+        on { publicKey } doReturn onePublicKey
+    }
+    private val certificateTwoA = mock<Certificate> {
+        on { publicKey } doReturn mock()
+    }
+    private val certificateTwoB = mock<Certificate> {
+        on { publicKey } doReturn mock()
+    }
+    private val aliasOne = mock<SigningService.Alias> {
+        on { name } doReturn "one"
+        on { certificates } doReturn listOf(certificateOne)
+    }
+    private val aliasTwo = mock<SigningService.Alias> {
+        on { name } doReturn "two"
+        on { certificates } doReturn listOf(certificateTwoA, certificateTwoB)
+    }
+    private val aliasThree = mock<SigningService.Alias> {
+        on { name } doReturn "three"
+        on { certificates } doReturn emptyList()
+    }
+    private val service = mock<SigningService> {
+        on { aliases } doReturn listOf(aliasTwo, aliasOne, aliasThree)
+    }
+
+    @Test
+    fun `engineLoad ignores unknown types`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(mock())
+
+        assertThat(keyStore.engineGetCertificateChain("one")).isEmpty()
+    }
+
+    @Test
+    fun `engineGetCertificateChain return empty list when there is no service`() {
+        val keyStore = DelegateKeyStore()
+
+        assertThat(keyStore.engineGetCertificateChain("one")).isEmpty()
+    }
+
+    @Test
+    fun `engineGetCertificateChain return correct list of aliases`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineGetCertificateChain("one")).contains(certificateOne)
+    }
+
+    @Test
+    fun `engineGetCertificateChain return empty list for unknown alias`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineGetCertificateChain("four")).isEmpty()
+    }
+
+    @Test
+    fun `engineGetCertificate return empty list when there is no service`() {
+        val keyStore = DelegateKeyStore()
+
+        assertThat(keyStore.engineGetCertificate("one")).isNull()
+    }
+
+    @Test
+    fun `engineGetCertificate return first item when there are certificates`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineGetCertificate("two")).isEqualTo(certificateTwoA)
+    }
+
+    @Test
+    fun `engineGetCertificate return null when there are no certificates`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineGetCertificate("three")).isNull()
+    }
+
+    @Test
+    fun `engineAliases return empty collection when there is no service`() {
+        val keyStore = DelegateKeyStore()
+
+        assertThat(keyStore.engineAliases().toList()).isEmpty()
+    }
+
+    @Test
+    fun `engineAliases return the list of aliases`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineAliases().toList()).contains("one", "two", "three")
+    }
+
+    @Test
+    fun `engineContainsAlias return false if keystore has no service`() {
+        val keyStore = DelegateKeyStore()
+
+        assertThat(keyStore.engineContainsAlias("one")).isFalse
+    }
+
+    @Test
+    fun `engineContainsAlias return true if keystore has alias`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineContainsAlias("one")).isTrue
+    }
+
+    @Test
+    fun `engineIsKeyEntry return false if keystore has no alias`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineIsKeyEntry("false")).isFalse
+    }
+
+    @Test
+    fun `engineSize return 0 if key store has no service`() {
+        val keyStore = DelegateKeyStore()
+
+        assertThat(keyStore.engineSize()).isZero
+    }
+
+    @Test
+    fun `engineSize return real size if key store has service`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineSize()).isEqualTo(3)
+    }
+
+    @Test
+    fun `engineGetKey return null if key store has no service`() {
+        val keyStore = DelegateKeyStore()
+
+        assertThat(keyStore.engineGetKey("one", "one".toCharArray())).isNull()
+    }
+
+    @Test
+    fun `engineGetKey return null for unknown alias`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineGetKey("four", "one".toCharArray())).isNull()
+    }
+
+    @Test
+    fun `engineGetKey return null for alias without certificates`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        assertThat(keyStore.engineGetKey("three", "one".toCharArray())).isNull()
+    }
+
+    @Test
+    fun `engineGetKey return correct key for alias with certificates`() {
+        val keyStore = DelegateKeyStore()
+        keyStore.engineLoad(DelegateKeyStore.LoadParameter(service))
+
+        val key = keyStore.engineGetKey("one", "one".toCharArray())
+
+        assertThat(key).isInstanceOf(DelegatedPrivateKey::class.java)
+    }
+
+    @Nested
+    inner class UnsupportedOperationTests {
+        private val keyStore = DelegateKeyStore()
+        @Test
+        fun engineIsCertificateEntry() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineIsCertificateEntry(null)
+            }
+        }
+
+        @Test
+        fun engineGetCertificateAlias() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineGetCertificateAlias(null)
+            }
+        }
+
+        @Test
+        fun engineGetCreationDate() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineGetCreationDate(null)
+            }
+        }
+
+        @Test
+        fun `engineSetKeyEntry with password`() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineSetKeyEntry(null, null, null, null)
+            }
+        }
+        @Test
+        fun `engineSetKeyEntry without password`() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineSetKeyEntry(null, null, null)
+            }
+        }
+
+        @Test
+        fun engineSetCertificateEntry() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineSetCertificateEntry(null, null)
+            }
+        }
+
+        @Test
+        fun engineDeleteEntry() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineDeleteEntry(null)
+            }
+        }
+
+        @Test
+        fun engineStore() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineStore(null, null)
+            }
+        }
+
+        @Test
+        fun engineLoad() {
+            assertThrows<UnsupportedOperationException> {
+                keyStore.engineLoad(null, null)
+            }
+        }
+    }
+}

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/DelegatedSignatureTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/DelegatedSignatureTest.kt
@@ -1,0 +1,206 @@
+package net.corda.p2p.gateway.security.delegates
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.security.PrivateKey
+import java.security.Provider
+import java.security.PublicKey
+import java.security.Security
+import java.security.Signature
+
+class DelegatedSignatureTest {
+    private inner class SignatureTestProvider : Provider(
+        SignatureTestProvider::class.java.canonicalName,
+        "0.0",
+        "Test signature provider"
+    ) {
+        init {
+            putService(SignatureTestService(this, null))
+            SigningService.Hash.values().forEach {
+                putService(SignatureTestService(this, it))
+            }
+        }
+    }
+
+    private inner class SignatureTestService(
+        provider: Provider,
+        private val defaultHash:
+            SigningService.Hash?
+    ) : Provider.Service(
+        provider,
+        "Signature",
+        "Test-$defaultHash",
+        SignatureTestService::class.java.canonicalName,
+        emptyList(),
+        emptyMap()
+
+    ) {
+        override fun newInstance(constructorParameter: Any?): Any {
+            return DelegatedSignature(defaultHash)
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        Security.addProvider(SignatureTestProvider())
+    }
+    @AfterEach
+    fun cleanUp() {
+        Security.removeProvider(SignatureTestProvider::class.java.canonicalName)
+    }
+
+    @Test
+    fun `engineInitSign throws exception if private key is not DelegatedRsaPrivateKey`() {
+        val signature = Signature.getInstance("test-null")
+        val privateKey = mock<PrivateKey>()
+
+        assertThrows<UnsupportedOperationException> {
+
+            signature.initSign(privateKey)
+        }
+    }
+
+    @Test
+    fun `engineSign returns data from service`() {
+        val hash = SigningService.Hash.SHA384
+        val data = "data".toByteArray()
+        val sign = "sign".toByteArray()
+        val signature = Signature.getInstance("test-$hash")
+        val service = mock<SigningService.Alias> {
+            on { sign(hash, data) } doReturn sign
+        }
+        val privateKey = mock<DelegatedPrivateKey> {
+            on { aliasService } doReturn service
+        }
+        signature.initSign(privateKey)
+        signature.update(data)
+
+        assertThat(signature.sign()).isEqualTo(sign)
+    }
+
+    @Test
+    fun `engineSign without hash throws an exception`() {
+        val data = "data".toByteArray()
+        val signature = Signature.getInstance("test-null")
+        val service = mock<SigningService.Alias>()
+        val privateKey = mock<DelegatedPrivateKey> {
+            on { aliasService } doReturn service
+        }
+        signature.initSign(privateKey)
+        signature.update(data)
+
+        assertThrows<UnsupportedOperationException> {
+            signature.sign()
+        }
+    }
+
+    @Test
+    fun `engineSign without service throws exception`() {
+        val hash = SigningService.Hash.SHA384
+        val data = "data".toByteArray()
+        val signature = Signature.getInstance("test-$hash")
+        val privateKey = mock<DelegatedPrivateKey>()
+        signature.initSign(privateKey)
+        signature.update(data)
+
+        assertThrows<UnsupportedOperationException> {
+            signature.sign()
+        }
+    }
+
+    @Test
+    fun `engineSetParameter set the correct hash`() {
+        val hash = SigningService.Hash.SHA384
+        val data = "data".toByteArray()
+        val signature = Signature.getInstance("test-null")
+        val service = mock<SigningService.Alias> {
+            on { sign(hash, data) } doReturn ByteArray(0)
+        }
+        val privateKey = mock<DelegatedPrivateKey> {
+            on { aliasService } doReturn service
+        }
+
+        signature.initSign(privateKey)
+        signature.setParameter(hash.rsaParameter)
+        data.forEach {
+            signature.update(it)
+        }
+        signature.sign()
+
+        verify(service).sign(hash, data)
+    }
+
+    @Test
+    fun `engineSetParameter will ignore unknown parameters`() {
+        val data = "data".toByteArray()
+        val signature = Signature.getInstance("test-null")
+        val service = mock<SigningService.Alias> {
+            on { sign(any(), any()) } doReturn ByteArray(0)
+        }
+        val privateKey = mock<DelegatedPrivateKey> {
+            on { aliasService } doReturn service
+        }
+
+        signature.initSign(privateKey)
+        signature.setParameter(mock())
+        signature.update(data)
+
+        assertThrows<UnsupportedOperationException> {
+            signature.sign()
+        }
+    }
+
+    @Test
+    fun `engineGetParameter will return null by default`() {
+        val signature = Signature.getInstance("test-null")
+
+        assertThat(signature.parameters).isNull()
+    }
+
+    @Test
+    fun `engineGetParameter will return valid parameter if set`() {
+        val hash = SigningService.Hash.SHA512
+        val signature = Signature.getInstance("test-$hash")
+
+        val parameters = signature.parameters
+
+        assertThat(parameters?.algorithm).isEqualTo("RSASSA-PSS")
+    }
+
+    @Test
+    fun `engineSetParameter by name will throw an exception`() {
+        val signature = Signature.getInstance("test-null")
+
+        assertThrows<UnsupportedOperationException> {
+            @Suppress("DEPRECATION")
+            signature.setParameter("name", "value")
+        }
+    }
+
+    @Test
+    fun `engineGetParameter by name will throw an exception`() {
+        val signature = Signature.getInstance("test-null")
+
+        assertThrows<UnsupportedOperationException> {
+            @Suppress("DEPRECATION")
+            signature.getParameter("name")
+        }
+    }
+
+    @Test
+    fun `engineInitVerify will throws an exception`() {
+        val hash = SigningService.Hash.SHA512
+        val signature = Signature.getInstance("test-$hash")
+
+        assertThrows<UnsupportedOperationException> {
+            signature.initVerify(mock<PublicKey>())
+        }
+    }
+}

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/JksSigningServiceTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/JksSigningServiceTest.kt
@@ -1,0 +1,352 @@
+package net.corda.p2p.gateway.security.delegates
+
+import net.corda.p2p.gateway.security.delegates.SecurityDelegateProvider.RSA_SINGING_ALGORITHM
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.InputStream
+import java.security.KeyStoreSpi
+import java.security.PrivateKey
+import java.security.Provider
+import java.security.PublicKey
+import java.security.Security
+import java.security.Signature
+import java.security.cert.Certificate
+import java.util.Collections
+
+class JksSigningServiceTest {
+    private val myProvider = mock<SecurityDelegateProvider>()
+    private val rsaCertificateAlias = "rc-name"
+    private val ecCertificateAlias = "ec-name"
+    private val privateKey = mock<PrivateKey>()
+    private val rsaPublicKey = mock<PublicKey> {
+        on { algorithm } doReturn "RSA"
+    }
+    private val ecPublicKey = mock<PublicKey> {
+        on { algorithm } doReturn "EC"
+    }
+    private val rsaCertificate = mock<Certificate> {
+        on { publicKey } doReturn rsaPublicKey
+    }
+    private val ecCertificate = mock<Certificate> {
+        on { publicKey } doReturn ecPublicKey
+    }
+    private val keyStoreSpi = mock< KeyStoreSpi> {
+        on { engineAliases() } doReturn Collections.enumeration(listOf(rsaCertificateAlias, ecCertificateAlias))
+        on { engineGetKey(any(), any()) } doReturn privateKey
+        on { engineGetCertificateChain(rsaCertificateAlias) } doReturn arrayOf(rsaCertificate)
+        on { engineGetCertificateChain(ecCertificateAlias) } doReturn arrayOf(ecCertificate)
+    }
+    private val jksService = mock<Provider.Service> {
+        on { algorithm } doReturn "JKS"
+        on { type } doReturn "KeyStore"
+        on { newInstance(anyOrNull()) } doReturn keyStoreSpi
+    }
+    private val nonKeyStoreJksService = mock<Provider.Service> {
+        on { algorithm } doReturn "JKS"
+        on { type } doReturn "Yo"
+        on { newInstance(anyOrNull()) } doReturn keyStoreSpi
+    }
+    private val nonJksKeyStoreService = mock<Provider.Service> {
+        on { algorithm } doReturn "ALG"
+        on { type } doReturn "KeyStore"
+        on { newInstance(anyOrNull()) } doReturn keyStoreSpi
+    }
+    private val originalProvider = mock<Provider> {
+        on { services } doReturn setOf(nonJksKeyStoreService, nonKeyStoreJksService, jksService)
+    }
+    private val rsaSignatureService = mock<Provider.Service> {
+        on { algorithm } doReturn RSA_SINGING_ALGORITHM
+        on { type } doReturn "Signature"
+    }
+    private val rsaNonSignatureService = mock<Provider.Service> {
+        on { algorithm } doReturn RSA_SINGING_ALGORITHM
+        on { type } doReturn "NotSignature"
+    }
+    private val rsaSignatureProvider = mock<Provider> {
+        on { services } doReturn setOf(rsaNonSignatureService, rsaSignatureService)
+    }
+    private val ecSignatureServices = SigningService.Hash.values().flatMap { hash ->
+        listOf(
+            mock<Provider.Service> {
+                on { algorithm } doReturn hash.ecName
+                on { type } doReturn "NotSignature"
+            },
+            mock {
+                on { algorithm } doReturn hash.ecName
+                on { type } doReturn "Signature"
+            }
+        )
+    }
+
+    private val ecSignatureProvider = mock<Provider> {
+        on { services } doReturn ecSignatureServices.toSet()
+    }
+
+    private val mockSecurity = mockStatic(Security::class.java).also {
+        it.`when`<Array<Provider>> {
+            Security.getProviders()
+        }.doReturn(
+            arrayOf(myProvider, originalProvider, rsaSignatureProvider, ecSignatureProvider)
+        )
+
+        whenever(rsaSignatureService.provider).doReturn(rsaSignatureProvider)
+        ecSignatureServices.forEach {
+            whenever(it.provider).doReturn(ecSignatureProvider)
+        }
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        mockSecurity.close()
+    }
+
+    @Nested
+    inner class AliasTests {
+        @Test
+        fun `alias return the correct names for RSA certificate`() {
+            val service = JksSigningService(ByteArray(0), "password")
+
+            assertThat(service.aliases.map { it.name }).contains(rsaCertificateAlias)
+        }
+
+        @Test
+        fun `alias return the correct names for CE certificate`() {
+            val service = JksSigningService(ByteArray(0), "password")
+
+            assertThat(service.aliases.map { it.name }).contains(ecCertificateAlias)
+        }
+
+        @Test
+        fun `alias return the correct certificates for RSA certificate`() {
+            val service = JksSigningService(ByteArray(0), "password")
+
+            assertThat(service.aliases.flatMap { it.certificates }).contains(rsaCertificate)
+        }
+
+        @Test
+        fun `alias return the correct certificates for CE certificate`() {
+            val service = JksSigningService(ByteArray(0), "password")
+
+            assertThat(service.aliases.flatMap { it.certificates }).contains(ecCertificate)
+        }
+
+        @Test
+        fun `aliases throw an exception when there is no valid provider`() {
+            mockSecurity.`when`<Array<Provider>> {
+                Security.getProviders()
+            }.doReturn(
+                emptyArray()
+            )
+            val service = JksSigningService(ByteArray(0), "password")
+
+            assertThrows<SecurityException> {
+                service.aliases
+            }
+        }
+
+        @Test
+        fun `aliases throw an exception when there is no valid service`() {
+            whenever(jksService.newInstance(anyOrNull())).doReturn(null)
+            val service = JksSigningService(ByteArray(0), "password")
+
+            assertThrows<SecurityException> {
+                service.aliases
+            }
+        }
+
+        @Test
+        fun `aliases load with the correct data`() {
+            val data = argumentCaptor<InputStream>()
+            val password = argumentCaptor<CharArray>()
+            whenever(keyStoreSpi.engineLoad(data.capture(), password.capture())).doAnswer { }
+            val service = JksSigningService("hello".toByteArray(), "password")
+
+            service.aliases
+
+            assertThat(data.firstValue.readAllBytes()).isEqualTo("hello".toByteArray())
+            assertThat(password.firstValue).isEqualTo("password".toCharArray())
+        }
+    }
+
+    @Nested
+    inner class SignTests {
+        @Nested
+        inner class RsaSignTests {
+            @Test
+            fun `rsa sign return the signature`() {
+                val data = "data".toByteArray()
+                val hash = SigningService.Hash.SHA384
+                val service = JksSigningService("hello".toByteArray(), "password")
+                val alias = service.aliases.first { it.name == rsaCertificateAlias }
+                val signature = mock<Signature> {
+                    on { sign() } doReturn "signature".toByteArray()
+                }
+                val sign = mockStatic(Signature::class.java).use { mockSignature ->
+                    mockSignature.`when`<Signature> {
+                        Signature.getInstance(
+                            RSA_SINGING_ALGORITHM,
+                            rsaSignatureProvider
+                        )
+                    }.doReturn(
+                        signature
+                    )
+
+                    alias.sign(hash, data)
+                }
+
+                assertThat(sign).isEqualTo("signature".toByteArray())
+            }
+
+            @Test
+            fun `rsa sign sends the correct data`() {
+                val data = "data".toByteArray()
+                val hash = SigningService.Hash.SHA512
+                val service = JksSigningService("hello".toByteArray(), "password")
+                val alias = service.aliases.first { it.name == rsaCertificateAlias }
+                val signature = mock<Signature> {
+                    on { sign() } doReturn "signature".toByteArray()
+                }
+                mockStatic(Signature::class.java).use { mockSignature ->
+                    mockSignature.`when`<Signature> {
+                        Signature.getInstance(
+                            RSA_SINGING_ALGORITHM,
+                            rsaSignatureProvider
+                        )
+                    }.doReturn(
+                        signature
+                    )
+
+                    alias.sign(hash, data)
+                }
+
+                verify(signature).initSign(privateKey)
+                verify(signature).setParameter(hash.rsaParameter)
+                verify(signature).update(data)
+            }
+
+            @Test
+            fun `rsa sign will fail if it cant find the original service provider`() {
+                mockSecurity.`when`<Array<Provider>> {
+                    Security.getProviders()
+                }.doReturn(
+                    arrayOf(myProvider, originalProvider, ecSignatureProvider)
+                )
+                val data = "data".toByteArray()
+                val hash = SigningService.Hash.SHA384
+                val service = JksSigningService("hello".toByteArray(), "password")
+                val alias = service.aliases.first { it.name == rsaCertificateAlias }
+                val signature = mock<Signature>()
+                mockStatic(Signature::class.java).use { mockSignature ->
+                    mockSignature.`when`<Signature> {
+                        Signature.getInstance(
+                            RSA_SINGING_ALGORITHM,
+                            rsaSignatureProvider
+                        )
+                    }.doReturn(
+                        signature
+                    )
+
+                    assertThrows<SecurityException> {
+                        alias.sign(hash, data)
+                    }
+                }
+            }
+        }
+
+        @Nested
+        inner class EcSignTests {
+            @Test
+            fun `ec sign return the signature`() {
+                val data = "data".toByteArray()
+                val hash = SigningService.Hash.SHA256
+                val service = JksSigningService("hello".toByteArray(), "password")
+                val alias = service.aliases.first { it.name == ecCertificateAlias }
+                val signature = mock<Signature> {
+                    on { sign() } doReturn "signature".toByteArray()
+                }
+                val sign = mockStatic(Signature::class.java).use { mockSignature ->
+                    mockSignature.`when`<Signature> {
+                        Signature.getInstance(
+                            SigningService.Hash.SHA256.ecName,
+                            ecSignatureProvider
+                        )
+                    }.doReturn(
+                        signature
+                    )
+
+                    alias.sign(hash, data)
+                }
+
+                assertThat(sign).isEqualTo("signature".toByteArray())
+            }
+
+            @Test
+            fun `ec sign sends the correct data`() {
+                val data = "data".toByteArray()
+                val hash = SigningService.Hash.SHA512
+                val service = JksSigningService("hello".toByteArray(), "password")
+                val alias = service.aliases.first { it.name == ecCertificateAlias }
+                val signature = mock<Signature> {
+                    on { sign() } doReturn "signature".toByteArray()
+                }
+                mockStatic(Signature::class.java).use { mockSignature ->
+                    mockSignature.`when`<Signature> {
+                        Signature.getInstance(
+                            SigningService.Hash.SHA512.ecName,
+                            ecSignatureProvider
+                        )
+                    }.doReturn(
+                        signature
+                    )
+
+                    alias.sign(hash, data)
+                }
+
+                verify(signature).initSign(privateKey)
+                verify(signature, never()).setParameter(any())
+                verify(signature).update(data)
+            }
+
+            @Test
+            fun `ec sign will fail if it cant find the original service provider`() {
+                mockSecurity.`when`<Array<Provider>> {
+                    Security.getProviders()
+                }.doReturn(
+                    arrayOf(myProvider, originalProvider, rsaSignatureProvider)
+                )
+                val data = "data".toByteArray()
+                val hash = SigningService.Hash.SHA384
+                val service = JksSigningService("hello".toByteArray(), "password")
+                val alias = service.aliases.first { it.name == ecCertificateAlias }
+                val signature = mock<Signature>()
+                mockStatic(Signature::class.java).use { mockSignature ->
+                    mockSignature.`when`<Signature> {
+                        Signature.getInstance(
+                            hash.ecName,
+                            ecSignatureProvider
+                        )
+                    }.doReturn(
+                        signature
+                    )
+
+                    assertThrows<SecurityException> {
+                        alias.sign(hash, data)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/SecurityDelegateProviderTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/security/delegates/SecurityDelegateProviderTest.kt
@@ -1,0 +1,74 @@
+package net.corda.p2p.gateway.security.delegates
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.security.Security
+import java.security.Signature
+
+class SecurityDelegateProviderTest {
+    @Test
+    fun `init add the SecurityDelegateProvider to the providers`() {
+        SecurityDelegateProvider.size
+
+        assertThat(Security.getProviders()[0]).isEqualTo(SecurityDelegateProvider)
+    }
+
+    @Test
+    fun `init add the key store delegate service`() {
+        assertThat(
+            SecurityDelegateProvider.services
+                .map {
+                    it.type to it.algorithm
+                }
+        ).contains("KeyStore" to "CordaDelegateKeyStore")
+    }
+
+    @Test
+    fun `init add RSA signature service`() {
+        assertThat(
+            SecurityDelegateProvider.services
+                .map {
+                    it.type to it.algorithm
+                }
+        ).contains("Signature" to "RSASSA-PSS")
+    }
+
+    @Test
+    fun `init add EC signature service`() {
+        assertThat(
+            SecurityDelegateProvider.services
+                .map {
+                    it.type to it.algorithm
+                }
+        ).containsAll(
+            SigningService.Hash.values().map {
+                "Signature" to it.ecName
+            }
+        )
+    }
+
+    @Test
+    fun `createKeyStore create a keystore with the requested service`() {
+        val alias = mock<SigningService.Alias>() {
+            on { name } doReturn "aliasName"
+        }
+        val service = mock<SigningService> {
+            on { aliases } doReturn listOf(alias)
+        }
+
+        val keyStore = SecurityDelegateProvider.createKeyStore(service)
+
+        assertThat(keyStore.aliases().toList()).contains("aliasName")
+    }
+
+    @Test
+    fun `newInstance of DelegateSignatureService creates DelegatedSignature`() {
+        SecurityDelegateProvider.size
+
+        val signature = Signature.getInstance(SigningService.Hash.SHA384.ecName)
+
+        assertThat(signature.provider).isEqualTo(SecurityDelegateProvider)
+    }
+}


### PR DESCRIPTION
This PR defines an interface (`SigningService`) that intercepts the SSL signing and certificates and should allow us to use external services for this. It also defines an implementation of this interface (`JksSigningService`) that uses legacy JKS raw data.

The verification stream will just throw an exception - which will cause the Java security layer to use the default verification. If we will want to implement our own certificates type we will have to implement the verification as well. An example of how to do this is in https://github.com/corda/corda-runtime-os/pull/657