### PR TITLE
CORE-5032 - fix for uplolad cpi with shared cpk

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/DatabaseChunkPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/DatabaseChunkPersistence.kt
@@ -224,11 +224,11 @@ class DatabaseChunkPersistence(private val entityManagerFactory: EntityManagerFa
         val cpiMetadataEntity = createCpiMetadataEntity(cpi, cpiFileName, checksum, requestId, groupId)
         entityManagerFactory.createEntityManager().transaction { em ->
             // persist metadata
-            em.persist(cpiMetadataEntity)
+            em.merge(cpiMetadataEntity)
             // persist file data
             cpi.cpks.forEach {
                 val cpkChecksum = it.metadata.fileChecksum.toString()
-                em.persist(CpkFileEntity(cpkChecksum, Files.readAllBytes(it.path!!)))
+                em.merge(CpkFileEntity(cpkChecksum, Files.readAllBytes(it.path!!)))
             }
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/DatabaseChunkPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/DatabaseChunkPersistence.kt
@@ -26,6 +26,7 @@ import java.nio.file.Files
 import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
+import javax.persistence.LockModeType
 
 /**
  * This class provides some simple APIs to interact with the database.
@@ -257,7 +258,7 @@ class DatabaseChunkPersistence(private val entityManagerFactory: EntityManagerFa
                 "Cannot find CPI metadata for ${cpiId.name} v${cpiId.version}"
             }
 
-            val updatedMetadata = existingMetadataEntity.createUpdated(
+            val updatedMetadata = existingMetadataEntity.update(
                 fileUploadRequestId = requestId,
                 fileName = cpiFileName,
                 fileChecksum = checksum.toString(),
@@ -287,7 +288,14 @@ class DatabaseChunkPersistence(private val entityManagerFactory: EntityManagerFa
             version,
             signerSummaryHash
         )
-        return entityManager.find(CpiMetadataEntity::class.java, primaryKey)
+
+        return entityManager.find(
+            CpiMetadataEntity::class.java,
+            primaryKey,
+            // In case of force update, we want the entity to change regardless of whether the CPI being uploaded
+            //  is identical to an existing.
+            //  OPTIMISTIC_FORCE_INCREMENT means the version number will always be bumped.
+            LockModeType.OPTIMISTIC_FORCE_INCREMENT)
     }
 
     private fun getCpiMetadataEntity(name: String, version: String, signerSummaryHash: String): CpiMetadataEntity? {

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -76,7 +76,10 @@ data class CpiMetadataEntity(
     @Column(name = "insert_ts", insertable = false, updatable = true)
     var insertTimestamp: Instant? = null,
     @Column(name = "is_deleted", nullable = false)
-    var isDeleted: Boolean = false
+    var isDeleted: Boolean = false,
+    @Version
+    @Column(name = "entity_version", nullable = false)
+    var entityVersion: Int = 0,
 ) {
     companion object {
         // Create a [CpiMetadataEntity] with CPKs as filename/metadata pairs
@@ -116,21 +119,18 @@ data class CpiMetadataEntity(
         }
     }
 
-    @Version
-    @Column(name = "entity_version", nullable = false)
-    var entityVersion: Int = 0
-
     @PreUpdate
     fun onUpdate() {
         insertTimestamp = Instant.now()
     }
 
     // return a clone of this object with the updated properties
-    fun createUpdated(
+    fun update(
         fileUploadRequestId: String,
         fileName: String,
         fileChecksum: String,
-        cpks: List<Pair<String, CpkMetadataEntity>>) =
+        cpks: List<Pair<String, CpkMetadataEntity>>
+    ) =
         this.copy(
             fileUploadRequestId = fileUploadRequestId,
             fileName = fileName,


### PR DESCRIPTION
Using JPA `merge` rather than `persist` as a CPI may contain a CPK that already exists.