### PR TITLE
CORE-3172 Fix for flaky membership group reader test

### DIFF
--- a/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
+++ b/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
@@ -183,10 +183,9 @@ class MembershipGroupReaderProviderIntegrationTest {
         eventually { membershipGroupReaderProvider.failGetAliceGroupReader() }
 
         configurationReadService.startAndWait()
-        eventually {
-            assertTrue(startableServices.all { it.isRunning })
-            assertDoesNotThrow { membershipGroupReaderProvider.getAliceGroupReader() }
-        }
+        eventually { assertTrue(startableServices.all { it.isRunning }) }
+        eventually { assertDoesNotThrow { groupPolicyProvider.getGroupPolicy(aliceHoldingIdentity) } }
+        eventually { assertDoesNotThrow { membershipGroupReaderProvider.getAliceGroupReader() } }
     }
 
     fun runTest(testFunction: KFunction<Unit>) {


### PR DESCRIPTION
Fix flaky test: net.corda.membership.impl.read.MembershipGroupReaderProviderIntegrationTest
Found to be flaky during this run: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os/detail/PR-866/7/tests/

Failed with error 
```
Error
Tried to read group data before starting the component or while the component is down.
Stacktrace
net.corda.v5.base.exceptions.CordaRuntimeException: Tried to read group data before starting the component or while the component is down.
	at net.corda.membership.impl.read.component.MembershipGroupReaderProviderImpl.getGroupReader(MembershipGroupReaderProviderImpl.kt:105)
	at net.corda.membership.impl.read.MembershipGroupReaderProviderIntegrationTest.getAliceGroupReader(MembershipGroupReaderProviderIntegrationTest.kt:225)
	at net.corda.membership.impl.read.MembershipGroupReaderProviderIntegrationTest.access$getAliceGroupReader(MembershipGroupReaderProviderIntegrationTest.kt:43)
	at net.corda.membership.impl.read.MembershipGroupReaderProviderIntegrationTest$Stopping and starting dependency service configuration read service, stops and starts group read provider component$2.invoke(MembershipGroupReaderProviderIntegrationTest.kt:187)
```

Test was using `eventually` function to check that a service call eventually worked by calling the service. This should have been wrapped in assertions to correctly work with the `eventually` function. Instead it was a standalone call with no assertion so when it threw an exception it failed the test instead of retrying.