### PR TITLE
CORE-4328 Implement `SandboxGroupContextServiceImpl.hasCpks`

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -288,13 +288,10 @@ class SandboxGroupContextServiceImpl(
         )
     }
 
-    override fun hasCpks(cpkIdentifiers: Set<CpkIdentifier>): Boolean {
-        cpkIdentifiers.forEach {
-            if (cpkReadService.get(it) == null)
-                return false
+    override fun hasCpks(cpkIdentifiers: Set<CpkIdentifier>) =
+        cpkIdentifiers.all {
+            cpkReadService.get(it) != null
         }
-        return true
-    }
 
     /**
      * [MutableSandboxGroupContext] / [SandboxGroupContext] wrapped so that we set [close] now that the user has

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
@@ -224,9 +224,11 @@ class SandboxGroupContextServiceImplTest {
         )
         val nonExistingCpk = setOf(Helpers.mockTrivialCpk("MAIN4", "orange", "4.0.0"))
 
-        val sandboxCreationService = Helpers.mockSandboxCreationService(listOf(existingCpks))
-        val cpkService = CpkReadServiceFake(existingCpks)
-        val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext)
+        val service = existingCpks.let {
+            val sandboxCreationService = Helpers.mockSandboxCreationService(listOf(it))
+            val cpkService = CpkReadServiceFake(it)
+            SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext)
+        }
 
         val existingCpkIds = existingCpks.map {
             CpkIdentifier.fromLegacy(it.metadata.id)
@@ -234,7 +236,10 @@ class SandboxGroupContextServiceImplTest {
 
         val nonExistingCpkId = nonExistingCpk.map { CpkIdentifier.fromLegacy(it.metadata.id) }.toSet()
 
+        val noCpks = emptySet<CpkIdentifier>()
+
         assertTrue(service.hasCpks(existingCpkIds))
         assertFalse(service.hasCpks(nonExistingCpkId))
+        assertTrue(service.hasCpks(noCpks))
     }
 }


### PR DESCRIPTION
Implements `SandboxGroupContextServiceImpl.hasCpks` since we now have implemented `CpkReadService`.