### PR TITLE
CORE-4699 Revert change to membership tests until time allows for proper investigation in to failure

### DIFF
--- a/components/membership/membership-service-impl/build.gradle
+++ b/components/membership/membership-service-impl/build.gradle
@@ -24,5 +24,5 @@ dependencies {
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
 }

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -18,7 +18,11 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
-import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.hamcrest.Matchers.lessThanOrEqualTo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -64,8 +68,10 @@ class MemberOpsServiceProcessorTest {
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
         val now = Instant.now()
-        assertThat(actual.responseTimestamp.epochSecond).isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-        assertThat(actual.responseTimestamp.epochSecond).isLessThanOrEqualTo(now.epochSecond)
+        assertThat(
+            actual.responseTimestamp.epochSecond,
+            allOf(greaterThanOrEqualTo(expected.requestTimestamp.epochSecond), lessThanOrEqualTo(now.epochSecond))
+        )
     }
 
     @Test
@@ -111,6 +117,6 @@ class MemberOpsServiceProcessorTest {
             future.get()
         }
         assertNotNull(exception.cause)
-        assertThat(exception.cause).isInstanceOf(MembershipRegistrationException::class.java)
+        assertThat(exception.cause, instanceOf(MembershipRegistrationException::class.java))
     }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -1,19 +1,17 @@
 package net.corda.membership.impl.registration.staticnetwork
 
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts
-import net.corda.crypto.core.CryptoConsts.SigningKeyFilters.ALIAS_FILTER
+import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
-import net.corda.data.crypto.wire.ops.rpc.queries.CryptoKeyOrderBy
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.SignedMemberInfo
 import net.corda.layeredpropertymap.LayeredPropertyMapFactory
 import net.corda.layeredpropertymap.create
-import net.corda.layeredpropertymap.toWire
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.membership.GroupPolicy
+import net.corda.layeredpropertymap.toWire
 import net.corda.membership.exceptions.BadGroupPolicyException
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.impl.MGMContextImpl
@@ -29,23 +27,23 @@ import net.corda.membership.impl.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.impl.MemberInfoImpl
 import net.corda.membership.impl.buildMerkleTree
+import net.corda.membership.registration.MemberRegistrationService
+import net.corda.membership.registration.MembershipRequestRegistrationOutcome.NOT_SUBMITTED
+import net.corda.membership.registration.MembershipRequestRegistrationOutcome.SUBMITTED
+import net.corda.membership.registration.MembershipRequestRegistrationResult
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.ENDPOINT_PROTOCOL
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.ENDPOINT_URL
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.KEY_ALIAS
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.staticMembers
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.staticMgm
-import net.corda.membership.registration.MemberRegistrationService
-import net.corda.membership.registration.MembershipRequestRegistrationOutcome.NOT_SUBMITTED
-import net.corda.membership.registration.MembershipRequestRegistrationOutcome.SUBMITTED
-import net.corda.membership.registration.MembershipRequestRegistrationResult
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
-import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.schema.Schemas
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.KeyEncodingService
 import net.corda.v5.crypto.DigestService
 import net.corda.v5.crypto.calculateHash
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -84,6 +82,8 @@ class StaticMemberRegistrationService @Activate constructor(
         private val endpointUrlIdentifier = ENDPOINT_URL.substringBefore("-")
         private val endpointProtocolIdentifier = ENDPOINT_PROTOCOL.substringBefore("-")
     }
+
+    private val topic = Schemas.Membership.MEMBER_LIST_TOPIC
 
     // Handler for lifecycle events
     private val lifecycleHandler = RegistrationServiceLifecycleHandler(this)
