### PR TITLE
CORE-4546 Make sending session closes idempotent

### DIFF
--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/interactions/SessionCloseIntegrationTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/interactions/SessionCloseIntegrationTest.kt
@@ -277,7 +277,7 @@ class SessionCloseIntegrationTest {
         bob.processNextReceivedMessage(sendMessages = true)
         alice.processNextReceivedMessage()
 
-        alice.assertStatus(SessionStateType.ERROR)
-        bob.assertStatus(SessionStateType.ERROR)
+        alice.assertStatus(SessionStateType.CLOSED)
+        bob.assertStatus(SessionStateType.CLOSED)
     }
 }

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosedTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosedTransitionTest.kt
@@ -40,7 +40,7 @@ class SessionStateClosedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant)
         val outputState = sessionManager.processMessageToSend(sessionState, sessionState, sessionEvent, instant)
-        Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.ERROR)
+        Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSED)
     }
 
     @Test

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosingTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosingTransitionTest.kt
@@ -59,7 +59,7 @@ class SessionStateClosingTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant)
         val outputState = sessionManager.processMessageToSend(sessionState, sessionState, sessionEvent, instant)
-        Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.ERROR)
+        Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSING)
     }
 
     @Test

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateWaitFinalAckTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateWaitFinalAckTransitionTest.kt
@@ -40,7 +40,7 @@ class SessionStateWaitFinalAckTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant)
         val outputState = sessionManager.processMessageToSend(sessionState, sessionState, sessionEvent, Instant.now())
-        Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.ERROR)
+        Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.WAIT_FOR_FINAL_ACK)
     }
 
     @Test

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionCloseProcessorSend.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionCloseProcessorSend.kt
@@ -10,7 +10,6 @@ import net.corda.session.manager.impl.processor.helper.generateErrorSessionState
 import net.corda.v5.base.util.contextLogger
 import java.time.Instant
 
-
 /**
  * Handle send of a [SessionClose] event.
  * If the state is null, ERROR or CLOSED send an error response to the counterparty as this indicates a bug in client code or  a
@@ -38,16 +37,17 @@ class SessionCloseProcessorSend(
             sessionState == null -> {
                 handleNullSession(sessionId)
             }
-            currentStatus == SessionStateType.ERROR || currentStatus == SessionStateType.WAIT_FOR_FINAL_ACK || currentStatus ==
-                    SessionStateType.CLOSED -> {
+            currentStatus == SessionStateType.CLOSED || currentStatus == SessionStateType.WAIT_FOR_FINAL_ACK -> {
+                sessionState
+            }
+            currentStatus == SessionStateType.ERROR -> {
                 handleInvalidStatus(sessionState)
             }
-            sessionState.receivedEventsState.undeliveredMessages.any { it.payload !is SessionClose } -> {
+            hasUnprocessedReceivedDataEvents(sessionState) -> {
                 handleUnprocessedReceivedDataEvents(sessionId, sessionState)
             }
-            currentStatus == SessionStateType.CLOSING &&
-                    sessionState.receivedEventsState.undeliveredMessages.none { it.payload is SessionClose } -> {
-                handleDuplicateCloseSent(sessionState)
+            isClosingWithClosesToSend(currentStatus, sessionState) -> {
+                sessionState
             }
             else -> {
                 val nextSeqNum = sessionState.sendEventsState.lastProcessedSequenceNum + 1
@@ -63,14 +63,8 @@ class SessionCloseProcessorSend(
         return generateErrorSessionStateFromSessionEvent(errorMessage, sessionEvent, "SessionCLose-StateNull", instant)
     }
 
-    private fun handleDuplicateCloseSent(
-        sessionState: SessionState
-    ): SessionState {
-        val sessionId = sessionState.sessionId
-        val errorMessage = "Tried to send SessionClose on key $key and sessionId $sessionId, session status is " +
-                "${sessionState.status}, however SessionClose has already been sent. " +
-                "Current SessionState: $sessionState."
-        return logAndGenerateErrorResult(errorMessage, sessionState, "SessionClose-SessionMismatch")
+    private fun hasUnprocessedReceivedDataEvents(sessionState: SessionState): Boolean {
+        return sessionState.receivedEventsState.undeliveredMessages.any { it.payload !is SessionClose }
     }
 
     private fun handleUnprocessedReceivedDataEvents(
@@ -85,7 +79,7 @@ class SessionCloseProcessorSend(
 
     private fun handleInvalidStatus(
         sessionState: SessionState
-    ) : SessionState {
+    ): SessionState {
         val errorMessage = "Tried to send SessionClose on key $key for sessionId ${sessionState.sessionId} " +
                 "with status of : ${sessionState.status}"
         logger.error(errorMessage)
@@ -95,6 +89,11 @@ class SessionCloseProcessorSend(
                 generateErrorEvent(sessionState, sessionEvent, errorMessage, "SessionClose-InvalidStatus", instant)
             )
         }
+    }
+
+    private fun isClosingWithClosesToSend(currentStatus: SessionStateType?, sessionState: SessionState): Boolean {
+        return currentStatus == SessionStateType.CLOSING &&
+                sessionState.receivedEventsState.undeliveredMessages.none { it.payload is SessionClose }
     }
 
     private fun getResultByCurrentState(
@@ -110,7 +109,7 @@ class SessionCloseProcessorSend(
             }
         }
         SessionStateType.CLOSING -> {
-            //Doesn't go to closed until ack received
+            // Doesn't go to closed until ack received
             sessionState.apply {
                 status = SessionStateType.WAIT_FOR_FINAL_ACK
                 sendEventsState.lastProcessedSequenceNum = nextSeqNum


### PR DESCRIPTION
`SessionCloseProcessorSend` will no longer error a session if a
duplicate session close is attempted.

The following logic is followed:

- Sessions already `CLOSED` or `WAIT_FOR_FINAL_ACK` - Do nothing.
- Sessions in `CLOSING` that already have an outgoing `SessionClose` to
  send - Do nothing.

Other code paths remain the same.