### PR TITLE
NOTICK: Remove development packages from Quasar package exclusions.

### DIFF
--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -9,25 +9,14 @@ quasar {
     instrumentTests = false
     instrumentJavaExec = false
     excludePackages = [
-            'co.paralleluniverse**',
-            'com.esotericsoftware.**',
-            'jdk**',
-            'junit**',
-            'kotlin**',
-            'net.rubygrapefruit.**',
-            'org.gradle.**',
-            'org.apache.**',
-            'org.jacoco.**',
-            'org.junit**',
-            'org.slf4j**',
-            'worker.org.gradle.**',
-            'org.assertj**',
-            'org.hamcrest**',
-            'org.mockito**',
-            'org.opentest4j**',
-            'org.eclipse**',
-            'net.corda.sandboxhooks.**',
-            'net.corda.osgi.**'
+        'co.paralleluniverse**',
+        'com.esotericsoftware.**',
+        'jdk**',
+        'kotlin**',
+        'org.apache.**',
+        'org.slf4j**',
+        'net.corda.sandboxhooks.**',
+        'net.corda.osgi.**'
     ]
 }
 


### PR DESCRIPTION
Quasar package exclusions are applied to the application artifact only. The
```
instrumentTests = false
instrumentJavaExec = false
```
properties mean that exclusions are irrelevant during application development, and so there is no need to exclude Gradle, JUnit, AssertJ, Mockito, Hamcrest, JaCoCo etc.

Note that only applications which apply the `corda.quasar-app` convention plugin are affected by this. Flow libraries are still free to make their own Faustian Pact with Quasar and the `quasar-utils` plugin, should they so choose.