### PR TITLE
CORE-4563 - Create group id if not defined

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/GroupPolicyParser.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/GroupPolicyParser.kt
@@ -6,7 +6,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import java.util.UUID
 
 object GroupPolicyParser {
-    private const val MGM_GROUP_ID = "CREATE_ID"
+    const val MGM_GROUP_ID = "CREATE_ID"
 
     fun groupId(groupPolicyJson: String): String {
         try {

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/GroupPolicyParser.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/GroupPolicyParser.kt
@@ -3,11 +3,15 @@ package net.corda.chunking.db.impl.validation
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import java.util.UUID
 
 object GroupPolicyParser {
+    private const val MGM_GROUP_ID = "CREATE_ID"
+
     fun groupId(groupPolicyJson: String): String {
         try {
-            return ObjectMapper().readTree(groupPolicyJson).get("groupId").asText()
+            val groupId = ObjectMapper().readTree(groupPolicyJson).get("groupId").asText()
+            return if (groupId == MGM_GROUP_ID) UUID.randomUUID().toString() else groupId
         } catch (e: NullPointerException) {
             throw CordaRuntimeException("Failed to parse group policy file - could not find `groupId` in the JSON", e)
         } catch (e: JsonParseException) {

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/GroupPolicyParserTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/GroupPolicyParserTest.kt
@@ -1,6 +1,7 @@
 package net.corda.chunking.db.impl
 
 import net.corda.chunking.db.impl.validation.GroupPolicyParser
+import net.corda.chunking.db.impl.validation.GroupPolicyParser.MGM_GROUP_ID
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -9,10 +10,6 @@ import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 internal class GroupPolicyParserTest {
-    companion object {
-        private const val MGM_GROUP_ID = "CREATE_ID"
-    }
-
     @Test
     fun `group policy parser can extract group id`() {
         val groupId = UUID.randomUUID().toString()

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/GroupPolicyParserTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/GroupPolicyParserTest.kt
@@ -9,6 +9,10 @@ import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 internal class GroupPolicyParserTest {
+    companion object {
+        private const val MGM_GROUP_ID = "CREATE_ID"
+    }
+
     @Test
     fun `group policy parser can extract group id`() {
         val groupId = UUID.randomUUID().toString()
@@ -24,5 +28,12 @@ internal class GroupPolicyParserTest {
         assertThrows<CordaRuntimeException> {
             GroupPolicyParser.groupId(groupPolicyJson)
         }
+    }
+
+    @Test
+    fun `group policy parser generates group id when not defined for MGM`() {
+        val groupPolicyJson = """{ "groupId" : "$MGM_GROUP_ID"}"""
+        val groupId = GroupPolicyParser.groupId(groupPolicyJson)
+        assertThat(groupId).isNotEqualTo(MGM_GROUP_ID)
     }
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-4563

Testing using local kubernetes deployment:
Used the sample MGM Group Policy defined [here](https://github.com/corda/platform-eng-design/blob/6fd58060e94b649bb979df79364b787133d60794/core/corda-5/corda-5.0/the-host/group-policy.md).
After uploading the cpb and creating the virtual node, the database tables looked like this:
<img width="1609" alt="Screenshot 2022-05-31 at 16 50 22" src="https://user-images.githubusercontent.com/61757742/171366050-483c068f-eaf0-44f5-a213-cfd433cfd0c1.png">
<img width="1253" alt="Screenshot 2022-05-31 at 16 51 48" src="https://user-images.githubusercontent.com/61757742/171366065-349d05b8-c53d-4b8a-adfb-7f0ce70bd92c.png">
You can see that in the group policy column we have `CREATE_ID` group ID. But as final group ID we got the generated group ID in both `cpi` and `holding_identity` tables.
