### PR TITLE
NOTICK - Switch gonepostal infix to p2p-preview

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ platformVersion = 999
 
 # Versioning constants.
 ## The release/marketing version
-cordaProductVersion=5.0.0-gonepostal
+cordaProductVersion=5.0.0-p2p-preview
 ## The revision number. This lines up the versioning of the runtime-os repo with the API repo, which allows the build
 ## system to assume the same versioning scheme.
 cordaRuntimeRevision=0
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XX-SNAPSHOT
-cordaApiVersion=5.0.0.88-gonepostal-beta+
+cordaApiVersion=5.0.0.88-p2p-preview-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22
@@ -123,7 +123,7 @@ artifactoryPluginVersion = 4.28.2
 pf4jVersion=3.6.0
 
 # corda-cli plugin host
-pluginHostVersion=0.0.1-gonepostal-beta+
+pluginHostVersion=0.0.1-p2p-preview-beta+
 systemLambdaVersion=1.2.1
 
 # DB integration tests


### PR DESCRIPTION
Switching from `gonepostal` to `p2p-preview` to prevent confusion.

Requires: https://github.com/corda/corda-api/pull/378