### PR TITLE
CORE-4671 - close rpcSender instead of stopping 

### DIFF
--- a/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
+++ b/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
@@ -89,9 +89,9 @@ internal class PermissionManagementServiceEventHandler(
                         permissionValidator = permissionValidationService.permissionValidator
                     }
                     LifecycleStatus.DOWN -> {
-                        permissionManager?.stop()
+                        permissionManager?.close()
                         permissionManager = null
-                        basicAuthenticationService?.stop()
+                        basicAuthenticationService?.close()
                         basicAuthenticationService = null
                         permissionValidator = null
                         coordinator.updateStatus(LifecycleStatus.DOWN)
@@ -118,7 +118,7 @@ internal class PermissionManagementServiceEventHandler(
                 configSubscription = null
                 rpcSender?.close()
                 rpcSender = null
-                permissionManager?.stop()
+                permissionManager?.close()
                 permissionManager = null
                 registrationHandle?.close()
                 registrationHandle = null
@@ -138,13 +138,13 @@ internal class PermissionManagementServiceEventHandler(
             "Configuration received for permission manager but permission validation cache was null."
         }
 
-        permissionManager?.stop()
+        permissionManager?.close()
         log.info("Creating and starting permission manager.")
         permissionManager =
             permissionManagerFactory.createPermissionManager(config, rpcSender!!, permissionManagementCache, permissionValidationCache)
                 .also { it.start() }
 
-        basicAuthenticationService?.stop()
+        basicAuthenticationService?.close()
         log.info("Creating and starting basic authentication service using permission system.")
         basicAuthenticationService = permissionManagerFactory.createBasicAuthenticationService(permissionManagementCache)
             .also { it.start() }

--- a/components/permissions/permission-management-service/src/test/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandlerTest.kt
+++ b/components/permissions/permission-management-service/src/test/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandlerTest.kt
@@ -127,7 +127,7 @@ internal class PermissionManagementServiceEventHandlerTest {
 
         handler.processEvent(RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN), coordinator)
 
-        verify(permissionManager).stop()
+        verify(permissionManager).close()
         verify(coordinator).updateStatus(LifecycleStatus.DOWN)
     }
 
@@ -150,7 +150,7 @@ internal class PermissionManagementServiceEventHandlerTest {
 
         handler.processEvent(RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN), coordinator)
 
-        verify(permissionManager).stop()
+        verify(permissionManager).close()
         verify(coordinator).updateStatus(LifecycleStatus.DOWN)
 
         assertNull(handler.permissionManager)
@@ -177,7 +177,7 @@ internal class PermissionManagementServiceEventHandlerTest {
         assertNull(handler.rpcSender)
 
         verify(rpcSender).close()
-        verify(permissionManager).stop()
+        verify(permissionManager).close()
         verify(registrationHandle).close()
         verify(coordinator).updateStatus(LifecycleStatus.DOWN)
     }


### PR DESCRIPTION
This means its coordinator gets removed from the coordinator registry and allows permission management service to stop and start without conflict with the new rpc sender's coordinator ID.

Here is where coordinator ID for rpc sender is set to the instance ID.
https://github.com/corda/corda-runtime-os/blob/701fc1159fb6dfeaa4d658813aaea8a08d4ccd9d/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt#L78-L84

Here is where calling stop only calls coordinator.stop, whereas close calls coordinator.close().
https://github.com/corda/corda-runtime-os/blob/701fc1159fb6dfeaa4d658813aaea8a08d4ccd9d/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt#L113-L125

Here is the coordinator code where we can see calling close removes from registry.
https://github.com/corda/corda-runtime-os/blob/8e1710c33553546a97b034567715a24128feb8b7/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt#L258-L269