### PR TITLE
CORE-4643: add contributors list as place holder for open sourcing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,7 +49,6 @@ omissions, and create a pull request if you wish to see changes to this list.
 * Razvan Codreanu (R3)
 * Ronan Browne (R3)
 * Ryan Fowler (R3)
-* Schife (R3)
 * Simon Dobson (R3)
 * Stefano Franz (R3)
 * Viktor Kolomeyko (R3)


### PR DESCRIPTION
generated with `git shortlog -s -n --all` and then some formatting