### PR TITLE
NOTICK: Fixing `HttpRpcServerDurableStreamsRequestsTest` (#644)

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/build.gradle
+++ b/libs/http-rpc/http-rpc-server-impl/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
     // Constraints block can be removed when Swagger is upgraded to the next version
     constraints {
-        implementation('com.fasterxml.jackson.core:jackson-databind:2.13+') {
+        implementation("com.fasterxml.jackson.core:$jacksonVersion") {
             because 'sonatype-2021-4682'
         }
     }
@@ -48,6 +48,7 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
     testRuntimeOnly 'org.osgi:osgi.core'
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     runtimeOnly "org.webjars:swagger-ui:$swaggeruiVersion"
     runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"

--- a/libs/http-rpc/http-rpc-server-impl/src/integration-test/kotlin/net/corda/httprpc/server/impl/HttpRpcServerDurableStreamsRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integration-test/kotlin/net/corda/httprpc/server/impl/HttpRpcServerDurableStreamsRequestsTest.kt
@@ -59,7 +59,7 @@ class HttpRpcServerDurableStreamsRequestsTest {
 
         val response = HttpRpcServerTestBase.client.call(net.corda.httprpc.tools.HttpVerb.POST, WebRequest<Any>("numberseq/retrieve", requestBody), HttpRpcServerTestBase.userName, HttpRpcServerTestBase.password)
 
-        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(HttpStatus.SC_OK, response.responseStatus, response.toString())
         assertEquals(responseBody, response.body)
     }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/integration-test/kotlin/net/corda/httprpc/server/impl/HttpRpcServerTestBase.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integration-test/kotlin/net/corda/httprpc/server/impl/HttpRpcServerTestBase.kt
@@ -15,7 +15,6 @@ abstract class HttpRpcServerTestBase {
         val password = "admin"
         fun findFreePort() = ServerSocket(0).use { it.localPort }
         val securityManager = RPCSecurityManagerFactoryStubImpl().createRPCSecurityManager()
-        val classLoader = ClassLoader.getSystemClassLoader()
         val context = HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description")
     }
 }

--- a/libs/schema-registry/schema-registry-impl/build.gradle
+++ b/libs/schema-registry/schema-registry-impl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
     // Constraints block can be removed when Avro is upgraded to the next version
     constraints {
-        implementation('com.fasterxml.jackson.core:jackson-databind:2.13+') {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion") {
             because 'sonatype-2021-4682'
         }
     }

--- a/libs/schema-registry/schema-registry/build.gradle
+++ b/libs/schema-registry/schema-registry/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
     // Constraints block can be removed when Avro is upgraded to the next version
     constraints {
-        implementation('com.fasterxml.jackson.core:jackson-databind:2.13+') {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion") {
             because 'sonatype-2021-4682'
         }
     }


### PR DESCRIPTION
`jackson-databind` had to be properly constrained to avoid unintentional library upgrades.
Cherry-pick of https://github.com/corda/corda-runtime-os/pull/644 from main branch