### PR TITLE
CORE-4156 Check payloads in `FlowSession` receive methods

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
@@ -12,6 +12,7 @@ import net.corda.v5.application.services.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.castIfPossible
 import net.corda.v5.base.util.contextLogger
 import java.io.NotSerializableException
 
@@ -43,7 +44,6 @@ class FlowSessionImpl(
         ensureSessionIsOpen()
         val request = FlowIORequest.SendAndReceive(mapOf(sourceSessionId to serialize(payload)))
         val received = fiber.suspend(request)
-        // TODO CORE-4156 Re-add `checkPayloadIs` code in `FlowSessionImpl`
         return deserializeReceivedPayload(received, receiveType)
     }
 
@@ -53,7 +53,6 @@ class FlowSessionImpl(
         ensureSessionIsOpen()
         val request = FlowIORequest.Receive(setOf(sourceSessionId))
         val received = fiber.suspend(request)
-        // TODO CORE-4156 Re-add `checkPayloadIs` code in `FlowSessionImpl`
         return deserializeReceivedPayload(received, receiveType)
     }
 
@@ -111,7 +110,9 @@ class FlowSessionImpl(
     private fun <R : Any> deserializeReceivedPayload(received: Map<String, ByteArray>, receiveType: Class<R>): UntrustworthyData<R> {
         return received[sourceSessionId]?.let {
             try {
-                UntrustworthyData(deserialize(it, receiveType))
+                val payload = getSerializationService().deserialize(it, receiveType)
+                checkPayloadIs(payload, receiveType)
+                UntrustworthyData(payload)
             } catch (e: NotSerializableException) {
                 log.info("Received a payload but failed to deserialize it into a ${receiveType.name}", e)
                 throw e
@@ -119,8 +120,15 @@ class FlowSessionImpl(
         } ?: throw CordaRuntimeException("The session [${sourceSessionId}] did not receive a payload when trying to receive one")
     }
 
-    private fun <R : Any> deserialize(payload: ByteArray, receiveType: Class<R>): R {
-        return getSerializationService().deserialize(payload, receiveType)
+    /**
+     * AMQP deserialization outputs an object whose type is solely based on the serialized content, therefore although the generic type is
+     * specified, it can still be the wrong type. We check this type here, so that we can throw an accurate error instead of failing later
+     * on when the object is used.
+     */
+    private fun <R : Any> checkPayloadIs(payload: Any, receiveType: Class<R>) {
+        receiveType.castIfPossible(payload) ?: throw CordaRuntimeException(
+            "Expecting to receive a ${receiveType.name} but received a ${payload.javaClass.name} instead, payload: ($payload)"
+        )
     }
 
     private fun getSerializationService(): SerializationService {

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -54,7 +54,7 @@ public class FlowSessionImplJavaTest {
         Map<String, byte[]> received = new HashMap<>();
         received.put("session id", new byte[]{ 1, 2, 3 });
         when(serializationService.serialize(any())).thenReturn(new SerializedBytes(new byte[]{ 1, 2, 3 }));
-        when(serializationService.deserialize(any(byte[].class), any())).thenReturn("hello there");
+        when(serializationService.deserialize(any(byte[].class), any())).thenReturn(1);
         when(sandboxGroupContext.get(FlowSandboxContextTypes.AMQP_P2P_SERIALIZATION_SERVICE, SerializationService.class))
             .thenReturn(serializationService);
         when(flowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext);

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -85,6 +86,13 @@ class FlowSessionImplTest {
     }
 
     @Test
+    fun `receiving the wrong object type in sendAndReceive throws an exception`() {
+        whenever(serializationService.deserialize(eq(HELLO_THERE.toByteArray()), any<Class<*>>())).thenReturn(1)
+        val session = createSession(FlowSessionImpl.State.INITIATED)
+        assertThrows<CordaRuntimeException> { session.sendAndReceive(String::class.java, HI) }
+    }
+
+    @Test
     fun `sendAndReceive returns the result of the flow's suspension`() {
         val session = createSession(FlowSessionImpl.State.INITIATED)
         assertEquals(HELLO_THERE, session.sendAndReceive(String::class.java, HI).unwrap { it })
@@ -112,6 +120,13 @@ class FlowSessionImplTest {
         val session = createSession(FlowSessionImpl.State.CLOSED)
         assertThrows<CordaRuntimeException> { session.receive(String::class.java) }
         verify(flowFiber, never()).suspend(any<FlowIORequest.InitiateFlow>())
+    }
+
+    @Test
+    fun `receiving the wrong object type in receive throws an exception`() {
+        whenever(serializationService.deserialize(eq(HELLO_THERE.toByteArray()), any<Class<*>>())).thenReturn(1)
+        val session = createSession(FlowSessionImpl.State.INITIATED)
+        assertThrows<CordaRuntimeException> { session.receive(String::class.java) }
     }
 
     @Test


### PR DESCRIPTION
In `FlowSession.receive` and `FlowSession.sendAndReceive`, check the
received payload type.

The wrong payload could be send back to the
receiving session, and the AMQP deserialization will not inherently fail
by itself.

Therefore, a check has been added to ensure the received type is the
same type expected by the session.