### PR TITLE
NOTICK Ensure workers start once topics exist

### DIFF
--- a/applications/workers/release/deploy/docker-compose.yaml
+++ b/applications/workers/release/deploy/docker-compose.yaml
@@ -134,6 +134,9 @@ services:
       interval: 5s
       timeout: 1s
       retries: 20
+    depends_on:
+      init-kafka:
+        condition: service_completed_successfully
 
   db-worker:
     container_name: db-worker
@@ -156,6 +159,11 @@ services:
       interval: 5s
       timeout: 1s
       retries: 20
+    depends_on:
+      init-kafka:
+        condition: service_completed_successfully
+      corda-cluster-db:
+        condition: service_healthy
 
   flow-worker:
     container_name: flow-worker
@@ -174,6 +182,9 @@ services:
       interval: 5s
       timeout: 1s
       retries: 20
+    depends_on:
+      init-kafka:
+        condition: service_completed_successfully
 
   rpc-worker:
     container_name: rpc-worker
@@ -193,6 +204,9 @@ services:
       interval: 5s
       timeout: 1s
       retries: 20
+    depends_on:
+      init-kafka:
+        condition: service_completed_successfully
 
   member-worker:
     container_name: member-worker
@@ -211,3 +225,6 @@ services:
       interval: 5s
       timeout: 1s
       retries: 20
+    depends_on:
+      init-kafka:
+        condition: service_completed_successfully


### PR DESCRIPTION
If we try and start the workers whilst the topics are being created we
see huge amounts of extra logging, noise, and exception callstacks
because of the missing topics.

Also ensure the db worker additionally depends on the cluster-db
being healthy.