### PR TITLE
NOTICK:  use  id 'corda.common-publishing' rather than r3 publish

### DIFF
--- a/testing/virtual-node-info-read-service-fake/build.gradle
+++ b/testing/virtual-node-info-read-service-fake/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'corda.common-publishing'
     id 'corda.common-library'
 }
 


### PR DESCRIPTION
 id 'corda.common-publishing' should now be used for publishing logic - use of 'com.r3.internal.gradle.plugins.r3Publish' will break builds for those outside of r3 as it requires resolving the r3Publish from internal Artifactory which they will not have access to.

logic in https://github.com/corda/corda-runtime-os/blob/release/os/5.0/buildSrc/src/main/groovy/corda.common-publishing.gradle applies this conditionally based on if a user is internal or not, if not standard maven publishing conventions are applied, 