### PR TITLE
NOTICK Make TlsCertificatesPublisher read certificates from the right topic

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
@@ -16,7 +16,6 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTlsCertificates
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_CERTIFICATES
-import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_TRUSTSTORES
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -104,7 +103,7 @@ internal class TlsCertificatesPublisher(
         }
     }
     private val subscription = subscriptionFactory.createCompactedSubscription(
-        SubscriptionConfig(CURRENT_DATA_READER_GROUP_NAME, GATEWAY_TLS_TRUSTSTORES, instanceId),
+        SubscriptionConfig(CURRENT_DATA_READER_GROUP_NAME, GATEWAY_TLS_CERTIFICATES, instanceId),
         Processor(),
         configuration,
     )


### PR DESCRIPTION
This probably means the LinkManager can't read already published TLS certificates (if it is restarted). This only causes duplicated entries to be published (as we read these from the hosting map).

I noticed this due to an exceptions in the Link Manager logs on startup (when testing with more than one LinkManager):
```
p2p-link-manager-3: 07:48:00.443 [compacted subscription thread gateway.tls.truststores-linkmanager_tlscertificates_reader-gateway.tls.truststores] ERROR gateway.tls.truststores-linkmanager_tlscertificates_reader - Failed to read records from group gateway.tls.truststores-linkmanager_tlscertificates_reader, topic gateway.tls.truststores. Fatal error occurred. Closing subscription.
p2p-link-manager-3: net.corda.messaging.api.exception.CordaMessageAPIFatalException: Failed to process records from topic gateway.tls.truststores, group gateway.tls.truststores-linkmanager_tlscertificates_reader.
p2p-link-manager-3: 	at net.corda.messaging.subscription.CompactedSubscriptionImpl.pollAndProcessRecords(CompactedSubscriptionImpl.kt:208) ~[corda-messaging-impl-5.0.0.0-alpha-1651134247147.jar:?]
p2p-link-manager-3: 	at net.corda.messaging.subscription.CompactedSubscriptionImpl.runConsumeLoop(CompactedSubscriptionImpl.kt:132) [corda-messaging-impl-5.0.0.0-alpha-1651134247147.jar:?]
p2p-link-manager-3: 	at net.corda.messaging.subscription.CompactedSubscriptionImpl.access$runConsumeLoop(CompactedSubscriptionImpl.kt:29) [corda-messaging-impl-5.0.0.0-alpha-1651134247147.jar:?]
p2p-link-manager-3: 	at net.corda.messaging.subscription.CompactedSubscriptionImpl$start$2$1.invoke(CompactedSubscriptionImpl.kt:99) [corda-messaging-impl-5.0.0.0-alpha-1651134247147.jar:?]
p2p-link-manager-3: 	at net.corda.messaging.subscription.CompactedSubscriptionImpl$start$2$1.invoke(CompactedSubscriptionImpl.kt:29) [corda-messaging-impl-5.0.0.0-alpha-1651134247147.jar:?]
p2p-link-manager-3: 	at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30) [p2p-link-manager.jar:?]
p2p-link-manager-3: Caused by: java.lang.ClassCastException: class net.corda.p2p.GatewayTruststore cannot be cast to class net.corda.p2p.GatewayTlsCertificates (net.corda.p2p.GatewayTruststore and net.corda.p2p.GatewayTlsCertificates are in unnamed module of loader org.apache.felix.framework.BundleWiringImpl$BundleClassLoader @ea9e141)
p2p-link-manager-3: 	at net.corda.p2p.linkmanager.TlsCertificatesPublisher$Processor.onNext(TlsCertificatesPublisher.kt:98) ~[?:?]
p2p-link-manager-3: 	at net.corda.p2p.linkmanager.TlsCertificatesPublisher$Processor.onNext(TlsCertificatesPublisher.kt:80) ~[?:?]
p2p-link-manager-3: 	at net.corda.messaging.subscription.CompactedSubscriptionImpl.processCompactedRecords(CompactedSubscriptionImpl.kt:231) ~[corda-messaging-impl-5.0.0.0-alpha-1651134247147.jar:?]
p2p-link-manager-3: 	at net.corda.messaging.subscription.CompactedSubscriptionImpl.pollAndProcessRecords(CompactedSubscriptionImpl.kt:200) ~[corda-messaging-impl-5.0.0.0-alpha-1651134247147.jar:?]
p2p-link-manager-3: 	... 5 more
```