### PR TITLE
NOTICK Fix p2p-setup README

### DIFF
--- a/applications/tools/p2p-test/p2p-setup/README.md
+++ b/applications/tools/p2p-test/p2p-setup/README.md
@@ -211,10 +211,9 @@ The file should look like the following:
 {
   "linkManagerConfig": {
     "maxMessageSize": 1000000,
-    "messageReplay": {
-      "BasePeriod": 2000,
-      "Cutoff": 10000,
-      "MaxMessages": 100
+    "maxMessages": 100,
+    "ConstantReplayAlgorithm": {
+      "replayPeriod": 2000
     },
     "heartbeatMessagePeriod": 2000,
     "sessionTimeout": 10000,


### PR DESCRIPTION
So that it publishes valid config for the Link Manager.