### PR TITLE
CORE-3292: Testing proposed change to corda-api in runtime-os

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XX-SNAPSHOT
-cordaApiVersion=5.0.0.87-beta+
+cordaApiVersion=5.0.0.88-alpha-1649944733093
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22


### PR DESCRIPTION
PR #2 
This PR replaces the beta api version number in runtime-os with the alpha produced by PR #1 in order to test the proposed change.


*PR #1 -> https://github.com/corda/corda-api/pull/327 