### PR TITLE
CORE-4540 Push all close logic into handlers

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/factory/FlowSessionFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/factory/FlowSessionFactoryImpl.kt
@@ -15,11 +15,6 @@ class FlowSessionFactoryImpl @Activate constructor(
 ) : FlowSessionFactory {
 
     override fun create(sessionId: String, x500Name: MemberX500Name, initiated: Boolean): FlowSession {
-        return FlowSessionImpl(
-            counterparty = x500Name,
-            sourceSessionId = sessionId,
-            flowFiberService = flowFiberService,
-            state = if (initiated) FlowSessionImpl.State.INITIATED else FlowSessionImpl.State.UNINITIATED
-        )
+        return FlowSessionImpl(counterparty = x500Name, sessionId, flowFiberService, initiated)
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -11,7 +11,7 @@ import net.corda.v5.base.util.uncheckedCast
 import org.slf4j.Logger
 import org.slf4j.MDC
 import java.nio.ByteBuffer
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
 
@@ -129,11 +129,6 @@ class FlowFiberImpl<R>(
         val flowStackItem = getRemainingFlowStackItem()
         if (flowStackItem.sessionIds.isNotEmpty()) {
             suspend(FlowIORequest.CloseSessions(flowStackItem.sessionIds.toSet()))
-        } else {
-            // If there are no sessions to close, we need to suspend anyway to ensure that any acknowledgements to received closed events
-            // are sent. This is due to the flow finish code removing the flow's checkpoint, which is needed to determine which sessions
-            // need to send acknowledgements.
-            suspend(FlowIORequest.ForceCheckpoint)
         }
     }
 

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -1,7 +1,6 @@
 package net.corda.flow.application.sessions;
 
 import net.corda.data.identity.HoldingIdentity;
-import net.corda.flow.application.sessions.FlowSessionImpl.State;
 import net.corda.flow.fiber.FlowFiber;
 import net.corda.flow.fiber.FlowFiberExecutionContext;
 import net.corda.flow.fiber.FlowFiberService;
@@ -46,7 +45,7 @@ public class FlowSessionImplJavaTest {
             new MemberX500Name("Alice", "Alice Corp", "LDN", "GB"),
             "session id",
             flowFiberService,
-            State.INITIATED
+            true
     );
 
     @BeforeEach

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
@@ -1,12 +1,12 @@
 package net.corda.flow.application.sessions
 
+import net.corda.flow.ALICE_X500_NAME
 import net.corda.flow.application.services.MockFlowFiberService
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.sandbox.FlowSandboxContextTypes
 import net.corda.v5.application.messaging.unwrap
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.serialization.SerializedBytes
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -54,7 +54,7 @@ class FlowSessionImplTest {
 
     @Test
     fun `calling sendAndReceive with an uninitiated session will cause the flow to suspend to initiate the session`() {
-        val session = createSession(FlowSessionImpl.State.UNINITIATED)
+        val session = createSession(initiated = false)
         session.sendAndReceive(String::class.java, HI)
         verify(flowFiber).suspend(any<FlowIORequest.InitiateFlow>())
         verify(flowFiber).suspend(any<FlowIORequest.SendAndReceive>())
@@ -62,36 +62,29 @@ class FlowSessionImplTest {
 
     @Test
     fun `calling sendAndReceive with an initiated session will not cause the flow to suspend to initiate the session`() {
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         session.sendAndReceive(String::class.java, HI)
         verify(flowFiber, never()).suspend(any<FlowIORequest.InitiateFlow>())
         verify(flowFiber).suspend(any<FlowIORequest.SendAndReceive>())
     }
 
     @Test
-    fun `calling sendAndReceive with a closed session will throw an exception`() {
-        val session = createSession(FlowSessionImpl.State.CLOSED)
-        assertThrows<CordaRuntimeException> { session.sendAndReceive(String::class.java, HI) }
-        verify(flowFiber, never()).suspend(any<FlowIORequest.InitiateFlow>())
-    }
-
-    @Test
     fun `receiving the wrong object type in sendAndReceive throws an exception`() {
         whenever(serializationService.deserialize(eq(HELLO_THERE.toByteArray()), any<Class<*>>())).thenReturn(1)
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         assertThrows<CordaRuntimeException> { session.sendAndReceive(String::class.java, HI) }
     }
 
     @Test
     fun `sendAndReceive returns the result of the flow's suspension`() {
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         assertEquals(HELLO_THERE, session.sendAndReceive(String::class.java, HI).unwrap { it })
         verify(flowFiber).suspend(any<FlowIORequest.SendAndReceive>())
     }
 
     @Test
     fun `calling receive with an uninitiated session will cause the flow to suspend to initiate the session`() {
-        val session = createSession(FlowSessionImpl.State.UNINITIATED)
+        val session = createSession(initiated = false)
         session.receive(String::class.java)
         verify(flowFiber).suspend(any<FlowIORequest.InitiateFlow>())
         verify(flowFiber).suspend(any<FlowIORequest.Receive>())
@@ -99,36 +92,29 @@ class FlowSessionImplTest {
 
     @Test
     fun `calling receive with an initiated session will not cause the flow to suspend to initiate the session`() {
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         session.receive(String::class.java)
         verify(flowFiber, never()).suspend(any<FlowIORequest.InitiateFlow>())
         verify(flowFiber).suspend(any<FlowIORequest.Receive>())
     }
 
     @Test
-    fun `calling receive with a closed session will throw an exception`() {
-        val session = createSession(FlowSessionImpl.State.CLOSED)
-        assertThrows<CordaRuntimeException> { session.receive(String::class.java) }
-        verify(flowFiber, never()).suspend(any<FlowIORequest.InitiateFlow>())
-    }
-
-    @Test
     fun `receiving the wrong object type in receive throws an exception`() {
         whenever(serializationService.deserialize(eq(HELLO_THERE.toByteArray()), any<Class<*>>())).thenReturn(1)
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         assertThrows<CordaRuntimeException> { session.receive(String::class.java) }
     }
 
     @Test
     fun `receive returns the result of the flow's suspension`() {
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         assertEquals(HELLO_THERE, session.receive(String::class.java).unwrap { it })
         verify(flowFiber).suspend(any<FlowIORequest.Receive>())
     }
 
     @Test
     fun `calling send with an uninitiated session will cause the flow to suspend to initiate the session`() {
-        val session = createSession(FlowSessionImpl.State.UNINITIATED)
+        val session = createSession(initiated = false)
         session.send(HI)
         verify(flowFiber).suspend(any<FlowIORequest.InitiateFlow>())
         verify(flowFiber).suspend(any<FlowIORequest.Send>())
@@ -136,37 +122,25 @@ class FlowSessionImplTest {
 
     @Test
     fun `calling send with an initiated session will not cause the flow to suspend to initiate the session`() {
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         session.send(HI)
         verify(flowFiber, never()).suspend(any<FlowIORequest.InitiateFlow>())
         verify(flowFiber).suspend(any<FlowIORequest.Send>())
-    }
-
-    @Test
-    fun `calling send with a closed session will throw an exception`() {
-        val session = createSession(FlowSessionImpl.State.CLOSED)
-        assertThrows<CordaRuntimeException> { session.send(HI) }
-        verify(flowFiber, never()).suspend(any<FlowIORequest.InitiateFlow>())
     }
 
     @Test
     fun `send suspends the fiber to send a message`() {
-        val session = createSession(FlowSessionImpl.State.INITIATED)
+        val session = createSession(initiated = true)
         session.send(HI)
         verify(flowFiber).suspend(any<FlowIORequest.Send>())
     }
 
-    private fun createSession(state: FlowSessionImpl.State): FlowSessionImpl {
+    private fun createSession(initiated: Boolean): FlowSessionImpl {
         return FlowSessionImpl(
-            counterparty = MemberX500Name(
-                commonName = "Alice",
-                organisation = "Alice Corp",
-                locality = "LDN",
-                country = "GB"
-            ),
+            counterparty = ALICE_X500_NAME,
             sourceSessionId = SESSION_ID,
             mockFlowFiberService,
-            state
+            initiated
         )
     }
 }

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/corda/flowworker/development/flows/MessagingFlow.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/corda/flowworker/development/flows/MessagingFlow.kt
@@ -96,8 +96,17 @@ class MessagingInitiatedFlow(private val session: FlowSession) : Flow<String> {
         log.info("Closing session")
 
         session.close()
-
-        log.info("Closed session")
+        log.info("Closed session 1")
+        session.close()
+        log.info("Closed session 2")
+        session.close()
+        log.info("Closed session 3")
+        session.close()
+        log.info("Closed session 4")
+        session.close()
+        log.info("Closed session 4")
+        session.close()
+        log.info("Closed session 5")
 
         return "finished top level initiated flow"
     }


### PR DESCRIPTION
Remove session close state checking in `FlowSessionImpl` and rely on the
logic in `CloseSessionsRequestHandler` instead.

Sessions are not removed from the current flow stack item now, which
means when a subflow or flow finishes it will implicitly clean up the
sessions due to popping the flow stack item off.

This means sessions that even if a subflow's sessions are already
closed, a suspension will still occur but might instantly resume if
they're already closed. Similar behaviour is done at the end of a flow.

The `initiated` state of `FlowSessionImpl` is still kept as it's
required for the lazy session init, which the handlers cannot help with,
as reaching the handlers requires a suspension in the first place.