### PR TITLE
CORE-4656 - try eliminate flaky test by increasing permission endpoint timeout

### DIFF
--- a/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/SmartConfigUtil.kt
+++ b/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/SmartConfigUtil.kt
@@ -5,7 +5,7 @@ import net.corda.schema.configuration.ConfigKeys.RPC_ENDPOINT_TIMEOUT_MILLIS
 import java.time.Duration
 
 internal object SmartConfigUtil {
-    private const val DEFAULT_ENDPOINT_TIMEOUT_MS = 10000L
+    private const val DEFAULT_ENDPOINT_TIMEOUT_MS = 30000L
 
     fun SmartConfig.getEndpointTimeout(): Duration {
         return if (hasPath(RPC_ENDPOINT_TIMEOUT_MILLIS)) {

--- a/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
+++ b/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
@@ -80,10 +80,12 @@ class PermissionUserManagerImplTest {
     private val manager =
         PermissionUserManagerImpl(config, rpcSender, permissionManagementCache, permissionValidationCache, passwordService)
 
+    private val defaultTimeout = Duration.ofSeconds(30)
+
     @Test
     fun `create a user sends rpc request and converts result`() {
         val future = mock<CompletableFuture<PermissionManagementResponse>>()
-        whenever(future.getOrThrow(Duration.ofSeconds(10))).thenReturn(permissionManagementResponse)
+        whenever(future.getOrThrow(defaultTimeout)).thenReturn(permissionManagementResponse)
 
         val requestCaptor = argumentCaptor<PermissionManagementRequest>()
         whenever(rpcSender.sendRequest(requestCaptor.capture())).thenReturn(future)
@@ -122,7 +124,7 @@ class PermissionUserManagerImplTest {
     @Test
     fun `create a user sends rpc request and converts result correctly when no password is provided`() {
         val future = mock<CompletableFuture<PermissionManagementResponse>>()
-        whenever(future.getOrThrow(Duration.ofSeconds(10))).thenReturn(permissionManagementResponseWithoutPassword)
+        whenever(future.getOrThrow(defaultTimeout)).thenReturn(permissionManagementResponseWithoutPassword)
 
         val requestCaptor = argumentCaptor<PermissionManagementRequest>()
         whenever(rpcSender.sendRequest(requestCaptor.capture())).thenReturn(future)
@@ -161,7 +163,7 @@ class PermissionUserManagerImplTest {
     fun `create a user throws exception if result is not an avro User`() {
         val future = mock<CompletableFuture<PermissionManagementResponse>>()
         val incorrectResponse = PermissionManagementResponse(true)
-        whenever(future.getOrThrow(Duration.ofSeconds(10))).thenReturn(incorrectResponse)
+        whenever(future.getOrThrow(defaultTimeout)).thenReturn(incorrectResponse)
 
         val requestCaptor = argumentCaptor<PermissionManagementRequest>()
         whenever(rpcSender.sendRequest(requestCaptor.capture())).thenReturn(future)
@@ -221,7 +223,7 @@ class PermissionUserManagerImplTest {
     @Test
     fun `add role to user sends rpc request and converts result to response dto`() {
         val future = mock<CompletableFuture<PermissionManagementResponse>>()
-        whenever(future.getOrThrow(Duration.ofSeconds(10))).thenReturn(permissionManagementResponse)
+        whenever(future.getOrThrow(defaultTimeout)).thenReturn(permissionManagementResponse)
 
         val capture = argumentCaptor<PermissionManagementRequest>()
         whenever(rpcSender.sendRequest(capture.capture())).thenReturn(future)
@@ -244,7 +246,7 @@ class PermissionUserManagerImplTest {
     @Test
     fun `add role to user throws if exception is returned`() {
         val future = mock<CompletableFuture<PermissionManagementResponse>>()
-        whenever(future.getOrThrow(Duration.ofSeconds(10))).thenThrow(IllegalArgumentException("Invalid user."))
+        whenever(future.getOrThrow(defaultTimeout)).thenThrow(IllegalArgumentException("Invalid user."))
 
         val capture = argumentCaptor<PermissionManagementRequest>()
         whenever(rpcSender.sendRequest(capture.capture())).thenReturn(future)
@@ -266,7 +268,7 @@ class PermissionUserManagerImplTest {
         val permissionManagementResponse = PermissionManagementResponse(avroUser)
 
         val future = mock<CompletableFuture<PermissionManagementResponse>>()
-        whenever(future.getOrThrow(Duration.ofSeconds(10))).thenReturn(permissionManagementResponse)
+        whenever(future.getOrThrow(defaultTimeout)).thenReturn(permissionManagementResponse)
 
         val capture = argumentCaptor<PermissionManagementRequest>()
         whenever(rpcSender.sendRequest(capture.capture())).thenReturn(future)
@@ -288,7 +290,7 @@ class PermissionUserManagerImplTest {
     @Test
     fun `remove role from user throws if exception is returned`() {
         val future = mock<CompletableFuture<PermissionManagementResponse>>()
-        whenever(future.getOrThrow(Duration.ofSeconds(10))).thenThrow(IllegalArgumentException("Invalid user."))
+        whenever(future.getOrThrow(defaultTimeout)).thenThrow(IllegalArgumentException("Invalid user."))
 
         val capture = argumentCaptor<PermissionManagementRequest>()
         whenever(rpcSender.sendRequest(capture.capture())).thenReturn(future)


### PR DESCRIPTION
This search on gradle enterprise identifies this test as being flaky on release branch:

https://gradle.dev.r3.com/scans/tests?search.relativeStartTime=P28D&search.tags=e2e&search.tags=release*&search.timeZoneId=Europe/London&tests.sortField=FLAKY&tests.unstableOnly=true

Flaky means the test failed and was re-run as part of the same build and passed the second time.

[https://gradle.dev.r3.com/scans/tests?search.relativeStartTime=P28D&search.tags=e2e&search.tags=release*&search.timeZoneId=Europe/London&tests.container=net.corda.applications.workers.rpc.PermissionSummaryConcurrentE2eTest&tests.sortField=FLAKY&tests.test=permission summary eventually consistent()&tests.unstableOnly=true](https://gradle.dev.r3.com/scans/tests?search.relativeStartTime=P28D&search.tags=e2e&search.tags=release*&search.timeZoneId=Europe/London&tests.container=net.corda.applications.workers.rpc.PermissionSummaryConcurrentE2eTest&tests.sortField=FLAKY&tests.test=permission%20summary%20eventually%20consistent()&tests.unstableOnly=true)

When it’s flaky it seems to have a timeout. There are 2 timeouts involved in this test:

- RPC endpoint timeout (configurable by RPC_ENDPOINT_TIMEOUT_MILLIS and defaults to 10s if not set)
- Timeout in the test (eventually block only runs for 5 seconds)

But given the output from failed test it seems to fail on adding a permission to a role, which indicates the RPC_ENDPOINT_TIMEOUT_MILLIS is being reached.

This change increases the endpoint timeout.

But maybe this jira should further investigate WHY the request is taking so long.