### PR TITLE
CORE-4823 Fix CPI metadata DB streaming

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -55,7 +55,8 @@ class CpiValidatorImpl(
             fileInfo.checksum,
             cpi.cpks.map { it.metadata },
             cpi.metadata.groupPolicy,
-            version = -1,
+            // TODO the below version should be populated from the DB as per https://r3-cev.atlassian.net/browse/CORE-4890
+            version = 0,
             timestamp
         )
         cpiInfoWriteService.put(cpiMetadata)

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiEntities.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiEntities.kt
@@ -5,7 +5,5 @@ object CpiEntities {
         CpiMetadataEntity::class.java,
         CpkDataEntity::class.java,
         CpkMetadataEntity::class.java,
-        CpkDependencyEntity::class.java,
-        CpkCordappManifestEntity::class.java
     )
 }

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReaderTest.kt
@@ -1,5 +1,6 @@
 package net.corda.processors.db.internal.reconcile.db
 
+import java.util.stream.Stream
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -41,10 +42,7 @@ class CpiInfoDbReaderTest {
     @Test
     fun `doGetAllVersionedRecords converts db data to version records`() {
         val typeQuery = mock<TypedQuery<CpiMetadataEntity>>()
-        // TODO to be reverted when CpiMetadataEntity.kt EntityManager.findAllCpiMetadata() is fixed (to use a stream again)
-        //  as per https://r3-cev.atlassian.net/browse/CORE-4823.
-        //whenever(typeQuery.resultStream).thenReturn(Stream.of(dummyCpiMetadataEntity))
-        whenever(typeQuery.resultList).thenReturn(listOf(dummyCpiMetadataEntity))
+        whenever(typeQuery.resultStream).thenReturn(Stream.of(dummyCpiMetadataEntity))
         val entityManager = mock<EntityManager>()
         whenever(entityManager.transaction).thenReturn(mock())
         whenever(entityManager.createQuery(any(), any<Class<CpiMetadataEntity>>())).thenReturn(typeQuery)


### PR DESCRIPTION
- refactored `CpkMetadata` child entities.
- tweaked find all `CpiMetadataEntity` query to load everything eagerly. Ideally we need the result set to be created on the DB side and then stream through that result set.

Querying still needs investigation as it seems to be producing 1 select statement for loading a CPI and 1 select statement per CPK. [CORE-4864](https://r3-cev.atlassian.net/browse/CORE-4864) was registered for this reason.