### PR TITLE
CORE-3707: Domino logic for `PermissionCacheService`

### DIFF
--- a/components/permissions/permission-cache-service/src/main/kotlin/net/corda/permissions/cache/PermissionCacheService.kt
+++ b/components/permissions/permission-cache-service/src/main/kotlin/net/corda/permissions/cache/PermissionCacheService.kt
@@ -136,12 +136,13 @@ class PermissionCacheService @Activate constructor(
                 downTransition()
                 _permissionCache?.stop()
                 _permissionCache = null
-                coordinator.updateStatus(LifecycleStatus.DOWN)
             }
         }
     }
 
     private fun downTransition() {
+        coordinator.updateStatus(LifecycleStatus.DOWN)
+
         configHandle?.close()
         configHandle = null
         topicsRegistration?.close()


### PR DESCRIPTION
Make `PermissionCacheService` react to any of the subscriptions going down. And when Kafka connectivity is restored, ensure that `PermissionCacheService` reacts to it correctly.

Local testing proven that this is not quite working as expected, a [bug](https://r3-cev.atlassian.net/browse/CORE-3735) been raised to that effect.