### PR TITLE
CORE-4883 add cache logic

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -368,4 +368,24 @@ gradleEnterprise {
             accessKey = apiKey
         }
     }
+    buildCache {
+        local {
+            enabled = false
+        }
+        remote(HttpBuildCache) {
+            url = "${gradleEnterpriseUrl}/cache/"
+            credentials {
+                username = settings.ext.find('BUILD_CACHE_CREDENTIALS_USR') ?: System.getenv('BUILD_CACHE_CREDENTIALS_USR')
+                password = settings.ext.find('BUILD_CACHE_CREDENTIALS_PSW') ?: System.getenv('BUILD_CACHE_CREDENTIALS_PSW')
+            }
+            // For the remote build cache we will populate cache only from Jenkins, all machines can pull from cache however.
+            if (System.getenv().containsKey("JENKINS_URL")) {
+                push = true
+                enabled = true
+            } else {
+                push = false
+                enabled = true
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Add logic to leverage Gradle Ent remote build cache
- Only CI runs will push to cache, however all machines can pull.

Accompanying pipeline logic:
https://github.com/corda/corda-shared-build-pipeline-steps/pull/180