### PR TITLE
CORE-1984: Name prefix fix-up

### DIFF
--- a/applications/http-rpc-gateway/src/e2e-test/kotlin/net/corda/applications/rpc/http/TestToolkitImpl.kt
+++ b/applications/http-rpc-gateway/src/e2e-test/kotlin/net/corda/applications/rpc/http/TestToolkitImpl.kt
@@ -9,6 +9,20 @@ class TestToolkitImpl(private val testCaseClass: Class<Any>, private val baseAdd
 
     private val counter = AtomicInteger()
 
+    private val uniqueNamePrefix: String = run {
+        if (testCaseClass.simpleName != "Companion") {
+            testCaseClass.simpleName
+        } else {
+            // Converts "net.corda.applications.rpc.LimitedUserAuthorizationE2eTest$Companion"
+            // Into: LimitedUserAuthorizationE2eTest
+            testCaseClass.name
+                .substringBeforeLast('$')
+                .substringAfterLast('.')
+
+        }
+        .substring(0..15) // Also need to truncate it to avoid DB errors
+    }
+
     /**
      * Good unique name will be:
      * "$testCaseClass-counter-currentTimeMillis"
@@ -16,7 +30,7 @@ class TestToolkitImpl(private val testCaseClass: Class<Any>, private val baseAdd
      * testcase run and `currentTimeMillis` will provision for re-runs of the same test without wiping the database.
      */
     override val uniqueName: String
-        get() = "${testCaseClass.simpleName}-${counter.incrementAndGet()}-${System.currentTimeMillis()}"
+        get() = "$uniqueNamePrefix-${counter.incrementAndGet()}-${System.currentTimeMillis()}"
 
     override fun <I : RpcOps> httpClientFor(rpcOpsClass: Class<I>, userName: String, password: String): HttpRpcClient<I> {
         return HttpRpcClient(


### PR DESCRIPTION
Upon inspecting the database after E2E run I noticed users named `Companion-5-1642178998596`.
This was due to the fact that we now use `TestToolkit` inside `companion object`.
This change rectifies that to make unique name more easily attributable to actual testcase.