### PR TITLE
CORE-4152 Add configuration to flow event pipeline

### DIFF
--- a/applications/examples/sandbox-app/build.gradle
+++ b/applications/examples/sandbox-app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-config-schema"
     implementation 'net.corda:corda-topic-schema'
     implementation 'net.corda:corda-serialization'
     implementation 'net.corda:corda-packaging'
@@ -33,6 +34,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
 
     implementation project(':testing:sandboxes')
+    implementation project(":libs:configuration:configuration-core")
     implementation project(':libs:messaging:messaging')
     implementation project(':libs:virtual-node:sandbox-group-context')
     implementation project(':components:flow:flow-service')

--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
@@ -3,6 +3,8 @@ package net.corda.example.vnode
 
 import co.paralleluniverse.fibers.instrument.Retransform
 import com.sun.management.HotSpotDiagnosticMXBean
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
 import net.corda.data.flow.FlowInitiatorType
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
@@ -11,10 +13,12 @@ import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.StartFlow
 import net.corda.data.virtualnode.VirtualNodeInfo
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
+import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.messaging.api.records.Record
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.schema.Schemas.Flow.Companion.FLOW_EVENT_TOPIC
+import net.corda.schema.configuration.FlowConfig
 import net.corda.securitymanager.SecurityManagerService
 import net.corda.v5.base.util.loggerFor
 import net.corda.virtualnode.HoldingIdentity
@@ -77,6 +81,12 @@ class CordaVNode @Activate constructor(
 
         private const val TIMEOUT_MILLIS = 1000L
         private const val WAIT_MILLIS = 100L
+
+        private val config = ConfigFactory.empty()
+            .withValue(FlowConfig.SESSION_MESSAGE_RESEND_WINDOW, ConfigValueFactory.fromAnyRef(500000L))
+            .withValue(FlowConfig.SESSION_HEARTBEAT_TIMEOUT_WINDOW, ConfigValueFactory.fromAnyRef(500000L))
+        private val configFactory = SmartConfigFactory.create(config)
+        private val smartConfig = configFactory.create(config)
     }
 
     private val logger = loggerFor<CordaVNode>()
