### PR TITLE
NO-TICKET: Avoid publishing any trust store when publisher is not ready; try to publish them when publisher become ready

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
@@ -105,11 +105,12 @@ internal class TrustStoresPublisher(
     private fun createResources(
         @Suppress("UNUSED_PARAMETER") resourcesHolder: ResourcesHolder
     ): CompletableFuture<Unit> {
+        publishQueueIfPossible()
         return ready
     }
 
     private fun publishQueueIfPossible() {
-        while (ready.isDone) {
+        while ((publisher.isRunning) && (ready.isDone)) {
             val groupInfo = toPublish.poll() ?: return
             val groupId = groupInfo.groupId
             val certificates = groupInfo.trustedCertificates

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisherTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisherTest.kt
@@ -50,6 +50,7 @@ class TrustStoresPublisherTest {
     }
     private val mockPublisher = mockConstruction(PublisherWithDominoLogic::class.java) { mock, _ ->
         whenever(mock.publish(publishedRecords.capture())).doReturn(emptyList())
+        whenever(mock.isRunning).doReturn(true)
     }
     private val lifecycleCoordinatorFactory = mock<LifecycleCoordinatorFactory>()
     private val configuration = mock<SmartConfig>()
@@ -167,6 +168,18 @@ class TrustStoresPublisherTest {
         fun `groupAdded will not publish before it has the snapshots`() {
             trustStoresPublisher.start()
             creteResources.get().invoke(ResourcesHolder())
+
+            trustStoresPublisher.groupAdded(groupInfo)
+
+            verify(mockPublisher.constructed().first(), never()).publish(any())
+        }
+
+        @Test
+        fun `groupAdded will not publish before the publisher is ready`() {
+            trustStoresPublisher.start()
+            whenever(mockPublisher.constructed().first().isRunning).doReturn(false)
+            creteResources.get().invoke(ResourcesHolder())
+            processor.firstValue.onSnapshot(emptyMap())
 
             trustStoresPublisher.groupAdded(groupInfo)
 


### PR DESCRIPTION
This should fix the issue in [here](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/PR-844/16/testReport/net.corda.p2p/P2PLayerEndToEndTest/two_hosts_can_exchange_data_messages_over_p2p_with_ECDSA_keys__/)

Before we will try to publish any trusted store, we will check if the publisher is running.
When the publisher will start, the `createResources` will be called, so we will retry to publish the queue.