### PR TITLE
CORE-4776: Upgrade to Corda Gradle plugins 6.0.0-BETA15.

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -13,10 +13,7 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
                     afterEvaluate {
                         artifactId = tasks.named('jar', Jar).flatMap { it.archiveBaseName }.get()
                         groupId group.toString()
-                        from components.findByName('kotlin') ?: components.java
-                    }
-                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
-                        artifact tasks.named('cpk', Jar)
+                        from components.findByName('cordapp') ?: components.findByName('kotlin') ?: components.java
                     }
                     if (project.hasProperty("sourceJar")) {
                         maven.artifact(tasks.getByName("sourcesJar"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ cordaRuntimeRevision=0
 # Plugin dependency versions
 avroGradlePluginVersion=1.1.0
 bndVersion=6.2.0
-cordaGradlePluginsVersion=6.0.0-BETA14
+cordaGradlePluginsVersion=6.0.0-BETA15
 detektPluginVersion=1.19.+
 internalPublishVersion=1.+
 internalDockerVersion=1.+


### PR DESCRIPTION
The updated `cordapp-cpk` plugin creates a new Gradle `SoftwareComponent` called "cordapp" which contains the artifacts to be published. This allows modules to leave the exact contents of the "cordapp" component up to the plugin.