### PR TITLE
CORE-4856 - fix disparity between log level and appender level 

### DIFF
--- a/buildSrc/README.md
+++ b/buildSrc/README.md
@@ -130,6 +130,26 @@ The application logs in a single flow according the time of generations all even
 or the code bootstrapping and controlling Felix.
 
 
+### Change the log level
+
+By default `log4j2-console.xml` configures log4j with a console appender outputting logs at `info` level but this can be overridden by setting environment variable `CONSOLE_LOG_LEVEL` on the container at startup.
+
+`DeployableContainerBuilder.groovy` sets this on the JibContainerBuilder.
+
+```groovy
+builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
+```
+
+### Enabling Log4j2 debug mode
+
+Log4j2 debug mode can be enabled by setting environment variable `ENABLE_LOG4J2_DEBUG` on the container at startup.
+
+`DeployableContainerBuilder.groovy` sets this on the JibContainerBuilder.
+
+```groovy
+builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
+```
+
 ### How to define the entry point of an application
 
 Just one class must implement the `net.corda.osgi.api.Application` interface. This class must be an OSGi component to

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -180,6 +180,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
                         AbsoluteUnixPath.get(CONTAINER_LOCATION + subDir.get())
                 )
         List<String> javaArgs = new ArrayList<String>(arguments.get())
+        javaArgs.add("-Dlog4j2.debug=\${ENABLE_LOG4J2_DEBUG:-false}")
         javaArgs.add("-Dlog4j.configurationFile=\${LOG4J_CONFIG_FILE}")
 
         if (setEntry.get()) {
@@ -187,8 +188,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             builder.setEntrypoint(
                     "/bin/sh",
                     "-c",
-                    "exec java -Dlog4j.configurationFile=\${LOG4J_CONFIG_FILE} ${javaArgs.join(" ")} -jar " +
-                            CONTAINER_LOCATION + entryName + ".jar \$@",
+                    "exec java ${javaArgs.join(" ")} -jar " + CONTAINER_LOCATION + entryName + ".jar \$@",
                     "\$@"
             )
         }

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -193,12 +193,14 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             )
         }
         if (!environment.get().empty) {
-            environment.get().each {String key, String value ->
+            environment.get().each { String key, String value ->
                 logger.info("Adding Env var $key with value $value")
                 builder.addEnvironmentVariable(key, value)
             }
         }
         builder.addEnvironmentVariable('LOG4J_CONFIG_FILE', 'log4j2-console.xml')
+        builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
+        builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()
 

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
@@ -291,6 +291,7 @@ internal class HttpRpcServerInternal(
 
     private fun RouteInfo.invokeMethod(): (Context) -> Unit {
         return { ctx ->
+            log.info("Servicing ${ctx.method()} request to '${ctx.path()}")
             log.debug { "Invoke method \"${this.method.method.name}\" for route info." }
             log.trace { "Get parameter values." }
             try {

--- a/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
@@ -9,7 +9,7 @@
         <logger name="Console">
             <AppenderRef ref="Console" level="info"/>
         </logger>
-        <root level="debug">
+        <root level="info">
             <AppenderRef ref="Console" level="info"/>
         </root>
     </Loggers>

--- a/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
@@ -9,8 +9,8 @@
         <logger name="Console">
             <AppenderRef ref="Console" level="info"/>
         </logger>
-        <root level="info">
-            <AppenderRef ref="Console" level="info"/>
+        <root level="${env:CONSOLE_LOG_LEVEL:-info}">
+            <AppenderRef ref="Console" level="${env:CONSOLE_LOG_LEVEL:-info}"/>
         </root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
New log for requests:

```
12:09:08.170 [qtp439187511-87] INFO  net.corda.httprpc.server.impl.internal.HttpRpcServerInternal - Servicing GET request to '/api/v1/user'.
```
```
12:07:39.309 [qtp439187511-80] INFO  net.corda.httprpc.server.impl.internal.HttpRpcServerInternal - Servicing POST request to '/api/v1/user'.
```

With debug logging enabled, the original longer javalin debug log will be output.

I decided not to put extra info in this log e.g.
- query parameters
- outputting the body
- form parameters
- file names

Extra info can be obtained from the debug log. WDYT?