### PR TITLE
NOTICK: Amend hardcoded CPI upload path check

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
@@ -189,8 +189,8 @@ internal class HttpRpcServerInternal(
             try {
                 log.info("Add \"$handlerType\" handler for \"${routeInfo.fullPath}\".")
                 // TODO the following hardcoded handler registration is only meant for Scaffold and needs change
-                //  once "multipart/form-data" support gets implemented correctly.
-                if (routeInfo.fullPath == "//api/v1/cpi//") {
+                //  once "multipart/form-data" support gets implemented correctly as part of CORE-3813.
+                if (routeInfo.fullPath == "/api/v1/cpi") {
                     addHandler(handlerType, routeInfo.fullPath, routeInfo.invokeMultiPartMethod())
                 } else {
                     addHandler(handlerType, routeInfo.fullPath, routeInfo.invokeMethod())


### PR DESCRIPTION
Recent changes on the HTTP RPC layer should have removed `//` as well as trailing `/` hence this check no longer works.