### PR TITLE
NOTICK: Update sandbox-app to apply its own security policy.

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/SandboxBootstrap.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/SandboxBootstrap.kt
@@ -1,7 +1,5 @@
 package net.corda.example.vnode
 
-import net.corda.securitymanager.ConditionalPermission
-import net.corda.securitymanager.ConditionalPermission.Access
 import java.io.FilePermission
 import java.lang.management.ManagementPermission
 import java.lang.reflect.ReflectPermission
@@ -10,7 +8,13 @@ import java.net.SocketPermission
 import java.nio.file.Files
 import java.nio.file.LinkPermission
 import java.nio.file.Paths
+import java.security.AllPermission
+import java.security.Permission
 import java.util.PropertyPermission
+import net.corda.securitymanager.ConditionalPermission
+import net.corda.securitymanager.ConditionalPermission.Access
+import net.corda.securitymanager.ConditionalPermission.Access.ALLOW
+import net.corda.securitymanager.ConditionalPermission.Access.DENY
 import net.corda.securitymanager.SecurityManagerService
 import net.corda.testing.sandboxes.SandboxSetup
 import org.osgi.framework.AdminPermission
@@ -28,7 +32,6 @@ import org.osgi.service.condpermadmin.BundleLocationCondition
 import org.osgi.service.condpermadmin.ConditionInfo
 import org.osgi.service.permissionadmin.PermissionAdmin
 import org.osgi.service.permissionadmin.PermissionInfo
-import java.security.Permission
 
 @Suppress("unused")
 @Component(service = [], immediate = true)
@@ -40,40 +43,43 @@ class SandboxBootstrap @Activate constructor(
     bundleContext: BundleContext
 ){
     init {
-        securityManager.startRestrictiveMode()
-        securityManager.denyPermissions("FLOW/*", listOf(
-            // OSGi permissions.
-            AdminPermission(),
-            ServicePermission("*", GET),
-            ServicePermission("net.corda.v5.*", REGISTER),
-            PackagePermission("net.corda", "$EXPORTONLY,$IMPORT"),
-            PackagePermission("net.corda.*", "$EXPORTONLY,$IMPORT"),
+        securityManager.updatePermissions(listOf(
+            bundleLocationPermission("*", listOf(
+                ServicePermission(PermissionAdmin::class.java.name, REGISTER)
+            ), DENY),
+            bundleLocationPermission("FLOW/*", listOf(
+                PackagePermission("net.corda.v5.*", IMPORT),
+                ServicePermission("(location=FLOW/*)", GET),
+                ServicePermission("net.corda.v5.*", GET),
+                RuntimePermission("accessClassInPackage.net.corda.v5.*")
+            ), ALLOW),
+            bundleLocationPermission("FLOW/*", listOf(
+                // OSGi permissions.
+                AdminPermission(),
+                ServicePermission("*", GET),
+                ServicePermission("net.corda.v5.*", REGISTER),
+                PackagePermission("net.corda", "$EXPORTONLY,$IMPORT"),
+                PackagePermission("net.corda.*", "$EXPORTONLY,$IMPORT"),
 
-            // Prevent the FLOW sandboxes from importing these packages,
-            // which effectively forbids them from executing most OSGi code.
-            PackagePermission("org.osgi.framework", IMPORT),
-            PackagePermission("org.osgi.service.component", IMPORT),
+                // Prevent the FLOW sandboxes from importing these packages,
+                // which effectively forbids them from executing most OSGi code.
+                PackagePermission("org.osgi.framework", IMPORT),
+                PackagePermission("org.osgi.service.component", IMPORT),
 
-            // Java permissions.
-            RuntimePermission("*"),
-            ReflectPermission("*"),
-            NetPermission("*"),
-            LinkPermission("hard"),
-            LinkPermission("symbolic"),
-            ManagementPermission("control"),
-            ManagementPermission("monitor"),
-            PropertyPermission("*", "read,write"),
-            SocketPermission("*", "accept,connect,listen"),
-            FilePermission("<<ALL FILES>>", "read,write,execute,delete,readlink")
-        ))
-        securityManager.grantPermissions("FLOW/*", listOf(
-            PackagePermission("net.corda.v5.*", IMPORT),
-            ServicePermission("(location=FLOW/*)", GET),
-            ServicePermission("net.corda.v5.*", GET)
-        ))
-        securityManager.denyPermissions("*", listOf(
-            ServicePermission(PermissionAdmin::class.java.name, REGISTER)
-        ))
+                // Java permissions.
+                RuntimePermission("*"),
+                ReflectPermission("*"),
+                NetPermission("*"),
+                LinkPermission("hard"),
+                LinkPermission("symbolic"),
+                ManagementPermission("control"),
+                ManagementPermission("monitor"),
+                PropertyPermission("*", "read,write"),
+                SocketPermission("*", "accept,connect,listen"),
+                FilePermission("<<ALL FILES>>", "read,write,execute,delete,readlink")
+            ), DENY),
+            bundleLocationPermission("*", listOf(AllPermission()), ALLOW)
+        ), clear = true)
 
         val baseDirectory = Paths.get(System.getProperty("app.name", System.getProperty("user.dir", "."))).toAbsolutePath()
         sandboxSetup.configure(bundleContext, Files.createDirectories(baseDirectory))
@@ -84,28 +90,8 @@ class SandboxBootstrap @Activate constructor(
      */
     private fun bundleLocationPermission(location: String, permissions: List<Permission>, access: Access) =
         ConditionalPermission(
-            ConditionInfo(BundleLocationCondition::class.java.canonicalName, arrayOf(location)),
-            permissions.map { PermissionInfo(it::class.java.canonicalName, it.name, it.actions) }.toTypedArray(),
+            ConditionInfo(BundleLocationCondition::class.java.name, arrayOf(location)),
+            permissions.map { PermissionInfo(it::class.java.name, it.name, it.actions) }.toTypedArray(),
             access
         )
-
-    /**
-     * Updates [SecurityManagerService] permissions by granting given [permissions] for specified bundle [location] filter
-     */
-    private fun SecurityManagerService.grantPermissions(location: String, permissions: List<Permission>) {
-        this.updatePermissions(listOf(
-            bundleLocationPermission(location, permissions, Access.ALLOW)),
-            clear = false
-        )
-    }
-
-    /**
-     * Updates [SecurityManagerService] permissions by denying given [permissions] for specified bundle [location] filter
-     */
-    private fun SecurityManagerService.denyPermissions(location: String, permissions: List<Permission>) {
-        this.updatePermissions(listOf(
-            bundleLocationPermission(location, permissions, Access.DENY)),
-            clear = false
-        )
-    }
 }


### PR DESCRIPTION
Update `:sandbox-app` example to apply its permissions as a single policy rather than one-by-one.

Also grant `RuntimePermission("accessClassInPackage.net.corda.v5.*")` to `FLOW` bundles, as this is now required (although I don't understand _why_, because I cannot see any class from a `FLOW` bundle on the exception call stack :thinking:).