### PR TITLE
CORE-4805 Discard orphaned session events

### DIFF
--- a/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
+++ b/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
@@ -4,6 +4,10 @@ The test coverage of the flow event pipeline's acceptance tests are documented h
 
 This document should be maintained so that we can ensure that we have quick visibility into our coverage as we are expecting a number of scenarios to be exercised.
 
+## General
+
+- Receiving a non-session init event for a flow that does not exist discards the event ✅
+
 ## Sending
 - Calling 'send' on initiated sessions sends a session data event and schedules a wakeup event ✅
 - Calling 'send' on a closed session schedules an error event (not fully implemented, assert CLOSING, CLOSED, WAIT_FOR_FINAL_ACK states)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.testing.tests
 
-import net.corda.data.flow.FlowStackItem
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.event.session.SessionAck
 import net.corda.data.flow.event.session.SessionClose

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SessionsAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SessionsAcceptanceTest.kt
@@ -1,0 +1,73 @@
+package net.corda.flow.testing.tests
+
+import net.corda.data.flow.event.session.SessionAck
+import net.corda.data.flow.event.session.SessionClose
+import net.corda.data.flow.event.session.SessionData
+import net.corda.data.flow.event.session.SessionError
+import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.testing.context.FlowServiceTestBase
+import net.corda.flow.testing.context.StepSetup
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.osgi.test.junit5.service.ServiceExtension
+import java.util.stream.Stream
+
+/**
+ * Contains general session related tests that do not fit into one of the more specific [FlowIORequest] tests.
+ */
+@ExtendWith(ServiceExtension::class)
+@Execution(ExecutionMode.SAME_THREAD)
+class SessionsAcceptanceTest : FlowServiceTestBase() {
+
+    private companion object {
+        @JvmStatic
+        fun nonInitSessionEventTypes(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(
+                    SessionAck::class.simpleName,
+                    { dsl: StepSetup -> dsl.sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1) }
+                ),
+                Arguments.of(
+                    SessionData::class.simpleName,
+                    { dsl: StepSetup ->
+                        dsl.sessionDataEventReceived(FLOW_ID1, SESSION_ID_1, byteArrayOf(1), sequenceNum = 1, receivedSequenceNum = 1)
+                    }),
+                Arguments.of(
+                    SessionClose::class.simpleName,
+                    { dsl: StepSetup -> dsl.sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1) }
+                ),
+                Arguments.of(
+                    SessionError::class.simpleName,
+                    { dsl: StepSetup -> dsl.sessionErrorEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1) }
+                ),
+            )
+        }
+    }
+
+    @ParameterizedTest(name = "Receiving a {0} event for a flow that does not exist discards the event")
+    @MethodSource("nonInitSessionEventTypes")
+    fun `Receiving a non-session init event for a flow that does not exist discards the event`(
+        @Suppress("UNUSED_PARAMETER") name: String,
+        parameter: (StepSetup) -> Unit
+    ) {
+        given {
+            sessionInitiatingIdentity(ALICE_HOLDING_IDENTITY)
+            sessionInitiatedIdentity(BOB_HOLDING_IDENTITY)
+        }
+
+        `when` {
+            parameter(this)
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                flowDidNotResume()
+                noFlowEvents()
+            }
+        }
+    }
+}

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
@@ -14,6 +14,7 @@ import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.ALICE_X500_HOLDING_IDENTITY
 import net.corda.flow.BOB_X500_HOLDING_IDENTITY
+import net.corda.flow.pipeline.exceptions.FlowEventException
 import net.corda.flow.pipeline.exceptions.FlowProcessingException
 import net.corda.flow.pipeline.handlers.waiting.sessions.WaitingForSessionInit
 import net.corda.flow.pipeline.sandbox.FlowSandboxContextTypes
@@ -133,7 +134,7 @@ class SessionEventHandlerTest {
 
         whenever(sessionManager.getNextReceivedEvent(updatedSessionState)).thenReturn(null)
 
-        assertThrows<FlowProcessingException> {
+        assertThrows<FlowEventException> {
             sessionEventHandler.preProcess(inputContext)
         }
 
@@ -154,13 +155,13 @@ class SessionEventHandlerTest {
 
     @ParameterizedTest(name = "Receiving a {0} payload when a checkpoint does not exist throws an exception")
     @MethodSource("nonInitSessionEventTypes")
-    fun `Receiving a non-session data payload when a checkpoint does not exist throws an exception`(payload: Any) {
+    fun `Receiving a non-session init payload when a checkpoint does not exist throws an exception`(payload: Any) {
         val sessionEvent = createSessionEvent(payload)
         val inputContext = buildFlowEventContext(checkpoint = checkpoint, inputEventPayload = sessionEvent)
 
         whenever(sessionManager.getNextReceivedEvent(any())).thenReturn(null)
 
-        assertThrows<FlowProcessingException> {
+        assertThrows<FlowEventException> {
             sessionEventHandler.preProcess(inputContext)
         }
     }


### PR DESCRIPTION
When a flow finishes session events could still arive for the flow due
to a race condition between the flow mapper and flow processor.

We now discard session events that were received for a flow that does
not exist. In most cases, this will be receiving a session event for a
flow that has finished or failed already.