### PR TITLE
NOTICK: Update example sandbox app for new flow handling.

### DIFF
--- a/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/ExampleFlow.kt
+++ b/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/ExampleFlow.kt
@@ -8,12 +8,11 @@ import net.corda.v5.application.services.json.JsonMarshallingService
 import net.corda.v5.application.services.json.parseJson
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.util.loggerFor
-import net.corda.v5.crypto.SecureHash
 
 @Suppress("unused")
 @InitiatingFlow
 @StartableByRPC
-class ExampleFlow(private val json: String) : Flow<SecureHash> {
+class ExampleFlow(private val json: String) : Flow<String> {
     private val logger = loggerFor<ExampleFlow>()
 
     @CordaInject
@@ -27,13 +26,13 @@ class ExampleFlow(private val json: String) : Flow<SecureHash> {
     }
 
     @Suspendable
-    override fun call(): SecureHash {
+    override fun call(): String {
         logger.info("Invoked: JSON=$json")
         val input = jsonMarshaller.parseJson<FlowInput>(json)
         return customCrypto.hashOf(
             bytes = input.message?.toByteArray() ?: byteArrayOf()
         ).also { result ->
             logger.info("Result=$result")
-        }
+        }.toHexString()
     }
 }

--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
@@ -151,8 +151,12 @@ class CordaVNode @Activate constructor(
                 val record = Record(FLOW_EVENT_TOPIC, flowKey, FlowEvent(flowKey, rpcStartFlow))
                 flowEventProcessorFactory.create().apply {
                     val result = onNext(null, record)
-                    @Suppress("unchecked_cast")
-                    onNext(result.updatedState, result.responseEvents.single() as Record<FlowKey, FlowEvent>)
+                    result.responseEvents.singleOrNull { evt ->
+                        evt.topic == FLOW_EVENT_TOPIC
+                    }?.also { evt ->
+                        @Suppress("unchecked_cast")
+                        onNext(result.updatedState, evt as Record<FlowKey, FlowEvent>)
+                    }
                 }
             } finally {
                 (sandboxContext as AutoCloseable).close()


### PR DESCRIPTION
- Flows initiated by RPC _must_ now return a `String`.
- Filter flow's response events for `flow.event` events.