### PR TITLE
CORE-3764 Use dummy link manager temporarily

### DIFF
--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(':libs:configuration:configuration-validation')
     implementation project(':processors:flow-processor')
-    implementation project(':processors:link-manager-processor')
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'

--- a/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
+++ b/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
@@ -11,7 +11,6 @@ import net.corda.libs.configuration.validation.ConfigurationValidatorFactory
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.flow.FlowProcessor
-import net.corda.processors.p2p.linkmanager.LinkManagerProcessor
 import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -24,8 +23,6 @@ import picocli.CommandLine.Mixin
 class FlowWorker @Activate constructor(
     @Reference(service = FlowProcessor::class)
     private val flowProcessor: FlowProcessor,
-    @Reference(service = LinkManagerProcessor::class)
-    private val linkManagerProcessor: LinkManagerProcessor,
     @Reference(service = Shutdown::class)
     private val shutDownService: Shutdown,
     @Reference(service = HealthMonitor::class)
@@ -50,13 +47,11 @@ class FlowWorker @Activate constructor(
         val config = getBootstrapConfig(params.defaultParams, configurationValidatorFactory.createConfigValidator())
 
         flowProcessor.start(config)
-        linkManagerProcessor.start(config)
     }
 
     override fun shutdown() {
         logger.info("Flow worker stopping.")
         flowProcessor.stop()
-        linkManagerProcessor.stop()
         healthMonitor.stop()
     }
 }

--- a/processors/flow-processor/build.gradle
+++ b/processors/flow-processor/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'net.corda:corda-base'
 
     implementation project(":components:configuration:configuration-read-service")
+    implementation project(":testing:flow:dummy-link-manager")
     implementation project(":components:flow:flow-mapper-service")
     implementation project(":components:flow:flow-service")
     implementation project(":components:flow:flow-p2p-filter-service")

--- a/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
+++ b/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
@@ -2,6 +2,7 @@ package net.corda.processors.flow.internal
 
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
+import net.corda.flow.dummy.link.DummyLinkManagerService
 import net.corda.flow.p2p.filter.FlowP2PFilterService
 import net.corda.flow.service.FlowService
 import net.corda.libs.configuration.SmartConfig
@@ -36,6 +37,8 @@ class FlowProcessorImpl @Activate constructor(
     private val flowService: FlowService,
     @Reference(service = FlowMapperService::class)
     private val flowMapperService: FlowMapperService,
+    @Reference(service = DummyLinkManagerService::class)
+    private val dummyLinkManagerService: DummyLinkManagerService,
     @Reference(service = FlowP2PFilterService::class)
     private val flowP2PFilterService: FlowP2PFilterService,
     @Reference(service = VirtualNodeInfoReadService::class)
@@ -57,6 +60,7 @@ class FlowProcessorImpl @Activate constructor(
         ::configurationReadService,
         ::flowService,
         ::flowMapperService,
+        ::dummyLinkManagerService,
         ::flowP2PFilterService,
         ::virtualNodeInfoReadService,
         ::cpiInfoReadService,


### PR DESCRIPTION
The `LinkManagerProcessor` has not been integrated into the `FlowWorker`
application correctly which is affecting the overall network deployment.
Fall back to the dummy implementation until the issues have been
resolved.