### PR TITLE
CORE-4825: new github action

### DIFF
--- a/.github/workflows/consistency-checks.yaml
+++ b/.github/workflows/consistency-checks.yaml
@@ -18,4 +18,4 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: wzur-r3/check-correct-publish-plugin-is-in-use-action@v1
+    - uses: corda/check-correct-publish-plugin-is-in-use-action@v1


### PR DESCRIPTION
Very crude check, just search with `grep` for occurrences of internal plugin ID and if sees more than 2 it fails.