### PR TITLE
CORE-4128: Select non-injectable singletons as not having prototype scope.

### DIFF
--- a/components/configuration/configuration-read-service-impl/test.bndrun
+++ b/components/configuration/configuration-read-service-impl/test.bndrun
@@ -69,6 +69,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/components/flow/flow-mapper-service/test.bndrun
+++ b/components/flow/flow-mapper-service/test.bndrun
@@ -70,6 +70,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowSandboxServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowSandboxServiceImpl.kt
@@ -22,7 +22,7 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.framework.BundleContext
-import org.osgi.framework.Constants.SCOPE_SINGLETON
+import org.osgi.framework.Constants.SCOPE_PROTOTYPE
 import org.osgi.framework.Constants.SERVICE_SCOPE
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -44,6 +44,10 @@ class FlowSandboxServiceImpl @Activate constructor(
     private val checkpointSerializerBuilderFactory: CheckpointSerializerBuilderFactory,
     private val bundleContext: BundleContext
 ) : FlowSandboxService {
+    private companion object {
+        private const val NON_PROTOTYPE_SERVICES = "(!($SERVICE_SCOPE=$SCOPE_PROTOTYPE))"
+    }
+
     private val logger = loggerFor<FlowSandboxServiceImpl>()
 
     override fun get(
@@ -115,9 +119,11 @@ class FlowSandboxServiceImpl @Activate constructor(
     }
 
     private fun getNonInjectableSingletons(cleanups: MutableList<AutoCloseable>): Set<SingletonSerializeAsToken> {
-        return bundleContext.getServiceReferences(SingletonSerializeAsToken::class.java, "($SERVICE_SCOPE=$SCOPE_SINGLETON)")
-            .mapTo(HashSet()) { ref ->
-                bundleContext.getService(ref).also {
+        // An OSGi singleton component can still register bundle-scoped services, so
+        // select the non-prototype ones here. They should all be internal to Corda.
+        return bundleContext.getServiceReferences(SingletonSerializeAsToken::class.java, NON_PROTOTYPE_SERVICES)
+            .mapNotNullTo(HashSet()) { ref ->
+                bundleContext.getService(ref)?.also {
                     cleanups.add(AutoCloseable { bundleContext.ungetService(ref) })
                 }
             }

--- a/components/flow/flow-service/test.bndrun
+++ b/components/flow/flow-service/test.bndrun
@@ -74,8 +74,6 @@
 	net.corda.lifecycle;version='[5.0.0,5.0.1)',\
 	net.corda.lifecycle-impl;version='[5.0.0,5.0.1)',\
 	net.corda.membership;version='[5.0.0,5.0.1)',\
-	net.corda.membership-conversion;version='[5.0.0,5.0.1)',\
-	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging-avro-converters;version='[5.0.0,5.0.1)',\
@@ -109,6 +107,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/components/install/install-service-file-based-impl/test.bndrun
+++ b/components/install/install-service-file-based-impl/test.bndrun
@@ -78,6 +78,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/components/membership/membership-group-read-impl/test.bndrun
+++ b/components/membership/membership-group-read-impl/test.bndrun
@@ -61,12 +61,12 @@
 	net.corda.membership;version='[5.0.0,5.0.1)',\
 	net.corda.membership-group-read;version='[5.0.0,5.0.1)',\
 	net.corda.membership-group-read-impl;version='[5.0.0,5.0.1)',\
-	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.membership-impl;version='[5.0.0,5.0.1)',\
 	net.corda.membership-internal;version='[5.0.0,5.0.1)',\
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging-avro-converters;version='[5.0.0,5.0.1)',\
+	net.corda.packaging-core;version='[5.0.0,5.0.1)',\
 	net.corda.registry;version='[5.0.0,5.0.1)',\
 	net.corda.test-utilities;version='[5.0.0,5.0.1)',\
 	net.corda.virtual-node-common;version='[5.0.0,5.0.1)',\
@@ -81,6 +81,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/components/virtual-node/sandbox-group-context-service/test.bndrun
+++ b/components/virtual-node/sandbox-group-context-service/test.bndrun
@@ -67,11 +67,10 @@
 	net.corda.lifecycle;version='[5.0.0,5.0.1)',\
 	net.corda.lifecycle-impl;version='[5.0.0,5.0.1)',\
 	net.corda.membership;version='[5.0.0,5.0.1)',\
-	net.corda.membership-conversion;version='[5.0.0,5.0.1)',\
-	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging-avro-converters;version='[5.0.0,5.0.1)',\
+	net.corda.packaging-core;version='[5.0.0,5.0.1)',\
 	net.corda.registry;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox-group-context;version='[5.0.0,5.0.1)',\

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -32,6 +32,7 @@
 	com.sun.activation.javax.activation;version='[1.2.0,1.2.1)',\
 	com.typesafe.config;version='[1.4.1,1.4.2)',\
 	com.zaxxer.HikariCP;version='[5.0.0,5.0.1)',\
+	javax.activation-api;version='[1.2.0,1.2.1)',\
 	javax.interceptor-api;version='[1.2.0,1.2.1)',\
 	javax.persistence-api;version='[2.2.0,2.2.1)',\
 	jaxb-api;version='[2.3.1,2.3.2)',\

--- a/libs/layered-property-map/test.bndrun
+++ b/libs/layered-property-map/test.bndrun
@@ -43,6 +43,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/libs/sandbox-internal/test.bndrun
+++ b/libs/sandbox-internal/test.bndrun
@@ -71,8 +71,6 @@
 	net.corda.lifecycle;version='[5.0.0,5.0.1)',\
 	net.corda.lifecycle-impl;version='[5.0.0,5.0.1)',\
 	net.corda.membership;version='[5.0.0,5.0.1)',\
-	net.corda.membership-conversion;version='[5.0.0,5.0.1)',\
-	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging-avro-converters;version='[5.0.0,5.0.1)',\
@@ -100,6 +98,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	sandbox-internal-tests;version='[5.0.0,5.0.1)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/libs/security-manager/test.bndrun
+++ b/libs/security-manager/test.bndrun
@@ -29,8 +29,6 @@
 	net.corda.base;version='[5.0.0,5.0.1)',\
 	net.corda.crypto;version='[5.0.0,5.0.1)',\
 	net.corda.membership;version='[5.0.0,5.0.1)',\
-	net.corda.membership-conversion;version='[5.0.0,5.0.1)',\
-	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.security-manager;version='[5.0.0,5.0.1)',\
 	net.corda.serialization;version='[5.0.0,5.0.1)',\
 	org.apache.felix.framework.security;version='[2.8.3,2.8.4)',\
@@ -43,6 +41,5 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	security-manager-tests;version='[5.0.0,5.0.1)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/libs/serialization/serialization-amqp/test.bndrun
+++ b/libs/serialization/serialization-amqp/test.bndrun
@@ -58,11 +58,10 @@
 	net.corda.lifecycle;version='[5.0.0,5.0.1)',\
 	net.corda.lifecycle-impl;version='[5.0.0,5.0.1)',\
 	net.corda.membership;version='[5.0.0,5.0.1)',\
-	net.corda.membership-conversion;version='[5.0.0,5.0.1)',\
-	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging-avro-converters;version='[5.0.0,5.0.1)',\
+	net.corda.packaging-core;version='[5.0.0,5.0.1)',\
 	net.corda.registry;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox-hooks;version='[5.0.0,5.0.1)',\

--- a/libs/serialization/serialization-kryo/test.bndrun
+++ b/libs/serialization/serialization-kryo/test.bndrun
@@ -71,6 +71,7 @@
 	net.corda.messaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging-avro-converters;version='[5.0.0,5.0.1)',\
+	net.corda.packaging-core;version='[5.0.0,5.0.1)',\
 	net.corda.registry;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox;version='[5.0.0,5.0.1)',\
 	net.corda.sandbox-hooks;version='[5.0.0,5.0.1)',\

--- a/processors/crypto-processor/test.bndrun
+++ b/processors/crypto-processor/test.bndrun
@@ -84,6 +84,5 @@
 	org.osgi.test.junit5;version='[1.0.1,1.0.2)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
-	slf4j.api;version='[1.7.26,1.7.27)',\
 	slf4j.api;version='[1.7.32,1.7.33)',\
 	slf4j.simple;version='[1.7.32,1.7.33)'

--- a/processors/member-processor/test.bndrun
+++ b/processors/member-processor/test.bndrun
@@ -89,7 +89,6 @@
 	net.corda.membership-application;version='[5.0.0,5.0.1)',\
 	net.corda.membership-group-read;version='[5.0.0,5.0.1)',\
 	net.corda.membership-group-read-impl;version='[5.0.0,5.0.1)',\
-	net.corda.membership-identity;version='[5.0.0,5.0.1)',\
 	net.corda.membership-impl;version='[5.0.0,5.0.1)',\
 	net.corda.membership-internal;version='[5.0.0,5.0.1)',\
 	net.corda.membership-service;version='[5.0.0,5.0.1)',\
@@ -99,6 +98,7 @@
 	net.corda.messaging-impl;version='[5.0.0,5.0.1)',\
 	net.corda.packaging;version='[5.0.0,5.0.1)',\
 	net.corda.packaging-avro-converters;version='[5.0.0,5.0.1)',\
+	net.corda.packaging-core;version='[5.0.0,5.0.1)',\
 	net.corda.registration;version='[5.0.0,5.0.1)',\
 	net.corda.registration-impl;version='[5.0.0,5.0.1)',\
 	net.corda.registry;version='[5.0.0,5.0.1)',\


### PR DESCRIPTION
Singleton OSGi components can clearly register `bundle`-scoped services, so select non-injectable, checkpointable Corda services as not having `prototype` scope instead.

Also resync the `.bndrun` files. Again. (Again).