### PR TITLE
Core 3314 GW does not drop inbound TLS connection with malformed http headers

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServerChannelHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServerChannelHandler.kt
@@ -27,7 +27,7 @@ class HttpServerChannelHandler(private val serverListener: HttpServerListener,
     @Suppress("ComplexMethod")
     override fun channelRead0(ctx: ChannelHandlerContext, msg: HttpObject) {
         if (msg is HttpRequest) {
-            val responseCode: HttpResponseStatus = msg.validate()
+            val responseCode = msg.validate()
             if (responseCode != HttpResponseStatus.OK) {
                 logger.warn ("Received invalid HTTP request from ${ctx.channel().remoteAddress()}\n" +
                         "Protocol version: ${msg.protocolVersion()}\n" +


### PR DESCRIPTION
The gateway did not immediately close inbound TLS connection with malformed HTTP headers. For headers of length 0 it remained open for 10 minutes and for headers missing entirely an exception was escaping to netty, which closed the connection.  https://r3-cev.atlassian.net/browse/CORE-3314

These two scenarios were tested manually:
Content length of 0 - open 10m then stops
`time echo -e "GET / HTTP/1.0\r\nContent-Length: 0\r\n" | openssl s_client -connect localhost:37111 -servername www.ebowe-test.com -ign_eof -CAfile p2p-deployment/keystores/root.pem `
		
Content length header missing - error escapes to Netty
`time echo -e "GET / HTTP/1.0\r\n" | openssl s_client -connect localhost:37111 -servername www.ebowe-test.com -ign_eof -CAfile p2p-deployment/keystores/root.pem`

HTTP Response status is checked earlier as part of the fix. 

Now manual testing of the two scenarios shows the desired output:
400 Bad Request
No exceptions
Quick termination of connection