### PR TITLE
CORE-3789: Use the same namespace type for all P2P namespaces

### DIFF
--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/ConfigureAll.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/ConfigureAll.kt
@@ -62,7 +62,7 @@ class ConfigureAll : Runnable {
             "get",
             "namespace",
             "-l",
-            "namespace-type=p2p-deployment,creator=${MyUserName.userName},p2p-namespace-type=deployed-layer",
+            "namespace-type=p2p-deployment,creator=${MyUserName.userName},p2p-namespace-type=p2p-cluster",
             "-o",
             "jsonpath={range .items[*]}{.metadata.name}{\"|\"}{.metadata.annotations}{\"\\n\"}{end}",
         ).lines()

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/Status.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/Status.kt
@@ -21,7 +21,7 @@ class Status : Runnable {
         val now = Instant.now()
         val nameSpaces = ProcessRunner.execute(
             "kubectl", "get", "ns",
-            "-l", "namespace-type=p2p-deployment,p2p-namespace-type=deployed-layer",
+            "-l", "namespace-type=p2p-deployment,p2p-namespace-type=p2p-cluster",
             "-o",
             "jsonpath={range .items[*]}" +
                 "{.metadata.name}{\"\\t\"}" +
@@ -54,7 +54,7 @@ class Status : Runnable {
 
         val dbs = ProcessRunner.execute(
             "kubectl", "get", "ns",
-            "-l", "namespace-type=p2p-deployment,p2p-namespace-type=db",
+            "-l", "namespace-type=p2p-deployment,p2p-namespace-type=simulator-db",
             "-o",
             "jsonpath={range .items[*]}" +
                 "{.metadata.name}{\"\\t\"}" +

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/UpdateIps.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/UpdateIps.kt
@@ -67,7 +67,7 @@ class UpdateIps : Runnable {
             "get",
             "namespace",
             "-l",
-            "namespace-type=p2p-deployment,creator=${MyUserName.userName},p2p-namespace-type=deployed-layer",
+            "namespace-type=p2p-deployment,creator=${MyUserName.userName},p2p-namespace-type=p2p-cluster",
             "-o",
             "jsonpath={range .items[*]}{.metadata.name}{\",\"}{.metadata.annotations.host}{\"\\n\"}{end}",
         ).lines()

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/simulator/db/StartDb.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/simulator/db/StartDb.kt
@@ -50,7 +50,7 @@ class StartDb : Runnable {
                 "name" to name,
                 "labels" to mapOf(
                     "namespace-type" to "p2p-deployment",
-                    "p2p-namespace-type" to "db",
+                    "p2p-namespace-type" to "simulator-db",
                     "creator" to MyUserName.userName,
                 ),
                 "annotations" to mapOf(

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/Namespace.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/Namespace.kt
@@ -53,7 +53,7 @@ class Namespace(
                     "name" to identifier.namespaceName,
                     "labels" to mapOf(
                         "namespace-type" to "p2p-deployment",
-                        "p2p-namespace-type" to "deployed-layer",
+                        "p2p-namespace-type" to "p2p-cluster",
                         "creator" to MyUserName.userName,
                     ),
                     "annotations" to mapOf(


### PR DESCRIPTION
Change the name of the database namespace type to `p2p-deployment` so it will be caught by the clean-up cron job, add another metadata label to distinguish between the database namespace and the layer itself.  