### PR TITLE
CORE-3620 added LifecycleDependenciesTracker

### DIFF
--- a/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/LifecycleDependenciesTracker.kt
+++ b/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/LifecycleDependenciesTracker.kt
@@ -1,0 +1,115 @@
+package net.corda.lifecycle
+
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.debug
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Encapsulates a group of Dependent components which UP status should be tracked.
+ *
+ * @constructor Create object which can track dependencies UP status
+ *
+ * @throws [IllegalArgumentException] if the list of dependencies is empty set.
+ *
+ * @sample
+ * private fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
+ *  when (event) {
+ *      is StartEvent -> {
+ *          tracker?.close()
+ *          tracker = lifecycleCoordinator.track(SoftKeysPersistenceProvider::class.java)
+ *      }
+ *      is StopEvent -> {
+ *          tracker?.close()
+ *          tracker = null
+ *      }
+ *      is RegistrationStatusChangeEvent -> {
+ *          if (tracker?.areUpAfter(event, coordinator) == true) {
+ *              this.lifecycleCoordinator.updateStatus(LifecycleStatus.UP)
+ *          } else {
+ *              this.lifecycleCoordinator.updateStatus(LifecycleStatus.DOWN)
+ *      }
+ *  }
+ *  else -> logger.error("Unexpected event $event!")
+ * }
+ *}
+ */
+class LifecycleDependenciesTracker(
+    private val owner: LifecycleCoordinator,
+    dependencies: Set<LifecycleCoordinatorName>
+) : AutoCloseable {
+    companion object {
+        private val logger = contextLogger()
+
+        /**
+         * Instantiates [LifecycleDependenciesTracker] for a given set of [LifecycleCoordinatorName]
+         */
+        fun LifecycleCoordinator.track(vararg dependencies: LifecycleCoordinatorName) =
+            LifecycleDependenciesTracker(this, dependencies.toSet())
+
+        /**
+         * Instantiates [LifecycleDependenciesTracker] for a given set of dependencies implementing [Lifecycle],
+         * uses LifecycleCoordinatorName(it.name) under the hood
+         */
+        fun LifecycleCoordinator.track(vararg dependencies: Class<out Lifecycle>) =
+            LifecycleDependenciesTracker(this, dependencies.map {
+                LifecycleCoordinatorName(it.name)
+            }.toSet())
+    }
+
+    private val registrations: ConcurrentHashMap<RegistrationHandle, StatusHolder>
+
+    init {
+        require(dependencies.isNotEmpty()) {
+            "There should be at least one dependency."
+        }
+        val map = dependencies.associate {
+            owner.followStatusChangesByName(setOf(it)) to StatusHolder(null)
+        }
+        registrations = ConcurrentHashMap(map)
+        logger.debug { "${owner.name}: follows status of [${dependencies.joinToString()}]" }
+    }
+
+    /**
+     * Releases all follow status registrations
+     */
+    override fun close() {
+        registrations.forEach { it.key.close() }
+        registrations.clear()
+    }
+
+    /**
+     * Processes [RegistrationStatusChangeEvent] event and checks whenever all dependencies have UP status.
+     *
+     * @return true if all dependencies are UP
+     */
+    fun areUpAfter(event: RegistrationStatusChangeEvent, coordinator: LifecycleCoordinator): Boolean {
+        processEvent(event, coordinator)
+        return areUp()
+    }
+
+    /**
+     * Processes [RegistrationStatusChangeEvent] event.
+     */
+    fun processEvent(event: RegistrationStatusChangeEvent, coordinator: LifecycleCoordinator) {
+        logger.info("{}: processing {} from {}", owner.name, event, coordinator.name)
+        registrations.computeIfPresent(event.registration) { _, _ ->
+            StatusHolder(event.status)
+        }
+    }
+
+    /**
+     * Returns true if all dependencies are UP
+     */
+    fun areUp(): Boolean {
+        val upCount = upCount()
+        logger.debug { "${owner.name}: up $upCount out of ${registrations.size}" }
+        return upCount == registrations.size
+    }
+
+    private fun upCount(): Int =
+        registrations.count { it.value.status == LifecycleStatus.UP }
+
+    class StatusHolder(
+        val status: LifecycleStatus?
+    )
+}

