### PR TITLE
NOTICK: Remove use of `devMode` from Production code

### DIFF
--- a/components/http-rpc-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/HttpRpcGatewayEventHandler.kt
+++ b/components/http-rpc-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/HttpRpcGatewayEventHandler.kt
@@ -156,8 +156,7 @@ internal class HttpRpcGatewayEventHandler(
         server = httpRpcServerFactory.createHttpRpcServer(
             rpcOpsImpls = dynamicRpcOps.toList(),
             rpcSecurityManager = rbacSecurityManagerService.securityManager,
-            httpRpcSettings = httpRpcSettings,
-            devMode = true
+            httpRpcSettings = httpRpcSettings
         ).also { it.start() }
 
         val numberOfRpcOps = dynamicRpcOps.filterIsInstance<Lifecycle>()

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/factory/HttpRpcServerFactoryImpl.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/factory/HttpRpcServerFactoryImpl.kt
@@ -10,15 +10,15 @@ import net.corda.httprpc.RpcOps
 import org.osgi.service.component.annotations.Component
 
 @Component(immediate = true, service = [HttpRpcServerFactory::class])
+@Suppress("Unused")
 class HttpRpcServerFactoryImpl : HttpRpcServerFactory {
 
     override fun createHttpRpcServer(
         rpcOpsImpls: List<PluggableRPCOps<out RpcOps>>,
         rpcSecurityManager: RPCSecurityManager,
-        httpRpcSettings: HttpRpcSettings,
-        devMode: Boolean
+        httpRpcSettings: HttpRpcSettings
     ): HttpRpcServer {
 
-        return HttpRpcServerImpl(rpcOpsImpls, rpcSecurityManager, httpRpcSettings, devMode)
+        return HttpRpcServerImpl(rpcOpsImpls, rpcSecurityManager, httpRpcSettings, devMode = false)
     }
 }

--- a/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/factory/HttpRpcServerFactory.kt
+++ b/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/factory/HttpRpcServerFactory.kt
@@ -11,7 +11,6 @@ interface HttpRpcServerFactory {
     fun createHttpRpcServer(
         rpcOpsImpls: List<PluggableRPCOps<out RpcOps>>,
         rpcSecurityManager: RPCSecurityManager,
-        httpRpcSettings: HttpRpcSettings,
-        devMode: Boolean
+        httpRpcSettings: HttpRpcSettings
     ): HttpRpcServer
 }


### PR DESCRIPTION
The change been verified by passing E2E tests.