### PR TITLE
NOTICK - VersionedRecord optimisation

### DIFF
--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/VersionedRecord.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/VersionedRecord.kt
@@ -5,9 +5,9 @@ package net.corda.reconciliation
  * means Kafka records with deleted values (null`ed values) are filtered out and cannot be returned by
  * [ReconcilerReader]s.
  */
-data class VersionedRecord<K, V>(
-    val version: Int,
-    val isDeleted: Boolean,
-    val key: K,
-    val value: V,
-)
+interface VersionedRecord<K, V> {
+    val version: Int
+    val isDeleted: Boolean
+    val key: K
+    val value: V
+}

--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReadServiceImpl.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReadServiceImpl.kt
@@ -92,12 +92,12 @@ class CpiInfoReadServiceImpl @Activate constructor(
         getAll()
             .stream()
             .map {
-                VersionedRecord(
-                    version = it.version,
-                    isDeleted = false,
-                    key = it.cpiId,
-                    value = it
-                )
+                object : VersionedRecord<CpiIdentifier, CpiMetadata> {
+                    override val version = it.version
+                    override val isDeleted = false
+                    override val key = it.cpiId
+                    override val value = it
+                }
             }
 
     override fun get(identifier: CpiIdentifier): CpiMetadata? = cpiInfoProcessor.get(identifier)

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
@@ -25,12 +25,12 @@ class CpiInfoServiceImpl @Activate constructor(
 
     override fun getAllVersionedRecords(): Stream<VersionedRecord<CpiIdentifier, CpiMetadata>> =
         getAll().stream().map {
-            VersionedRecord(
-                version = it.version,
-                isDeleted = false,
-                key = it.cpiId,
-                value = it
-            )
+            object : VersionedRecord<CpiIdentifier, CpiMetadata> {
+                override val version = it.version
+                override val isDeleted = false
+                override val key = it.cpiId
+                override val value = it
+            }
         }
 
     override val isRunning: Boolean


### PR DESCRIPTION
- Changed VersionedRecord to interface so that the implementation can be optimised dependent on its usaged.
- Delay conversion of DTO in CpiInfoDbReader until it's needed.