### PR TITLE
CORE-4851 Discard orphaned `Wakeup` events

### DIFF
--- a/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
+++ b/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
@@ -8,6 +8,12 @@ This document should be maintained so that we can ensure that we have quick visi
 
 - Receiving a non-session init event for a flow that does not exist discards the event ✅
 
+## Wakeup
+
+- Receiving a wakeup event for a flow that does not exist discards the event ✅
+- Receiving a wakeup event for a flow that finished discards the event ✅
+- Receiving a wakeup event for a flow that failed discards the event ✅
+
 ## Sending
 - Calling 'send' on initiated sessions sends a session data event and schedules a wakeup event ✅
 - Calling 'send' on a closed session schedules an error event (not fully implemented, assert CLOSING, CLOSED, WAIT_FOR_FINAL_ACK states)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
@@ -59,12 +59,9 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
         }
 
         @JvmStatic
-        fun flowIORequestsExcludingReceiveAndCloseAndSubFlowFinished(): Stream<Arguments> {
+        fun flowIORequestsThatDoNotWaitForWakeup(): Stream<Arguments> {
             return Stream.of(
-                Arguments.of(FlowIORequest.ForceCheckpoint::class.simpleName, FlowIORequest.ForceCheckpoint),
-                Arguments.of(FlowIORequest.InitialCheckpoint::class.simpleName, FlowIORequest.InitialCheckpoint),
-                Arguments.of(FlowIORequest.InitiateFlow::class.simpleName, FlowIORequest.InitiateFlow(BOB_X500_NAME, SESSION_ID_1)),
-                Arguments.of(FlowIORequest.Send::class.simpleName, FlowIORequest.Send(mapOf(SESSION_ID_1 to DATA_MESSAGE_1))),
+                Arguments.of(FlowIORequest.InitiateFlow::class.simpleName, FlowIORequest.InitiateFlow(BOB_X500_NAME, SESSION_ID_2))
             )
         }
     }
@@ -140,12 +137,10 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
 
             sessionAckEventReceived(FLOW_ID1, SESSION_ID_2, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
-
-            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -170,12 +165,10 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 2)
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
-
-            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -200,12 +193,11 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionErrorEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -390,12 +382,10 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
 
             sessionAckEventReceived(FLOW_ID1, SESSION_ID_2, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
-
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 2)
@@ -443,8 +433,6 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            wakeupEventReceived(FLOW_ID1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -491,8 +479,6 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            wakeupEventReceived(FLOW_ID1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -529,12 +515,11 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
 
             sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 2)
@@ -571,12 +556,11 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1)))
 
             sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 2)
@@ -638,25 +622,17 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
     }
 
     @ParameterizedTest(name = "Given a flow suspended with {0} receiving a session close event does not resume the flow and sends a session ack")
