### PR TITLE
CORE-4097: flip defaults for composite build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -115,8 +115,8 @@ nimbusVersion = 9.8
 unirestVersion = 3.11.00
 jettyVersion = 9.4.43.v20210629
 # Enables the substitution of binaries for source code if it exists in expected location
-# Default behaviour is false.
-compositeBuild=false
+# Default behaviour is true. possible to override in ~/.gradle/gradle.properties or with -PcompositeBuild=false on command line
+compositeBuild=true
 cordaApiLocation=../corda-api
 cordaPluginsLocation=../corda-internal-gradle-plugins
 cordaCliHostLocation=../corda-cli-plugin-host


### PR DESCRIPTION
swap to true so for a non R3er the project "just works" with out any modifications 

**Note will hold off merging till send internal comms about change in behavior** 