### PR TITLE
NOTICK: Support MembershipGroupReader inside :testing:sandboxes.

### DIFF
--- a/components/membership/membership-group-read/build.gradle
+++ b/components/membership/membership-group-read/build.gradle
@@ -6,13 +6,12 @@ plugins {
 description 'Membership data read service'
 
 dependencies {
-    compileOnly "org.osgi:osgi.annotation"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    compileOnly 'org.osgi:osgi.annotation'
+    api platform("net.corda:corda-api:$cordaApiVersion")
+    api 'net.corda:corda-membership'
+    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     implementation project(":libs:membership:membership-internal")
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:virtual-node:virtual-node-info")
-
-    implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda:corda-membership"
 }

--- a/testing/sandboxes/build.gradle
+++ b/testing/sandboxes/build.gradle
@@ -19,10 +19,12 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation project(':components:membership:membership-group-read')
     implementation project(':components:virtual-node:cpi-info-read-service')
     implementation project(':components:virtual-node:virtual-node-info-read-service')
     implementation project(':components:virtual-node:cpk-read-service')
 
+    implementation project(':libs:membership:membership-internal')
     implementation project(':libs:virtual-node:packaging-core')
 
     runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -1,0 +1,57 @@
+package net.corda.testing.sandboxes.impl
+
+import net.corda.membership.CPIWhiteList
+import net.corda.membership.read.MembershipGroupReader
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.loggerFor
+import net.corda.v5.crypto.PublicKeyHash
+import net.corda.v5.membership.GroupParameters
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.propertytypes.ServiceRanking
+
+@Suppress("unused")
+@Component
+@ServiceRanking(Int.MAX_VALUE)
+class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
+    private val logger = loggerFor<MembershipGroupReaderProvider>()
+
+    override fun getGroupReader(holdingIdentity: HoldingIdentity): MembershipGroupReader {
+        return MembershipGroupReaderImpl(holdingIdentity)
+    }
+
+    override val isRunning: Boolean
+        get() = true
+
+    override fun start() {
+        logger.info("Starting")
+    }
+
+    override fun stop() {
+        logger.info("Stopping")
+    }
+
+    private class MembershipGroupReaderImpl(holdingIdentity: HoldingIdentity) : MembershipGroupReader {
+        override val groupId: String = holdingIdentity.groupId
+        override val owningMember: MemberX500Name = MemberX500Name.parse(holdingIdentity.x500Name)
+
+        override val groupParameters: GroupParameters
+            get() = TODO("groupParameters: Not yet implemented")
+        override val cpiWhiteList: CPIWhiteList
+            get() = TODO("cpiWhiteList: Not yet implemented")
+
+        override fun lookup(): Collection<MemberInfo> {
+            throw IllegalStateException("TEST MODULE: Membership not supported")
+        }
+
+        override fun lookup(publicKeyHash: PublicKeyHash): MemberInfo? {
+            return null
+        }
+
+        override fun lookup(name: MemberX500Name): MemberInfo? {
+            return null
+        }
+    }
+}


### PR DESCRIPTION
Add a basic `MembershipGroupReaderProvider` component to the sandbox testing module.

Note: If Gradle project `A` depends on Gradle project `B`, and any project that wants to compile against `A` must also compile against `B`, then that is the _definition_ of `A` having an `api` dependency on `B`.

This also means that `:components:membership:membership-group-read` should have an `api` dependency on `:libs:membership:membership-internal` too, which doesn't sound right to me at all... :worried:.