### PR TITLE
CORE-4689 - close instead of stop direct dependencies in components

### DIFF
--- a/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
+++ b/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
@@ -136,7 +136,7 @@ class PermissionManagementCacheService @Activate constructor(
                 configRegistration?.close()
                 configRegistration = null
                 downTransition()
-                _permissionManagementCache?.stop()
+                _permissionManagementCache?.close()
                 _permissionManagementCache = null
             }
         }
@@ -149,13 +149,13 @@ class PermissionManagementCacheService @Activate constructor(
         configHandle = null
         topicsRegistration?.close()
         topicsRegistration = null
-        userSubscription?.stop()
+        userSubscription?.close()
         userSubscription = null
-        groupSubscription?.stop()
+        groupSubscription?.close()
         groupSubscription = null
-        roleSubscription?.stop()
+        roleSubscription?.close()
         roleSubscription = null
-        permissionSubscription?.stop()
+        permissionSubscription?.close()
         permissionSubscription = null
 
         userSnapshotReceived = false
@@ -175,28 +175,28 @@ class PermissionManagementCacheService @Activate constructor(
         val roleData = ConcurrentHashMap<String, Role>()
         val permissionData = ConcurrentHashMap<String, Permission>()
 
-        userSubscription?.stop()
+        userSubscription?.close()
         val userSubscription = createUserSubscription(userData, config)
             .also {
                 it.start()
                 userSubscription = it
             }
 
-        groupSubscription?.stop()
+        groupSubscription?.close()
         val groupSubscription = createGroupSubscription(groupData, config)
             .also {
                 it.start()
                 groupSubscription = it
             }
 
-        roleSubscription?.stop()
+        roleSubscription?.close()
         val roleSubscription = createRoleSubscription(roleData, config)
             .also {
                 it.start()
                 roleSubscription = it
             }
 
-        permissionSubscription?.stop()
+        permissionSubscription?.close()
         val permissionSubscription = createPermissionSubscription(permissionData, config)
             .also {
                 it.start()
@@ -211,7 +211,7 @@ class PermissionManagementCacheService @Activate constructor(
             )
         )
 
-        _permissionManagementCache?.stop()
+        _permissionManagementCache?.close()
         _permissionManagementCache = permissionManagementCacheFactory.createPermissionManagementCache(
             userData,
             groupData,

--- a/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
+++ b/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
@@ -96,7 +96,7 @@ class PermissionStorageReaderServiceEventHandler(
                 )
             }
             LifecycleStatus.DOWN -> {
-                permissionStorageReader?.stop()
+                permissionStorageReader?.close()
                 permissionStorageReader = null
                 crsSub?.close()
                 crsSub = null
@@ -133,7 +133,7 @@ class PermissionStorageReaderServiceEventHandler(
         permissionManagementCacheService.stop()
         publisher?.close()
         publisher = null
-        permissionStorageReader?.stop()
+        permissionStorageReader?.close()
         permissionStorageReader = null
         registrationHandle?.close()
         registrationHandle = null
@@ -154,7 +154,7 @@ class PermissionStorageReaderServiceEventHandler(
             it.start()
         }
 
-        permissionStorageReader?.stop()
+        permissionStorageReader?.close()
         permissionStorageReader = permissionStorageReaderFactory.create(
             checkNotNull(permissionValidationCacheService.permissionValidationCache) {
                 "The ${PermissionValidationCacheService::class.java} should be up and ready to provide the cache"

--- a/components/permissions/permission-storage-reader-service/src/test/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandlerTest.kt
+++ b/components/permissions/permission-storage-reader-service/src/test/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandlerTest.kt
@@ -135,7 +135,7 @@ class PermissionStorageReaderServiceEventHandlerTest {
         handler.processEvent(RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN), coordinator)
 
         assertNull(handler.permissionStorageReader)
-        verify(permissionStorageReader).stop()
+        verify(permissionStorageReader).close()
     }
 
     @Test
@@ -162,7 +162,7 @@ class PermissionStorageReaderServiceEventHandlerTest {
         verify(permissionManagementCacheService).stop()
         verify(permissionValidationCacheService).stop()
         verify(registrationHandle).close()
-        verify(permissionStorageReader).stop()
+        verify(permissionStorageReader).close()
         verify(publisher).close()
     }
 

--- a/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
+++ b/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
@@ -86,7 +86,7 @@ class PermissionStorageWriterServiceEventHandler(
     @VisibleForTesting
     internal fun onConfigurationUpdated(messagingConfig: SmartConfig) {
 
-        subscription?.stop()
+        subscription?.close()
         subscription = subscriptionFactory.createRPCSubscription(
             rpcConfig = RPCConfig(
                 groupName = GROUP_NAME,
@@ -106,7 +106,7 @@ class PermissionStorageWriterServiceEventHandler(
     }
 
     private fun downTransition(coordinator: LifecycleCoordinator) {
-        subscription?.stop()
+        subscription?.close()
         subscription = null
         crsSub?.close()
         crsSub = null

--- a/components/permissions/permission-storage-writer-service/src/test/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandlerTest.kt
+++ b/components/permissions/permission-storage-writer-service/src/test/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandlerTest.kt
@@ -88,6 +88,6 @@ class PermissionStorageWriterServiceEventHandlerTest {
         verify(subscription).start()
         handler.processEvent(StopEvent(), mock())
         assertNull(handler.subscription)
-        verify(subscription).stop()
+        verify(subscription).close()
     }
 }

--- a/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
+++ b/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
@@ -108,7 +108,7 @@ class PermissionValidationCacheService @Activate constructor(
                 configRegistration?.close()
                 configRegistration = null
                 downTransition()
-                _permissionValidationCache?.stop()
+                _permissionValidationCache?.close()
                 _permissionValidationCache = null
             }
         }
@@ -121,7 +121,7 @@ class PermissionValidationCacheService @Activate constructor(
         configHandle = null
         topicsRegistration?.close()
         topicsRegistration = null
-        permissionSummarySubscription?.stop()
+        permissionSummarySubscription?.close()
         permissionSummarySubscription = null
         permissionSummarySnapshotReceived = false
     }
@@ -134,7 +134,7 @@ class PermissionValidationCacheService @Activate constructor(
     private fun createAndStartSubscriptionsAndCache(config: SmartConfig) {
         val permissionSummaryData = ConcurrentHashMap<String, UserPermissionSummary>()
 
-        permissionSummarySubscription?.stop()
+        permissionSummarySubscription?.close()
         val permissionSummarySubscription = createPermissionSummarySubscription(permissionSummaryData, config)
             .also {
                 it.start()
@@ -144,7 +144,7 @@ class PermissionValidationCacheService @Activate constructor(
         topicsRegistration?.close()
         topicsRegistration = coordinator.followStatusChangesByName(setOf(permissionSummarySubscription.subscriptionName))
 
-        _permissionValidationCache?.stop()
+        _permissionValidationCache?.close()
         _permissionValidationCache = permissionValidationCacheFactory.createPermissionValidationCache(permissionSummaryData)
             .also { it.start() }
     }

--- a/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
+++ b/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
@@ -79,7 +79,7 @@ class PermissionValidationService @Activate constructor(
             is StopEvent -> {
                 log.info("Stop event received, stopping dependencies.")
                 permissionValidationCacheService.stop()
-                _permissionValidator?.stop()
+                _permissionValidator?.close()
                 _permissionValidator = null
                 registration?.close()
                 registration = null
@@ -91,6 +91,7 @@ class PermissionValidationService @Activate constructor(
         checkNotNull(permissionValidationCacheService.permissionValidationCache) {
             "Permission Validation Service received status UP but permission validation cache was null."
         }
+        _permissionValidator?.close()
         _permissionValidator = permissionValidatorFactory.create(permissionValidationCacheService.permissionValidationCache!!)
             .also { it.start() }
     }

--- a/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
+++ b/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
@@ -74,6 +74,7 @@ class RBACSecurityManagerService @Activate constructor(
                 log.info("Received registration status update ${event.status}.")
                 when (event.status) {
                     LifecycleStatus.UP -> {
+                        _securityManager?.close()
                         _securityManager = RBACSecurityManager(
                             permissionManagementService.permissionValidator,
                             permissionManagementService.basicAuthenticationService
@@ -92,6 +93,7 @@ class RBACSecurityManagerService @Activate constructor(
                 log.info("Stop event received, stopping dependencies and setting status to DOWN.")
                 registration?.close()
                 registration = null
+                _securityManager?.close()
                 _securityManager = null
             }
         }


### PR DESCRIPTION
components who directly create and manage instances of some dependency should close them in stop events and before creating a new instance.