### PR TITLE
CORE-4139 Remove health/debug ports from services

### DIFF
--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -1,21 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "corda.fullname" . }}-crypto
-  labels: &id001
-    app: {{ include "corda.fullname" . }}-crypto-node
-    type: crypto-worker
-spec:
-  type: NodePort
-  selector: *id001
-  ports:
-  - name: worker-debug
-    port: 5005
-    targetPort: 5005
-  - name: worker-health
-    port: 7000
-    targetPort: 7000
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -1,21 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "corda.fullname" . }}-db
-  labels: &id002
-    app: {{ include "corda.fullname" . }}-db-node
-    type: database-worker
-spec:
-  type: NodePort
-  selector: *id002
-  ports:
-  - name: worker-debug
-    port: 5005
-    targetPort: 5005
-  - name: worker-health
-    port: 7000
-    targetPort: 7000
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -1,21 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "corda.fullname" . }}-flow
-  labels: &id003
-    app: {{ include "corda.fullname" . }}-flow-node
-    type: flow-worker
-spec:
-  type: NodePort
-  selector: *id003
-  ports:
-  - name: worker-debug
-    port: 5005
-    targetPort: 5005
-  - name: worker-health
-    port: 7000
-    targetPort: 7000
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -6,18 +6,12 @@ metadata:
     app: {{ include "corda.fullname" . }}-rpc-node
     type: rpc-worker
 spec:
-  type: NodePort
+  type: ClusterIP
   selector: *id004
   ports:
   - name: node-rpc
     port: 443
     targetPort: 8888
-  - name: worker-debug
-    port: 5005
-    targetPort: 5005
-  - name: worker-health
-    port: 7000
-    targetPort: 7000
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
It doesn't make sense to expose the health and debug ports via a service as these are not things you ever want to load-balance over. That just leaves the `node-rpc` on the RPC worker. This service should only be exposed as a `ClusterIP` for now. We'll add ingress in future.