### PR TITLE
NOTICK Update topics in Helm chart

### DIFF
--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -22,39 +22,39 @@ spec:
         args:
         - |
           echo -e 'Creating kafka topics'
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic config.management.request
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic config.management.request.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic config.topic --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic p2p.in
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic p2p.out
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic virtual.node.creation.request
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic virtual.node.creation.request.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic virtual.node.info --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic cpi.info --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic cpi.upload
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic cpi.upload.status
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic cpk.file --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic rpc.permissions.management
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic rpc.permissions.management.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic rpc.permissions.user --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic rpc.permissions.group --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic rpc.permissions.role --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic rpc.permissions.permission --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic permissions.user.summary --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic flow.status --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic flow.event
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic flow.event.state --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic flow.event.dlq
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic flow.mapper.event
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic flow.mapper.event.state --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic flow.mapper.event.dlq
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic membership.members --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic membership.rpc.ops
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic membership.rpc.ops.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic crypto.ops.rpc
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic crypto.ops.rpc.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic crypto.key.soft
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions 1 --replication-factor 1 --create --topic crypto.key.info
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.management.request
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.management.request.resp
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.topic --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic p2p.in
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic p2p.out
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.creation.request
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.creation.request.resp
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.info --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.info --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.upload
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.upload.status
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpk.file --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.management
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.management.resp
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.user --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.group --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.role --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.permission --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic permissions.user.summary --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.status --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event.state --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event.dlq
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event.state --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event.dlq
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.members --config "cleanup.policy=compact"
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.rpc.ops
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.rpc.ops.resp
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.ops.rpc
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.ops.rpc.resp
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.key.soft
+          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.key.info
           echo -e 'Successfully created the following topics:'
           kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --list
       restartPolicy: OnFailure

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -17,6 +17,7 @@ debug:
 
 kafka:
   url: prereqs-kafka:9092
+  partitions: 3
 
 workers:
   crypto:


### PR DESCRIPTION
Update the list of topics. Reformatted so it's easier to cut and paste from the Compose (until we have a better solution). Annotated as a Helm hook so that the topics get created before the workers start. Exposed the number of topic partitions as a parameter with a default of 3.