### PR TITLE
CORE-3910 Remove dependency on module that was removed

### DIFF
--- a/applications/tools/mgm-test/group-policy-uploader/build.gradle
+++ b/applications/tools/mgm-test/group-policy-uploader/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     implementation "org.slf4j:slf4j-api"
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-crypto"
-    implementation "net.corda:corda-membership-identity"
     implementation "net.corda:corda-packaging"
     implementation "net.corda:corda-packaging-avro-converters"
     implementation project(":libs:configuration:configuration-core")


### PR DESCRIPTION
CORE-3910 was merged after the `membership-identity` module was removed but the PR was already green so the missing module was not noticed before merging.
