### PR TITLE
CORE-4139 Refactor chart configuration

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
             post {
                 unsuccessful {
                     sh '''
-                        kubectl logs -lfamily=e2e -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs.txt
+                        kubectl logs -lapp.kubernetes.io/instance=corda -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs.txt
                         kubectl describe all -n ${NAMESPACE} > describe.txt
                     '''
                     archiveArtifacts artifacts: 'logs.txt, describe.txt', allowEmptyArchive: true
@@ -119,7 +119,7 @@ pipeline {
                 }
                 unsuccessful {
                     sh '''
-                        kubectl logs -lfamily=e2e -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs.txt
+                        kubectl logs -lapp.kubernetes.io/instance=corda -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs.txt
                         kubectl describe all -n ${NAMESPACE} > describe.txt
                     '''
                     archiveArtifacts artifacts: 'forward.txt, logs.txt, describe.txt', allowEmptyArchive: true

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -1,0 +1,11 @@
+imagePullSecrets:
+  - docker-registry-cred
+
+kafka:
+  bootstrapServers: prereqs-kafka:9092
+
+db:
+  cluster:
+    host: prereqs-postgresql
+    existingSecret:
+      prereqs-postgresql

--- a/charts/corda/Chart.yaml
+++ b/charts/corda/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0"
+appVersion: "unstable"

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "corda.name" -}}
-    {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -11,41 +11,122 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "corda.fullname" -}}
-    {{- if .Values.fullnameOverride }}
-        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-    {{- else }}
-        {{- $name := default .Chart.Name .Values.nameOverride }}
-        {{- if contains $name .Release.Name }}
-            {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-        {{- else }}
-            {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-        {{- end }}
-    {{- end }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "corda.chart" -}}
-    {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
 {{- define "corda.labels" -}}
-    helm.sh/chart: {{ include "corda.chart" . }}
-    {{ include "corda.selectorLabels" . }}
-    {{- if .Chart.AppVersion }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-    {{- end }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "corda.chart" . }}
+{{ include "corda.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "corda.selectorLabels" -}}
-    app.kubernetes.io/name: {{ include "corda.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "corda.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Image pull secrets
+*/}}
+{{- define "corda.imagePullSecrets" -}}
+{{- if ( not ( empty  .Values.imagePullSecrets ) ) }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Worker name
+*/}}
+{{- define "corda.workerName" -}}
+"{{ include "corda.fullname" . }}-{{ .worker }}-worker"
+{{- end }}
+
+{{/*
+Worker common labels
+*/}}
+{{- define "corda.workerLabels" -}}
+{{ include "corda.labels" . }}
+{{ include "corda.workerComponentLabel" . }}
+{{- end }}
+
+{{/*
+Worker selector labels
+*/}}
+{{- define "corda.workerSelectorLabels" -}}
+{{ include "corda.selectorLabels" . }}
+{{ include "corda.workerComponentLabel" . }}
+{{- end }}
+
+{{/*
+Worker component label
+*/}}
+{{- define "corda.workerComponentLabel" -}}
+app.kubernetes.io/component: {{ .worker }}-worker
+{{- end }}
+
+{{/*
+Worker image
+*/}}
+{{- define "corda.workerImage" -}}
+"{{ .Values.image.registry }}/{{ ( get .Values.workers .worker ).image.repository }}:{{ ( get .Values.workers .worker ).image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+{{- end }}
+
+{{/*
+Worker JAVA_TOOL_OPTIONS
+*/}}
+{{- define "corda.workerJavaToolOptions" -}}
+{{- if ( get .Values.workers .worker ).debug.enabled -}}
+- name: JAVA_TOOL_OPTIONS
+  value: -agentlib:jdwp=transport=dt_socket,server=y,suspend={{ if ( get .Values.workers .worker ).debug.suspend }}y{{ else }}n{{ end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Kafka bootstrap servers
+*/}}
+{{- define "corda.kafkaBootstrapServers" -}}
+{{ required "Must specify kafka.bootstrapServers" .Values.kafka.bootstrapServers }}
+{{- end }}
+
+{{/*
+Worker Kafka arguments
+*/}}
+{{- define "corda.workerKafkaArgs" -}}
+- -mkafka.common.bootstrap.servers={{ include "corda.kafkaBootstrapServers" . }}
+{{- end }}
+
+
+{{/*
+Cluster DB secret name
+*/}}
+{{- define "corda.clusterDbSecretName" -}}
+{{- .Values.db.cluster.existingSecret | default ( printf "%s-cluster-db" (include "corda.fullname" .) ) }}
+{{- end -}}

--- a/charts/corda/templates/cluster-db-secret.yaml
+++ b/charts/corda/templates/cluster-db-secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.db.cluster.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-cluster-db" (include "corda.fullname" .) }}
+  labels:
+    {{- include "corda.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ required "Must specify db.cluster.existingSecret or db.cluster.password" .Values.db.cluster.password | b64enc | quote }}
+{{- end }}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -1,59 +1,52 @@
+{{- $_ := set . "worker" "crypto" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "corda.fullname" . }}-crypto
+  name: {{ include "corda.workerName" . }}
   labels:
-    app: {{ include "corda.fullname" . }}-crypto-node
-    family: e2e
-    type: crypto-worker
+    {{- include "corda.workerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.workers.crypto.replicas }}
+  replicas: {{ .Values.workers.crypto.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "corda.fullname" . }}-crypto-node
-      family: e2e
-      type: crypto-worker
+      {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ include "corda.fullname" . }}-crypto-node
-        family: e2e
-        type: crypto-worker
+        {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-      imagePullSecrets:
-      - name: docker-registry-cred
+      {{- include "corda.imagePullSecrets" . | nindent 6 }}
       containers:
-      - name: {{ include "corda.fullname" . }}-crypto
-        image: corda-os-docker.software.r3.com/corda-os-crypto-worker:{{ .Values.imageTag }}
-        imagePullPolicy: Always
+      - name: {{ include "corda.workerName" . }}
+        image: {{ include "corda.workerImage" . }}
+        imagePullPolicy:  {{ .Values.imagePullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
         env:
-        - name: JAVA_TOOL_OPTIONS
-          value: -agentlib:jdwp=transport=dt_socket,server={{ .Values.debug.server }},suspend={{ .Values.debug.suspend }},address=*:5005
+        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
         args:
-        - -mkafka.common.bootstrap.servers={{ .Values.kafka.url }}
+        {{- include "corda.workerKafkaArgs" . | nindent 10 }}
         ports:
-        - name: worker-debug
-          containerPort: 5005
-        - name: worker-health
-          containerPort: 7000
+        {{- if .Values.workers.crypto.debug.enabled }}
+          - name: debug
+            containerPort: 5005
+        {{- end }}
+          - name: health
+            containerPort: 7000
         livenessProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 1
         startupProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 5
       nodeSelector:

--- a/charts/corda/templates/db-worker-secret.yaml
+++ b/charts/corda/templates/db-worker-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+{{- $name := printf "%s-db-worker" (include "corda.fullname" .) }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "corda.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- if $existingSecret }}
+  salt: {{ index $existingSecret.data "salt" }}
+  passphrase: {{ index $existingSecret.data "passphrase" }}
+{{- else }}
+  salt: {{ randAlphaNum 32 | b64enc | quote }}
+  passphrase: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -1,64 +1,72 @@
+{{- $_ := set . "worker" "db" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "corda.fullname" . }}-db
+  name: {{ include "corda.workerName" . }}
   labels:
-    app: {{ include "corda.fullname" . }}-db-node
-    family: e2e
-    type: database-worker
+    {{- include "corda.workerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.workers.db.replicas }}
+  replicas: {{ .Values.workers.db.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "corda.fullname" . }}-db-node
-      family: e2e
-      type: database-worker
+      {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ include "corda.fullname" . }}-db-node
-        family: e2e
-        type: database-worker
+        {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-      imagePullSecrets:
-      - name: docker-registry-cred
+      {{- include "corda.imagePullSecrets" . | nindent 6 }}
       containers:
-      - name: {{ include "corda.fullname" . }}-db
-        image: corda-os-docker.software.r3.com/corda-os-db-worker:{{ .Values.imageTag }}
-        imagePullPolicy: Always
+      - name: {{ include "corda.workerName" . }}
+        image: {{ include "corda.workerImage" . }}
+        imagePullPolicy:  {{ .Values.imagePullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
         env:
-        - name: JAVA_TOOL_OPTIONS
-          value: -agentlib:jdwp=transport=dt_socket,server={{ .Values.debug.server }},suspend={{ .Values.debug.suspend }},address=*:5005
+        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+          - name: DATABASE_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "corda.clusterDbSecretName" . }}
+                key: password
+          - name: SALT
+            valueFrom:
+              secretKeyRef:
+                name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
+                key: salt
+          - name: PASSPHRASE
+            valueFrom:
+              secretKeyRef:
+                name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
+                key: passphrase
         args:
-        - -mkafka.common.bootstrap.servers={{ .Values.kafka.url }}
-        - -spassphrase=bad passphrase
-        - -ssalt=not so random
-        - -ddatabase.user={{ .Values.db.cluster.user }}
-        - -ddatabase.pass.configSecret.encryptedSecret={{ .Values.db.cluster.secret }}
-        - -ddatabase.jdbc.url=jdbc:{{ .Values.db.cluster.url }}
+        {{- include "corda.workerKafkaArgs" . | nindent 10 }}
+          - -spassphrase=$(PASSPHRASE)
+          - -ssalt=$(SALT)
+          - -ddatabase.user={{ .Values.db.cluster.user }}
+          - -ddatabase.pass=$(DATABASE_PASS)
+          - -ddatabase.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" .Values.db.cluster.host }}:{{ .Values.db.cluster.port }}/{{ .Values.db.cluster.database }}
         ports:
-        - name: worker-debug
-          containerPort: 5005
-        - name: worker-health
-          containerPort: 7000
+        {{- if .Values.workers.db.debug.enabled }}
+          - name: debug
+            containerPort: 5005
+        {{- end }}
+          - name: health
+            containerPort: 7000
         livenessProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 1
         startupProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 5
       nodeSelector:

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -1,59 +1,52 @@
+{{- $_ := set . "worker" "flow" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "corda.fullname" . }}-flow
+  name: {{ include "corda.workerName" . }}
   labels:
-    app: {{ include "corda.fullname" . }}-flow-node
-    family: e2e
-    type: flow-worker
+    {{- include "corda.workerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.workers.flow.replicas }}
+  replicas: {{ .Values.workers.flow.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "corda.fullname" . }}-flow-node
-      family: e2e
-      type: flow-worker
+      {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ include "corda.fullname" . }}-flow-node
-        family: e2e
-        type: flow-worker
+        {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-      imagePullSecrets:
-      - name: docker-registry-cred
+      {{- include "corda.imagePullSecrets" . | nindent 6 }}
       containers:
-      - name: {{ include "corda.fullname" . }}-flow
-        image: corda-os-docker.software.r3.com/corda-os-flow-worker:{{ .Values.imageTag }}
-        imagePullPolicy: Always
+      - name: {{ include "corda.workerName" . }}
+        image: {{ include "corda.workerImage" . }}
+        imagePullPolicy:  {{ .Values.imagePullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
         env:
-        - name: JAVA_TOOL_OPTIONS
-          value: -agentlib:jdwp=transport=dt_socket,server={{ .Values.debug.server }},suspend={{ .Values.debug.suspend }},address=*:5005
+        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
         args:
-        - -mkafka.common.bootstrap.servers={{ .Values.kafka.url }}
+        {{- include "corda.workerKafkaArgs" . | nindent 10 }}
         ports:
-        - name: worker-debug
-          containerPort: 5005
-        - name: worker-health
-          containerPort: 7000
+        {{- if .Values.workers.rpc.debug.enabled }}
+          - name: debug
+            containerPort: 5005
+        {{- end }}
+          - name: health
+            containerPort: 7000
         livenessProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 1
         startupProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 5
       nodeSelector:

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -1,76 +1,69 @@
+{{- $_ := set . "worker" "rpc" }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "corda.fullname" . }}-rpc
-  labels: &id004
-    app: {{ include "corda.fullname" . }}-rpc-node
-    type: rpc-worker
+  name: {{ include "corda.workerName" . }}
+  labels:
+    {{- include "corda.workerLabels" . | nindent 4 }}
 spec:
   type: ClusterIP
-  selector: *id004
+  selector:
+    {{- include "corda.workerSelectorLabels" . | nindent 4 }}
   ports:
-  - name: node-rpc
+  - name: http
     port: 443
-    targetPort: 8888
+    targetPort: http
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "corda.fullname" . }}-rpc
+  name: {{ include "corda.workerName" . }}
   labels:
-    app: {{ include "corda.fullname" . }}-rpc-node
-    family: e2e
-    type: rpc-worker
+    {{- include "corda.workerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.workers.rpc.replicas }}
+  replicas: {{ .Values.workers.rpc.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "corda.fullname" . }}-rpc-node
-      family: e2e
-      type: rpc-worker
+      {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ include "corda.fullname" . }}-rpc-node
-        family: e2e
-        type: rpc-worker
+        {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-      imagePullSecrets:
-      - name: docker-registry-cred
+      {{- include "corda.imagePullSecrets" . | nindent 6 }}
       containers:
-      - name: {{ include "corda.fullname" . }}-rpc
-        image: corda-os-docker.software.r3.com/corda-os-rpc-worker:{{ .Values.imageTag }}
-        imagePullPolicy: Always
+      - name: {{ include "corda.workerName" . }}
+        image: {{ include "corda.workerImage" . }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false
         env:
-        - name: JAVA_TOOL_OPTIONS
-          value: -agentlib:jdwp=transport=dt_socket,server={{ .Values.debug.server }},suspend={{ .Values.debug.suspend }},address=*:5005
+        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
         args:
-        - -mkafka.common.bootstrap.servers={{ .Values.kafka.url }}
+        {{- include "corda.workerKafkaArgs" . | nindent 10 }}
         ports:
-        - name: node-rpc
-          containerPort: 8888
-        - name: worker-debug
-          containerPort: 5005
-        - name: worker-health
-          containerPort: 7000
+          - name: http
+            containerPort: 8888
+        {{- if .Values.workers.rpc.debug.enabled }}
+          - name: debug
+            containerPort: 5005
+        {{- end }}
+          - name: health
+            containerPort: 7000
         livenessProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 1
         startupProbe:
           httpGet:
             path: /isHealthy
-            port: 7000
-            scheme: HTTP
+            port: health
           periodSeconds: 10
           failureThreshold: 5
       nodeSelector:

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -13,49 +13,50 @@ spec:
       labels: *id012
     spec:
       containers:
-      - name: create-topics
-        image: bitnami/kafka:2.8.1-debian-10-r99
-        imagePullPolicy: Always
-        command:
-        - /bin/sh
-        - -c
-        args:
-        - |
-          echo -e 'Creating kafka topics'
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.management.request
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.management.request.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.topic --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic p2p.in
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic p2p.out
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.creation.request
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.creation.request.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.info --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.info --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.upload
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.upload.status
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpk.file --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.management
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.management.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.user --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.group --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.role --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.permission --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic permissions.user.summary --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.status --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event.state --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event.dlq
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event.state --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event.dlq
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.members --config "cleanup.policy=compact"
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.rpc.ops
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.rpc.ops.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.ops.rpc
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.ops.rpc.resp
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.key.soft
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.key.info
-          echo -e 'Successfully created the following topics:'
-          kafka-topics.sh --bootstrap-server {{ .Values.kafka.url }} --list
+        - name: create-topics
+          image: bitnami/kafka:2.8.1-debian-10-r99
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              echo -e 'Creating kafka topics'
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.management.request
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.management.request.resp
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic config.topic --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic p2p.in
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic p2p.out
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.creation.request
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.creation.request.resp
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic virtual.node.info --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.info --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.upload
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpi.upload.status
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic cpk.file --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.management
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.management.resp
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.user --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.group --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.role --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic rpc.permissions.permission --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic permissions.user.summary --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.status --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event.state --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.event.dlq
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event.state --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic flow.mapper.event.dlq
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.members --config "cleanup.policy=compact"
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.rpc.ops
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic membership.rpc.ops.resp
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.ops.rpc
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.ops.rpc.resp
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.key.soft
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --partitions {{ .Values.kafka.partitions }} --replication-factor 1 --create --topic crypto.key.info
+              echo -e 'Successfully created the following topics:'
+              kafka-topics.sh --bootstrap-server {{ include "corda.kafkaBootstrapServers" . }} --list
       restartPolicy: OnFailure
   backoffLimit: 10
+

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -2,29 +2,116 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- override chart fullname
 fullnameOverride: ""
-imageTag: "unstable"
 
+# -- override chart name
+nameOverride: ""
+
+# worker image defaults
+image:
+  # -- worker image registry
+  registry: "corda-os-docker.software.r3.com"
+  # -- worker image tag, defaults to Chart appVersion
+  tag: ""
+
+# -- image pull secrets
+imagePullSecrets: []
+
+# -- the image policy
+imagePullPolicy: Always
+
+# Database configuration
 db:
+  # Cluster database configuration
   cluster:
-    url: postgresql://prereqs-postgresql:5432/cordacluster
+    # -- the cluster database host (required)
+    host: ""
+    # -- the cluster database port
+    port: 5432
+    # -- the cluster database user
     user: user
-    secret: 4LNuCvt+NhGIBwL7gRRhvAZh3k6JRN9NHv0aG3pi1xM=
+    # -- the name of the cluster database
+    database: cordacluster
+    # -- the cluster database password (ignored if existingSecret is set, otherwise required)
+    password: ""
+    # -- the name of an existing secret containing the cluster database password with a key of 'password'
+    existingSecret: ""
 
-debug:
-  suspend: "n"
-  server: "y"
-
+# Kafka configuration
 kafka:
-  url: prereqs-kafka:9092
+  # -- comma-separated list of Kafka bootstrap servers (required)
+  bootstrapServers: ""
+  # -- Kafka topic partitions
   partitions: 3
 
+# worker configuration
 workers:
+
+  # crypto worker configuration
   crypto:
-    replicas: 1
+    # crypto worker image configuration
+    image:
+      # -- crypto worker image repository
+      repository: "corda-os-crypto-worker"
+      # -- crypto worker image tag, defaults to image.tag
+      tag: ""
+    # -- crypto worker replica count
+    replicaCount: 1
+    # crypto worker debug configuration
+    debug:
+      # -- run crypto worker with debug enabled
+      enabled: false
+      # -- if debug is enabled, suspend the crypto worker until the debugger is attached
+      suspend: false
+
+  # DB worker configuration
   db:
-    replicas: 1
+    # DB worker image configuration
+    image:
+      # -- DB worker image repository
+      repository: "corda-os-db-worker"
+      # -- DB worker image tag, defaults to image.tag
+      tag: ""
+    # -- DB worker replica count
+    replicaCount: 1
+    # DB worker debug configuration
+    debug:
+      # -- run DB worker with debug enabled
+      enabled: false
+      # -- if debug is enabled, suspend the DB worker until the debugger is attached
+      suspend: false
+
+  # flow worker configuration
   flow:
-    replicas: 1
+    # flow worker image configuration
+    image:
+      # -- flow worker image repository
+      repository: "corda-os-flow-worker"
+      # -- flow worker image tag, defaults to image.tag
+      tag: ""
+    # -- flow worker replica count
+    replicaCount: 1
+    # flow worker debug configuration
+    debug:
+      # -- run flow worker with debug enabled
+      enabled: false
+      # -- if debug is enabled, suspend the flow worker until the debugger is attached
+      suspend: false
+
+  # RPC worker configuration
   rpc:
-    replicas: 1
+    # RPC worker image configuration
+    image:
+      # -- RPC worker image repository
+      repository: "corda-os-rpc-worker"
+      # -- RPC worker image tag, defaults to image.tag
+      tag: ""
+    # -- RPC worker replica count
+    replicaCount: 1
+    # RPC worker debug configuration
+    debug:
+      # -- run RPC worker with debug enabled
+      enabled: false
+      # -- if debug is enabled, suspend the RPC worker until the debugger is attached
+      suspend: false


### PR DESCRIPTION
Summary of changes as follows:

- The chart no longer assumes that you are using the `prereqs` chart by default. As a consequence, the chart is not usable with no overrides. At a minimum, you need to provide `kafka.bootstrapServers`, `db.cluster.host`, and `db.cluster.password` or `db.cluster.existingSecret`. If using `existingSecret` for the DB password, it expects to find the password against a key of `password`. This matches the output of the PostgreSQL chart. It also doesn't assume an image pull secret called `docker-registry-cred`. An example override file to work with the prereqs chart can be found in .ci/e2eTests/corda.yaml.
- The image tag now defaults to use the `appVersion` from the chart. It is still possible to override this using `imageTag` and can also be overridden on a per-worker basis.
- The debug port is not enabled by default. This can be enabled on a per-worker basis e.g. `workers.db.debug.enabled=true`
- The salt and passphrase used by the DB worker are generated at install time and can be found in the secret with the `-db-worker` suffix if needed.