### PR TITLE
CORE-3654 Fix flaky integration test

### DIFF
--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -21,6 +21,7 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.assertThrows
 
 class MemberProcessorTestUtils {
@@ -63,6 +64,7 @@ class MemberProcessorTestUtils {
             groupPolicy: String = sampleGroupPolicy1,
             cpiVersion: String = "1.0"
         ) {
+            val previous = getVirtualNodeInfo(virtualNodeInfoReader)
             // Create test data
             val cpiMetadata = getCpiMetadata(
                 groupPolicy = groupPolicy,
@@ -75,14 +77,9 @@ class MemberProcessorTestUtils {
             publishVirtualNodeInfo(virtualNodeInfo)
 
             // wait for virtual node info reader to pick up changes
-            waitForVNodeInfoChange(virtualNodeInfoReader)
-        }
-
-        fun waitForVNodeInfoChange(virtualNodeInfoReader: VirtualNodeInfoReadService): VirtualNodeInfo? {
-            val previous = getVirtualNodeInfo(virtualNodeInfoReader)
-            return eventually {
+            eventually {
                 val newVNodeInfo = getVirtualNodeInfo(virtualNodeInfoReader)
-                Assertions.assertNotEquals(previous, newVNodeInfo)
+                assertNotEquals(previous, newVNodeInfo)
                 newVNodeInfo
             }
         }
@@ -118,14 +115,14 @@ class MemberProcessorTestUtils {
 
         fun assertGroupPolicy(new: GroupPolicy, old: GroupPolicy? = null) {
             old?.let {
-                Assertions.assertNotEquals(new, it)
+                assertNotEquals(new, it)
             }
             Assertions.assertEquals(groupId, new.groupId)
             Assertions.assertEquals(6, new.keys.size)
         }
 
         fun assertSecondGroupPolicy(new: GroupPolicy, old: GroupPolicy) {
-            Assertions.assertNotEquals(new, old)
+            assertNotEquals(new, old)
             Assertions.assertEquals("DEF456", new.groupId)
             Assertions.assertEquals(2, new.size)
         }


### PR DESCRIPTION
Flaky test was introduced by https://github.com/corda/corda-runtime-os/pull/801

Flakiness seems to have been caused by incorrect ordering of calls in test. The test in question attempts to check that the virtual node callback for the group policy provider is called when the virtual node's CPI changes by pushing CPI data to the message bus for the virtual node read service to pick up. The test attempts to check the before and after virtual node info read from the virtual node read service but the way it was written was incorrect and only worked if the virtual node read service was slow to update.
_Previously_: Push data to message bus, read virtual node info, wait for virtual node info service to change the virtual node info.
_Now_: Read virtual node info, push data to message bus, wait for virtual node info service to change the virtual node info.

Was failing consistently on window builds and intermittently for usual PR builds. Now it's passing after numerous runs.