### PR TITLE
NOTICK: cater for base image which needs credentials when local invocation 

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -166,7 +166,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
                 builder = setCredentialsOnBaseImage(builder)
             } else {
                 logger.info("Resolving base image ${baseImageName.get()}: ${baseImageTag.get()} from remote repo")
-                builder = Jib.from(baseImage)
+                    builder = Jib.from(imageName)
             }
         } else {  // CI use case
             logger.info("No daemon available")


### PR DESCRIPTION
 - remove redundant code
 - use logger.info call for quieter logging
 - ensure when running locally and NOT in a composite build we authenticate base image
 - support method added for the above 