### PR TITLE
CORE-4130 Add workspace and temporary configurable root storages

### DIFF
--- a/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
+++ b/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
@@ -18,7 +18,8 @@ import org.osgi.framework.Bundle
 class ConfigTests {
 
     @Test
-    fun `instance ID, topic prefix, messaging params, database params and additional params are passed through to the processor`() {
+    @Suppress("MaxLineLength")
+    fun `instance ID, topic prefix, workspace dir, temp dir, messaging params, database params and additional params are passed through to the processor`() {
         val processor = DummyProcessor()
         val dbWorker = DBWorker(processor, DummyShutdown(), DummyHealthMonitor())
         val args = arrayOf(
@@ -34,6 +35,8 @@ class ConfigTests {
         val expectedKeys = setOf(
             KEY_INSTANCE_ID,
             KEY_TOPIC_PREFIX,
+            WORKSPACE_DIR,
+            TEMP_DIR,
             "$CUSTOM_CONFIG_PATH.$CUSTOM_KEY_ONE",
             "$MSG_CONFIG_PATH.$MSG_KEY_ONE",
             "${ConfigKeys.DB_CONFIG}.$DB_KEY_ONE"
@@ -60,20 +63,20 @@ class ConfigTests {
         val config = processor.config!!
 
         // Instance ID and topic prefix are always present, with default values if none are provided.
-        val expectedKeys = setOf(KEY_INSTANCE_ID, KEY_TOPIC_PREFIX)
+        val expectedKeys = setOf(KEY_INSTANCE_ID, KEY_TOPIC_PREFIX, WORKSPACE_DIR, TEMP_DIR)
         val actualKeys = config.entrySet().map { entry -> entry.key }.toSet()
         assertEquals(expectedKeys, actualKeys)
     }
 
     @Test
-    fun `defaults are provided for instance ID and topic prefix`() {
+    fun `defaults are provided for instance Id, topic prefix, workspace dir and temp dir`() {
         val processor = DummyProcessor()
         val dbWorker = DBWorker(processor, DummyShutdown(), DummyHealthMonitor())
         val args = arrayOf<String>()
         dbWorker.startup(args)
         val config = processor.config!!
 
-        val expectedKeys = setOf(KEY_INSTANCE_ID, KEY_TOPIC_PREFIX)
+        val expectedKeys = setOf(KEY_INSTANCE_ID, KEY_TOPIC_PREFIX, WORKSPACE_DIR, TEMP_DIR)
         val actualKeys = config.entrySet().map { entry -> entry.key }.toSet()
         assertEquals(expectedKeys, actualKeys)
 

--- a/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/Constants.kt
+++ b/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/Constants.kt
@@ -24,6 +24,8 @@ internal const val CUSTOM_KEY_ONE = "customKeyOne"
 internal const val CUSTOM_VAL_ONE = "customValOne"
 internal const val CUSTOM_KEY_TWO = "customKeyTwo"
 internal const val CUSTOM_VAL_TWO = "customValTwo"
+internal const val WORKSPACE_DIR = "dir.workspace"
+internal const val TEMP_DIR = "dir.tmp"
 
 internal const val DEFAULT_TOPIC_PREFIX = ""
 internal const val MSG_CONFIG_PATH = "messaging"

--- a/applications/workers/release/deploy/docker-compose.yaml
+++ b/applications/workers/release/deploy/docker-compose.yaml
@@ -169,6 +169,7 @@ services:
     command:
       - --messagingParams
       - kafka.common.bootstrap.servers=kafka:9092
+      - --workspace-dir=/tmp/corda
     healthcheck:
       test: [ "CMD-SHELL", "curl --fail http://localhost:7000/isHealthy || exit 1" ]
       interval: 5s

--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':processors:flow-processor')
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'net.corda:corda-base'
+    implementation 'net.corda:corda-config-schema'
 
     runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
     runtimeOnly "net.corda:corda-application"

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
@@ -1,6 +1,7 @@
 package net.corda.applications.workers.workercommon
 
 import net.corda.applications.workers.workercommon.internal.HEALTH_MONITOR_PORT
+import net.corda.schema.configuration.ConfigDefaults
 import picocli.CommandLine.Option
 import kotlin.math.absoluteValue
 import kotlin.random.Random
@@ -40,6 +41,12 @@ class DefaultWorkerParams {
 
     @Option(names = ["-s", "--secretsParams"], description = ["Secrets parameters for the worker."])
     var secretsParams = emptyMap<String, String>()
+
+    @Option(names = ["--workspace-dir"], description = ["Corda worspace directory."])
+    var workspaceDir = ConfigDefaults.WORKSPACE_DIR
+
+    @Option(names = ["--temp-dir"], description = ["Corda temp directory."])
+    var tempDir = ConfigDefaults.TEMP_DIR
 
     @Option(names = ["-c", "--additionalParams"], description = ["Additional parameters for the worker."])
     var additionalParams = emptyMap<String, String>()

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
@@ -54,8 +54,13 @@ class WorkerHelpers {
                 .flatMap { map -> map.entries }
                 .associate { (key, value) -> key to value }
 
+            val dirsConfig = mapOf(
+                ConfigKeys.WORKSPACE_DIR to defaultParams.workspaceDir,
+                ConfigKeys.TEMP_DIR to defaultParams.tempDir
+            )
+
             val config = ConfigFactory
-                .parseMap(messagingParamsMap + additionalParamsMap + extraParamsMap)
+                .parseMap(messagingParamsMap + dirsConfig + additionalParamsMap + extraParamsMap)
                 .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(defaultParams.instanceId))
                 .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(defaultParams.topicPrefix))
 

--- a/components/chunking/chunk-db-write-impl/build.gradle
+++ b/components/chunking/chunk-db-write-impl/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"
+    implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-db-schema'
     implementation 'net.corda:corda-topic-schema'
     implementation 'net.corda:corda-packaging'
@@ -28,6 +29,7 @@ dependencies {
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:virtual-node:cpi-datamodel")
     implementation project(":libs:virtual-node:packaging-core")
+    implementation project(":libs:utilities")
     implementation project(':components:chunking:chunk-db-write')
 
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -10,17 +10,20 @@ import net.corda.libs.packaging.CpkMetadata
 import net.corda.packaging.CPI
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
+import java.nio.file.Path
 
 class CpiValidatorImpl(
     private val publisher: StatusPublisher,
     private val persistence: ChunkPersistence,
-    private val cpiInfoWriteService: CpiInfoWriteService
+    private val cpiInfoWriteService: CpiInfoWriteService,
+    cpiCacheDir: Path,
+    cpiPartsDir: Path
 ) : CpiValidator {
     companion object {
         private val log = contextLogger()
     }
 
-    private val validationFunctions = ValidationFunctions()
+    private val validationFunctions = ValidationFunctions(cpiCacheDir, cpiPartsDir)
 
     override fun validate(requestId: RequestId): SecureHash {
         //  Each function may throw a [ValidationException]

--- a/components/http-rpc-gateway-comp/build.gradle
+++ b/components/http-rpc-gateway-comp/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation project(':libs:http-rpc:http-rpc')
     implementation project(':libs:http-rpc:ssl-cert-read')
     implementation project(':libs:http-rpc:http-rpc-server')
+    implementation project(":libs:utilities")
 
     implementation project(":osgi-framework-api")
 

--- a/components/virtual-node/cpk-read-service-impl/build.gradle
+++ b/components/virtual-node/cpk-read-service-impl/build.gradle
@@ -23,9 +23,8 @@ dependencies {
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:utilities")
-    implementation project(":components:virtual-node:cpk-service-common")
     implementation project(":components:configuration:configuration-read-service")
-
+    implementation project(":components:virtual-node:cpk-service-common")
 
     api project(":components:virtual-node:cpk-read-service")
 

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
@@ -18,7 +18,7 @@ import java.util.SortedSet
 
 // TODO should be enough for now to keep it simple and not replace/ delete CPK chunks?
 class CpkChunksKafkaReader(
-    private val tempCpkCacheDir: Path,
+    private val cpkPartsDir: Path,
     private val cpkChunksFileManager: CpkChunksFileManager,
     private val onCpkAssembled: (CpkIdentifier, CPK) -> Unit
 ) : CompactedProcessor<CpkChunkId, Chunk> {
@@ -83,7 +83,7 @@ class CpkChunksKafkaReader(
         val cpkPath = cpkChunksFileManager.assembleCpk(cpkChecksum, chunks)
         cpkPath?.let {
             val cpk = Files.newInputStream(it).use { inStream ->
-                CPK.from(inStream, tempCpkCacheDir)
+                CPK.from(inStream, cpkPartsDir)
             }
             onCpkAssembled(CpkIdentifier.fromLegacy(cpk.metadata.id), cpk)
         } ?: logger.warn("CPK assemble has failed for: $cpkChecksum")

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
@@ -16,7 +16,7 @@ import java.util.SortedSet
 /**
  * Creates resources on disk, that something needs to clear them on shutdown.
  */
-class CpkChunksFileManagerImpl(private val cpksAssembleCacheDir: Path) : CpkChunksFileManager {
+class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileManager {
     companion object {
         val logger = contextLogger()
 
@@ -34,14 +34,14 @@ class CpkChunksFileManagerImpl(private val cpksAssembleCacheDir: Path) : CpkChun
     }
 
     override fun chunkFileExists(chunkId: CpkChunkId): CpkChunkFileLookUp {
-        val cpkXDir = cpksAssembleCacheDir.resolve(chunkId.cpkChecksum.toCorda().toCpkDirName())
+        val cpkXDir = cpkCacheDir.resolve(chunkId.cpkChecksum.toCorda().toCpkDirName())
         val filePath = cpkXDir.resolve(chunkId.toFileName())
         return CpkChunkFileLookUp(Files.exists(filePath), filePath)
     }
 
     override fun writeChunkFile(chunkId: CpkChunkId, chunk: Chunk) {
         logger.debug { "Writing CPK chunk file ${chunkId.toFileName()}" }
-        val cpkXDir = cpksAssembleCacheDir.resolve(chunkId.cpkChecksum.toCorda().toCpkDirName())
+        val cpkXDir = cpkCacheDir.resolve(chunkId.cpkChecksum.toCorda().toCpkDirName())
         if (!Files.exists(cpkXDir)) {
             logger.debug { "Creating CPK directory: $cpkXDir" }
             Files.createDirectory(cpkXDir)
@@ -55,7 +55,7 @@ class CpkChunksFileManagerImpl(private val cpksAssembleCacheDir: Path) : CpkChun
 
     // TODO need to take care of incomplete CPK assemble as per https://r3-cev.atlassian.net/browse/CORE-4155
     override fun assembleCpk(cpkChecksum: SecureHash, chunkParts: SortedSet<CpkChunkId>): Path? {
-        val cpkXDir = cpksAssembleCacheDir.resolve(cpkChecksum.toCpkDirName())
+        val cpkXDir = cpkCacheDir.resolve(cpkChecksum.toCpkDirName())
         logger.info("Assembling CPK on disk: $cpkXDir")
         if (!Files.exists(cpkXDir)) {
             logger.warn("CPK directory should exist but it does not: $cpkXDir")

--- a/components/virtual-node/cpk-read-service-impl/src/test/kotlin/net/corda/cpk/read/impl/CpkReadServiceImplTest.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/test/kotlin/net/corda/cpk/read/impl/CpkReadServiceImplTest.kt
@@ -1,7 +1,11 @@
 package net.corda.cpk.read.impl
 
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.cpk.read.impl.CpkReadServiceImpl.Companion.CPK_CACHE_DIR
+import net.corda.cpk.read.impl.CpkReadServiceImpl.Companion.CPK_PARTS_DIR
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -12,10 +16,12 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.configuration.ConfigKeys
-import org.junit.jupiter.api.Assertions
+import net.corda.utilities.PathProvider
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -26,7 +32,7 @@ class CpkReadServiceImplTest {
     lateinit var configReadService: ConfigurationReadService
     lateinit var subscriptionFactory: SubscriptionFactory
 
-    private lateinit var coordinator: LifecycleCoordinator
+    lateinit var coordinator: LifecycleCoordinator
 
     @BeforeEach
     fun setUp() {
@@ -45,7 +51,7 @@ class CpkReadServiceImplTest {
             .thenReturn(registration)
 
         cpkReadService.processEvent(StartEvent(), coordinator)
-        Assertions.assertNotNull(cpkReadService.configReadServiceRegistration)
+        assertNotNull(cpkReadService.configReadServiceRegistration)
     }
 
     @Test
@@ -53,23 +59,32 @@ class CpkReadServiceImplTest {
         whenever(configReadService.registerComponentForUpdates(any(), any())).thenReturn(mock())
 
         cpkReadService.processEvent(RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), coordinator)
-        Assertions.assertNotNull(cpkReadService.configSubscription)
+        assertNotNull(cpkReadService.configSubscription)
     }
 
     @Test
     fun `on onConfigChangedEvent fully sets the component`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val workspacePathProvider = mock<PathProvider>()
+        whenever(workspacePathProvider.getOrCreate(any(), anyVararg())).thenReturn(fs.getPath("/workspace/$CPK_CACHE_DIR"))
+        val tempPathProvider = mock<PathProvider>()
+        whenever(tempPathProvider.getOrCreate(any(), any())).thenReturn(fs.getPath("/tmp/$CPK_PARTS_DIR"))
         whenever(subscriptionFactory.createCompactedSubscription<Any, Any>(any(), any(), any())).thenReturn(mock())
+
+        val cpkReadService =
+            CpkReadServiceImpl(coordinatorFactory, configReadService, subscriptionFactory, workspacePathProvider, tempPathProvider)
 
         val keys = mock<Set<String>>()
         whenever(keys.contains(ConfigKeys.BOOT_CONFIG)).thenReturn(true)
         val config = mock<Map<String, SmartConfig>>()
         whenever(config[ConfigKeys.BOOT_CONFIG]).thenReturn(mock())
-        val messagingSmartConfigMock = mock<SmartConfig>()
-        whenever(messagingSmartConfigMock.withFallback(any())).thenReturn(mock())
-        whenever(config[ConfigKeys.MESSAGING_CONFIG]).thenReturn(messagingSmartConfigMock)
+        val messagingConfig = mock<SmartConfig>()
+        whenever(config[ConfigKeys.MESSAGING_CONFIG]).thenReturn(messagingConfig)
+        whenever(messagingConfig.withFallback(any())).thenReturn(messagingConfig)
+
         cpkReadService.processEvent(ConfigChangedEvent(keys, config), coordinator)
 
-        Assertions.assertNotNull(cpkReadService.cpkChunksKafkaReaderSubscription)
+        assertNotNull(cpkReadService.cpkChunksKafkaReaderSubscription)
         verify(coordinator).updateStatus(LifecycleStatus.UP)
     }
 }

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
@@ -14,7 +14,7 @@ import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 
 /**
- * Receives binary chunks and reassembles full binary and executes completed
+ * Receives binary chunks and reassembles full binary under [destDir] and executes completed
  * callback when binary is assembled.
  */
 internal class ChunkReaderImpl(private val destDir: Path) : ChunkReader {

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/java/net/corda/httprpc/client/HttpRpcJavaClientIntegrationTest.java
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/java/net/corda/httprpc/client/HttpRpcJavaClientIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import static net.corda.httprpc.test.utls.TestUtilsKt.findFreePort;
@@ -30,11 +31,13 @@ public class HttpRpcJavaClientIntegrationTest extends HttpRpcIntegrationTestBase
             HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
         );
         HttpRpcIntegrationTestBase.Companion.setServer(
-            new HttpRpcServerImpl(
-                List.of(
-                    new TestHealthCheckAPIImpl(), new CustomSerializationAPIImpl()
-                ), HttpRpcIntegrationTestBase.Companion.getSecurityManager(), httpRpcSettings, true
-            )
+                new HttpRpcServerImpl(
+                        List.of(new TestHealthCheckAPIImpl(), new CustomSerializationAPIImpl()),
+                        HttpRpcIntegrationTestBase.Companion.getSecurityManager(),
+                        httpRpcSettings,
+                        Path.of(System.getProperty("java.io.tmpdir")),
+                        true
+                )
         );
         HttpRpcIntegrationTestBase.Companion.getServer().start();
     }

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientAadIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientAadIntegrationTest.kt
@@ -13,6 +13,7 @@ import net.corda.v5.base.util.NetworkHostAndPort
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import kotlin.test.assertEquals
 
 class HttpRpcClientAadIntegrationTest : HttpRpcIntegrationTestBase() {
@@ -28,7 +29,13 @@ class HttpRpcClientAadIntegrationTest : HttpRpcIntegrationTestBase() {
             SsoSettings(AzureAdSettings(AzureAdMock.clientId, null, AzureAdMock.tenantId, trustedIssuers = listOf(AzureAdMock.issuer))),
             HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
         )
-        server = HttpRpcServerImpl(listOf(TestHealthCheckAPIImpl()), securityManager, httpRpcSettings, true).apply { start() }
+        server = HttpRpcServerImpl(
+            listOf(TestHealthCheckAPIImpl()),
+            securityManager,
+            httpRpcSettings,
+            multipartDir,
+            true
+        ).apply { start() }
     }
 
     @AfterEach

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
@@ -58,7 +58,11 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
                     NumberSequencesRPCOpsImpl(),
                     CalendarRPCOpsImpl(),
                     TestEntityRpcOpsImpl()
-                ), securityManager, httpRpcSettings, true
+                ),
+                securityManager,
+                httpRpcSettings,
+                multipartDir,
+                true
             ).apply { start() }
         }
 

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcIntegrationTestBase.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcIntegrationTestBase.kt
@@ -2,6 +2,7 @@ package net.corda.httprpc.client
 
 import net.corda.httprpc.server.HttpRpcServer
 import net.corda.httprpc.server.config.models.HttpRpcContext
+import java.nio.file.Path
 
 abstract class HttpRpcIntegrationTestBase {
     internal companion object {
@@ -11,5 +12,6 @@ abstract class HttpRpcIntegrationTestBase {
         val userAlice = User("admin", password, setOf())
         val securityManager = FakeSecurityManager()
         val context = HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description")
+        val multipartDir: Path = Path.of(System.getProperty("java.io.tmpdir"), "multipart")
     }
 }

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcSSLClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcSSLClientIntegrationTest.kt
@@ -45,6 +45,7 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
                 listOf(TestHealthCheckAPIImpl(), CustomSerializationAPIImpl()),
                 securityManager,
                 httpRpcSettings,
+                multipartDir,
                 true
             ).apply { start() }
         }

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerAzureAdTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerAzureAdTest.kt
@@ -1,7 +1,6 @@
 package net.corda.httprpc.server.impl
 
 import kong.unirest.HttpStatus
-import net.corda.v5.base.util.NetworkHostAndPort
 import net.corda.httprpc.security.read.RPCSecurityManager
 import net.corda.httprpc.server.HttpRpcServer
 import net.corda.httprpc.server.config.models.AzureAdSettings
@@ -12,13 +11,16 @@ import net.corda.httprpc.server.impl.HttpRpcServerTestBase.Companion.findFreePor
 import net.corda.httprpc.server.impl.utils.TestHttpClient
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utls.AzureAdMock
 import net.corda.httprpc.tools.HttpVerb
+import net.corda.v5.base.util.NetworkHostAndPort
 import org.junit.jupiter.api.AfterEach
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.test.assertEquals
 
 
 class HttpRpcServerAzureAdTest {
@@ -34,7 +36,13 @@ class HttpRpcServerAzureAdTest {
                 HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description"),
                 null,
                 SsoSettings(AzureAdSettings(AzureAdMock.clientId, null, AzureAdMock.tenantId, trustedIssuers = listOf(AzureAdMock.issuer))), HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE)
-        httpRpcServer = HttpRpcServerImpl(listOf(TestHealthCheckAPIImpl()), securityManager, httpRpcSettings, true).apply { start() }
+        httpRpcServer = HttpRpcServerImpl(
+            listOf(TestHealthCheckAPIImpl()),
+            securityManager,
+            httpRpcSettings,
+            multipartDir,
+            true
+        ).apply { start() }
         client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
     }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveLoginTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveLoginTest.kt
@@ -3,13 +3,15 @@ package net.corda.httprpc.server.impl
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.v5.base.util.NetworkHostAndPort
 import org.apache.http.HttpStatus
 import org.junit.jupiter.api.AfterAll
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.test.assertEquals
 
 class HttpRpcServerCaseSensitiveLoginTest: HttpRpcServerTestBase() {
     companion object {
@@ -28,6 +30,7 @@ class HttpRpcServerCaseSensitiveLoginTest: HttpRpcServerTestBase() {
                 listOf(TestHealthCheckAPIImpl()),
                 securityManager,
                 httpRpcSettings,
+                multipartDir,
                 true
             ).apply { start() }
             client =

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveUrlTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveUrlTest.kt
@@ -3,15 +3,17 @@ package net.corda.httprpc.server.impl
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.tools.HttpVerb.GET
 import net.corda.httprpc.tools.HttpVerb.POST
 import net.corda.v5.base.util.NetworkHostAndPort
 import org.apache.http.HttpStatus
 import org.junit.jupiter.api.AfterAll
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.test.assertEquals
 
 class HttpRpcServerCaseSensitiveUrlTest: HttpRpcServerTestBase() {
     companion object {
@@ -21,7 +23,13 @@ class HttpRpcServerCaseSensitiveUrlTest: HttpRpcServerTestBase() {
         @Suppress("Unused")
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost", findFreePort()), context, null, null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE)
-            server = HttpRpcServerImpl(listOf(TestHealthCheckAPIImpl()), securityManager, httpRpcSettings, true).apply { start() }
+            server = HttpRpcServerImpl(
+                listOf(TestHealthCheckAPIImpl()),
+                securityManager,
+                httpRpcSettings,
+                multipartDir,
+                true
+            ).apply { start() }
             client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerDurableStreamsRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerDurableStreamsRequestsTest.kt
@@ -1,21 +1,21 @@
 package net.corda.httprpc.server.impl
 
-import net.corda.v5.base.util.NetworkHostAndPort
-
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.HttpRpcServerTestBase.Companion.findFreePort
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
 import net.corda.httprpc.server.impl.utils.compact
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.CalendarRPCOpsImpl
 import net.corda.httprpc.test.CustomSerializationAPIImpl
 import net.corda.httprpc.test.NumberSequencesRPCOpsImpl
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
-
+import net.corda.v5.base.util.NetworkHostAndPort
 import org.apache.http.HttpStatus
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import kotlin.test.assertEquals
 
 
@@ -30,6 +30,7 @@ class HttpRpcServerDurableStreamsRequestsTest {
                 listOf(NumberSequencesRPCOpsImpl(), CalendarRPCOpsImpl(), TestHealthCheckAPIImpl(), CustomSerializationAPIImpl()),
                 HttpRpcServerTestBase.securityManager,
                 httpRpcSettings,
+                multipartDir,
                 true
             ).apply { start() }
             HttpRpcServerTestBase.client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerLifecycleTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerLifecycleTest.kt
@@ -3,6 +3,7 @@ package net.corda.httprpc.server.impl
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.LifecycleRPCOpsImpl
 import net.corda.httprpc.tools.HttpVerb.GET
 import net.corda.v5.base.util.NetworkHostAndPort
@@ -10,6 +11,7 @@ import org.apache.http.HttpStatus
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import kotlin.test.assertEquals
 
 
@@ -32,6 +34,7 @@ class HttpRpcServerLifecycleTest : HttpRpcServerTestBase() {
                 listOf(lifecycleRPCOpsImpl),
                 securityManager,
                 httpRpcSettings,
+                multipartDir,
                 true
             ).apply { start() }
             client =

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerMaxContentLengthTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerMaxContentLengthTest.kt
@@ -3,15 +3,17 @@ package net.corda.httprpc.server.impl
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.v5.base.util.NetworkHostAndPort
 import org.apache.http.HttpStatus
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
 
 class HttpRpcServerMaxContentLengthTest : HttpRpcServerTestBase() {
     companion object {
@@ -20,7 +22,13 @@ class HttpRpcServerMaxContentLengthTest : HttpRpcServerTestBase() {
         @JvmStatic
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost",  findFreePort()), context, null, null, MAX_CONTENT_LENGTH)
-            server = HttpRpcServerImpl(listOf(TestHealthCheckAPIImpl()), securityManager, httpRpcSettings, true).apply { start() }
+            server = HttpRpcServerImpl(
+                listOf(TestHealthCheckAPIImpl()),
+                securityManager,
+                httpRpcSettings,
+                multipartDir,
+                true
+            ).apply { start() }
             client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
@@ -3,23 +3,24 @@ package net.corda.httprpc.server.impl
 import io.swagger.v3.core.util.Json
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.ArraySchema
-import net.corda.v5.base.util.NetworkHostAndPort
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.internal.OptionalDependency
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
 import net.corda.httprpc.server.impl.utils.compact
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.CalendarRPCOpsImpl
 import net.corda.httprpc.test.TestEntityRpcOpsImpl
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.tools.HttpVerb.GET
-
+import net.corda.v5.base.util.NetworkHostAndPort
 import org.apache.http.HttpStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import java.nio.file.Path
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,6 +37,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
                 listOf(CalendarRPCOpsImpl(), TestHealthCheckAPIImpl(), TestEntityRpcOpsImpl()),
                 securityManager,
                 httpRpcSettings,
+                multipartDir,
                 true
             ).apply { start() }
             client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
@@ -5,28 +5,26 @@ import io.javalin.core.util.Header.ACCESS_CONTROL_ALLOW_CREDENTIALS
 import io.javalin.core.util.Header.ACCESS_CONTROL_ALLOW_ORIGIN
 import io.javalin.core.util.Header.CACHE_CONTROL
 import io.javalin.core.util.Header.WWW_AUTHENTICATE
-import net.corda.v5.application.flows.BadRpcStartFlowRequestException
-import net.corda.v5.base.util.NetworkHostAndPort
 import net.corda.httprpc.server.apigen.test.TestJavaPrimitivesRPCopsImpl
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.toExample
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
-import net.corda.httprpc.test.CustomNonSerializableString
-import net.corda.httprpc.test.CustomSerializationAPIImpl
-import net.corda.httprpc.test.CustomUnsafeString
-import net.corda.httprpc.test.TestEntityRpcOpsImpl
-import net.corda.httprpc.test.TestHealthCheckAPIImpl
+import net.corda.httprpc.server.impl.utils.multipartDir
+import net.corda.httprpc.test.*
 import net.corda.httprpc.tools.HttpVerb.GET
 import net.corda.httprpc.tools.HttpVerb.POST
+import net.corda.v5.application.flows.BadRpcStartFlowRequestException
+import net.corda.v5.base.util.NetworkHostAndPort
 import org.apache.http.HttpStatus
-import org.junit.jupiter.api.BeforeAll
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import java.time.Instant
 import java.time.ZonedDateTime
-import org.assertj.core.api.Assertions.assertThat
 import kotlin.test.assertEquals
 
 
@@ -51,6 +49,7 @@ class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
                 ),
                 securityManager,
                 httpRpcSettings,
+                multipartDir,
                 true
             ).apply { start() }
             client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/InvalidRequestTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/InvalidRequestTest.kt
@@ -2,19 +2,20 @@ package net.corda.httprpc.server.impl
 
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-
-import net.corda.v5.base.util.NetworkHostAndPort
 import net.corda.httprpc.server.apigen.test.TestJavaPrimitivesRPCopsImpl
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.server.impl.utils.WebRequest
+import net.corda.httprpc.server.impl.utils.multipartDir
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
+import net.corda.v5.base.util.NetworkHostAndPort
 import org.apache.http.HttpStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -41,6 +42,7 @@ class InvalidRequestTest : HttpRpcServerTestBase() {
                 listOf(TestHealthCheckAPIImpl(), TestJavaPrimitivesRPCopsImpl()),
                 securityManager,
                 httpRpcSettings,
+                multipartDir,
                 true
             ).apply { start() }
             client =

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/utils/TestHelpers.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/utils/TestHelpers.kt
@@ -1,3 +1,7 @@
 package net.corda.httprpc.server.impl.utils
 
+import java.nio.file.Path
+
 fun String.compact() = this.trimMargin().replace("[\n\r]".toRegex(),"")
+
+internal val multipartDir = Path.of(System.getProperty("java.io.tmpdir"), "multipart")

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/HttpRpcServerImpl.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/HttpRpcServerImpl.kt
@@ -19,6 +19,7 @@ import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.RpcOps
+import java.nio.file.Path
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.write
 
@@ -27,8 +28,8 @@ class HttpRpcServerImpl(
     rpcOpsImpls: List<PluggableRPCOps<out RpcOps>>,
     rpcSecurityManager: RPCSecurityManager,
     httpRpcSettings: HttpRpcSettings,
+    multiPartDir: Path,
     devMode: Boolean
-
 ) : HttpRpcServer {
     private companion object {
         private val log = contextLogger()
@@ -52,7 +53,8 @@ class HttpRpcServerImpl(
         ),
         SecurityManagerRPCImpl(createAuthenticationProviders(httpRpcObjectConfigProvider, rpcSecurityManager)),
         httpRpcObjectConfigProvider,
-        OpenApiInfoProvider(resources, httpRpcObjectConfigProvider)
+        OpenApiInfoProvider(resources, httpRpcObjectConfigProvider),
+        multiPartDir
     )
 
 

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/factory/HttpRpcServerFactoryImpl.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/factory/HttpRpcServerFactoryImpl.kt
@@ -8,6 +8,7 @@ import net.corda.httprpc.server.factory.HttpRpcServerFactory
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.RpcOps
 import org.osgi.service.component.annotations.Component
+import java.nio.file.Path
 
 @Component(immediate = true, service = [HttpRpcServerFactory::class])
 @Suppress("Unused")
@@ -16,9 +17,10 @@ class HttpRpcServerFactoryImpl : HttpRpcServerFactory {
     override fun createHttpRpcServer(
         rpcOpsImpls: List<PluggableRPCOps<out RpcOps>>,
         rpcSecurityManager: RPCSecurityManager,
-        httpRpcSettings: HttpRpcSettings
+        httpRpcSettings: HttpRpcSettings,
+        multiPartDir: Path
     ): HttpRpcServer {
 
-        return HttpRpcServerImpl(rpcOpsImpls, rpcSecurityManager, httpRpcSettings, devMode = false)
+        return HttpRpcServerImpl(rpcOpsImpls, rpcSecurityManager, httpRpcSettings, multiPartDir, devMode = false)
     }
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
@@ -41,6 +41,7 @@ import org.osgi.framework.FrameworkUtil
 import org.osgi.framework.wiring.BundleWiring
 import java.io.OutputStream
 import java.io.PrintStream
+import java.nio.file.Path
 import javax.security.auth.login.FailedLoginException
 import javax.servlet.MultipartConfigElement
 
@@ -50,8 +51,8 @@ internal class HttpRpcServerInternal(
     private val securityManager: HttpRpcSecurityManager,
     private val configurationsProvider: HttpRpcSettingsProvider,
     private val openApiInfoProvider: OpenApiInfoProvider,
-
-    ) {
+    multiPartDir: Path
+) {
 
     internal companion object {
         private val log = contextLogger()
@@ -121,7 +122,7 @@ internal class HttpRpcServerInternal(
         MultipartUtil.preUploadFunction = { req ->
             req.setAttribute("org.eclipse.jetty.multipartConfig",
                 MultipartConfigElement(
-                    System.getProperty("java.io.tmpdir"),
+                    multiPartDir.toString(),
                     configurationsProvider.maxContentLength().toLong(),
                     configurationsProvider.maxContentLength().toLong(),
                     1024))

--- a/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/HttpRpcServerTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/HttpRpcServerTest.kt
@@ -21,11 +21,14 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
+import java.nio.file.Path
 import java.nio.file.Paths
 
 class HttpRpcServerTest {
 
     private val portAllocator = 8080 // doesn't matter, server won't start anyway
+
+    private val multiPartDir = Path.of(System.getProperty("java.io.tmpdir"))
 
     @Test
     fun `start server with ssl option but without ssl password specified throws illegal argument exception`() {
@@ -46,7 +49,8 @@ class HttpRpcServerTest {
                     ),
                     SecurityManagerRPCImpl(emptySet()),
                     configProvider,
-                    OpenApiInfoProvider(APIStructureRetriever(listOf(TestHealthCheckAPIImpl())).structure, configProvider)
+                    OpenApiInfoProvider(APIStructureRetriever(listOf(TestHealthCheckAPIImpl())).structure, configProvider),
+                    multiPartDir
                 )
             },
             SSL_PASSWORD_MISSING
@@ -72,7 +76,8 @@ class HttpRpcServerTest {
                     ),
                     SecurityManagerRPCImpl(emptySet()),
                     configProvider,
-                    OpenApiInfoProvider(APIStructureRetriever(listOf(TestHealthCheckAPIImpl())).structure, configProvider)
+                    OpenApiInfoProvider(APIStructureRetriever(listOf(TestHealthCheckAPIImpl())).structure, configProvider),
+                    multiPartDir
                 )
             },
             INSECURE_SERVER_DEV_MODE_WARNING
@@ -119,7 +124,8 @@ class HttpRpcServerTest {
                 ),
                 SecurityManagerRPCImpl(emptySet()),
                 configProvider,
-                OpenApiInfoProvider(APIStructureRetriever(listOf(TestHealthCheckAPIImpl())).structure, configProvider)
+                OpenApiInfoProvider(APIStructureRetriever(listOf(TestHealthCheckAPIImpl())).structure, configProvider),
+                multiPartDir
             )
         }.isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage(

--- a/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/factory/HttpRpcServerFactory.kt
+++ b/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/factory/HttpRpcServerFactory.kt
@@ -5,12 +5,14 @@ import net.corda.httprpc.RpcOps
 import net.corda.httprpc.security.read.RPCSecurityManager
 import net.corda.httprpc.server.HttpRpcServer
 import net.corda.httprpc.server.config.models.HttpRpcSettings
+import java.nio.file.Path
 
 interface HttpRpcServerFactory {
 
     fun createHttpRpcServer(
         rpcOpsImpls: List<PluggableRPCOps<out RpcOps>>,
         rpcSecurityManager: RPCSecurityManager,
-        httpRpcSettings: HttpRpcSettings
+        httpRpcSettings: HttpRpcSettings,
+        multiPartDir: Path
     ): HttpRpcServer
 }

--- a/libs/utilities/build.gradle
+++ b/libs/utilities/build.gradle
@@ -10,9 +10,12 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
+    implementation 'net.corda:corda-config-schema'
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     // Concluded this is the one acceptable dependency in addition to kotlin.
     implementation 'org.slf4j:slf4j-api'
+
+    implementation project(":libs:configuration:configuration-core")
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/PathProvider.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/PathProvider.kt
@@ -1,0 +1,44 @@
+package net.corda.utilities
+
+import net.corda.libs.configuration.SmartConfig
+import net.corda.schema.configuration.ConfigKeys
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+interface PathProvider {
+    /**
+     * Resolves a directory path and creates the directory if it does not exist.
+     */
+    fun getOrCreate(config: SmartConfig, vararg dirPath: String): Path
+}
+
+@Suppress("SpreadOperator")
+class WorkspacePathProvider(
+    private val dirResolver: (String, Array<out String>) -> Path = { first, more -> Paths.get(first, *more) }
+) : PathProvider {
+    override fun getOrCreate(config: SmartConfig, vararg dirPath: String): Path {
+        require(config.hasPath(ConfigKeys.WORKSPACE_DIR)) {
+            "Configuration should not be null for ${ConfigKeys.WORKSPACE_DIR}"
+        }
+
+        return dirResolver(config.getString(ConfigKeys.WORKSPACE_DIR)!!, dirPath).also {
+            Files.createDirectories(it)
+        }
+    }
+}
+
+@Suppress("SpreadOperator")
+class TempPathProvider(
+    private val dirResolver: (String, Array<out String>) -> Path = { first, more -> Paths.get(first, *more) }
+) : PathProvider {
+    override fun getOrCreate(config: SmartConfig, vararg dirPath: String): Path {
+        require(config.hasPath(ConfigKeys.TEMP_DIR)) {
+            "Configuration should not be null for ${ConfigKeys.TEMP_DIR}"
+        }
+
+        return dirResolver(config.getString(ConfigKeys.TEMP_DIR)!!, dirPath).also {
+            Files.createDirectories(it)
+        }
+    }
+}

--- a/libs/utilities/src/test/kotlin/net/corda/utilities/PathProviderTest.kt
+++ b/libs/utilities/src/test/kotlin/net/corda/utilities/PathProviderTest.kt
@@ -1,0 +1,43 @@
+package net.corda.utilities
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import net.corda.libs.configuration.SmartConfig
+import net.corda.schema.configuration.ConfigKeys
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.nio.file.FileSystem
+
+@Suppress("SpreadOperator")
+class PathProviderTest {
+    lateinit var fs: FileSystem
+    lateinit var config: SmartConfig
+
+    @BeforeEach
+    fun setUp() {
+        fs = Jimfs.newFileSystem(Configuration.unix())
+
+        config = mock()
+    }
+
+    @AfterEach
+    fun clear() {
+        fs.close()
+    }
+
+    @Test
+    fun `on get or create creates dir if not existing`() {
+        whenever(config.hasPath(ConfigKeys.WORKSPACE_DIR)).thenReturn(true)
+        whenever(config.getString(ConfigKeys.WORKSPACE_DIR)).thenReturn("/workspace")
+        val workspacePathProvider = WorkspacePathProvider { first, more ->
+            fs.getPath(first, *more)
+        }
+
+        val dir = workspacePathProvider.getOrCreate(config)
+        assertTrue(dir.exists())
+    }
+}


### PR DESCRIPTION
- adds `--workspace-dir` command line option to configure workspace directory (a root directory for storing that can benefit from disk caching on workers restarts).
- adds `--temp-dir` command line option to configure the temp directory (a root directory that gets wiped out on workers shutdown).