### PR TITLE
CORE-3787: Enforce JUnit lifecycle when testing sandboxes.

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
@@ -31,7 +31,6 @@ import net.corda.v5.base.util.loggerFor
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.osgi.framework.AdminPermission
-import org.osgi.framework.BundleContext
 import org.osgi.framework.BundleReference
 import org.osgi.framework.PackagePermission
 import org.osgi.framework.PackagePermission.EXPORTONLY
@@ -40,16 +39,26 @@ import org.osgi.framework.ServicePermission
 import org.osgi.framework.ServicePermission.GET
 import org.osgi.framework.ServicePermission.REGISTER
 import org.osgi.framework.wiring.BundleWiring
+import org.osgi.service.component.ComponentContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL
+import org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC
 import org.osgi.service.permissionadmin.PermissionAdmin
 
 val CPK.id: CPK.Identifier get() = metadata.id
+const val VNODE_SERVICE = "vnode"
 
 @Suppress("unused", "LongParameterList")
-@Component
+@Component(reference = [
+    Reference(
+        name = VNODE_SERVICE,
+        service = VNodeService::class,
+        cardinality = OPTIONAL,
+        policy = DYNAMIC
+    )
+])
 class CordaVNode @Activate constructor(
     @Reference
     private val flowEventProcessorFactory: FlowEventProcessorFactory,
@@ -60,7 +69,7 @@ class CordaVNode @Activate constructor(
     @Reference
     private val shutdown: Shutdown,
 
-    private val bundleContext: BundleContext
+    private val componentContext: ComponentContext
 ) : Application {
     private companion object {
         private const val EXAMPLE_CPI_RESOURCE = "META-INF/example-cpi-package.cpb"
@@ -79,26 +88,20 @@ class CordaVNode @Activate constructor(
         HotSpotDiagnosticMXBean::class.java
     )
 
-    private val cleanups = mutableListOf<AutoCloseable>()
-    private val vnode: VNodeService = fetchService(TIMEOUT_MILLIS)
+    private val vnode: VNodeService = fetchService(VNODE_SERVICE, TIMEOUT_MILLIS)
 
-    @Deactivate
-    fun done() {
-        cleanups.forEach(AutoCloseable::close)
-        logger.info("Deactivated")
+    private inline fun <reified T> fetchService(name: String, timeout: Long): T {
+        return fetchService(name, T::class.java, timeout)
     }
 
-    private inline fun <reified T> fetchService(timeout: Long): T {
-        return fetchService(T::class.java, timeout)
-    }
-
-    private fun <T> fetchService(serviceType: Class<T>, timeout: Long): T {
-        var remainingMillis = timeout
-        while (remainingMillis >= 0) {
-            bundleContext.getServiceReference(serviceType)?.let { ref ->
-                return bundleContext.getService(ref).also {
-                    cleanups.add(AutoCloseable { bundleContext.ungetService(ref) })
-                }
+    private fun <T> fetchService(name: String, serviceType: Class<T>, timeout: Long): T {
+        var remainingMillis = timeout.coerceAtLeast(0)
+        while (true) {
+            componentContext.locateService<T>(name)?.also { svc ->
+                return svc
+            }
+            if (remainingMillis <= 0) {
+                break
             }
             val waitMillis = remainingMillis.coerceAtMost(WAIT_MILLIS)
             Thread.sleep(waitMillis)
@@ -206,7 +209,7 @@ class CordaVNode @Activate constructor(
             executeSandbox("client-3", EXAMPLE_CPI_RESOURCE)
         } finally {
             dumpHeap("finished")
-            shutdown.shutdown(bundleContext.bundle)
+            shutdown.shutdown(componentContext.usingBundle)
 
             val instrumentor = Retransform.getInstrumentor()
             logger.info("Instrumentor: {}", instrumentor::class.java)

--- a/libs/sandbox-internal/sandbox-cpk-library/src/main/kotlin/com/example/sandbox/library/impl/SandboxQueryImpl.kt
+++ b/libs/sandbox-internal/sandbox-cpk-library/src/main/kotlin/com/example/sandbox/library/impl/SandboxQueryImpl.kt
@@ -8,6 +8,7 @@ import org.osgi.framework.BundleEvent
 import org.osgi.framework.ServiceEvent
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Deactivate
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.Collections.unmodifiableList
@@ -26,6 +27,11 @@ class SandboxQueryImpl @Activate constructor(
         logger.info("Activating!")
         context.addBundleListener(bundleEvents::add)
         context.addServiceListener(serviceEvents::add)
+    }
+
+    @Deactivate
+    fun done() {
+        logger.info("Deactivating!")
     }
 
     override fun getAllServiceClasses(): List<Class<out Any>> {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
@@ -2,11 +2,13 @@ package net.corda.sandboxtests
 
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.test.common.annotation.InjectBundleContext
@@ -19,24 +21,23 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxBundleDifferentLibrariesTest {
     @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
+
+        lateinit var sandboxFactory: SandboxFactory
 
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `different CPKs in the same sandbox group can use different versions of the same library`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
@@ -2,11 +2,13 @@ package net.corda.sandboxtests
 
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.framework.BundleEvent
@@ -18,26 +20,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the isolation of bundle events across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxBundleEventIsolationTest {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `sandbox receives bundle events from its own sandbox group`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
@@ -2,11 +2,13 @@ package net.corda.sandboxtests
 
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
@@ -18,26 +20,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the isolation of bundles across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxBundleIsolationTest {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `sandbox can see bundles in its own sandbox group`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
@@ -2,11 +2,13 @@ package net.corda.sandboxtests
 
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.test.common.annotation.InjectBundleContext
@@ -17,26 +19,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the use of non-exported implementation classes from one bundle in another bundle. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxBundlePrivateImplementationTest {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `sandbox can invoke a private implementation in a non-exported package of another bundle`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
@@ -3,13 +3,15 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.sandbox.SandboxException
 import net.corda.testing.sandboxes.SandboxSetup
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.v5.application.flows.Flow
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
@@ -22,26 +24,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the use of class tags for serialisation and deserialisation. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxClassTagTests {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `can create class tags for a non-bundle class and use them to retrieve the class`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
@@ -3,12 +3,14 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.sandbox.SandboxGroup
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.test.common.annotation.InjectBundleContext
@@ -19,26 +21,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the ability to retrieve the calling sandbox group. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxGetCallingGroupTest {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `can retrieve the calling sandbox group from within a sandbox`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
@@ -3,12 +3,14 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.sandbox.SandboxException
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.test.common.annotation.InjectBundleContext
@@ -19,26 +21,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the inability to resolve against private bundles in a public sandbox. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxIrresolvableBundleTest {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `bundle cannot resolve against a private bundle in a public sandbox`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
@@ -2,11 +2,13 @@ package net.corda.sandboxtests
 
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.framework.ServiceEvent
@@ -18,26 +20,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the isolation of service events across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxServiceEventIsolationTest {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `sandbox receives service events from its own sandbox group`() {

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
@@ -4,13 +4,15 @@ import java.nio.file.Path
 import net.corda.sandbox.SandboxContextService
 import net.corda.sandbox.SandboxCreationService
 import net.corda.testing.sandboxes.SandboxSetup
-import org.junit.jupiter.api.AfterAll
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.framework.FrameworkUtil
@@ -24,26 +26,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the isolation of services across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 class SandboxServiceIsolationTest {
-    @Suppress("unused")
     companion object {
+        @RegisterExtension
+        private val lifecycle = EachTestLifecycle()
+
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
+        lateinit var sandboxFactory: SandboxFactory
+
+        @Suppress("unused")
         @JvmStatic
         @BeforeAll
         fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
             sandboxSetup.configure(bundleContext, testDirectory)
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun done() {
-            sandboxSetup.shutdown()
+            lifecycle.accept(sandboxSetup) { setup ->
+                sandboxFactory = setup.fetchService(timeout = 1000)
+            }
         }
     }
-
-    @InjectService(timeout = 1500)
-    lateinit var sandboxFactory: SandboxFactory
 
     @Test
     fun `sandbox can see services from its own sandbox`() {

--- a/libs/sandbox-internal/test.bndrun
+++ b/libs/sandbox-internal/test.bndrun
@@ -16,6 +16,13 @@
 # Enable debugging.
 # -runjdb: 1044
 
+-runproperties: \
+    org.slf4j.simpleLogger.defaultLogLevel=info,\
+    org.slf4j.simpleLogger.showShortLogName=true,\
+    org.slf4j.simpleLogger.showThreadName=false,\
+    org.slf4j.simpleLogger.showDateTime=true,\
+    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z'
+
 -runrequires: \
     bnd.identity;id='sandbox-internal-tests',\
     bnd.identity;id='net.corda.sandbox-internal',\

--- a/libs/virtual-node/virtual-node-manager/src/integrationTest/kotlin/net/corda/virtualnode/manager/test/IntegrationTestService.kt
+++ b/libs/virtual-node/virtual-node-manager/src/integrationTest/kotlin/net/corda/virtualnode/manager/test/IntegrationTestService.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.fail
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 
 @Component(service = [ IntegrationTestService::class ])
@@ -23,14 +22,12 @@ class IntegrationTestService @Activate constructor(
     @Reference
     private val registration: RuntimeRegistration
 ) {
-    @Suppress("unused")
-    @Deactivate
-    fun done() {
-        loader.stop()
-    }
-
     fun loadCPIFromResource(resourceName: String): CPI {
         return loader.loadCPI(resourceName)
+    }
+
+    fun unloadCPI(cpi: CPI) {
+        loader.unloadCPI(cpi)
     }
 
     fun createSandboxGroupFor(cpks: Set<CPK>): SandboxGroup =

--- a/testing/sandboxes/build.gradle
+++ b/testing/sandboxes/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api project(':libs:sandbox')
     api project(':libs:virtual-node:virtual-node-info')
     api 'net.corda:corda-packaging'
+    api "org.junit.jupiter:junit-jupiter-api:$junit5Version"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'

--- a/testing/sandboxes/src/main/java/net/corda/testing/sandboxes/lifecycle/package-info.java
+++ b/testing/sandboxes/src/main/java/net/corda/testing/sandboxes/lifecycle/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.testing.sandboxes.lifecycle;
+
+import org.osgi.annotation.bundle.Export;

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
@@ -9,5 +9,13 @@ interface SandboxSetup {
         baseDirectory: Path,
         extraPublicBundleNames: Set<String> = emptySet()
     )
+
+    fun start()
     fun shutdown()
+
+    fun <T> getService(serviceType: Class<T>, timeout: Long): T
+}
+
+inline fun <reified T> SandboxSetup.fetchService(timeout: Long): T {
+    return getService(T::class.java, timeout)
 }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/InstallServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/InstallServiceImpl.kt
@@ -30,8 +30,6 @@ class InstallServiceImpl @Activate constructor(
     properties: Map<String, Any?>
 ) : InstallService, CpiLoaderService {
     companion object {
-        private const val PARALLELISM_THRESHOLD = 10L
-
         const val BASE_DIRECTORY_KEY = "baseDirectory"
         const val TEST_BUNDLE_KEY = "testBundle"
     }
@@ -49,6 +47,10 @@ class InstallServiceImpl @Activate constructor(
         get() = cpis.values.flatMap(CPI::cpks)
 
     override val isRunning: Boolean get() = true
+
+    init {
+        logger.info("Activated")
+    }
 
     private fun getInputStream(resourceName: String): InputStream {
         return testBundle.getResource(resourceName)?.openStream()
@@ -103,7 +105,7 @@ class InstallServiceImpl @Activate constructor(
 
     @Deactivate
     override fun stop() {
-        cpis.forEachValue(PARALLELISM_THRESHOLD, ::unloadCPI)
+        ArrayList(cpis.values).forEach(::unloadCPI)
         logger.info("Stopped")
     }
 }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxLoaderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxLoaderImpl.kt
@@ -4,6 +4,7 @@ import net.corda.testing.sandboxes.CpiLoaderService
 import net.corda.testing.sandboxes.SandboxLoader
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.write.VirtualNodeInfoWriteService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -14,7 +15,7 @@ class SandboxLoaderImpl @Activate constructor(
     @Reference
     private val loader: CpiLoaderService,
     @Reference
-    private val vnodeInfoService: VirtualNodeInfoService
+    private val vnodeInfoService: VirtualNodeInfoWriteService
 ) : SandboxLoader {
     override fun loadCPI(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo {
         val cpi = loader.loadCPI(resourceName)

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -3,18 +3,19 @@ package net.corda.testing.sandboxes.impl
 import java.nio.file.Path
 import java.util.Hashtable
 import java.util.Collections.unmodifiableSet
-import net.corda.install.InstallService
+import java.util.concurrent.TimeoutException
 import net.corda.sandbox.SandboxCreationService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.impl.InstallServiceImpl.Companion.BASE_DIRECTORY_KEY
 import net.corda.testing.sandboxes.impl.InstallServiceImpl.Companion.TEST_BUNDLE_KEY
 import org.osgi.framework.BundleContext
-import org.osgi.framework.FrameworkUtil
-import org.osgi.framework.ServiceReference
 import org.osgi.service.cm.ConfigurationAdmin
+import org.osgi.service.component.ComponentContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("unused")
 @Component
@@ -22,9 +23,12 @@ class SandboxSetupImpl @Activate constructor(
     @Reference
     private val configAdmin: ConfigurationAdmin,
     @Reference
-    private val sandboxCreator: SandboxCreationService
+    private val sandboxCreator: SandboxCreationService,
+    private val componentContext: ComponentContext
 ) : SandboxSetup {
     companion object {
+        private const val WAIT_MILLIS = 100L
+
         // The names of the bundles to place as public bundles in the sandbox service's platform sandbox.
         private val PLATFORM_PUBLIC_BUNDLE_NAMES: Set<String> = unmodifiableSet(setOf(
             "javax.persistence-api",
@@ -44,17 +48,24 @@ class SandboxSetupImpl @Activate constructor(
             "org.jetbrains.kotlin.osgi-bundle",
             "slf4j.api"
         ))
+
+        private val logger = LoggerFactory.getLogger(SandboxSetup::class.java)
     }
+
+    private val cleanups = mutableListOf<AutoCloseable>()
 
     override fun configure(
         bundleContext: BundleContext,
         baseDirectory: Path,
         extraPublicBundleNames: Set<String>
     ) {
+        val testBundle = bundleContext.bundle
+        logger.info("Configuring sandboxes for [{}]", testBundle.symbolicName)
+
         configAdmin.getConfiguration(InstallServiceImpl::class.java.name)?.also { config ->
             val properties = Hashtable<String, Any?>()
             properties[BASE_DIRECTORY_KEY] = baseDirectory.toString()
-            properties[TEST_BUNDLE_KEY] = bundleContext.bundle.location
+            properties[TEST_BUNDLE_KEY] = testBundle.location
             config.update(properties)
         }
 
@@ -66,21 +77,50 @@ class SandboxSetupImpl @Activate constructor(
     }
 
     /**
-     * Grab a reference to the current [InstallService] and shut it down.
+     * Enables the InstallService component, allowing
+     * the framework to create new instances of it.
+     */
+    override fun start() {
+        componentContext.enableComponent(InstallServiceImpl::class.java.name)
+    }
+
+    /**
+     * Disables the InstallService component to unload all CPIs.
      * We must ensure this happens before JUnit tries to remove the
      * temporary directory.
      */
+    @Deactivate
     override fun shutdown() {
-        val bundleContext = (FrameworkUtil.getBundle(this::class.java) ?: return).bundleContext
-        bundleContext.getServiceReference(InstallService::class.java.name)?.also { ref ->
-            @Suppress("unchecked_cast")
-            bundleContext.getService(ref as ServiceReference<InstallService>)?.also { install ->
-                try {
-                    install.stop()
-                } finally {
-                    bundleContext.ungetService(ref)
+        synchronized(this) {
+            cleanups.forEach(AutoCloseable::close)
+            cleanups.clear()
+        }
+        componentContext.disableComponent(InstallServiceImpl::class.java.name)
+        logger.info("Shutdown complete")
+    }
+
+    /**
+     * Fetch and hold a reference to a service of class [serviceType].
+     * Service objects are reference-counted, and so we must release
+     * this reference when we've finished with it to allow the
+     * service to be destroyed.
+     */
+    override fun <T> getService(serviceType: Class<T>, timeout: Long): T {
+        val bundleContext = componentContext.bundleContext
+        var remainingMillis = timeout.coerceAtLeast(0)
+        while (true) {
+            bundleContext.getServiceReference(serviceType)?.let { ref ->
+                return bundleContext.getService(ref).also {
+                    cleanups.add(AutoCloseable { bundleContext.ungetService(ref) })
                 }
             }
+            if (remainingMillis <= 0) {
+                break
+            }
+            val waitMillis = remainingMillis.coerceAtMost(WAIT_MILLIS)
+            Thread.sleep(waitMillis)
+            remainingMillis -= waitMillis
         }
+        throw TimeoutException("Service $serviceType did not arrive in $timeout milliseconds")
     }
 }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeInfoServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeInfoServiceImpl.kt
@@ -10,17 +10,14 @@ import net.corda.virtualnode.write.VirtualNodeInfoWriteService
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.propertytypes.ServiceRanking
 
-interface VirtualNodeInfoService  : VirtualNodeInfoReadService, VirtualNodeInfoWriteService
-
 @Suppress("unused")
 @Component(service = [
-    VirtualNodeInfoService::class,
     VirtualNodeInfoReadService::class,
     VirtualNodeInfoWriteService::class
 ])
 @ServiceRanking(Int.MAX_VALUE)
-class VirtualNodeInfoServiceImpl : VirtualNodeInfoService {
-    private val logger = loggerFor<VirtualNodeInfoService>()
+class VirtualNodeInfoServiceImpl : VirtualNodeInfoReadService, VirtualNodeInfoWriteService {
+    private val logger = loggerFor<VirtualNodeInfoServiceImpl>()
     private val virtualNodeInfoMap = ConcurrentHashMap<HoldingIdentity, VirtualNodeInfo>()
 
     override val isRunning: Boolean

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/lifecycle/AllTestsLifecycle.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/lifecycle/AllTestsLifecycle.kt
@@ -1,0 +1,20 @@
+package net.corda.testing.sandboxes.lifecycle
+
+import java.util.function.Consumer
+import net.corda.testing.sandboxes.SandboxSetup
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class AllTestsLifecycle : TestLifecycle, AfterAllCallback {
+    private var sandboxSetup: SandboxSetup? = null
+
+    override fun accept(setup: SandboxSetup, initializer: Consumer<SandboxSetup>) {
+        sandboxSetup = setup
+        setup.start()
+        initializer.accept(setup)
+    }
+
+    override fun afterAll(context: ExtensionContext?) {
+        sandboxSetup?.shutdown()
+    }
+}

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/lifecycle/EachTestLifecycle.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/lifecycle/EachTestLifecycle.kt
@@ -1,0 +1,28 @@
+package net.corda.testing.sandboxes.lifecycle
+
+import net.corda.testing.sandboxes.SandboxSetup
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.util.function.Consumer
+
+class EachTestLifecycle : TestLifecycle, BeforeEachCallback, AfterEachCallback {
+    private var initializer: Consumer<SandboxSetup> = Consumer {}
+    private var sandboxSetup: SandboxSetup? = null
+
+    override fun accept(setup: SandboxSetup, initializer: Consumer<SandboxSetup>) {
+        this.initializer = initializer
+        sandboxSetup = setup
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        sandboxSetup?.also { setup ->
+            setup.start()
+            initializer.accept(setup)
+        } ?: throw IllegalStateException("Lifecycle not configured.")
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        sandboxSetup?.shutdown()
+    }
+}

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/lifecycle/TestLifecycle.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/lifecycle/TestLifecycle.kt
@@ -1,0 +1,8 @@
+package net.corda.testing.sandboxes.lifecycle
+
+import java.util.function.Consumer
+import net.corda.testing.sandboxes.SandboxSetup
+
+interface TestLifecycle {
+    fun accept(setup: SandboxSetup, initializer: Consumer<SandboxSetup>)
+}


### PR DESCRIPTION
Try to resolve `sanbox-internal` OSGi test failures on Windows.

While the OSGi container _does_ shut unused components down, it doesn't seem to do this strictly within the `@BeforeEach` / `@AfterEach` and `@BeforeAll` / `@AfterAll` intervals when running `TestOSGi` tasks. Create JUnit extensions to enforce the JUnit lifecycle.