### PR TITLE
CORE-4190: Change the way how Config RPC Operations are exposed

### DIFF
--- a/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/ConfigRPCOps.kt
+++ b/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/ConfigRPCOps.kt
@@ -1,7 +1,7 @@
 package net.corda.libs.configuration.endpoints.v1
 
 import net.corda.httprpc.RpcOps
-import net.corda.httprpc.annotations.HttpRpcPOST
+import net.corda.httprpc.annotations.HttpRpcPUT
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
 import net.corda.libs.configuration.endpoints.v1.types.HTTPUpdateConfigRequest
@@ -21,8 +21,7 @@ interface ConfigRPCOps : RpcOps {
      * @throws `ConfigRPCOpsServiceException` If the updated configuration could not be published.
      * @throws `HttpApiException` If the request returns an exceptional response.
      */
-    @HttpRpcPOST(
-        path = "update",
+    @HttpRpcPUT(
         title = "Update cluster configuration",
         description = "Updates a section of the cluster configuration.",
         responseDescription = "The updated cluster configuration for the specified section."


### PR DESCRIPTION
HTTP invocation has changed to: `PUT /api/v1/config`