### PR TITLE
CORE-3780 p2p bug fix, boot config was in incorrect format for p2p apps

### DIFF
--- a/applications/p2p-gateway/build.gradle
+++ b/applications/p2p-gateway/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'
 
+    implementation project(":libs:configuration:configuration-merger")
+
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"

--- a/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/CliArguments.kt
+++ b/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/CliArguments.kt
@@ -4,7 +4,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import kotlin.random.Random
-import net.corda.schema.configuration.BootConfig
+import net.corda.schema.configuration.BootConfig.BOOT_KAFKA_COMMON
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
 import picocli.CommandLine
@@ -53,7 +53,7 @@ internal class CliArguments {
 
     val bootConfiguration: Config by lazy {
         ConfigFactory.empty()
-            .withValue("${BootConfig.BOOT_KAFKA_COMMON}.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))
+            .withValue("$BOOT_KAFKA_COMMON.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))
             .withValue(
                 TOPIC_PREFIX,
                 ConfigValueFactory.fromAnyRef(topicPrefix)

--- a/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/CliArguments.kt
+++ b/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/CliArguments.kt
@@ -4,10 +4,9 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import kotlin.random.Random
+import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
-import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
-import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
 import picocli.CommandLine
 import picocli.CommandLine.Option
 
@@ -52,16 +51,9 @@ internal class CliArguments {
     )
     var instanceId = System.getenv("INSTANCE_ID")?.toInt() ?: Random.nextInt()
 
-    val kafkaNodeConfiguration: Config by lazy {
+    val bootConfiguration: Config by lazy {
         ConfigFactory.empty()
-            .withValue(
-                KAFKA_BOOTSTRAP_SERVERS,
-                ConfigValueFactory.fromAnyRef(kafkaServers)
-            )
-            .withValue(
-                BUS_TYPE,
-                ConfigValueFactory.fromAnyRef("KAFKA")
-            )
+            .withValue("${BootConfig.BOOT_KAFKA_COMMON}.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))
             .withValue(
                 TOPIC_PREFIX,
                 ConfigValueFactory.fromAnyRef(topicPrefix)

--- a/applications/p2p-link-manager/build.gradle
+++ b/applications/p2p-link-manager/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     runtimeOnly project(":components:configuration:configuration-read-service-impl")
     implementation project(":libs:utilities")
     implementation project(":libs:configuration:configuration-core")
+    implementation project(":libs:configuration:configuration-merger")
     implementation project(":libs:messaging:messaging")
     implementation project(":components:configuration:configuration-read-service")
 }

--- a/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
+++ b/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
@@ -4,7 +4,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import kotlin.random.Random
-import net.corda.schema.configuration.BootConfig
+import net.corda.schema.configuration.BootConfig.BOOT_KAFKA_COMMON
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
 import net.corda.schema.configuration.MessagingConfig
@@ -54,7 +54,7 @@ internal class CliArguments {
 
     val bootConfiguration: Config by lazy {
         ConfigFactory.empty()
-            .withValue("${BootConfig.BOOT_KAFKA_COMMON}.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))
+            .withValue("$BOOT_KAFKA_COMMON.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))
             .withValue(
                 TOPIC_PREFIX,
                 ConfigValueFactory.fromAnyRef(topicPrefix)

--- a/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
+++ b/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
@@ -62,14 +62,7 @@ internal class CliArguments {
                 MessagingConfig.Bus.BUS_TYPE,
                 ConfigValueFactory.fromAnyRef("KAFKA")
             )
-            //This is not longer supported. you will need to set this in the messaging config posted to kafka
-            /*.withValue(
-                // The default value of poll timeout is quite high (6 seconds), so setting it to something lower.
-                // Specifically, state & event subscriptions have an issue where they are polling with high timeout on events topic,
-                // leading to slow syncing upon startup. See: https://r3-cev.atlassian.net/browse/CORE-3163
-                POLL_TIMEOUT,
-                ConfigValueFactory.fromAnyRef(100)
-            )*/.withValue(
+            .withValue(
                 INSTANCE_ID,
                 ConfigValueFactory.fromAnyRef(instanceId)
             )

--- a/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
+++ b/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
@@ -4,11 +4,10 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import kotlin.random.Random
+import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
 import net.corda.schema.configuration.MessagingConfig
-import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
-import net.corda.schema.configuration.MessagingConfig.Subscription.POLL_TIMEOUT
 import picocli.CommandLine
 import picocli.CommandLine.Option
 
@@ -53,24 +52,24 @@ internal class CliArguments {
     )
     var instanceId = System.getenv("INSTANCE_ID")?.toInt() ?: Random.nextInt()
 
-    val kafkaNodeConfiguration: Config by lazy {
+    val bootConfiguration: Config by lazy {
         ConfigFactory.empty()
+            .withValue("${BootConfig.BOOT_KAFKA_COMMON}.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))
             .withValue(
-                KAFKA_BOOTSTRAP_SERVERS,
-                ConfigValueFactory.fromAnyRef(kafkaServers)
-            ).withValue(
                 TOPIC_PREFIX,
                 ConfigValueFactory.fromAnyRef(topicPrefix)
             ).withValue(
                 MessagingConfig.Bus.BUS_TYPE,
                 ConfigValueFactory.fromAnyRef("KAFKA")
-            ).withValue(
+            )
+            //This is not longer supported. you will need to set this in the messaging config posted to kafka
+            /*.withValue(
                 // The default value of poll timeout is quite high (6 seconds), so setting it to something lower.
                 // Specifically, state & event subscriptions have an issue where they are polling with high timeout on events topic,
                 // leading to slow syncing upon startup. See: https://r3-cev.atlassian.net/browse/CORE-3163
                 POLL_TIMEOUT,
                 ConfigValueFactory.fromAnyRef(100)
-            ).withValue(
+            )*/.withValue(
                 INSTANCE_ID,
                 ConfigValueFactory.fromAnyRef(instanceId)
             )

--- a/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/LinkManagerApp.kt
+++ b/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/LinkManagerApp.kt
@@ -1,8 +1,10 @@
 package net.corda.applications.linkmanager
 
 import com.typesafe.config.ConfigFactory
+import kotlin.concurrent.thread
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.libs.configuration.merger.ConfigMerger
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
@@ -15,7 +17,6 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import kotlin.concurrent.thread
 
 @Component
 @Suppress("LongParameterList")
@@ -30,6 +31,8 @@ class LinkManagerApp @Activate constructor(
     private val publisherFactory: PublisherFactory,
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = ConfigMerger::class)
+    private val configMerger: ConfigMerger,
 ) : Application {
 
     companion object {
@@ -47,7 +50,7 @@ class LinkManagerApp @Activate constructor(
             // TODO - move to common worker and pick up secrets params
             consoleLogger.info("Starting the configuration service")
             val secretsConfig = ConfigFactory.empty()
-            val bootConfig = SmartConfigFactory.create(secretsConfig).create(arguments.kafkaNodeConfiguration)
+            val bootConfig = SmartConfigFactory.create(secretsConfig).create(arguments.bootConfiguration)
             configurationReadService.start()
             configurationReadService.bootstrapConfig(bootConfig)
 
@@ -57,7 +60,7 @@ class LinkManagerApp @Activate constructor(
                 publisherFactory,
                 lifecycleCoordinatorFactory,
                 configurationReadService,
-                bootConfig,
+                configMerger.getMessagingConfig(bootConfig)
             ).also { linkmanager ->
                 linkmanager.start()
 

--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/TaskContext.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/TaskContext.kt
@@ -1,6 +1,8 @@
 package net.corda.applications.flowworker.setup
 
 import com.typesafe.config.ConfigValueFactory
+import java.util.Properties
+import java.util.concurrent.TimeUnit
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
@@ -8,14 +10,12 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
-import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
+import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
 import net.corda.v5.base.concurrent.getOrThrow
 import org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
-import java.util.*
-import java.util.concurrent.TimeUnit
 
 class TaskContext(
     val startArgs: Args,
@@ -27,12 +27,12 @@ class TaskContext(
 
     init {
         kafkaAdminClient = AdminClient.create(getKafkaProperties())
-        val bootConfig = SmartConfigImpl.empty()
+        val messagingConfig = SmartConfigImpl.empty()
             .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(startArgs.instanceId))
             .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(startArgs.topicPrefix))
             .withValue(KAFKA_BOOTSTRAP_SERVERS, ConfigValueFactory.fromAnyRef(startArgs.bootstrapServer))
             .withValue(BUS_TYPE, ConfigValueFactory.fromAnyRef("KAFKA"))
-        publisher = publisherFactory.createPublisher(PublisherConfig("Flow Worker Setup", false), bootConfig)
+        publisher = publisherFactory.createPublisher(PublisherConfig("Flow Worker Setup", false), messagingConfig)
     }
 
     fun createTopics(topics: List<NewTopic>) {

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.typesafe.config.ConfigValueFactory
+import java.io.Closeable
+import java.time.Duration
+import java.time.Instant
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
@@ -16,12 +19,9 @@ import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
-import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
+import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
 import net.corda.v5.base.util.contextLogger
-import java.io.Closeable
-import java.time.Duration
-import java.time.Instant
 
 @Suppress("LongParameterList")
 class Receiver(private val subscriptionFactory: SubscriptionFactory,
@@ -42,13 +42,13 @@ class Receiver(private val subscriptionFactory: SubscriptionFactory,
     fun start() {
         (1..clients).forEach { client ->
             val subscriptionConfig = SubscriptionConfig("app-simulator-receiver", receiveTopic, )
-            val kafkaConfig = SmartConfigImpl.empty()
+            val messagingConfig = SmartConfigImpl.empty()
                 .withValue(KAFKA_BOOTSTRAP_SERVERS, ConfigValueFactory.fromAnyRef(kafkaServers))
                 .withValue(BUS_TYPE, ConfigValueFactory.fromAnyRef("KAFKA"))
                 .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(""))
                 .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef("$instanceId-$client".hashCode()))
             val subscription = subscriptionFactory.createEventLogSubscription(subscriptionConfig,
-                InboundMessageProcessor(metadataTopic), kafkaConfig, null)
+                InboundMessageProcessor(metadataTopic), messagingConfig, null)
             subscription.start()
             subscriptions.add(subscription)
         }

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
@@ -37,14 +37,14 @@ class Sink(private val subscriptionFactory: SubscriptionFactory,
     fun start() {
         (1..clients).forEach { client ->
             val subscriptionConfig = SubscriptionConfig("app-simulator-sink", APP_RECEIVED_MESSAGES_TOPIC)
-            val kafkaConfig = SmartConfigImpl.empty()
+            val messagingConfig = SmartConfigImpl.empty()
                 .withValue(KAFKA_BOOTSTRAP_SERVERS, ConfigValueFactory.fromAnyRef(kafkaServers))
                 .withValue(BUS_TYPE, ConfigValueFactory.fromAnyRef("KAFKA"))
                 .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(""))
                 .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef("$instanceId-$client".hashCode()))
             val processor = DBSinkProcessor()
             resources.add(processor)
-            val subscription = subscriptionFactory.createEventLogSubscription(subscriptionConfig, processor, kafkaConfig, null)
+            val subscription = subscriptionFactory.createEventLogSubscription(subscriptionConfig, processor, messagingConfig, null)
             subscription.start()
             resources.add(subscription)
         }

--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Command.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Command.kt
@@ -43,7 +43,7 @@ class Command {
     )
     private var kafkaServers = System.getenv("KAFKA_SERVERS") ?: "localhost:9092"
 
-    internal fun nodeConfiguration(): SmartConfig {
+    internal fun messagingConfiguration(): SmartConfig {
         val secretsConfig = ConfigFactory.empty()
         return SmartConfigFactory.create(secretsConfig).create(
             ConfigFactory.empty()

--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Setup.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Setup.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.setup
 
+import kotlin.system.exitProcess
 import net.corda.lifecycle.impl.LifecycleCoordinatorFactoryImpl
 import net.corda.lifecycle.impl.LifecycleCoordinatorSchedulerFactoryImpl
 import net.corda.lifecycle.impl.registry.LifecycleRegistryImpl
@@ -12,7 +13,6 @@ import net.corda.messaging.publisher.factory.CordaPublisherFactory
 import net.corda.schema.registry.impl.AvroSchemaRegistryImpl
 import net.corda.v5.base.util.contextLogger
 import picocli.CommandLine
-import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
     Setup(args).run()
@@ -56,7 +56,7 @@ class Setup(
         if (records.isNotEmpty()) {
             publisherFactory.createPublisher(
                 PublisherConfig("p2p-setup", false),
-                command.nodeConfiguration(),
+                command.messagingConfiguration(),
             ).use { publisher ->
                 logger.info("Publishing ${records.size} records")
                 publisher.publish(records).forEach {

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/PublisherWithDominoLogic.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/PublisherWithDominoLogic.kt
@@ -1,5 +1,6 @@
 package net.corda.lifecycle.domino.logic.util
 
+import java.util.concurrent.CompletableFuture
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -8,13 +9,12 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
-import java.util.concurrent.CompletableFuture
 
 class PublisherWithDominoLogic(
     private val publisherFactory: PublisherFactory,
     coordinatorFactory: LifecycleCoordinatorFactory,
     private val publisherConfig: PublisherConfig,
-    private val configuration: SmartConfig,
+    private val messagingConfiguration: SmartConfig,
 ) : LifecycleWithDominoTile {
 
     @Volatile
@@ -26,7 +26,7 @@ class PublisherWithDominoLogic(
         val resourceReady = CompletableFuture<Unit>()
         publisher = publisherFactory.createPublisher(
             publisherConfig,
-            configuration
+            messagingConfiguration
         ).also {
             resources.keep {
                 it.close()

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
@@ -29,7 +29,7 @@ class Gateway(
     subscriptionFactory: SubscriptionFactory,
     publisherFactory: PublisherFactory,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    nodeConfiguration: SmartConfig,
+    messagingConfiguration: SmartConfig,
 ) : LifecycleWithDominoTile {
 
     private val inboundMessageHandler = InboundMessageHandler(
@@ -37,13 +37,13 @@ class Gateway(
         configurationReaderService,
         publisherFactory,
         subscriptionFactory,
-        nodeConfiguration,
+        messagingConfiguration,
     )
     private val outboundMessageProcessor = OutboundMessageHandler(
         lifecycleCoordinatorFactory,
         configurationReaderService,
         subscriptionFactory,
-        nodeConfiguration,
+        messagingConfiguration,
     )
 
     @VisibleForTesting

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
@@ -1,5 +1,11 @@
 package net.corda.p2p.gateway.messaging
 
+import java.io.ByteArrayInputStream
+import java.security.InvalidKeyException
+import java.security.PublicKey
+import java.security.cert.CertificateFactory
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import net.corda.crypto.delegated.signing.Alias
 import net.corda.crypto.delegated.signing.CertificateChain
 import net.corda.crypto.delegated.signing.DelegatedCertificateStore
@@ -18,17 +24,11 @@ import net.corda.p2p.GatewayTlsCertificates
 import net.corda.p2p.test.stub.crypto.processor.StubCryptoProcessor
 import net.corda.schema.Schemas
 import net.corda.v5.crypto.SignatureSpec
-import java.io.ByteArrayInputStream
-import java.security.InvalidKeyException
-import java.security.PublicKey
-import java.security.cert.CertificateFactory
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
 
 internal class DynamicKeyStore(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
-    nodeConfiguration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     private val certificateFactory: CertificateFactory = CertificateFactory.getInstance("X.509"),
 ) : DelegatedCertificateStore, LifecycleWithDominoTile, DelegatedSigner {
     companion object {
@@ -45,7 +45,7 @@ internal class DynamicKeyStore(
     private val subscription = subscriptionFactory.createCompactedSubscription(
         SubscriptionConfig(CONSUMER_GROUP_ID, Schemas.P2P.GATEWAY_TLS_CERTIFICATES),
         Processor(),
-        nodeConfiguration
+        messagingConfiguration
     )
 
     private val subscriptionTile = SubscriptionDominoTile(
@@ -58,7 +58,7 @@ internal class DynamicKeyStore(
     private val signer = StubCryptoProcessor(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
-        nodeConfiguration,
+        messagingConfiguration,
     )
 
     override val dominoTile = ComplexDominoTile(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -1,5 +1,10 @@
 package net.corda.p2p.gateway.messaging.http
 
+import java.io.ByteArrayInputStream
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -12,16 +17,11 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTruststore
 import net.corda.schema.Schemas
-import java.io.ByteArrayInputStream
-import java.security.KeyStore
-import java.security.cert.CertificateFactory
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
 
 internal class TrustStoresMap(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
-    nodeConfiguration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     private val certificateFactory: CertificateFactory = CertificateFactory.getInstance("X.509"),
 ) :
     LifecycleWithDominoTile {
@@ -33,7 +33,7 @@ internal class TrustStoresMap(
     private val subscription = subscriptionFactory.createCompactedSubscription(
         SubscriptionConfig(CONSUMER_GROUP_ID, Schemas.P2P.GATEWAY_TLS_TRUSTSTORES),
         Processor(),
-        nodeConfiguration
+        messagingConfiguration
     )
     private val groupIdToTrustRoots = ConcurrentHashMap<String, TrustedCertificates>()
     private val subscriptionTile = SubscriptionDominoTile(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -1,6 +1,8 @@
 package net.corda.p2p.gateway.messaging.internal
 
 import io.netty.handler.codec.http.HttpResponseStatus
+import java.nio.ByteBuffer
+import java.util.UUID
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.p2p.gateway.GatewayMessage
 import net.corda.data.p2p.gateway.GatewayResponse
@@ -27,8 +29,6 @@ import net.corda.p2p.gateway.messaging.http.ReconfigurableHttpServer
 import net.corda.p2p.gateway.messaging.session.SessionPartitionMapperImpl
 import net.corda.schema.Schemas.P2P.Companion.LINK_IN_TOPIC
 import net.corda.v5.base.util.contextLogger
-import java.nio.ByteBuffer
-import java.util.*
 
 /**
  * This class implements a simple message processor for p2p messages received from other Gateways.
@@ -39,7 +39,7 @@ internal class InboundMessageHandler(
     configurationReaderService: ConfigurationReadService,
     publisherFactory: PublisherFactory,
     subscriptionFactory: SubscriptionFactory,
-    nodeConfiguration: SmartConfig,
+    messagingConfiguration: SmartConfig,
 ) : HttpServerListener, LifecycleWithDominoTile {
 
     companion object {
@@ -50,12 +50,12 @@ internal class InboundMessageHandler(
         publisherFactory,
         lifecycleCoordinatorFactory,
         PublisherConfig("inbound-message-handler", false),
-        nodeConfiguration
+        messagingConfiguration
     )
     private val sessionPartitionMapper = SessionPartitionMapperImpl(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
-        nodeConfiguration
+        messagingConfiguration
     )
 
     private val server = ReconfigurableHttpServer(
@@ -63,7 +63,7 @@ internal class InboundMessageHandler(
         configurationReaderService,
         this,
         subscriptionFactory,
-        nodeConfiguration,
+        messagingConfiguration,
     )
     override val dominoTile = ComplexDominoTile(
         this::class.java.simpleName,

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
@@ -1,6 +1,12 @@
 package net.corda.p2p.gateway.messaging.internal
 
 import io.netty.handler.codec.http.HttpResponseStatus
+import java.net.URI
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.p2p.gateway.GatewayMessage
 import net.corda.libs.configuration.SmartConfig
@@ -25,12 +31,6 @@ import net.corda.schema.Schemas.P2P.Companion.LINK_OUT_TOPIC
 import net.corda.v5.base.util.debug
 import org.bouncycastle.asn1.x500.X500Name
 import org.slf4j.LoggerFactory
-import java.net.URI
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 
 /**
  * This is an implementation of an [PubSubProcessor] used to consume messages from a P2P message subscription. The received
@@ -41,7 +41,7 @@ internal class OutboundMessageHandler(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     configurationReaderService: ConfigurationReadService,
     subscriptionFactory: SubscriptionFactory,
-    nodeConfiguration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     private val retryThreadPoolFactory: () -> ScheduledExecutorService
         = { Executors.newSingleThreadScheduledExecutor() },
 ) : PubSubProcessor<String, LinkOutMessage>, LifecycleWithDominoTile {
@@ -61,13 +61,13 @@ internal class OutboundMessageHandler(
     private val trustStoresMap = TrustStoresMap(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
-        nodeConfiguration
+        messagingConfiguration
     )
 
     private val outboundSubscription = subscriptionFactory.createPubSubSubscription(
         SubscriptionConfig("outbound-message-handler", LINK_OUT_TOPIC),
         this,
-        nodeConfiguration,
+        messagingConfiguration,
     )
     private val outboundSubscriptionTile = SubscriptionDominoTile(
         lifecycleCoordinatorFactory,

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
@@ -1,5 +1,7 @@
 package net.corda.p2p.gateway.messaging.session
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -12,13 +14,11 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.SessionPartitions
 import net.corda.schema.Schemas.P2P.Companion.SESSION_OUT_PARTITIONS
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
 
 class SessionPartitionMapperImpl(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
-    nodeConfiguration: SmartConfig
+    messagingConfiguration: SmartConfig
 ) : SessionPartitionMapper, LifecycleWithDominoTile {
 
     companion object {
@@ -32,7 +32,7 @@ class SessionPartitionMapperImpl(
     private val sessionPartitionSubscription = subscriptionFactory.createCompactedSubscription(
         SubscriptionConfig(CONSUMER_GROUP_ID, SESSION_OUT_PARTITIONS),
         processor,
-        nodeConfiguration
+        messagingConfiguration
     )
     private val sessionPartitionSubscriptionTile = SubscriptionDominoTile(
         lifecycleCoordinatorFactory,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/CommonComponents.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/CommonComponents.kt
@@ -22,7 +22,7 @@ internal class CommonComponents(
     linkManagerCryptoProcessor: CryptoProcessor,
     subscriptionFactory: SubscriptionFactory,
     publisherFactory: PublisherFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     clock: Clock,
 ) : LifecycleWithDominoTile {
     internal val inboundAssignmentListener = InboundAssignmentListener(
@@ -33,7 +33,7 @@ internal class CommonComponents(
     internal val messagesPendingSession = PendingSessionMessageQueuesImpl(
         publisherFactory,
         lifecycleCoordinatorFactory,
-        configuration
+        messagingConfiguration
     )
 
     internal val sessionManager = SessionManagerImpl(
@@ -44,7 +44,7 @@ internal class CommonComponents(
         publisherFactory,
         configurationReaderService,
         lifecycleCoordinatorFactory,
-        configuration,
+        messagingConfiguration,
         inboundAssignmentListener,
         linkManagerHostingMap,
         clock = clock,
@@ -54,7 +54,7 @@ internal class CommonComponents(
         subscriptionFactory,
         publisherFactory,
         lifecycleCoordinatorFactory,
-        configuration,
+        messagingConfiguration,
     ).also {
         groups.registerListener(it)
     }
@@ -63,7 +63,7 @@ internal class CommonComponents(
         subscriptionFactory,
         publisherFactory,
         lifecycleCoordinatorFactory,
-        configuration,
+        messagingConfiguration,
     ).also {
         linkManagerHostingMap.registerListener(it)
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/InboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/InboundLinkManager.kt
@@ -16,7 +16,7 @@ internal class InboundLinkManager(
     groups: LinkManagerGroupPolicyProvider,
     members: LinkManagerMembershipGroupReader,
     subscriptionFactory: SubscriptionFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     clock: Clock,
 ) : LifecycleWithDominoTile {
     companion object {
@@ -31,7 +31,7 @@ internal class InboundLinkManager(
             commonComponents.inboundAssignmentListener,
             clock
         ),
-        configuration,
+        messagingConfiguration,
         partitionAssignmentListener = commonComponents.inboundAssignmentListener
     )
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.linkmanager
 
+import java.util.UUID
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -12,7 +13,6 @@ import net.corda.p2p.test.stub.crypto.processor.StubCryptoProcessor
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import org.osgi.service.component.annotations.Reference
-import java.util.UUID
 
 @Suppress("LongParameterList")
 class LinkManager(
@@ -24,21 +24,21 @@ class LinkManager(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     configurationReaderService: ConfigurationReadService,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     groups: LinkManagerGroupPolicyProvider = StubGroupPolicyProvider(
-        lifecycleCoordinatorFactory, subscriptionFactory, configuration
+        lifecycleCoordinatorFactory, subscriptionFactory, messagingConfiguration
     ),
     members: LinkManagerMembershipGroupReader = StubMembershipGroupReader(
-        lifecycleCoordinatorFactory, subscriptionFactory, configuration
+        lifecycleCoordinatorFactory, subscriptionFactory, messagingConfiguration
     ),
     linkManagerHostingMap: LinkManagerHostingMap =
         StubLinkManagerHostingMap(
             lifecycleCoordinatorFactory,
             subscriptionFactory,
-            configuration,
+            messagingConfiguration,
         ),
     linkManagerCryptoProcessor: CryptoProcessor =
-        StubCryptoProcessor(lifecycleCoordinatorFactory, subscriptionFactory, configuration),
+        StubCryptoProcessor(lifecycleCoordinatorFactory, subscriptionFactory, messagingConfiguration),
     clock: Clock = UTCClock()
 ) : LifecycleWithDominoTile {
 
@@ -57,7 +57,7 @@ class LinkManager(
         linkManagerCryptoProcessor = linkManagerCryptoProcessor,
         subscriptionFactory = subscriptionFactory,
         publisherFactory = publisherFactory,
-        configuration = configuration,
+        messagingConfiguration = messagingConfiguration,
         clock = clock,
     )
     private val outboundLinkManager = OutboundLinkManager(
@@ -70,7 +70,7 @@ class LinkManager(
         linkManagerCryptoProcessor = linkManagerCryptoProcessor,
         subscriptionFactory = subscriptionFactory,
         publisherFactory = publisherFactory,
-        configuration = configuration,
+        messagingConfiguration = messagingConfiguration,
         clock = clock,
     )
     private val inboundLinkManager = InboundLinkManager(
@@ -79,7 +79,7 @@ class LinkManager(
         groups = groups,
         members = members,
         subscriptionFactory = subscriptionFactory,
-        configuration = configuration,
+        messagingConfiguration = messagingConfiguration,
         clock = clock,
     )
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundLinkManager.kt
@@ -24,7 +24,7 @@ internal class OutboundLinkManager(
     linkManagerCryptoProcessor: CryptoProcessor,
     subscriptionFactory: SubscriptionFactory,
     publisherFactory: PublisherFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     clock: Clock,
 ) : LifecycleWithDominoTile {
     companion object {
@@ -43,7 +43,7 @@ internal class OutboundLinkManager(
         lifecycleCoordinatorFactory,
         configurationReaderService,
         publisherFactory,
-        configuration,
+        messagingConfiguration,
         subscriptionFactory,
         groups,
         members,
@@ -55,7 +55,7 @@ internal class OutboundLinkManager(
     private val outboundMessageSubscription = subscriptionFactory.createEventLogSubscription(
         SubscriptionConfig(OUTBOUND_MESSAGE_PROCESSOR_GROUP, Schemas.P2P.P2P_OUT_TOPIC),
         outboundMessageProcessor,
-        configuration,
+        messagingConfiguration,
         partitionAssignmentListener = null
     )
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/PendingSessionMessageQueuesImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/PendingSessionMessageQueuesImpl.kt
@@ -1,5 +1,7 @@
 package net.corda.p2p.linkmanager
 
+import java.util.LinkedList
+import java.util.Queue
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
@@ -13,14 +15,11 @@ import net.corda.p2p.linkmanager.sessions.SessionManagerImpl
 import net.corda.p2p.linkmanager.sessions.recordsForSessionEstablished
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
-import java.util.HashMap
-import java.util.LinkedList
-import java.util.Queue
 
 internal class PendingSessionMessageQueuesImpl(
     publisherFactory: PublisherFactory,
     coordinatorFactory: LifecycleCoordinatorFactory,
-    configuration: SmartConfig
+    messagingConfiguration: SmartConfig
 ) : PendingSessionMessageQueues {
 
     companion object {
@@ -34,7 +33,7 @@ internal class PendingSessionMessageQueuesImpl(
         publisherFactory,
         coordinatorFactory,
         PublisherConfig(LINK_MANAGER_PUBLISHER_CLIENT_ID, false),
-        configuration
+        messagingConfiguration
     )
     override val dominoTile = publisher.dominoTile
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
@@ -1,5 +1,8 @@
 package net.corda.p2p.linkmanager
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -16,16 +19,13 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTlsCertificates
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_CERTIFICATES
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
 
 @Suppress("LongParameterList")
 internal class TlsCertificatesPublisher(
     subscriptionFactory: SubscriptionFactory,
     publisherFactory: PublisherFactory,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
 ) : LifecycleWithDominoTile, HostingMapListener {
 
     companion object {
@@ -40,7 +40,7 @@ internal class TlsCertificatesPublisher(
         publisherFactory,
         lifecycleCoordinatorFactory,
         PublisherConfig(MISSING_DATA_WRITER_GROUP_NAME, false),
-        configuration,
+        messagingConfiguration,
     )
 
     private fun HoldingIdentity.asString(): String {
@@ -104,7 +104,7 @@ internal class TlsCertificatesPublisher(
     private val subscription = subscriptionFactory.createCompactedSubscription(
         SubscriptionConfig(CURRENT_DATA_READER_GROUP_NAME, GATEWAY_TLS_CERTIFICATES),
         Processor(),
-        configuration,
+        messagingConfiguration,
     )
     private val subscriptionDominoTile = SubscriptionDominoTile(
         lifecycleCoordinatorFactory,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
@@ -1,5 +1,8 @@
 package net.corda.p2p.linkmanager
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -16,16 +19,13 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTruststore
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_TRUSTSTORES
 import net.corda.v5.base.util.contextLogger
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
 
 @Suppress("LongParameterList")
 internal class TrustStoresPublisher(
     subscriptionFactory: SubscriptionFactory,
     publisherFactory: PublisherFactory,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
 ) : LifecycleWithDominoTile, GroupPolicyListener {
 
     companion object {
@@ -41,12 +41,12 @@ internal class TrustStoresPublisher(
         publisherFactory,
         lifecycleCoordinatorFactory,
         PublisherConfig(MISSING_DATA_WRITER_GROUP_NAME, false),
-        configuration,
+        messagingConfiguration,
     )
     private val subscription = subscriptionFactory.createCompactedSubscription(
         SubscriptionConfig(CURRENT_DATA_READER_GROUP_NAME, GATEWAY_TLS_TRUSTSTORES),
         Processor(),
-        configuration,
+        messagingConfiguration,
     )
     private val subscriptionTile = SubscriptionDominoTile(
         lifecycleCoordinatorFactory,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.linkmanager.delivery
 
+import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -30,14 +31,13 @@ import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.LoggerFactory
-import java.util.concurrent.ConcurrentHashMap
 
 @Suppress("LongParameterList")
 internal class DeliveryTracker(
     coordinatorFactory: LifecycleCoordinatorFactory,
     configReadService: ConfigurationReadService,
     publisherFactory: PublisherFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     subscriptionFactory: SubscriptionFactory,
     groups: LinkManagerGroupPolicyProvider,
     members: LinkManagerMembershipGroupReader,
@@ -50,7 +50,7 @@ internal class DeliveryTracker(
     private val appMessageReplayer = AppMessageReplayer(
         coordinatorFactory,
         publisherFactory,
-        configuration,
+        messagingConfiguration,
         processAuthenticatedMessage
     )
     private val replayScheduler = ReplayScheduler(
@@ -65,7 +65,7 @@ internal class DeliveryTracker(
     private val messageTrackerSubscription = subscriptionFactory.createStateAndEventSubscription(
         SubscriptionConfig("message-tracker-group", P2P_OUT_MARKERS),
         messageTracker.processor,
-        configuration,
+        messagingConfiguration,
         messageTracker.listener
     )
     private val messageTrackerSubscriptionTile = StateAndEventSubscriptionDominoTile(
@@ -90,7 +90,7 @@ internal class DeliveryTracker(
     private class AppMessageReplayer(
         coordinatorFactory: LifecycleCoordinatorFactory,
         publisherFactory: PublisherFactory,
-        configuration: SmartConfig,
+        messagingConfiguration: SmartConfig,
         private val processAuthenticatedMessage: (message: AuthenticatedMessageAndKey) -> List<Record<String, *>>
     ): LifecycleWithDominoTile {
 
@@ -103,7 +103,7 @@ internal class DeliveryTracker(
             publisherFactory,
             coordinatorFactory,
             PublisherConfig(MESSAGE_REPLAYER_CLIENT_ID, false),
-            configuration
+            messagingConfiguration
         )
 
         override val dominoTile = publisher.dominoTile

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
@@ -25,7 +25,7 @@ internal class InMemorySessionReplayer(
     publisherFactory: PublisherFactory,
     configurationReaderService: ConfigurationReadService,
     coordinatorFactory: LifecycleCoordinatorFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     private val groups: LinkManagerGroupPolicyProvider,
     private val members: LinkManagerMembershipGroupReader,
     private val clock: Clock
@@ -41,7 +41,7 @@ internal class InMemorySessionReplayer(
         publisherFactory,
         coordinatorFactory,
         PublisherConfig(MESSAGE_REPLAYER_CLIENT_ID, false),
-        configuration
+        messagingConfiguration
     )
 
     private val replayScheduler = ReplayScheduler(coordinatorFactory, configurationReaderService,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -82,7 +82,7 @@ internal class SessionManagerImpl(
     publisherFactory: PublisherFactory,
     private val configurationReaderService: ConfigurationReadService,
     coordinatorFactory: LifecycleCoordinatorFactory,
-    configuration: SmartConfig,
+    messagingConfiguration: SmartConfig,
     private val inboundAssignmentListener: InboundAssignmentListener,
     private val linkManagerHostingMap: LinkManagerHostingMap,
     private val protocolFactory: ProtocolFactory = CryptoProtocolFactory(),
@@ -91,7 +91,7 @@ internal class SessionManagerImpl(
         publisherFactory,
         configurationReaderService,
         coordinatorFactory,
-        configuration,
+        messagingConfiguration,
         groups,
         members,
         clock,
@@ -122,7 +122,7 @@ internal class SessionManagerImpl(
         publisherFactory,
         configurationReaderService,
         coordinatorFactory,
-        configuration,
+        messagingConfiguration,
         groups,
         members,
         ::refreshOutboundSession,
@@ -135,7 +135,7 @@ internal class SessionManagerImpl(
         publisherFactory,
         coordinatorFactory,
         PublisherConfig(SESSION_MANAGER_CLIENT_ID, false),
-        configuration
+        messagingConfiguration
     )
 
     override val dominoTile = ComplexDominoTile(

--- a/components/p2p-test/stub-crypto-processor/src/main/kotlin/net/corda/p2p/test/stub/crypto/processor/StubCryptoProcessor.kt
+++ b/components/p2p-test/stub-crypto-processor/src/main/kotlin/net/corda/p2p/test/stub/crypto/processor/StubCryptoProcessor.kt
@@ -1,5 +1,10 @@
 package net.corda.p2p.test.stub.crypto.processor
 
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.Signature
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -12,22 +17,17 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.test.TenantKeys
 import net.corda.schema.TestSchema.Companion.CRYPTO_KEYS_TOPIC
 import net.corda.v5.crypto.SignatureSpec
-import java.security.PrivateKey
-import java.security.PublicKey
-import java.security.Signature
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
 
 class StubCryptoProcessor(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
-    configuration: SmartConfig
+    messagingConfiguration: SmartConfig
 ) : CryptoProcessor {
 
     private val keyPairEntryProcessor = KeyPairEntryProcessor()
     private val subscriptionConfig = SubscriptionConfig("crypto-service", CRYPTO_KEYS_TOPIC)
     private val subscription =
-        subscriptionFactory.createCompactedSubscription(subscriptionConfig, keyPairEntryProcessor, configuration)
+        subscriptionFactory.createCompactedSubscription(subscriptionConfig, keyPairEntryProcessor, messagingConfiguration)
     private class TenantKeyMap {
         val publicKeyToPrivateKey = ConcurrentHashMap<PublicKey, PrivateKey>()
     }


### PR DESCRIPTION
P2P apps which have hardcoded boot configs were not updated to use the new format for boot config. 
Config P2P components are messagingConfigs only so params were updated to be more explicit  