### PR TITLE
NOTICK - Windows build fix

### DIFF
--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
@@ -32,7 +32,7 @@ class CpiEntitiesIntegrationTest {
     init {
         // comment this out if you want to run the test against a real postgres
         //  NOTE: the blob storage doesn't work in HSQL, hence skipping the majority of the test.
-        System.setProperty("postgresPort", "5432")
+//        System.setProperty("postgresPort", "5432")
         dbConfig = DbUtils.getEntityManagerConfiguration("cpi_db")
     }
     @BeforeAll


### PR DESCRIPTION
Remove force running test against postgres so that this doesn't fail as part of the windows build.