### PR TITLE
CORE-3851: Update SandboxGroupContextService.registerMetadataServices().

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -402,7 +402,7 @@ def appJar = tasks.register('appJar', Jar) {
     inputs.files(configurations.bootstrapClasspath)
     finalizedBy verifyApp
 
-    archivesBaseName = appJarBaseName
+    archiveBaseName = appJarBaseName
     destinationDirectory = layout.buildDirectory.dir("bin")
 
     exclude "META-INF/MANIFEST.MF"

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -85,8 +85,11 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     override fun registerMetadataServices(
         sandboxGroupContext: SandboxGroupContext,
         serviceNames: (CPK.Metadata) -> Iterable<String>,
-        isMetadataService: (Class<*>) -> Boolean
-    ): AutoCloseable = sandboxGroupContextServiceImpl.registerMetadataServices(sandboxGroupContext, serviceNames, isMetadataService)
+        isMetadataService: (Class<*>) -> Boolean,
+        serviceMarkerType: Class<*>
+    ): AutoCloseable = sandboxGroupContextServiceImpl.registerMetadataServices(
+        sandboxGroupContext, serviceNames, isMetadataService, serviceMarkerType
+    )
 
     override fun hasCpks(cpkIdentifiers: Set<CPK.Identifier>): Boolean =
         sandboxGroupContextServiceImpl.hasCpks(cpkIdentifiers)

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -200,7 +200,8 @@ class SandboxGroupContextServiceImpl(
     override fun registerMetadataServices(
         sandboxGroupContext: SandboxGroupContext,
         serviceNames: (CPK.Metadata) -> Iterable<String>,
-        isMetadataService: (Class<*>) -> Boolean
+        isMetadataService: (Class<*>) -> Boolean,
+        serviceMarkerType: Class<*>
     ): AutoCloseable {
         val groupMetadata = sandboxGroupContext.sandboxGroup.metadata
         val services = groupMetadata.flatMap { (mainBundle, cpkMetadata) ->
@@ -210,10 +211,8 @@ class SandboxGroupContextServiceImpl(
             }
         }
 
-        val serviceMarkerTypeName = sandboxGroupContext.virtualNodeContext.serviceMarkerType.name
-
         // Register each metadata service as an OSGi service for its host main bundle.
-        val registrations = registerMetadataServices(serviceMarkerTypeName, services)
+        val registrations = registerMetadataServices(serviceMarkerType.name, services)
         return AutoCloseable {
             registrations.forEach { registration ->
                 runIgnoringExceptions(registration::close)

--- a/libs/sandbox-internal/build.gradle
+++ b/libs/sandbox-internal/build.gradle
@@ -41,7 +41,6 @@ dependencies {
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation "net.corda:corda-application"
-    integrationTestRuntimeOnly 'net.corda:corda-cipher-suite'
     integrationTestRuntimeOnly project(':libs:crypto:crypto-impl')
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
     integrationTestRuntimeOnly project(':libs:messaging:inmemory-messaging-impl')

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextService.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextService.kt
@@ -84,6 +84,7 @@ interface SandboxGroupContextService {
      * @param sandboxGroupContext
      * @param serviceNames A lambda to extract the service class names from the CPK metadata.
      * @param isMetadataService A lambda to validate that each class is compatible with this metadata service type.
+     * @param serviceMarkerType A common base type that all service implementations must share.
      *
      * @return an [AutoCloseable] for unregistering the services.
      *
@@ -91,7 +92,8 @@ interface SandboxGroupContextService {
     fun registerMetadataServices(
         sandboxGroupContext: SandboxGroupContext,
         serviceNames: (CPK.Metadata) -> Iterable<String>,
-        isMetadataService: (Class<*>) -> Boolean
+        isMetadataService: (Class<*>) -> Boolean = { true },
+        serviceMarkerType: Class<*> = sandboxGroupContext.virtualNodeContext.serviceMarkerType
     ): AutoCloseable
 
     /**

--- a/libs/virtual-node/virtual-node-info/build.gradle
+++ b/libs/virtual-node/virtual-node-info/build.gradle
@@ -14,8 +14,6 @@ dependencies {
 
     implementation "net.corda:corda-packaging-avro-converters"
 
-    runtimeOnly project(':libs:crypto:crypto-impl')
-
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/libs/virtual-node/virtual-node-manager/build.gradle
+++ b/libs/virtual-node/virtual-node-manager/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation "net.corda:corda-cipher-suite"
 
     implementation project(":libs:crypto:crypto-client")
+    runtimeOnly project(':libs:crypto:crypto-impl')
     implementation project(":libs:sandbox")
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/testing/sandboxes/build.gradle
+++ b/testing/sandboxes/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation project(':components:install:install-service')
     implementation project(':components:virtual-node:cpi-info-read-service')
-    implementation project(':components:virtual-node:cpi-info-read-service')
     implementation project(':components:virtual-node:virtual-node-info-read-service')
     implementation project(':components:virtual-node:virtual-node-info-write-service')
 


### PR DESCRIPTION
Allow sandbox metadata services to be assignable to something other than `VirtualNodeContext.serviceMarkerType`.

Also remove some weird dependencies from the `build.gradle` files?!

And the use of "archive**s**BaseName" rather than "archiveBaseName" in `common-app` looks like a typo.