### PR TITLE
CORE-4083: Upgrade to Bnd 6.2.0, and Corda Gradle plugins 6.0.0-BETA14.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@ cordaRuntimeRevision=0
 
 # Plugin dependency versions
 avroGradlePluginVersion=1.1.0
-bndVersion=6.1.0
-cordaGradlePluginsVersion=6.0.0-BETA13
+bndVersion=6.2.0
+cordaGradlePluginsVersion=6.0.0-BETA14
 detektPluginVersion=1.19.+
 internalPublishVersion=1.+
 gradleVersions=0.39.+


### PR DESCRIPTION
Corda Gradle plugins 6.0.0-BETA14 also uses Bnd 6.2.0, so upgrade these two together.