### PR TITLE
CORE-5014 Config Kafka/DB Reconciliation Readers

### DIFF
--- a/components/configuration/configuration-read-service/build.gradle
+++ b/components/configuration/configuration-read-service/build.gradle
@@ -9,9 +9,11 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
+    api project(":components:reconciliation:reconciliation")
     api project(":libs:configuration:configuration-core")
     api project(":libs:lifecycle:lifecycle")
     api "com.typesafe:config:$typeSafeConfigVersion"

--- a/components/configuration/configuration-read-service/src/main/java/net/corda/configuration/read/reconcile/package-info.java
+++ b/components/configuration/configuration-read-service/src/main/java/net/corda/configuration/read/reconcile/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.configuration.read.reconcile;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/configuration/configuration-read-service/src/main/kotlin/net/corda/configuration/read/reconcile/ConfigReconcilerReader.kt
+++ b/components/configuration/configuration-read-service/src/main/kotlin/net/corda/configuration/read/reconcile/ConfigReconcilerReader.kt
@@ -1,0 +1,11 @@
+package net.corda.configuration.read.reconcile
+
+import net.corda.data.config.Configuration
+import net.corda.reconciliation.ReconcilerReader
+
+/**
+ * A message bus reconciler reader for [Configuration].
+ *
+ * Fetches all <ConfigurationSection: String, [Configuration]> from [CONFIG_TOPIC] to be used for reconciliation.
+ */
+interface ConfigReconcilerReader : ReconcilerReader<String, Configuration>

