### PR TITLE
updated all workers for  anti-affinity

### DIFF
--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -22,14 +22,16 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "app.kubernetes.io/component"
-                operator: In
-                values:
-                - crypto-worker
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: "app.kubernetes.io/component"
+                  operator: In
+                  values:
+                  - crypto-worker
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ include "corda.workerName" . }}
         image: {{ include "corda.workerImage" . }}

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -22,14 +22,16 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "app.kubernetes.io/component"
-                operator: In
-                values:
-                - db-worker
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: "app.kubernetes.io/component"
+                  operator: In
+                  values:
+                  - db-worker
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ include "corda.workerName" . }}
         image: {{ include "corda.workerImage" . }}

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -22,14 +22,16 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "app.kubernetes.io/component"
-                operator: In
-                values:
-                - flow-worker
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: "app.kubernetes.io/component"
+                  operator: In
+                  values:
+                  - flow-worker
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ include "corda.workerName" . }}
         image: {{ include "corda.workerImage" . }}

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -37,14 +37,16 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: "app.kubernetes.io/component"
-                operator: In
-                values:
-                - rpc-worker
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: "app.kubernetes.io/component"
+                  operator: In
+                  values:
+                  - rpc-worker
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ include "corda.workerName" . }}
         image: {{ include "corda.workerImage" . }}


### PR DESCRIPTION
By default, for this helm chart, all workers are set to 1.

This feature will enable the scheduler to schedule Pods on nodes which do not already contain a replica of that worker. So increasing the replica count also scales out the number of nodes in the cluster if no nodes are available. 

This has been tested in AKS starting with 2 nodes, the replica count for each worker was then increased to 3 and a further node was created via the scheduler.