@@ -136,11 +136,11 @@ class StaticMemberRegistrationService @Activate constructor(
      * Parses the static member list template as SignedMemberInfo objects and creates the records for the
      * kafka publisher.
      */
-    private fun parseMemberTemplate(registeringMember: HoldingIdentity): List<Record<String, PersistentMemberInfo>> {
+    private fun parseMemberTemplate(member: HoldingIdentity): List<Record<String, PersistentMemberInfo>> {
         val members = mutableListOf<Record<String, PersistentMemberInfo>>()
 
         val policy = try {
-            groupPolicyProvider.getGroupPolicy(registeringMember)
+            groupPolicyProvider.getGroupPolicy(member)
         } catch (e: BadGroupPolicyException) {
             logger.error("Creating empty member list since group policy file could not be found for holding identity.")
             return emptyList()
@@ -156,10 +156,10 @@ class StaticMemberRegistrationService @Activate constructor(
             isValidStaticMemberDeclaration(processedMembers, staticMember)
             val memberName = MemberX500Name.parse(staticMember.name!!).toString()
             val memberId = HoldingIdentity(memberName, groupId).id
-            val memberKey = getIdentityKey(staticMember, memberId)
+            val memberKey = generateOwningKey(staticMember, memberId)
             val encodedMemberKey = keyEncodingService.encodeAsString(memberKey)
-            val mgmKey = getMgmIdentityKey(memberId, policy)
-            val memberInfo = MemberInfoImpl(
+            val mgmKey = parseMgmTemplate(memberId, policy)
+            val memberInfo =  MemberInfoImpl(
                 memberProvidedContext = layeredPropertyMapFactory.create<MemberContextImpl>(
                     sortedMapOf(
                         PARTY_NAME to memberName,
@@ -183,9 +183,9 @@ class StaticMemberRegistrationService @Activate constructor(
             val signedMemberInfo = signMemberInfo(memberId, memberInfo, memberKey, mgmKey)
             members.add(
                 Record(
-                    MEMBER_LIST_TOPIC,
-                    registeringMember.id + "-" + memberId,
-                    PersistentMemberInfo(registeringMember.toAvro(), signedMemberInfo)
+                    topic,
+                    member.id + "-" + memberId,
+                    PersistentMemberInfo(member.toAvro(), signedMemberInfo)
                 )
             )
             processedMembers.add(memberName)
@@ -210,7 +210,7 @@ class StaticMemberRegistrationService @Activate constructor(
     /**
      * If the keyAlias is not defined in the static template, we are going to use the id of the HoldingIdentity as default.
      */
-    private fun getIdentityKey(
+    private fun generateOwningKey(
         member: StaticMember,
         memberId: String
     ): PublicKey {
@@ -218,13 +218,17 @@ class StaticMemberRegistrationService @Activate constructor(
         if (keyAlias.isNullOrBlank()) {
             keyAlias = memberId
         }
-        return getOrGenerateKeyPair(memberId, keyAlias)
+        return cryptoOpsClient.generateKeyPair(
+            tenantId = memberId,
+            category = CryptoConsts.HsmCategories.LEDGER,
+            alias = keyAlias
+        )
     }
 
     /**
      * Generates the MGM's key used for signing the MemberInfo from the static template.
      */
-    private fun getMgmIdentityKey(
+    private fun parseMgmTemplate(
         memberId: String,
         policy: GroupPolicy
     ): PublicKey {
@@ -234,29 +238,12 @@ class StaticMemberRegistrationService @Activate constructor(
         val keyAlias: String? = staticMgm[KEY_ALIAS]
         require(!keyAlias.isNullOrBlank()) { "MGM's key alias is not provided." }
 
-        return getOrGenerateKeyPair(memberId, keyAlias)
+        return cryptoOpsClient.generateKeyPair(
+            tenantId = memberId,
+            category = CryptoConsts.HsmCategories.LEDGER,
+            alias = keyAlias
+        )
     }
-
-    private fun getOrGenerateKeyPair(tenantId: String, keyAlias: String): PublicKey {
-        return with(cryptoOpsClient) {
-            lookup(
-                tenantId = tenantId,
-                skip = 0,
-                take = 10,
-                orderBy = CryptoKeyOrderBy.NONE,
-                filter = mapOf(
-                    ALIAS_FILTER to keyAlias,
-                )
-            ).firstOrNull()?.let {
-                keyEncodingService.decodePublicKey(it.publicKey.array())
-            } ?: generateKeyPair(
-                tenantId = tenantId,
-                category = CryptoConsts.HsmCategories.LEDGER,
-                alias = keyAlias
-            )
-        }
-    }
-
 
     /**
      * Mapping the keys from the json format to the keys expected in the [MemberInfo].

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -10,8 +10,6 @@ import net.corda.layeredpropertymap.create
 import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.lifecycle.LifecycleStatus
-import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.impl.MGMContextImpl
 import net.corda.membership.impl.MemberContextImpl
@@ -146,15 +144,10 @@ class StaticMemberRegistrationServiceTest {
     private val publishedList = mutableListOf<Record<String, PersistentMemberInfo>>()
 
     private var coordinatorIsRunning = false
-    private var coordinatorStatus = LifecycleStatus.DOWN
     private val coordinator: LifecycleCoordinator = mock {
         on { isRunning } doAnswer { coordinatorIsRunning }
         on { start() } doAnswer { coordinatorIsRunning = true }
         on { stop() } doAnswer { coordinatorIsRunning = false }
-        on { updateStatus(any(), any()) } doAnswer {
-            coordinatorStatus = it.arguments[0] as LifecycleStatus
-        }
-        on { status } doAnswer { coordinatorStatus }
     }
 
     private var registrationServiceLifecycleHandler: RegistrationServiceLifecycleHandler? = null
@@ -342,25 +335,6 @@ class StaticMemberRegistrationServiceTest {
             MembershipRequestRegistrationResult(
                 NOT_SUBMITTED,
                 "Registration failed. Reason: MGM's key alias is not provided."
-            ),
-            registrationResult
-        )
-        registrationService.stop()
-    }
-
-    @Test
-    fun `registration fails when dependency component goes down`() {
-        setUpPublisher()
-        registrationService.start()
-        registrationServiceLifecycleHandler?.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN),
-            coordinator
-        )
-        val registrationResult = registrationService.register(alice)
-        assertEquals(
-            MembershipRequestRegistrationResult(
-                NOT_SUBMITTED,
-                "Registration failed. Reason: StaticMemberRegistrationService is not running/down."
             ),
             registrationResult
         )

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
@@ -31,7 +31,6 @@ import net.corda.processor.member.MemberProcessorTestUtils.Companion.aliceName
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.aliceX500Name
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.assertGroupPolicy
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.assertSecondGroupPolicy
-import net.corda.processor.member.MemberProcessorTestUtils.Companion.bobHoldingIdentity
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.bobName
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.bobX500Name
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.bootConf
@@ -174,17 +173,16 @@ class MemberProcessorIntegrationTest {
                 coordinatorFactory,
                 lifecycleRegistry,
                 setOf(
-                    LifecycleCoordinatorName.forComponent<MemberProcessor>(),
+                    //LifecycleCoordinatorName.forComponent<MemberProcessor>(),
                     LifecycleCoordinatorName.forComponent<CryptoProcessor>(),
-                    LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>()
+                    //LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>()
                 )
             ).also { it.startAndWait() }
 
             publisher = publisherFactory.createPublisher(PublisherConfig(CLIENT_ID), SmartConfigImpl.empty())
             publisher.publishCryptoConf()
             publisher.publishMessagingConf()
-            publisher.publishRawGroupPolicyData(virtualNodeInfoReader, cpiInfoReader, aliceHoldingIdentity)
-            publisher.publishRawGroupPolicyData(virtualNodeInfoReader, cpiInfoReader, bobHoldingIdentity)
+            publisher.publishRawGroupPolicyData(virtualNodeInfoReader, cpiInfoReader)
 
             // Wait for published content to be picked up by components.
             eventually { assertNotNull(virtualNodeInfoReader.get(aliceHoldingIdentity)) }
@@ -248,126 +246,140 @@ class MemberProcessorIntegrationTest {
                 )
             }
         }
+
+        private fun runTest(testFunction: KFunction<Unit>) {
+            logger.info("Running test: \"${testFunction.name}\"")
+            testFunction.call()
+        }
     }
 
     @Test
+    fun `Run all tests`() {
+        logger.info("Running multiple member processor related integration tests under one test run.")
+        logger.info("Running ${GroupPolicyProvider::class.simpleName} tests.")
+        for (test in groupPolicyProviderTests) {
+            runTest(test)
+        }
+        logger.info("Running ${RegistrationProxy::class.simpleName} tests.")
+        for (test in registrationProxyTests) {
+            runTest(test)
+        }
+        logger.info("Finished test run.")
+        logger.info("Ran ${groupPolicyProviderTests.size + registrationProxyTests.size} tests successfully.")
+    }
+
+    /**
+     * Group Policy provider tests.
+     */
+    val groupPolicyProviderTests = listOf(
+        ::`Group policy can be retrieved for valid holding identity`,
+        ::`Additional group policy reads return the same (cached) instance`,
+        ::`Get group policy fails for unknown holding identity`,
+        ::`Group policy fails to be read if the component stops`,
+        ::`Group policy cache is cleared after a restart (new instance is returned)`,
+        ::`Group policy cannot be retrieved if virtual node info reader dependency component goes down`,
+        ::`Group policy cannot be retrieved if CPI info reader dependency component goes down`,
+        ::`Group policy object is updated when CPI info changes`
+    )
+
     fun `Group policy can be retrieved for valid holding identity`() {
-        assertGroupPolicy(
-            getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity)
-        )
+        assertGroupPolicy(getGroupPolicy(groupPolicyProvider))
     }
 
-    @Test
     fun `Additional group policy reads return the same (cached) instance`() {
-        assertEquals(
-            getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity),
-            getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity)
-        )
+        assertEquals(getGroupPolicy(groupPolicyProvider), getGroupPolicy(groupPolicyProvider))
     }
 
-    @Test
     fun `Get group policy fails for unknown holding identity`() {
-        getGroupPolicyFails(
-            groupPolicyProvider,
-            invalidHoldingIdentity,
-            BadGroupPolicyException::class.java
-        )
+        getGroupPolicyFails(groupPolicyProvider, invalidHoldingIdentity, BadGroupPolicyException::class.java)
     }
 
-    @Test
     fun `Group policy fails to be read if the component stops`() {
         groupPolicyProvider.stopAndWait()
-        getGroupPolicyFails(groupPolicyProvider, aliceHoldingIdentity)
+        getGroupPolicyFails(groupPolicyProvider)
         groupPolicyProvider.startAndWait()
     }
 
-    @Test
     fun `Group policy cache is cleared after a restart (new instance is returned)`() {
-        val groupPolicy1 = getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity)
+        val groupPolicy1 = getGroupPolicy(groupPolicyProvider)
         groupPolicyProvider.stopAndWait()
         groupPolicyProvider.startAndWait()
         eventually {
             assertGroupPolicy(
-                getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity),
+                getGroupPolicy(groupPolicyProvider),
                 groupPolicy1
             )
         }
     }
 
-    @Test
     fun `Group policy cannot be retrieved if virtual node info reader dependency component goes down`() {
-        val groupPolicy1 = getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity)
+        val groupPolicy1 = getGroupPolicy(groupPolicyProvider)
         virtualNodeInfoReader.stopAndWait()
-        getGroupPolicyFails(groupPolicyProvider, aliceHoldingIdentity)
+        getGroupPolicyFails(groupPolicyProvider)
 
         virtualNodeInfoReader.startAndWait()
         groupPolicyProvider.isStarted()
         eventually {
             assertGroupPolicy(
-                getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity),
+                getGroupPolicy(groupPolicyProvider),
                 groupPolicy1
             )
         }
     }
 
-    @Test
     fun `Group policy cannot be retrieved if CPI info reader dependency component goes down`() {
-        val groupPolicy1 = getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity)
+        val groupPolicy1 = getGroupPolicy(groupPolicyProvider)
         cpiInfoReader.stopAndWait()
-        getGroupPolicyFails(groupPolicyProvider, aliceHoldingIdentity)
+        getGroupPolicyFails(groupPolicyProvider)
 
         cpiInfoReader.startAndWait()
         groupPolicyProvider.isStarted()
         eventually {
             assertGroupPolicy(
-                getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity),
+                getGroupPolicy(groupPolicyProvider),
                 groupPolicy1
             )
         }
     }
 
-    @Test
     fun `Group policy object is updated when CPI info changes`() {
         // Increase duration for `eventually` usage since the expected change needs to propagate through
         // multiple components
         val waitDuration = 10.seconds
 
-        val groupPolicy1 = getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity)
-        publisher.publishRawGroupPolicyData(
-            virtualNodeInfoReader,
-            cpiInfoReader,
-            aliceHoldingIdentity,
-            groupPolicy = sampleGroupPolicy2
-        )
+        val groupPolicy1 = getGroupPolicy(groupPolicyProvider)
+        publisher.publishRawGroupPolicyData(virtualNodeInfoReader, cpiInfoReader, groupPolicy = sampleGroupPolicy2)
 
         eventually(duration = waitDuration) {
             assertSecondGroupPolicy(
-                getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity),
+                getGroupPolicy(groupPolicyProvider),
                 groupPolicy1
             )
         }
-        publisher.publishRawGroupPolicyData(
-            virtualNodeInfoReader,
-            cpiInfoReader,
-            aliceHoldingIdentity,
-            groupPolicy = sampleGroupPolicy1
-        )
+        publisher.publishRawGroupPolicyData(virtualNodeInfoReader, cpiInfoReader, groupPolicy = sampleGroupPolicy1)
 
         // Wait for the group policy change to be visible (so following tests don't fail as a result)
         eventually(duration = waitDuration) {
             assertEquals(
                 groupPolicy1.groupId,
-                getGroupPolicy(groupPolicyProvider, aliceHoldingIdentity).groupId
+                getGroupPolicy(groupPolicyProvider).groupId
             )
         }
     }
 
     /**
+     * Registration provider tests.
+     */
+    val registrationProxyTests = listOf(
+        ::`Register and view static member list`,
+        //::`Registration proxy fails to register if registration service is down`
+    )
+
+    /**
      * Test assumes the group policy file is configured to use the static member registration.
      */
-    @Test
     fun `Register and view static member list`() {
-        val result = getRegistrationResult(registrationProxy, aliceHoldingIdentity)
+        val result = getRegistrationResult(registrationProxy)
         assertEquals(MembershipRequestRegistrationOutcome.SUBMITTED, result.outcome)
 
         val groupReader = eventually {
@@ -389,5 +401,18 @@ class MemberProcessorIntegrationTest {
         assertEquals(aliceMemberInfo, lookUpFromPublicKey(groupReader, aliceMemberInfo))
         assertEquals(bobMemberInfo, lookUpFromPublicKey(groupReader, bobMemberInfo))
 
+    }
+
+    fun `Registration proxy fails to register if registration service is down`() {
+        // bringing down the group policy provider brings down the static registration service
+        groupPolicyProvider.stopAndWait()
+
+        getRegistrationResultFails(registrationProxy)
+
+        // bring back up
+        groupPolicyProvider.startAndWait()
+
+        // Wait for it to pass again before moving to next test
+        getRegistrationResult(registrationProxy)
     }
 }

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -71,16 +71,15 @@ class MemberProcessorTestUtils {
         val charlieX500Name = MemberX500Name.parse(charlieName)
         val groupId = "ABC123"
         val aliceHoldingIdentity = HoldingIdentity(aliceName, groupId)
-        val bobHoldingIdentity = HoldingIdentity(bobName, groupId)
 
         fun Publisher.publishRawGroupPolicyData(
             virtualNodeInfoReader: VirtualNodeInfoReadService,
             cpiInfoReadService: CpiInfoReadService,
-            holdingIdentity: HoldingIdentity,
+            holdingIdentity: HoldingIdentity = aliceHoldingIdentity,
             groupPolicy: String = sampleGroupPolicy1
         ) {
             val cpiVersion = UUID.randomUUID().toString()
-            val previous = getVirtualNodeInfo(virtualNodeInfoReader, holdingIdentity)
+            val previous = getVirtualNodeInfo(virtualNodeInfoReader)
             val previousCpiInfo = getCpiInfo(cpiInfoReadService, previous?.cpiIdentifier)
             // Create test data
             val cpiMetadata = getCpiMetadata(
@@ -104,7 +103,7 @@ class MemberProcessorTestUtils {
 
             // wait for virtual node info reader to pick up changes
             eventually {
-                val newVNodeInfo = getVirtualNodeInfo(virtualNodeInfoReader, holdingIdentity)
+                val newVNodeInfo = getVirtualNodeInfo(virtualNodeInfoReader)
                 assertNotNull(newVNodeInfo)
                 assertNotEquals(previous, newVNodeInfo)
                 assertEquals(virtualNodeInfo.cpiIdentifier, newVNodeInfo?.cpiIdentifier)
@@ -128,15 +127,15 @@ class MemberProcessorTestUtils {
         val sampleGroupPolicy1 get() = getSampleGroupPolicy("/SampleGroupPolicy.json")
         val sampleGroupPolicy2 get() = getSampleGroupPolicy("/SampleGroupPolicy2.json")
 
-        fun getRegistrationResult(registrationProxy: RegistrationProxy, holdingIdentity: HoldingIdentity): MembershipRequestRegistrationResult = eventually {
+        fun getRegistrationResult(registrationProxy: RegistrationProxy): MembershipRequestRegistrationResult = eventually {
             assertDoesNotThrow {
-                registrationProxy.register(holdingIdentity)
+                registrationProxy.register(aliceHoldingIdentity)
             }
         }
 
-        fun getRegistrationResultFails(registrationProvider: RegistrationProxy, holdingIdentity: HoldingIdentity) = eventually {
+        fun getRegistrationResultFails(registrationProvider: RegistrationProxy) = eventually {
             assertThrows<IllegalStateException> {
-                registrationProvider.register(holdingIdentity)
+                registrationProvider.register(aliceHoldingIdentity)
             }
         }
 
@@ -159,7 +158,7 @@ class MemberProcessorTestUtils {
 
         fun getGroupPolicyFails(
             groupPolicyProvider: GroupPolicyProvider,
-            holdingIdentity: HoldingIdentity,
+            holdingIdentity: HoldingIdentity = aliceHoldingIdentity,
             expectedException: Class<out Exception> = IllegalStateException::class.java
         ) = eventually {
             val e = assertThrows<Exception> { groupPolicyProvider.getGroupPolicy(holdingIdentity) }
@@ -168,7 +167,7 @@ class MemberProcessorTestUtils {
 
         fun getGroupPolicy(
             groupPolicyProvider: GroupPolicyProvider,
-            holdingIdentity: HoldingIdentity
+            holdingIdentity: HoldingIdentity = aliceHoldingIdentity
         ) = eventually {
             assertDoesNotThrow { groupPolicyProvider.getGroupPolicy(holdingIdentity) }
         }
@@ -213,8 +212,8 @@ class MemberProcessorTestUtils {
             groupPolicy
         )
 
-        fun getVirtualNodeInfo(virtualNodeInfoReader: VirtualNodeInfoReadService, holdingIdentity: HoldingIdentity) =
-            virtualNodeInfoReader.get(holdingIdentity)
+        fun getVirtualNodeInfo(virtualNodeInfoReader: VirtualNodeInfoReadService) =
+            virtualNodeInfoReader.get(aliceHoldingIdentity)
 
         fun getCpiInfo(cpiInfoReadService: CpiInfoReadService, cpiIdentifier: CpiIdentifier?) =
             when (cpiIdentifier) {


### PR DESCRIPTION
This reverts https://github.com/corda/corda-runtime-os/pull/1193
The above PR passed all PR gates but when merged the release branch build failed. As I'm away on PTO until next week I will revert that change until I have time to do a proper investigation when I am back.