### PR TITLE
CORE-3968 - Add support for signaling DQL behavior

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -268,7 +268,7 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
         val partitionId = event.partition
         val thisEventUpdates = getUpdatesForEvent(state, event)
 
-        if (thisEventUpdates == null) {
+        if (thisEventUpdates == null || thisEventUpdates.markForDLQ) {
             log.warn("Sending event: $event, and state: $state to dead letter queue. Processor failed to complete.")
             outputRecords.add(generateDeadLetterRecord(event, state))
             outputRecords.add(Record(stateTopic, key, null))

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/processor/StateAndEventProcessor.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/processor/StateAndEventProcessor.kt
@@ -33,7 +33,12 @@ interface StateAndEventProcessor<K : Any, S : Any, E : Any> {
          *
          * NOTE: The [responseEvents] can be of any type and are not required to match [K] or [E] on input.
          */
-        val responseEvents: List<Record<*, *>>
+        val responseEvents: List<Record<*, *>>,
+
+        /**
+         * Flag to indicate processing failed and the State and Event should be moved to the Dead Letter Queue
+         */
+        val markForDLQ: Boolean = false
     )
 
     /**


### PR DESCRIPTION
Add support for signaling DQL behavior from the State and Event Processor

When trying to amend the tests for this change it was found that the tests were flaky, we need to remove the need for Thread.Sleep() in the tests.

CORE-4760 has been created to review the flaky tests.