### PR TITLE
NOTICK: use latest beta version for cli host

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -127,7 +127,7 @@ artifactoryPluginVersion = 4.28.2
 pf4jVersion=3.6.0
 
 # corda-cli plugin host
-pluginHostVersion=0.0.1-beta
+pluginHostVersion=0.0.1-beta+
 systemLambdaVersion=1.2.1
 
 # DB integration tests


### PR DESCRIPTION
cli host ci produces timestamped artifacts  e.g. version-beta-timestamp  - consume this rather than static version to ensure latest cli changes actually work with runtime os