### PR TITLE
CORE-3411 - E2E test for static registration

### DIFF
--- a/applications/workers/release/rpc-worker/build.gradle
+++ b/applications/workers/release/rpc-worker/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
 
+    e2eTestImplementation project(":components:membership:membership-http-rpc")
     e2eTestImplementation project(":libs:http-rpc:http-rpc-client")
     e2eTestImplementation project(":libs:permissions:permission-endpoint")
     e2eTestImplementation project(":testing:test-utilities")

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/StaticRegistrationE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/StaticRegistrationE2eTest.kt
@@ -1,0 +1,26 @@
+package net.corda.applications.workers.rpc
+
+import net.corda.applications.workers.rpc.http.TestToolkitProperty
+import net.corda.membership.httprpc.v1.MemberRegistrationRpcOps
+import net.corda.membership.httprpc.v1.types.request.MemberRegistrationRequest
+import net.corda.membership.httprpc.v1.types.request.RegistrationAction
+import org.junit.jupiter.api.Test
+
+class StaticRegistrationE2eTest {
+    private val testToolkit by TestToolkitProperty()
+
+    @Test
+    fun test() {
+        testToolkit.httpClientFor(MemberRegistrationRpcOps::class.java).use { client ->
+            val proxy = client.start().proxy
+
+            proxy.startRegistration(
+                MemberRegistrationRequest(
+                    "test",
+                    RegistrationAction.REQUEST_JOIN
+                )
+            )
+
+        }
+    }
+}

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/StaticRegistrationE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/StaticRegistrationE2eTest.kt
@@ -4,23 +4,41 @@ import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.membership.httprpc.v1.MemberRegistrationRpcOps
 import net.corda.membership.httprpc.v1.types.request.MemberRegistrationRequest
 import net.corda.membership.httprpc.v1.types.request.RegistrationAction
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class StaticRegistrationE2eTest {
     private val testToolkit by TestToolkitProperty()
 
+    private val nonExistentId = "failure"
+
     @Test
-    fun test() {
+    fun `using a non-existent holding identity id results in exception during registration`() {
         testToolkit.httpClientFor(MemberRegistrationRpcOps::class.java).use { client ->
             val proxy = client.start().proxy
 
-            proxy.startRegistration(
-                MemberRegistrationRequest(
-                    "test",
-                    RegistrationAction.REQUEST_JOIN
+            val ex = assertThrows<CordaRuntimeException> {
+                proxy.startRegistration(
+                    MemberRegistrationRequest(
+                        nonExistentId,
+                        RegistrationAction.REQUEST_JOIN
+                    )
                 )
-            )
+            }
+            assert(ex.message!!.contains("MembershipRegistrationException"))
+        }
+    }
 
+    @Test
+    fun `using a non-existent holding identity id results in exception during registration status check`() {
+        testToolkit.httpClientFor(MemberRegistrationRpcOps::class.java).use { client ->
+            val proxy = client.start().proxy
+
+            val ex = assertThrows<CordaRuntimeException> {
+                proxy.checkRegistrationProgress(nonExistentId)
+            }
+            assert(ex.message!!.contains("MembershipRegistrationException"))
         }
     }
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-3411

For now only adding failing scenarios as we don't have the tool to push the required information to Kafka (cpi, group policy, virtual node info).