### PR TITLE
NOTICK - worker local run configs

### DIFF
--- a/.run/Flow Worker Local Debug.run.xml
+++ b/.run/Flow Worker Local Debug.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Flow Worker Local Debug" type="JarApplication">
+    <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/flow-worker/build/bin/corda-flow-worker-5.0.0.0-SNAPSHOT.jar" />
+    <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5008" />
+    <option name="PROGRAM_PARAMETERS" value="--instanceId=1 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <method v="2">
+      <option name="Gradle.BeforeRunTask" enabled="true" tasks="appJar" externalProjectPath="$PROJECT_DIR$/applications/workers/release/flow-worker" vmOptions="" scriptParameters="" />
+    </method>
+  </configuration>
+</component>

--- a/.run/K8s - DB Worker Local.run.xml
+++ b/.run/K8s - DB Worker Local.run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="K8s/telepresence - DB Worker Local (debug agent 5009)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/.run/db-worker-local-debug.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/sh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2">
+      <option name="Gradle.BeforeRunTask" enabled="true" tasks="appJar" externalProjectPath="$PROJECT_DIR$/applications/workers/release/db-worker" vmOptions="" scriptParameters="" />
+    </method>
+  </configuration>
+</component>

--- a/.run/K8s - Flow Worker Local.run.xml
+++ b/.run/K8s - Flow Worker Local.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Flow Worker Local Debug" type="JarApplication">
+  <configuration default="false" name="K8s/telepresence - Flow Worker Local  (debug agent 5008)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/flow-worker/build/bin/corda-flow-worker-5.0.0.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5008" />
     <option name="PROGRAM_PARAMETERS" value="--instanceId=1 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA" />

--- a/.run/K8s - RPC Worker.run.xml
+++ b/.run/K8s - RPC Worker.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="K8s/telepresence - RPC Worker Local  (debug agent 5007)" type="JarApplication">
+    <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/rpc-worker/build/bin/corda-rpc-worker-5.0.0.0-SNAPSHOT.jar" />
+    <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5007" />
+    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <method v="2">
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="appJar" externalProjectPath="$PROJECT_DIR$/applications/workers/release/rpc-worker" vmOptions="" scriptParameters="" />
+    </method>
+  </configuration>
+</component>

--- a/.run/db-worker-local-debug.sh
+++ b/.run/db-worker-local-debug.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+JAR_PATH=$SCRIPT_DIR/../applications/workers/release/db-worker/build/bin/corda-db-worker-5.0.0.0-SNAPSHOT.jar
+VM_PARAMETERS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5009
+
+SALT=$(kubectl get secret corda-db-worker -o go-template='{{ .data.salt | base64decode }}')
+PASSPHRASE=$(kubectl get secret corda-db-worker -o go-template='{{ .data.passphrase | base64decode }}')
+DATABASE_PASS=$(kubectl get secret prereqs-postgresql -o go-template='{{ .data.password | base64decode }}')
+
+PROGRAM_PARAMETERS="--instanceId=2 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA -spassphrase=$PASSPHRASE -ssalt=$SALT -ddatabase.user=user -ddatabase.pass=$DATABASE_PASS -ddatabase.jdbc.url=jdbc:postgresql://prereqs-postgresql.corda:5432/cordacluster"
+
+java $VM_PARAMETERS -jar $JAR_PATH $PROGRAM_PARAMETERS

--- a/.run/db-worker-local-debug.sh
+++ b/.run/db-worker-local-debug.sh
@@ -11,4 +11,4 @@ DATABASE_PASS=$(kubectl get secret prereqs-postgresql -o go-template='{{ .data.p
 
 PROGRAM_PARAMETERS="--instanceId=2 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA -spassphrase=$PASSPHRASE -ssalt=$SALT -ddatabase.user=user -ddatabase.pass=$DATABASE_PASS -ddatabase.jdbc.url=jdbc:postgresql://prereqs-postgresql.corda:5432/cordacluster"
 
-java $VM_PARAMETERS -jar $JAR_PATH $PROGRAM_PARAMETERS
+java $VM_PARAMETERS -Dlog4j.configurationFile=log4j2-console.xml -jar $JAR_PATH $PROGRAM_PARAMETERS


### PR DESCRIPTION
I'm not sure whether we should commit this to git, looking for opinions.

These are intellij run configurations that start the worker processes locally, integrating with the rest of the cluster deployed in K8s.
This relies on having telepresence to be able to connect to Kafka and the DB.
The DB worker is slightly different. It is a shell configuration rather than jar because the salt, passphrase and db password are picked up from the running K8s cluster.