### PR TITLE
CORE-4706: Ensure JVM canonicalises file paths when applying security policy.

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/test.bndrun
+++ b/components/virtual-node/sandbox-group-context-service/test.bndrun
@@ -8,6 +8,7 @@
     osgi.service;objectClass:List<String>='org.osgi.service.condpermadmin.ConditionalPermissionAdmin';effective:=active
 
 -runvm: \
+    -Djdk.io.permissionsUseCanonicalPath=true, \
     --add-opens, 'java.base/java.net=ALL-UNNAMED'
 
 -runsystempackages: \


### PR DESCRIPTION
Canonicalise file paths to ensure OSGi tests also pass on MacOS and Windows.