### PR TITLE
NOTICK: Seal the Kotlin reflection bundles.

### DIFF
--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -43,6 +43,7 @@ def jar = tasks.named('jar', Jar) {
         bnd """\
 Bundle-Name: Corda Kotlin Reflection
 Bundle-SymbolicName: \${project.group}.kotlin-reflection
+Sealed: true
 -includeresource: @kotlinx-metadata-jvm-${kotlinMetadataVersion}.jar
 -conditionalpackage: org.objectweb.asm
 """
@@ -56,6 +57,7 @@ def testingBundle = tasks.register('testingBundle', Bundle) {
     bundle {
         bnd '''\
 Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}
+Sealed: true
 '''
     }
 }


### PR DESCRIPTION
Prevent any possibility of tampering by sealing the bundle. This will prevent any other bundle from containing its own version of any of these packages.