### PR TITLE
NOTICK  OSGi logs missing implementation errors

### DIFF
--- a/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
+++ b/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/OSGiFrameworkWrap.kt
@@ -524,7 +524,7 @@ class OSGiFrameworkWrap(
         val frameworkContext = framework.bundleContext
         val applicationServiceReference = frameworkContext.getServiceReference(Application::class.java)
 
-        //  Log only any errors that occur in the OSGi framework, such trying to instantiate missing implementations.
+        //  Log errors that occur in the OSGi framework, such trying to instantiate missing implementations.
         frameworkContext.addFrameworkListener {
             if (it.type and FrameworkEvent.ERROR != 0) {
                 logger.error(it.throwable.localizedMessage, it.throwable.cause)


### PR DESCRIPTION
Improve OSGi logging by adding a framework listener that reports errors.
One group of OSGi errors are missing implementations of our components
that may not necessarily be reported by any other mechanism.

This listener may log other errors reported by the OSGi framework.

Example log:

```
2022-04-20 17:51:18.002 [FelixDispatchQueue] ERROR net.corda.osgi.framework.OSGiFrameworkWrap - Service factory exception: net/corda/reconciliation/ReconcilerReader
java.lang.NoClassDefFoundError: net/corda/reconciliation/ReconcilerReader
        at java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
        at java.lang.ClassLoader.defineClass(ClassLoader.java:1017) ~[?:?]
        at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.defineClass(BundleWiringImpl.java:2332) ~[corda-db-worker-5.0.0.0-SNAPSHOT.jar:?]
        at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.defineClassParallel(BundleWiringImpl.java:2150) ~[corda-db-worker-5.0.0.0-SNAPSHOT.jar:?]
        ...
Caused by: java.lang.ClassNotFoundException: net.corda.reconciliation.ReconcilerReader not found by net.corda.reconciliation-impl [47]
	at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1585) ~[corda-db-worker-5.0.0.0-SNAPSHOT.jar:?]        

```