### PR TITLE
CORE-4216: Refactor the OSGi framework shutdown logic.

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/SandboxBootstrap.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/SandboxBootstrap.kt
@@ -1,5 +1,6 @@
 package net.corda.example.vnode
 
+import java.nio.file.Files
 import java.nio.file.Paths
 import net.corda.testing.sandboxes.SandboxSetup
 import org.osgi.framework.BundleContext
@@ -15,7 +16,7 @@ class SandboxBootstrap @Activate constructor(
     bundleContext: BundleContext
 ){
     init {
-        val baseDirectory = Paths.get(System.getProperty("user.dir", ".")).toAbsolutePath()
-        sandboxSetup.configure(bundleContext, baseDirectory)
+        val baseDirectory = Paths.get(System.getProperty("app.name", System.getProperty("user.dir", "."))).toAbsolutePath()
+        sandboxSetup.configure(bundleContext, Files.createDirectories(baseDirectory))
     }
 }

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -25,7 +25,8 @@ quasar {
             'org.hamcrest**',
             'org.mockito**',
             'org.opentest4j**',
-            'org.eclipse**'
+            'org.eclipse**',
+            'net.corda.osgi.**'
     ]
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,9 +41,9 @@ commonsTextVersion = 1.9
 cordaApiVersion=5.0.0.84-beta+
 
 disruptorVersion=3.4.2
-felixConfigAdminVersion=1.9.20
+felixConfigAdminVersion=1.9.22
 felixVersion=7.0.3
-felixScrVersion=2.1.28
+felixScrVersion=2.2.0
 felixSecurityVersion=2.8.3
 # NOTE: Guava cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.

--- a/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/JavaAgentLauncher.kt
+++ b/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/JavaAgentLauncher.kt
@@ -7,14 +7,14 @@ object JavaAgentLauncher {
 
     @JvmStatic
     fun premain(@Suppress("UNUSED_PARAMETER") agentArguments : String, instrumentation: Instrumentation) {
-        val cl = JavaAgentLauncher.javaClass.classLoader
+        val cl = JavaAgentLauncher::class.java.classLoader
         cl.getResources("META-INF/javaAgents.properties").asSequence().forEach { url ->
             val properties = Properties()
             url.openStream().use(properties::load)
             properties.entries.forEach { entry ->
                 val agentClassName = entry.key as String
                 val agentArgs = entry.value as String
-                val agentClass = cl.loadClass(agentClassName)
+                val agentClass = Class.forName(agentClassName, false, cl)
                 val premainMethod = agentClass.getMethod("premain", String::class.java, Instrumentation::class.java)
                 premainMethod.invoke(null, agentArgs, instrumentation)
             }

--- a/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiBundleDescriptor.kt
+++ b/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiBundleDescriptor.kt
@@ -11,12 +11,8 @@ import java.util.concurrent.CountDownLatch
  *
  * The [active] latch is decremented once: the first time the bundle results
  * activated. OSGi framework can notify bundle states more than once.
- *
- * The [shutdown] latch is decremented once if the bundle implements [net.corda.osgi.api.Application]
- * before to call [net.corda.osgi.api.Application.shutdown] to assure it is called once.
  */
 internal data class OSGiBundleDescriptor(
     val bundle: Bundle,
-    val active: CountDownLatch = CountDownLatch(1),
-    val shutdown: CountDownLatch = CountDownLatch(1),
+    val active: CountDownLatch = CountDownLatch(1)
 )


### PR DESCRIPTION
- Release references to `Application` service so that OSGi can deactivate it. And hence delete our unecessary `shutdown` latch.
- Assign names to various threads to assist debugging.
- Do not try to delete the bundle cache on exit, because we cannot delete a non-empty directory.
- Upgrade Service Component Runtime (SCR) 2.1.28 -> 2.2.0
- Configure Quasar applications _not_ to instrument the OSGi framework bootstrapper classes.