### PR TITLE
NOTICK: Apply OSGi resolving tweak to :testing:message-patterns

### DIFF
--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -71,8 +71,11 @@ def resolve = tasks.register('resolve', Resolve) {
     dependsOn jar, kafkaTestingBundle
     bundles = files(sourceSets.kafkaIntegrationTest.runtimeClasspath, configurations.archives.artifacts.files)
     bndrun = file('test.bndrun')
-    //  bnd attempts to use ~/ for caching if this is unavailable the build will fail.
-    System.setProperty("bnd.home.dir", "$rootDir/bnd/")
+    outputBndrun = layout.buildDirectory.file('resolved-test.bndrun')
+    doFirst {
+        //  bnd attempts to use ~/ for caching if this is unavailable the build will fail.
+        System.setProperty('bnd.home.dir', "$rootDir/bnd/")
+    }
 }
 
 tasks.register('kafkaIntegrationTest', TestOSGi) {


### PR DESCRIPTION
The `:testing:messge-patterns` module creates its own `Resolve` and `TestOSGi` tasks, so configure the name of their `outputBndrun` file to be consistent.