### PR TITLE
NOTICK bump dependency versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ cordaGradlePluginsVersion=6.0.0-BETA15
 detektPluginVersion=1.19.+
 internalPublishVersion=1.+
 internalDockerVersion=1.+
-dependencyCheckerVersion=0.42.+
+dependencyCheckVersion=0.42.+
 
 # Implementation dependency versions
 activationVersion = 1.2.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,7 +48,7 @@ pluginManagement {
         id 'net.corda.plugins.cordapp-cpb' version cordaGradlePluginsVersion
         id 'net.corda.plugins.quasar-utils' version cordaGradlePluginsVersion
         id 'io.gitlab.arturbosch.detekt' version detektPluginVersion
-        id 'com.github.ben-manes.versions' version dependencyCheckerVersion
+        id 'com.github.ben-manes.versions' version dependencyCheckVersion
         id "org.gradle.test-retry" version gradleTestRetryPluginVersion
         id "com.jfrog.artifactory" version artifactoryPluginVersion
     }


### PR DESCRIPTION
bump versions of where various updates are available 

- gradleVersions refers to com.github.ben-manes.versions this IDs potential upgrades for us via a custom gradle task
- gradle test retry plugin
- apachie commonsLang
- postgres driver
- log4J minor version
