### PR TITLE
CORE-3282: Create missing Crypto topics

### DIFF
--- a/applications/workers/release/deploy/docker-compose.yaml
+++ b/applications/workers/release/deploy/docker-compose.yaml
@@ -74,6 +74,9 @@ services:
       kafka-topics.sh --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --create --topic membership.members --config "cleanup.policy=compact"
       kafka-topics.sh --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --create --topic membership.rpc.ops
       kafka-topics.sh --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --create --topic membership.rpc.ops.resp
+      
+      kafka-topics.sh --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --create --topic crypto.ops.rpc
+      kafka-topics.sh --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --create --topic crypto.ops.rpc.resp
 
       echo -e 'Successfully created the following topics:'
       kafka-topics.sh --bootstrap-server kafka:9092 --list


### PR DESCRIPTION
Without this change `member-worker` keeps logging this sort of lines:
```
11:44:31.330 [rpc response subscription thread crypto.ops.rpc-crypto.ops.rpc-crypto.ops.rpc] WARN  org.apache.kafka.clients.NetworkClient - [Consumer clientId=crypto.ops.rpc.resp-consumer-0, groupId=crypto.ops.rpc-crypto.ops.rpc] Error while fetching metadata with correlation id 8687 : {crypto.ops.rpc.resp=UNKNOWN_TOPIC_OR_PARTITION}
```
When running on Docker Compose locally.