### PR TITLE
CORE-3657 - Update GroupPolicy

### DIFF
--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/factory/GroupPolicyParserTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/factory/GroupPolicyParserTest.kt
@@ -36,6 +36,8 @@ class GroupPolicyParserTest {
         const val IDENTITY_KEY_POLICY = "identityKeyPolicy"
         const val IDENTITY_TRUST_STORE = "identityTrustStore"
         const val TLS_TRUST_STORE = "tlsTrustStore"
+        const val TLS_PKI = "tlsPki"
+        const val P2P_PROTOCOL_MODE = "p2pProtocolMode"
         const val MGM_INFO = "mgmInfo"
         const val CIPHER_SUITE = "cipherSuite"
         const val ROLES = "roles"
@@ -80,11 +82,10 @@ class GroupPolicyParserTest {
         assertEquals("net.corda.membership.impl.registration.staticnetwork.StaticMemberRegistrationService", result.registrationProtocol)
         assertEquals("net.corda.v5.mgm.MGMSynchronisationProtocolFactory", result[SYNC_PROTOCOL_FACTORY])
         assertTrue(result[PROTOCOL_PARAMETERS] is Map<*, *>)
-        assertTrue(result[STATIC_NETWORK] is Map<*, *>)
 
         // Protocol parameters
         val protocolParameters = result[PROTOCOL_PARAMETERS] as Map<*, *>
-        assertEquals(7, protocolParameters.size)
+        assertEquals(10, protocolParameters.size)
         assertEquals("Standard", protocolParameters[IDENTITY_PKI])
         assertEquals("Combined", protocolParameters[IDENTITY_KEY_POLICY])
 
@@ -93,6 +94,10 @@ class GroupPolicyParserTest {
 
         assertTrue(protocolParameters[TLS_TRUST_STORE] is List<*>)
         assertEquals(3, (protocolParameters[TLS_TRUST_STORE] as List<*>).size)
+
+        assertEquals("C5", protocolParameters[TLS_PKI])
+
+        assertEquals("AUTHENTICATED_ENCRYPTION", protocolParameters[P2P_PROTOCOL_MODE])
 
         assertTrue(protocolParameters[MGM_INFO] is Map<*, *>)
         assertEquals(9, (protocolParameters[MGM_INFO] as Map<*, *>).size)
@@ -104,7 +109,8 @@ class GroupPolicyParserTest {
         assertEquals(2, (protocolParameters[ROLES] as Map<*, *>).size)
 
         // Static network
-        val staticNetwork = result[STATIC_NETWORK] as Map<*, *>
+        assertTrue(protocolParameters[STATIC_NETWORK] is Map<*, *>)
+        val staticNetwork = protocolParameters[STATIC_NETWORK] as Map<*, *>
         assertEquals(2, staticNetwork.size)
 
         val staticMembers = staticNetwork[STATIC_MEMBERS] as List<*>

--- a/components/membership/group-policy-impl/src/test/resources/SampleGroupPolicy.json
+++ b/components/membership/group-policy-impl/src/test/resources/SampleGroupPolicy.json
@@ -13,6 +13,8 @@
       "-----BEGIN CERTIFICATE-----\nMIIDdTCCKSZp4A==\n-----END CERTIFICATE-----",
       "-----BEGIN CERTIFICATE-----\nMIIFPDCCIlifT20M\n-----END CERTIFICATE-----"
     ],
+    "tlsPki": "C5",
+    "p2pProtocolMode": "AUTHENTICATED_ENCRYPTION",
     "mgmInfo": {
       "name": "C=GB, L=London, O=Corda Network, OU=MGM, CN=Corda Network MGM",
       "sessionKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHK+B3YGgcIALw==\n-----END PUBLIC KEY-----\n",
@@ -66,39 +68,39 @@
         "optionalMemberInfo" : [
         ]
       }
-    }
-  },
-  "staticNetwork": {
-    "mgm": {
-      "keyAlias": "mgm-alias"
     },
-    "members": [
-      {
-        "name": "C=GB, L=London, O=Alice", // party name
-        "keyAlias": "alice-alias", // current party identity key
-        "rotatedKeyAlias-1": "alice-historic-alias-1", // Used to force old keys no longer in use (i.e. rotated key)
-        "memberStatus": "ACTIVE", // Member status usually set by the MGM
-        "endpointUrl-1": "https://alice.corda5.r3.com:10000", // Endpoint url & protocol. Iterable.
-        "endpointProtocol-1": 1 //(uses incrementing postfix for repeating elements)
+    "staticNetwork": {
+      "mgm": {
+        "keyAlias": "mgm-alias"
       },
-      {
-        "name": "C=GB, L=London, O=Bob",
-        "keyAlias": "bob-alias",
-        "rotatedKeyAlias-1": "bob-historic-alias-1",
-        "rotatedKeyAlias-2": "bob-historic-alias-2",
-        "memberStatus": "ACTIVE",
-        "endpointUrl-1": "https://bob.corda5.r3.com:10000",
-        "endpointProtocol-1": 1
-      },
-      {
-        "name": "C=GB, L=London, O=Charlie",
-        "keyAlias": "charlie-alias",
-        "memberStatus": "SUSPENDED",
-        "endpointUrl-1": "https://charlie.corda5.r3.com:10000",
-        "endpointProtocol-1": 1,
-        "endpointUrl-2": "https://charlie-dr.corda5.r3.com:10001",
-        "endpointProtocol-2": 1
-      }
-    ]
+      "members": [
+        {
+          "name": "C=GB, L=London, O=Alice", // party name
+          "keyAlias": "alice-alias", // current party identity key
+          "rotatedKeyAlias-1": "alice-historic-alias-1", // Used to force old keys no longer in use (i.e. rotated key)
+          "memberStatus": "ACTIVE", // Member status usually set by the MGM
+          "endpointUrl-1": "https://alice.corda5.r3.com:10000", // Endpoint url & protocol. Iterable.
+          "endpointProtocol-1": 1 //(uses incrementing postfix for repeating elements)
+        },
+        {
+          "name": "C=GB, L=London, O=Bob",
+          "keyAlias": "bob-alias",
+          "rotatedKeyAlias-1": "bob-historic-alias-1",
+          "rotatedKeyAlias-2": "bob-historic-alias-2",
+          "memberStatus": "ACTIVE",
+          "endpointUrl-1": "https://bob.corda5.r3.com:10000",
+          "endpointProtocol-1": 1
+        },
+        {
+          "name": "C=GB, L=London, O=Charlie",
+          "keyAlias": "charlie-alias",
+          "memberStatus": "SUSPENDED",
+          "endpointUrl-1": "https://charlie.corda5.r3.com:10000",
+          "endpointProtocol-1": 1,
+          "endpointUrl-2": "https://charlie-dr.corda5.r3.com:10001",
+          "endpointProtocol-2": 1
+        }
+      ]
+    }
   }
 }

--- a/components/membership/membership-group-read-impl/src/integrationTest/resources/SampleGroupPolicy.json
+++ b/components/membership/membership-group-read-impl/src/integrationTest/resources/SampleGroupPolicy.json
@@ -13,6 +13,8 @@
       "-----BEGIN CERTIFICATE-----\nMIIDdTCCKSZp4A==\n-----END CERTIFICATE-----",
       "-----BEGIN CERTIFICATE-----\nMIIFPDCCIlifT20M\n-----END CERTIFICATE-----"
     ],
