### PR TITLE
NOTICK Up session timeout to 10 seconds in SessionManagerTest

### DIFF
--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -1280,7 +1280,7 @@ class SessionManagerTest {
     fun `when sending a heartbeat, if an exception is thrown, the heartbeat is resent`() {
         val configLongTimeout = SessionManagerImpl.HeartbeatManager.HeartbeatManagerConfig(
             Duration.ofMillis(100),
-            Duration.ofMillis(1000)
+            Duration.ofMillis(10000)
         )
         val publishLatch = CountDownLatch(2)
        var throwFirst = true


### PR DESCRIPTION
For some reason this test flakes and the session times out. I think this is caused by the thread not being scheduled for 400 ms for some reason. Maybe a garbage collection cycle happens at the wrong moment.
Bad test run:
```13:35:11.323 [Test worker] INFO  net.corda.p2p.linkmanager.sessions.SessionManagerImpl - Local identity (HoldingIdentity(x500Name=Alice, groupId=myGroup)) initiating new session 3f2a3614-b957-4e0e-9506-44b44e9d160f with remote identity HoldingIdentity(x500Name=Bob, groupId=myGroup)
13:35:11.598 [pool-42-thread-1] TRACE net.corda.p2p.linkmanager.sessions.SessionManagerImpl$HeartbeatManager - Sending heartbeat message between HoldingIdentity(x500Name=Alice, groupId=myGroup) (our Identity) and HoldingIdentity(x500Name=Bob, groupId=myGroup).
13:35:11.994 [pool-42-thread-1] WARN  net.corda.p2p.linkmanager.sessions.SessionManagerImpl$HeartbeatManager - An exception was thrown when sending a heartbeat message.
Exception:
java.lang.RuntimeException: Ohh No something went wrong.
	at net.corda.p2p.linkmanager.sessions.SessionManagerTest$when sending a heartbeat, if an exception is thrown, the heartbeat is resent$1.invoke(SessionManagerTest.kt:1291) ~[test/:?]
...
13:35:12.357 [pool-42-thread-1] INFO  net.corda.p2p.linkmanager.sessions.SessionManagerImpl$HeartbeatManager - Outbound session 3f2a3614-b957-4e0e-9506-44b44e9d160f (local=HoldingIdentity(x500Name=Alice, groupId=myGroup), remote=HoldingIdentity(x500Name=Bob, groupId=myGroup)) timed out due to inactivity and it will be cleaned up.
```
Not the 396 ms delay before the execption message.
Good test run:
```
12:02:12.757 [pool-35-thread-1] TRACE net.corda.p2p.linkmanager.sessions.SessionManagerImpl$HeartbeatManager - Sending heartbeat message between HoldingIdentity(x500Name=Alice, groupId=myGroup) (our Identity) and HoldingIdentity(x500Name=Bob, groupId=myGroup).
12:02:12.760 [pool-35-thread-1] WARN  net.corda.p2p.linkmanager.sessions.SessionManagerImpl$HeartbeatManager - An exception was thrown when sending a heartbeat message.
Exception:
java.lang.RuntimeException: Ohh No something went wrong.
	at net.corda.p2p.linkmanager.sessions.SessionManagerTest$when sending a heartbeat, if an exception is thrown, the heartbeat is resent$1.invoke(SessionManagerTest.kt:1291) ~[test/:?]
...
12:02:12.875 [pool-35-thread-1] TRACE net.corda.p2p.linkmanager.sessions.SessionManagerImpl$HeartbeatManager - Sending heartbeat message between HoldingIdentity(x500Name=Alice, groupId=myGroup) (our Identity) and HoldingIdentity(x500Name=Bob, groupId=myGroup).
```
In this case the delay was 3 ms.

This change should have no impact on how long the test takes.