### PR TITLE
CORE-4585: Fix lifecycle event propagation for `FlowRPCOpsService`

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
@@ -21,7 +21,7 @@ class ClusterBootstrapTest {
         // "crypto-worker" to System.getProperty("cryptoWorkerHealthHttp"),
         "db-worker" to System.getProperty("dbWorkerHealthHttp"),
         // "flow-worker" to System.getProperty("flowWorkerHealthHttp"),
-        // "rpc-worker" to System.getProperty("rpcWorkerHealthHttp"),
+        "rpc-worker" to System.getProperty("rpcWorkerHealthHttp"),
     )
     private val client = HttpClient.newBuilder().build()
 

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowRPCOpsServiceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowRPCOpsServiceImpl.kt
@@ -5,6 +5,7 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.flow.rpcops.FlowRPCOpsService
 import net.corda.flow.rpcops.FlowStatusCacheService
 import net.corda.flow.rpcops.v1.FlowRpcOps
+import net.corda.lifecycle.CustomEvent
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -43,8 +44,8 @@ internal class FlowRPCOpsServiceImpl @Activate constructor(
         val log: Logger = contextLogger()
     }
 
-    private var isUp = false;
-    private var isCacheLoaded = false;
+    private var isUp = false
+    private var isCacheLoaded = false
 
     private val lifecycleCoordinator = coordinatorFactory.createCoordinator<FlowRPCOpsService>(::eventHandler)
     private val dependentComponents = DependentComponents.of(
@@ -66,6 +67,12 @@ internal class FlowRPCOpsServiceImpl @Activate constructor(
                 if(!isUp){
                     isUp=true
                     signalUpStatus()
+                }
+            }
+            is CustomEvent -> {
+                val cacheLoadCompeted = event.payload as? CacheLoadCompleteEvent
+                if (cacheLoadCompeted != null) {
+                    lifecycleCoordinator.postEvent(cacheLoadCompeted)
                 }
             }
             is CacheLoadCompleteEvent -> {

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
@@ -77,7 +77,7 @@ class FlowStatusCacheServiceImpl @Activate constructor(
             .filter { it.value.initiatorType == FlowInitiatorType.RPC }
             .forEach { cache[it.key] = it.value }
 
-        lifecycleCoordinator.postEvent(CacheLoadCompleteEvent())
+        lifecycleCoordinator.postCustomEventToFollowers(CacheLoadCompleteEvent())
     }
 
     override fun onNext(

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/tests/FlowStatusCacheServiceImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/tests/FlowStatusCacheServiceImplTest.kt
@@ -161,7 +161,7 @@ class FlowStatusCacheServiceImplTest {
 
         flowStatusCacheService.onSnapshot(mapOf(key to value))
 
-        verify(lifecycleCoordinator).postEvent(isA<CacheLoadCompleteEvent>())
+        verify(lifecycleCoordinator).postCustomEventToFollowers(isA<CacheLoadCompleteEvent>())
     }
 
     @Test


### PR DESCRIPTION
The cache is loaded by `FlowStatusCacheService`, but notification about cache being loaded is meant to be sent to `FlowRPCOpsService`. Else `FlowRPCOpsService` is not getting `isCacheLoaded` set to `true`, which in turn prevents it from going into `UP` state.