### PR TITLE
CORE-3314 Fix null pointer exception occurring when gateway closes malformed connection

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServerChannelHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServerChannelHandler.kt
@@ -35,9 +35,7 @@ class HttpServerChannelHandler(private val serverListener: HttpServerListener,
                         "Hostname: ${msg.headers()[HttpHeaderNames.HOST]?:"unknown"}\n" +
                         "Request URI: ${msg.uri()}\n and the response code was $responseCode.")
 
-            }
-
-            if(responseCode == HttpResponseStatus.OK) {
+            } else {
                 logger.debug ("Received HTTP request from ${ctx.channel().remoteAddress()}\n" +
                         "Protocol version: ${msg.protocolVersion()}\n" +
                         "Hostname: ${msg.headers()[HttpHeaderNames.HOST]?:"unknown"}\n" +
@@ -73,16 +71,16 @@ class HttpServerChannelHandler(private val serverListener: HttpServerListener,
                 val returnByteArray = readBytesFromBodyBuffer()
                 val sourceAddress = ctx.channel().remoteAddress()
                 val targetAddress = ctx.channel().localAddress()
-                return serverListener.onRequest(HttpRequest(returnByteArray, sourceAddress, targetAddress))
+                serverListener.onRequest(HttpRequest(returnByteArray, sourceAddress, targetAddress))
             } else {
                 val response = createResponse(null, responseCode!!)
                 ctx.writeAndFlush(response)
                     .addListener(ChannelFutureListener.CLOSE)
-                return
             }
-        }
             releaseBodyBuffer()
             responseCode = null
+        }
+
     }
 
 


### PR DESCRIPTION
The gateway did not immediately close inbound TLS connection with malformed HTTP headers. For headers of length 0 it remained open for 10 minutes and for headers missing entirely an exception was escaping to netty, which closed the connection. This issue was fixed, however now a Null Pointer Exception is thrown because unprocessed bytes are attempted to be read after the connection was closed. To fix this the early closures at the beginning of the logic are removed and the connection is just closed at the end of the logic, so unprocessed bytes will not throw a NPE and the connection will still close quickly. https://r3-cev.atlassian.net/browse/CORE-3314

Scenarios for testing:
1) Content length of 0 - open 10m then stops
time echo -e "GET / HTTP/1.0\r\nContent-Length: 0\r\n" | openssl s_client -connect localhost:37111 -servername www.ebowe-test.com -ign_eof -CAfile p2p-deployment/keystores/root.pem

2) Content length header missing - error escapes to Netty
time echo -e "GET / HTTP/1.0\r\n" | openssl s_client -connect localhost:37111 -servername www.ebowe-test.com -ign_eof -CAfile p2p-deployment/keystores/root.pem

After manual testing:

Scenario 1) - Content length of 0 - open 10m then stops

Response:
400 Bad Request [...] closed
real    0m0.578s
user    0m0.023s
sys     0m0.002s
	
Logs:
Received invalid HTTP request [...] and the response code was 400 Bad Request.
[nioEventLoopGroup-5-1] INFO  net.corda.p2p.gateway.messaging.http.HttpServer - Closed client connection

Scenario 2) - Content length header missing - error escapes to Netty

Response:
400 Bad Request [...] closed
real    0m0.161s
user    0m0.012s
sys     0m0.000s

Logs:
Received invalid HTTP request [...] and the response code was 400 Bad Request.
[nioEventLoopGroup-5-2] INFO  net.corda.p2p.gateway.messaging.http.HttpServer - Closed client connection