### PR TITLE
CORE-4712: Remove hardcoded "admin" RPC User account

### DIFF
--- a/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACAuthorizingSubject.kt
+++ b/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACAuthorizingSubject.kt
@@ -15,9 +15,6 @@ class RBACAuthorizingSubject(
      * Use the permission validator to determine if this user is authorized for the requested action.
      */
     override fun isPermitted(action: String, vararg arguments: String): Boolean {
-        // for now, admin is a super admin and can do anything
-        if ("admin".equals(principal, true)) return true
-
         return permissionValidator.authorizeUser(principal, action)
     }
 }

--- a/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACSecurityManager.kt
+++ b/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACSecurityManager.kt
@@ -16,8 +16,6 @@ class RBACSecurityManager(
     override val id = AuthServiceId(RBACSecurityManager::class.java.name)
 
     override fun authenticate(principal: String, password: Password): AuthorizingSubject {
-        if("admin".equals(principal, true) && password.valueAsString == "admin") return buildSubject(principal)
-
         if(!basicAuthenticationService.authenticateUser(principal.toLowerCase(), password.value)) {
             throw FailedLoginException("User not authenticated.")
         }


### PR DESCRIPTION
With new cluster bootstrapping approach implemented, it should now be possible to remove "admin/admin" credentials we use in the production code.