### PR TITLE
NOTICK  consolidate virtual node interfaces

### DIFF
--- a/components/install/install-service-file-based-impl/test.bndrun
+++ b/components/install/install-service-file-based-impl/test.bndrun
@@ -34,7 +34,10 @@
 # The version ranges will change as the versions of
 # the artifacts and/or their dependencies change.
 -runbundles: \
+	avro;version='[1.11.0,1.11.1)',\
+	bcpkix;version='[1.69.0,1.69.1)',\
 	bcprov;version='[1.69.0,1.69.1)',\
+	bcutil;version='[1.69.0,1.69.1)',\
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.12.5,2.12.6)',\
 	com.fasterxml.jackson.core.jackson-core;version='[2.12.5,2.12.6)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.12.5,2.12.6)',\
@@ -56,11 +59,9 @@
 	net.corda.configuration-read-service-impl;version='[5.0.0,5.0.1)',\
 	net.corda.crypto;version='[5.0.0,5.0.1)',\
 	net.corda.crypto-internal;version='[5.0.0,5.0.1)',\
-	net.corda.file-configuration-read-impl;version='[5.0.0,5.0.1)',\
+	net.corda.inmemory-messaging-impl;version='[5.0.0,5.0.1)',\
 	net.corda.install-service;version='[5.0.0,5.0.1)',\
 	net.corda.install-service-file-based-impl;version='[5.0.0,5.0.1)',\
-	net.corda.inmemory-messaging-impl;version='[5.0.0,5.0.1)',\
-	net.corda.install;version='[5.0.0,5.0.1)',\
 	net.corda.kotlin-stdlib-jdk7.osgi-bundle;version='[1.4.32,1.4.33)',\
 	net.corda.kotlin-stdlib-jdk8.osgi-bundle;version='[1.4.32,1.4.33)',\
 	net.corda.lifecycle;version='[5.0.0,5.0.1)',\
@@ -68,6 +69,7 @@
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.registry;version='[5.0.0,5.0.1)',\
+	net.i2p.crypto.eddsa;version='[0.3.0,0.3.1)',\
 	org.apache.commons.commons-compress;version='[1.21.0,1.21.1)',\
 	org.apache.felix.scr;version='[2.1.28,2.1.29)',\
 	org.jetbrains.kotlin.osgi-bundle;version='[1.4.32,1.4.33)',\

