### PR TITLE
CORE-3650: Add note for uniqueness of aliases

### DIFF
--- a/applications/tools/p2p-test/cryptoservice-key-creator/README.md
+++ b/applications/tools/p2p-test/cryptoservice-key-creator/README.md
@@ -38,6 +38,8 @@ The file provided on the `--keys-config` CLI parameter should have the following
     ]
 }
 ```
+Note: the `alias` field acts as a unique identifier for each key pair entry and thus needs to be unique for each entry. If you want to deploy multiple identities behind a single host, make sure you use a different alias for the entry of each identity. 
+
 
 Key files are expected to be `.jks` files. You can create them using Java's `keytool`, e.g.:
 ```


### PR DESCRIPTION
Adding a note to explicitly call out aliases need to be unique, when deploying multiple identities behind a single host since they act as identifiers/keys in the message bus. 