### PR TITLE
CORE-4668: Prevent Quasar from instrumenting Corda's OSGi hooks.

### DIFF
--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -26,6 +26,7 @@ quasar {
             'org.mockito**',
             'org.opentest4j**',
             'org.eclipse**',
+            'net.corda.sandboxhooks.**',
             'net.corda.osgi.**'
     ]
 }


### PR DESCRIPTION
The OSGi hooks determine how the framework resolves each bundle, which creates the bundle wirings. However, the Quasar agent uses the bundle wirings to determine which bundle (i.e. classloader) provides each package. So exclude the OSGi hooks from Quasar instrumentation to avoid a circular dependency.