### PR TITLE
Update db-worker-secret.yaml

### DIFF
--- a/charts/corda/templates/db-worker-secret.yaml
+++ b/charts/corda/templates/db-worker-secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 {{- $name := printf "%s-db-worker" (include "corda.fullname" .) }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
 metadata:
+  annotations:
+    "helm.sh/resource-policy": keep
   name: {{ $name }}
   labels:
     {{- include "corda.labels" . | nindent 4 }}


### PR DESCRIPTION
Corda-db-worker pod would fail to ready up, after uninstalling the Corda helm chart then installing it again. An annotation was crated for the db-worker-secret in order to keep this resource when uninstalling the Corda helm chart. Reference to the ticket can be found here https://r3-cev.atlassian.net/browse/CORE-4460 