### PR TITLE
CORE-3563 - Remove logic that waits for configuration read service to start as not needed anymore

### DIFF
--- a/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/GatewayApp.kt
+++ b/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/GatewayApp.kt
@@ -49,11 +49,6 @@ class GatewayApp @Activate constructor(
             val bootConfig = SmartConfigFactory.create(secretsConfig).create(arguments.kafkaNodeConfiguration)
             configurationReadService.start()
             configurationReadService.bootstrapConfig(bootConfig)
-            while (!configurationReadService.isRunning) {
-                consoleLogger.info("Waiting for the configuration service to start.")
-                Thread.sleep(100)
-            }
-            consoleLogger.info("Configuration service is running")
 
             consoleLogger.info("Starting gateway")
             gateway = Gateway(

--- a/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/LinkManagerApp.kt
+++ b/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/LinkManagerApp.kt
@@ -50,11 +50,6 @@ class LinkManagerApp @Activate constructor(
             val bootConfig = SmartConfigFactory.create(secretsConfig).create(arguments.kafkaNodeConfiguration)
             configurationReadService.start()
             configurationReadService.bootstrapConfig(bootConfig)
-            while (!configurationReadService.isRunning) {
-                consoleLogger.info("Waiting for the configuration service to start.")
-                Thread.sleep(100)
-            }
-            consoleLogger.info("Configuration service is running")
 
             consoleLogger.info("Starting link manager")
             linkManager = LinkManager(

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
@@ -105,9 +105,6 @@ open class TestBase {
                 it.start()
                 val bootstrapper = ConfigFactory.empty()
                 it.bootstrapConfig(smartConfigFactory.create(bootstrapper))
-                eventually {
-                    assertThat(it.isRunning).isTrue
-                }
             }
         }
 

--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -382,9 +382,6 @@ class P2PLayerEndToEndTest {
         fun startWith(otherHost: Host) {
             configReadService.start()
             configReadService.bootstrapConfig(bootstrapConfig)
-            eventually {
-                assertThat(configReadService.isRunning).isTrue
-            }
 
             linkManager.start()
             gateway.start()


### PR DESCRIPTION
At some point, the configuration read service was adjusted so that it required registration to happen after it had started fully. We responded to that by adding some waiting logic on the p2p workers to ensure when domino logic kicks off for p2p components, the config read service will have started fully by that point (see https://github.com/corda/corda-runtime-os/pull/724). I talked with JamesH and confirmed that this logic has been updated now and the config read service only requires registrations to happen after `start` has been invoked on the config read service (not after it has been fully started), so this change removes the waiting logic that is not needed anymore.