### PR TITLE
NOTICK Increase wait for flow to complete in smoke test

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -240,7 +240,7 @@ class VirtualNodeRpcTest {
 
             val json = assertWithRetry {
                 command { flowStatus(id, counter) }
-                timeout(Duration.ofSeconds(10))
+                timeout(FLOW_WAIT_DURATION)
                 condition { it.code == 200 && it.toJson()["flowStatus"].textValue() == "COMPLETED" }
             }.toJson()
 


### PR DESCRIPTION
What it says on the tin ^^^

We might be eagerly failing when we might want to wait a little bit longer for a flow to complete.