### PR TITLE
CORE-3309: Resolve some sandbox / flow / OSGi / Gradle technical debt.

### DIFF
--- a/applications/examples/serialization-amqp/custom-serializer-poc/build.gradle
+++ b/applications/examples/serialization-amqp/custom-serializer-poc/build.gradle
@@ -49,7 +49,6 @@ dependencies {
 
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-    runtimeOnly "org.ow2.asm:asm:$asmVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
     runtimeOnly project(':libs:crypto:crypto-impl')
     runtimeOnly project(':libs:sandbox-internal')

--- a/applications/examples/serialization-amqp/type-evolution-poc/build.gradle
+++ b/applications/examples/serialization-amqp/type-evolution-poc/build.gradle
@@ -47,7 +47,6 @@ dependencies {
 
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-    runtimeOnly "org.ow2.asm:asm:$asmVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
     runtimeOnly project(':libs:crypto:crypto-impl')
     runtimeOnly project(':libs:sandbox-internal')

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation project(':processors:flow-processor')
     implementation project(':processors:rpc-processor')
     implementation "info.picocli:picocli:$picocliVersion"
+    implementation 'net.corda:corda-base'
 
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"

--- a/applications/workers/release/crypto-worker/build.gradle
+++ b/applications/workers/release/crypto-worker/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(':processors:crypto-processor')
     implementation "info.picocli:picocli:$picocliVersion"
+    implementation 'net.corda:corda-base'
 
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"

--- a/applications/workers/release/db-worker/build.gradle
+++ b/applications/workers/release/db-worker/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(':processors:db-processor')
     implementation "info.picocli:picocli:$picocliVersion"
+    implementation 'net.corda:corda-base'
 
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"

--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(':processors:flow-processor')
     implementation "info.picocli:picocli:$picocliVersion"
+    implementation 'net.corda:corda-base'
 
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"

--- a/applications/workers/release/rpc-worker/build.gradle
+++ b/applications/workers/release/rpc-worker/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(':processors:rpc-processor')
     implementation "info.picocli:picocli:$picocliVersion"
+    implementation 'net.corda:corda-base'
 
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -70,7 +70,6 @@ dependencies {
     systemPackages "net.corda.kotlin:kotlin-stdlib-jdk7-osgi:$kotlinVersion"
     systemPackages "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
     systemPackages "org.slf4j:slf4j-api:$slf4jVersion"
-    systemPackages "net.corda:corda-base:$cordaApiVersion"
     systemPackages project(":osgi-framework-api")
 }
 
@@ -442,15 +441,17 @@ artifacts {
     archives appJar
 }
 
-publishing {
-    publications {
-        mavenAppJar(MavenPublication) {
-            artifactId appJarBaseName
+pluginManager.withPlugin('maven-publish') {
+    publishing {
+        publications {
+            mavenAppJar(MavenPublication) {
+                artifactId appJarBaseName
 
-            afterEvaluate { proj ->
-                groupId proj.group
-                version proj.version
-                artifact appJar
+                afterEvaluate { proj ->
+                    groupId proj.group
+                    version proj.version
+                    artifact appJar
+                }
             }
         }
     }

--- a/components/install/install-service-file-based-impl/test.bndrun
+++ b/components/install/install-service-file-based-impl/test.bndrun
@@ -34,7 +34,10 @@
 # The version ranges will change as the versions of
 # the artifacts and/or their dependencies change.
 -runbundles: \
+	avro;version='[1.11.0,1.11.1)',\
+	bcpkix;version='[1.69.0,1.69.1)',\
 	bcprov;version='[1.69.0,1.69.1)',\
+	bcutil;version='[1.69.0,1.69.1)',\
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.12.5,2.12.6)',\
 	com.fasterxml.jackson.core.jackson-core;version='[2.12.5,2.12.6)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.12.5,2.12.6)',\
@@ -56,11 +59,9 @@
 	net.corda.configuration-read-service-impl;version='[5.0.0,5.0.1)',\
 	net.corda.crypto;version='[5.0.0,5.0.1)',\
 	net.corda.crypto-internal;version='[5.0.0,5.0.1)',\
-	net.corda.file-configuration-read-impl;version='[5.0.0,5.0.1)',\
+	net.corda.inmemory-messaging-impl;version='[5.0.0,5.0.1)',\
 	net.corda.install-service;version='[5.0.0,5.0.1)',\
 	net.corda.install-service-file-based-impl;version='[5.0.0,5.0.1)',\
-	net.corda.inmemory-messaging-impl;version='[5.0.0,5.0.1)',\
-	net.corda.install;version='[5.0.0,5.0.1)',\
 	net.corda.kotlin-stdlib-jdk7.osgi-bundle;version='[1.4.32,1.4.33)',\
 	net.corda.kotlin-stdlib-jdk8.osgi-bundle;version='[1.4.32,1.4.33)',\
 	net.corda.lifecycle;version='[5.0.0,5.0.1)',\
@@ -68,6 +69,7 @@
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.registry;version='[5.0.0,5.0.1)',\
+	net.i2p.crypto.eddsa;version='[0.3.0,0.3.1)',\
 	org.apache.commons.commons-compress;version='[1.21.0,1.21.1)',\
 	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.jetbrains.kotlin.osgi-bundle;version='[1.4.32,1.4.33)',\

--- a/components/sandbox/sandbox-service/src/main/kotlin/net/corda/sandbox/service/impl/SandboxServiceImpl.kt
+++ b/components/sandbox/sandbox-service/src/main/kotlin/net/corda/sandbox/service/impl/SandboxServiceImpl.kt
@@ -114,7 +114,7 @@ class SandboxServiceImpl @Activate constructor(
     ): SandboxGroupContext {
         val cpb = installService.get(cpiIdentifier).get()
             ?: throw CordaRuntimeException("Could not get cpi from its identifier $cpiIdentifier")
-        val identifiers = cpb.cpks.map { it.metadata.id }.toSet()
+        val identifiers = cpb.cpks.mapTo(LinkedHashSet()) { it.metadata.id }
         val virtualNodeContext = VirtualNodeContext(holdingIdentity, identifiers, sandboxGroupType)
         return sandboxGroupContextService.getOrCreate(virtualNodeContext, initializer)
     }

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
@@ -63,15 +63,15 @@ internal class SandboxGroupContextServiceImplTest {
         }
     }
 
-    private fun Set<CPK>.toIds() = map { it.metadata.id }.toSet()
-    private fun Set<CPK>.toMap() = map { it.metadata.id to it }.toMap()
+    private fun Set<CPK>.toIds() = mapTo(LinkedHashSet()) { it.metadata.id }
+    private fun Set<CPK>.toMap() = associateBy { it.metadata.id }
 
     private val cpkServiceImpl = InstallServiceImpl(cpks.toMap())
 
     @BeforeEach
     private fun beforeEach() {
         service = SandboxGroupContextServiceImpl(Helpers.mockSandboxCreationService(listOf(cpks)), cpkServiceImpl)
-        virtualNodeContext = VirtualNodeContext(holdingIdentity, cpks.toMap().keys, SandboxGroupType.FLOW)
+        virtualNodeContext = VirtualNodeContext(holdingIdentity, cpks.toIds(), SandboxGroupType.FLOW)
     }
 
     @Test

--- a/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/JsonMarshallingServiceImpl.kt
+++ b/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/JsonMarshallingServiceImpl.kt
@@ -1,6 +1,10 @@
 package net.corda.application.impl.services.json
 
+import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.type.TypeFactory
+import com.fasterxml.jackson.databind.util.LRUMap
+import com.fasterxml.jackson.databind.util.LookupCache
 import net.corda.v5.application.injection.CordaFlowInjectable
 import net.corda.v5.application.services.json.JsonMarshallingService
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -12,8 +16,16 @@ import org.osgi.service.component.annotations.Component
  */
 @Component(service = [SingletonSerializeAsToken::class])
 class JsonMarshallingServiceImpl : JsonMarshallingService, SingletonSerializeAsToken, CordaFlowInjectable {
+    private companion object {
+        private const val INITIAL_SIZE = 16
+        private const val MAX_SIZE = 200
+    }
 
-    private val mapper = ObjectMapper()
+    private val mapper = ObjectMapper().apply {
+        // Provide our own TypeFactory instance rather than using shared global one.
+        typeFactory = TypeFactory.defaultInstance()
+            .withCache(LRUMap<Any, JavaType>(INITIAL_SIZE, MAX_SIZE) as LookupCache<Any, JavaType>)
+    }
 
     override fun formatJson(input: Any): String {
         return mapper.writeValueAsString(input)

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -31,6 +31,7 @@
 	com.fasterxml.classmate;version='[1.5.1,1.5.2)',\
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
+	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
 	javax.persistence-api;version='[2.2.0,2.2.1)',\
 	jaxb-api;version='[2.3.1,2.3.2)',\

--- a/libs/flows/flow-manager-impl/src/main/kotlin/net/corda/flow/manager/impl/factory/SandboxDependencyInjectionFactoryImpl.kt
+++ b/libs/flows/flow-manager-impl/src/main/kotlin/net/corda/flow/manager/impl/factory/SandboxDependencyInjectionFactoryImpl.kt
@@ -8,19 +8,21 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ReferencePolicy
-import org.osgi.service.component.annotations.ReferenceCardinality
+import org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC
+import org.osgi.service.component.annotations.ReferenceCardinality.MULTIPLE
 
-
+@Suppress("CanBePrimaryConstructorProperty")
 @Component(service = [SandboxDependencyInjectionFactory::class])
 class SandboxDependencyInjectionFactoryImpl(
     singletons: List<SingletonSerializeAsToken>
 ) : SandboxDependencyInjectionFactory {
 
+    @Suppress("unused")
     @Activate
     constructor() : this(mutableListOf())
 
-    @Reference(service = SingletonSerializeAsToken::class, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    // We cannot use constructor injection with DYNAMIC policy.
+    @Reference(service = SingletonSerializeAsToken::class, cardinality = MULTIPLE, policy = DYNAMIC)
     private val singletons: List<SingletonSerializeAsToken> = singletons
 
     override fun create(sandboxGroupContext: SandboxGroupContext): SandboxDependencyInjector {

--- a/libs/flows/flow-manager-impl/src/main/kotlin/net/corda/flow/manager/impl/pipeline/factory/FlowEventPipelineFactoryImpl.kt
+++ b/libs/flows/flow-manager-impl/src/main/kotlin/net/corda/flow/manager/impl/pipeline/factory/FlowEventPipelineFactoryImpl.kt
@@ -13,9 +13,10 @@ import net.corda.flow.manager.impl.runner.FlowRunner
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ReferenceCardinality
-import org.osgi.service.component.annotations.ReferencePolicy
+import org.osgi.service.component.annotations.ReferenceCardinality.MULTIPLE
+import org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC
 
+@Suppress("CanBePrimaryConstructorProperty")
 @Component(service = [FlowEventPipelineFactory::class])
 class FlowEventPipelineFactoryImpl(
     private val flowRunner: FlowRunner,
@@ -23,18 +24,20 @@ class FlowEventPipelineFactoryImpl(
     flowRequestHandlers: List<FlowRequestHandler<out FlowIORequest<*>>>
 ) : FlowEventPipelineFactory {
 
-    @Reference(service = FlowEventHandler::class, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    // We cannot use constructor injection with DYNAMIC policy.
+    @Reference(service = FlowEventHandler::class, cardinality = MULTIPLE, policy = DYNAMIC)
     private val flowEventHandlers: List<FlowEventHandler<Any>> = flowEventHandlers
 
-    @Reference(service = FlowRequestHandler::class, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    // We cannot use constructor injection with DYNAMIC policy.
+    @Reference(service = FlowRequestHandler::class, cardinality = MULTIPLE, policy = DYNAMIC)
     private val flowRequestHandlers: List<FlowRequestHandler<out FlowIORequest<*>>> = flowRequestHandlers
 
     private val flowEventHandlerMap: Map<Any, FlowEventHandler<Any>> by lazy {
-        flowEventHandlers.associateBy { it.type }
+        flowEventHandlers.associateBy(FlowEventHandler<*>::type)
     }
 
     private val flowRequestHandlerMap: Map<Class<out FlowIORequest<*>>, FlowRequestHandler<out FlowIORequest<*>>> by lazy {
-        flowRequestHandlers.associateBy { it.type }
+        flowRequestHandlers.associateBy(FlowRequestHandler<*>::type)
     }
 
     @Activate

--- a/libs/permissions/permission-datamodel/test.bndrun
+++ b/libs/permissions/permission-datamodel/test.bndrun
@@ -30,6 +30,7 @@
 	com.fasterxml.classmate;version='[1.5.1,1.5.2)',\
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
+	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
 	javax.persistence-api;version='[2.2.0,2.2.1)',\
 	jaxb-api;version='[2.3.1,2.3.2)',\

--- a/libs/serialization/serialization-kryo/test.bndrun
+++ b/libs/serialization/serialization-kryo/test.bndrun
@@ -1,7 +1,7 @@
 -tester: biz.aQute.tester.junit-platform
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
--resolve.effective: active
+-resolve.effective: resolve,active
 -runtrace: true
 
 -runvm: \

--- a/libs/virtual-node/virtual-node-manager/build.gradle
+++ b/libs/virtual-node/virtual-node-manager/build.gradle
@@ -43,10 +43,9 @@ dependencies {
     integrationTestRuntimeOnly project(":libs:sandbox-hooks")
     integrationTestRuntimeOnly project(":libs:sandbox-internal")
 
-    // Use custom configurations in consumer cpks to gather location of cpis to add into `resources`
-    // Note:  we define the configuration `cpiForTest` in each project's gradle script.
-    cpis project(path: 'test-resources:crypto-custom-digest-one-consumer-cpk', configuration: 'cpiForTest')
-    cpis project(path: 'test-resources:crypto-custom-digest-two-consumer-cpk', configuration: 'cpiForTest')
+    // Gather locations of CPIs to add into `resources`
+    cpis project(path: 'test-resources:crypto-custom-digest-one-consumer-cpk', configuration: 'cordaCPB')
+    cpis project(path: 'test-resources:crypto-custom-digest-two-consumer-cpk', configuration: 'cordaCPB')
 }
 
 def integrationTestResources = tasks.named('processIntegrationTestResources', ProcessResources) {

--- a/libs/virtual-node/virtual-node-manager/test-resources/crypto-custom-digest-one-consumer-cpk/build.gradle
+++ b/libs/virtual-node/virtual-node-manager/test-resources/crypto-custom-digest-one-consumer-cpk/build.gradle
@@ -17,16 +17,6 @@ cordapp {
     }
 }
 
-configurations {
-    cpiForTest {
-        canBeResolved = false
-    }
-}
-
-artifacts {
-    cpiForTest tasks.named('cpb', Jar)
-}
-
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"

--- a/libs/virtual-node/virtual-node-manager/test-resources/crypto-custom-digest-two-consumer-cpk/build.gradle
+++ b/libs/virtual-node/virtual-node-manager/test-resources/crypto-custom-digest-two-consumer-cpk/build.gradle
@@ -17,16 +17,6 @@ cordapp {
     }
 }
 
-configurations {
-    cpiForTest {
-        canBeResolved = false
-    }
-}
-
-artifacts {
-    cpiForTest tasks.named('cpb', Jar)
-}
-
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
     implementation project(":osgi-framework-api")
-    implementation 'net.corda:corda-base'
     implementation 'org.slf4j:slf4j-api'
     implementation "org.slf4j:jul-to-slf4j:$slf4jVersion"
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
+++ b/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
@@ -461,9 +461,7 @@ class OSGiFrameworkWrap(
                     // No risk of deadlock because applications are registered by [startApplications]
                     // after this method returned and [stop] runs in separate thread.
                     override fun shutdown(bundle: Bundle) {
-                        Thread {
-                            stop()
-                        }.run()
+                        Thread(::stop).start()
                     }
                 },
                 null


### PR DESCRIPTION
- Execute OSGi framework shutdown in its own thread, as originally intended.
- Allow `common-app` convention plugin not to publish its application, and remove unnecessary `corda-base` from system packages.
- Remove dependency on ASM from example applications.
- Each `JsonMarshallingService` instance now uses `ObjectMapper` with its own `TypeFactory` instead of sharing global one.
- Allow `SandboxDependencyInjector` to associate service objects with their own object class if they do not implement an acceptable interface.
- `FlowRunner` must use its own `ExecutorService`, and shut it down on deactivation so that the JVM can exit cleanly.