### PR TITLE
NOTICK - Standardise build instructions ahead of p2p preview

### DIFF
--- a/applications/p2p-gateway/README.md
+++ b/applications/p2p-gateway/README.md
@@ -1,12 +1,14 @@
-# P2p Gateway Application
-A standalone Gateway application
+# P2P Gateway worker
+The p2p gateway worker
 
-## Building
+## Building the worker
 To build run:
-`./gradlew :applications:p2p-gateway:clean :applications:p2p-gateway:appJar`
-This will create an executable jar in `applications/p2p-gateway/build/bin/` 
+```
+./gradlew :applications:p2p-gateway:clean :applications:p2p-gateway:appJar
+```
+This will create an executable jar in `applications/p2p-gateway/build/bin/`.
 
-## Running
+## Running the worker
 To run the application use:
 `java -jar ./applications/p2p-gateway/build/bin/corda-p2p-gateway-5.0.0.0-SNAPSHOT.jar`
 

--- a/applications/p2p-link-manager/README.md
+++ b/applications/p2p-link-manager/README.md
@@ -1,12 +1,14 @@
-# P2p Link Manager Application
-A standalone Link Manager application
+# P2P Link Manager worker
+The p2p link manager worker.
 
-## Building
+## Building the worker
 To build run:
-`./gradlew :applications:p2p-link-manager:clean :applications:p2p-link-manager:appJar`
-This will create an executable jar in `applications/p2p-link-manager/build/bin/` 
+```
+./gradlew :applications:p2p-link-manager:clean :applications:p2p-link-manager:appJar
+```
+This will create an executable jar in `applications/p2p-link-manager/build/bin/`. 
 
-## Running
+## Running the worker
 Before starting the application, run a kafka cluster. See examples in [here](../../testing/message-patterns/README.md).
 To run the application use:
 `java -jar ./applications/p2p-link-manager/build/bin/corda-p2p-link-manager-5.0.0.0-SNAPSHOT.jar`

--- a/applications/tools/kafka-setup/README.md
+++ b/applications/tools/kafka-setup/README.md
@@ -1,10 +1,25 @@
-The purpose of this application is to help set up kafka topics required for configuration storage as well as pushing
+# Kafka setup tool
+
+The purpose of this tool is to help set up kafka topics required for configuration storage as well as pushing
 configuration objects onto the newly created topic.
 
-The application runs via executable java jar with some added property files
-e.g. `java -jar corda-kafka-setup-5.0.0.jar --kafka kafkaPropertiesFile --topic topicTemplateFile --config typesafeConfigurationFile`
-Command line args may also be used instead of kafkaPropertiesFile
-e.g. `java -jar  -Dbootstrap.servers=localhost:9092 -Dmessaging.topic.prefix=demo build/bin/corda-kafka-setup-5.0.0.0-SNAPSHOT.jar --topic topics.conf --config config.conf`
+## Building the tool
+To build run:
+```
+./gradlew :applications:tools:kafka-setup:clean :applications:tools:kafka-setup:appJar
+```
+This will create an executable jar in `applications/tools/kafka-setup/build/bin`.
+
+## Running the tool
+To run the tool use:
+```
+java -jar corda-kafka-setup-5.0.0.jar --kafka kafkaPropertiesFile --topic topicTemplateFile --config typesafeConfigurationFile
+```
+
+Alternatively, command line args can be used instead of the `kafkaPropertiesFile`:
+```
+java -jar  -Dbootstrap.servers=localhost:9092 -Dmessaging.topic.prefix=demo build/bin/corda-kafka-setup-5.0.0.0-SNAPSHOT.jar --topic topics.conf --config config.conf
+```
 
 The `kafkaPropertiesFile` will contain the properties kafka needs to connect to the broker, like
 

--- a/applications/tools/p2p-test/app-simulator/README.md
+++ b/applications/tools/p2p-test/app-simulator/README.md
@@ -1,4 +1,6 @@
-This is a tool that can be used to simulate the application layer by sending/receiving messages to/from the p2p layer and writing metadata for analysis to a relational database.
+# P2P application-simulator worker
+
+This is an application that can be used to simulate the application layer by sending/receiving messages to/from the p2p layer and writing metadata for analysis to a relational database.
 
 It can be executed in three main modes:
 * `SENDER`: in this mode, the tool sends messages to the Kafka topics monitored by p2p components and (optionally) writes metadata to a postgres DB.
@@ -7,14 +9,15 @@ It can be executed in three main modes:
 
 ![Overview diagram](p2p_app_simulator.png)
 
-## Building the tool
+## Building the application
 
+To build run:
 ```
-./gradlew applications:tools:p2p-test:app-simulator:clean
-./gradlew applications:tools:p2p-test:app-simulator:appJar
+./gradlew applications:tools:p2p-test:app-simulator:clean applications:tools:p2p-test:app-simulator:appJar
 ```
+This will create an executable jar in `applications/tools/p2p-test/app-simulator/build/bin/`.
 
-## Executing the tool
+## Executing the application
 
 ```
 java -jar applications/tools/p2p-test/app-simulator/build/bin/corda-app-simulator-5.0.0.0-SNAPSHOT.jar --kafka-servers localhost:9092 --simulator-config ~/Desktop/simulator.conf

--- a/applications/tools/p2p-test/fake-ca/README.md
+++ b/applications/tools/p2p-test/fake-ca/README.md
@@ -1,11 +1,17 @@
+# Fake Certificate Authority tool
 A tool that can act as a fake Certificate Authority to create TLS certificates (without revocation)
 
 **⚠ WARNING:** This tool is not safe for production use, and it should only be used for testing purposes.
 
+## Building the tool
+
 To build, run:
 ```bash
-./gradlew :applications:tools:p2p-test:fake-ca:install
+./gradlew :applications:tools:p2p-test:fake-ca:clean :applications:tools:p2p-test:fake-ca:install
 ```
+This will create an executable in `applications/tools/p2p-test/fake-ca/build/install/fake-ca/bin/fake-ca`.
+
+## Running the tool
 
 To create an authority run:
 ```bash

--- a/applications/tools/p2p-test/p2p-setup/README.md
+++ b/applications/tools/p2p-test/p2p-setup/README.md
@@ -1,9 +1,12 @@
+# P2P Setup tool
 This is a tool that can be used to setup a P2P deployment. 
 
 ## Building the tool
+To build run:
 ```
 ./gradlew applications:tools:p2p-test:p2p-setup:clean applications:tools:p2p-test:p2p-setup:appJar
 ```
+This will create an executable jar in `applications/tools/p2p-test/p2p-setup/build/bin/`.
 
 ## Running the tool
 


### PR DESCRIPTION
I slightly adjusted the instructions for all the artefacts that will be included in the p2p preview to standardise them. This so that we can point people directly from the blog post to the README file to build the artefacts, instead of repeating the instructions one-by-one.