### PR TITLE
NOTICK: Use ComponentContext.locateServices() to find dynamic services.

### DIFF
--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -17,6 +17,7 @@ configurations {
 
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
+    compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation project(":components:configuration:configuration-read-service")


### PR DESCRIPTION
Use `ComponentContext.locateServices()` to look-up the current `InternalCustomSerializer` services instances on demand.