--- a/components/membership/group-policy-impl/src/integrationTest/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderIntegrationTest.kt
+++ b/components/membership/group-policy-impl/src/integrationTest/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderIntegrationTest.kt
@@ -23,7 +23,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.read.VirtualNodeInfoReaderComponent
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -48,7 +48,7 @@ class GroupPolicyProviderIntegrationTest {
     lateinit var groupPolicyProvider: GroupPolicyProvider
 
     @InjectService(timeout = 5000L)
-    lateinit var virtualNodeInfoReader: VirtualNodeInfoReaderComponent
+    lateinit var virtualNodeInfoReader: VirtualNodeInfoReadService
 
     @InjectService(timeout = 5000L)
     lateinit var cpiInfoReader: CpiInfoReadService

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -15,7 +15,7 @@ import net.corda.v5.membership.identity.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoListener
-import net.corda.virtualnode.read.VirtualNodeInfoReaderComponent
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -73,7 +73,7 @@ class GroupPolicyProviderImplTest {
 
     var virtualNodeListener: VirtualNodeInfoListener? = null
 
-    val virtualNodeInfoReader: VirtualNodeInfoReaderComponent = mock<VirtualNodeInfoReaderComponent>().apply {
+    val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock<VirtualNodeInfoReadService>().apply {
         doReturn(VirtualNodeInfo(holdingIdentity1, cpiIdentifier1)).whenever(this).get(eq(holdingIdentity1))
         doReturn(VirtualNodeInfo(holdingIdentity2, cpiIdentifier2)).whenever(this).get(eq(holdingIdentity2))
         doReturn(VirtualNodeInfo(holdingIdentity3, cpiIdentifier3)).whenever(this).get(eq(holdingIdentity3))
@@ -110,7 +110,7 @@ class GroupPolicyProviderImplTest {
     @BeforeEach
     fun setUp() {
         groupPolicyProvider = GroupPolicyProviderImpl(
-            virtualNodeInfoReader,
+            virtualNodeInfoReadService,
             cpiInfoReader,
             lifecycleCoordinatorFactory
         )

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/component/MembershipGroupReaderProviderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/component/MembershipGroupReaderProviderImpl.kt
@@ -16,7 +16,7 @@ import net.corda.membership.read.MembershipGroupReader
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.HoldingIdentity
-import net.corda.virtualnode.read.VirtualNodeInfoReaderComponent
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -34,8 +34,8 @@ import org.osgi.service.component.annotations.Reference
  */
 @Component(service = [MembershipGroupReaderProvider::class])
 class MembershipGroupReaderProviderImpl @Activate constructor(
-    @Reference(service = VirtualNodeInfoReaderComponent::class)
-    val virtualNodeInfoReader: VirtualNodeInfoReaderComponent,
+    @Reference(service = VirtualNodeInfoReadService::class)
+    val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
     val cpiInfoReader: CpiInfoReadService,
     @Reference(service = ConfigurationReadService::class)

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/lifecycle/MembershipGroupReadLifecycleHandler.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/lifecycle/MembershipGroupReadLifecycleHandler.kt
@@ -19,7 +19,7 @@ import net.corda.membership.impl.read.cache.MembershipGroupReadCache
 import net.corda.membership.impl.read.component.MembershipGroupReaderProviderImpl
 import net.corda.membership.impl.read.subscription.MembershipGroupReadSubscriptions
 import net.corda.membership.lifecycle.MembershipConfigReceived
-import net.corda.virtualnode.read.VirtualNodeInfoReaderComponent
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 
 /**
  * Lifecycle handler for the membership group read component.
@@ -37,7 +37,7 @@ interface MembershipGroupReadLifecycleHandler : LifecycleEventHandler {
         private var componentRegistrationHandle: AutoCloseable? = null
 
         private val virtualNodeInfoReader
-            get() = membershipGroupReadService.virtualNodeInfoReader
+            get() = membershipGroupReadService.virtualNodeInfoReadService
 
         private val cpiInfoReader
             get() = membershipGroupReadService.cpiInfoReader
@@ -68,7 +68,7 @@ interface MembershipGroupReadLifecycleHandler : LifecycleEventHandler {
                 setOf(
                     LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
                     LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
-                    LifecycleCoordinatorName.forComponent<VirtualNodeInfoReaderComponent>(),
+                    LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
                 )
             )
         }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/component/MembershipGroupReaderProviderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/component/MembershipGroupReaderProviderImplTest.kt
@@ -9,7 +9,7 @@ import net.corda.membership.impl.read.TestProperties.Companion.aliceName
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.HoldingIdentity
-import net.corda.virtualnode.read.VirtualNodeInfoReaderComponent
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -43,7 +43,7 @@ class MembershipGroupReaderProviderImplTest {
     }
 
     private val cpiInfoReader: CpiInfoReadService = mock()
-    private val virtualNodeInfoReader: VirtualNodeInfoReaderComponent = mock()
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock()
     private val subscriptionFactory: SubscriptionFactory = mock()
     private val configurationReadService: ConfigurationReadService = mock()
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory = mock<LifecycleCoordinatorFactory>().apply {
@@ -53,7 +53,7 @@ class MembershipGroupReaderProviderImplTest {
     @BeforeEach
     fun setUp() {
         membershipGroupReadService = MembershipGroupReaderProviderImpl(
-            virtualNodeInfoReader,
+            virtualNodeInfoReadService,
             cpiInfoReader,
             configurationReadService,
             subscriptionFactory,

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/lifecycle/MembershipGroupReadLifecycleHandlerTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/lifecycle/MembershipGroupReadLifecycleHandlerTest.kt
@@ -19,7 +19,7 @@ import net.corda.membership.impl.read.component.MembershipGroupReaderProviderImp
 import net.corda.membership.impl.read.lifecycle.MembershipGroupReadLifecycleHandler.Impl.MembershipGroupConfigurationHandler
 import net.corda.membership.impl.read.subscription.MembershipGroupReadSubscriptions
 import net.corda.membership.lifecycle.MembershipConfigReceived
-import net.corda.virtualnode.read.VirtualNodeInfoReaderComponent
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -39,7 +39,7 @@ class MembershipGroupReadLifecycleHandlerTest {
     val componentRegistrationHandle: RegistrationHandle = mock()
     val configRegistrationHandle: AutoCloseable = mock()
 
-    val virtualNodeInfoReader: VirtualNodeInfoReaderComponent = mock()
+    val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock()
     val cpiInfoReader: CpiInfoReadService = mock()
     val configurationReadService: ConfigurationReadService = mock<ConfigurationReadService>().apply {
         doReturn(configRegistrationHandle).whenever(this).registerForUpdates(any())
@@ -49,7 +49,7 @@ class MembershipGroupReadLifecycleHandlerTest {
         doReturn(readServiceCoordinator).whenever(this).createCoordinator(any(), any())
     }
     private val membershipGroupReadService: MembershipGroupReaderProviderImpl = MembershipGroupReaderProviderImpl(
-        virtualNodeInfoReader, cpiInfoReader, configurationReadService, mock(), coordinatorFactory
+        virtualNodeInfoReadService, cpiInfoReader, configurationReadService, mock(), coordinatorFactory
     )
     private val membershipGroupReadSubscriptions: MembershipGroupReadSubscriptions = mock()
 
@@ -74,7 +74,7 @@ class MembershipGroupReadLifecycleHandlerTest {
 
         verify(configurationReadService).start()
         verify(cpiInfoReader).start()
-        verify(virtualNodeInfoReader).start()
+        verify(virtualNodeInfoReadService).start()
         verify(membershipGroupReadCache).start()
 
         verify(coordinator).followStatusChangesByName(
@@ -82,7 +82,7 @@ class MembershipGroupReadLifecycleHandlerTest {
                 setOf(
                     LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
                     LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
-                    LifecycleCoordinatorName.forComponent<VirtualNodeInfoReaderComponent>(),
+                    LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
                 )
             )
         )
@@ -94,7 +94,7 @@ class MembershipGroupReadLifecycleHandlerTest {
 
         verify(configurationReadService).stop()
         verify(cpiInfoReader).stop()
-        verify(virtualNodeInfoReader).stop()
+        verify(virtualNodeInfoReadService).stop()
         verify(membershipGroupReadSubscriptions).stop()
         verify(membershipGroupReadCache).stop()
 

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/VirtualNodeInfoReadService.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/VirtualNodeInfoReadService.kt
@@ -1,5 +1,6 @@
 package net.corda.virtualnode.read
 
+import net.corda.lifecycle.Lifecycle
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 
@@ -13,7 +14,7 @@ import net.corda.virtualnode.VirtualNodeInfo
  * You will probably use the callback if you are automatically interacting with the service,
  * e.g. a status page listening all nodes in the system.
  */
-interface VirtualNodeInfoReader {
+interface VirtualNodeInfoReadService : Lifecycle {
     /**
      * Returns virtual node context information for a given holding identity
      * without starting any bundles or instantiating any classes.

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/VirtualNodeInfoReaderComponent.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/VirtualNodeInfoReaderComponent.kt
@@ -1,8 +1,0 @@
-package net.corda.virtualnode.read
-
-import net.corda.lifecycle.Lifecycle
-
-/**
- * Virtual node service component interface, particularly for OSGi
- */
-interface VirtualNodeInfoReaderComponent : VirtualNodeInfoReader, Lifecycle

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReadServiceImpl.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReadServiceImpl.kt
@@ -13,28 +13,28 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.common.ConfigChangedEvent
 import net.corda.virtualnode.impl.VirtualNodeInfoProcessor
 import net.corda.virtualnode.read.VirtualNodeInfoListener
-import net.corda.virtualnode.read.VirtualNodeInfoReader
-import net.corda.virtualnode.read.VirtualNodeInfoReaderComponent
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 
 /**
- * Virtual Node Info Service Component which implements [VirtualNodeInfoReader]
+ * Virtual Node Info Service Component which implements [VirtualNodeInfoReadService]
  *
  * Split into an event handler, a message processor, and this class, which contains the [LifecycleCoordinator]
  * for this component.
  */
-@Component(service = [VirtualNodeInfoReaderComponent::class])
-class VirtualNodeInfoReaderComponentImpl @Activate constructor(
+@Suppress("Unused")
+@Component(service = [VirtualNodeInfoReadService::class])
+class VirtualNodeInfoReadServiceImpl @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val coordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     configurationReadService: ConfigurationReadService,
     @Reference(service = SubscriptionFactory::class)
     subscriptionFactory: SubscriptionFactory
-) : VirtualNodeInfoReaderComponent {
+) : VirtualNodeInfoReadService {
     companion object {
         val log: Logger = contextLogger()
     }
@@ -58,7 +58,7 @@ class VirtualNodeInfoReaderComponentImpl @Activate constructor(
         this::onConfigChangeEvent
     )
 
-    private val coordinator = coordinatorFactory.createCoordinator<VirtualNodeInfoReader>(eventHandler)
+    private val coordinator = coordinatorFactory.createCoordinator<VirtualNodeInfoReadService>(eventHandler)
 
     /** Post a [ConfigChangedEvent]  */
     private fun onConfigChangeEvent(event: ConfigChangedEvent) = coordinator.postEvent(event)

--- a/components/virtual-node/virtual-node-info-write-service/src/main/kotlin/net/corda/virtualnode/write/VirtualNodeInfoWriteService.kt
+++ b/components/virtual-node/virtual-node-info-write-service/src/main/kotlin/net/corda/virtualnode/write/VirtualNodeInfoWriteService.kt
@@ -1,5 +1,6 @@
 package net.corda.virtualnode.write
 
+import net.corda.lifecycle.Lifecycle
 import net.corda.virtualnode.VirtualNodeInfo
 
 /**
@@ -8,7 +9,7 @@ import net.corda.virtualnode.VirtualNodeInfo
  *
  * This interface complements [VirtualNodeInfoReader]
  */
-interface VirtualNodeInfoWriter {
+interface VirtualNodeInfoWriteService : Lifecycle {
     /** Put a new [VirtualNodeInfo] into some implementation (e.g. a Kafka component) */
     fun put(virtualNodeInfo: VirtualNodeInfo)
     

--- a/components/virtual-node/virtual-node-info-write-service/src/main/kotlin/net/corda/virtualnode/write/VirtualNodeInfoWriterComponent.kt
+++ b/components/virtual-node/virtual-node-info-write-service/src/main/kotlin/net/corda/virtualnode/write/VirtualNodeInfoWriterComponent.kt
@@ -1,5 +1,0 @@
-package net.corda.virtualnode.write
-
-import net.corda.lifecycle.Lifecycle
-
-interface VirtualNodeInfoWriterComponent : VirtualNodeInfoWriter, Lifecycle

--- a/components/virtual-node/virtual-node-info-write-service/src/main/kotlin/net/corda/virtualnode/write/impl/VirtualNodeInfoWriteServiceImpl.kt
+++ b/components/virtual-node/virtual-node-info-write-service/src/main/kotlin/net/corda/virtualnode/write/impl/VirtualNodeInfoWriteServiceImpl.kt
@@ -18,21 +18,21 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.common.ConfigChangedEvent
 import net.corda.virtualnode.common.MessagingConfigEventHandler
 import net.corda.virtualnode.toAvro
-import net.corda.virtualnode.write.VirtualNodeInfoWriterComponent
+import net.corda.virtualnode.write.VirtualNodeInfoWriteService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 
-@Component(service = [VirtualNodeInfoWriterComponent::class])
-class VirtualNodeInfoWriterComponentImpl @Activate constructor(
+@Component(service = [VirtualNodeInfoWriteService::class])
+class VirtualNodeInfoWriteServiceImpl @Activate constructor(
     @Reference
     private val coordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,
     @Reference(service = PublisherFactory::class)
     private val publisherFactory: PublisherFactory
-) : VirtualNodeInfoWriterComponent {
+) : VirtualNodeInfoWriteService {
     companion object {
         val log: Logger = contextLogger()
         internal const val CLIENT_ID = "VIRTUAL_NODE_INFO_WRITER"
@@ -44,7 +44,7 @@ class VirtualNodeInfoWriterComponentImpl @Activate constructor(
     private val eventHandler: MessagingConfigEventHandler =
         MessagingConfigEventHandler(configurationReadService, this::onConfigChangeEvent, this::onConfig)
 
-    private val coordinator = coordinatorFactory.createCoordinator<VirtualNodeInfoWriterComponent>(eventHandler)
+    private val coordinator = coordinatorFactory.createCoordinator<VirtualNodeInfoWriteService>(eventHandler)
     private var publisher: Publisher? = null
 
     override fun put(virtualNodeInfo: VirtualNodeInfo) {


### PR DESCRIPTION
Simplify VirtualNodeInfo interfaces, and rename for consistency
and ease of discovery.  The previous interface name (and 
used by the coordinator) was horrible.

Might need another push if PR #721 is merged first.