### PR TITLE
CORE-4354: Refactor V1 packaging code to prepare for V2

### DIFF
--- a/applications/examples/amqp-custom-serializer-poc/src/main/kotlin/net/corda/poc/customserializer/CpkReadServiceLocalImpl.kt
+++ b/applications/examples/amqp-custom-serializer-poc/src/main/kotlin/net/corda/poc/customserializer/CpkReadServiceLocalImpl.kt
@@ -2,6 +2,7 @@ package net.corda.poc.customserializer
 
 import net.corda.cpk.read.CpkReadService
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.CpiReader
 import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.core.CpkIdentifier
 import org.osgi.service.component.annotations.Component
@@ -26,8 +27,8 @@ class CpkReadServiceLocalImpl : CpkReadService, CpkReadServiceLoader {
     override fun start() { }
     override fun stop() { }
 
-    override fun load(cpiInputStream: InputStream) : Cpi {
-        val cpi = Cpi.from(cpiInputStream, expansionLocation = tmpDir, verifySignature = true)
+    override fun load(cpiInputStream: InputStream): Cpi {
+        val cpi = CpiReader.readCpi(cpiInputStream, expansionLocation = tmpDir, verifySignature = true)
 
         cpi.cpks.forEach { cpkById[it.metadata.cpkId] = it }
 

--- a/applications/examples/amqp-custom-serializer-poc/src/main/kotlin/net/corda/poc/customserializer/Main.kt
+++ b/applications/examples/amqp-custom-serializer-poc/src/main/kotlin/net/corda/poc/customserializer/Main.kt
@@ -5,7 +5,7 @@ import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
-import net.corda.libs.packaging.Cpk
+import net.corda.libs.packaging.CpkReader
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.sandbox.SandboxCreationService
@@ -87,7 +87,7 @@ class Main @Activate constructor(
     private fun prepareSandbox(cpkFiles: List<Path>, cacheDir: String): SandboxAndSerializers {
 
         val cpks = cpkFiles.map { cpkPath ->
-            cpkPath.inputStream(StandardOpenOption.READ).use { inputStream -> Cpk.from(inputStream, Path.of(cacheDir)) }
+            cpkPath.inputStream(StandardOpenOption.READ).use { inputStream -> CpkReader.readCpk(inputStream, Path.of(cacheDir)) }
         }
 
         val serializers: List<String> = cpks.map { it.metadata }.flatMap { it.cordappManifest.serializers }

--- a/applications/examples/amqp-evolution-poc/src/main/kotlin/net/corda/poc/typeevolution/CpkReadServiceLocalImpl.kt
+++ b/applications/examples/amqp-evolution-poc/src/main/kotlin/net/corda/poc/typeevolution/CpkReadServiceLocalImpl.kt
@@ -2,6 +2,7 @@ package net.corda.poc.typeevolution
 
 import net.corda.cpk.read.CpkReadService
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.CpiReader
 import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.core.CpkIdentifier
 import org.osgi.service.component.annotations.Component
@@ -26,8 +27,8 @@ class CpkReadServiceLocalImpl : CpkReadService, CpkReadServiceLoader {
     override fun start() { }
     override fun stop() { }
 
-    override fun load(cpiInputStream: InputStream) : Cpi {
-        val cpi = Cpi.from(cpiInputStream, expansionLocation = tmpDir, verifySignature = true)
+    override fun load(cpiInputStream: InputStream): Cpi {
+        val cpi = CpiReader.readCpi(cpiInputStream, expansionLocation = tmpDir, verifySignature = true)
 
         cpi.cpks.forEach { cpk -> cpkById[cpk.metadata.cpkId] = cpk }
 

--- a/applications/examples/amqp-evolution-poc/src/main/kotlin/net/corda/poc/typeevolution/Main.kt
+++ b/applications/examples/amqp-evolution-poc/src/main/kotlin/net/corda/poc/typeevolution/Main.kt
@@ -4,7 +4,7 @@ import net.corda.cpk.read.CpkReadService
 import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
-import net.corda.libs.packaging.Cpk
+import net.corda.libs.packaging.CpkReader
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.sandbox.SandboxCreationService
@@ -63,7 +63,7 @@ class Main @Activate constructor(
         )
 
         val cpks = listOf(cpk).map { cpkPath ->
-            cpkPath.inputStream(StandardOpenOption.READ).use { inputStream -> Cpk.from(inputStream, Path.of(tmpDir)) }
+            cpkPath.inputStream(StandardOpenOption.READ).use { inputStream -> CpkReader.readCpk(inputStream, Path.of(tmpDir)) }
         }
 
         val sandboxGroup = sandboxCreationService.createSandboxGroup(cpks)

--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/SetupVirtualNode.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/SetupVirtualNode.kt
@@ -9,6 +9,7 @@ import net.corda.chunking.ChunkWriterFactory.SUGGESTED_CHUNK_SIZE
 import net.corda.chunking.toAvro
 import net.corda.data.chunking.CpkChunkId
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.CpiReader
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import net.corda.schema.Schemas.VirtualNode.Companion.CPI_INFO_TOPIC
@@ -84,7 +85,7 @@ class SetupVirtualNode(private val context: TaskContext) : Task {
                     val fileName = it.fileName.toString()
                     Cpi.fileExtensions.any(fileName::endsWith)
                 }.map {
-                    Cpi.from(Files.newInputStream(it), cacheDir, it.toString(), true)
+                    CpiReader.readCpi(Files.newInputStream(it), cacheDir, it.toString(), true)
                 }.toList()
             }
         } ?: listOf()

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -5,6 +5,7 @@ import net.corda.chunking.RequestId
 import net.corda.chunking.db.impl.persistence.ChunkPersistence
 import net.corda.chunking.db.impl.persistence.PersistenceUtils.signerSummaryHashForDbQuery
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.CpiReader
 import net.corda.libs.packaging.core.exception.PackagingException
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
@@ -63,7 +64,7 @@ internal class ValidationFunctions(
     fun checkCpi(cpiFile: FileInfo): Cpi {
         val cpi: Cpi =
             try {
-                Files.newInputStream(cpiFile.path).use { Cpi.from(it, cpiPartsDir) }
+                Files.newInputStream(cpiFile.path).use { CpiReader.readCpi(it, cpiPartsDir) }
             } catch (ex: Exception) {
                 when (ex) {
                     is PackagingException -> {

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
@@ -6,6 +6,7 @@ import net.corda.cpk.read.impl.services.persistence.CpkChunksFileManager
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.CpkChunkId
 import net.corda.libs.packaging.Cpk
+import net.corda.libs.packaging.CpkReader
 import net.corda.libs.packaging.core.CpkIdentifier
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
@@ -83,7 +84,7 @@ class CpkChunksKafkaReader(
         val cpkPath = cpkChunksFileManager.assembleCpk(cpkChecksum, chunks)
         cpkPath?.let {
             val cpk = Files.newInputStream(it).use { inStream ->
-                Cpk.from(inStream, cpkPartsDir)
+                CpkReader.readCpk(inStream, cpkPartsDir)
             }
             onCpkAssembled(cpk.metadata.cpkId, cpk)
         } ?: logger.warn("CPK assemble has failed for: $cpkChecksum")

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/exception/UnknownFormatVersionException.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/exception/UnknownFormatVersionException.kt
@@ -1,0 +1,4 @@
+package net.corda.libs.packaging.core.exception
+
+/** Thown if a FormatVersion is unknown */
+class UnknownFormatVersionException(message: String, cause: Throwable? = null) : PackagingException(message, cause)

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/Cpi.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/Cpi.kt
@@ -2,39 +2,15 @@ package net.corda.libs.packaging
 
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkIdentifier
-import net.corda.libs.packaging.internal.CpiLoader
-import net.corda.libs.packaging.internal.jarSignatureVerificationEnabledByDefault
-import java.io.InputStream
-import java.nio.file.Path
 
 interface Cpi : AutoCloseable {
 
     companion object {
-
         /**
          * Known file extensions for a CPI file; the only difference between CPI and CPB files is that CPB files
          * have no groupPolicy
          */
         val fileExtensions = listOf(".cpb", ".cpi")
-
-        /**
-         * Parses a CPI file and stores its information in a [Cpi] instance
-         * @param inputStream a stream with the CPI file content
-         * @param expansionLocation a filesystem directory where the CPK files
-         * contained in the provided CPI will be extracted
-         * @param cpiLocation an optional string containing information about the cpi location that will be used
-         * in exception messages to ease troubleshooting
-         * @param verifySignature whether to verify CPI and CPK files signatures
-         * @return a new [Cpi] instance containing information about the provided CPI
-         */
-        @JvmStatic
-        @JvmOverloads
-        fun from(inputStream : InputStream,
-                 expansionLocation : Path,
-                 cpiLocation : String? = null,
-                 verifySignature : Boolean = jarSignatureVerificationEnabledByDefault()) : Cpi =
-            CpiLoader.loadCpi(inputStream, expansionLocation, cpiLocation, verifySignature)
-
     }
 
     val metadata : CpiMetadata
@@ -42,3 +18,4 @@ interface Cpi : AutoCloseable {
 
     fun getCpkById(id : CpkIdentifier) : Cpk?
 }
+

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpiReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpiReader.kt
@@ -1,0 +1,54 @@
+package net.corda.libs.packaging
+
+import net.corda.libs.packaging.core.CpkFormatVersion
+import net.corda.libs.packaging.core.exception.CordappManifestException
+import net.corda.libs.packaging.core.exception.UnknownFormatVersionException
+import net.corda.libs.packaging.internal.CpiLoader
+import net.corda.libs.packaging.internal.FormatVersionReader
+import net.corda.libs.packaging.internal.jarSignatureVerificationEnabledByDefault
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.nio.file.Path
+import java.util.jar.JarInputStream
+
+class CpiReader {
+    companion object {
+        private val version1 = CpkFormatVersion(1, 0)
+        private val version2 = CpkFormatVersion(2, 0)
+
+        /**
+         * Parses a CPI file and stores its information in a [Cpi] instance
+         * @param inputStream a stream with the CPI file content
+         * @param expansionLocation a filesystem directory where the CPK files
+         * contained in the provided CPI will be extracted
+         * @param cpiLocation an optional string containing information about the cpi location that will be used
+         * in exception messages to ease troubleshooting
+         * @param verifySignature whether to verify CPI and CPK files signatures
+         * @return a new [Cpi] instance containing information about the provided CPI
+         */
+        fun readCpi(
+            inputStream: InputStream,
+            expansionLocation: Path,
+            cpiLocation: String? = null,
+            verifySignature: Boolean = jarSignatureVerificationEnabledByDefault()
+        ): Cpi {
+            // Read input stream, so we can process it through different classes that will consume the stream
+            val buffer = inputStream.readAllBytes()
+
+            // Read format version
+            val manifest = ByteArrayInputStream(buffer).use {
+                JarInputStream(it).use { it.manifest }
+            } ?: throw CordappManifestException("No manifest in Jar file")
+            val formatVersion = FormatVersionReader.readCpiFormatVersion(manifest)
+
+            // Choose correct implementation to read this version
+            ByteArrayInputStream(buffer).use {
+                return when (formatVersion) {
+                    version1 -> CpiLoader.loadCpi(it, expansionLocation, cpiLocation, verifySignature)
+                    version2 -> TODO("Implement format version 2")
+                    else -> throw UnknownFormatVersionException("Unknown Corda-CPI-Format - \"$formatVersion\"")
+                }
+            }
+        }
+    }
+}

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/Cpk.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/Cpk.kt
@@ -1,26 +1,12 @@
 package net.corda.libs.packaging
 
 import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.libs.packaging.internal.CpkLoader
-import net.corda.libs.packaging.internal.jarSignatureVerificationEnabledByDefault
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Path
 
 /** Represents a Cpk file in the filesystem */
 interface Cpk : AutoCloseable {
-
-    companion object {
-        @JvmStatic
-        @JvmOverloads
-        fun from(inputStream : InputStream,
-                 cacheDir : Path,
-                 cpkLocation : String? = null,
-                 verifySignature : Boolean = jarSignatureVerificationEnabledByDefault(),
-                 cpkFileName: String? = null
-        ) : Cpk =
-            CpkLoader.loadCPK(inputStream, cacheDir, cpkLocation, verifySignature, cpkFileName)
-    }
 
     /**
      * Stores the metadata associated with this Cpk file
@@ -48,3 +34,4 @@ interface Cpk : AutoCloseable {
     @Throws(IOException::class)
     fun getResourceAsStream(resourceName : String) : InputStream
 }
+

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkReader.kt
@@ -1,0 +1,46 @@
+package net.corda.libs.packaging
+
+import net.corda.libs.packaging.core.CpkFormatVersion
+import net.corda.libs.packaging.core.exception.CordappManifestException
+import net.corda.libs.packaging.core.exception.UnknownFormatVersionException
+import net.corda.libs.packaging.internal.CpkLoader
+import net.corda.libs.packaging.internal.FormatVersionReader
+import net.corda.libs.packaging.internal.jarSignatureVerificationEnabledByDefault
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.nio.file.Path
+import java.util.jar.JarInputStream
+
+class CpkReader {
+    companion object {
+        private val version1 = CpkFormatVersion(1, 0)
+        private val version2 = CpkFormatVersion(2, 0)
+
+        fun readCpk(
+            inputStream: InputStream,
+            cacheDir: Path,
+            cpkLocation: String? = null,
+            verifySignature: Boolean = jarSignatureVerificationEnabledByDefault(),
+            cpkFileName: String? = null
+        ): Cpk {
+
+            // Read input stream, so we can process it through different classes that will consume the stream
+            val buffer = inputStream.readAllBytes()
+
+            // Read format version
+            val manifest = ByteArrayInputStream(buffer).use {
+                JarInputStream(it).use { it.manifest }
+            } ?: throw CordappManifestException("No manifest in Jar file")
+            val formatVersion = FormatVersionReader.readCpkFormatVersion(manifest)
+
+            // Choose correct implementation to read this version
+            ByteArrayInputStream(buffer).use {
+                return when (formatVersion) {
+                    version1 -> CpkLoader.loadCPK(it, cacheDir, cpkLocation, verifySignature, cpkFileName)
+                    version2 -> TODO("Implement format version 2")
+                    else -> throw UnknownFormatVersionException("Unknown Corda-CPK-Format - \"$formatVersion\"")
+                }
+            }
+        }
+    }
+}

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/CpiLoader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/CpiLoader.kt
@@ -2,6 +2,7 @@ package net.corda.libs.packaging.internal
 
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.Cpk
+import net.corda.libs.packaging.CpkReader
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkMetadata
@@ -57,8 +58,7 @@ internal object CpiLoader {
                         /** We need to do this as [Cpk.from] closes the stream, while we still need it afterward **/
                         val uncloseableInputStream = UncloseableInputStream(jarInputStream)
                         if(expansionLocation != null) {
-                            val cpk = Cpk.from(
-                                uncloseableInputStream,
+                            val cpk = CpkReader.readCpk(uncloseableInputStream,
                                 expansionLocation,
                                 cpkLocation = cpiLocation.plus("/${entry.name}"),
                                 verifySignature = verifySignature,

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/CpkLoader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/CpkLoader.kt
@@ -334,7 +334,7 @@ internal object CpkLoader {
         }.use { jarInputStream ->
             val jarManifest =
                 jarInputStream.manifest ?: throw PackagingException(ctx.fileLocationAppender("Invalid file format"))
-            ctx.cpkManifest = CpkManifest(FormatVersionReader.readFormatVersion(Manifest(jarManifest)))
+            ctx.cpkManifest = CpkManifest(FormatVersionReader.readCpkFormatVersion(Manifest(jarManifest)))
             while (true) {
                 val cpkEntry = jarInputStream.nextEntry ?: break
                 when {
@@ -343,7 +343,7 @@ internal object CpkLoader {
                     }
                     isLibJar(cpkEntry) -> processLibJar(jarInputStream, cpkEntry, ctx)
                     isManifest(cpkEntry) -> {
-                        ctx.cpkManifest = CpkManifest(FormatVersionReader.readFormatVersion(Manifest(jarInputStream)))
+                        ctx.cpkManifest = CpkManifest(FormatVersionReader.readCpkFormatVersion(Manifest(jarInputStream)))
                     }
                 }
                 jarInputStream.closeEntry()

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/FormatVersionReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/FormatVersionReader.kt
@@ -7,13 +7,29 @@ import java.util.jar.Manifest
 internal class FormatVersionReader {
     companion object {
         private const val CPK_FORMAT = "Corda-CPK-Format"
+        private const val CPB_FORMAT = "Corda-CPB-Format"
+        private const val CPI_FORMAT = "Corda-CPI-Format"
 
         // A regex matching CPK format strings.
-        private val CPK_VERSION_PATTERN = "(\\d++)\\.(\\d++)".toRegex()
+        private val VERSION_PATTERN = "(\\d++)\\.(\\d++)".toRegex()
 
-        fun readFormatVersion(manifest: Manifest): CpkFormatVersion {
+        private val version1 = CpkFormatVersion(1, 0)
+
+        fun readCpkFormatVersion(manifest: Manifest): CpkFormatVersion {
             val formatAttribute = manifest.mainAttributes.getValue(CPK_FORMAT)
-                ?: throw PackagingException("CPK manifest does not specify a `${CPK_FORMAT}` attribute.")
+                ?: return version1 // Version 1 files sometimes lacked the FormatVersion
+            return parse(formatAttribute)
+        }
+
+        fun readCpbFormatVersion(manifest: Manifest): CpkFormatVersion {
+            val formatAttribute = manifest.mainAttributes.getValue(CPB_FORMAT)
+                ?: return version1 // Version 1 files sometimes lacked the FormatVersion
+            return parse(formatAttribute)
+        }
+
+        fun readCpiFormatVersion(manifest: Manifest): CpkFormatVersion {
+            val formatAttribute = manifest.mainAttributes.getValue(CPI_FORMAT)
+                ?: return version1 // Version 1 files sometimes lacked the FormatVersion
             return parse(formatAttribute)
         }
 
@@ -23,7 +39,7 @@ internal class FormatVersionReader {
          * Throws [PackagingException] if the CPK format is missing or incorrectly specified.
          */
         private fun parse(formatAttribute: String): CpkFormatVersion {
-            val matches = CPK_VERSION_PATTERN.matchEntire(formatAttribute)
+            val matches = VERSION_PATTERN.matchEntire(formatAttribute)
                 ?: throw PackagingException("Does not match 'majorVersion.minorVersion': '$formatAttribute'")
             return CpkFormatVersion(matches.groupValues[1].toInt(), matches.groupValues[2].toInt())
         }

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/CPKTests.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/CPKTests.kt
@@ -65,7 +65,7 @@ class CPKTests {
 
         workflowCPKPath = Path.of(URI(System.getProperty("net.corda.packaging.test.workflow.cpk")))
         processedWorkflowCPKPath = testDir.resolve(workflowCPKPath.fileName)
-        workflowCPK = Cpk.from(Files.newInputStream(workflowCPKPath), processedWorkflowCPKPath, workflowCPKPath.toString())
+        workflowCPK = CpkReader.readCpk(Files.newInputStream(workflowCPKPath), processedWorkflowCPKPath, workflowCPKPath.toString())
         cordappJarPath = Path.of(URI(System.getProperty("net.corda.packaging.test.workflow.cordapp")))
         nonJarFile = Files.createFile(testDir.resolve("someFile.bin"))
         workflowCPKLibraries = System.getProperty("net.corda.packaging.test.workflow.libs").split(' ').stream().map { jarFilePath ->
@@ -421,7 +421,7 @@ class CPKTests {
                 jarSignatureVerificationEnabledByDefault())
         }
         assertThrows<PackagingException> {
-            Cpk.from(Files.newInputStream(nonJarFile), processedWorkflowCPKPath, nonJarFile.toString())
+            CpkReader.readCpk(Files.newInputStream(nonJarFile), processedWorkflowCPKPath, nonJarFile.toString())
                 .also(Cpk::close)
         }
     }

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/FormatVersionReaderTest.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/FormatVersionReaderTest.kt
@@ -13,37 +13,77 @@ class FormatVersionReaderTest {
     private fun String.toManifest() = "$this\n".byteInputStream().use { Manifest(it) }
 
     @ParameterizedTest
-    @MethodSource("invalidVersionsToTest")
-    fun testInvalidVersion(testCase: String) {
+    @MethodSource("invalidCpkVersionsToTest")
+    fun testInvalidCpkVersion(testCase: String) {
         val manifest = testCase.toManifest()
 
         assertThrows(PackagingException::class.java) {
-            FormatVersionReader.readFormatVersion(manifest)
+            FormatVersionReader.readCpkFormatVersion(manifest)
         }
     }
 
     @ParameterizedTest
-    @MethodSource("validVersionsToTest")
-    fun testValidVersion(testCaseAndExpectedResult: Pair<String, CpkFormatVersion>) {
+    @MethodSource("validCpkVersionsToTest")
+    fun testValidCpkVersion(testCaseAndExpectedResult: Pair<String, CpkFormatVersion>) {
         val (testCase, expected) = testCaseAndExpectedResult
 
-        val formatVersion = FormatVersionReader.readFormatVersion(testCase.toManifest())
+        val formatVersion = FormatVersionReader.readCpkFormatVersion(testCase.toManifest())
+
+        assertEquals(expected, formatVersion)
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCpbVersionsToTest")
+    fun testInvalidCpbVersion(testCase: String) {
+        val manifest = testCase.toManifest()
+
+        assertThrows(PackagingException::class.java) {
+            FormatVersionReader.readCpbFormatVersion(manifest)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("validCpbVersionsToTest")
+    fun testValidCpbVersion(testCaseAndExpectedResult: Pair<String, CpkFormatVersion>) {
+        val (testCase, expected) = testCaseAndExpectedResult
+
+        val formatVersion = FormatVersionReader.readCpbFormatVersion(testCase.toManifest())
+
+        assertEquals(expected, formatVersion)
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidCpiVersionsToTest")
+    fun testInvalidCpiVersion(testCase: String) {
+        val manifest = testCase.toManifest()
+
+        assertThrows(PackagingException::class.java) {
+            FormatVersionReader.readCpiFormatVersion(manifest)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("validCpiVersionsToTest")
+    fun testValidCpiVersion(testCaseAndExpectedResult: Pair<String, CpkFormatVersion>) {
+        val (testCase, expected) = testCaseAndExpectedResult
+
+        val formatVersion = FormatVersionReader.readCpiFormatVersion(testCase.toManifest())
 
         assertEquals(expected, formatVersion)
     }
 
     companion object {
         @JvmStatic
-        fun invalidVersionsToTest() = listOf(
+        fun invalidCpkVersionsToTest() = listOf(
             "Corda-CPK-Format: ",      // Missing version
-            "",                        // Missing attribute
             "Corda-CPK-Format: 1",     // Missing minor version
             "Corda-CPK-Format: .1",    // Missing major version
             "Corda-CPK-Format: 1.1.1", // Three version number components
         )
-        
+
         @JvmStatic
-        fun validVersionsToTest() = listOf(
+        fun validCpkVersionsToTest() = listOf(
+            "" to CpkFormatVersion(1, 0), // Missing attribute maps to 1.0
             "Corda-CPK-Format: 0.0"  to CpkFormatVersion(0, 0),
             "Corda-CPK-Format: 0.1"  to CpkFormatVersion(0, 1),
             "Corda-CPK-Format: 0.01" to CpkFormatVersion(0, 1),
@@ -55,6 +95,52 @@ class FormatVersionReaderTest {
             "Corda-CPK-Format: 2.10" to CpkFormatVersion(2, 10),
             "Corda-CPK-Format: 1000.2000" to CpkFormatVersion(1000, 2000),
             "Corda-CPK-Format: ${Int.MAX_VALUE}.${Int.MAX_VALUE}" to CpkFormatVersion(Int.MAX_VALUE, Int.MAX_VALUE),
+        )
+        @JvmStatic
+        fun invalidCpbVersionsToTest() = listOf(
+            "Corda-CPB-Format: ",      // Missing version
+            "Corda-CPB-Format: 1",     // Missing minor version
+            "Corda-CPB-Format: .1",    // Missing major version
+            "Corda-CPB-Format: 1.1.1", // Three version number components
+        )
+
+        @JvmStatic
+        fun validCpbVersionsToTest() = listOf(
+            "" to CpkFormatVersion(1, 0), // Missing attribute maps to 1.0
+            "Corda-CPB-Format: 0.0"  to CpkFormatVersion(0, 0),
+            "Corda-CPB-Format: 0.1"  to CpkFormatVersion(0, 1),
+            "Corda-CPB-Format: 0.01" to CpkFormatVersion(0, 1),
+            "Corda-CPB-Format: 1.0"  to CpkFormatVersion(1, 0),
+            "Corda-CPB-Format: 1.1"  to CpkFormatVersion(1, 1),
+            "Corda-CPB-Format: 1.10" to CpkFormatVersion(1, 10),
+            "Corda-CPB-Format: 2.0"  to CpkFormatVersion(2, 0),
+            "Corda-CPB-Format: 2.1"  to CpkFormatVersion(2, 1),
+            "Corda-CPB-Format: 2.10" to CpkFormatVersion(2, 10),
+            "Corda-CPB-Format: 1000.2000" to CpkFormatVersion(1000, 2000),
+            "Corda-CPB-Format: ${Int.MAX_VALUE}.${Int.MAX_VALUE}" to CpkFormatVersion(Int.MAX_VALUE, Int.MAX_VALUE),
+        )
+        @JvmStatic
+        fun invalidCpiVersionsToTest() = listOf(
+            "Corda-CPI-Format: ",      // Missing version
+            "Corda-CPI-Format: 1",     // Missing minor version
+            "Corda-CPI-Format: .1",    // Missing major version
+            "Corda-CPI-Format: 1.1.1", // Three version number components
+        )
+
+        @JvmStatic
+        fun validCpiVersionsToTest() = listOf(
+            "" to CpkFormatVersion(1, 0), // Missing attribute maps to 1.0
+            "Corda-CPI-Format: 0.0"  to CpkFormatVersion(0, 0),
+            "Corda-CPI-Format: 0.1"  to CpkFormatVersion(0, 1),
+            "Corda-CPI-Format: 0.01" to CpkFormatVersion(0, 1),
+            "Corda-CPI-Format: 1.0"  to CpkFormatVersion(1, 0),
+            "Corda-CPI-Format: 1.1"  to CpkFormatVersion(1, 1),
+            "Corda-CPI-Format: 1.10" to CpkFormatVersion(1, 10),
+            "Corda-CPI-Format: 2.0"  to CpkFormatVersion(2, 0),
+            "Corda-CPI-Format: 2.1"  to CpkFormatVersion(2, 1),
+            "Corda-CPI-Format: 2.10" to CpkFormatVersion(2, 10),
+            "Corda-CPI-Format: 1000.2000" to CpkFormatVersion(1000, 2000),
+            "Corda-CPI-Format: ${Int.MAX_VALUE}.${Int.MAX_VALUE}" to CpkFormatVersion(Int.MAX_VALUE, Int.MAX_VALUE),
         )
     }
 }

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/ZipTweakerTest.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/ZipTweakerTest.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.internal
 
-import net.corda.libs.packaging.Cpk
+import net.corda.libs.packaging.CpkReader
 import net.corda.v5.crypto.SecureHash
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
@@ -32,7 +32,7 @@ class ZipTweakerTest {
     @Test
     @Suppress("ComplexMethod")
     fun `Ensure a jar with removed signature can be read`() {
-        Cpk.from(workflowCPKPath.openStream(), testDir).use { cpk ->
+        CpkReader.readCpk(workflowCPKPath.openStream(), testDir).use { cpk ->
             val algo = "SHA-256"
             val originalEntries = ZipInputStream(cpk.getResourceAsStream(cpk.metadata.mainBundle)).use { zipInputStream ->
                 generateSequence { zipInputStream.nextEntry }.map {

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
@@ -6,6 +6,7 @@ import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkIdentifier
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.CpiReader
 import net.corda.libs.packaging.Cpk
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.v5.base.util.loggerFor
@@ -64,7 +65,7 @@ class CpkReadServiceImpl @Activate constructor(
 
     override fun loadCPI(resourceName: String): Cpi {
         return getInputStream(resourceName).buffered().use { input ->
-            Cpi.from(input, expansionLocation = cpkDir, verifySignature = true)
+            CpiReader.readCpi(input, expansionLocation = cpkDir, verifySignature = true)
         }.let { newCpi ->
             val cpiId = newCpi.metadata.cpiId
             cpis.putIfAbsent(cpiId, newCpi)?.also {


### PR DESCRIPTION
- Add `CpkReader` and `CpiReader` as entry points for CPK/CPI reading
- Remove `from` method from Cpk and Cpi interfaces
- Expand `FormatVersionReader` to support CPB and CPI format versions
- Add `UnknownFormatVersionException`