### PR TITLE
CORE-4724: Revert generate information from Nexus

### DIFF
--- a/.ci/nightly/JenkinsfileNexusScan
+++ b/.ci/nightly/JenkinsfileNexusScan
@@ -1,6 +1,5 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaNexusScanPipeline(
-    nexusAppId: 'flow-worker-5.0',
-    nexusAppStage: 'build'
+    nexusAppId: 'flow-worker-5.0'
 )


### PR DESCRIPTION
This reverts commit f66e080af6f5ecf019f10c99a15941410fd1c3f3. (#1297)

It is no longer needed as a newly introduced parameter has been removed.

Test build at https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNexus-Scan-Corda-Runtime-OS/detail/CORE-4724-fixes/1/artifacts