### PR TITLE
NOTICK: add build scans for e2e tests

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -112,7 +112,7 @@ pipeline {
                     procno=$! #remember process number started in background
                     trap "kill -9 ${procno}" EXIT
 
-                    ./gradlew cleanE2eTest e2eTest
+                    ./gradlew cleanE2eTest e2eTest ${GRADLE_PERFORMANCE_TUNING}
                 '''
             }
             post {


### PR DESCRIPTION
- changes to set API key and surface scans to UI 
- add parallel tag for performance gains 
- tag all builds in Gradle Ent from this job with the namespace and E2E
- Just run the target e2eTest project wide so we catch others should they be added to release branch 