### PR TITLE
CORE-4086 Remove unnecessary package export causing error in member worker start up

### DIFF
--- a/components/membership/registration-impl/src/main/java/net/corda/membership/registration/provider/package-info.java
+++ b/components/membership/registration-impl/src/main/java/net/corda/membership/registration/provider/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.membership.registration.provider;
-
-import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Package export in the `registration-impl` module prevented the member worker from starting.
This was because the package used was a duplicate of the interface package. Also we don't need to export the implementation so it was possible to just delete it instead of updating the package.