### PR TITLE
CORE-4860 Security Manager issues in flow worker

### DIFF
--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
@@ -19,7 +19,7 @@ class StartFlow(private val context: TaskContext) : Task {
         context.publish(
             getStartRPCEventRecord(
                 clientId = UUID.randomUUID().toString(),
-                flowName = "net.corda.flowworker.development.flows.MessagingFlow",
+                flowName = "net.cordapp.flowworker.development.flows.MessagingFlow",
                 x500Name = context.startArgs.x500NName,
                 groupId = "flow-worker-dev",
                 jsonArgs = "{ \"who\":\"${context.startArgs.x500NName}\"}"

--- a/applications/workers/release/flow-worker/README.md
+++ b/applications/workers/release/flow-worker/README.md
@@ -116,7 +116,7 @@ or it can be run/debugged direct from intelliJ:
 1) Start the flow:
 ```shell
 curl --insecure -u admin:admin -X PUT -d '{ "requestBody": "{\"inputValue\":\"hello\", \"memberInfoLookup\":\"CN=Bob, O=Bob Corp, L=LDN, 
-C=GB\", \"throwException\": false }" }' https://localhost:8888/api/v1/flow/[HOLDING_ID_HASH]/request1/net.corda.flowworker.development.flows.TestFlow
+C=GB\", \"throwException\": false }" }' https://localhost:8888/api/v1/flow/[HOLDING_ID_HASH]/request1/net.cordapp.flowworker.development.flows.TestFlow
 ```
 The holding ID is taken from the output of the 'create virtual node' step
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
@@ -98,8 +98,7 @@ class FlowSessionImpl(
                 log.info("Received a payload but failed to deserialize it into a ${receiveType.name}", e)
                 throw e
             }
-        }
-            ?: throw CordaRuntimeException("The session [${sourceSessionId}] did not receive a payload when trying to receive one")
+        } ?: throw CordaRuntimeException("The session [${sourceSessionId}] did not receive a payload when trying to receive one")
     }
 
     /**

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/factory/FlowSessionFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/factory/FlowSessionFactoryImpl.kt
@@ -7,6 +7,9 @@ import net.corda.v5.base.types.MemberX500Name
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.security.AccessController
+import java.security.PrivilegedActionException
+import java.security.PrivilegedExceptionAction
 
 @Component(service = [FlowSessionFactory::class])
 class FlowSessionFactoryImpl @Activate constructor(
@@ -15,6 +18,12 @@ class FlowSessionFactoryImpl @Activate constructor(
 ) : FlowSessionFactory {
 
     override fun create(sessionId: String, x500Name: MemberX500Name, initiated: Boolean): FlowSession {
-        return FlowSessionImpl(counterparty = x500Name, sessionId, flowFiberService, initiated)
+        return try {
+            AccessController.doPrivileged(PrivilegedExceptionAction {
+                FlowSessionImpl(counterparty = x500Name, sessionId, flowFiberService, initiated)
+            })
+        } catch (e: PrivilegedActionException) {
+            throw e.exception
+        }
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
@@ -7,6 +7,9 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.types.sequence
 import net.corda.v5.serialization.SerializedBytes
 import net.corda.v5.serialization.SingletonSerializeAsToken
+import java.security.AccessController
+import java.security.PrivilegedActionException
+import java.security.PrivilegedExceptionAction
 
 class SerializationServiceImpl(
     private val serializationOutput: SerializationOutput,
@@ -15,15 +18,33 @@ class SerializationServiceImpl(
 ) : SerializationService {
 
     override fun <T : Any> serialize(obj: T): SerializedBytes<T> {
-        return serializationOutput.serialize(obj, context)
+        return try {
+            AccessController.doPrivileged(PrivilegedExceptionAction {
+                serializationOutput.serialize(obj, context)
+            })
+        } catch (e: PrivilegedActionException) {
+            throw e.exception
+        }
     }
 
     override fun <T : Any> deserialize(serializedBytes: SerializedBytes<T>, clazz: Class<T>): T {
-        return deserializationInput.deserialize(serializedBytes, clazz, context)
+        return try {
+            AccessController.doPrivileged(PrivilegedExceptionAction {
+                deserializationInput.deserialize(serializedBytes, clazz, context)
+            })
+        } catch (e: PrivilegedActionException) {
+            throw e.exception
+        }
     }
 
     override fun <T : Any> deserialize(bytes: ByteArray, clazz: Class<T>): T {
-        return deserializationInput.deserialize(bytes.sequence(), clazz, context)
+        return try {
+            AccessController.doPrivileged(PrivilegedExceptionAction {
+                deserializationInput.deserialize(bytes.sequence(), clazz, context)
+            })
+        } catch (e: PrivilegedActionException) {
+            throw e.exception
+        }
     }
 }
 

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/MessagingFlow.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/MessagingFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.flowworker.development.flows
+package net.cordapp.flowworker.development.flows
 
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.Flow

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/TestFlow.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/TestFlow.kt
@@ -1,7 +1,7 @@
-package net.corda.flowworker.development.flows
+package net.cordapp.flowworker.development.flows
 
-import net.corda.flowworker.development.messages.TestFlowInput
-import net.corda.flowworker.development.messages.TestFlowOutput
+import net.cordapp.flowworker.development.messages.TestFlowInput
+import net.cordapp.flowworker.development.messages.TestFlowOutput
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.StartableByRPC

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/TestGetNodeNameSubFlow.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/TestGetNodeNameSubFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.flowworker.development.flows
+package net.cordapp.flowworker.development.flows
 
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.FlowEngine

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/messages/TestFlowInput.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/messages/TestFlowInput.kt
@@ -1,4 +1,4 @@
-package net.corda.flowworker.development.messages
+package net.cordapp.flowworker.development.messages
 
 class TestFlowInput{
     var inputValue: String? = null

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/messages/TestFlowOutput.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/messages/TestFlowOutput.kt
@@ -1,4 +1,4 @@
-package net.corda.flowworker.development.messages
+package net.cordapp.flowworker.development.messages
 
 data class TestFlowOutput(
     val inputValue: String,


### PR DESCRIPTION
Change `net.corda.flowworker.development.flows` to 
`net.cordapp.flowworker.development.flows` because `net.corda`
cannot be used by CPKs.

Add `doPrivileged` to a number of calls that included reflection in
their call stack.