### PR TITLE
NOTICK: Remove unused flask Gradle plugin.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation "biz.aQute.bnd:biz.aQute.bndlib:$bndVersion"
 
     implementation "net.corda.plugins:quasar-utils:$cordaGradlePluginsVersion"
-    implementation "net.corda.plugins:flask:$cordaGradlePluginsVersion"
     implementation "com.google.cloud.tools:jib-core:$jibCoreVersion"
 }
 


### PR DESCRIPTION
We no longer use the `flask` plugin, so remove it from our convention plugins' classpath.