### PR TITLE
NOTICK: Remove transitive dependencies from Quasar agent.

### DIFF
--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -28,7 +28,9 @@ dependencies {
     // OSGi frameworks containing Quasar and Kryo must resolve
     // the version of ASM as specified in the OSGi metadata.
     quasarBundles "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
-    integrationTestRuntimeOnly "co.paralleluniverse:quasar-core-osgi:$quasarVersion:agent"
+    integrationTestRuntimeOnly("co.paralleluniverse:quasar-core-osgi:$quasarVersion:agent") {
+        transitive = false
+    }
     integrationTestRuntimeOnly files(configurations.quasarBundles)
 
     integrationTestImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"


### PR DESCRIPTION
The Quasar agent doesn't have any transitive dependencies, but Gradle is providing some anyway :facepalm:. This is adding spurious extra `slf4-api:1.7.26` bundles to our OSGi tests, which must be removed.