### PR TITLE
NOTICK: Use JUnit @TestInstance(PER_CLASS) for OSGi tests.

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/sandbox/SandboxInjectableTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/sandbox/SandboxInjectableTest.kt
@@ -13,6 +13,8 @@ import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.fail
@@ -28,6 +30,7 @@ import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
 
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxInjectableTest {
     companion object {
         private const val CPB_INJECT = "sandbox-cpk-inject-package.cpb"
@@ -37,23 +40,25 @@ class SandboxInjectableTest {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
 
         private val holdingIdentity = HoldingIdentity(X500_NAME, UUID.randomUUID().toString())
+    }
 
-        @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+    @RegisterExtension
+    private val lifecycle = EachTestLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @BeforeAll
-        @JvmStatic
-        fun setup(@InjectBundleContext context: BundleContext, @TempDir baseDirectory: Path) {
-            sandboxSetup.configure(context, baseDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        context: BundleContext,
+        @TempDir
+        baseDirectory: Path
+    ) {
+        sandboxSetup.configure(context, baseDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/CustomCryptoDigestTests.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/CustomCryptoDigestTests.kt
@@ -9,6 +9,8 @@ import net.corda.v5.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -20,6 +22,7 @@ import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
 
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 @Suppress("FunctionName")
 class CustomCryptoDigestTests {
     companion object {
@@ -30,23 +33,25 @@ class CustomCryptoDigestTests {
 
         private const val DIGEST_CPB_ONE = "META-INF/crypto-custom-digest-one-consumer.cpb"
         private const val DIGEST_CPB_TWO = "META-INF/crypto-custom-digest-two-consumer.cpb"
+    }
 
-        @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+    @RegisterExtension
+    private val lifecycle = EachTestLifecycle()
 
+    private lateinit var virtualNode: VirtualNodeService
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var virtualNode: VirtualNodeService
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                virtualNode = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            virtualNode = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
@@ -7,6 +7,8 @@ import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -18,24 +20,24 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the ability to have different copies of the same library in different sandboxes. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxBundleDifferentLibrariesTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
@@ -7,6 +7,8 @@ import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -19,24 +21,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the isolation of bundle events across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxBundleEventIsolationTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
@@ -7,6 +7,8 @@ import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -19,24 +21,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the isolation of bundles across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxBundleIsolationTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
@@ -7,6 +7,8 @@ import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -18,24 +20,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the use of non-exported implementation classes from one bundle in another bundle. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxBundlePrivateImplementationTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
@@ -9,6 +9,8 @@ import net.corda.v5.application.flows.Flow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -23,24 +25,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the use of class tags for serialisation and deserialisation. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxClassTagTests {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -20,24 +22,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the ability to retrieve the calling sandbox group. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxGetCallingGroupTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
@@ -8,6 +8,8 @@ import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -20,24 +22,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the inability to resolve against private bundles in a public sandbox. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxIrresolvableBundleTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
@@ -7,6 +7,8 @@ import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -19,24 +21,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the isolation of service events across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxServiceEventIsolationTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -25,24 +27,25 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 /** Tests the isolation of services across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class SandboxServiceIsolationTest {
-    companion object {
-        @RegisterExtension
-        private val lifecycle = AllTestsLifecycle()
+    @RegisterExtension
+    private val lifecycle = AllTestsLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setup(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @Suppress("unused")
-        @JvmStatic
-        @BeforeAll
-        fun setup(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1000)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1000)
         }
     }
 

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -22,6 +22,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -41,26 +43,27 @@ import java.util.concurrent.TimeUnit
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(PER_CLASS)
 class AMQPwithOSGiSerializationTests {
-
     private val testSerializationContext = AMQP_STORAGE_CONTEXT
 
-    companion object {
-        @RegisterExtension
-        private val lifecycle = EachTestLifecycle()
+    @RegisterExtension
+    private val lifecycle = EachTestLifecycle()
 
+    private lateinit var sandboxFactory: SandboxFactory
+
+    @BeforeAll
+    fun setUp(
         @InjectService(timeout = 1000)
-        lateinit var sandboxSetup: SandboxSetup
-
-        private lateinit var sandboxFactory: SandboxFactory
-
-        @BeforeAll
-        @JvmStatic
-        fun setUp(@InjectBundleContext bundleContext: BundleContext, @TempDir testDirectory: Path) {
-            sandboxSetup.configure(bundleContext, testDirectory)
-            lifecycle.accept(sandboxSetup) { setup ->
-                sandboxFactory = setup.fetchService(timeout = 1500)
-            }
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            sandboxFactory = setup.fetchService(timeout = 1500)
         }
     }
 


### PR DESCRIPTION
No need for `companion object` and `@JvmStatic` methods - just annotate the test class as `@TestInstance(PER_CLASS)` and JUnit will use the same class instance for all its `@Test` cases.

The `osgi-test` extension currently assumes that instance fields are always initialised `PER_METHOD` rather than `PER_CLASS`, regardless of how the class has been annotated. However, we can annotate the `@BeforeAll` constructor parameters instead, and this actually makes more sense anyway.