### PR TITLE
NOTICK: Also archive logs on successful runs for e2e tests

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
                 }
             }
             post {
-                allways {
+                always {
                     sh '''
                         kubectl logs -lapp.kubernetes.io/instance=prereqs -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > prereqsLogs.txt
                         kubectl describe all -n ${NAMESPACE} > prereqsDescribe.txt


### PR DESCRIPTION
Currently we only log on failures, When investigating build issues or e2e test failures sometimes it is beneficial to have some logs easily available from a run where everything went as expected for comparison

Example e2e test run:
https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-e2e-tests/job/ronanb%252FNOTICK%252Fextra-logging/3/