### PR TITLE
CORE-3793: Create a Capability / Requirement for the sandbox hooks bundle.

### DIFF
--- a/components/flow/flow-service/test.bndrun
+++ b/components/flow/flow-service/test.bndrun
@@ -20,7 +20,6 @@
 -runrequires: \
     bnd.identity;id='flow-service-tests',\
     bnd.identity;id='net.corda.flow-service',\
-    bnd.identity;id='net.corda.sandbox-hooks',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
     bnd.identity;id='slf4j.simple'

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -12,6 +12,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.packaging.CPK
+import net.corda.sandbox.RequireSandboxHooks
 import net.corda.sandbox.SandboxCreationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
@@ -33,6 +34,7 @@ import java.util.Collections.unmodifiableList
  */
 @Suppress("Unused", "LongParameterList")
 @Component(service = [SandboxGroupContextComponent::class])
+@RequireSandboxHooks
 class SandboxGroupContextComponentImpl @Activate constructor(
     @Reference(service = InstallService::class)
     private val installService: InstallService,

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -30,6 +30,7 @@
 	antlr.osgi;version='[2.7.7,2.7.8)',\
 	com.fasterxml.classmate;version='[1.5.1,1.5.2)',\
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
+	com.typesafe.config;version='[1.4.1,1.4.2)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
 	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
@@ -74,7 +75,7 @@
 	org.osgi.test.junit5;version='[1.0.0,1.0.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	org.postgresql.jdbc;version='[42.3.1,42.3.2)',\
+	org.postgresql.jdbc;version='[42.3.2,42.3.3)',\
 	osgi-integration-tests-tests;version='[5.0.0,5.0.1)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/libs/permissions/permission-datamodel/test.bndrun
+++ b/libs/permissions/permission-datamodel/test.bndrun
@@ -29,6 +29,7 @@
 	antlr.osgi;version='[2.7.7,2.7.8)',\
 	com.fasterxml.classmate;version='[1.5.1,1.5.2)',\
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
+	com.typesafe.config;version='[1.4.1,1.4.2)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
 	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
@@ -73,7 +74,7 @@
 	org.osgi.test.junit5;version='[1.0.0,1.0.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	org.postgresql.jdbc;version='[42.3.1,42.3.2)',\
+	org.postgresql.jdbc;version='[42.3.2,42.3.3)',\
 	permission-datamodel-tests;version='[5.0.0,5.0.1)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/libs/sandbox-hooks/src/main/java/net/corda/sandboxhooks/package-info.java
+++ b/libs/sandbox-hooks/src/main/java/net/corda/sandboxhooks/package-info.java
@@ -1,0 +1,12 @@
+@Capability(
+    namespace = SANDBOX_NAMESPACE,
+    name = SANDBOX_HOOKS,
+    version = SANDBOX_HOOKS_VERSION
+)
+package net.corda.sandboxhooks;
+
+import org.osgi.annotation.bundle.Capability;
+
+import static net.corda.sandbox.RequireSandboxHooks.SANDBOX_HOOKS;
+import static net.corda.sandbox.RequireSandboxHooks.SANDBOX_HOOKS_VERSION;
+import static net.corda.sandbox.RequireSandboxHooks.SANDBOX_NAMESPACE;

--- a/libs/sandbox-internal/build.gradle
+++ b/libs/sandbox-internal/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'net.corda:corda-packaging'
     implementation 'net.corda:corda-serialization'
     implementation project(':libs:sandbox')
+    runtimeOnly project(':libs:sandbox-hooks')
 
     testCompileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -2,6 +2,7 @@
 package net.corda.sandbox.internal
 
 import net.corda.packaging.CPK
+import net.corda.sandbox.RequireSandboxHooks
 import net.corda.sandbox.SandboxContextService
 import net.corda.sandbox.SandboxCreationService
 import net.corda.sandbox.SandboxException
@@ -27,6 +28,7 @@ import kotlin.streams.asSequence
 
 /** An implementation of [SandboxCreationService] and [SandboxContextService]. */
 @Component(service = [SandboxCreationService::class, SandboxContextService::class])
+@RequireSandboxHooks
 internal class SandboxServiceImpl @Activate constructor(
     @Reference
     private val bundleUtils: BundleUtils

--- a/libs/sandbox-internal/test.bndrun
+++ b/libs/sandbox-internal/test.bndrun
@@ -19,7 +19,6 @@
 
 -runrequires: \
     bnd.identity;id='sandbox-internal-tests',\
-    bnd.identity;id='net.corda.sandbox-hooks',\
     bnd.identity;id='net.corda.sandbox-internal',\
     bnd.identity;id='net.corda.application',\
     bnd.identity;id='net.corda.cipher-suite',\

--- a/libs/sandbox/src/main/java/net/corda/sandbox/RequireSandboxHooks.java
+++ b/libs/sandbox/src/main/java/net/corda/sandbox/RequireSandboxHooks.java
@@ -1,0 +1,26 @@
+package net.corda.sandbox;
+
+import org.osgi.annotation.bundle.Requirement;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+import static net.corda.sandbox.RequireSandboxHooks.SANDBOX_HOOKS;
+import static net.corda.sandbox.RequireSandboxHooks.SANDBOX_HOOKS_VERSION;
+import static net.corda.sandbox.RequireSandboxHooks.SANDBOX_NAMESPACE;
+
+@Requirement(
+    namespace = SANDBOX_NAMESPACE,
+    name = SANDBOX_HOOKS,
+    version = SANDBOX_HOOKS_VERSION
+)
+@Target({ PACKAGE, TYPE })
+@Retention(CLASS)
+public @interface RequireSandboxHooks {
+    String SANDBOX_NAMESPACE = "corda.sandbox";
+    String SANDBOX_HOOKS = "sandbox.hooks";
+    String SANDBOX_HOOKS_VERSION = "1.0.0";
+}

--- a/libs/serialization/serialization-amqp/test.bndrun
+++ b/libs/serialization/serialization-amqp/test.bndrun
@@ -62,6 +62,7 @@
 	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox;version='[5.0.0,5.0.1)',\
+	net.corda.sandbox-hooks;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox-internal;version='[5.0.0,5.0.1)',\
 	net.corda.serialization;version='[5.0.0,5.0.1)',\
 	net.corda.serialization-internal;version='[5.0.0,5.0.1)',\

--- a/libs/serialization/serialization-kryo/test.bndrun
+++ b/libs/serialization/serialization-kryo/test.bndrun
@@ -12,18 +12,17 @@
 # -runjdb: 5005
 
 -runsystempackages: \
-    sun.net.www.protocol.jar,\
     sun.security.x509, \
     javax.xml.stream;version=1.0.0,\
     javax.xml.stream.events;version=1.0.0,\
     javax.xml.stream.util;version=1.0.0
 -runrequires: \
+    bnd.identity;id='serialization-kryo-tests',\
     bnd.identity;id='net.corda.serialization-kryo',\
+    bnd.identity;id='net.corda.sandbox-internal',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
-    bnd.identity;id='slf4j.simple',\
-    bnd.identity;id='${project.archivesBaseName}-tests',\
-    bnd.identity;id='net.corda.sandbox-hooks'
+    bnd.identity;id='slf4j.simple'
 -runproperties: \
     test.cordapp.version=${project.version}
 -runstartlevel: \

--- a/libs/virtual-node/virtual-node-manager/test.bndrun
+++ b/libs/virtual-node/virtual-node-manager/test.bndrun
@@ -18,7 +18,6 @@
     bnd.identity;id='virtual-node-manager-tests',\
     bnd.identity;id='net.corda.virtual-node-manager',\
     bnd.identity;id='net.corda.crypto-impl',\
-    bnd.identity;id='net.corda.sandbox-hooks',\
     bnd.identity;id='net.corda.sandbox-internal',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\


### PR DESCRIPTION
Tell OSGi's resolver that the `sandbox-hooks` bundle is _**required**_ by `sandbox-internal`, and by `sandbox-group-context-service` too for good measure. This ensures that the _critically important_ OSGi hooks are always present.

We can now remove `bnd.identity;id='net.corda.sandbox-hooks'` from the `-runrequires` list in the `.bndrun` files without also removing it from `-runbundles`.