### PR TITLE
NOTICK: Fix message patterns Kafka integration tests

### DIFF
--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -2,6 +2,8 @@ import aQute.bnd.gradle.Bundle
 import aQute.bnd.gradle.Resolve
 import aQute.bnd.gradle.TestOSGi
 
+import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
+
 plugins {
     id 'corda.common-library'
     id 'com.r3.internal.gradle.plugins.r3Publish'
@@ -75,6 +77,10 @@ def resolve = tasks.register('resolve', Resolve) {
 tasks.register('kafkaIntegrationTest', TestOSGi) {
     description = "Runs Kafka OSGi integration tests."
     group = "verification"
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = of(11)
+    }
+    resultsDirectory = file("$testResultsDir/kafkaIntegrationTest")
     bundles = files(sourceSets.kafkaIntegrationTest.runtimeClasspath, configurations.archives.artifacts.files)
     bndrun = resolve.flatMap { it.outputBndrun }
 }

--- a/testing/message-patterns/src/kafka-integration-test/kotlin/net/corda/messaging/kafka/integration/subscription/DurableSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/kafka-integration-test/kotlin/net/corda/messaging/kafka/integration/subscription/DurableSubscriptionIntegrationTest.kt
@@ -153,7 +153,7 @@ class DurableSubscriptionIntegrationTest {
             assertEquals(LifecycleStatus.UP, coordinator.status)
         }
 
-        assertTrue(latch.await(5, TimeUnit.SECONDS))
+        assertTrue(latch.await(1, TimeUnit.MINUTES))
         durableSub.stop()
 
         eventually(duration = 5.seconds, waitBetween = 10.millis, waitBefore = 0.millis) {
@@ -167,10 +167,10 @@ class DurableSubscriptionIntegrationTest {
         publisher = publisherFactory.createPublisher(publisherConfig, kafkaConfig)
         val futures = publisher.publish(getStringRecords(DURABLE_TOPIC3, 5, 2))
         assertThat(futures.size).isEqualTo(10)
-        futures.forEach { it.get(10, TimeUnit.SECONDS) }
+        futures.forEach { it.get(30, TimeUnit.SECONDS) }
         val futures2 = publisher.publish(getDemoRecords(DURABLE_TOPIC3, 5, 2))
         assertThat(futures2.size).isEqualTo(10)
-        futures2.forEach { it.get(10, TimeUnit.SECONDS) }
+        futures2.forEach { it.get(30, TimeUnit.SECONDS) }
         publisher.close()
 
         val latch = CountDownLatch(10)
@@ -188,12 +188,12 @@ class DurableSubscriptionIntegrationTest {
             null
         )
         durableSub.start()
+        dlqDurableSub.start()
 
-        assertTrue(latch.await(5, TimeUnit.SECONDS))
+        assertTrue(latch.await(1, TimeUnit.MINUTES))
         durableSub.stop()
 
-        dlqDurableSub.start()
-        assertTrue(dlqLatch.await(5, TimeUnit.SECONDS))
+        assertTrue(dlqLatch.await(5, TimeUnit.MINUTES))
         durableSub.stop()
     }
 

--- a/testing/message-patterns/src/kafka-integration-test/kotlin/net/corda/messaging/kafka/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/kafka-integration-test/kotlin/net/corda/messaging/kafka/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
@@ -356,7 +356,7 @@ class StateAndEventSubscriptionIntegrationTest {
         publisher = publisherFactory.createPublisher(publisherConfig, kafkaConfig)
         publisher.publish(getStringRecords(EVENT_TOPIC5, 5, 2)).forEach { it.get() }
 
-        assertTrue(stateAndEventLatch.await(75, TimeUnit.SECONDS))
+        assertTrue(stateAndEventLatch.await(5, TimeUnit.MINUTES))
         assertTrue(durableLatch.await(30, TimeUnit.SECONDS))
         assertTrue(deadLetterLatch.await(30, TimeUnit.SECONDS))
 

--- a/testing/message-patterns/test.bndrun
+++ b/testing/message-patterns/test.bndrun
@@ -1,11 +1,8 @@
 -tester: biz.aQute.tester.junit-platform
-
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
+-runtrace: true
 -resolve.effective: active
-
--runvm: \
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
 
 #uncomment to remote debug
 #-runjdb: 5005


### PR DESCRIPTION
The message patterns integration tests were missing some system packages in the bndrun file. I was also seeing some overly slow tests locally, so I increased a few timeouts. There's a performance epic to investigate later for this.