### PR TITLE
NOTICK: fix compilation problems blocking release branch

### DIFF
--- a/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/CpiUploadManagerImpl.kt
+++ b/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/CpiUploadManagerImpl.kt
@@ -8,7 +8,7 @@ import net.corda.libs.cpiupload.CpiUploadManager
 import net.corda.libs.cpiupload.CpiUploadManagerException
 import net.corda.libs.cpiupload.RequestId
 import net.corda.messaging.api.publisher.RPCSender
-import net.corda.schema.configuration.ConfigKeys.Companion.RPC_ENDPOINT_TIMEOUT_MILLIS
+import net.corda.schema.configuration.ConfigKeys.RPC_ENDPOINT_TIMEOUT_MILLIS
 import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.concurrent.getOrThrow
 import net.corda.v5.base.util.contextLogger


### PR DESCRIPTION
Fixing compilation issues on release branch which is blocking builds - incorrect import.

see failures here

https://ci02.dev.r3.com/job/Corda5/view/C5%20Main%20-%20build%20health%20-%20detailed/job/corda-runtime-os/job/release%252Fent%252F5.0/782/console

Originally came in here https://github.com/corda/corda-runtime-os/pull/755  this passed PR gate at time but a later change to API level (https://github.com/corda/corda-api/pull/220) then had knock on effects here breaking compilation

