### PR TITLE
NOTICK Fix flaky test

### DIFF
--- a/testing/p2p/inmemory-messaging-impl/src/integrationTest/kotlin/net/corda/messaging/emulation/subscription/pubsub/PubSubSubscriptionIntegrationTest.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/integrationTest/kotlin/net/corda/messaging/emulation/subscription/pubsub/PubSubSubscriptionIntegrationTest.kt
@@ -175,7 +175,6 @@ class PubSubSubscriptionIntegrationTest {
         publish(
             Record(topic, "key1", Event("one", 1)),
         )
-        assertThat(processed).isEmpty()
         waitForProcessed.get().await(1, TimeUnit.SECONDS)
         eventually(duration = 1.seconds, waitBetween = 50.millis) {
             assertThat(lastFuture.get()).isNotNull


### PR DESCRIPTION
Remove unneeded assertion. This made the test flaky as we were adding a record to the processed map in one thread whilst checking it is empty in another.