### PR TITLE
Increase retry duration in smoke test even more

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -46,7 +46,7 @@ class VirtualNodeRpcTest {
 
         // BUG:  https://r3-cev.atlassian.net/browse/CORE-3966 and https://r3-cev.atlassian.net/browse/CORE-3968
         // Max wait duration CPI to arrive for flow - arbitrarily picked.
-        private val FLOW_WAIT_DURATION = Duration.ofSeconds(30)
+        private val FLOW_WAIT_DURATION = Duration.ofSeconds(60)
     }
 
     private val clusterUri = URI(System.getProperty("rpcHost"))


### PR DESCRIPTION
Gradle enterprise is reporting the run-flow test as flaky, which in turn
implies that flow-worker *still doesn't receive the CPI in time*,
presumably as a consequence of being severely resource constrained in
the CI environment.

Double the timeout.