### PR TITLE
NOTICK: Declare packaging-core dependencies as API, and remove duplicate.

### DIFF
--- a/libs/virtual-node/packaging-core/build.gradle
+++ b/libs/virtual-node/packaging-core/build.gradle
@@ -8,13 +8,10 @@ description "Packaging Interfaces and Data Classes"
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
+    api platform("net.corda:corda-api:$cordaApiVersion")
     api "net.corda:corda-avro-schema"
-
-    implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda:corda-packaging"
-    implementation "net.corda:corda-packaging"
-
-    implementation "net.corda:corda-packaging-avro-converters"
+    api "net.corda:corda-packaging"
+    api "net.corda:corda-packaging-avro-converters"
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"


### PR DESCRIPTION
Declare `packaging-core` dependencies as `api` because their types are part of this module's public API. We therefore cannot compile against `packaging-core` without also having its dependencies on the `compleClasspath`