### PR TITLE
CORE-4177: Provide JsonMarshallingService with its own AnnotationIntrospector.

### DIFF
--- a/applications/examples/sandbox-app/example-cpi/build.gradle
+++ b/applications/examples/sandbox-app/example-cpi/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-cipher-suite'
     cordaProvided 'org.slf4j:slf4j-api'
+    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
 }

--- a/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/FlowInput.kt
+++ b/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/FlowInput.kt
@@ -1,5 +1,9 @@
 package com.example.cpk
 
-class FlowInput {
-    var message: String? = null
-}
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class FlowInput @JsonCreator constructor(
+    @JsonProperty("message")
+    val message: String?
+)

--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
@@ -231,7 +231,7 @@ class CordaVNode @Activate constructor(
                     val bundle = classLoader.bundle
                     if (bundle == null) {
                         logger.info("CLASSLOADER>> {} is DEAD", classLoader)
-                    } else if (bundle.symbolicName.startsWith("com.example.")) {
+                    } else if (bundle.location.startsWith("FLOW/")) {
                         logger.info("BUNDLE>> {} is-in-use={} (classloader={})",
                             bundle, bundle.adapt(BundleWiring::class.java)?.isInUse, classLoader::class.java)
                     }

--- a/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/JsonMarshallingServiceImpl.kt
+++ b/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/JsonMarshallingServiceImpl.kt
@@ -2,9 +2,11 @@ package net.corda.application.impl.services.json
 
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector
 import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.databind.util.LRUMap
 import com.fasterxml.jackson.databind.util.LookupCache
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import java.security.AccessController.doPrivileged
 import java.security.PrivilegedActionException
 import java.security.PrivilegedExceptionAction
@@ -29,6 +31,12 @@ class JsonMarshallingServiceImpl : JsonMarshallingService, SingletonSerializeAsT
         // Provide our own TypeFactory instance rather than using shared global one.
         typeFactory = TypeFactory.defaultInstance()
             .withCache(LRUMap<Any, JavaType>(INITIAL_SIZE, MAX_SIZE) as LookupCache<Any, JavaType>)
+
+        // Provide our own AnnotationIntrospector to avoid using a shared global cache.
+        setAnnotationIntrospector(JacksonAnnotationIntrospector())
+
+        // Register Kotlin after resetting the AnnotationIntrospector.
+        registerModule(KotlinModule.Builder().build())
     }
 
     // Truncate the execution stack down to JsonMarshallingServiceImpl


### PR DESCRIPTION
Configure the `ObjectMapper` inside `JsonMarshallingServiceImpl` to use its own `JacksonAnnotationIntrospector`, to prevent any Jackson annotations bundle inside a sandbox from being leaked by the JVM after the sandbox is unloaded.

Jackson's `KotlonModule` also affects the `AnnotationIntrospector`, so we need to register this _after_ we've configured the "core" introspector.