### PR TITLE
NOTICK: Restore ability to run Docker Compose plant locally

### DIFF
--- a/applications/workers/release/deploy/docker-compose.yaml
+++ b/applications/workers/release/deploy/docker-compose.yaml
@@ -147,10 +147,10 @@ services:
       JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006"
     command:
       - -mkafka.common.bootstrap.servers=kafka:9092
-      - -spassphrase=bad passphrase
-      - -ssalt=not so random
+      - -spassphrase=bad_passphrase
+      - -ssalt=not_so_random
       - -ddatabase.user=user
-      - -ddatabase.pass.configSecret.encryptedSecret=4LNuCvt+NhGIBwL7gRRhvAZh3k6JRN9NHv0aG3pi1xM=
+      - -ddatabase.pass.configSecret.encryptedSecret=5oDOdkf5E6aH+ZtnIa1tZ12oSFeUaUDijeHPWTy+8Us=
       - -ddatabase.jdbc.url=jdbc:postgresql://corda-cluster-db:5432/cordacluster
     healthcheck:
       test: [ "CMD-SHELL", "curl --fail http://localhost:7000/isHealthy || exit 1" ]

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
@@ -42,7 +42,7 @@ class DefaultWorkerParams {
     @Option(names = ["-s", "--secretsParams"], description = ["Secrets parameters for the worker."])
     var secretsParams = emptyMap<String, String>()
 
-    @Option(names = ["--workspace-dir"], description = ["Corda worspace directory."])
+    @Option(names = ["--workspace-dir"], description = ["Corda workspace directory."])
     var workspaceDir = ConfigDefaults.WORKSPACE_DIR
 
     @Option(names = ["--temp-dir"], description = ["Corda temp directory."])

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/ConfigEncryptor.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/ConfigEncryptor.kt
@@ -11,8 +11,8 @@ class ConfigEncryptor {
      */
     @Test
     fun createConfigSection() {
-        val salt = "not so random"
-        val passphrase = "bad passphrase"
+        val salt = "not_so_random"
+        val passphrase = "bad_passphrase"
         val passwordToEncrypt = "pass"
 
         val encryptionService = EncryptionSecretsServiceImpl(passphrase, salt)


### PR DESCRIPTION
The problem was that DBWorker was dying like so:
```
08:17:20.689 [main] INFO  net.corda.processors.db.internal.DBProcessorImpl - DB processor stopping.
08:17:20.699 [main] ERROR net.corda.osgi.framework.OSGiFrameworkMain - Error: Unmatched arguments from index 2: 'passphrase', 'so', 'random'!
java.lang.IllegalArgumentException: Unmatched arguments from index 2: 'passphrase', 'so', 'random'
at net.corda.applications.workers.workercommon.WorkerHelpers$Companion.getParams(WorkerHelpers.kt:37) ~[?:?]
at net.corda.applications.workers.db.DBWorker.startup(DBWorker.kt:43) ~[?:?]
at net.corda.osgi.framework.OSGiFrameworkWrap.startApplication(OSGiFrameworkWrap.kt:529) ~[db-worker.jar:?]
at net.corda.osgi.framework.OSGiFrameworkMain$Companion.main(OSGiFrameworkMain.kt:141) [db-worker.jar:?]
at net.corda.osgi.framework.OSGiFrameworkMain.main(OSGiFrameworkMain.kt) [db-worker.jar:?]
```
which was caused by the fact that spaces are not being handled correctly in `docker-compose.yaml`.

Use of spaces been eliminated (yes - I have tried using quotes without much luck) and the underlying password re-coded.

The change is verified by passing E2E and Smoke tests locally.