### PR TITLE
NOTICK: fix syntax for boolean check

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -337,7 +337,7 @@ if (compositeBuild.toBoolean() && file(cordaApiLocation).exists()) {
         }
     }
 }
-if (compositeBuild && file(cordaCliHostLocation).exists()) {
+if (compositeBuild.toBoolean() && file(cordaCliHostLocation).exists()) {
     includeBuild(cordaCliHostLocation)
 }
 


### PR DESCRIPTION
incorrect syntax here causes issues where build job incorrectly thinks we are in a composite build with corda-cli