### PR TITLE
CORE-4691: Change P2P publishers to be non transactional

### DIFF
--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Setup.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Setup.kt
@@ -54,7 +54,7 @@ class Setup(
 
         if (records.isNotEmpty()) {
             publisherFactory.createPublisher(
-                PublisherConfig("p2p-setup"),
+                PublisherConfig("p2p-setup", false),
                 command.nodeConfiguration(),
             ).use { publisher ->
                 logger.info("Publishing ${records.size} records")

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -105,7 +105,7 @@ class GatewayIntegrationTest : TestBase() {
         val lifecycleCoordinatorFactory = LifecycleCoordinatorFactoryImpl(LifecycleRegistryImpl())
         val subscriptionFactory = InMemSubscriptionFactory(topicService, rpcTopicService, lifecycleCoordinatorFactory)
         val publisherFactory = CordaPublisherFactory(topicService, rpcTopicService, lifecycleCoordinatorFactory)
-        val publisher = publisherFactory.createPublisher(PublisherConfig("$name.id"), messagingConfig)
+        val publisher = publisherFactory.createPublisher(PublisherConfig("$name.id", false), messagingConfig)
 
         fun stop() {
             publisher.close()

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
@@ -155,7 +155,7 @@ open class TestBase {
                 .withValue("connectionConfig.initialReconnectionDelay", ConfigValueFactory.fromAnyRef(configuration.connectionConfig.initialReconnectionDelay))
                 .withValue("connectionConfig.maximalReconnectionDelay", ConfigValueFactory.fromAnyRef(configuration.connectionConfig.maximalReconnectionDelay))
             CordaPublisherFactory(configurationTopicService, rpcTopicService, lifecycleCoordinatorFactory)
-                .createPublisher(PublisherConfig(configPublisherClientId), messagingConfig).use { publisher ->
+                .createPublisher(PublisherConfig(configPublisherClientId, false), messagingConfig).use { publisher ->
                 val configurationPublisher = ConfigPublisherImpl(CONFIG_TOPIC, publisher)
                 configurationPublisher.updateConfiguration(
                     CordaConfigurationKey(
@@ -171,7 +171,7 @@ open class TestBase {
             val publishConfig = ConfigFactory.empty()
                 .withValue("hello", ConfigValueFactory.fromAnyRef("world"))
             CordaPublisherFactory(configurationTopicService, rpcTopicService, lifecycleCoordinatorFactory)
-                .createPublisher(PublisherConfig(configPublisherClientId), messagingConfig)
+                .createPublisher(PublisherConfig(configPublisherClientId, false), messagingConfig)
                 .use { publisher ->
                     val configurationPublisher = ConfigPublisherImpl(CONFIG_TOPIC, publisher)
                     configurationPublisher.updateConfiguration(

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
@@ -35,7 +35,7 @@ class TrustStoresMapIntegrationTests : TestBase() {
             subscriptionFactory,
             messagingConfig
         )
-        publisherFactory.createPublisher(PublisherConfig("client.ID"), messagingConfig).use {
+        publisherFactory.createPublisher(PublisherConfig("client.ID", false), messagingConfig).use {
             it.publish(
                 listOf(
                     Record(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -49,7 +49,7 @@ internal class InboundMessageHandler(
     private var p2pInPublisher = PublisherWithDominoLogic(
         publisherFactory,
         lifecycleCoordinatorFactory,
-        PublisherConfig("inbound-message-handler"),
+        PublisherConfig("inbound-message-handler", false),
         nodeConfiguration
     )
     private val sessionPartitionMapper = SessionPartitionMapperImpl(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
@@ -682,7 +682,7 @@ class LinkManager(
         private val publisher = PublisherWithDominoLogic(
             publisherFactory,
             coordinatorFactory,
-            PublisherConfig(LINK_MANAGER_PUBLISHER_CLIENT_ID),
+            PublisherConfig(LINK_MANAGER_PUBLISHER_CLIENT_ID, false),
             configuration
         )
         override val dominoTile = publisher.dominoTile

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
@@ -40,7 +40,7 @@ internal class TlsCertificatesPublisher(
     private val publisher = PublisherWithDominoLogic(
         publisherFactory,
         lifecycleCoordinatorFactory,
-        PublisherConfig(MISSING_DATA_WRITER_GROUP_NAME),
+        PublisherConfig(MISSING_DATA_WRITER_GROUP_NAME, false),
         configuration,
     )
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
@@ -40,7 +40,7 @@ internal class TrustStoresPublisher(
     private val publisher = PublisherWithDominoLogic(
         publisherFactory,
         lifecycleCoordinatorFactory,
-        PublisherConfig(MISSING_DATA_WRITER_GROUP_NAME),
+        PublisherConfig(MISSING_DATA_WRITER_GROUP_NAME, false),
         configuration,
     )
     private val subscription = subscriptionFactory.createCompactedSubscription(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -103,7 +103,7 @@ class DeliveryTracker(
         private val publisher = PublisherWithDominoLogic(
             publisherFactory,
             coordinatorFactory,
-            PublisherConfig(MESSAGE_REPLAYER_CLIENT_ID),
+            PublisherConfig(MESSAGE_REPLAYER_CLIENT_ID, false),
             configuration
         )
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
@@ -41,7 +41,7 @@ class InMemorySessionReplayer(
     private val publisher = PublisherWithDominoLogic(
         publisherFactory,
         coordinatorFactory,
-        PublisherConfig(MESSAGE_REPLAYER_CLIENT_ID),
+        PublisherConfig(MESSAGE_REPLAYER_CLIENT_ID, false),
         configuration
     )
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -136,7 +136,7 @@ open class SessionManagerImpl(
     private val publisher = PublisherWithDominoLogic(
         publisherFactory,
         coordinatorFactory,
-        PublisherConfig(SESSION_MANAGER_CLIENT_ID),
+        PublisherConfig(SESSION_MANAGER_CLIENT_ID, false),
         configuration
     )
 
@@ -722,7 +722,7 @@ open class SessionManagerImpl(
         private val publisher = PublisherWithDominoLogic(
             publisherFactory,
             coordinatorFactory,
-            PublisherConfig(HEARTBEAT_MANAGER_CLIENT_ID),
+            PublisherConfig(HEARTBEAT_MANAGER_CLIENT_ID, false),
             configuration
         )
 

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -329,7 +329,7 @@ class P2PLayerEndToEndTest {
         private val configReadService = ConfigurationReadServiceImpl(lifecycleCoordinatorFactory, subscriptionFactory)
         private val configPublisher = ConfigPublisherImpl(
             CONFIG_TOPIC,
-            publisherFactory.createPublisher(PublisherConfig("config-writer"), bootstrapConfig)
+            publisherFactory.createPublisher(PublisherConfig("config-writer", false), bootstrapConfig)
         )
         private val gatewayConfig = createGatewayConfig(p2pPort, p2pAddress, sslConfig)
         private val tlsTenantId by lazy {
@@ -445,7 +445,7 @@ class P2PLayerEndToEndTest {
             )
 
         private fun publishNetworkMapAndIdentityKeys(otherHost: Host) {
-            val publisherForHost = publisherFactory.createPublisher(PublisherConfig("test-runner-publisher"), bootstrapConfig)
+            val publisherForHost = publisherFactory.createPublisher(PublisherConfig("test-runner-publisher", false), bootstrapConfig)
             val networkMapEntries = mapOf(
                 "$x500Name-$GROUP_ID" to memberInfoEntry,
                 "${otherHost.x500Name}-$GROUP_ID" to otherHost.memberInfoEntry,
@@ -509,7 +509,7 @@ class P2PLayerEndToEndTest {
                 )
             }
             publisherFactory.createPublisher(
-                PublisherConfig("test-runner-publisher"),
+                PublisherConfig("test-runner-publisher", false),
                 bootstrapConfig
             ).use { publisher ->
                 publisher.start()
@@ -566,7 +566,7 @@ class P2PLayerEndToEndTest {
         }
 
         fun sendMessages(messagesToSend: Int, peer: Host, ttl: Long? = null) {
-            val hostAApplicationWriter = publisherFactory.createPublisher(PublisherConfig("app-layer", true), bootstrapConfig)
+            val hostAApplicationWriter = publisherFactory.createPublisher(PublisherConfig("app-layer", false), bootstrapConfig)
             val initialMessages = (1..messagesToSend).map { index ->
                 val incrementalId = index.toString()
                 val messageHeader = AuthenticatedMessageHeader(


### PR DESCRIPTION
Change all the P2P publishers to be non-transactional.

As far as I can see, we don't really need any of them to be transactional.

(Tested a couple of times on K8S)