### PR TITLE
CORE-4783 - entity error response

### DIFF
--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/fake/FakeCpiInfoReadService.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/fake/FakeCpiInfoReadService.kt
@@ -1,0 +1,44 @@
+package net.corda.entityprocessor.impl.tests.fake
+
+import net.corda.cpiinfo.read.CpiInfoListener
+import net.corda.cpiinfo.read.CpiInfoReadService
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpiMetadata
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.reconciliation.VersionedRecord
+import java.util.stream.Stream
+
+/**
+ * Intentional - we're going to override a few specific methods elsewhere.
+ */
+open class FakeCpiInfoReadService : CpiInfoReadService {
+    override fun getAll(): List<CpiMetadata> {
+        TODO("Not yet implemented")
+    }
+
+    override fun get(identifier: CpiIdentifier): CpiMetadata? {
+        TODO("Not yet implemented")
+    }
+
+    override fun registerCallback(listener: CpiInfoListener): AutoCloseable {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllVersionedRecords(): Stream<VersionedRecord<CpiIdentifier, CpiMetadata>>? {
+        TODO("Not yet implemented")
+    }
+
+    override val lifecycleCoordinatorName: LifecycleCoordinatorName
+        get() = TODO("Not yet implemented")
+
+    override val isRunning: Boolean
+        get() = TODO("Not yet implemented")
+
+    override fun start() {
+        TODO("Not yet implemented")
+    }
+
+    override fun stop() {
+        TODO("Not yet implemented")
+    }
+}

--- a/components/virtual-node/entity-processor-service-impl/src/main/java/net/corda/entityprocessor/impl/internal/exceptions/package-info.java
+++ b/components/virtual-node/entity-processor-service-impl/src/main/java/net/corda/entityprocessor/impl/internal/exceptions/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.entityprocessor.impl.internal.exceptions;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
@@ -136,7 +136,6 @@ class EntityMessageProcessor(
                         holdingIdentity
                     )
                     else -> {
-                        // Flow worker could retry and a *different* db processor that supports the command is used.
                         failureResponse(requestId, CordaRuntimeException("Unknown command"), Error.FATAL)
                     }
                 }

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntitySandboxServiceImpl.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntitySandboxServiceImpl.kt
@@ -5,6 +5,8 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.entityprocessor.impl.internal.EntitySandboxContextTypes.SANDBOX_EMF
 import net.corda.entityprocessor.impl.internal.EntitySandboxContextTypes.SANDBOX_SERIALIZER
 import net.corda.entityprocessor.impl.internal.EntitySandboxServiceImpl.Companion.INTERNAL_CUSTOM_SERIALIZERS
+import net.corda.entityprocessor.impl.internal.exceptions.NotReadyException
+import net.corda.entityprocessor.impl.internal.exceptions.VirtualNodeException
 import net.corda.internal.serialization.AMQP_P2P_CONTEXT
 import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.DeserializationInput
@@ -22,7 +24,6 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putObjectByKey
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.serialization.InternalCustomSerializer
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.serialization.SerializationCustomSerializer
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -56,7 +57,7 @@ import org.osgi.service.component.annotations.ReferencePolicy
         )
     ]
 )
