### PR TITLE
CORE-4175: Ensure we run postgres DB as part of nightly windows job

### DIFF
--- a/.ci/nightly/JenkinsfileWindowsCompatibility
+++ b/.ci/nightly/JenkinsfileWindowsCompatibility
@@ -2,5 +2,6 @@
 
 windowsCompatibility(
     runIntegrationTests: true,
+    createPostgresDb: true,
     dailyBuildCron: 'H 03 * * *'
     )


### PR DESCRIPTION
Tested and passed here on windows:
https://ci02.dev.r3.com/job/Corda5/job/Nightlys/job/Corda-Runtime-OS/job/Windows/view/change-requests/job/PR-1070/

Prior to this we used n memory DB only 