### PR TITLE
CORE-4857 - add description to swagger for file uploads

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
@@ -195,6 +195,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file.type, "Multipart file type should be a string.")
             assertEquals("binary", file.format, "Multipart file format should be binary.")
             assertFalse(file.nullable)
+            assertEquals("A file to upload.", file.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/uploadwithname"]) {
@@ -212,6 +213,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file.type, "Multipart file type should be a string.")
             assertEquals("binary", file.format, "Multipart file format should be binary.")
             assertFalse(file.nullable)
+            assertEquals("A file to upload.", file.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/uploadwithoutparameterannotations"]) {
@@ -229,6 +231,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file.type, "Multipart file type should be a string.")
             assertEquals("binary", file.format, "Multipart file format should be binary.")
             assertFalse(file.nullable)
+            assertEquals("A file to upload.", file.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/fileuploadobject"]) {
@@ -242,6 +245,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file.type, "Multipart file type should be a string.")
             assertEquals("binary", file.format, "Multipart file format should be binary.")
             assertFalse(file.nullable)
+            assertEquals("A file to upload.", file.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/multifileuploadobject"]) {
@@ -255,11 +259,13 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file1.type, "Multipart file type should be a string.")
             assertEquals("binary", file1.format, "Multipart file format should be binary.")
             assertFalse(file1.nullable)
+            assertEquals("A file to upload.", file1.description, "File upload should have a description.")
             val file2 = multipartFormData.schema.properties["file2"]
             assertNotNull(file2)
             assertEquals("string", file2.type, "Multipart file type should be a string.")
             assertEquals("binary", file2.format, "Multipart file format should be binary.")
             assertFalse(file2.nullable)
+            assertEquals("A file to upload.", file2.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/multiinputstreamfileupload"]) {
@@ -273,11 +279,13 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file1.type, "Multipart file type should be a string.")
             assertEquals("binary", file1.format, "Multipart file format should be binary.")
             assertFalse(file1.nullable)
+            assertEquals("A file to upload.", file1.description, "File upload should have a description.")
             val file2 = multipartFormData.schema.properties["file2"]
             assertNotNull(file2)
             assertEquals("string", file2.type, "Multipart file type should be a string.")
             assertEquals("binary", file2.format, "Multipart file format should be binary.")
             assertFalse(file2.nullable)
+            assertEquals("A file to upload.", file2.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/fileuploadobjectlist"]) {
@@ -309,6 +317,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file.type)
             assertEquals("binary", file.format)
             assertFalse(file.nullable)
+            assertEquals("A file to upload.", file.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/uploadwithpathparam/{tenant}"]) {
@@ -325,6 +334,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file.type)
             assertEquals("binary", file.format)
             assertFalse(file.nullable)
+            assertEquals("A file to upload.", file.description, "File upload should have a description.")
         }
 
         with(openAPI.paths["/fileupload/uploadwithnameinannotation"]) {
@@ -338,6 +348,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("string", file.type)
             assertEquals("binary", file.format)
             assertFalse(file.nullable)
+            assertEquals("differentDesc", file.description, "File upload should have a description.")
         }
     }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelProvider.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelProvider.kt
@@ -168,7 +168,7 @@ internal class DefaultSchemaModelProvider(private val schemaModelContextHolder: 
 
     private fun SchemaModel.applyMetaInfo(param: EndpointParameter) = this.apply {
         this.name = param.name
-        this.description = param.description
+        if(param.description.isNotBlank()) this.description = param.description
         this.required = param.required
         this.nullable = param.nullable
     }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/SchemaPrimitiveBuilders.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/SchemaPrimitiveBuilders.kt
@@ -108,7 +108,7 @@ internal class SchemaHttpFileUploadBuilder : SchemaBuilder {
         SchemaModel(
             DataType.STRING,
             DataFormat.BINARY
-        )
+        ).apply { description = "A file to upload." }
 }
 
 internal class SchemaInputStreamBuilder : SchemaBuilder {
@@ -118,7 +118,7 @@ internal class SchemaInputStreamBuilder : SchemaBuilder {
         SchemaModel(
             DataType.STRING,
             DataFormat.BINARY
-        )
+        ).apply { description = "A file to upload." }
 }
 
 internal class SchemaDateBuilder : SchemaBuilder {

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/TestFileUploadAPI.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/TestFileUploadAPI.kt
@@ -50,6 +50,6 @@ interface TestFileUploadAPI : RpcOps {
 
     @HttpRpcPOST(path = "uploadWithNameInAnnotation")
     fun fileUploadWithNameInAnnotation(
-        @HttpRpcRequestBodyParameter(name = "differentName") file: HttpFileUpload
+        @HttpRpcRequestBodyParameter(name = "differentName", description = "differentDesc") file: HttpFileUpload
     ): String
 }


### PR DESCRIPTION
EG1:

```
  /fileupload/upload:
    post:
      tags:
        - TestFileUploadAPI
      description: ''
      operationId: post_fileupload_upload
      parameters: []
      requestBody:
        description: requestBody
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                file:
                  type: string
                  description: A file to upload.
                  format: binary
                  nullable: false
                  example: No example available for this type
        required: true
```

EG2:

```
  /fileupload/fileuploadobjectlist:
    post:
      tags:
        - TestFileUploadAPI
      description: ''
      operationId: post_fileupload_fileuploadobjectlist
      parameters: []
      requestBody:
        description: requestBody
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                files:
                  uniqueItems: false
                  type: array
                  nullable: false
                  items:
                    type: string
                    description: A file to upload.
                    format: binary
                    nullable: false
                    example: No example available for this type
```
