### PR TITLE
NOTICK: update to have team leads owners of gradle.prop file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 
 # Build scripts should be audited by BLT
-*.gradle        @corda/blt
-gradle.*        @corda/blt
-Jenkinsfile     @corda/blt
-.ci/*           @corda/blt
-gradle/*        @corda/blt
+*.gradle           @corda/blt
+gradle.properties  @corda/corda5-team-leads
+Jenkinsfile        @corda/blt
+.ci/*              @corda/blt
+gradle/*           @corda/blt


### PR DESCRIPTION
To prevent bottle necks dependent on BLT for property version bumps added a new github group with corda5-team-leads

Group details here https://github.com/orgs/corda/teams/corda5-team-leads/members?query=