### PR TITLE
CORE-4354: Refactor V1 packaging code to prepare for V2

### DIFF
--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpiBuilder.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpiBuilder.kt
@@ -8,7 +8,6 @@ import net.corda.packaging.Cpk
 import net.corda.packaging.DependencyResolutionException
 import net.corda.packaging.SigningParameters
 import net.corda.packaging.internal.PackagingConstants.CPI_GROUP_POLICY_ENTRY
-import net.corda.packaging.util.ZipTweaker
 import java.io.BufferedOutputStream
 import java.io.OutputStream
 import java.io.Reader

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpiImpl.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpiImpl.kt
@@ -8,7 +8,7 @@ import java.util.Collections
 import java.util.NavigableMap
 import java.util.TreeMap
 
-data class CpiIdentifierImpl(
+internal data class CpiIdentifierImpl(
     override val name: String,
     override val version: String,
     override val signerSummaryHash: SecureHash?

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpiLoader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpiLoader.kt
@@ -6,7 +6,6 @@ import net.corda.packaging.PackagingException
 import net.corda.packaging.internal.PackagingConstants.CPI_GROUP_POLICY_ENTRY
 import net.corda.packaging.internal.PackagingConstants.CPI_NAME_ATTRIBUTE
 import net.corda.packaging.internal.PackagingConstants.CPI_VERSION_ATTRIBUTE
-import net.corda.packaging.util.UncloseableInputStream
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import java.io.InputStream

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpkLoader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/CpkLoader.kt
@@ -12,8 +12,6 @@ import net.corda.packaging.internal.PackagingConstants.CPK_DEPENDENCIES_FILE_ENT
 import net.corda.packaging.internal.PackagingConstants.CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY
 import net.corda.packaging.internal.PackagingConstants.CPK_LIB_FOLDER
 import net.corda.packaging.internal.PackagingConstants.JAR_FILE_EXTENSION
-import net.corda.packaging.util.TeeInputStream
-import net.corda.packaging.util.UncloseableInputStream
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/SignatureCollector.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/SignatureCollector.kt
@@ -11,7 +11,7 @@ import java.util.jar.JarEntry
  * after having consumed their entry content from the source [java.util.jar.JarInputStream], then [certificates] property
  * will contain the public keys of the jar's signers.
  */
-class SignatureCollector {
+internal class SignatureCollector {
 
     companion object {
         /**

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/TeeInputStream.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/TeeInputStream.kt
@@ -1,4 +1,4 @@
-package net.corda.packaging.util
+package net.corda.packaging.internal
 
 import java.io.FilterInputStream
 import java.io.InputStream
@@ -7,7 +7,7 @@ import java.io.OutputStream
 /**
  * [InputStream] that also writes its content to the provided [OutputStream] while reading
  */
-class TeeInputStream(inputStream : InputStream, private val destination : OutputStream): FilterInputStream(inputStream) {
+internal class TeeInputStream(inputStream : InputStream, private val destination : OutputStream): FilterInputStream(inputStream) {
     var written = 0
     override fun read(): Int {
         return super.read().also {

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/UncloseableInputStream.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/UncloseableInputStream.kt
@@ -1,4 +1,4 @@
-package net.corda.packaging.util
+package net.corda.packaging.internal
 
 import java.io.FilterInputStream
 import java.io.InputStream
@@ -8,7 +8,7 @@ import java.io.InputStream
  * to a method that closes the stream before it has been fully consumed
  * (and whose remaining content is still needed by the caller)
  */
-class UncloseableInputStream(source : InputStream) : FilterInputStream(source) {
+internal class UncloseableInputStream(source : InputStream) : FilterInputStream(source) {
     override fun close() {}
 }
 

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/ZipTweaker.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/packaging/internal/ZipTweaker.kt
@@ -1,4 +1,4 @@
-package net.corda.packaging.util
+package net.corda.packaging.internal
 
 import java.io.InputStream
 import java.io.OutputStream
@@ -14,7 +14,7 @@ import java.util.zip.ZipOutputStream
  * Helper class to ease the creation of a copy of zip archive,
  * editing some of its [ZipEntry]
  */
-open class ZipTweaker {
+internal open class ZipTweaker {
 
     protected enum class AfterTweakAction {
         WRITE_ORIGINAL_ENTRY, DO_NOTHING

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
@@ -3,8 +3,8 @@ package net.corda.packaging
 import net.corda.packaging.internal.PackagingConstants
 import net.corda.packaging.internal.hash
 import net.corda.packaging.internal.summaryHash
-import net.corda.packaging.util.UncloseableInputStream
-import net.corda.packaging.util.ZipTweaker
+import net.corda.packaging.internal.UncloseableInputStream
+import net.corda.packaging.internal.ZipTweaker
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import org.junit.jupiter.api.AfterAll

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/packaging/internal/ZipTweakerTest.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/packaging/internal/ZipTweakerTest.kt
@@ -1,7 +1,6 @@
 package net.corda.packaging.internal
 
 import net.corda.packaging.Cpk
-import net.corda.packaging.util.ZipTweaker
 import net.corda.v5.crypto.SecureHash
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll


### PR DESCRIPTION
Move all classes inside `net.corda.packaging.util` package into `net.corda.packaging.internal`.

Make `CpiIdentifierImpl`, `SignatureCollector`, `TeeInputStream`, `UncloseableInputStream`, and `ZipTweaker` internal.