-    @MethodSource("flowIORequestsExcludingReceiveAndCloseAndSubFlowFinished")
+    @MethodSource("flowIORequestsThatDoNotWaitForWakeup")
     fun `Given a non-close request type receiving a session close event does not resume the flow and sends a session ack`(
         @Suppress("UNUSED_PARAMETER") name: String,
         request: FlowIORequest<*>
     ) {
         given {
-            if (request !is FlowIORequest.InitiateFlow) {
-                startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
-                    .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
 
-                sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
-                    .suspendsWith(request)
-            } else {
-                startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
-                    .suspendsWith(request)
-
-                sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
-                    .suspendsWith(FlowIORequest.ForceCheckpoint)
-            }
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
+                .suspendsWith(request)
         }
 
         `when` {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ReceiveAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ReceiveAcceptanceTest.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.testing.tests
 
-import net.corda.data.flow.FlowStackItem
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.event.session.SessionAck
 import net.corda.data.flow.event.session.SessionData
@@ -25,8 +24,6 @@ import java.util.stream.Stream
 class ReceiveAcceptanceTest : FlowServiceTestBase() {
 
     private companion object {
-
-        val FLOW_STACK_ITEM = FlowStackItem("flow name", false, listOf())
 
         @JvmStatic
         fun wakeupAndSessionAck(): Stream<Arguments> {
@@ -62,12 +59,9 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
         }
 
         @JvmStatic
-        fun flowIORequestsExcludingReceiveAndCloseAndSubFlowFinished(): Stream<Arguments> {
+        fun flowIORequestsThatDoNotWaitForWakeup(): Stream<Arguments> {
             return Stream.of(
-                Arguments.of(FlowIORequest.ForceCheckpoint::class.simpleName, FlowIORequest.ForceCheckpoint),
-                Arguments.of(FlowIORequest.InitialCheckpoint::class.simpleName, FlowIORequest.InitialCheckpoint),
-                Arguments.of(FlowIORequest.InitiateFlow::class.simpleName, FlowIORequest.InitiateFlow(BOB_X500_NAME, SESSION_ID_1)),
-                Arguments.of(FlowIORequest.Send::class.simpleName, FlowIORequest.Send(mapOf(SESSION_ID_1 to byteArrayOf(1)))),
+                Arguments.of(FlowIORequest.InitiateFlow::class.simpleName, FlowIORequest.InitiateFlow(BOB_X500_NAME, SESSION_ID_2))
             )
         }
     }
@@ -251,8 +245,6 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionDataEventReceived(FLOW_ID1, SESSION_ID_1, DATA_MESSAGE_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            wakeupEventReceived(FLOW_ID1)
                 .suspendsWith(FlowIORequest.Receive(setOf(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -282,12 +274,11 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionDataEventReceived(FLOW_ID1, SESSION_ID_1, DATA_MESSAGE_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            sessionDataEventReceived(FLOW_ID1, SESSION_ID_2, DATA_MESSAGE_2, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionDataEventReceived(FLOW_ID1, SESSION_ID_2, DATA_MESSAGE_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.Receive(setOf(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -311,12 +302,11 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionDataEventReceived(FLOW_ID1, SESSION_ID_1, DATA_MESSAGE_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            sessionDataEventReceived(FLOW_ID1, SESSION_ID_2, DATA_MESSAGE_2, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionDataEventReceived(FLOW_ID1, SESSION_ID_2, DATA_MESSAGE_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.Receive(setOf(SESSION_ID_1)))
 
             wakeupEventReceived(FLOW_ID1)
@@ -336,25 +326,17 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
     }
 
     @ParameterizedTest(name = "Given a flow suspended with {0} receiving a session data event does not resume the flow and sends a session ack")
-    @MethodSource("flowIORequestsExcludingReceiveAndCloseAndSubFlowFinished")
+    @MethodSource("flowIORequestsThatDoNotWaitForWakeup")
     fun `Given a non-receive request type receiving a session data event does not resume the flow and sends a session ack`(
         @Suppress("UNUSED_PARAMETER") name: String,
         request: FlowIORequest<*>
     ) {
         given {
-            if (request !is FlowIORequest.InitiateFlow) {
-                startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
-                    .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
 
-                sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
-                    .suspendsWith(request)
-            } else {
-                startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
-                    .suspendsWith(request)
-
-                sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
-                    .suspendsWith(FlowIORequest.ForceCheckpoint)
-            }
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
+                .suspendsWith(request)
         }
 
         `when` {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFailedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFailedAcceptanceTest.kt
@@ -117,11 +117,11 @@ class SubFlowFailedAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionErrorEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 2)
-            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 2)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 2)
                 .suspendsWith(FlowIORequest.SubFlowFailed(RuntimeException(), initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -207,12 +207,10 @@ class SubFlowFailedAcceptanceTest : FlowServiceTestBase() {
 
             sessionInitEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, CPI1)
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
-
-            sessionErrorEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.SubFlowFailed(RuntimeException(), FlowStackItem(FLOW_NAME, false, listOf(INITIATED_SESSION_ID_1))))
         }
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFinishedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFinishedAcceptanceTest.kt
@@ -185,12 +185,10 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 2)
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
-
-            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.SubFlowFinished(initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -215,12 +213,11 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionErrorEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.SubFlowFinished(initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -405,12 +402,10 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
 
             sessionAckEventReceived(FLOW_ID1, SESSION_ID_2, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
-
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.SubFlowFinished(initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 2)
@@ -458,8 +453,6 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            wakeupEventReceived(FLOW_ID1)
                 .suspendsWith(FlowIORequest.SubFlowFinished(initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -506,8 +499,6 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
 
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-
-            wakeupEventReceived(FLOW_ID1)
                 .suspendsWith(FlowIORequest.SubFlowFinished(initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
         }
 
@@ -666,12 +657,10 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
 
             sessionInitEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, CPI1)
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
-
-            sessionErrorEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
         }
 
         `when` {
-            wakeupEventReceived(FLOW_ID1)
+            sessionErrorEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.SubFlowFinished(FlowStackItem(FLOW_NAME, false, listOf(INITIATED_SESSION_ID_1))))
         }
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/WakeupAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/WakeupAcceptanceTest.kt
@@ -1,0 +1,66 @@
+package net.corda.flow.testing.tests
+
+import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.testing.context.FlowServiceTestBase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.osgi.test.junit5.service.ServiceExtension
+
+@ExtendWith(ServiceExtension::class)
+@Execution(ExecutionMode.SAME_THREAD)
+class WakeupAcceptanceTest : FlowServiceTestBase() {
+
+    @Test
+    fun `Receiving a wakeup event for a flow that does not exist discards the event`() {
+        `when` {
+            wakeupEventReceived(FLOW_ID1)
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                flowDidNotResume()
+                noFlowEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `Receiving a wakeup event for a flow that finished discards the event`() {
+        given {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.FlowFinished("done"))
+        }
+
+        `when` {
+            wakeupEventReceived(FLOW_ID1)
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                flowDidNotResume()
+                noFlowEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `Receiving a wakeup event for a flow that failed discards the event`() {
+        given {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.FlowFailed(RuntimeException("done")))
+        }
+
+        `when` {
+            wakeupEventReceived(FLOW_ID1)
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                flowDidNotResume()
+                noFlowEvents()
+            }
+        }
+    }
+}

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandler.kt
@@ -2,14 +2,31 @@ package net.corda.flow.pipeline.handlers.events
 
 import net.corda.data.flow.event.Wakeup
 import net.corda.flow.pipeline.FlowEventContext
+import net.corda.flow.pipeline.exceptions.FlowEventException
+import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Component
 
 @Component(service = [FlowEventHandler::class])
 class WakeupEventHandler : FlowEventHandler<Wakeup> {
 
+    private companion object {
+        val log = contextLogger()
+    }
+
     override val type = Wakeup::class.java
 
     override fun preProcess(context: FlowEventContext<Wakeup>): FlowEventContext<Wakeup> {
-        return context
+        return if (context.checkpoint.doesExist) {
+            context
+        } else {
+            log.info(
+                "Received a ${Wakeup::class.simpleName} for flow [${context.inputEvent.flowId}] that does not exist. " +
+                        "The event will be discarded."
+            )
+            throw FlowEventException(
+                "Received a ${Wakeup::class.simpleName} for flow [${context.inputEvent.flowId}] that does not exist" ,
+                context
+            )
+        }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandler.kt
@@ -16,15 +16,7 @@ class WakeupWaitingForHandler : FlowWaitingForHandler<Wakeup> {
     override val type = Wakeup::class.java
 
     override fun runOrContinue(context: FlowEventContext<*>, waitingFor: Wakeup): FlowContinuation {
-        return if (context.inputEventPayload is net.corda.data.flow.event.Wakeup) {
-            log.info("Waking up [${context.checkpoint.flowId}]")
-            FlowContinuation.Run(Unit)
-        } else {
-            log.info(
-                "Not waking up flow [${context.checkpoint.flowId}] as it received a ${context.inputEventPayload!!::class.qualifiedName} " +
-                        "instead of a ${net.corda.data.flow.event.Wakeup::class.qualifiedName} event"
-            )
-            FlowContinuation.Continue
-        }
+        log.info("Waking up [${context.checkpoint.flowId}]")
+        return FlowContinuation.Run(Unit)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandlerTest.kt
@@ -1,0 +1,33 @@
+package net.corda.flow.pipeline.handlers.events
+
+import net.corda.data.flow.event.Wakeup
+import net.corda.flow.pipeline.exceptions.FlowEventException
+import net.corda.flow.state.FlowCheckpoint
+import net.corda.flow.test.utils.buildFlowEventContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class WakeupEventHandlerTest {
+
+    private val checkpoint = mock<FlowCheckpoint>()
+    private val handler = WakeupEventHandler()
+
+    @Test
+    fun `When the checkpoint exists the context is returned unmodified`() {
+        whenever(checkpoint.doesExist).thenReturn(true)
+        val inputContext = buildFlowEventContext(checkpoint = checkpoint, inputEventPayload = Wakeup())
+        val outputContext = handler.preProcess(inputContext)
+        assertEquals(inputContext, outputContext)
+    }
+
+    @Test
+    fun `When the checkpoint does not exist an exception is thrown to discard the event`() {
+        whenever(checkpoint.doesExist).thenReturn(false)
+        assertThrows<FlowEventException> {
+            handler.preProcess(buildFlowEventContext(checkpoint = checkpoint, inputEventPayload = Wakeup()))
+        }
+    }
+}

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandlerTest.kt
@@ -3,34 +3,20 @@ package net.corda.flow.pipeline.handlers.waiting
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.state.waiting.Wakeup
 import net.corda.flow.fiber.FlowContinuation
-import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.test.utils.buildFlowEventContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class WakeupWaitingForHandlerTest {
 
     @Test
-    fun `Returns a FlowContinuation#Run when a wakeup event is received`() {
+    fun `Returns a FlowContinuation#Run when an event is received`() {
         val inputContext = buildFlowEventContext(
             checkpoint = mock(),
-            inputEventPayload = net.corda.data.flow.event.Wakeup()
-        )
-        val continuation = WakeupWaitingForHandler().runOrContinue(inputContext, Wakeup())
-        assertEquals(FlowContinuation.Run(Unit), continuation)
-    }
-
-    @Test
-    fun `Returns a FlowContinuation#Continue when a non-wakeup event is received`() {
-        val checkpoint = mock<FlowCheckpoint>()
-        whenever(checkpoint.flowId).thenReturn("flow id")
-        val inputContext = buildFlowEventContext(
-            checkpoint = checkpoint,
             inputEventPayload = SessionEvent()
         )
         val continuation = WakeupWaitingForHandler().runOrContinue(inputContext, Wakeup())
-        assertEquals(FlowContinuation.Continue, continuation)
+        assertEquals(FlowContinuation.Run(Unit), continuation)
     }
 }


### PR DESCRIPTION
If a flow does not exist and a `Wakeup` event is received, then discard
the event. It is highly likely that a `Wakeup` received this way was due
to a flow finishing but still having a `Wakeup` event in the message
queue, that was either scheduled by the flow or by the flow heartbeating
mechanism.