### PR TITLE
NOTICK Match kafka/pg images to prereqs

### DIFF
--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -25,7 +25,7 @@ spec:
             - mountPath: /tmp/working_dir
               name: working-volume
         - name: apply-db-schemas
-          image: bitnami/postgresql:13
+          image: bitnami/postgresql:14.2.0-debian-10-r88
           command: [ 'sh', '-c', 'for f in /tmp/working_dir/*.sql; do psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -54,7 +54,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-db-config
-          image: bitnami/postgresql:13
+          image: bitnami/postgresql:14.2.0-debian-10-r88
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -83,7 +83,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-rpc-admin
-          image: bitnami/postgresql:13
+          image: bitnami/postgresql:14.2.0-debian-10-r88
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/rbac-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -95,7 +95,7 @@ spec:
                   name: {{ include "corda.clusterDbSecretName" . }}
                   key: password
         - name: create-db-users-and-grant
-          image: bitnami/postgresql:13
+          image: bitnami/postgresql:14.2.0-debian-10-r88
           command: [ '/bin/sh', '-e', '-c' ]
           args:
             - |

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: create-topics
-          image: bitnami/kafka:2.8.1-debian-10-r99
+          image: bitnami/kafka:3.1.0-debian-10-r89
           imagePullPolicy: Always
           command:
             - /bin/sh


### PR DESCRIPTION
To reduce image pulls, match the kafka/postgresql images to those currently being pulled by the `corda-dev` chart. Longer term, I think we need to have our own versions of these images so that a Corda deployment is not dependent on third-party images (though these are in optional paths which we might expect our more paranoid customers to not be using).