--- a/components/configuration/configuration-write-service/src/main/kotlin/net/corda/configuration/write/publish/ConfigPublishService.kt
+++ b/components/configuration/configuration-write-service/src/main/kotlin/net/corda/configuration/write/publish/ConfigPublishService.kt
@@ -6,7 +6,7 @@ import net.corda.lifecycle.Lifecycle
 import net.corda.reconciliation.ReconcilerWriter
 
 /**
- * Configuration publisher interface. [ConfigurationDto] contains its own key, [ConfigurationDto.section].
+ * Configuration publisher interface.
  *
  * Because it is being used by [ConfigWriteService] which needs boot config, [ConfigPublishService] needs
  * also boot config. It cannot wait for dynamic config because that would mean a deadlock, i.e.

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
@@ -157,7 +157,7 @@ open class TestBase {
             this.publish(listOf(Record(
                 CONFIG_TOPIC,
                 "p2p.gateway",
-                Configuration(config.root().render(ConfigRenderOptions.concise()), "0.1", ConfigurationSchemaVersion(1, 0))
+                Configuration(config.root().render(ConfigRenderOptions.concise()), "0", ConfigurationSchemaVersion(1, 0))
             ))).forEach { it.get() }
         }
 

--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
@@ -84,7 +84,7 @@ class LinkManagerIntegrationTest {
         this.publish(listOf(Record(
             Schemas.Config.CONFIG_TOPIC,
             "${LinkManagerConfiguration.PACKAGE_NAME}.${LinkManagerConfiguration.COMPONENT_NAME}",
-            Configuration(config.root().render(ConfigRenderOptions.concise()), "0.1", ConfigurationSchemaVersion(1, 0))
+            Configuration(config.root().render(ConfigRenderOptions.concise()), "0", ConfigurationSchemaVersion(1, 0))
         ))).forEach { it.get() }
     }
 

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -387,7 +387,7 @@ class P2PLayerEndToEndTest {
             this.publish(listOf(Record(
                 CONFIG_TOPIC,
                 key,
-                Configuration(config.root().render(ConfigRenderOptions.concise()), "0.1", ConfigurationSchemaVersion(1, 0))
+                Configuration(config.root().render(ConfigRenderOptions.concise()), "0", ConfigurationSchemaVersion(1, 0))
             ))).forEach { it.get() }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XX-SNAPSHOT
-cordaApiVersion=5.0.0.108-beta+
+cordaApiVersion=5.0.0.109-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigEntity.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigEntity.kt
@@ -3,6 +3,7 @@ package net.corda.libs.configuration.datamodel
 import java.time.Instant
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EntityManager
 import javax.persistence.Id
 import javax.persistence.Table
 import javax.persistence.Version
@@ -36,7 +37,9 @@ data class ConfigEntity(
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,
     @Column(name = "update_actor", nullable = false)
-    var updateActor: String
+    var updateActor: String,
+    @Column(name = "is_deleted", nullable = false)
+    val isDeleted: Boolean = false
 ) {
     @Version
     @Column(name = "version", nullable = false)
@@ -51,3 +54,9 @@ data class ConfigEntity(
         updateActor = configEntity.updateActor
     }
 }
+
+fun EntityManager.findAllConfig() =
+    createQuery(
+        "FROM ${ConfigEntity::class.simpleName}",
+        ConfigEntity::class.java
+    ).resultStream

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigDbReconcilerReader.kt
@@ -1,0 +1,24 @@
+package net.corda.processors.db.internal.reconcile.db
+
+import java.util.stream.Stream
+import javax.persistence.EntityManager
+import net.corda.data.config.Configuration
+import net.corda.data.config.ConfigurationSchemaVersion
+import net.corda.libs.configuration.datamodel.findAllConfig
+import net.corda.reconciliation.VersionedRecord
+
+val getAllConfigDBVersionedRecords: (EntityManager) -> Stream<VersionedRecord<String, Configuration>> = { em ->
+    em.findAllConfig().map { configEntity ->
+        val config = Configuration(
+            configEntity.config,
+            configEntity.version.toString(),
+            ConfigurationSchemaVersion(configEntity.schemaVersionMajor, configEntity.schemaVersionMinor)
+        )
+        object : VersionedRecord<String, Configuration> {
+            override val version = configEntity.version
+            override val isDeleted = configEntity.isDeleted
+            override val key = configEntity.section
+            override val value = config
+        }
+    }
+}

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReader.kt
@@ -1,0 +1,45 @@
+package net.corda.processors.db.internal.reconcile.db
+
+import java.time.Instant
+import java.util.stream.Stream
+import javax.persistence.EntityManager
+import net.corda.reconciliation.VersionedRecord
+import net.corda.libs.cpi.datamodel.findAllCpiMetadata
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpiMetadata
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.v5.crypto.SecureHash
+
+val getAllCpiInfoDBVersionedRecords: (EntityManager) -> Stream<VersionedRecord<CpiIdentifier, CpiMetadata>> = { em ->
+    em.findAllCpiMetadata().map { cpiMetadataEntity ->
+        val cpiId = CpiIdentifier(
+            cpiMetadataEntity.name,
+            cpiMetadataEntity.version,
+            if (cpiMetadataEntity.signerSummaryHash != "")
+                SecureHash.create(cpiMetadataEntity.signerSummaryHash)
+            else
+                null
+        )
+        object : VersionedRecord<CpiIdentifier, CpiMetadata> {
+            override val version = cpiMetadataEntity.entityVersion
+            override val isDeleted = cpiMetadataEntity.isDeleted
+            override val key = cpiId
+            override val value by lazy {
+                CpiMetadata(
+                    cpiId = cpiId,
+                    fileChecksum = SecureHash.create(cpiMetadataEntity.fileChecksum),
+                    cpksMetadata = cpiMetadataEntity.cpks.map {
+                        CpkMetadata.fromJsonAvro(it.metadata.serializedMetadata)
+                    },
+                    groupPolicy = cpiMetadataEntity.groupPolicy,
+                    version = cpiMetadataEntity.entityVersion,
+                    timestamp = cpiMetadataEntity.insertTimestamp.getOrNow()
+                )
+            }
+        }
+    }
+}
+
+private fun Instant?.getOrNow(): Instant {
+    return this ?: Instant.now()
+}


### PR DESCRIPTION
- makes `ConfigurationReadService` a config reconciler Kafka reader.
- introduces config reconciler DB reader.
- abstracts out common code for DB readers.
- adds `is_deleted` column/ property for config. 

Relies on [#389](https://github.com/corda/corda-api/pull/389).