### PR TITLE
NOTICK: Explicitly set a `host` in case of SSL connection.

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
@@ -379,6 +379,7 @@ internal class HttpRpcServerInternal(
             val ssl = SslConnectionFactory(sslContextFactory, http11.protocol)
             addConnector(ServerConnector(this, ssl, http11).apply {
                 port = configurationsProvider.getHostAndPort().port
+                host = configurationsProvider.getHostAndPort().host
             })
         }
 


### PR DESCRIPTION
Similar to how this is done in case of insecure connection.

Verified by passing E2E tests.