### PR TITLE
NOTICK: Exclude SLF4J from the Quasar bundles.

### DIFF
--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -27,7 +27,9 @@ dependencies {
 
     // OSGi frameworks containing Quasar and Kryo must resolve
     // the version of ASM as specified in the OSGi metadata.
-    quasarBundles "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
+    quasarBundles("co.paralleluniverse:quasar-core-osgi:$quasarVersion") {
+        exclude group: 'org.slf4j'
+    }
     integrationTestRuntimeOnly("co.paralleluniverse:quasar-core-osgi:$quasarVersion:agent") {
         transitive = false
     }


### PR DESCRIPTION
Quasar's OSGi metadata accepts `slf4j-api-1.7.32`, and so we don't need to include its own SLF4J API.