### PR TITLE
CORE-5045 Register custom internal AMQP serializers in flow worker

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
@@ -12,6 +12,7 @@ import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
+import net.corda.internal.serialization.registerCustomSerializers
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.sandbox.SandboxGroup
@@ -161,6 +162,9 @@ class FlowSandboxServiceImpl @Activate constructor(
 
     private fun MutableSandboxGroupContext.putAMQPSerializationEnvironment(cpiMetadata: CpiMetadata) {
         val factory = SerializerFactoryBuilder.build(sandboxGroup)
+
+        registerCustomSerializers(factory)
+
         for (customSerializer in internalCustomSerializers) {
             log.info("Registering internal serializer {}", customSerializer.javaClass.name)
             factory.register(customSerializer, factory)


### PR DESCRIPTION
Call `AMQPSerializationScheme.registerCustomSerializers` in
`FlowSandboxServiceImpl` as it was incorrectly trying to scan for
serializers which are not currently OSGi components and
`ThrowableSerializer` couldn't be converted as it had a constructor
argument.

Remove now unused code from `EntitySandboxServiceImpl` and
`FlowSandboxServiceImpl`.