-class EntitySandboxServiceImpl @Activate constructor (
+class EntitySandboxServiceImpl @Activate constructor(
     @Reference
     private val sandboxService: SandboxGroupContextComponent,
     @Reference
@@ -82,39 +83,41 @@ class EntitySandboxServiceImpl @Activate constructor (
         get() = componentContext.fetchServices<InternalCustomSerializer<out Any>>(INTERNAL_CUSTOM_SERIALIZERS)
 
     override fun get(holdingIdentity: HoldingIdentity): SandboxGroupContext {
-        // TODO - error handling (CORE-4783)
+        // We're throwing internal exceptions so that we can relay some information back to the flow worker
+        // on how to proceed with any request to us that fails.
         val virtualNode = virtualNodeInfoService.get(holdingIdentity)
-            ?: throw CordaRuntimeException("Could not get virtual node for $holdingIdentity")
+            ?: throw VirtualNodeException("Could not get virtual node for $holdingIdentity")
 
         val cpks = cpiInfoService.get(virtualNode.cpiIdentifier)?.cpksMetadata
-            ?: throw CordaRuntimeException("Could not get list of CPKs for ${virtualNode.cpiIdentifier}")
+            ?: throw VirtualNodeException("Could not get list of CPKs for ${virtualNode.cpiIdentifier}")
 
         val cpkIds = cpks.map { it.cpkId }.toSet()
-        if(!sandboxService.hasCpks(cpkIds))
-            throw CordaRuntimeException("CPKs not available (yet): $cpkIds")
+        if (!sandboxService.hasCpks(cpkIds))
+            throw NotReadyException("CPKs not available (yet): $cpkIds")
 
         return sandboxService.getOrCreate(getVirtualNodeContext(virtualNode, cpks)) { _, ctx ->
-            initializeSandbox(
-                cpks,
-                virtualNode,
-                ctx
-            )
+            initializeSandbox(cpks, virtualNode, ctx)
         }
     }
 
     private fun initializeSandbox(
         cpks: Collection<CpkMetadata>,
         virtualNode: VirtualNodeInfo,
-        ctx: MutableSandboxGroupContext): AutoCloseable {
+        ctx: MutableSandboxGroupContext
+    ): AutoCloseable {
         val serializerCloseable = putSerializer(ctx, cpks, virtualNode)
         val emfCloseable = putEntityManager(ctx, cpks, virtualNode)
 
-        logger.info("Initialising DB Sandbox for ${virtualNode.holdingIdentity}/" +
-                "${virtualNode.cpiIdentifier.name}[${virtualNode.cpiIdentifier.version}]")
+        logger.info(
+            "Initialising DB Sandbox for ${virtualNode.holdingIdentity}/" +
+                    "${virtualNode.cpiIdentifier.name}[${virtualNode.cpiIdentifier.version}]"
+        )
 
         return AutoCloseable {
-            logger.info("Closing DB Sandbox for ${virtualNode.holdingIdentity}/" +
-                    "${virtualNode.cpiIdentifier.name}[${virtualNode.cpiIdentifier.version}]")
+            logger.info(
+                "Closing DB Sandbox for ${virtualNode.holdingIdentity}/" +
+                        "${virtualNode.cpiIdentifier.name}[${virtualNode.cpiIdentifier.version}]"
+            )
             serializerCloseable.close()
             emfCloseable.close()
         }
@@ -137,7 +140,7 @@ class EntitySandboxServiceImpl @Activate constructor (
             try {
                 ctx.sandboxGroup.loadClassFromMainBundles(it)
             } catch (e: SandboxException) {
-                throw e // TODO - correct error handling
+                throw e
             }
         }.toSet()
 
@@ -152,8 +155,8 @@ class EntitySandboxServiceImpl @Activate constructor (
 
         // Create the per-sandbox EMF for all the entities
         // NOTE: this is create and not getOrCreate as the dbConnectionManager does not cache vault EMFs.
-        //  This is because sandboxes themselves are caches, so the EMF will be cached and cleaned up
-        //  as part of that.
+        // This is because sandboxes themselves are caches, so the EMF will be cached and cleaned up
+        // as part of that.
         val entityManagerFactory = dbConnectionManager.createEntityManagerFactory(
             virtualNode.vaultDmlConnectionId,
             entitiesSet
@@ -187,8 +190,9 @@ class EntitySandboxServiceImpl @Activate constructor (
             cpkSerializers
         )
 
-        logger.debug("Creating SerializationService for DB Sandbox (${virtualNode.holdingIdentity}) with " +
-                cpkSerializers.joinToString(",")
+        logger.debug(
+            "Creating SerializationService for DB Sandbox (${virtualNode.holdingIdentity}) with " +
+                    cpkSerializers.joinToString(",")
         )
 
         customSerializers.forEach { factory.registerExternal(it, factory) }

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
@@ -1,19 +1,20 @@
 package net.corda.entityprocessor.impl.internal
 
 import net.corda.data.virtualnode.DeleteEntity
+import net.corda.data.virtualnode.EntityResponse
+import net.corda.data.virtualnode.EntityResponseSuccess
 import net.corda.data.virtualnode.FindEntity
 import net.corda.data.virtualnode.MergeEntity
 import net.corda.data.virtualnode.PersistEntity
 import net.corda.v5.application.serialization.SerializationService
-import net.corda.v5.serialization.SerializedBytes
 import net.corda.virtualnode.HoldingIdentity
+import java.nio.ByteBuffer
+import java.time.Instant
 import javax.persistence.EntityManager
 
-fun EntitySandboxService.getClass(holdingIdentity: HoldingIdentity, fullyQualifiedClassName: String) =
-    this.get(holdingIdentity).sandboxGroup.loadClassFromMainBundles(fullyQualifiedClassName)
 
 /**
- * This the final set of calls that originated from the flow worker [PersistenceService], i.e.
+ * This the final set of calls that originated from the flow worker [net.corda.v5.application.persistence.PersistenceService], i.e.
  *
  * Flow worker:
  *
@@ -35,19 +36,24 @@ fun EntitySandboxService.getClass(holdingIdentity: HoldingIdentity, fullyQualifi
  *
  * If the [EntityResponse] contains an exception, the flow-worker is expected to treat that
  * as an error and handle it appropriately (such as retrying).
+ *
+ * @param classProvider a lambda that returns the class _type_ for the given fully qualified name and
+ * a given holding identity.  The supplied lambda should look up the class type in a context appropriate
+ * to the given [HoldingIdentity]
+ * @param requestId the request id for this action.
  * */
-class PersistenceServiceInternal(private val entitySandboxService: EntitySandboxService) {
-    // TODO - these want to also handle exceptions and/or possible return EntityResponse
-    //   here instead of bytes (CORE-4783)
-
+class PersistenceServiceInternal(
+    private val classProvider: (holdingIdentity: HoldingIdentity, fullyQualifiedClassName: String) -> Class<*>,
+    private val requestId: String
+) {
     fun persist(
         serializationService: SerializationService,
         entityManager: EntityManager,
         payload: PersistEntity
-    ): SerializedBytes<Any>? {
+    ): EntityResponse {
         val entity = serializationService.deserialize(payload.entity.array(), Any::class.java)
         entityManager.persist(entity)
-        return null
+        return EntityResponse(Instant.now(), requestId, EntityResponseSuccess())
     }
 
     fun find(
@@ -55,34 +61,35 @@ class PersistenceServiceInternal(private val entitySandboxService: EntitySandbox
         entityManager: EntityManager,
         payload: FindEntity,
         holdingIdentity: HoldingIdentity
-    ): SerializedBytes<Any>? {
+    ): EntityResponse {
         val primaryKey = serializationService.deserialize(payload.primaryKey.array(), Any::class.java)
-        val clazz = entitySandboxService.getClass(holdingIdentity, payload.entityClassName)
-        val entity = entityManager.find(clazz, primaryKey)
-        return if (entity == null) {
-            null
-        } else {
-            serializationService.serialize(entity)
+        val clazz = classProvider(holdingIdentity, payload.entityClassName)
+        val innerMsg = when (val entity = entityManager.find(clazz, primaryKey)) {
+            null -> EntityResponseSuccess()
+            else -> EntityResponseSuccess(ByteBuffer.wrap(serializationService.serialize(entity).bytes))
         }
+        return EntityResponse(Instant.now(), requestId, innerMsg)
     }
 
     fun merge(
         serializationService: SerializationService,
         entityManager: EntityManager,
         payload: MergeEntity
-    ): SerializedBytes<Any> {
+    ): EntityResponse {
         val entity = serializationService.deserialize(payload.entity.array(), Any::class.java)
-        return serializationService.serialize(entityManager.merge(entity))
+        val innerMsg =
+            EntityResponseSuccess(ByteBuffer.wrap(serializationService.serialize(entityManager.merge(entity)).bytes))
+        return EntityResponse(Instant.now(), requestId, innerMsg)
     }
 
     fun remove(
         serializationService: SerializationService,
         entityManager: EntityManager,
         payload: DeleteEntity
-    ): SerializedBytes<Any>? {
+    ): EntityResponse {
         val entity = serializationService.deserialize(payload.entity.array(), Any::class.java)
         // NOTE: JPA expects the entity to be managed before removing, hence the merge.
         entityManager.remove(entityManager.merge(entity))
-        return null
+        return EntityResponse(Instant.now(), requestId, EntityResponseSuccess())
     }
 }

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/exceptions/NotReadyException.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/exceptions/NotReadyException.kt
@@ -1,0 +1,3 @@
+package net.corda.entityprocessor.impl.internal.exceptions
+
+internal class NotReadyException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/exceptions/VirtualNodeException.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/exceptions/VirtualNodeException.kt
@@ -1,0 +1,3 @@
+package net.corda.entityprocessor.impl.internal.exceptions
+
+internal class VirtualNodeException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XX-SNAPSHOT
-cordaApiVersion=5.0.0.101-beta+
+cordaApiVersion=5.0.0.102-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22


### PR DESCRIPTION
Return richer error information to the flow worker, when it makes a request via the `PersistenceService` to the db worker (entity processor).

Some categories of errors have been added in corda-api.  There's several types, a couple are likely "recoverable" via a retry - see the comments.

Please review those and decide whether there are enough or too many.

https://github.com/corda/corda-api/pull/374