### PR TITLE
NOTICK: dbIntegrationTest Task should not be hooked into check

### DIFF
--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -137,11 +137,6 @@ tasks.named('integrationTest') {
     enabled = false
 }
 
-tasks.named('check') {
-    // We'll need to figure out how to check kafka when we know a broker is available
-    dependsOn dbIntegrationTest
-}
-
 artifacts {
     archives testingBundle
 }


### PR DESCRIPTION
dbIntegrationTest should not be hooked into check - current set up means dbIntegrationTest will be executed as part of the unit test task  (when a ./gradlew build is triggered) this is not desirable - it should be executed with the rest of the integration tests triggered via the integration test task