### PR TITLE
CORE-3067 Revert addition of incorrect package-info that breaks the membership endpoint bundle

### DIFF
--- a/components/membership/membership-http-rpc-impl/src/main/java/net/corda/membership/httprpc/v1/package-info.java
+++ b/components/membership/membership-http-rpc-impl/src/main/java/net/corda/membership/httprpc/v1/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.membership.httprpc.v1;
-
-import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Added in https://github.com/corda/corda-runtime-os/pull/939

This should not have been included in that PR. It doesn't match the package structure if the module and clashes with the `membership-http-rpc` bundle exports meaning importing this bundle stopped working.

