### PR TITLE
CORE-4783 Updated comments for db-sandbox

### DIFF
--- a/components/virtual-node/entity-processor-service-impl/build.gradle
+++ b/components/virtual-node/entity-processor-service-impl/build.gradle
@@ -66,12 +66,15 @@ dependencies {
     cpis project(path: ':testing:cpbs:extendable-cpb', configuration: 'cordaCPB')
     cpis project(path: ':testing:cpbs:calculator', configuration: 'cordaCPB')
 
+    // IMPORTANT: do NOT include cpbs (or cpks) as dependencies of the integration test.
+    // This would cause OSGi to load the bundle twice (once as part of the test) and again
+    // as part of the CPB loading.  This introduces *two* unique instances of classes in the CPKs (remember
+    // the class is unique by name **and** classloader).
 
-    integrationTestImplementation("org.mockito:mockito-core:$mockitoVersion") {
-        // do I need this? - trying to ensure this doesn't get "suggested" to the unwary
-        // it doesn't @Export anything for OSGi and anyone that uses it gets a resolution failure at _runtime_
-        exclude group: 'org.mockito.kotlin', module: 'mockito-kotlin'
-    }
+    // IMPORTANT:  do NOT attempt to use mockito-kotlin in the integration tests.
+    // It's not an OSGi bundle, so you will get errors (despite Intellij appearing to allow you to use it).
+
+    integrationTestImplementation("org.mockito:mockito-core:$mockitoVersion")
 
     integrationTestImplementation project(":testing:db-message-bus-testkit")
 
@@ -82,7 +85,6 @@ dependencies {
     integrationTestImplementation project(':components:virtual-node:cpk-read-service')
     integrationTestImplementation project(':components:virtual-node:sandbox-group-context-service')
 
-    // Get it compiling and running.
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(":libs:messaging:messaging-impl")
@@ -90,7 +92,6 @@ dependencies {
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
-
 }
 
 //  Copy the cpi builds declared in the cpis configuration into our resources so we find and load them

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -68,6 +68,9 @@ import javax.persistence.EntityManagerFactory
  *     docker run --rm --name test-instance -e POSTGRES_PASSWORD=password -p 5432:5432 postgres
  *
  *     gradlew integrationTest -PpostgresPort=5432
+ *
+ * Rather than creating a new serializer in these tests from scratch,
+ * we grab a reference to the one in the sandbox and use that to serialize and de-serialize.
  */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class, DBSetup::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -134,7 +137,6 @@ class PersistenceServiceInternalTests {
         persistenceService.persist(sandbox.getSerializer(), entityManager, payload)
 
         Mockito.verify(entityManager).persist(Mockito.any())
-
     }
 
     @Test
@@ -200,6 +202,7 @@ class PersistenceServiceInternalTests {
 
         assertThat(responses.size).isEqualTo(1)
         assertThat((responses[0].value as EntityResponse).result).isInstanceOf(ExceptionEnvelope::class.java)
+
         // TODO - error types should not be string but categories of errors
         assertThat(((responses[0].value as EntityResponse).result as ExceptionEnvelope).errorType).contains("NotSerializableException")
     }

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/MockitoHelper.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/MockitoHelper.kt
@@ -2,7 +2,8 @@ package net.corda.entityprocessor.impl.tests.helpers
 
 import org.mockito.Mockito
 
-// Might not be needed - Mockito.any() may just work.
+
+/** Helps where `Mockito.any()` can't infer the type correctly and returns `null` instead */
 object MockitoHelper {
     fun <T> anyObject(): T {
         Mockito.any<T>()

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/SandboxHelper.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/SandboxHelper.kt
@@ -8,6 +8,11 @@ import net.corda.v5.application.serialization.SerializationService
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * We need to use this object because we cannot include the `Cat` and `Dog` bundles as
+ * _direct gradle dependencies_ of this test.  That means they would be loaded by OSGi
+ * twice, with a separate class loader.
+ */
 object SandboxHelper {
     const val DOG_CLASS_NAME = "net.corda.testing.bundles.dogs.Dog"
 

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityExtractor.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityExtractor.kt
@@ -3,7 +3,7 @@ package net.corda.entityprocessor.impl.internal
 import net.corda.libs.packaging.core.CpkMetadata
 
 object EntityExtractor {
-    /** Extract the set of class names (that were annotated with @Entity */
+    /** Extract the set of class names (that were annotated with @Entity and @CordaSerializable) */
     fun getEntityClassNames(cpksMetadata: Collection<CpkMetadata>): Collection<String> =
         cpksMetadata.flatMap { it.cordappManifest.entities }.toSet()
 }

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
@@ -23,7 +23,12 @@ import java.time.Instant
 import javax.persistence.EntityManagerFactory
 
 /**
- * Handles incoming requests and sends responses.
+ * Handles incoming requests, typically from the flow worker, and sends responses.
+ *
+ * The [EntityRequest] contains the request and a typed payload.
+ *
+ * The [EntityResponse] contains the response or an exception-like payload whose presence indicates
+ * an error has occurred.
  */
 class EntityMessageProcessor(
     private val entitySandboxService: EntitySandboxService,

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntitySandboxServiceImpl.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntitySandboxServiceImpl.kt
@@ -36,15 +36,14 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality
 import org.osgi.service.component.annotations.ReferencePolicy
 
-/** It's a sandbox service, that's internal to this component!
+/** This is a sandbox service that is internal to this component.
  *
- * It gets/creates a per-sandbox with:
+ * It gets/creates a sandbox with a per-sandbox:
  *
  *   * serializer
  *   * entity manager factory
  *
- *
- * */
+ */
 @Suppress("LongParameterList")
 @Component(
     service = [EntitySandboxService::class],
@@ -129,8 +128,9 @@ class EntitySandboxServiceImpl @Activate constructor (
     ): AutoCloseable {
         // Get all the entity class names from the cpk metadata, and then map to their types
         // This bit is quite important - we've bnd-scanned the **CPKS** (not jars!) and written the list
-        // of classes annotated with @Entity to the CPK manifest.  We now use them and convert to types
-        // so that we can correctly construct an entity manager factory per sandbox.
+        // of classes annotated with @Entity and @CordaSerializable to the CPK manifest.
+        // We now use them and convert them to types so that we can correctly construct an
+        // entity manager factory per sandbox.
 
         // TODO - add general vault entities
         val entityClasses = EntityExtractor.getEntityClassNames(cpks).map {

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
@@ -21,16 +21,20 @@ fun EntitySandboxService.getClass(holdingIdentity: HoldingIdentity, fullyQualifi
  *
  * Kafka -> EntityRequest
  *
- * Here:
+ * This (pseudo) code:
  *
- *    persistenceServiceInternal.persist(ss, emf, someEntityWrappedBytes)
- *    publisher.publish(FLOW_WORKER_EVENT_TOPIC, EntityResponse(...))
+ *    val entityResponse
+ *      = persistenceServiceInternal.persist(ss, emf, someEntityWrappedBytes)
+ *    publisher.publish(FLOW_WORKER_EVENT_TOPIC, entityResponse)
  *
  * Kafka -> EntityResponse
  *
  * Flow worker:
  *
- *    // resumes...
+ *    // resumes processing
+ *
+ * If the [EntityResponse] contains an exception, the flow-worker is expected to treat that
+ * as an error and handle it appropriately (such as retrying).
  * */
 class PersistenceServiceInternal(private val entitySandboxService: EntitySandboxService) {
     // TODO - these want to also handle exceptions and/or possible return EntityResponse

--- a/components/virtual-node/entity-processor-service-impl/test.bndrun
+++ b/components/virtual-node/entity-processor-service-impl/test.bndrun
@@ -28,7 +28,8 @@
     postgresUser=${project.postgresUser},\
     postgresPassword=${project.postgresPassword}
 
-#  include the impl and the tests since they're bundles to be run inside an osgi framework
+# Include the the tests since they're the bundle to be run inside an osgi framework.
+# This should make bnd resolve everything else we need.
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='net.bytebuddy.byte-buddy',\

--- a/testing/bundles/testing-cats/build.gradle
+++ b/testing/bundles/testing-cats/build.gradle
@@ -5,7 +5,9 @@ plugins {
 
 description 'Cats test bundle'
 
-// so that we can build this into CPBs without the corda gradle plugin complaining
+// IMPORTANT:  We must set the group to anything other than `net.corda`.
+// This is so that we can link this into a CPB without the corda gradle plugin refusing.
+// `net.corda` is reserved for Corda "system" bundles.
 group 'com.r3.testing'
 
 cordapp {

--- a/testing/bundles/testing-dogs/build.gradle
+++ b/testing/bundles/testing-dogs/build.gradle
@@ -5,7 +5,9 @@ plugins {
 
 description 'Dogs test bundle'
 
-// so that we can build this into CPBs without the corda gradle plugin complaining
+// IMPORTANT:  We must set the group to anything other than `net.corda`.
+// This is so that we can link this into a CPB without the corda gradle plugin refusing.
+// `net.corda` is reserved for Corda "system" bundles.
 group 'com.r3.testing'
 
 cordapp {


### PR DESCRIPTION
Improve the comments and ensure some of our OSGi knowledge about arcane problems is actually recorded somewhere.

* Do NOT add cpks as dependencies of unit tests.  If you want the types
in a cpk, use reflection to get them.

* Do NOT use mockito-kotlin in OSGi integration tests, it's not an OSGi
bundle so you'll get errors.