### PR TITLE
Changes (DB Audit Tables) for CORE-4141.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XX-SNAPSHOT
-cordaApiVersion=5.0.0.74-beta+
+cordaApiVersion=5.0.0.75-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.20

--- a/libs/configuration/configuration-datamodel/build.gradle
+++ b/libs/configuration/configuration-datamodel/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
+
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }
 
 tasks.named('jar', Jar) {

--- a/libs/configuration/configuration-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/ConfigEntityManagerIntegrationTest.kt
+++ b/libs/configuration/configuration-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/ConfigEntityManagerIntegrationTest.kt
@@ -6,16 +6,18 @@ import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
+import net.corda.libs.configuration.datamodel.DbConnectionAudit
+import net.corda.libs.configuration.datamodel.DbConnectionConfig
 import net.corda.libs.configuration.datamodel.ConfigAuditEntity
 import net.corda.libs.configuration.datamodel.ConfigEntity
 import net.corda.libs.configuration.datamodel.ConfigurationEntities
-import net.corda.libs.configuration.datamodel.DbConnectionConfig
 import net.corda.libs.configuration.datamodel.findDbConnectionByNameAndPrivilege
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -105,6 +107,7 @@ class ConfigEntityManagerIntegrationTest {
 hello=world
             """.trimIndent()
         )
+        val dbConnectionAudit = DbConnectionAudit(dbConnection)
 
         entityManagerFactory.createEntityManager().transaction { em ->
             em.persist(dbConnection)
@@ -114,5 +117,7 @@ hello=world
             dbConnection,
             entityManagerFactory.createEntityManager().findDbConnectionByNameAndPrivilege("batman", DbPrivilege.DDL)
         )
+
+        verify(entityManagerFactory.createEntityManager()).persist(dbConnectionAudit)
     }
 }

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigAuditEntity.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigAuditEntity.kt
@@ -1,7 +1,6 @@
 package net.corda.libs.configuration.datamodel
 
-import net.corda.db.schema.DbSchema.CONFIG
-import net.corda.db.schema.DbSchema.CONFIG_AUDIT_DB_TABLE
+import net.corda.db.schema.DbSchema
 import net.corda.db.schema.DbSchema.CONFIG_AUDIT_ID_SEQUENCE
 import net.corda.db.schema.DbSchema.CONFIG_AUDIT_ID_SEQUENCE_ALLOC_SIZE
 import net.corda.libs.configuration.datamodel.internal.CONFIG_AUDIT_GENERATOR
@@ -25,7 +24,7 @@ import javax.persistence.Table
  * @param updateActor The ID of the user that last updated this section of the configuration.
  */
 @Entity
-@Table(name = CONFIG_AUDIT_DB_TABLE, schema = CONFIG)
+@Table(name = DbSchema.CONFIG_AUDIT_TABLE, schema = DbSchema.CONFIG)
 data class ConfigAuditEntity(
     @Id
     @SequenceGenerator(
@@ -36,6 +35,7 @@ data class ConfigAuditEntity(
     @GeneratedValue(strategy = SEQUENCE, generator = CONFIG_AUDIT_GENERATOR)
     @Column(name = "change_number", nullable = false)
     val changeNumber: Int,
+
     @Column(name = "section", nullable = false)
     val section: String,
     @Column(name = "config", nullable = false)

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigEntity.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigEntity.kt
@@ -1,7 +1,7 @@
 package net.corda.libs.configuration.datamodel
 
 import net.corda.db.schema.DbSchema.CONFIG
-import net.corda.db.schema.DbSchema.CONFIG_DB_TABLE
+import net.corda.db.schema.DbSchema.CONFIG_TABLE
 import java.time.Instant
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -21,7 +21,7 @@ import javax.persistence.Version
  * @property version The version number used for optimistic locking.
  */
 @Entity
-@Table(name = CONFIG_DB_TABLE, schema = CONFIG)
+@Table(name = CONFIG_TABLE, schema = CONFIG)
 data class ConfigEntity(
     @Id
     @Column(name = "section", nullable = false)

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigurationEntities.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigurationEntities.kt
@@ -4,6 +4,7 @@ object ConfigurationEntities {
     val classes = setOf(
         ConfigAuditEntity::class.java,
         ConfigEntity::class.java,
+        DbConnectionAudit::class.java,
         DbConnectionConfig::class.java,
     )
 }

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionAudit.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionAudit.kt
@@ -1,0 +1,69 @@
+package net.corda.libs.configuration.datamodel
+
+import net.corda.db.core.DbPrivilege
+import net.corda.db.schema.DbSchema
+import net.corda.libs.configuration.datamodel.internal.DB_CONNECTION_AUDIT_GENERATOR
+import java.time.Instant
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Enumerated
+import javax.persistence.EnumType
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType.SEQUENCE
+import javax.persistence.Id
+import javax.persistence.SequenceGenerator
+import javax.persistence.Table
+
+/**
+ * Db Connection Audit data class
+ *
+ * @property changeNumber The sequence number of the audit event.
+ * @property id
+ * @property name
+ * @property privilege DB privilege associated with the connection details (DDL/DML)
+ * @property updateTimestamp
+ * @property updateActor
+ * @property description (optional)
+ * @property config DB configuration section that can be parsed as SmartConfig.
+ */
+@Entity
+@Table(name = DbSchema.DB_CONNECTION_AUDIT_TABLE, schema = DbSchema.CONFIG)
+data class DbConnectionAudit (
+    @Id
+    @SequenceGenerator(
+        name = DB_CONNECTION_AUDIT_GENERATOR,
+        sequenceName = DbSchema.DB_CONNECTION_AUDIT_ID_SEQUENCE,
+        allocationSize = DbSchema.DB_CONNECTION_AUDIT_ID_SEQUENCE_ALLOC_SIZE
+    )
+    @GeneratedValue(strategy = SEQUENCE, generator = DB_CONNECTION_AUDIT_GENERATOR)
+    @Column(name = "change_number", nullable = false)
+    val changeNumber: Int,
+
+    @Column(name = "connection_id", nullable = false)
+    val id: UUID,
+    @Column(name = "connection_name", nullable = false)
+    val name: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "privilege", nullable = false)
+    val privilege: DbPrivilege,
+    @Column(name = "update_ts", nullable = false)
+    var updateTimestamp: Instant,
+    @Column(name = "update_actor", nullable = false)
+    var updateActor: String,
+    @Column(name = "description")
+    var description: String?,
+    @Column(name = "config", nullable = false)
+    var config: String,
+) {
+    constructor(dbEntity: DbConnectionConfig) : this(
+        0,
+        dbEntity.id,
+        dbEntity.name,
+        dbEntity.privilege,
+        dbEntity.updateTimestamp,
+        dbEntity.updateActor,
+        dbEntity.description,
+        dbEntity.config
+    )
+}

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionConfig.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionConfig.kt
@@ -19,19 +19,20 @@ internal const val QUERY_PARAM_NAME = "name"
 internal const val QUERY_PARAM_PRIVILEGE = "privilege"
 
 /**
- * Db connection config data class
+ * Db Connection Config data class
  *
  * @property id
+ * @property name
+ * @property privilege DB privilege associated with the connection details (DDL/DML)
  * @property updateTimestamp
  * @property updateActor
- * @property privilege DB privilege associated with the connection details (DDL/DML)
  * @property description (optional)
  * @property config DB configuration section that can be parsed as SmartConfig.
  *
  * @property version The version number used for optimistic locking.
  */
 @Entity
-@Table(name = DbSchema.CONFIG_DB_CONNECTION_TABLE, schema = DbSchema.CONFIG)
+@Table(name = DbSchema.DB_CONNECTION_TABLE, schema = DbSchema.CONFIG)
 @NamedQuery(
     name = QUERY_FIND_BY_NAME_AND_PRIVILEGE,
     query = "SELECT c FROM DbConnectionConfig c WHERE c.name=:$QUERY_PARAM_NAME AND c.privilege=:$QUERY_PARAM_PRIVILEGE")

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/internal/Constants.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/internal/Constants.kt
@@ -1,3 +1,4 @@
 package net.corda.libs.configuration.datamodel.internal
 
 internal const val CONFIG_AUDIT_GENERATOR = "config_audit_generator"
+internal const val DB_CONNECTION_AUDIT_GENERATOR = "db_connection_audit_generator"


### PR DESCRIPTION
Updates to corda-runtime-os for changes to DB Audit Tables.
(This PR replaces 299 which will be closed & deleted).