### PR TITLE
NOTICK Replacing r3Publish with corda.common-publishing

### DIFF
--- a/components/virtual-node/entity-processor-service-impl/build.gradle
+++ b/components/virtual-node/entity-processor-service-impl/build.gradle
@@ -1,7 +1,7 @@
 import aQute.bnd.gradle.Bundle
 
 plugins {
-    id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'corda.common-publishing'
     id 'corda.osgi-test-conventions'
     id 'corda.common-library'
 }

--- a/components/virtual-node/entity-processor-service/build.gradle
+++ b/components/virtual-node/entity-processor-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'corda.common-publishing'
     id 'corda.common-library'
 }
 


### PR DESCRIPTION
id 'corda.common-publishing' should now be used for publishing logic - use of 'com.r3.internal.gradle.plugins.r3Publish' will break builds for those outside of r3 as it requires resolving the r3Publish from internal Artifactory which they will not have access to.
Similar issue - https://github.com/corda/corda-runtime-os/pull/1271 

We may need to take a more defensive approach so that the 'R3Publish' plugin is not added as this breaks the non-R3 Composite Build pipeline - https://ci02.dev.r3.com/job/Corda5/job/Open-Sourcing/job/Release_Branch/job/Corda_Composite_Build/