### PR TITLE
CORE 3314 Gateway does not drop inbound TLS connection with malformed http headers

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServerChannelHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServerChannelHandler.kt
@@ -2,6 +2,7 @@ package net.corda.p2p.gateway.messaging.http
 
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelFutureListener
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.DefaultFullHttpResponse
 import io.netty.handler.codec.http.HttpContent
@@ -19,25 +20,31 @@ import java.lang.IndexOutOfBoundsException
 
 class HttpServerChannelHandler(private val serverListener: HttpServerListener,
                                private val logger: Logger): BaseHttpChannelHandler(serverListener, logger) {
-
-    private var responseCode: HttpResponseStatus? = null
-
     /**
      * Reads the HTTP objects into a [ByteBuf] and publishes them to all subscribers
      */
     @Suppress("ComplexMethod")
     override fun channelRead0(ctx: ChannelHandlerContext, msg: HttpObject) {
         if (msg is HttpRequest) {
-            responseCode = msg.validate()
-            logger.debug("Received HTTP request from ${ctx.channel().remoteAddress()}\n" +
+            val responseCode = msg.validate()
+            if (responseCode != HttpResponseStatus.OK) {
+                logger.warn ("Received invalid HTTP request from ${ctx.channel().remoteAddress()}\n" +
+                        "Protocol version: ${msg.protocolVersion()}\n" +
+                        "Hostname: ${msg.headers()[HttpHeaderNames.HOST]?:"unknown"}\n" +
+                        "Request URI: ${msg.uri()}\n and the response code was $responseCode.")
+                val response = createResponse(null, responseCode)
+                ctx.writeAndFlush(response)
+                    .addListener(ChannelFutureListener.CLOSE)
+                return
+            }
+
+            logger.debug ("Received HTTP request from ${ctx.channel().remoteAddress()}\n" +
                     "Protocol version: ${msg.protocolVersion()}\n" +
                     "Hostname: ${msg.headers()[HttpHeaderNames.HOST]?:"unknown"}\n" +
                     "Request URI: ${msg.uri()}\n" +
                     "Content length: ${msg.headers()[HttpHeaderNames.CONTENT_LENGTH]}\n")
             // initialise byte array to read the request into
-            if (responseCode!! != HttpResponseStatus.LENGTH_REQUIRED) {
-                allocateBodyBuffer(ctx, msg.headers()[HttpHeaderNames.CONTENT_LENGTH].toInt())
-            }
+            allocateBodyBuffer(ctx, msg.headers()[HttpHeaderNames.CONTENT_LENGTH].toInt())
 
             if (HttpUtil.is100ContinueExpected(msg)) {
                 send100Continue(ctx)
@@ -61,21 +68,10 @@ class HttpServerChannelHandler(private val serverListener: HttpServerListener,
         if (msg is LastHttpContent) {
             logger.debug("Read end of response body $msg")
             val returnByteArray = readBytesFromBodyBuffer()
-
-            when(responseCode) {
-                HttpResponseStatus.OK -> {
-                    val sourceAddress = ctx.channel().remoteAddress()
-                    val targetAddress = ctx.channel().localAddress()
-                    serverListener.onRequest(HttpRequest(returnByteArray, sourceAddress, targetAddress))
-                }
-                else -> {
-                    val response = createResponse(null, responseCode!!)
-                    ctx.writeAndFlush(response)
-                }
-            }
-
+            val sourceAddress = ctx.channel().remoteAddress()
+            val targetAddress = ctx.channel().localAddress()
+            serverListener.onRequest(HttpRequest(returnByteArray, sourceAddress, targetAddress))
             releaseBodyBuffer()
-            responseCode = null
         }
     }
 


### PR DESCRIPTION
The gateway did not immediately close inbound TLS connection with malformed HTTP headers. For headers of length 0 it remained open for 10 minutes and for headers missing entirely an exception was escaping to netty, which closed the connection. https://r3-cev.atlassian.net/browse/CORE-3314

These two scenarios were tested manually:
Content length of 0 - open 10m then stops
`time echo -e "GET / HTTP/1.0\r\nContent-Length: 0\r\n" | openssl s_client -connect localhost:37111 -servername www.ebowe-test.com -ign_eof -CAfile p2p-deployment/keystores/root.pem`

Content length header missing - error escapes to Netty
`time echo -e "GET / HTTP/1.0\r\n" | openssl s_client -connect localhost:37111 -servername www.ebowe-test.com -ign_eof -CAfile p2p-deployment/keystores/root.pem`

HTTP Response status is checked earlier as part of the fix.

Now manual testing of the two scenarios shows the desired output:
400 Bad Request
No exceptions
Quick termination of connection