### PR TITLE
CORE-4656: Fix concurrency issue for `WeakValueHashMap`

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/WeakValueHashMap.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/WeakValueHashMap.kt
@@ -3,6 +3,7 @@ package net.corda.messaging.utils
 import net.corda.v5.base.util.uncheckedCast
 import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
 
 
 /**
@@ -11,8 +12,8 @@ import java.lang.ref.WeakReference
  */
 class WeakValueHashMap<K, V>: MutableMap<K, V> {
 
-    /* Hash table mapping Keys to WeakValues */
-    private val map = HashMap<K, WeakValueRef<K, V>>()
+    /* Mutable map of Keys to WeakValues */
+    private val map: MutableMap<K, WeakValueRef<K, V>> = ConcurrentHashMap()
 
     /* Reference queue for cleared WeakValues */
     private val queue = ReferenceQueue<V>()


### PR DESCRIPTION
Since `WeakValueHashMap` is part of `FutureTracker` it ought to be suitable for multi-thread use.

It was using `HashMap` as an underlying store which is not thread safe.
The change is supported by the unit test.