### PR TITLE
CORE-4461 ensure tasks are cacheable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -302,6 +302,17 @@ subprojects {
             downloadSources = true
         }
     }
+    
+    // we do this to allow for Gradle task caching. OSGI attribute Bnd-LastModified breaks gradle caching as it is a timestamp
+    // below block tells Gradle to ignore specifically the Bnd-LastModified attribute of the manifest when checking if
+    // a task is up-to-date, this has no impact on publishing or production of jar
+    normalization {
+        runtimeClasspath {
+            metaInf {
+                ignoreAttribute("Bnd-LastModified")
+            }
+        }
+    }   
 
     detekt {
         baseline = file("$projectDir/detekt-baseline.xml")


### PR DESCRIPTION
- normalize Bnd-LastModified we tell Gradle to ignore this for up-to-date checks as the timestamp here breaks caching
