### PR TITLE
CORE-3456: Reduce footprint of explicit checks for `HttpRpcGET` and `HttpRpcPOST`

### DIFF
--- a/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/processing/MethodInformationResolver.kt
+++ b/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/processing/MethodInformationResolver.kt
@@ -2,12 +2,13 @@ package net.corda.httprpc.client.processing
 
 import net.corda.httprpc.annotations.HttpRpcGET
 import net.corda.httprpc.annotations.HttpRpcPOST
+import net.corda.httprpc.annotations.isRpcEndpointAnnotation
 import net.corda.httprpc.tools.HttpVerb
 import net.corda.httprpc.tools.staticExposedGetMethods
 import java.lang.reflect.Method
 
 internal val Method.endpointHttpVerb: HttpVerb
-    get() = this.annotations.singleOrNull { it is HttpRpcPOST || it is HttpRpcGET }.let {
+    get() = this.annotations.singleOrNull { it.isRpcEndpointAnnotation() }.let {
         when {
             it is HttpRpcGET -> HttpVerb.GET
             it is HttpRpcPOST -> HttpVerb.POST

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/APIStructureRetriever.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/APIStructureRetriever.kt
@@ -20,6 +20,7 @@ import net.corda.v5.base.stream.returnsDurableCursorBuilder
 import net.corda.v5.base.stream.isFiniteDurableStreamsMethod
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.RpcOps
+import net.corda.httprpc.annotations.isRpcEndpointAnnotation
 import net.corda.httprpc.tools.annotations.extensions.name
 import net.corda.httprpc.tools.annotations.extensions.path
 import net.corda.httprpc.tools.annotations.extensions.title
@@ -136,8 +137,8 @@ class APIStructureRetriever(private val opsImplList: List<PluggableRPCOps<*>>) {
     }
 
     private fun getEndpointsByAnnotations(methods: Array<Method>) =
-        methods.filter {
-            hasEndpointAnnotation(it)
+        methods.filter { method ->
+            method.annotations.singleOrNull { it.isRpcEndpointAnnotation() } != null
         }.map { method ->
             method.toEndpoint()
         }
@@ -173,41 +174,14 @@ class APIStructureRetriever(private val opsImplList: List<PluggableRPCOps<*>>) {
             }
     }
 
-    @SuppressWarnings("ComplexMethod")
-    private fun hasEndpointAnnotation(method: Method): Boolean {
-        try {
-            log.trace { "Has endpoint annotation check for method \"${method.name}\"." }
-            val countGET = method.annotations.count { annotation -> annotation is HttpRpcGET }
-            val countPOST = method.annotations.count { annotation -> annotation is HttpRpcPOST }
-            val count = countGET.plus(countPOST)
-            return when (count) {
-                1 -> true
-                0 -> false
-                else -> throw IllegalArgumentException("Only one of ${HttpRpcPOST::class.simpleName}, " +
-                        "${HttpRpcGET::class.simpleName} can be specified on an endpoint")
-            }.also {
-                val annotationTypeText = if (countGET > 0) "HttpRpcGET" else "HttpRpcPOST"
-                log.trace {
-                    "Has endpoint annotation check for method \"${method.name}\" " +
-                            "with annotation $annotationTypeText found completed."
-                }
-            }
-        } catch (e: Exception) {
-            "Error during endpoint annotation check for method \"${method.name}\" ".let {
-                log.error("$it: ${e.message}")
-                throw e
-            }
-        }
-    }
-
     private fun Method.toEndpoint(): Endpoint {
         try {
             log.trace { "Method \"${this.name}\" to endpoint." }
-            val annotation = this.annotations.single { it is HttpRpcPOST || it is HttpRpcGET }
+            val annotation = this.annotations.single { it.isRpcEndpointAnnotation() }
             return when (annotation) {
                 is HttpRpcGET -> this.toGETEndpoint(annotation)
                 is HttpRpcPOST -> this.toPOSTEndpoint(annotation)
-                else -> throw IllegalArgumentException("Unknown endpoint type")
+                else -> throw IllegalArgumentException("Unknown endpoint type for: ${this.name}")
             }.also { log.trace { "Method \"${this.name}\" to endpoint completed." } }
         } catch (e: Exception) {
             "Error during Method \"${this.name}\" to endpoint".let {

--- a/libs/http-rpc/http-rpc-tools/src/main/kotlin/net/corda/httprpc/tools/annotations/validation/EndpointAnnotationValidator.kt
+++ b/libs/http-rpc/http-rpc-tools/src/main/kotlin/net/corda/httprpc/tools/annotations/validation/EndpointAnnotationValidator.kt
@@ -1,23 +1,21 @@
 package net.corda.httprpc.tools.annotations.validation
 
 import net.corda.httprpc.RpcOps
-import net.corda.httprpc.annotations.HttpRpcGET
-import net.corda.httprpc.annotations.HttpRpcPOST
+import net.corda.httprpc.annotations.isRpcEndpointAnnotation
 import java.lang.reflect.Method
 
 /**
- * Validates that every method is not annotated with both [HttpRpcPOST] and [HttpRpcGET].
+ * Validates that every method has no more than one HTTP RPC endpoint annotation.
  */
 internal class EndpointAnnotationValidator(private val clazz: Class<out RpcOps>) : HttpRpcValidator {
 
     companion object {
-        fun error(method: Method) = "Only one of ${HttpRpcPOST::class.simpleName}, ${HttpRpcGET::class.simpleName} " +
-                "can be specified on method ${method.name}."
+        fun error(method: Method) = "Only one of HttpRpc endpoint annotations can be applied on method ${method.name}."
     }
 
     override fun validate(): HttpRpcValidationResult =
         clazz.methods.fold(HttpRpcValidationResult()) { total, method ->
-            total + method.annotations.count { annotation -> annotation is HttpRpcPOST || annotation is HttpRpcGET }.run {
+            total + method.annotations.count { annotation -> annotation.isRpcEndpointAnnotation() }.run {
                 when (this) {
                     1 -> HttpRpcValidationResult(listOf())
                     0 -> HttpRpcValidationResult(listOf())

--- a/libs/http-rpc/http-rpc-tools/src/main/kotlin/net/corda/httprpc/tools/annotations/validation/NestedGenericsParameterTypeValidator.kt
+++ b/libs/http-rpc/http-rpc-tools/src/main/kotlin/net/corda/httprpc/tools/annotations/validation/NestedGenericsParameterTypeValidator.kt
@@ -1,8 +1,7 @@
 package net.corda.httprpc.tools.annotations.validation
 
 import net.corda.httprpc.RpcOps
-import net.corda.httprpc.annotations.HttpRpcGET
-import net.corda.httprpc.annotations.HttpRpcPOST
+import net.corda.httprpc.annotations.isRpcEndpointAnnotation
 import java.lang.reflect.Method
 import java.lang.reflect.Parameter
 import java.lang.reflect.ParameterizedType
@@ -16,7 +15,7 @@ class NestedGenericsParameterTypeValidator(private val clazz: Class<out RpcOps>)
 
     override fun validate(): HttpRpcValidationResult =
         clazz.methods.fold(HttpRpcValidationResult()) { total, method ->
-            total + if (method.annotations.any { it is HttpRpcPOST || it is HttpRpcGET }) {
+            total + if (method.annotations.any { it.isRpcEndpointAnnotation() }) {
                 validateTypeNotNestedGenerics(method)
             } else HttpRpcValidationResult()
         }

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcEndpoint.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcEndpoint.kt
@@ -46,3 +46,7 @@ annotation class HttpRpcGET(
     val description: String = "",
     val responseDescription: String = ""
 )
+
+fun Annotation.isRpcEndpointAnnotation(): Boolean {
+    return this.annotationClass.annotations.any { it is HttpRpcEndpoint }
+}

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcPathParameter.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcPathParameter.kt
@@ -1,7 +1,7 @@
 package net.corda.httprpc.annotations
 
 /**
- * Marks a function parameter of a function annotated with @[HttpRpcGET] or @[HttpRpcPOST] as a path parameter.
+ * Marks a function parameter of a function annotated with HTTP Endpoint annotation as a path parameter.
 
  * Path parameters need to also be defined in the endpoint's path, in the form of `/{parameter}/`.
  *

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcQueryParameter.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcQueryParameter.kt
@@ -1,11 +1,11 @@
 package net.corda.httprpc.annotations
 
 /**
- * Marks a function parameter of a function annotated with @[HttpRpcGET] or @[HttpRpcPOST] as a query parameter.
+ * Marks a function parameter of a function annotated with HTTP Endpoint annotation as a query parameter.
  *
  * @property name The name of the query parameter in the call. Defaults to the parameter's name in the function signature.
  * @property description The description of the path parameter, used for documentation. Defaults to empty string.
- * @property required Whether this parameter is required when making an http call. Defaults to true.
+ * @property required Whether this parameter is required when making an HTTP call. Defaults to true.
  * @property default The default value of this parameter. Defaults to null.
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)


### PR DESCRIPTION
By introducing a helper method `isRpcEndpointAnnotation()`.
This should pave the way to more easily create annotation for other HTTP methods.