### PR TITLE
NOTICK: Use a fixed consumer group for the flow service

### DIFF
--- a/applications/tools/flow-worker-setup/config.conf
+++ b/applications/tools/flow-worker-setup/config.conf
@@ -18,16 +18,6 @@ corda {
     }
     flow {
         componentVersion="5.1"
-        manager {
-            consumer {
-                group = "FlowEventConsumer"
-            }
-        }
-        mapper {
-            consumer {
-                group = "FlowMapperConsumer"
-            }
-        }
     }
     cpi {
         componentVersion="5.1"

--- a/components/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutor.kt
+++ b/components/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutor.kt
@@ -29,7 +29,7 @@ class FlowExecutor(
 
     companion object {
         private val logger = contextLogger()
-        private const val GROUP = "FlowEventConsumer"
+        private const val CONSUMER_GROUP = "FlowEventConsumer"
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<FlowExecutor> { event, _ -> eventHandler(event) }
@@ -42,7 +42,7 @@ class FlowExecutor(
                 logger.debug { "Starting the flow executor" }
                 val instanceId = config.getInt(INSTANCE_ID)
                 messagingSubscription = subscriptionFactory.createStateAndEventSubscription(
-                    SubscriptionConfig(GROUP, FLOW_EVENT_TOPIC, instanceId),
+                    SubscriptionConfig(CONSUMER_GROUP, FLOW_EVENT_TOPIC, instanceId),
                     flowEventProcessorFactory.create(),
                     config
                 )


### PR DESCRIPTION
I managed to break the flow worker last week by changing how configuration parsing works, unsurprisingly. The issue was missing configuration about the consumer group for the flow service. I've changed this to a fixed value, as it's not clear to me that this should be configurable anyway. It's certainly ok for now, and can easily be switched back if required.