+    "tlsPki": "C5",
+    "p2pProtocolMode": "AUTHENTICATED_ENCRYPTION",
     "mgmInfo": {
       "name": "C=GB, L=London, O=Corda Network, OU=MGM, CN=Corda Network MGM",
       "sessionKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHK+B3YGgcIALw==\n-----END PUBLIC KEY-----\n",
@@ -66,39 +68,39 @@
         "optionalMemberInfo" : [
         ]
       }
-    }
-  },
-  "staticNetwork": {
-    "mgm": {
-      "keyAlias": "mgm-alias"
     },
-    "members": [
-      {
-        "name": "C=GB, L=London, O=Alice", // party name
-        "keyAlias": "alice-alias", // current party identity key
-        "rotatedKeyAlias-1": "alice-historic-alias-1", // Used to force old keys no longer in use (i.e. rotated key)
-        "memberStatus": "ACTIVE", // Member status usually set by the MGM
-        "endpointUrl-1": "https://alice.corda5.r3.com:10000", // Endpoint url & protocol. Iterable.
-        "endpointProtocol-1": 1 //(uses incrementing postfix for repeating elements)
+    "staticNetwork": {
+      "mgm": {
+        "keyAlias": "mgm-alias"
       },
-      {
-        "name": "C=GB, L=London, O=Bob",
-        "keyAlias": "bob-alias",
-        "rotatedKeyAlias-1": "bob-historic-alias-1",
-        "rotatedKeyAlias-2": "bob-historic-alias-2",
-        "memberStatus": "ACTIVE",
-        "endpointUrl-1": "https://bob.corda5.r3.com:10000",
-        "endpointProtocol-1": 1
-      },
-      {
-        "name": "C=GB, L=London, O=Charlie",
-        "keyAlias": "charlie-alias",
-        "memberStatus": "SUSPENDED",
-        "endpointUrl-1": "https://charlie.corda5.r3.com:10000",
-        "endpointProtocol-1": 1,
-        "endpointUrl-2": "https://charlie-dr.corda5.r3.com:10001",
-        "endpointProtocol-2": 1
-      }
-    ]
+      "members": [
+        {
+          "name": "C=GB, L=London, O=Alice", // party name
+          "keyAlias": "alice-alias", // current party identity key
+          "rotatedKeyAlias-1": "alice-historic-alias-1", // Used to force old keys no longer in use (i.e. rotated key)
+          "memberStatus": "ACTIVE", // Member status usually set by the MGM
+          "endpointUrl-1": "https://alice.corda5.r3.com:10000", // Endpoint url & protocol. Iterable.
+          "endpointProtocol-1": 1 //(uses incrementing postfix for repeating elements)
+        },
+        {
+          "name": "C=GB, L=London, O=Bob",
+          "keyAlias": "bob-alias",
+          "rotatedKeyAlias-1": "bob-historic-alias-1",
+          "rotatedKeyAlias-2": "bob-historic-alias-2",
+          "memberStatus": "ACTIVE",
+          "endpointUrl-1": "https://bob.corda5.r3.com:10000",
+          "endpointProtocol-1": 1
+        },
+        {
+          "name": "C=GB, L=London, O=Charlie",
+          "keyAlias": "charlie-alias",
+          "memberStatus": "SUSPENDED",
+          "endpointUrl-1": "https://charlie.corda5.r3.com:10000",
+          "endpointProtocol-1": 1,
+          "endpointUrl-2": "https://charlie-dr.corda5.r3.com:10001",
+          "endpointProtocol-2": 1
+        }
+      ]
+    }
   }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMember.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMember.kt
@@ -54,7 +54,7 @@ class StaticMember(private val staticMemberData: Map<String, Any>) : Map<String,
     fun getEndpoint(index: Int): EndpointInfo {
         return EndpointInfoImpl(
             staticMemberData[String.format(ENDPOINT_URL, index)].toString(),
-            staticMemberData[String.format(ENDPOINT_PROTOCOL, index)]!! as Int
+            Integer.parseInt(staticMemberData[String.format(ENDPOINT_PROTOCOL, index)].toString())
         )
     }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberTemplateExtension.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberTemplateExtension.kt
@@ -4,6 +4,9 @@ import net.corda.membership.GroupPolicy
 
 class StaticMemberTemplateExtension {
     companion object {
+        /** Key name for protocol parameters property. */
+        const val PROTOCOL_PARAMS = "protocolParameters"
+
         /** Key name for static member template property. */
         const val STATIC_NETWORK_TEMPLATE = "staticNetwork"
 
@@ -46,12 +49,23 @@ class StaticMemberTemplateExtension {
         /** Key name for modified time. */
         const val STATIC_MODIFIED_TIME = "modifiedTime"
 
+        /** Protocol parameters. */
+        @JvmStatic
+        @Suppress("UNCHECKED_CAST")
+        val GroupPolicy.protocolParams: Map<String, Any>
+            get() = if (containsKey(PROTOCOL_PARAMS)) {
+                get(PROTOCOL_PARAMS) as? Map<String, Any>
+                    ?: throw ClassCastException("Casting failed for protocol parameters from group policy JSON.")
+            } else {
+                emptyMap()
+            }
+
         /** Static network template. */
         @JvmStatic
         @Suppress("UNCHECKED_CAST")
         val GroupPolicy.staticNetwork: Map<String, Any>
-            get() = if (containsKey(STATIC_NETWORK_TEMPLATE)) {
-                get(STATIC_NETWORK_TEMPLATE) as? Map<String, Any>
+            get() = if (protocolParams.containsKey(STATIC_NETWORK_TEMPLATE)) {
+                protocolParams[STATIC_NETWORK_TEMPLATE] as? Map<String, Any>
                     ?: throw ClassCastException("Casting failed for static network from group policy JSON.")
             } else {
                 emptyMap()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -1,0 +1,176 @@
+package net.corda.membership.impl.registration.staticnetwork
+
+import net.corda.configuration.read.ConfigChangedEvent
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.layeredpropertymap.LayeredPropertyMapFactory
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.RegistrationHandle
+import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.StartEvent
+import net.corda.lifecycle.StopEvent
+import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.configs
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
+import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
+import net.corda.v5.crypto.DigestService
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class RegistrationServiceLifecycleHandlerTest {
+    private val componentHandle: RegistrationHandle = mock()
+    private val configHandle: AutoCloseable = mock()
+
+    private val groupPolicyProvider: GroupPolicyProvider = mock()
+
+    private val configurationReadService: ConfigurationReadService = mock {
+        on { registerComponentForUpdates(any(), any()) } doReturn configHandle
+    }
+
+    private val publisher: Publisher = mock()
+
+    private val publisherFactory: PublisherFactory = mock {
+        on { createPublisher(any(), any()) } doReturn publisher
+    }
+
+    private val coordinator: LifecycleCoordinator = mock {
+        on { followStatusChangesByName(any()) } doReturn componentHandle
+    }
+
+    private val coordinatorFactory: LifecycleCoordinatorFactory = mock {
+        on { createCoordinator(any(), any()) } doReturn coordinator
+    }
+
+    private val layeredPropertyMapFactory: LayeredPropertyMapFactory = mock()
+
+    private val digestService: DigestService = mock()
+
+    private val staticMemberRegistrationService = StaticMemberRegistrationService(
+        groupPolicyProvider,
+        publisherFactory,
+        mock(),
+        mock(),
+        configurationReadService,
+        coordinatorFactory,
+        layeredPropertyMapFactory,
+        digestService
+    )
+
+    private val registrationServiceLifecycleHandler = RegistrationServiceLifecycleHandler(
+        staticMemberRegistrationService
+    )
+
+    @Test
+    fun `Start event starts following the statuses of the required dependencies`() {
+        registrationServiceLifecycleHandler.processEvent(StartEvent(), coordinator)
+        assertThrows<IllegalArgumentException> { registrationServiceLifecycleHandler.publisher }
+
+        verify(coordinator).followStatusChangesByName(
+            eq(
+                setOf(
+                    LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
+                    LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Stop event sets the publisher to null`() {
+        registrationServiceLifecycleHandler.processEvent(
+            ConfigChangedEvent(setOf(BOOT_CONFIG, MESSAGING_CONFIG), configs),
+            coordinator
+        )
+        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
+        assertThrows<IllegalArgumentException> { registrationServiceLifecycleHandler.publisher }
+
+        verify(componentHandle, never()).close()
+        verify(configHandle, never()).close()
+    }
+
+    @Test
+    fun `Component handle is created after starting and closed when stopping`() {
+        registrationServiceLifecycleHandler.processEvent(StartEvent(), coordinator)
+        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
+
+        verify(componentHandle).close()
+    }
+
+    @Test
+    fun `Config handle is created after registration status changes to UP and closed when stopping`() {
+        registrationServiceLifecycleHandler.processEvent(
+            RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), coordinator
+        )
+        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
+
+        verify(configHandle).close()
+    }
+
+    @Test
+    fun `Registration status UP registers for config updates`() {
+        registrationServiceLifecycleHandler.processEvent(
+            RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), coordinator
+        )
+
+        verify(configurationReadService).registerComponentForUpdates(
+            any(), any()
+        )
+        verify(coordinator, never()).updateStatus(eq(LifecycleStatus.UP), any())
+    }
+
+    @Test
+    fun `Registration status DOWN sets component status to DOWN`() {
+        registrationServiceLifecycleHandler.processEvent(
+            RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN), coordinator
+        )
+
+        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+    }
+
+    @Test
+    fun `Registration status ERROR sets component status to DOWN`() {
+        registrationServiceLifecycleHandler.processEvent(
+            RegistrationStatusChangeEvent(mock(), LifecycleStatus.ERROR), coordinator
+        )
+
+        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+    }
+
+    @Test
+    fun `Registration status DOWN closes config handle if status was previously UP`() {
+        registrationServiceLifecycleHandler.processEvent(
+            RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), coordinator
+        )
+
+        verify(configurationReadService).registerComponentForUpdates(
+            any(), any()
+        )
+
+        registrationServiceLifecycleHandler.processEvent(
+            RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN), coordinator
+        )
+
+        verify(configHandle).close()
+    }
+
+    @Test
+    fun `After receiving the messaging configuration the publisher is initialized`() {
+        registrationServiceLifecycleHandler.processEvent(
+            ConfigChangedEvent(setOf(BOOT_CONFIG, MESSAGING_CONFIG), configs),
+            coordinator
+        )
+        assertNotNull(registrationServiceLifecycleHandler.publisher)
+        verify(coordinator).updateStatus(LifecycleStatus.UP)
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -1,0 +1,343 @@
+package net.corda.membership.impl.registration.staticnetwork
+
+import net.corda.configuration.read.ConfigChangedEvent
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.KeyValuePairList
+import net.corda.data.membership.PersistentMemberInfo
+import net.corda.layeredpropertymap.LayeredPropertyMapFactory
+import net.corda.layeredpropertymap.create
+import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.impl.MGMContextImpl
+import net.corda.membership.impl.MemberContextImpl
+import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.impl.MemberInfoExtension.Companion.endpoints
+import net.corda.membership.impl.MemberInfoExtension.Companion.groupId
+import net.corda.membership.impl.MemberInfoExtension.Companion.identityKeyHashes
+import net.corda.membership.impl.MemberInfoExtension.Companion.modifiedTime
+import net.corda.membership.impl.MemberInfoExtension.Companion.softwareVersion
+import net.corda.membership.impl.MemberInfoExtension.Companion.status
+import net.corda.membership.impl.converter.EndpointInfoConverter
+import net.corda.membership.impl.converter.PublicKeyConverter
+import net.corda.membership.impl.converter.PublicKeyHashConverter
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.DUMMY_GROUP_ID
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.aliceName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.bobName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.charlieName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.configs
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.daisyName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.ericName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.frankieName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithDuplicateMembers
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithInvalidStaticNetworkTemplate
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithStaticNetwork
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithoutMgm
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithoutMgmKeyAlias
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithoutStaticNetwork
+import net.corda.membership.impl.toMemberInfo
+import net.corda.membership.impl.toSortedMap
+import net.corda.membership.registration.MembershipRequestRegistrationOutcome.NOT_SUBMITTED
+import net.corda.membership.registration.MembershipRequestRegistrationOutcome.SUBMITTED
+import net.corda.membership.registration.MembershipRequestRegistrationResult
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas
+import net.corda.schema.configuration.ConfigKeys
+import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.crypto.DigestService
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.calculateHash
+import net.corda.virtualnode.HoldingIdentity
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import java.security.PublicKey
+import java.util.concurrent.CompletableFuture
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class StaticMemberRegistrationServiceTest {
+    companion object {
+        private const val DEFAULT_KEY = "3456"
+        private const val ALICE_KEY = "1234"
+        private const val BOB_KEY = "2345"
+        private const val CHARLIE_KEY = "6789"
+    }
+
+    private val alice = HoldingIdentity(aliceName.toString(), DUMMY_GROUP_ID)
+    private val bob = HoldingIdentity(bobName.toString(), DUMMY_GROUP_ID)
+    private val charlie = HoldingIdentity(charlieName.toString(), DUMMY_GROUP_ID)
+    private val daisy = HoldingIdentity(daisyName.toString(), DUMMY_GROUP_ID)
+    private val eric = HoldingIdentity(ericName.toString(), DUMMY_GROUP_ID)
+    private val frankie = HoldingIdentity(frankieName.toString(), DUMMY_GROUP_ID)
+    private val defaultKey: PublicKey = mock {
+        on { encoded } doReturn DEFAULT_KEY.toByteArray()
+    }
+    private val aliceKey: PublicKey = mock {
+        on { encoded } doReturn ALICE_KEY.toByteArray()
+    }
+    private val bobKey: PublicKey = mock {
+        on { encoded } doReturn BOB_KEY.toByteArray()
+    }
+    private val charlieKey: PublicKey = mock {
+        on { encoded } doReturn CHARLIE_KEY.toByteArray()
+    }
+
+    private val groupPolicyProvider: GroupPolicyProvider = mock {
+        on { getGroupPolicy(alice) } doReturn groupPolicyWithStaticNetwork
+        on { getGroupPolicy(bob) } doReturn groupPolicyWithInvalidStaticNetworkTemplate
+        on { getGroupPolicy(charlie) } doReturn groupPolicyWithoutStaticNetwork
+        on { getGroupPolicy(daisy) } doReturn groupPolicyWithDuplicateMembers
+        on { getGroupPolicy(eric) } doReturn groupPolicyWithoutMgm
+        on { getGroupPolicy(frankie) } doReturn groupPolicyWithoutMgmKeyAlias
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private val mockPublisher: Publisher = mock {
+        on { publish(any()) } doAnswer {
+            publishedList.addAll(it.arguments.first() as List<Record<String, PersistentMemberInfo>>)
+            listOf(CompletableFuture.completedFuture(Unit))
+        }
+    }
+
+    private val publisherFactory: PublisherFactory = mock {
+        on { createPublisher(any(), any()) } doReturn mockPublisher
+    }
+
+    private val keyEncodingService: KeyEncodingService = mock {
+        on { decodePublicKey(any<String>()) } doReturn defaultKey
+        on { decodePublicKey(ALICE_KEY) } doReturn aliceKey
+        on { decodePublicKey(BOB_KEY) } doReturn bobKey
+
+        on { encodeAsString(any()) } doReturn DEFAULT_KEY
+        on { encodeAsString(aliceKey) } doReturn ALICE_KEY
+        on { encodeAsString(bobKey) } doReturn BOB_KEY
+        on { encodeAsString(charlieKey) } doReturn CHARLIE_KEY
+
+        on { encodeAsByteArray(any()) } doReturn ByteArray(1)
+    }
+
+    private val signature: DigitalSignature.WithKey = DigitalSignature.WithKey(mock(), ByteArray(1))
+
+    private val cryptoOpsClient: CryptoOpsClient = mock {
+        on { generateKeyPair(any(), any(), any(), any()) } doReturn defaultKey
+        on { generateKeyPair(any(), any(), eq("alice-alias"), any()) } doReturn aliceKey
+        // when no keyAlias is defined in static template, we are using the HoldingIdentity's id
+        on { generateKeyPair(any(), any(), eq(bob.id), any()) } doReturn bobKey
+        on { generateKeyPair(any(), any(), eq(charlie.id), any()) } doReturn charlieKey
+        on { sign(any(), any<PublicKey>(), any<ByteArray>(), any()) } doReturn signature
+    }
+
+    private val configurationReadService: ConfigurationReadService = mock()
+
+    private val publishedList = mutableListOf<Record<String, PersistentMemberInfo>>()
+
+    private var coordinatorIsRunning = false
+    private val coordinator: LifecycleCoordinator = mock {
+        on { isRunning } doAnswer { coordinatorIsRunning }
+        on { start() } doAnswer { coordinatorIsRunning = true }
+        on { stop() } doAnswer { coordinatorIsRunning = false }
+    }
+
+    private var registrationServiceLifecycleHandler: RegistrationServiceLifecycleHandler? = null
+
+    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory = mock {
+        on { createCoordinator(any(), any()) } doReturn coordinator
+        on { createCoordinator(any(), any()) } doAnswer {
+            registrationServiceLifecycleHandler = it.arguments[1] as RegistrationServiceLifecycleHandler
+            coordinator
+        }
+    }
+
+    private val layeredPropertyMapFactory: LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(
+        listOf(EndpointInfoConverter(), PublicKeyConverter(keyEncodingService), PublicKeyHashConverter())
+    )
+
+    private val digestService: DigestService = mock {
+        on { hash(any<ByteArray>(), any()) } doReturn SecureHash("SHA256", "1234ABCD".toByteArray())
+    }
+
+    private val registrationService = StaticMemberRegistrationService(
+        groupPolicyProvider,
+        publisherFactory,
+        keyEncodingService,
+        cryptoOpsClient,
+        configurationReadService,
+        lifecycleCoordinatorFactory,
+        layeredPropertyMapFactory,
+        digestService
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun setUpPublisher() {
+        // clears the list before the test runs as we are using one list for the test cases
+        publishedList.clear()
+        // kicks off the MessagingConfigurationReceived event to be able to mock the Publisher
+        registrationServiceLifecycleHandler?.processEvent(
+            ConfigChangedEvent(setOf(ConfigKeys.BOOT_CONFIG, ConfigKeys.MESSAGING_CONFIG), configs),
+            coordinator
+        )
+    }
+
+    @Test
+    fun `starting and stopping the service succeeds`() {
+        registrationService.start()
+        assertTrue(registrationService.isRunning)
+        registrationService.stop()
+        assertFalse(registrationService.isRunning)
+    }
+
+    @Test
+    fun `during registration, the static network inside the GroupPolicy file gets parsed and published`() {
+        setUpPublisher()
+        registrationService.start()
+        val registrationResult = registrationService.register(alice)
+        registrationService.stop()
+
+        assertEquals(3, publishedList.size)
+
+        publishedList.forEach {
+            assertEquals(Schemas.Membership.MEMBER_LIST_TOPIC, it.topic)
+            assertTrue { it.key.startsWith(alice.id) }
+            val signedMemberPublished = it.value as PersistentMemberInfo
+            val memberPublished = toMemberInfo(
+                layeredPropertyMapFactory.create<MemberContextImpl>(
+                    KeyValuePairList.fromByteBuffer(signedMemberPublished.signedMemberInfo.memberContext).toSortedMap()
+                ),
+                layeredPropertyMapFactory.create<MGMContextImpl>(
+                    KeyValuePairList.fromByteBuffer(signedMemberPublished.signedMemberInfo.mgmContext).toSortedMap()
+                )
+            )
+            assertEquals(DUMMY_GROUP_ID, memberPublished.groupId)
+            assertNotNull(memberPublished.softwareVersion)
+            assertNotNull(memberPublished.platformVersion)
+            assertNotNull(memberPublished.serial)
+            assertNotNull(memberPublished.modifiedTime)
+
+            when (memberPublished.name) {
+                aliceName -> {
+                    assertEquals(aliceKey, memberPublished.owningKey)
+                    assertEquals(1, memberPublished.identityKeys.size)
+                    assertEquals(1, memberPublished.identityKeyHashes.size)
+                    assertEquals(aliceKey.calculateHash(), memberPublished.identityKeyHashes.first())
+                    assertEquals(MEMBER_STATUS_ACTIVE, memberPublished.status)
+                    assertEquals(1, memberPublished.endpoints.size)
+                }
+                bobName -> {
+                    assertEquals(bobKey, memberPublished.owningKey)
+                    assertEquals(1, memberPublished.identityKeys.size)
+                    assertEquals(1, memberPublished.identityKeyHashes.size)
+                    assertEquals(bobKey.calculateHash(), memberPublished.identityKeyHashes.first())
+                    assertNotNull(memberPublished.status)
+                    assertNotNull(memberPublished.endpoints)
+                }
+                charlieName -> {
+                    assertEquals(1, memberPublished.identityKeys.size)
+                    assertEquals(1, memberPublished.identityKeyHashes.size)
+                    assertEquals(MEMBER_STATUS_SUSPENDED, memberPublished.status)
+                    assertEquals(2, memberPublished.endpoints.size)
+                }
+            }
+        }
+        assertEquals(MembershipRequestRegistrationResult(SUBMITTED), registrationResult)
+    }
+
+    @Test
+    fun `parsing of MemberInfo list fails when name field is empty in the GroupPolicy file`() {
+        setUpPublisher()
+        registrationService.start()
+        val registrationResult = registrationService.register(bob)
+        assertEquals(
+            MembershipRequestRegistrationResult(
+                NOT_SUBMITTED,
+                "Registration failed. Reason: Member's name is not provided."
+            ),
+            registrationResult
+        )
+        registrationService.stop()
+    }
+
+    @Test
+    fun `registration fails when static network is empty`() {
+        setUpPublisher()
+        registrationService.start()
+        val registrationResult = registrationService.register(charlie)
+        assertEquals(
+            MembershipRequestRegistrationResult(
+                NOT_SUBMITTED,
+                "Registration failed. Reason: Static member list inside the group policy file cannot be empty."
+            ),
+            registrationResult
+        )
+        registrationService.stop()
+    }
+
+    @Test
+    fun `registration fails when we have duplicated members defined`() {
+        setUpPublisher()
+        registrationService.start()
+        val registrationResult = registrationService.register(daisy)
+        assertEquals(
+            MembershipRequestRegistrationResult(
+                NOT_SUBMITTED,
+                "Registration failed. Reason: Duplicated static member declaration."
+            ),
+            registrationResult
+        )
+        registrationService.stop()
+    }
+
+    @Test
+    fun `registration fails when coordinator is not running`() {
+        setUpPublisher()
+        val registrationResult = registrationService.register(daisy)
+        assertEquals(
+            MembershipRequestRegistrationResult(
+                NOT_SUBMITTED,
+                "Registration failed. Reason: StaticMemberRegistrationService is not running/down."
+            ),
+            registrationResult
+        )
+    }
+
+    @Test
+    fun `registration fails when mgm is not defined`() {
+        setUpPublisher()
+        registrationService.start()
+        val registrationResult = registrationService.register(eric)
+        assertEquals(
+            MembershipRequestRegistrationResult(
+                NOT_SUBMITTED,
+                "Registration failed. Reason: Static mgm inside the group policy file should be defined."
+            ),
+            registrationResult
+        )
+        registrationService.stop()
+    }
+
+    @Test
+    fun `registration fails when mgm's key alias is not defined`() {
+        setUpPublisher()
+        registrationService.start()
+        val registrationResult = registrationService.register(frankie)
+        assertEquals(
+            MembershipRequestRegistrationResult(
+                NOT_SUBMITTED,
+                "Registration failed. Reason: MGM's key alias is not provided."
+            ),
+            registrationResult
+        )
+        registrationService.stop()
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberTemplateExtensionTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberTemplateExtensionTest.kt
@@ -1,0 +1,62 @@
+package net.corda.membership.impl.registration.staticnetwork
+
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.mgmKeyAlias
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.protocolParams
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.staticMembers
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.staticMgm
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.staticNetwork
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.MGM_KEY_ALIAS
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.aliceName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.bobName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.charlieName
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithCastingFailure
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithStaticNetwork
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithoutStaticNetwork
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+class StaticMemberTemplateExtensionTest {
+    private val memberNames = listOf(aliceName.toString(), bobName.toString(), charlieName.toString())
+
+    @Test
+    fun `static network parameters are not empty when group policy file with static network is used`() {
+        assertNotEquals(0, groupPolicyWithStaticNetwork.staticNetwork.size)
+        val staticMgmSize = groupPolicyWithStaticNetwork.staticMgm.size
+        val staticMembersSize = groupPolicyWithStaticNetwork.staticMembers.size
+        assertNotEquals(0, staticMgmSize)
+        assertNotEquals(0, staticMembersSize)
+        assertEquals(1, staticMgmSize)
+        assertEquals(3, staticMembersSize)
+    }
+
+    @Test
+    fun `static network parameters are empty when group policy file without static network is used`() {
+        assertEquals(0, groupPolicyWithoutStaticNetwork.protocolParams.size)
+        assertEquals(0, groupPolicyWithoutStaticNetwork.staticNetwork.size)
+        assertEquals(0, groupPolicyWithoutStaticNetwork.staticMgm.size)
+        assertEquals(0, groupPolicyWithoutStaticNetwork.staticMembers.size)
+    }
+
+    @Test
+    fun `static member list parsing fails when invalid structure is used`() {
+        val ex = assertFailsWith<ClassCastException> { groupPolicyWithCastingFailure.staticMembers }
+        assertEquals("Casting failed for static members from group policy JSON.", ex.message)
+    }
+
+    @Test
+    fun `retrieving static MGM key alias`() {
+        val keyAlias = groupPolicyWithStaticNetwork.mgmKeyAlias
+        assertNotNull(keyAlias)
+        assertEquals(MGM_KEY_ALIAS, keyAlias)
+    }
+
+    @Test
+    fun `retrieving member list`() {
+        val names = groupPolicyWithStaticNetwork.staticMembers.map { it.get("name") }
+        assertEquals(3, names.size)
+        assertEquals(memberNames, names)
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/TestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/TestUtils.kt
@@ -1,0 +1,159 @@
+package net.corda.membership.impl.registration.staticnetwork
+
+import net.corda.libs.configuration.SmartConfig
+import net.corda.membership.impl.GroupPolicyExtension.Companion.GROUP_ID
+import net.corda.membership.impl.GroupPolicyImpl
+import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.ENDPOINT_PROTOCOL
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.ENDPOINT_URL
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.KEY_ALIAS
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.MEMBER_STATUS
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.NAME
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.PROTOCOL_PARAMS
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.STATIC_MEMBERS
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.STATIC_MGM
+import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.STATIC_NETWORK_TEMPLATE
+import net.corda.schema.configuration.ConfigKeys
+import net.corda.v5.base.types.MemberX500Name
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+
+class TestUtils {
+    companion object {
+        const val MGM_KEY_ALIAS = "mgm-alias"
+        const val DUMMY_GROUP_ID = "dummy_group"
+
+        private const val TEST_ENDPOINT_PROTOCOL = "1"
+        private const val TEST_ENDPOINT_URL = "https://dummyurl.corda5.r3.com:10000"
+
+        private val bootConfig: SmartConfig = mock()
+        private val messagingConfig: SmartConfig = mock {
+            on(it.withFallback(any())).thenReturn(mock())
+        }
+
+        val configs = mapOf(
+            ConfigKeys.BOOT_CONFIG to bootConfig,
+            ConfigKeys.MESSAGING_CONFIG to messagingConfig
+        )
+
+        val aliceName = MemberX500Name("Alice", "London", "GB")
+        val bobName = MemberX500Name("Bob", "London", "GB")
+        val charlieName = MemberX500Name("Charlie", "London", "GB")
+        val daisyName = MemberX500Name("Daisy", "London", "GB")
+        val ericName = MemberX500Name("Eric", "London", "GB")
+        val frankieName = MemberX500Name("Frankie", "London", "GB")
+
+        private val dummyMap = mapOf("key" to "value")
+
+        private val staticMemberTemplate: List<Map<String, String>> =
+            listOf(
+                mapOf(
+                    NAME to aliceName.toString(),
+                    KEY_ALIAS to "alice-alias",
+                    MEMBER_STATUS to MEMBER_STATUS_ACTIVE,
+                    String.format(ENDPOINT_URL, 1) to TEST_ENDPOINT_URL,
+                    String.format(ENDPOINT_PROTOCOL, 1) to TEST_ENDPOINT_PROTOCOL
+                ),
+                mapOf(
+                    NAME to bobName.toString(),
+                    MEMBER_STATUS to MEMBER_STATUS_ACTIVE,
+                    String.format(ENDPOINT_URL, 1) to TEST_ENDPOINT_URL,
+                    String.format(ENDPOINT_PROTOCOL, 1) to TEST_ENDPOINT_PROTOCOL
+                ),
+                mapOf(
+                    NAME to charlieName.toString(),
+                    MEMBER_STATUS to MEMBER_STATUS_SUSPENDED,
+                    String.format(ENDPOINT_URL, 1) to TEST_ENDPOINT_URL,
+                    String.format(ENDPOINT_PROTOCOL, 1) to TEST_ENDPOINT_PROTOCOL,
+                    String.format(ENDPOINT_URL, 2) to TEST_ENDPOINT_URL,
+                    String.format(ENDPOINT_PROTOCOL, 2) to TEST_ENDPOINT_PROTOCOL
+                )
+            )
+
+        private val staticMemberTemplateWithDuplicateMembers: List<Map<String, String>> =
+            listOf(
+                mapOf(
+                    NAME to daisyName.toString(),
+                    String.format(ENDPOINT_URL, 1) to TEST_ENDPOINT_URL,
+                    String.format(ENDPOINT_PROTOCOL, 1) to TEST_ENDPOINT_PROTOCOL
+                ),
+                mapOf(
+                    NAME to daisyName.toString(),
+                    String.format(ENDPOINT_URL, 1) to TEST_ENDPOINT_URL,
+                    String.format(ENDPOINT_PROTOCOL, 1) to TEST_ENDPOINT_PROTOCOL
+                )
+            )
+
+        private val staticMgmTemplate = mapOf("keyAlias" to MGM_KEY_ALIAS)
+
+        val groupPolicyWithStaticNetwork = GroupPolicyImpl(
+            mapOf(
+                GROUP_ID to DUMMY_GROUP_ID,
+                PROTOCOL_PARAMS to mapOf(
+                    STATIC_NETWORK_TEMPLATE to mapOf(
+                        STATIC_MGM to staticMgmTemplate,
+                        STATIC_MEMBERS to staticMemberTemplate
+                    )
+                )
+            )
+        )
+
+        val groupPolicyWithCastingFailure = GroupPolicyImpl(
+            mapOf(
+                PROTOCOL_PARAMS to mapOf(
+                    STATIC_NETWORK_TEMPLATE to mapOf(
+                        STATIC_MEMBERS to dummyMap
+                    )
+                )
+            )
+        )
+
+        val groupPolicyWithInvalidStaticNetworkTemplate = GroupPolicyImpl(
+            mapOf(
+                PROTOCOL_PARAMS to mapOf(
+                    STATIC_NETWORK_TEMPLATE to mapOf(
+                        STATIC_MEMBERS to listOf(dummyMap)
+                    )
+                )
+            )
+        )
+
+        val groupPolicyWithoutStaticNetwork = GroupPolicyImpl(emptyMap())
+
+        val groupPolicyWithDuplicateMembers = GroupPolicyImpl(
+            mapOf(
+                GROUP_ID to DUMMY_GROUP_ID,
+                PROTOCOL_PARAMS to mapOf(
+                    STATIC_NETWORK_TEMPLATE to mapOf(
+                        STATIC_MGM to staticMgmTemplate,
+                        STATIC_MEMBERS to staticMemberTemplateWithDuplicateMembers
+                    )
+                )
+            )
+        )
+
+        val groupPolicyWithoutMgm = GroupPolicyImpl(
+            mapOf(
+                GROUP_ID to DUMMY_GROUP_ID,
+                PROTOCOL_PARAMS to mapOf(
+                    STATIC_NETWORK_TEMPLATE to mapOf(
+                        STATIC_MEMBERS to staticMemberTemplate
+                    )
+                )
+            )
+        )
+
+        val groupPolicyWithoutMgmKeyAlias = GroupPolicyImpl(
+            mapOf(
+                GROUP_ID to DUMMY_GROUP_ID,
+                PROTOCOL_PARAMS to mapOf(
+                    STATIC_NETWORK_TEMPLATE to mapOf(
+                        STATIC_MGM to dummyMap,
+                        STATIC_MEMBERS to staticMemberTemplate
+                    )
+                )
+            )
+        )
+    }
+}

--- a/processors/member-processor/src/integrationTest/resources/SampleGroupPolicy.json
+++ b/processors/member-processor/src/integrationTest/resources/SampleGroupPolicy.json
@@ -13,6 +13,8 @@
       "-----BEGIN CERTIFICATE-----\nMIIDdTCCKSZp4A==\n-----END CERTIFICATE-----",
       "-----BEGIN CERTIFICATE-----\nMIIFPDCCIlifT20M\n-----END CERTIFICATE-----"
     ],
+    "tlsPki": "C5",
+    "p2pProtocolMode": "AUTHENTICATED_ENCRYPTION",
     "mgmInfo": {
       "name": "C=GB, L=London, O=Corda Network, OU=MGM, CN=Corda Network MGM",
       "sessionKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHK+B3YGgcIALw==\n-----END PUBLIC KEY-----\n",
@@ -66,39 +68,39 @@
         "optionalMemberInfo" : [
         ]
       }
-    }
-  },
-  "staticNetwork": {
-    "mgm": {
-      "keyAlias": "mgm-alias"
     },
-    "members": [
-      {
-        "name": "C=GB, L=London, O=Alice",
-        "keyAlias": "alice-alias",
-        "rotatedKeyAlias-1": "alice-historic-alias-1",
-        "memberStatus": "ACTIVE",
-        "endpointUrl-1": "https://alice.corda5.r3.com:10000",
-        "endpointProtocol-1": 1
+    "staticNetwork": {
+      "mgm": {
+        "keyAlias": "mgm-alias"
       },
-      {
-        "name": "C=GB, L=London, O=Bob",
-        "keyAlias": "bob-alias",
-        "rotatedKeyAlias-1": "bob-historic-alias-1",
-        "rotatedKeyAlias-2": "bob-historic-alias-2",
-        "memberStatus": "ACTIVE",
-        "endpointUrl-1": "https://bob.corda5.r3.com:10000",
-        "endpointProtocol-1": 1
-      },
-      {
-        "name": "C=GB, L=London, O=Charlie",
-        "keyAlias": "charlie-alias",
-        "memberStatus": "SUSPENDED",
-        "endpointUrl-1": "https://charlie.corda5.r3.com:10000",
-        "endpointProtocol-1": 1,
-        "endpointUrl-2": "https://charlie-dr.corda5.r3.com:10001",
-        "endpointProtocol-2": 1
-      }
-    ]
+      "members": [
+        {
+          "name": "C=GB, L=London, O=Alice",
+          "keyAlias": "alice-alias",
+          "rotatedKeyAlias-1": "alice-historic-alias-1",
+          "memberStatus": "ACTIVE",
+          "endpointUrl-1": "https://alice.corda5.r3.com:10000",
+          "endpointProtocol-1": 1
+        },
+        {
+          "name": "C=GB, L=London, O=Bob",
+          "keyAlias": "bob-alias",
+          "rotatedKeyAlias-1": "bob-historic-alias-1",
+          "rotatedKeyAlias-2": "bob-historic-alias-2",
+          "memberStatus": "ACTIVE",
+          "endpointUrl-1": "https://bob.corda5.r3.com:10000",
+          "endpointProtocol-1": 1
+        },
+        {
+          "name": "C=GB, L=London, O=Charlie",
+          "keyAlias": "charlie-alias",
+          "memberStatus": "SUSPENDED",
+          "endpointUrl-1": "https://charlie.corda5.r3.com:10000",
+          "endpointProtocol-1": 1,
+          "endpointUrl-2": "https://charlie-dr.corda5.r3.com:10001",
+          "endpointProtocol-2": 1
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-3657

This PR also contains:
 - Previously deleted test classes by accident: StaticMemberRegistrationServiceTest, RegistrationServiceLifecycleHandlerTest, StaticMemberTemplateExtensionTest and a commonly used TestUtils.kt which contains the sample group policies, member names and configs for these tests
 - Fix integer parsing error for StaticMember