### PR TITLE
CORE-4575 add extra logging for splunk specfic to e2e tests

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -132,6 +132,9 @@ pipeline {
         always {
             splunkLogGenerator()
             script{
+                writeFile file: "e2eTestDataForSplunk.log", text: "${env.BUILD_URL}\n${NAMESPACE}"
+                archiveArtifacts artifacts: "e2eTestDataForSplunk.log", fingerprint: true
+
                 def splunkK8URL = "https://r3ll3.splunkcloud.com/en-US/app/r3_kubernetes_app/overview?form.period.earliest=-4h%40m&form.period.latest=now&form.span=5m&form.cluster=eks-e2e&form.namespace=${NAMESPACE}&form.pod=*"
                 echo "Splunk K8 Url: $splunkK8URL"
             }


### PR DESCRIPTION
- Changes needed to link Splunk e2e tests dashboard back to build dashboards.
- generated new file which Splunk will ingest to parse namespace and URL

Example run.
https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-e2e-tests/job/ronanb%252FCORE-4575%252Fadd-extra-splunk-logging/3/