### PR TITLE
NOTICK remove duplicate picocli in gradle.props

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -116,9 +116,6 @@ compositeBuild=false
 cordaApiLocation=../corda-api
 jibCoreVersion=0.16.0
 
-# pico CLI
-picoCliVersion=4.5.2
-
 # PF4J
 pf4jVersion=3.6.0
 

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"
-    kapt "info.picocli:picocli-codegen:$picoCliVersion"
+    kapt "info.picocli:picocli-codegen:$picocliVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-db-schema'

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"
-    kapt "info.picocli:picocli-codegen:$picoCliVersion"
+    kapt "info.picocli:picocli-codegen:$picocliVersion"
 
     implementation project(':libs:permissions:permission-datamodel')
     implementation project(':libs:permissions:permission-password')

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"
-    kapt "info.picocli:picocli-codegen:$picoCliVersion"
+    kapt "info.picocli:picocli-codegen:$picocliVersion"
 
     implementation project(":libs:configuration:configuration-core")
 


### PR DESCRIPTION
Remove the duplicate version of picocli in the gradle.properties file
and replace previous usage.