@@ -150,7 +160,7 @@ class CordaVNode @Activate constructor(
                 val rpcStartFlow = createRPCStartFlow(clientId, vnodeInfo.toAvro())
                 val flowKey = FlowKey(generateRandomId(), holdingIdentity.toAvro())
                 val record = Record(FLOW_EVENT_TOPIC, flowKey, FlowEvent(flowKey, rpcStartFlow))
-                flowEventProcessorFactory.create().apply {
+                flowEventProcessorFactory.create(smartConfig).apply {
                     val result = onNext(null, record)
                     result.responseEvents.singleOrNull { evt ->
                         evt.topic == FLOW_EVENT_TOPIC

--- a/applications/tools/flow-worker-setup/config.conf
+++ b/applications/tools/flow-worker-setup/config.conf
@@ -16,6 +16,10 @@ corda {
         }
     }
     flow {
+        session {
+            messageResendWindow = 100000
+            heartbeatTimeout = 100000
+        }
     }
 }
 

--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
@@ -42,7 +42,7 @@ class StartFlow(private val context: TaskContext) : Task {
             FlowInitiatorType.RPC,
             clientId,
             identity,
-            "helloworld",
+            "flow-worker-dev",
             identity,
             flowName,
             Instant.now()

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
@@ -6,7 +6,7 @@ import net.corda.flow.mapper.factory.FlowMapperEventExecutorFactory
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.util.trace
+import net.corda.v5.base.util.debug
 
 class FlowMapperMessageProcessor(
     private val flowMapperEventExecutorFactory: FlowMapperEventExecutorFactory
@@ -21,7 +21,7 @@ class FlowMapperMessageProcessor(
         event: Record<String, FlowMapperEvent>
     ): StateAndEventProcessor.Response<FlowMapperState> {
         val key = event.key
-        logger.trace { "Received event: key: $key event: $event "}
+        logger.debug { "Received event: key: $key event: $event " }
         val value = event.value ?: return StateAndEventProcessor.Response(state, emptyList())
         val executor = flowMapperEventExecutorFactory.create(key, value, state)
         val result = executor.execute()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/FlowEventContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/FlowEventContext.kt
@@ -2,6 +2,7 @@ package net.corda.flow.pipeline
 
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.Checkpoint
+import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.records.Record
 
 /**
@@ -14,6 +15,7 @@ import net.corda.messaging.api.records.Record
  * @param checkpoint The [Checkpoint] of a flow that should be modified by the pipeline.
  * @param inputEvent The received [FlowEvent].
  * @param inputEventPayload The received [FlowEvent.payload].
+ * @param config The current flow config used by the pipeline when processing the current input event.
  * @param outputRecords The [Record]s that should be sent back to the message bus when the pipeline completes.
  * @param T The type of [FlowEvent.payload].
  */
@@ -21,6 +23,7 @@ data class FlowEventContext<T>(
     val checkpoint: Checkpoint?,
     val inputEvent: FlowEvent,
     val inputEventPayload: T,
+    val config: SmartConfig,
     val outputRecords: List<Record<*, *>>,
 )
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactory.kt
@@ -3,6 +3,7 @@ package net.corda.flow.pipeline.factory
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.Checkpoint
 import net.corda.flow.pipeline.FlowEventPipeline
+import net.corda.libs.configuration.SmartConfig
 
 /**
  * [FlowEventPipelineFactory] creates [FlowEventPipeline]s as part of flow event processing.
@@ -17,5 +18,5 @@ interface FlowEventPipelineFactory {
      *
      * @return A new [FlowEventPipeline] instance.
      */
-    fun create(checkpoint: Checkpoint?, event: FlowEvent): FlowEventPipeline
+    fun create(checkpoint: Checkpoint?, event: FlowEvent, config: SmartConfig): FlowEventPipeline
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowEventProcessorFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowEventProcessorFactory.kt
@@ -1,8 +1,22 @@
 package net.corda.flow.pipeline.factory
 
 import net.corda.flow.pipeline.FlowEventProcessor
+import net.corda.libs.configuration.SmartConfig
+import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 
+/**
+ * [FlowEventProcessorFactory] creates instances of [FlowEventProcessor].
+ */
 interface FlowEventProcessorFactory {
-    fun create(): FlowEventProcessor
+
+    /**
+     * Creates a [FlowEventProcessor] instance.
+     *
+     * @param config The configuration used within the flow event pipeline. The configuration block under the [FLOW_CONFIG] key should be
+     * used.
+     *
+     * @return A [FlowEventProcessor] instance.
+     */
+    fun create(config: SmartConfig): FlowEventProcessor
 }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventPipelineFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventPipelineFactoryImpl.kt
@@ -13,6 +13,7 @@ import net.corda.flow.pipeline.handlers.events.FlowEventHandler
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
 import net.corda.flow.pipeline.handlers.waiting.FlowWaitingForHandler
 import net.corda.flow.pipeline.runner.FlowRunner
+import net.corda.libs.configuration.SmartConfig
 import net.corda.v5.base.util.uncheckedCast
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -62,11 +63,12 @@ class FlowEventPipelineFactoryImpl(
         flowGlobalPostProcessor: FlowGlobalPostProcessor
     ) : this(flowRunner, flowGlobalPostProcessor, mutableListOf(), mutableListOf(), mutableListOf())
 
-    override fun create(checkpoint: Checkpoint?, event: FlowEvent): FlowEventPipeline {
+    override fun create(checkpoint: Checkpoint?, event: FlowEvent, config: SmartConfig): FlowEventPipeline {
         val context = FlowEventContext<Any>(
             checkpoint = checkpoint,
             inputEvent = event,
             inputEventPayload = event.payload,
+            config = config,
             outputRecords = emptyList()
         )
         return FlowEventPipelineImpl(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventProcessorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventProcessorFactoryImpl.kt
@@ -4,6 +4,7 @@ import net.corda.flow.pipeline.FlowEventProcessor
 import net.corda.flow.pipeline.impl.FlowEventProcessorImpl
 import net.corda.flow.pipeline.factory.FlowEventPipelineFactory
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
+import net.corda.libs.configuration.SmartConfig
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -15,8 +16,8 @@ class FlowEventProcessorFactoryImpl @Activate constructor(
     private val flowEventPipelineFactory: FlowEventPipelineFactory
 ) : FlowEventProcessorFactory {
 
-    override fun create(): FlowEventProcessor {
-        return FlowEventProcessorImpl(flowEventPipelineFactory)
+    override fun create(config: SmartConfig): FlowEventProcessor {
+        return FlowEventProcessorImpl(flowEventPipelineFactory, config)
     }
 }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandler.kt
@@ -44,7 +44,7 @@ class InitiateFlowRequestHandler @Activate constructor(
             .setFlowKey(checkpoint.flowKey)
             .setCpiId(checkpoint.flowStartContext.cpiId)
             // TODO Need member lookup service to get the holding identity of the peer
-            .setInitiatedIdentity(HoldingIdentity(request.x500Name.toString(), "helloworld"))
+            .setInitiatedIdentity(HoldingIdentity(request.x500Name.toString(), "flow-worker-dev"))
             .setInitiatingIdentity(checkpoint.flowKey.identity)
             .setPayload(ByteBuffer.wrap(byteArrayOf()))
             .build()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
@@ -7,11 +7,15 @@ import net.corda.flow.pipeline.FlowEventProcessor
 import net.corda.flow.pipeline.FlowHospitalException
 import net.corda.flow.pipeline.FlowProcessingException
 import net.corda.flow.pipeline.factory.FlowEventPipelineFactory
+import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.v5.base.util.contextLogger
 
-class FlowEventProcessorImpl(private val flowEventPipelineFactory: FlowEventPipelineFactory) : FlowEventProcessor {
+class FlowEventProcessorImpl(
+    private val flowEventPipelineFactory: FlowEventPipelineFactory,
+    private val config: SmartConfig
+) : FlowEventProcessor {
 
     private companion object {
         val log = contextLogger()
@@ -25,7 +29,7 @@ class FlowEventProcessorImpl(private val flowEventPipelineFactory: FlowEventPipe
         val flowEvent = event.value ?: throw FlowHospitalException("FlowEvent was null")
         log.info("Flow [${event.key}] Received event: ${flowEvent.payload::class.java} / ${flowEvent.payload}")
         return try {
-            flowEventPipelineFactory.create(state, flowEvent)
+            flowEventPipelineFactory.create(state, flowEvent, config)
                 .eventPreProcessing()
                 .runOrContinue()
                 .setCheckpointSuspendedOn()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutor.kt
@@ -1,10 +1,13 @@
 package net.corda.flow.service
 
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.Checkpoint
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.schema.messaging.INSTANCE_ID
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -12,17 +15,19 @@ import net.corda.lifecycle.LifecycleEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.messaging.api.config.toMessagingConfig
 import net.corda.messaging.api.subscription.StateAndEventSubscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.Flow.Companion.FLOW_EVENT_TOPIC
+import net.corda.schema.configuration.FlowConfig
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 
 @Suppress("LongParameterList")
 class FlowExecutor(
     coordinatorFactory: LifecycleCoordinatorFactory,
-    private val config: SmartConfig,
+    private val config: Map<String, SmartConfig>,
     private val subscriptionFactory: SubscriptionFactory,
     private val flowEventProcessorFactory: FlowEventProcessorFactory
 ) : Lifecycle {
@@ -30,6 +35,12 @@ class FlowExecutor(
     companion object {
         private val logger = contextLogger()
         private const val CONSUMER_GROUP = "FlowEventConsumer"
+
+        private val tempFlowConfig = ConfigFactory.empty()
+            .withValue(FlowConfig.SESSION_MESSAGE_RESEND_WINDOW, ConfigValueFactory.fromAnyRef(500000L))
+            .withValue(FlowConfig.SESSION_HEARTBEAT_TIMEOUT_WINDOW, ConfigValueFactory.fromAnyRef(500000L))
+        private val configFactory = SmartConfigFactory.create(tempFlowConfig)
+        private val tempFlowSmartConfig = configFactory.create(tempFlowConfig)
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<FlowExecutor> { event, _ -> eventHandler(event) }
@@ -40,11 +51,14 @@ class FlowExecutor(
         when (event) {
             is StartEvent -> {
                 logger.debug { "Starting the flow executor" }
-                val instanceId = config.getInt(INSTANCE_ID)
+                val messagingConfig = config.toMessagingConfig()
+                val instanceId = messagingConfig.getInt(INSTANCE_ID)
                 messagingSubscription = subscriptionFactory.createStateAndEventSubscription(
                     SubscriptionConfig(CONSUMER_GROUP, FLOW_EVENT_TOPIC, instanceId),
-                    flowEventProcessorFactory.create(),
-                    config
+                    // TODO Needs to be reviewed as part of CORE-3780, using temporary config for FLOW_CONFIG until then
+                    // flowEventProcessorFactory.create(config[FLOW_CONFIG] ?: throw CordaMessageAPIConfigException(FLOW_CONFIG)),
+                    flowEventProcessorFactory.create(tempFlowSmartConfig),
+                    messagingConfig
                 )
                 messagingSubscription?.start()
             }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
@@ -15,7 +15,6 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.messaging.api.config.toMessagingConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
@@ -84,10 +83,9 @@ class FlowService @Activate constructor(
             }
             is ConfigChangedEvent -> {
                 executor?.stop()
-                val messagingConfig = event.config.toMessagingConfig()
                 val newExecutor = FlowExecutor(
                     coordinatorFactory,
-                    messagingConfig,
+                    event.config,
                     subscriptionFactory,
                     flowEventProcessorFactory
                 )

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/acceptance/dsl/FlowEventDSL.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/acceptance/dsl/FlowEventDSL.kt
@@ -1,5 +1,7 @@
 package net.corda.flow.acceptance.dsl
 
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.StartFlow
@@ -7,8 +9,6 @@ import net.corda.data.flow.state.Checkpoint
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.acceptance.getBasicFlowStartContext
 import net.corda.flow.fiber.FlowIORequest
-import net.corda.flow.pipeline.impl.FlowEventProcessorImpl
-import net.corda.flow.pipeline.impl.FlowGlobalPostProcessorImpl
 import net.corda.flow.pipeline.factory.impl.FlowEventPipelineFactoryImpl
 import net.corda.flow.pipeline.handlers.events.SessionEventHandler
 import net.corda.flow.pipeline.handlers.events.StartFlowEventHandler
@@ -31,11 +31,15 @@ import net.corda.flow.pipeline.handlers.waiting.WakeupWaitingForHandler
 import net.corda.flow.pipeline.handlers.waiting.sessions.SessionConfirmationWaitingForHandler
 import net.corda.flow.pipeline.handlers.waiting.sessions.SessionDataWaitingForHandler
 import net.corda.flow.pipeline.handlers.waiting.sessions.SessionInitWaitingForHandler
+import net.corda.flow.pipeline.impl.FlowEventProcessorImpl
+import net.corda.flow.pipeline.impl.FlowGlobalPostProcessorImpl
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
+import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.schema.Schemas
+import net.corda.schema.configuration.FlowConfig
 import net.corda.session.manager.impl.SessionManagerImpl
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -57,7 +61,8 @@ class FlowEventDSL {
                 flowEventHandlers,
                 flowWaitingForHandlers,
                 flowRequestHandlers
-            )
+            ),
+            testSmartConfig
         )
 
     private val inputFlowEvents = mutableListOf<Any>()
@@ -183,3 +188,9 @@ private val flowRequestHandlers = listOf(
     SubFlowFinishedRequestHandler(),
     WaitForSessionConfirmationsRequestHandler()
 )
+
+private val testConfig = ConfigFactory.empty()
+    .withValue(FlowConfig.SESSION_MESSAGE_RESEND_WINDOW, ConfigValueFactory.fromAnyRef(500000L))
+    .withValue(FlowConfig.SESSION_HEARTBEAT_TIMEOUT_WINDOW, ConfigValueFactory.fromAnyRef(500000L))
+private val configFactory = SmartConfigFactory.create(testConfig)
+private val testSmartConfig = configFactory.create(testConfig)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactoryImplTest.kt
@@ -6,15 +6,16 @@ import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowIORequest
-import net.corda.flow.pipeline.FlowEventContext
-import net.corda.flow.pipeline.impl.FlowEventPipelineImpl
 import net.corda.flow.pipeline.FlowGlobalPostProcessor
 import net.corda.flow.pipeline.FlowProcessingException
 import net.corda.flow.pipeline.factory.impl.FlowEventPipelineFactoryImpl
 import net.corda.flow.pipeline.handlers.events.FlowEventHandler
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
 import net.corda.flow.pipeline.handlers.waiting.FlowWaitingForHandler
+import net.corda.flow.pipeline.impl.FlowEventPipelineImpl
 import net.corda.flow.pipeline.runner.FlowRunner
+import net.corda.flow.test.utils.buildFlowEventContext
+import net.corda.libs.configuration.SmartConfig
 import net.corda.v5.base.util.uncheckedCast
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -55,20 +56,16 @@ class FlowEventPipelineFactoryImplTest {
     @Test
     fun `Creates a FlowEventPipeline instance`() {
         val checkpoint = Checkpoint()
+        val config = mock<SmartConfig>()
         val expected = FlowEventPipelineImpl(
             flowEventHandler,
             mapOf(net.corda.data.flow.state.waiting.Wakeup::class.java to flowWaitingForHandler),
             mapOf(FlowIORequest.ForceCheckpoint::class.java to flowRequestHandler),
             flowRunner,
             flowGlobalPostProcessor,
-            FlowEventContext(
-                checkpoint,
-                flowEvent,
-                flowEvent.payload,
-                emptyList()
-            )
+            buildFlowEventContext(checkpoint, flowEvent.payload, config)
         )
-        assertEquals(expected, factory.create(checkpoint, flowEvent))
+        assertEquals(expected, factory.create(checkpoint, flowEvent, config))
     }
 
     @Test
@@ -81,7 +78,7 @@ class FlowEventPipelineFactoryImplTest {
             listOf(flowRequestHandler)
         )
         assertThrows<FlowProcessingException> {
-            factory.create(Checkpoint(), flowEvent)
+            factory.create(Checkpoint(), flowEvent, mock())
         }
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
@@ -2,12 +2,11 @@ package net.corda.flow.pipeline.handlers.events
 
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.identity.HoldingIdentity
-import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -18,12 +17,11 @@ class StartFlowEventHandlerTest {
 
     private val startFlow = StartFlow(FlowStartContext(), "start args")
     private val flowKey = FlowKey("flow id", HoldingIdentity("x500 name", "group id"))
-    private val flowEvent = FlowEvent(flowKey, startFlow)
     private val handler = StartFlowEventHandler()
 
     @Test
     fun `Creates a new checkpoint if one doesn't exist already`() {
-        val inputContext = FlowEventContext(checkpoint = null, flowEvent, startFlow, emptyList())
+        val inputContext = buildFlowEventContext(checkpoint = null, inputEventPayload = startFlow, flowKey = flowKey)
         val outputContext = handler.preProcess(inputContext)
         assertNotNull(outputContext.checkpoint)
         assertEquals(flowKey, outputContext.checkpoint!!.flowKey)
@@ -33,7 +31,7 @@ class StartFlowEventHandlerTest {
 
     @Test
     fun `Throws if a checkpoint already exists`() {
-        val inputContext = FlowEventContext(Checkpoint(), flowEvent, startFlow, emptyList())
+        val inputContext = buildFlowEventContext(Checkpoint(), inputEventPayload = startFlow, flowKey = flowKey)
         assertThrows<FlowProcessingException> {
             handler.preProcess(inputContext)
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandlerTest.kt
@@ -1,12 +1,9 @@
 package net.corda.flow.pipeline.handlers.events
 
-import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.state.Checkpoint
-import net.corda.data.identity.HoldingIdentity
-import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -15,21 +12,17 @@ class WakeupEventHandlerTest {
 
     private val wakeupPayload = Wakeup()
 
-    private val flowKey = FlowKey("flow id", HoldingIdentity("x500 name", "group id"))
-
-    private val flowEvent = FlowEvent(flowKey, wakeupPayload)
-
     private val handler = WakeupEventHandler()
 
     @Test
     fun `Does not modify the context`() {
-        val inputContext = FlowEventContext(Checkpoint(), flowEvent, wakeupPayload, emptyList())
+        val inputContext = buildFlowEventContext(Checkpoint(), wakeupPayload)
         assertEquals(inputContext, handler.preProcess(inputContext))
     }
 
     @Test
     fun `Throws if a checkpoint does not exist`() {
-        val inputContext = FlowEventContext(checkpoint = null, flowEvent, wakeupPayload, emptyList())
+        val inputContext = buildFlowEventContext(checkpoint = null, wakeupPayload)
         assertThrows<FlowProcessingException> {
             handler.preProcess(inputContext)
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/ForceCheckpointRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/ForceCheckpointRequestHandlerTest.kt
@@ -7,8 +7,8 @@ import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.StateMachineState
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowIORequest
-import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Flow.Companion.FLOW_EVENT_TOPIC
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -20,8 +20,6 @@ class ForceCheckpointRequestHandlerTest {
 
     private val flowKey = FlowKey("flow id", HoldingIdentity("x500 name", "group id"))
 
-    private val flowEvent = FlowEvent()
-
     private val handler = ForceCheckpointRequestHandler()
 
     @Test
@@ -30,7 +28,7 @@ class ForceCheckpointRequestHandlerTest {
             flowState = StateMachineState()
             flowKey = this@ForceCheckpointRequestHandlerTest.flowKey
         }
-        val inputContext = FlowEventContext<Any>(checkpoint, flowEvent, "doesn't matter", emptyList())
+        val inputContext = buildFlowEventContext<Any>(checkpoint, "doesn't matter")
         val waitingFor = handler.getUpdatedWaitingFor(inputContext, FlowIORequest.ForceCheckpoint)
         assertTrue(waitingFor.value is net.corda.data.flow.state.waiting.Wakeup)
     }
@@ -41,7 +39,7 @@ class ForceCheckpointRequestHandlerTest {
             flowState = StateMachineState()
             flowKey = this@ForceCheckpointRequestHandlerTest.flowKey
         }
-        val inputContext = FlowEventContext<Any>(checkpoint, flowEvent, "doesn't matter", emptyList())
+        val inputContext = buildFlowEventContext<Any>(checkpoint, "doesn't matter")
         val outputContext = handler.postProcess(inputContext, FlowIORequest.ForceCheckpoint)
         assertEquals(
             listOf(Record(FLOW_EVENT_TOPIC, flowKey, FlowEvent(flowKey, Wakeup()))),
@@ -51,7 +49,7 @@ class ForceCheckpointRequestHandlerTest {
 
     @Test
     fun `Throws if there is no checkpoint`() {
-        val inputContext = FlowEventContext<Any>(checkpoint = null, flowEvent, "doesn't matter", emptyList())
+        val inputContext = buildFlowEventContext<Any>(checkpoint = null, "doesn't matter")
         assertThrows<FlowProcessingException> {
             handler.postProcess(inputContext, FlowIORequest.ForceCheckpoint)
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CloseSessionsRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CloseSessionsRequestHandlerTest.kt
@@ -1,7 +1,6 @@
 package net.corda.flow.pipeline.handlers.requests.sessions
 
 import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionClose
 import net.corda.data.flow.state.Checkpoint
@@ -14,6 +13,7 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.session.manager.SessionManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -62,12 +62,7 @@ class CloseSessionsRequestHandlerTest {
 
     @Test
     fun `Returns an updated WaitingFor of SessionConfirmation (Close)`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = Checkpoint(),
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = Checkpoint(), inputEventPayload = Unit)
         val sessions = setOf(SESSION_ID, ANOTHER_SESSION_ID)
         val result = closeSessionsRequestHandler.getUpdatedWaitingFor(
             inputContext,
@@ -101,12 +96,9 @@ class CloseSessionsRequestHandlerTest {
             fiber = checkpoint.fiber
             sessions = checkpoint.sessions
         }
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = checkpointCopy,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = checkpointCopy, inputEventPayload = Unit)
+
         val outputContext = closeSessionsRequestHandler.postProcess(
             inputContext,
             FlowIORequest.CloseSessions(setOf(SESSION_ID, ANOTHER_SESSION_ID))
@@ -125,12 +117,7 @@ class CloseSessionsRequestHandlerTest {
 
     @Test
     fun `Throws an exception if there is no checkpoint`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = null,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = null, inputEventPayload = Unit)
         assertThrows<FlowProcessingException> {
             closeSessionsRequestHandler.postProcess(inputContext, FlowIORequest.CloseSessions(setOf(SESSION_ID, ANOTHER_SESSION_ID)))
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandlerTest.kt
@@ -3,7 +3,6 @@ package net.corda.flow.pipeline.handlers.requests.sessions
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStackItem
 import net.corda.data.flow.FlowStartContext
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionInit
 import net.corda.data.flow.state.Checkpoint
@@ -16,6 +15,7 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.session.manager.SessionManager
 import net.corda.v5.base.types.MemberX500Name
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -66,12 +66,8 @@ class InitiateFlowRequestHandlerTest {
 
     @Test
     fun `Returns an updated WaitingFor of SessionConfirmation (Initiate)`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = Checkpoint(),
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = Checkpoint(), inputEventPayload = Unit)
+
         val result = closeSessionsRequestHandler.getUpdatedWaitingFor(
             inputContext,
             FlowIORequest.InitiateFlow(X500_NAME, SESSION_ID)
@@ -102,12 +98,9 @@ class InitiateFlowRequestHandlerTest {
             fiber = ByteBuffer.wrap(byteArrayOf(1, 1, 1, 1))
             sessions = emptyList()
         }
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = checkpoint,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = checkpoint, inputEventPayload = Unit)
+
         val outputContext = closeSessionsRequestHandler.postProcess(
             inputContext,
             FlowIORequest.InitiateFlow(X500_NAME, SESSION_ID)
@@ -119,13 +112,7 @@ class InitiateFlowRequestHandlerTest {
 
     @Test
     fun `Throws an exception if the flow has no checkpoint`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = null,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
-
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = null, inputEventPayload = Unit)
         assertThrows<FlowProcessingException> {
             closeSessionsRequestHandler.postProcess(
                 inputContext,

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
@@ -1,12 +1,10 @@
 package net.corda.flow.pipeline.handlers.requests.sessions
 
-import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.waiting.SessionData
-import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.FlowEventContext
+import net.corda.flow.test.utils.buildFlowEventContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -17,12 +15,7 @@ class ReceiveRequestHandlerTest {
         const val ANOTHER_SESSION_ID = "another session id"
     }
 
-    private val inputContext: FlowEventContext<Any> = FlowEventContext(
-        checkpoint = Checkpoint(),
-        inputEvent = FlowEvent(FlowKey("flow key", HoldingIdentity("x500 name", "group id")), Unit),
-        inputEventPayload = Unit,
-        outputRecords = emptyList()
-    )
+    private val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = Checkpoint(), inputEventPayload = Unit)
 
     private val receiveRequestHandler = ReceiveRequestHandler()
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
@@ -1,7 +1,6 @@
 package net.corda.flow.pipeline.handlers.requests.sessions
 
 import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.session.SessionProcessState
@@ -12,6 +11,7 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.session.manager.SessionManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -58,12 +58,7 @@ class SendAndReceiveRequestHandlerTest {
 
     @Test
     fun `Returns an updated WaitingFor of SessionData`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = Checkpoint(),
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = Checkpoint(), inputEventPayload = Unit)
         val result = sendAndReceiveRequestHandler.getUpdatedWaitingFor(
             inputContext,
             FlowIORequest.SendAndReceive(mapOf(SESSION_ID to PAYLOAD, ANOTHER_SESSION_ID to PAYLOAD))
@@ -98,12 +93,7 @@ class SendAndReceiveRequestHandlerTest {
             sessions = checkpoint.sessions
         }
 
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = checkpointCopy,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = checkpointCopy, inputEventPayload = Unit)
 
         val outputContext = sendAndReceiveRequestHandler.postProcess(
             inputContext,
@@ -124,12 +114,7 @@ class SendAndReceiveRequestHandlerTest {
 
     @Test
     fun `Throws an exception if there is no checkpoint`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = null,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext = buildFlowEventContext<Any>(checkpoint = null, inputEventPayload = Unit)
         assertThrows<FlowProcessingException> {
             sendAndReceiveRequestHandler.postProcess(
                 inputContext,

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
@@ -13,6 +13,7 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.session.manager.SessionManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -59,12 +60,7 @@ class SendRequestHandlerTest {
 
     @Test
     fun `Returns an updated WaitingFor of SessionData`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = Checkpoint(),
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = Checkpoint(), inputEventPayload = Unit)
         val result = sendRequestHandler.getUpdatedWaitingFor(
             inputContext,
             FlowIORequest.Send(mapOf(SESSION_ID to PAYLOAD, ANOTHER_SESSION_ID to PAYLOAD))
@@ -99,12 +95,7 @@ class SendRequestHandlerTest {
             sessions = checkpoint.sessions
         }
 
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = checkpointCopy,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = checkpointCopy, inputEventPayload = Unit)
 
         val outputContext = sendRequestHandler.postProcess(
             inputContext,
@@ -145,12 +136,7 @@ class SendRequestHandlerTest {
             sessions = listOf(sessionState, anotherSessionState)
         }
 
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = checkpoint,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(checkpoint = checkpoint, inputEventPayload = Unit)
 
         val outputContext = sendRequestHandler.postProcess(
             inputContext,
@@ -163,12 +149,7 @@ class SendRequestHandlerTest {
 
     @Test
     fun `Throws an exception if there is no checkpoint`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = null,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext = buildFlowEventContext<Any>(checkpoint = null, inputEventPayload = Unit)
         assertThrows<FlowProcessingException> {
             sendRequestHandler.postProcess(inputContext, FlowIORequest.Send(mapOf(SESSION_ID to PAYLOAD, ANOTHER_SESSION_ID to PAYLOAD)))
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/StartFlowWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/StartFlowWaitingForHandlerTest.kt
@@ -1,11 +1,10 @@
 package net.corda.flow.pipeline.handlers.waiting
 
 import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowContinuation
-import net.corda.flow.pipeline.FlowEventContext
+import net.corda.flow.test.utils.buildFlowEventContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -14,13 +13,11 @@ class StartFlowWaitingForHandlerTest {
     fun `Returns a FlowContinuation#Run`() {
         val flowKey = FlowKey("flow id", HoldingIdentity("x500 name", "group id"))
         val continuation = StartFlowWaitingForHandler().runOrContinue(
-            FlowEventContext(
+            buildFlowEventContext(
                 checkpoint = Checkpoint().apply {
                     this.flowKey = flowKey
                 },
-                inputEvent = FlowEvent(flowKey, Unit),
-                inputEventPayload = Unit,
-                outputRecords = emptyList()
+                inputEventPayload = Unit
             ),
             WaitingForStartFlow
         )

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandlerTest.kt
@@ -1,12 +1,11 @@
 package net.corda.flow.pipeline.handlers.waiting
 
 import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.waiting.Wakeup
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowContinuation
-import net.corda.flow.pipeline.FlowEventContext
+import net.corda.flow.test.utils.buildFlowEventContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -16,13 +15,11 @@ class WakeupWaitingForHandlerTest {
     fun `Returns a FlowContinuation#Run`() {
         val flowKey = FlowKey("flow id", HoldingIdentity("x500 name", "group id"))
         val continuation = WakeupWaitingForHandler().runOrContinue(
-            FlowEventContext(
+            buildFlowEventContext(
                 checkpoint = Checkpoint().apply {
                     this.flowKey = flowKey
                 },
-                inputEvent = FlowEvent(flowKey, Unit),
-                inputEventPayload = Unit,
-                outputRecords = emptyList()
+                inputEventPayload = Unit
             ),
             Wakeup()
         )

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionDataWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionDataWaitingForHandlerTest.kt
@@ -1,7 +1,6 @@
 package net.corda.flow.pipeline.handlers.waiting.sessions
 
 import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionClose
 import net.corda.data.flow.event.session.SessionData
@@ -9,8 +8,8 @@ import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.session.SessionState
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowContinuation
-import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.session.manager.SessionManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -59,14 +58,12 @@ class SessionDataWaitingForHandlerTest {
             sequenceNum = 1
         })
 
-        val inputContext = FlowEventContext(
+        val inputContext = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 flowKey = FLOW_KEY
                 sessions = listOf(sessionState, anotherSessionState)
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
+            inputEventPayload = Unit
         )
 
         val continuation = sessionDataWaitingForHandler.runOrContinue(
@@ -97,14 +94,12 @@ class SessionDataWaitingForHandlerTest {
             sequenceNum = 1
         })
 
-        val inputContext = FlowEventContext(
+        val inputContext = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 flowKey = FLOW_KEY
                 sessions = listOf(sessionState, anotherSessionState)
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
+            inputEventPayload = Unit
         )
 
         sessionDataWaitingForHandler.runOrContinue(
@@ -130,14 +125,12 @@ class SessionDataWaitingForHandlerTest {
             sequenceNum = 1
         })
 
-        val inputContext = FlowEventContext(
+        val inputContext = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 flowKey = FLOW_KEY
                 sessions = listOf(sessionState, anotherSessionState)
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
+            inputEventPayload = Unit
         )
 
         val continuation = sessionDataWaitingForHandler.runOrContinue(
@@ -168,14 +161,12 @@ class SessionDataWaitingForHandlerTest {
             sequenceNum = 1
         })
 
-        val inputContext = FlowEventContext(
+        val inputContext = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 flowKey = FLOW_KEY
                 sessions = listOf(sessionState, anotherSessionState)
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
+            inputEventPayload = Unit
         )
 
         assertThrows<FlowProcessingException> {
@@ -188,12 +179,7 @@ class SessionDataWaitingForHandlerTest {
 
     @Test
     fun `Throws an exception if there is no checkpoint`() {
-        val inputContext = FlowEventContext(
-            checkpoint = null,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext = buildFlowEventContext(checkpoint = null, inputEventPayload = Unit)
 
         assertThrows<FlowProcessingException> {
             sessionDataWaitingForHandler.runOrContinue(inputContext, net.corda.data.flow.state.waiting.SessionData())

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionInitWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionInitWaitingForHandlerTest.kt
@@ -1,15 +1,14 @@
 package net.corda.flow.pipeline.handlers.waiting.sessions
 
 import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionInit
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.session.SessionState
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowContinuation
-import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowProcessingException
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.session.manager.SessionManager
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -43,13 +42,11 @@ class SessionInitWaitingForHandlerTest {
 
         whenever(sessionManager.getNextReceivedEvent(sessionState)).thenReturn(sessionEvent)
 
-        val inputContext = FlowEventContext(
+        val inputContext = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 sessions = listOf(sessionState)
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = sessionEvent,
-            outputRecords = emptyList()
+            inputEventPayload = sessionEvent
         )
 
         val continuation = sessionInitWaitingForHandler.runOrContinue(inputContext, WaitingForSessionInit(SESSION_ID))
@@ -59,13 +56,11 @@ class SessionInitWaitingForHandlerTest {
 
     @Test
     fun `Throws an exception if the session being waited for does not exist in the checkpoint`() {
-        val inputContext = FlowEventContext(
+        val inputContext = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 sessions = emptyList()
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
+            inputEventPayload = Unit
         )
         assertThrows<FlowProcessingException> {
             sessionInitWaitingForHandler.runOrContinue(inputContext, WaitingForSessionInit(SESSION_ID))
@@ -80,13 +75,11 @@ class SessionInitWaitingForHandlerTest {
 
         whenever(sessionManager.getNextReceivedEvent(sessionState)).thenReturn(null)
 
-        val inputContext = FlowEventContext(
+        val inputContext = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 sessions = listOf(sessionState)
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
+            inputEventPayload = Unit
         )
         assertThrows<FlowProcessingException> {
             sessionInitWaitingForHandler.runOrContinue(inputContext, WaitingForSessionInit(SESSION_ID))
@@ -95,12 +88,7 @@ class SessionInitWaitingForHandlerTest {
 
     @Test
     fun `Throws an exception if there is no checkpoint`() {
-        val inputContext = FlowEventContext(
-            checkpoint = null,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext = buildFlowEventContext(checkpoint = null, inputEventPayload = Unit)
 
         assertThrows<FlowProcessingException> {
             sessionInitWaitingForHandler.runOrContinue(inputContext, WaitingForSessionInit(SESSION_ID))

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
@@ -1,19 +1,18 @@
 package net.corda.flow.pipeline.impl
 
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.StateMachineState
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.data.flow.state.waiting.Wakeup
 import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.fiber.FlowIORequest
-import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowGlobalPostProcessor
 import net.corda.flow.pipeline.FlowProcessingException
 import net.corda.flow.pipeline.handlers.events.FlowEventHandler
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
 import net.corda.flow.pipeline.handlers.waiting.FlowWaitingForHandler
 import net.corda.flow.pipeline.runner.FlowRunner
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import org.assertj.core.api.Assertions.assertThat
@@ -43,8 +42,8 @@ class FlowEventPipelineImplTest {
         fiber = ByteBuffer.wrap(byteArrayOf(0, 0, 0, 0))
     }
 
-    private val inputContext = FlowEventContext<Any>(checkpoint, FlowEvent(), "Original", emptyList())
-    private val outputContext = FlowEventContext<Any>(checkpoint, FlowEvent(), "Updated", emptyList())
+    private val inputContext = buildFlowEventContext<Any>(checkpoint, "Original")
+    private val outputContext = buildFlowEventContext<Any>(checkpoint, "Updated")
 
     private val flowEventHandler = mock<FlowEventHandler<Any>>().apply {
         whenever(preProcess(inputContext)).thenReturn(outputContext)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
@@ -5,11 +5,11 @@ import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.identity.HoldingIdentity
-import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowEventPipeline
 import net.corda.flow.pipeline.FlowHospitalException
 import net.corda.flow.pipeline.FlowProcessingException
 import net.corda.flow.pipeline.factory.FlowEventPipelineFactory
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Flow.Companion.FLOW_EVENT_TOPIC
@@ -27,7 +27,11 @@ class FlowEventProcessorImplTest {
     private val flowKey = FlowKey("flow id", HoldingIdentity("x500 name", "group id"))
     private val updatedCheckpoint = Checkpoint()
     private val outputRecords = listOf(Record(FLOW_EVENT_TOPIC, "key", "value"))
-    private val updatedContext = FlowEventContext<Any>(updatedCheckpoint, FlowEvent(flowKey, wakeupPayload), wakeupPayload, outputRecords)
+    private val updatedContext = buildFlowEventContext<Any>(
+        updatedCheckpoint,
+        wakeupPayload,
+        outputRecords = outputRecords
+    )
 
     private val flowEventPipeline = mock<FlowEventPipeline>().apply {
         whenever(eventPreProcessing()).thenReturn(this)
@@ -39,10 +43,10 @@ class FlowEventProcessorImplTest {
         whenever(toStateAndEventResponse()).thenReturn(StateAndEventProcessor.Response(updatedCheckpoint, outputRecords))
     }
     private val flowEventPipelineFactory = mock<FlowEventPipelineFactory>().apply {
-        whenever(create(any(), any())).thenReturn(flowEventPipeline)
+        whenever(create(any(), any(), any())).thenReturn(flowEventPipeline)
     }
 
-    private val processor = FlowEventProcessorImpl(flowEventPipelineFactory)
+    private val processor = FlowEventProcessorImpl(flowEventPipelineFactory, mock())
 
     @Test
     fun `Throws FlowHospitalException if there was no flow event`() {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -1,15 +1,13 @@
 package net.corda.flow.pipeline.impl
 
-import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.session.SessionData
 import net.corda.data.flow.state.Checkpoint
 import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
-import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.pipeline.FlowEventContext
+import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import net.corda.session.manager.SessionManager
@@ -26,13 +24,10 @@ import java.nio.ByteBuffer
 class FlowGlobalPostProcessorImplTest {
 
     private companion object {
-        const val FLOW_ID = "flow id"
         const val SESSION_ID = "session id"
         const val ANOTHER_SESSION_ID = "another session id"
         const val DATA = "data"
         const val MORE_DATA = "more data"
-        val HOLDING_IDENTITY = HoldingIdentity("x500 name", "group id")
-        val FLOW_KEY = FlowKey(FLOW_ID, HOLDING_IDENTITY)
     }
 
     private val sessionManager = mock<SessionManager>()
@@ -63,13 +58,11 @@ class FlowGlobalPostProcessorImplTest {
         whenever(sessionManager.getMessagesToSend(eq(anotherSessionState), any(), any()))
             .thenReturn(anotherSessionState to listOf(anotherSessionEvent))
 
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
+        val inputContext: FlowEventContext<Any> = buildFlowEventContext(
             checkpoint = Checkpoint().apply {
                 sessions = listOf(sessionState, anotherSessionState)
             },
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
+            inputEventPayload = Unit
         )
 
         val outputContext = flowGlobalPostProcessor.postProcess(inputContext)
@@ -118,12 +111,7 @@ class FlowGlobalPostProcessorImplTest {
         whenever(sessionManager.getMessagesToSend(eq(anotherSessionState), any(), any()))
             .thenReturn(updatedAnotherSessionState to listOf(anotherSessionEvent))
 
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
-            checkpoint = checkpointCopy,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
-            inputEventPayload = Unit,
-            outputRecords = emptyList()
-        )
+        val inputContext = buildFlowEventContext<Any>(checkpoint = checkpointCopy, inputEventPayload = Unit)
 
         val outputContext = flowGlobalPostProcessor.postProcess(inputContext)
 
@@ -132,9 +120,8 @@ class FlowGlobalPostProcessorImplTest {
 
     @Test
     fun `Does nothing when there is no checkpoint`() {
-        val inputContext: FlowEventContext<Any> = FlowEventContext(
+        val inputContext = buildFlowEventContext<Any>(
             checkpoint = null,
-            inputEvent = FlowEvent(FLOW_KEY, Unit),
             inputEventPayload = Unit,
             outputRecords = emptyList()
         )

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowExecutorTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowExecutorTest.kt
@@ -16,6 +16,9 @@ import net.corda.lifecycle.impl.LifecycleCoordinatorFactoryImpl
 import net.corda.lifecycle.impl.registry.LifecycleRegistryImpl
 import net.corda.messaging.api.subscription.StateAndEventSubscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
+import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
+import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -35,16 +38,20 @@ class FlowExecutorTest {
     }
 
     private val coordinatorFactory: LifecycleCoordinatorFactory = LifecycleCoordinatorFactoryImpl(LifecycleRegistryImpl())
-    private val config: SmartConfig = SmartConfigFactory.create(ConfigFactory.empty()).create(
-        ConfigFactory.empty().withValue(
-            INSTANCE_ID, ConfigValueFactory
-                .fromAnyRef(1)
-        ).withValue(GROUP_NAME_KEY, ConfigValueFactory.fromAnyRef("Group1"))
+    private val config: Map<String, SmartConfig> = mapOf(
+        MESSAGING_CONFIG to SmartConfigFactory.create(ConfigFactory.empty()).create(
+            ConfigFactory.empty().withValue(
+                INSTANCE_ID, ConfigValueFactory
+                    .fromAnyRef(1)
+            ).withValue(GROUP_NAME_KEY, ConfigValueFactory.fromAnyRef("Group1"))
+        ),
+        BOOT_CONFIG to SmartConfigFactory.create(ConfigFactory.empty()).create(ConfigFactory.empty()),
+        FLOW_CONFIG to SmartConfigFactory.create(ConfigFactory.empty()).create(ConfigFactory.empty())
     )
     private val subscriptionFactory: SubscriptionFactory = mock()
     private val flowEventProcessor: FlowEventProcessor = mock()
     private val flowEventProcessorFactory = mock<FlowEventProcessorFactory>().apply {
-        whenever(create()).thenReturn(flowEventProcessor)
+        whenever(create(any())).thenReturn(flowEventProcessor)
     }
 
     @Test

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/FlowEventContextHelper.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/FlowEventContextHelper.kt
@@ -1,0 +1,25 @@
+package net.corda.flow.test.utils
+
+import com.typesafe.config.ConfigFactory
+import net.corda.data.flow.FlowKey
+import net.corda.data.flow.event.FlowEvent
+import net.corda.data.flow.state.Checkpoint
+import net.corda.data.identity.HoldingIdentity
+import net.corda.flow.pipeline.FlowEventContext
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.messaging.api.records.Record
+
+private const val FLOW_ID = "flow id"
+private val HOLDING_IDENTITY = HoldingIdentity("x500 name", "group id")
+private val FLOW_KEY = FlowKey(FLOW_ID, HOLDING_IDENTITY)
+
+fun <T> buildFlowEventContext(
+    checkpoint: Checkpoint?,
+    inputEventPayload: T,
+    config: SmartConfig = SmartConfigFactory.create(ConfigFactory.empty()).create(ConfigFactory.empty()),
+    outputRecords: List<Record<*, *>> = emptyList(),
+    flowKey: FlowKey = FLOW_KEY
+): FlowEventContext<T> {
+    return FlowEventContext(checkpoint, FlowEvent(flowKey, inputEventPayload), inputEventPayload, config, outputRecords)
+}


### PR DESCRIPTION
Pass configuration into the flow event pipeline.

This is done by adding a `config` property to `FlowEventContext`. The
handlers in the pipeline can then access configuration via this
property.

The `FlowEventProcessorFactory` now takes in the configuration that the
`FlowService` receives, so that it can be passed through the pipeline.