### PR TITLE
Defined readiness probe for rpc endpoint

### DIFF
--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -58,7 +58,8 @@ spec:
         readinessProbe:
           httpGet:
             path: /status
-            port: 7000
+            port: health
+
           periodSeconds: 10
           failureThreshold: 1
         livenessProbe:


### PR DESCRIPTION
Tested locally by deploying CORDA in Kubernetes and RPC-worker waits for readiness probe before it stats excepting request.