### PR TITLE
NOTICK: Remove privileged functions from BundleUtils.

### DIFF
--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
@@ -4,11 +4,14 @@ import java.nio.file.Path
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
@@ -22,6 +25,7 @@ import org.osgi.test.junit5.service.ServiceExtension
 /** Tests the isolation of bundles across sandbox groups. */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
+@Suppress("FunctionName")
 class SandboxBundleIsolationTest {
     @RegisterExtension
     private val lifecycle = AllTestsLifecycle()
@@ -66,5 +70,26 @@ class SandboxBundleIsolationTest {
         val bundles = runFlow<List<Bundle>>(thisGroup, BUNDLES_FLOW)
 
         assertTrue(bundles.none { bundle -> sandboxGroupContainsBundle(otherGroup, bundle) })
+    }
+
+    @Test
+    fun `we can load two copies of the same sandbox`() {
+        val copyOne = assertDoesNotThrow {
+            sandboxFactory.createSandboxGroupFor(CPI_ONE)
+        }
+        try {
+            assertEquals(sandboxFactory.group1.metadata.keys.names, copyOne.metadata.keys.names)
+            assertNotEquals(sandboxFactory.group1.metadata.keys.ids, copyOne.metadata.keys.ids)
+        } finally {
+            sandboxFactory.destroySandboxGroup(copyOne)
+        }
+    }
+
+    private val Iterable<Bundle>.names: Set<String> get() {
+        return mapTo(LinkedHashSet()) { "${it.symbolicName}:${it.version}" }
+    }
+
+    private val Iterable<Bundle>.ids: Set<Long> get() {
+        return mapTo(LinkedHashSet(), Bundle::getBundleId)
     }
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
@@ -2,17 +2,12 @@ package net.corda.sandbox.internal.utilities
 
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
-import org.osgi.framework.BundleException
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.runtime.ServiceComponentRuntime
-import java.io.InputStream
-import java.security.AccessController.doPrivileged
-import java.security.PrivilegedActionException
-import java.security.PrivilegedExceptionAction
 
 /** Handles bundle operations for the `SandboxCreationService` and the `SandboxContextService`. */
 @Component(service = [BundleUtils::class])
@@ -22,38 +17,6 @@ internal class BundleUtils @Activate constructor(
     private val bundleContext: BundleContext
 ) {
     private val systemBundle = bundleContext.getBundle(SYSTEM_BUNDLE_ID)
-
-    /**
-     * Installs the contents of the [inputStream] as a bundle, using the [location] provided.
-     *
-     * A [BundleException] is thrown if the bundle fails to install.
-     */
-    fun installAsBundle(location: String, inputStream: InputStream): Bundle = inputStream.use {
-        // CorDapp code will call this method indirectly when creating transaction verification sandboxes. The use of
-        // `doPrivileged` here prevents the limited permissions of the calling code (i.e. the CorDapp code) from
-        // causing this operation to be denied.
-        try {
-            doPrivileged(PrivilegedExceptionAction {
-                bundleContext.installBundle(location, it)
-            })
-        } catch (e: PrivilegedActionException) {
-            throw e.exception
-        }
-    }
-
-    /**
-     * Starts the [bundle].
-     *
-     * A [BundleException] is thrown if the bundle fails to start.
-     */
-    fun startBundle(bundle: Bundle): Unit = try {
-        // CorDapp code will call this method indirectly when creating transaction verification sandboxes. The use of
-        // `doPrivileged` here prevents the limited permissions of the calling code (i.e. the CorDapp code) from 
-        // causing this operation to be denied.
-        doPrivileged(PrivilegedExceptionAction(bundle::start))
-    } catch (e: PrivilegedActionException) {
-        throw e.exception
-    }
 
     /** Returns the bundle from which [klass] is loaded, or null if there is no such bundle. */
     fun getBundle(klass: Class<*>): Bundle? = FrameworkUtil.getBundle(klass) ?: try {

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.osgi.framework.Bundle
+import org.osgi.framework.BundleContext
 import org.osgi.framework.BundleException
 import java.io.ByteArrayInputStream
 import java.nio.file.Paths
@@ -37,6 +38,7 @@ import kotlin.random.Random.Default.nextBytes
 class SandboxServiceImplTests {
     private val frameworkBundle = mockBundle("org.apache.felix.framework")
     private val scrBundle = mockBundle("org.apache.felix.scr")
+    private val bundleContext = mock<BundleContext>()
 
     private val cpkAndContentsOne = CpkAndContents(String::class.java, Boolean::class.java)
     private val cpkOne = cpkAndContentsOne.cpk
@@ -59,7 +61,7 @@ class SandboxServiceImplTests {
      * @param cpksAndContents Used to set up the mock [BundleUtils] that back the sandbox service
      */
     private fun createSandboxService(cpksAndContents: Collection<CpkAndContents>) =
-        SandboxServiceImpl(mockBundleUtils(cpksAndContents))
+        SandboxServiceImpl(mockBundleUtils(cpksAndContents), bundleContext)
 
     /** Mocks a [BundleUtils] that tracks which bundles have been started and uninstalled so far. */
     private fun mockBundleUtils(
@@ -76,7 +78,7 @@ class SandboxServiceImplTests {
             val mainBundlePath = contents.cpk.metadata.mainBundle
             val libPath = contents.cpk.metadata.libraries.single()
 
-            whenever(installAsBundle(argThat { endsWith(mainBundlePath) || endsWith(libPath) }, any())).then { answer ->
+            whenever(bundleContext.installBundle(argThat { endsWith(mainBundlePath) || endsWith(libPath) }, any())).then { answer ->
                 val bundleLocation = answer.arguments.first() as String
                 val (bundleName, bundleClass) = if (bundleLocation.endsWith(mainBundlePath)) {
                     contents.mainBundleName to contents.mainBundleClass
@@ -88,7 +90,7 @@ class SandboxServiceImplTests {
 
                 val bundle = mockBundle(bundleName, bundleClass, bundleLocation)
                 whenever(getBundle(bundleClass)).thenReturn(bundle)
-                whenever(startBundle(bundle)).then {
+                whenever(bundle.start()).then {
                     if (bundleName in notStartableBundles) throw BundleException("Start")
                     startedBundles.add(bundle)
                 }
@@ -149,7 +151,7 @@ class SandboxServiceImplTests {
             setOf(cpkAndContentsOne),
             notInstallableBundles = setOf(cpkAndContentsOne.mainBundleName!!)
         )
-        val sandboxService = SandboxServiceImpl(mockBundleUtils)
+        val sandboxService = SandboxServiceImpl(mockBundleUtils, bundleContext)
 
         val e = assertThrows<SandboxException> {
             sandboxService.createSandboxGroup(setOf(cpkOne))
@@ -161,7 +163,8 @@ class SandboxServiceImplTests {
     fun `throws if a CPK's main bundle does not have a symbolic name`() {
         val cpkAndContentsWithBadMainBundle = cpkAndContentsOne.copy(mainBundleName = null)
         val sandboxService = SandboxServiceImpl(
-            mockBundleUtils(setOf(cpkAndContentsWithBadMainBundle))
+            mockBundleUtils(setOf(cpkAndContentsWithBadMainBundle)),
+            bundleContext
         )
 
         val e = assertThrows<SandboxException> {
@@ -174,7 +177,8 @@ class SandboxServiceImplTests {
     fun `throws if a CPK's library bundle does not have a symbolic name`() {
         val cpkAndContentsWithBadLibraryBundle = cpkAndContentsOne.copy(libraryBundleName = null)
         val sandboxService = SandboxServiceImpl(
-            mockBundleUtils(setOf(cpkAndContentsWithBadLibraryBundle))
+            mockBundleUtils(setOf(cpkAndContentsWithBadLibraryBundle)),
+            bundleContext
         )
 
         val e = assertThrows<SandboxException> {
@@ -189,7 +193,7 @@ class SandboxServiceImplTests {
             setOf(cpkAndContentsOne),
             notStartableBundles = setOf(cpkAndContentsOne.mainBundleName!!)
         )
-        val sandboxService = SandboxServiceImpl(mockBundleUtils)
+        val sandboxService = SandboxServiceImpl(mockBundleUtils, bundleContext)
 
         val e = assertThrows<SandboxException> {
             sandboxService.createSandboxGroup(setOf(cpkOne))
@@ -203,7 +207,7 @@ class SandboxServiceImplTests {
             setOf(cpkAndContentsOne),
             notStartableBundles = setOf(cpkAndContentsOne.libraryBundleName!!)
         )
-        val sandboxService = SandboxServiceImpl(mockBundleUtils)
+        val sandboxService = SandboxServiceImpl(mockBundleUtils, bundleContext)
 
         val e = assertThrows<SandboxException> {
             sandboxService.createSandboxGroup(setOf(cpkOne))
@@ -322,7 +326,7 @@ class SandboxServiceImplTests {
             whenever(allBundles).thenReturn(listOf(frameworkBundle))
         }
 
-        val e = assertThrows<SandboxException> { SandboxServiceImpl(mockBundleUtils) }
+        val e = assertThrows<SandboxException> { SandboxServiceImpl(mockBundleUtils, bundleContext) }
         assertEquals(
             "The sandbox service cannot run without the Service Component Runtime bundle installed.",
             e.message
@@ -335,7 +339,7 @@ class SandboxServiceImplTests {
             whenever(getServiceRuntimeComponentBundle()).thenReturn(scrBundle)
         }
 
-        val sandboxService = SandboxServiceImpl(mockBundleUtils)
+        val sandboxService = SandboxServiceImpl(mockBundleUtils, bundleContext)
         val sandboxGroup = sandboxService.createSandboxGroup(setOf(cpkOne))
         val sandboxMainBundle = (sandboxGroup as SandboxGroupInternal).cpkSandboxes.single().mainBundle
 
@@ -350,7 +354,7 @@ class SandboxServiceImplTests {
             whenever(getBundle(any())).thenReturn(mock())
         }
 
-        val sandboxService = SandboxServiceImpl(mockBundleUtils)
+        val sandboxService = SandboxServiceImpl(mockBundleUtils, bundleContext)
         sandboxService.createSandboxGroup(setOf(cpkOne))
 
         assertNull(sandboxService.getCallingSandboxGroup())
@@ -377,7 +381,8 @@ class SandboxServiceImplTests {
             mockBundleUtils(
                 setOf(cpkAndContentsOne),
                 notUninstallableBundles = setOf(cpkAndContentsOne.mainBundleName!!)
-            )
+            ),
+            bundleContext
         )
 
         val sandboxGroup = sandboxService.createSandboxGroup(setOf(cpkOne))
@@ -392,7 +397,8 @@ class SandboxServiceImplTests {
             mockBundleUtils(
                 setOf(cpkAndContentsOne),
                 notUninstallableBundles = setOf(cpkAndContentsOne.mainBundleName!!)
-            )
+            ),
+            bundleContext
         )
 
         val sandboxGroup = sandboxService.createSandboxGroup(setOf(cpkOne))


### PR DESCRIPTION
Remove privileged utility functions for installing sandboxes and starting bundles. In fact, why would we ever want to create sandboxes from unprivileged code in the first place?

Also add test for loading two co-existing sandboxes from the same CPB.