### PR TITLE
CORE-4040: Upgrade to Gradle 7.4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 wrapper {
-    gradleVersion = '7.3.2'
+    gradleVersion = '7.4'
     distributionType = Wrapper.DistributionType.BIN
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade Gradle 7.3.2 -> 7.4.

This merely upgrades the version, and does not migrate to use any _spiffy_ new features,