--- a/libs/lifecycle/lifecycle/src/test/kotlin/net/corda/lifecycle/LifecycleDependenciesTrackerTest.kt
+++ b/libs/lifecycle/lifecycle/src/test/kotlin/net/corda/lifecycle/LifecycleDependenciesTrackerTest.kt
@@ -1,0 +1,156 @@
+package net.corda.lifecycle
+
+import net.corda.lifecycle.LifecycleDependenciesTracker.Companion.track
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+
+class LifecycleDependenciesTrackerTest {
+    @Test
+    fun `Should throw IllegalArgumentException when the list of dependencies is empty`() {
+        val coordinator = mock<LifecycleCoordinator> {
+            on { name } doReturn LifecycleCoordinatorName.forComponent<LifecycleDependenciesTrackerTest>()
+        }
+        assertThrows<IllegalArgumentException> {
+            LifecycleDependenciesTracker(coordinator, emptySet())
+        }
+    }
+
+    @Test
+    fun `areUpAfter close registration handle`() {
+        val handles = mutableListOf<RegistrationHandle>()
+        val dependencyNames = mutableListOf<LifecycleCoordinatorName>()
+        val coordinator = mock<LifecycleCoordinator> {
+            on { name } doReturn LifecycleCoordinatorName.forComponent<LifecycleDependenciesTrackerTest>()
+            on { followStatusChangesByName(any()) } doAnswer {
+                val names = it.getArgument(0) as Set<LifecycleCoordinatorName>
+                assertEquals(1, names.size)
+                dependencyNames.add(names.first())
+                val handle = mock<RegistrationHandle>()
+                handles.add(handle)
+                handle
+            }
+        }
+        val name1 = LifecycleCoordinatorName("name1")
+        val name2 = LifecycleCoordinatorName("name2")
+        val tracker = coordinator.track(name1, name2)
+        assertEquals(2, handles.size)
+        val event1 = RegistrationStatusChangeEvent(handles[0], LifecycleStatus.UP)
+        val event2 = RegistrationStatusChangeEvent(handles[1], LifecycleStatus.UP)
+        assertFalse(tracker.areUpAfter(event1, coordinator))
+        assertTrue(tracker.areUpAfter(event2, coordinator))
+        tracker.close()
+        handles.forEach {
+            Mockito.verify(it, times(1)).close()
+        }
+    }
+
+    @Test
+    fun `areUpAfter should return that all components are up only after all dependencies are up`() {
+        val handles = mutableListOf<RegistrationHandle>()
+        val dependencyNames = mutableListOf<LifecycleCoordinatorName>()
+        val coordinator = mock<LifecycleCoordinator> {
+            on { name } doReturn LifecycleCoordinatorName.forComponent<LifecycleDependenciesTrackerTest>()
+            on { followStatusChangesByName(any()) } doAnswer {
+                val names = it.getArgument(0) as Set<LifecycleCoordinatorName>
+                assertEquals(1, names.size)
+                dependencyNames.add(names.first())
+                val handle = mock<RegistrationHandle>()
+                handles.add(handle)
+                handle
+            }
+        }
+        val name1 = LifecycleCoordinatorName("name1")
+        val name2 = LifecycleCoordinatorName("name2")
+        val tracker = coordinator.track(name1, name2)
+        assertEquals(2, handles.size)
+        val event1 = RegistrationStatusChangeEvent(handles[0], LifecycleStatus.UP)
+        val event2 = RegistrationStatusChangeEvent(handles[1], LifecycleStatus.UP)
+        assertFalse(tracker.areUpAfter(event1, coordinator))
+        assertTrue(tracker.areUpAfter(event2, coordinator))
+        handles.forEach {
+            Mockito.verify(it, never()).close()
+        }
+    }
+
+    @Test
+    fun `processEvent and areUp should return that all components are up only after all dependencies are up`() {
+        val handles = mutableListOf<RegistrationHandle>()
+        val dependencyNames = mutableListOf<LifecycleCoordinatorName>()
+        val coordinator = mock<LifecycleCoordinator> {
+            on { name } doReturn LifecycleCoordinatorName.forComponent<LifecycleDependenciesTrackerTest>()
+            on { followStatusChangesByName(any()) } doAnswer {
+                val names = it.getArgument(0) as Set<LifecycleCoordinatorName>
+                assertEquals(1, names.size)
+                dependencyNames.add(names.first())
+                val handle = mock<RegistrationHandle>()
+                handles.add(handle)
+                handle
+            }
+        }
+        val name1 = LifecycleCoordinatorName("name1")
+        val name2 = LifecycleCoordinatorName("name2")
+        val tracker = coordinator.track(name1, name2)
+        assertEquals(2, handles.size)
+        val event1 = RegistrationStatusChangeEvent(handles[0], LifecycleStatus.UP)
+        val event2 = RegistrationStatusChangeEvent(handles[1], LifecycleStatus.UP)
+        tracker.processEvent(event1, coordinator)
+        assertFalse(tracker.areUp())
+        tracker.processEvent(event2, coordinator)
+        assertTrue(tracker.areUp())
+        handles.forEach {
+            Mockito.verify(it, never()).close()
+        }
+    }
+
+    @Test
+    fun `Should construct tracker from types`() {
+        val handles = mutableListOf<RegistrationHandle>()
+        val dependencyNames = mutableListOf<LifecycleCoordinatorName>()
+        val coordinator = mock<LifecycleCoordinator> {
+            on { name } doReturn LifecycleCoordinatorName.forComponent<LifecycleDependenciesTrackerTest>()
+            on { followStatusChangesByName(any()) } doAnswer {
+                val names = it.getArgument(0) as Set<LifecycleCoordinatorName>
+                assertEquals(1, names.size)
+                dependencyNames.add(names.first())
+                val handle = mock<RegistrationHandle>()
+                handles.add(handle)
+                handle
+            }
+        }
+        val tracker = coordinator.track(Component1::class.java, Component2::class.java)
+        assertEquals(2, handles.size)
+        val event1 = RegistrationStatusChangeEvent(handles[0], LifecycleStatus.UP)
+        val event2 = RegistrationStatusChangeEvent(handles[1], LifecycleStatus.UP)
+        assertFalse(tracker.areUpAfter(event1, coordinator))
+        assertTrue(tracker.areUpAfter(event2, coordinator))
+        handles.forEach {
+            Mockito.verify(it, never()).close()
+        }
+    }
+
+    private class Component1 : Lifecycle {
+        override val isRunning: Boolean = true
+        override fun start() {
+        }
+        override fun stop() {
+        }
+    }
+
+    private class Component2 : Lifecycle {
+        override val isRunning: Boolean = true
+        override fun start() {
+        }
+        override fun stop() {
+        }
+    }
+}


### PR DESCRIPTION
Tracks the UP status of life cycle dependencies. Could be useful if a components UP status depends on status of some other components.