### PR TITLE
NOTICK: Resolve some Kotlin warnings in sandbox-hooks.

### DIFF
--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingCollisionBundleHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingCollisionBundleHook.kt
@@ -28,7 +28,7 @@ internal class IsolatingCollisionBundleHook @Activate constructor(
     // Note that `target` is not the bundle being installed, but the bundle whose context triggered the installation.
     override fun filterCollisions(operationType: Int, target: Bundle, collisionCandidates: MutableCollection<Bundle>) {
         // We filter out any collisions that are installed into sandboxes.
-        val candidatesToRemove = collisionCandidates.filter { bundle -> sandboxService.isSandboxed(bundle) }
+        val candidatesToRemove = collisionCandidates.filterTo(HashSet(), sandboxService::isSandboxed)
         collisionCandidates.removeAll(candidatesToRemove)
     }
 }

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/service/IsolatingEventListenerHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/service/IsolatingEventListenerHook.kt
@@ -21,8 +21,8 @@ internal class IsolatingEventListenerHook @Activate constructor(
 ) : EventListenerHook {
 
     override fun event(event: ServiceEvent, listeners: MutableMap<BundleContext, MutableCollection<ListenerHook.ListenerInfo>>) {
-        val listenersToRemove = listeners.keys.filter { listener ->
-            !sandboxService.hasVisibility(listener.bundle, event.serviceReference.bundle)
+        val listenersToRemove = listeners.keys.filterNot { listener ->
+            sandboxService.hasVisibility(listener.bundle, event.serviceReference.bundle)
         }
 
         listenersToRemove.forEach(listeners::remove)


### PR DESCRIPTION
- Prefer `Set` over `List` when removing items from collections. (Kotlin says this improves performance.)
- Prefer `filterNot { x }` over `filter { !x }`.