### PR TITLE
NOTICK - Fix up integration-tests not being compiled.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@driessamyn/no-tick/ensure-everything-is-compiled') _
+@Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaPipeline(
     nexusAppId: 'flow-worker-5.0',


### PR DESCRIPTION
Some of the integration test weren't being compiled, see:

- New build pipeline shows failure: https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/PR-661/1
- And after fix integration-test: https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/PR-661/2

When https://github.com/corda/corda-shared-build-pipeline-steps/pull/111 is merged, it will compile everything.

Squash merge with "Fix up EntityManagerFactoryFactoryIntegrationTest compilation" 