### PR TITLE
NOTICK: Remove ANSI codes from PicoCli tests

### DIFF
--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPlugin.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPlugin.kt
@@ -9,12 +9,13 @@ class TestInitialConfigPlugin {
 
     @Test
     fun testSetupScriptMissingCommand() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()
 
         val outText = SystemLambda.tapSystemErrNormalized {
             CommandLine(
                 app
-            ).execute()
+            ).setColorScheme(colorScheme).execute()
         }
         assertThat(outText).startsWith("Missing required subcommand")
     }

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
@@ -8,12 +8,13 @@ import picocli.CommandLine
 class TestInitialConfigPluginDb {
     @Test
     fun testDbConfigCreationMissingOptions() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()
 
         val outText = SystemLambda.tapSystemErrNormalized {
             CommandLine(
                 app
-            ).execute("create-db-config")
+            ).setColorScheme(colorScheme).execute("create-db-config")
         }
         assertThat(outText).startsWith(
             "Missing required options: '--name=<connectionName>'," +
@@ -24,12 +25,13 @@ class TestInitialConfigPluginDb {
 
     @Test
     fun testDbConfigCreation() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()
 
         val outText = SystemLambda.tapSystemOutNormalized {
             CommandLine(
                 app
-            ).execute(
+            ).setColorScheme(colorScheme).execute(
                 "create-db-config",
                 "-n", "connection name",
                 "-j", "jdbd:postgres://testurl",

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginUser.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginUser.kt
@@ -10,12 +10,13 @@ class TestInitialConfigPluginUser {
 
     @Test
     fun testDevSetupScript() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()
 
         val outText = tapSystemOutNormalized {
             CommandLine(
                 app
-            ).execute("create-user-config", "create-dev-config")
+            ).setColorScheme(colorScheme).execute("create-user-config", "create-dev-config")
         }
 
         // can only compare the first bit as timestamp and salted hash will change.
@@ -27,12 +28,13 @@ class TestInitialConfigPluginUser {
 
     @Test
     fun testSetupScript() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()
 
         val outText = tapSystemOutNormalized {
             CommandLine(
                 app
-            ).execute("create-user-config", "-u", "user1", "-p", "password")
+            ).setColorScheme(colorScheme).execute("create-user-config", "-u", "user1", "-p", "password")
         }
 
         // can only compare the first bit as timestamp and salted hash will change.
@@ -46,24 +48,26 @@ class TestInitialConfigPluginUser {
 
     @Test
     fun testSetupScriptMissingUser() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()
 
         val outText = tapSystemErrNormalized {
             CommandLine(
                 app
-            ).execute("create-user-config")
+            ).setColorScheme(colorScheme).execute("create-user-config")
         }
         assertThat(outText).startsWith("A user id must be specified.")
     }
 
     @Test
     fun testSetupScriptNoPassword() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()
 
         val outText = tapSystemOutNormalized {
             CommandLine(
                 app
-            ).execute("create-user-config", "-u", "user1")
+            ).setColorScheme(colorScheme).execute("create-user-config", "-u", "user1")
         }
 
         assertThat(outText).startsWith(

--- a/tools/plugins/secret-config/src/test/kotlin/net/corda/cli/plugin/secretconfig/TestSecretConfigPlugin.kt
+++ b/tools/plugins/secret-config/src/test/kotlin/net/corda/cli/plugin/secretconfig/TestSecretConfigPlugin.kt
@@ -13,12 +13,13 @@ import java.util.stream.Stream
 class TestSecretConfigPlugin {
     @Test
     fun testEncryption() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = SecretConfigPlugin.PluginEntryPoint()
 
         val outText = SystemLambda.tapSystemOutNormalized {
             CommandLine(
                 app
-            ).execute("password", "-p", "not so secure", "-s", "not so secret", "create")
+            ).setColorScheme(colorScheme).execute("password", "-p", "not so secure", "-s", "not so secret", "create")
         }
 
         println(outText)
@@ -27,12 +28,13 @@ class TestSecretConfigPlugin {
 
     @Test
     fun testDecryption() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = SecretConfigPlugin.PluginEntryPoint()
 
         val outText = SystemLambda.tapSystemOutNormalized {
             CommandLine(
                 app
-            ).execute(
+            ).setColorScheme(colorScheme).execute(
                 "clCX2yEq3d/F0TvQsnqCp1n5ppEMKp+6WLnCJbufaJIxi4uI",
                 "-p",
                 "not so secure",
@@ -49,11 +51,12 @@ class TestSecretConfigPlugin {
     @ParameterizedTest
     @MethodSource("badCommandLineInputs")
     fun testBadCommandline(caseName: String, args: Array<String>, expectedError: String) {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = SecretConfigPlugin.PluginEntryPoint()
         val outText = SystemLambda.tapSystemErrNormalized {
             CommandLine(
                 app
-            ).execute(
+            ).setColorScheme(colorScheme).execute(
                 *args
             )
         }


### PR DESCRIPTION
Plugin tests can fail when using some terminals because picocli can choose to write ANSI control characters to stderr. This then breaks the test assertions as they are doing direct string comparisons and the picked up string contains the ANSI control characters. This is a problem for windows users running on msys (e.g. git bash) - I haven't tested any other potential setups but I'm sure there are others. Note that this does not happen inside intellij, presumably as picocli's ANSI enabling heuristic assumes that the terminal doesn't support it.

This forces the offending tests to never output ANSI control characters, which resolves the problem.