### PR TITLE
CORE-3897 - Deploy membership rpc ops endpoints

### DIFF
--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberRegistrationRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberRegistrationRpcOpsImpl.kt
@@ -47,11 +47,13 @@ class MemberRegistrationRpcOpsImpl @Activate constructor(
 
     override fun start() {
         logger.info("$className started.")
+        membershipRpcOpsClient.start()
         coordinator.start()
     }
 
     override fun stop() {
         logger.info("$className stopped.")
+        membershipRpcOpsClient.stop()
         coordinator.stop()
     }
 

--- a/processors/rpc-processor/build.gradle
+++ b/processors/rpc-processor/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 
     runtimeOnly project(':components:configuration:configuration-read-service-impl')
     runtimeOnly project(':components:configuration:configuration-rpcops-service-impl')
+    runtimeOnly project(":components:membership:membership-http-rpc-impl")
+    runtimeOnly project(":components:membership:membership-client-impl")
     runtimeOnly project(':components:virtual-node:virtual-node-rpcops-service-impl')
     runtimeOnly project(":components:permissions:permission-rpc-ops-impl")
 


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-3908

Followed the steps on [docs](https://github.com/corda/corda-runtime-os/blob/release/ent/5.0/applications/workers/release/deploy/README.md?plain=1) and started the workers.

Opened the swagger UI and checked that the endpoints are visible:
<img width="1460" alt="Screenshot 2022-02-21 at 14 35 08" src="https://user-images.githubusercontent.com/61757742/154985779-70ad03bc-2184-4f82-a910-1dcf9c08e3e9.png">

Checked the logs for proof that both the rpc ops impl and client impl are started:

15:25:16.580 [lifecycle-coordinator-7] INFO  net.corda.membership.impl.httprpc.v1.MemberRegistrationRpcOpsImpl - MemberRegistrationRpcOpsImpl started.

15:25:16.580 [lifecycle-coordinator-7] INFO  net.corda.membership.impl.client.MembershipRpcOpsClientImpl - MembershipRpcOpsClientImpl started.
