### PR TITLE
NOTICK Fix flow worker execution and setup

### DIFF
--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
@@ -19,9 +19,9 @@ class StartFlow(private val context: TaskContext) : Task {
         context.publish(
             getStartRPCEventRecord(
                 clientId = UUID.randomUUID().toString(),
-                flowName = "net.corda.linearstatesample.flows.MessagingFlow",
+                flowName = "net.corda.flowworker.development.flows.MessagingFlow",
                 x500Name = context.startArgs.x500NName,
-                groupId = "helloworld",
+                groupId = "flow-worker-dev",
                 jsonArgs = "{ \"who\":\"${context.startArgs.x500NName}\"}"
             )
         )

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -60,6 +60,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
                 "net.corda.crypto",
                 "net.corda.kotlin-stdlib-jdk7.osgi-bundle",
                 "net.corda.kotlin-stdlib-jdk8.osgi-bundle",
+                "net.corda.membership",
                 "net.corda.persistence",
                 "net.corda.serialization",
                 "org.apache.aries.spifly.dynamic.bundle",


### PR DESCRIPTION
- Add `net.corda.membership` to the list of
`PLATFORM_PUBLIC_BUNDLE_NAMES` as `MemberLookupService` (a public
interface) now has an implementation.

- Correct `StartFlow` in the flow worker setup tool due to flow package
renaming.