### PR TITLE
NOTICK: Remove technical debt for sandbox OSGi test.

### DIFF
--- a/components/membership/membership-group-read-impl/test.bndrun
+++ b/components/membership/membership-group-read-impl/test.bndrun
@@ -81,6 +81,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -22,12 +22,12 @@ class SandboxBundleDifferentLibrariesTest {
     @Suppress("unused")
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @JvmStatic
         @BeforeAll

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -22,12 +22,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxBundleEventIsolationTest {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -22,12 +22,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxBundleIsolationTest {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -21,12 +21,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxBundlePrivateImplementationTest {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
@@ -4,7 +4,7 @@ import java.nio.file.Path
 import net.corda.sandbox.SandboxException
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import net.corda.v5.application.flows.Flow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
@@ -26,12 +26,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxClassTagTests {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
@@ -4,7 +4,7 @@ import java.nio.file.Path
 import net.corda.sandbox.SandboxGroup
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
@@ -23,12 +23,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxGetCallingGroupTest {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
@@ -4,7 +4,7 @@ import java.nio.file.Path
 import net.corda.sandbox.SandboxException
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -23,12 +23,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxIrresolvableBundleTest {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxtests
 import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -22,12 +22,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxServiceEventIsolationTest {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
@@ -5,7 +5,7 @@ import net.corda.sandbox.SandboxContextService
 import net.corda.sandbox.SandboxCreationService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -28,12 +28,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 class SandboxServiceIsolationTest {
     companion object {
         @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+        private val lifecycle = AllTestsLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -11,7 +11,7 @@ import net.corda.sandbox.SandboxGroup
 import net.corda.serialization.SerializationContext
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
-import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.utilities.copyTo
 import net.corda.utilities.div
 import net.corda.utilities.reflection.packageName_
@@ -47,12 +47,12 @@ class AMQPwithOSGiSerializationTests {
 
     companion object {
         @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+        private val lifecycle = EachTestLifecycle()
 
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxFactory: SandboxFactory
+        private lateinit var sandboxFactory: SandboxFactory
 
         @BeforeAll
         @JvmStatic

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/SandboxFactory.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/SandboxFactory.kt
@@ -5,7 +5,6 @@ import net.corda.sandbox.SandboxGroup
 import net.corda.testing.sandboxes.CpiLoader
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 
 @Component(service = [ SandboxFactory::class ])
@@ -15,12 +14,6 @@ class SandboxFactory @Activate constructor(
     @Reference
     private val sandboxCreationService: SandboxCreationService
 ) {
-    @Suppress("unused")
-    @Deactivate
-    fun done() {
-        cpiLoader.stop()
-    }
-
     fun loadSandboxGroup(resourceName: String): SandboxGroup {
         return cpiLoader.loadCPI(resourceName).let { cpi ->
             sandboxCreationService.createSandboxGroup(cpi.cpks)

--- a/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/KryoCheckpointTest.kt
+++ b/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/KryoCheckpointTest.kt
@@ -34,7 +34,7 @@ class KryoCheckpointTest {
         @InjectService(timeout = 1000)
         lateinit var sandboxSetup: SandboxSetup
 
-        lateinit var sandboxManagementService: SandboxManagementService
+        private lateinit var sandboxManagementService: SandboxManagementService
 
         @Suppress("unused")
         @JvmStatic

--- a/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/SandboxManagementService.kt
+++ b/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/SandboxManagementService.kt
@@ -32,9 +32,6 @@ class SandboxManagementService @Activate constructor(
     fun cleanup() {
         sandboxCreationService.unloadSandboxGroup(group1)
         sandboxCreationService.unloadSandboxGroup(group2)
-
-        // Reset the CPI loader, ready for the next test.
-        cpiLoader.stop()
     }
 
     private fun loadCPI(resourceName: String): CPI {


### PR DESCRIPTION
- Reuse sandboxes for `sandbox-internal` tests.
- Migrate `flow-service` to use the new test model.
- Remove unnecessary `@Deactivate` method from serialization tests' `SandboxFactory` as it conflicts with the JUnit lifecycle. If we need to reload the CPIs after each test then use `EachTestLifecycle` instead of `AllTestsLifecycle` to do it properly.

This should reduce the time taken to execute the `sandbox-internal` integration tests, although I don't believe the reported times are accurate in the first place.