### PR TITLE
NOTICK: Configure sandbox cache for :sandbox-app project.

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -2,6 +2,7 @@ package net.corda.example.vnode
 
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.v5.base.util.loggerFor
@@ -24,12 +25,19 @@ class VNodeServiceImpl @Activate constructor(
     private val flowSandboxService: FlowSandboxService,
 
     @Reference
+    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+
+    @Reference
     private val cpiLoader: CpiLoader,
 
     @Reference
     private val virtualNodeLoader: VirtualNodeLoader
 ) : VNodeService {
     private val logger = loggerFor<VNodeService>()
+
+    init {
+        sandboxGroupContextComponent.initCache(1)
+    }
 
     override fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo {
         return virtualNodeLoader.loadVirtualNode(resourceName, holdingIdentity)

--- a/components/virtual-node/sandbox-group-context-service/build.gradle
+++ b/components/virtual-node/sandbox-group-context-service/build.gradle
@@ -30,9 +30,9 @@ dependencies {
 
     implementation "net.corda:corda-packaging-avro-converters"
 
+    api project(":libs:lifecycle:lifecycle")
     implementation project(":libs:configuration:configuration-core")
     implementation project(":libs:crypto:crypto-core")
-    implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:messaging")
 
     implementation project(':libs:virtual-node:packaging-core')


### PR DESCRIPTION
Initialise the sandbox cache for a basic use-case.

Note that `Lifecycle` is now required to compile `SandboxGroupContextComponent`, which makes this an API dependency.