### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://www.corda.net/wp-content/themes/corda/assets/images/crda-logo-big.svg" alt="Corda" width="500">
 </p>
 
---
+---
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Build Status](https://ci02.dev.r3.com/buildStatus/icon?job=Corda5%2Fcorda-runtime-os%2Frelease%252Fos%252F5.0)](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/release%252Fos%252F5.0/)
 


### PR DESCRIPTION
GitHub doesn't render two dashed separators in Markdown so make it a three-dash