### PR TITLE
NOTICK: Add synchronization to WriteOffsets call

### DIFF
--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/util/WriteOffsets.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/util/WriteOffsets.kt
@@ -30,6 +30,7 @@ class WriteOffsets(
         latestOffsets.putAll(state)
     }
 
+    @Synchronized
     fun getNextOffsetFor(topicPartition: CordaTopicPartition): Long {
         return latestOffsets.compute(topicPartition) { _: CordaTopicPartition, offset: Long? ->
             offset?.plus(1) ?: 0L


### PR DESCRIPTION
This is a test to see if we can stop the StateAndEvent integration test failing intermittently