### PR TITLE
NOTICK: ensure all e2e results captured in jenkins report 

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -120,6 +120,9 @@ pipeline {
                 '''
             }
             post {
+                always {
+                    junit allowEmptyResults: true, testResults: '**/test-results/**/TEST-*.xml'
+                }
                 unsuccessful {
                     sh '''
                         kubectl logs -lapp.kubernetes.io/instance=corda -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs.txt
@@ -133,7 +136,6 @@ pipeline {
     }
     post {
         always {
-            junit allowEmptyResults: true, testResults: '**/test-results/**/TEST-*.xml'
             findBuildScans()
             splunkLogGenerator()
             script{


### PR DESCRIPTION
Ensure all tests reports are captured

tested on e2e run here: https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-e2e-tests/job/ronanb%252Fnotick%252Fensure-all-e2e-ran/5/