### PR TITLE
NOTICK Simplify smoke test with a DSL

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -3,6 +3,7 @@ package net.corda.applications.workers.smoketest.virtualnode
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.applications.workers.smoketest.virtualnode.helpers.SimpleResponse
+import net.corda.applications.workers.smoketest.virtualnode.helpers.assertWithRetry
 import net.corda.applications.workers.smoketest.virtualnode.helpers.cluster
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.MethodOrderer
@@ -15,38 +16,12 @@ import java.time.Duration
 // The CPI we're using in this test
 const val CALCULATOR_CPI = "/META-INF/calculator.cpb"
 
-fun SimpleResponse.toJson(): JsonNode = ObjectMapper().readTree(this.body!!)!!
+fun SimpleResponse.toJson(): JsonNode = ObjectMapper().readTree(this.body)!!
 fun String.toJson(): JsonNode = ObjectMapper().readTree(this)
 
 // BUG:  Not sure if we should be requiring clients to use a method similar to this because we
 // return a full hash (64 chars?) but the same API only accepts the first 12 chars.
 fun String.toShortHash(): String = substring(0, 12)
-
-/**
- * Requests, and returns if [condition] is met, otherwise backs off and rerequests up to [maxTimeout] and returns
- * final [SimpleResponse].
- *
- * @return a [SimpleResponse] object that *you* need to close
- */
-fun requestWithRetryOrTimeOut(
-    maxTimeout: Duration,
-    condition: (code: Int, body: String) -> Boolean,
-    block: () -> SimpleResponse
-): SimpleResponse {
-    var timeout = Duration.ofMillis(250)
-    var response: SimpleResponse?
-
-    do {
-        Thread.sleep(timeout.toMillis())
-        timeout = timeout.multipliedBy(2)
-        response = block()
-        if (condition(response.code, response.body!!)) {
-            break
-        }
-    } while (timeout.toMillis() < maxTimeout.toMillis())
-
-    return response!!
-}
 
 /**
  * Any 'unordered' tests are run *last*
@@ -95,17 +70,10 @@ class VirtualNodeRpcTest {
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
             // BUG:  returning "OK" feels 'weakly' typed
-            val statusIsOk = { code: Int, body: String -> code == 200 && body.toJson()["status"].textValue() == "OK" }
-
-            val statusResponse = requestWithRetryOrTimeOut(WAIT_DURATION, statusIsOk) { cpiStatus(requestId) }
-
-            val json = statusResponse.let {
-                val jsonString = it.body!!
-                assertThat(statusIsOk(it.code, jsonString))
-                    .withFailMessage("$ERROR_CPI_NOT_UPLOADED\n\n$it")
-                    .isTrue
-                jsonString.toJson()
-            }
+            val json = assertWithRetry {
+                command { cpiStatus(requestId) }
+                condition { it.code == 200 && it.toJson()["status"].textValue() == "OK" }
+            }.toJson()
 
             val cpiHash = json["checksum"].textValue()
             assertThat(cpiHash).isNotNull.isNotEmpty
@@ -118,7 +86,7 @@ class VirtualNodeRpcTest {
 
             // Compare it to the hash in the cpi list - should be identical.
             // CORE-4475: tests fixed behaviour previously reported as a bug
-            val cpis = cpiList().let { it.toJson() }
+            val cpis = cpiList().toJson()
             val cpiJson = cpis["cpis"].first()
             val actualChecksum = cpiJson["fileChecksum"].textValue().toShortHash()
 
@@ -142,20 +110,10 @@ class VirtualNodeRpcTest {
             val requestId = cpbUpload(CALCULATOR_CPI).let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
-            val statusIsNotOk = { code: Int, _: String -> code == 500 }
-
-            val statusResponse = requestWithRetryOrTimeOut(WAIT_DURATION, statusIsNotOk) { cpiStatus(requestId) }
-
-            val json = statusResponse.let {
-                val jsonString = it.body!!
-                assertThat(
-                    statusIsNotOk(
-                        it.code,
-                        jsonString
-                    )
-                ).isTrue // We expect this to change as we improve the error reporting
-                jsonString.toJson()
-            }
+            val json = assertWithRetry {
+                command { cpiStatus(requestId) }
+                condition { it.code == 500 }
+            }.toJson()
 
             val titleJson = ObjectMapper().readTree(json["title"].textValue())
             assertThat(titleJson["errorMessage"].textValue()).isEqualTo(EXPECTED_ERROR_NO_GROUP_POLICY)
@@ -170,20 +128,10 @@ class VirtualNodeRpcTest {
             val requestId = cpiUpload(CALCULATOR_CPI, groupId).let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
-            val statusIsNotOk = { code: Int, _: String -> code == 500 }
-
-            val statusResponse = requestWithRetryOrTimeOut(WAIT_DURATION, statusIsNotOk) { cpiStatus(requestId) }
-
-            val json = statusResponse.let {
-                val jsonString = it.body!!
-                assertThat(
-                    statusIsNotOk(
-                        it.code,
-                        jsonString
-                    )
-                ).isTrue // We expect this to change as we improve the error reporting
-                jsonString.toJson()
-            }
+            val json = assertWithRetry {
+                command { cpiStatus(requestId) }
+                condition { it.code == 500 }
+            }.toJson()
 
             val titleJson = ObjectMapper().readTree(json["title"].textValue())
             assertThat(titleJson["errorMessage"].textValue().startsWith(EXPECTED_ERROR_ALREADY_UPLOADED)).isTrue()
@@ -195,10 +143,11 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(clusterUri, username, password)
 
-            val json = cpiList().let {
-                assertThat(it.code).isEqualTo(200)
-                it.toJson()
-            }
+            val json = assertWithRetry {
+                command { cpiList() }
+                condition { it.code == 200 }
+            }.toJson()
+
             assertThat(json["cpis"].size()).isGreaterThan(0)
         }
     }
@@ -208,7 +157,7 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(clusterUri, username, password)
 
-            val json = cpiList().let { it.toJson() }
+            val json = cpiList().toJson()
             val cpiJson = json["cpis"].first()
 
             val groupPolicyJson = cpiJson["groupPolicy"].textValue().toJson()
@@ -221,16 +170,15 @@ class VirtualNodeRpcTest {
     fun `can create virtual node with holding id and CPI`() {
         cluster {
             endpoint(clusterUri, username, password)
-            val cpis = cpiList().let { it.toJson() }["cpis"]
+            val cpis = cpiList().toJson()["cpis"]
             val json = cpis.toList().first { it["id"]["cpiName"].textValue() == "calculator" }
             val hash = json["fileChecksum"].textValue().toShortHash()
 
-            val vNodeJson = vNodeCreate(hash, X500_ALICE).let {
-                assertThat(it.code)
-                    .withFailMessage("$ERROR_HOLDING_ID\n$it\n${json.toPrettyString()}")
-                    .isEqualTo(200)
-                it.toJson()
-            }
+            val vNodeJson = assertWithRetry {
+                command { vNodeCreate(hash, X500_ALICE) }
+                condition { it.code == 200 }
+                failMessage(ERROR_HOLDING_ID)
+            }.toJson()
 
             assertThat(vNodeJson["holdingIdHash"].textValue()).isNotNull.isNotEmpty
         }
@@ -241,12 +189,13 @@ class VirtualNodeRpcTest {
     fun `cannot create duplicate virtual node`() {
         cluster {
             endpoint(clusterUri, username, password)
-            val cpis = cpiList().let { it.toJson() }["cpis"]
+            val cpis = cpiList().toJson()["cpis"]
             val json = cpis.toList().first { it["id"]["cpiName"].textValue() == "calculator" }
             val hash = json["fileChecksum"].textValue().toShortHash()
 
-            vNodeCreate(hash, X500_ALICE).let {
-                assertThat(it.code).isEqualTo(500) // This return code may change.
+            assertWithRetry {
+                command { vNodeCreate(hash, X500_ALICE) }
+                condition { it.code == 500 }
             }
         }
     }
@@ -256,7 +205,7 @@ class VirtualNodeRpcTest {
     fun `list virtual nodes`() {
         cluster {
             endpoint(clusterUri, username, password)
-            val json = vNodeList().let { it.toJson() }["virtualNodes"].first()
+            val json = vNodeList().toJson()["virtualNodes"].first()
             val actualX500Name = json["holdingIdentity"]["x500Name"].textValue()
 
             assertThat(actualX500Name).isEqualTo(X500_ALICE)
@@ -269,7 +218,7 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(clusterUri, username, password)
 
-            val vnJson = vNodeList().let { it.toJson() }["virtualNodes"].first()
+            val vnJson = vNodeList().toJson()["virtualNodes"].first()
             val id = vnJson["holdingIdentity"]["id"].textValue()
 
             val counter = 1
@@ -284,22 +233,15 @@ class VirtualNodeRpcTest {
 
             // Depends on the flows in the cpi
             val className = "net.corda.testing.calculator.CalculatorFlow"
-            flowStart(id, 1, className, requestBody).let {
-                assertThat(it.code)
-                    .withFailMessage("when calling ${it.url}")
-                    .isEqualTo(200)
+            assertWithRetry {
+                command { flowStart(id, 1, className, requestBody) }
+                condition { it.code == 200 }
             }
 
-            val flowFinished =
-                { code: Int, body: String -> code == 200 && body.toJson()["flowStatus"].textValue() == "COMPLETED" }
-
-            val flowStatusResponse = requestWithRetryOrTimeOut(WAIT_DURATION, flowFinished) { flowStatus(id, counter) }
-
-            val json = flowStatusResponse.let {
-                val jsonString = it.body!!
-                assertThat(flowFinished(it.code, jsonString)).isTrue
-                jsonString.toJson()
-            }
+            val json = assertWithRetry {
+                command { flowStatus(id, counter) }
+                condition { it.code == 200 && it.toJson()["flowStatus"].textValue() == "COMPLETED" }
+            }.toJson()
 
             // Depends on the keys in the test cpi
             val resultJson = ObjectMapper().readTree(json["flowResult"].textValue())

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/AssertWithRetryBuilder.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/AssertWithRetryBuilder.kt
@@ -1,0 +1,70 @@
+package net.corda.applications.workers.smoketest.virtualnode.helpers
+
+import org.assertj.core.api.Assertions.assertThat
+import java.time.Duration
+
+/** "Private args" that are only exposed in here */
+class AssertWithRetryArgs {
+    var timeout: Duration = Duration.ofSeconds(2)
+    var command: (() -> SimpleResponse)? = null
+    var condition: ((SimpleResponse) -> Boolean)? = null
+    var failMessage: String = ""
+}
+
+/** The [assertWithRetry] builder class that helps implement the "DSL" */
+class AssertWithRetryBuilder(private val args: AssertWithRetryArgs) {
+    fun timeout(timeout: Duration) {
+        args.timeout = timeout
+    }
+
+    fun command(command: () -> SimpleResponse) {
+        args.command = command
+    }
+
+    fun condition(condition: (SimpleResponse) -> Boolean) {
+        args.condition = condition
+    }
+
+    fun failMessage(failMessage: String) {
+        args.failMessage = failMessage + "\n"
+    }
+}
+
+/**
+ * Sort-of-DSL.  Asserts a command and retries if it doesn't initially succeed.
+ *
+ * Specify the [command] to execute, and the [condition] to assert, and optionally a [failMessage] and a different
+ * [timeout]
+ *
+ *      val statusResponse = assertWithRetry {
+ *          condition { it.code == 200 && it.toJson()["status"].textValue() == "OK" }
+ *          command { cpiStatus(requestId) }
+ *      }
+ *
+ * @throws [AssertionError] or similar if condition isn't successful.
+ * @return [SimpleResponse] if successful
+ */
+fun assertWithRetry(initialize: AssertWithRetryBuilder.() -> Unit): SimpleResponse {
+    var timeout = Duration.ofMillis(250)
+    val args = AssertWithRetryArgs()
+
+    AssertWithRetryBuilder(args).apply(initialize).run {
+        var response: SimpleResponse?
+
+        do {
+            Thread.sleep(timeout.toMillis())
+            timeout = timeout.multipliedBy(2)
+            response = args.command!!.invoke()
+            if (args.condition!!.invoke(response)) break
+        } while (timeout.toMillis() < args.timeout.toMillis())
+
+        assertThat(args.condition!!.invoke(response!!))
+            .withFailMessage(
+                "${args.failMessage}Retried ${response.url} and " +
+                        "failed with status code = ${response.code} and body =\n${response.body}"
+            )
+            .isTrue
+
+        return response
+    }
+}

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/SimpleResponse.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/SimpleResponse.kt
@@ -1,4 +1,4 @@
 package net.corda.applications.workers.smoketest.virtualnode.helpers
 
 /** Simplified response in case we switch underlying web clients, again */
-data class SimpleResponse(val code: Int, val body: String?, val url: String)
+data class SimpleResponse(val code: Int, val body: String, val url: String)


### PR DESCRIPTION
Converted the retry-and-assert to a DSL-style method so that we can
simply declare the call that returns a simple http response, and the
condition we test+retry.