### PR TITLE
CORE-4096 Install E2E test prereqs via Helm

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,5 +1,3 @@
-//placeholder pipeline WIP for e2e tests
-
 pipeline {
     agent {
         docker {
@@ -29,6 +27,8 @@ pipeline {
         CORDA_REVISION = "${env.GIT_COMMIT}"
         NAMESPACE = "run-${UUID.randomUUID().toString()}"
         CLUSTER_NAME = "eks-e2e.e2e.awsdev.r3.com"
+        HELM_CONFIG_HOME = "/tmp/helm"
+        HELM_REPOSITORY_CACHE = "/host_tmp/helm/repository"
     }
 
     options {
@@ -38,7 +38,7 @@ pipeline {
     }
 
     stages {
-        stage('Prepare') {
+        stage('Install CLI') {
             steps {
                 sh 'mkdir -p "${GRADLE_USER_HOME}"'
                 //download and set up CLI
@@ -48,18 +48,41 @@ pipeline {
                 sh "./corda-cli/bin/corda-cli -v"
             }
         }
-        stage('Set up cluster') {
+        stage ('Create namespace') {
+            steps {
+                sh '''
+                    kubectl create ns $NAMESPACE
+                    kubectl label ns $NAMESPACE namespace-type=corda-e2e --overwrite=true
+                '''
+            }
+        }
+        stage('Install prereqs') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'artifactory-credentials', passwordVariable: 'PASSWORD', usernameVariable: 'USER')]) {
+                    sh '''
+                        echo $PASSWORD | helm registry login corda-os-docker.software.r3.com -u $USER --password-stdin
+                        helm install prereqs oci://corda-os-docker.software.r3.com/helm-charts/corda-prereqs \
+                            -f .ci/e2eTests/prereqs.yaml -n $NAMESPACE --wait
+                    '''
+                }
+            }
+        }
+        stage('Deploy cluster') {
             steps {
                script {
                   env.BASE_IMAGE = params.BUILD_REV ? "preTest-${params.BUILD_REV}" : "unstable"
                }
                sh './corda-cli/bin/corda-cli cluster configure k8s "${NAMESPACE}"'
-               sh 'echo """cluster:""" | ./corda-cli/bin/corda-cli --stacktrace cluster deploy -t "${BASE_IMAGE}" -c "${NAMESPACE}" -f /dev/stdin | tee spec.yaml | kubectl apply -f /dev/stdin'
+               sh './corda-cli/bin/corda-cli --stacktrace cluster deploy -t "${BASE_IMAGE}" -c "${NAMESPACE}" -f .ci/e2eTests/cluster.yaml | kubectl apply -f /dev/stdin'
             }
         }
         stage('Wait for cluster') {
             steps {
-                sh './corda-cli/bin/corda-cli cluster wait -c "${NAMESPACE}"'
+                sh '''
+                    ./corda-cli/bin/corda-cli cluster wait -c "${NAMESPACE}"
+                    # Wait for the job to create the topics
+                    kubectl wait -n ${NAMESPACE} --for=condition=complete --timeout=30s job/create-topics
+                '''
             }
             post {
                 unsuccessful {
@@ -72,7 +95,7 @@ pipeline {
                 }
             }
         }
-        stage('Forward port and run the tests') {
+        stage('Forward port and run tests') {
             steps {
 
                 //for details see
@@ -84,10 +107,6 @@ pipeline {
                     nohup kubectl port-forward -n ${NAMESPACE} deploy/${NAMESPACE}-rpc 8888 > forward.txt 2>&1 &
                     procno=$! #remember process number started in background
                     trap "kill -9 ${procno}" EXIT
-
-                    echo forward.txt
-                    # Wait for the job to create the topics
-                    kubectl wait -n ${NAMESPACE} --for=condition=complete --timeout=30s job/create-topics
 
                     ./gradlew cleanE2eTest :applications:workers:release:rpc-worker:e2eTest
                 '''

--- a/.ci/e2eTests/cluster.yaml
+++ b/.ci/e2eTests/cluster.yaml
@@ -1,0 +1,20 @@
+cluster:
+  kafka:
+    bootstrapServers:
+      - host: "prereqs-kafka"
+        port: 9092
+  databases:
+    connectionDetails:
+      host: "prereqs-postgresql"
+      port: 5432
+      name: "cordacluster"
+      authentication:
+        username: "user"
+        password: "4LNuCvt+NhGIBwL7gRRhvAZh3k6JRN9NHv0aG3pi1xM="
+  workers:
+    p2p-worker: {}
+    p2p-link-worker: {}
+    rpc-worker: {}
+    crypto-worker: {}
+    db-worker: {}
+    flow-worker: {}

--- a/.ci/e2eTests/prereqs.yaml
+++ b/.ci/e2eTests/prereqs.yaml
@@ -1,0 +1,4 @@
+global:
+  imageRegistry: docker-remotes.software.r3.com
+  imagePullSecrets:
+    - docker-registry-cred

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,5 +8,5 @@ cordaPipeline(
     publishOSGiImage: true,
     publishPreTestImage: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
-    runE2eTests: false
+    runE2eTests: true
     )


### PR DESCRIPTION
Re-enables the E2E tests but now installing the pre-requisites via Helm and using the `docker-remotes` cache to avoid Docker Hub API rate limiting.