### PR TITLE
CORE-4973: Update packages of testing cpbs to avoid security manager issues

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -241,7 +241,7 @@ class VirtualNodeRpcTest {
             Thread.sleep(FLOW_WAIT_DURATION.toMillis())
 
             // Depends on the flows in the cpi
-            val className = "net.corda.testing.calculator.CalculatorFlow"
+            val className = "net.cordapp.testing.calculator.CalculatorFlow"
             assertWithRetry {
                 command { flowStart(id, 1, className, requestBody) }
                 condition { it.code == 200 }

--- a/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/CalculatorFlow.kt
+++ b/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/CalculatorFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.calculator
+package net.cordapp.testing.calculator
 
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.Flow

--- a/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/InputMessage.kt
+++ b/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/InputMessage.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.calculator
+package net.cordapp.testing.calculator
 
 class InputMessage{
     var a: Int? = null

--- a/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/OutputFormattingFlow.kt
+++ b/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/OutputFormattingFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.calculator
+package net.cordapp.testing.calculator
 
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.Flow

--- a/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/OutputMessage.kt
+++ b/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/OutputMessage.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.calculator
+package net.cordapp.testing.calculator
 
 data class OutputMessage(
     val result: Int

--- a/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/GameStateMessage.kt
+++ b/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/GameStateMessage.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.connectfour
+package net.cordapp.demo.connectfour
 
 data class GameStateMessage(
     val gameStatus: GameStates,

--- a/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/GameStates.kt
+++ b/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/GameStates.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.tictactoe
+package net.cordapp.demo.connectfour
 
 enum class GameStates {
     Playing

--- a/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/Move.kt
+++ b/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/Move.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.connectfour
+package net.cordapp.demo.connectfour
 
 data class Move(
     val playerX500Name: String,

--- a/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/StartConnectFourGameFlow.kt
+++ b/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/StartConnectFourGameFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.connectfour
+package net.cordapp.demo.connectfour
 
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.Flow

--- a/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/StartGameMessage.kt
+++ b/testing/cpbs/connect4/src/main/kotlin/net/cordapp/demo/connectfour/StartGameMessage.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.connectfour
+package net.cordapp.demo.connectfour
 
 class StartGameMessage {
     var opponentX500Name: String? = null

--- a/testing/cpbs/mandelbrot/src/main/kotlin/net/cordapp/demo/mandelbrot/CalculateBlockFlow.kt
+++ b/testing/cpbs/mandelbrot/src/main/kotlin/net/cordapp/demo/mandelbrot/CalculateBlockFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.mandelbrot
+package net.cordapp.demo.mandelbrot
 
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.Flow

--- a/testing/cpbs/mandelbrot/src/main/kotlin/net/cordapp/demo/mandelbrot/RequestMessage.kt
+++ b/testing/cpbs/mandelbrot/src/main/kotlin/net/cordapp/demo/mandelbrot/RequestMessage.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.mandelbrot
+package net.cordapp.demo.mandelbrot
 
 class RequestMessage {
     var startX: Double? = null

--- a/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/GameStateMessage.kt
+++ b/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/GameStateMessage.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.tictactoe
+package net.cordapp.demo.tictactoe
 
 data class GameStateMessage(
     val gameStatus: GameStates,

--- a/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/GameStates.kt
+++ b/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/GameStates.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.connectfour
+package net.cordapp.demo.tictactoe
 
 enum class GameStates {
     Playing

--- a/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/Move.kt
+++ b/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/Move.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.tictactoe
+package net.cordapp.demo.tictactoe
 
 data class Move(
     val playerX500Name: String,

--- a/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/StartGameMessage.kt
+++ b/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/StartGameMessage.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.tictactoe
+package net.cordapp.demo.tictactoe
 
 class StartGameMessage {
     var opponentX500Name: String? = null

--- a/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/StartTicTacToeGameFlow.kt
+++ b/testing/cpbs/tic-tac-toe/src/main/kotlin/net/cordapp/demo/tictactoe/StartTicTacToeGameFlow.kt
@@ -1,4 +1,4 @@
-package net.corda.demo.tictactoe
+package net.cordapp.demo.tictactoe
 
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.Flow

--- a/testing/flow-worker-demo/public/javascripts/demo.js
+++ b/testing/flow-worker-demo/public/javascripts/demo.js
@@ -97,7 +97,7 @@ function getStartRequest() {
     return {
         shortId: getNodeShortId(),
         requestId: Date.now().toString(),
-        flowClass: "net.corda.demo.connectfour.StartConnectFourGameFlow",
+        flowClass: "net.cordapp.demo.connectfour.StartConnectFourGameFlow",
         startMessage: '{ "opponentX500Name":"' + $("#opponent").val() + '", "startingSlotPlayed":"' + $("#startingColumn").val() + '"}'
     }
 }

--- a/testing/flow-worker-demo/public/mandy.html
+++ b/testing/flow-worker-demo/public/mandy.html
@@ -32,7 +32,7 @@
     const processing_colour = "#498f63";
 
     const holdingShortId = "28FD92C043BE";
-    const flowClass = "net.corda.demo.mandelbrot.CalculateBlockFlow";
+    const flowClass = "net.cordapp.demo.mandelbrot.CalculateBlockFlow";
     const apiAddress = "http://localhost:3000/flow/"
     const blockIndex = new Map();
 


### PR DESCRIPTION
The introduction of the security manager should block us from loading user classes in the flow sandbox that claim to be in the `net.corda` package. This unfortunately includes our test CPBs. While some were previously migrated it appears some were missed, so this PR tidies that up by moving the other CPBs across.