### PR TITLE
CORE-3828: Speed-up execution of concurrent E2E test

### DIFF
--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/PermissionSummaryConcurrentE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/PermissionSummaryConcurrentE2eTest.kt
@@ -4,6 +4,7 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit.DAYS
 import java.util.concurrent.Executors
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
+import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionType
 import net.corda.test.util.eventually
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -47,11 +48,13 @@ class PermissionSummaryConcurrentE2eTest {
         }
 
         val permissionsCount = 100
+        val client = testToolkit.httpClientFor(PermissionEndpoint::class.java, "admin", "admin")
+        val proxy = client.start().proxy
         val permissionIdsAllow = (1..permissionsCount).map {
-            adminTestHelper.createPermission(PermissionType.ALLOW, "$it-allow-${testToolkit.uniqueName}", false)
+            proxy.createPermission(PermissionType.ALLOW, "$it-allow-${testToolkit.uniqueName}", false)
         }
         val permissionIdsDeny = (1..permissionsCount).map {
-            adminTestHelper.createPermission(PermissionType.DENY, "$it-deny-${testToolkit.uniqueName}", false)
+            proxy.createPermission(PermissionType.DENY, "$it-deny-${testToolkit.uniqueName}", false)
         }
 
         val executorService = Executors.newFixedThreadPool(2)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
@@ -81,37 +81,7 @@ class RbacE2eClientRequestHelper(
         val client = testToolkit.httpClientFor(PermissionEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
 
-        val type = CreatePermissionType(permissionType, permissionString, null, null)
-        val permissionId = with(proxy.createPermission(type)) {
-            SoftAssertions.assertSoftly {
-                it.assertThat(this.permissionType).isEqualTo(permissionType)
-                it.assertThat(this.permissionString).isEqualTo(permissionString)
-            }
-            this.id
-        }
-        if (verify) {
-            verifyPermissionCreationPersisted(proxy, permissionId, permissionType, permissionString)
-        }
-        return permissionId
-    }
-
-    private fun verifyPermissionCreationPersisted(
-        proxy: PermissionEndpoint,
-        permissionId: String,
-        permissionType: PermissionType,
-        permissionString: String
-    ) {
-        eventually {
-            assertDoesNotThrow {
-                with(proxy.getPermission(permissionId)) {
-                    SoftAssertions.assertSoftly {
-                        it.assertThat(this.id).isEqualTo(permissionId)
-                        it.assertThat(this.permissionType).isEqualTo(permissionType)
-                        it.assertThat(this.permissionString).isEqualTo(permissionString)
-                    }
-                }
-            }
-        }
+        return proxy.createPermission(permissionType, permissionString, verify)
     }
 
     fun addPermissionsToRole(roleId: String, vararg permissionIds: String) {
@@ -187,6 +157,44 @@ class RbacE2eClientRequestHelper(
                 it.assertThat(this.loginName).isEqualToIgnoringCase(userLogin)
             }
             this
+        }
+    }
+}
+
+fun PermissionEndpoint.createPermission(
+    permissionType: PermissionType,
+    permissionString: String,
+    verify: Boolean
+): String {
+    val type = CreatePermissionType(permissionType, permissionString, null, null)
+    val permissionId = with(createPermission(type)) {
+        SoftAssertions.assertSoftly {
+            it.assertThat(this.permissionType).isEqualTo(permissionType)
+            it.assertThat(this.permissionString).isEqualTo(permissionString)
+        }
+        this.id
+    }
+    if (verify) {
+        verifyPermissionCreationPersisted(this, permissionId, permissionType, permissionString)
+    }
+    return permissionId
+}
+
+private fun verifyPermissionCreationPersisted(
+    proxy: PermissionEndpoint,
+    permissionId: String,
+    permissionType: PermissionType,
+    permissionString: String
+) {
+    eventually {
+        assertDoesNotThrow {
+            with(proxy.getPermission(permissionId)) {
+                SoftAssertions.assertSoftly {
+                    it.assertThat(this.id).isEqualTo(permissionId)
+                    it.assertThat(this.permissionType).isEqualTo(permissionType)
+                    it.assertThat(this.permissionString).isEqualTo(permissionString)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
With 100 denies and 100 allows it takes around 20 seconds for the whole scenario.

When creating permissions, we save time by not verifying it.
Also adding permissions to a role in bulk.