### PR TITLE
CORE-4557: Refactor member key properties based on key design

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeMembershipGroupReaderProvider.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeMembershipGroupReaderProvider.kt
@@ -55,7 +55,7 @@ class FakeMembershipGroupReaderProvider : MembershipGroupReaderProvider {
             TODO("Not yet implemented")
         }
 
-        override fun lookup(publicKeyHash: PublicKeyHash): MemberInfo? {
+        override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? {
             TODO("Not yet implemented")
         }
 

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
@@ -1,7 +1,7 @@
 package net.corda.membership.impl.read.reader
 
 import net.corda.membership.CPIWhiteList
-import net.corda.membership.impl.MemberInfoExtension.Companion.identityKeyHashes
+import net.corda.membership.impl.MemberInfoExtension.Companion.ledgerKeyHashes
 import net.corda.membership.impl.read.cache.MembershipGroupReadCache
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.v5.crypto.PublicKeyHash
@@ -30,7 +30,7 @@ class MembershipGroupReaderImpl(
     override fun lookup(): Collection<MemberInfo> = memberList.filter { it.isActive }
 
     override fun lookup(publicKeyHash: PublicKeyHash): MemberInfo? =
-        memberList.singleOrNull { it.isActive && publicKeyHash in it.identityKeyHashes }
+        memberList.singleOrNull { it.isActive && publicKeyHash in it.ledgerKeyHashes }
 
     override fun lookup(name: MemberX500Name) = memberList.singleOrNull { it.isActive && it.name == name }
 }

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
@@ -29,8 +29,8 @@ class MembershipGroupReaderImpl(
 
     override fun lookup(): Collection<MemberInfo> = memberList.filter { it.isActive }
 
-    override fun lookup(publicKeyHash: PublicKeyHash): MemberInfo? =
-        memberList.singleOrNull { it.isActive && publicKeyHash in it.ledgerKeyHashes }
+    override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? =
+        memberList.singleOrNull { it.isActive && ledgerKeyHash in it.ledgerKeyHashes }
 
     override fun lookup(name: MemberX500Name) = memberList.singleOrNull { it.isActive && it.name == name }
 }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -1,6 +1,6 @@
 package net.corda.membership.impl.read.reader
 
-import net.corda.membership.impl.MemberInfoExtension.Companion.IDENTITY_KEY_HASHES
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEY_HASHES
 import net.corda.membership.impl.read.TestProperties
 import net.corda.membership.impl.read.TestProperties.Companion.GROUP_ID_1
 import net.corda.membership.impl.read.cache.MemberListCache
@@ -35,9 +35,9 @@ class MembershipGroupReaderImplTest {
     private val knownKeyHash = PublicKeyHash.parse(knownKeyAsByteArray.sha256Bytes())
     private val suspendedMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
-        on { identityKeys } doReturn listOf(knownKey)
+        on { ledgerKeys } doReturn listOf(knownKey)
         val mockedMemberProvidedContext = mock<MemberContext> {
-            on { parseSet(eq(IDENTITY_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(knownKeyHash)
+            on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(knownKeyHash)
         }
         on { memberProvidedContext } doReturn mockedMemberProvidedContext
         on { isActive } doReturn false
@@ -45,9 +45,9 @@ class MembershipGroupReaderImplTest {
 
     private val activeMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
-        on { identityKeys } doReturn listOf(knownKey)
+        on { ledgerKeys } doReturn listOf(knownKey)
         val mockedMemberProvidedContext = mock<MemberContext> {
-            on { parseSet(eq(IDENTITY_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(knownKeyHash)
+            on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(knownKeyHash)
         }
         on { memberProvidedContext } doReturn mockedMemberProvidedContext
         on { isActive } doReturn true

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
@@ -9,13 +9,13 @@ import net.corda.membership.impl.EndpointInfoImpl
 import net.corda.membership.impl.MGMContextImpl
 import net.corda.membership.impl.MemberContextImpl
 import net.corda.membership.impl.MemberInfoExtension.Companion.GROUP_ID
-import net.corda.membership.impl.MemberInfoExtension.Companion.IDENTITY_KEYS_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
 import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.impl.MemberInfoExtension.Companion.MODIFIED_TIME
 import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_NAME
-import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_OWNING_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.impl.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.SERIAL
@@ -51,7 +51,7 @@ class MemberListProcessorTest {
             EndpointInfoImpl("https://corda5.r3.com:10000", EndpointInfo.DEFAULT_PROTOCOL_VERSION),
             EndpointInfoImpl("https://corda5.r3.com:10001", 10)
         )
-        private val identityKeys = listOf(knownKey, knownKey)
+        private val ledgerKeys = listOf(knownKey, knownKey)
         private lateinit var layeredPropertyMapFactory: LayeredPropertyMapFactory
         private val converters = listOf(
             EndpointInfoConverter(),
@@ -75,7 +75,7 @@ class MemberListProcessorTest {
             memberProvidedContext = layeredPropertyMapFactory.create<MemberContextImpl>(
                 sortedMapOf(
                     PARTY_NAME to x500Name,
-                    PARTY_OWNING_KEY to knownKeyAsString,
+                    PARTY_SESSION_KEY to knownKeyAsString,
                     GROUP_ID to "DEFAULT_MEMBER_GROUP_ID",
                     *convertPublicKeys().toTypedArray(),
                     *convertEndpoints().toTypedArray(),
@@ -135,11 +135,11 @@ class MemberListProcessorTest {
         }
 
         private fun convertPublicKeys(): List<Pair<String, String>> =
-            identityKeys.mapIndexed { index, identityKey ->
+            ledgerKeys.mapIndexed { index, ledgerKey ->
                 String.format(
-                    IDENTITY_KEYS_KEY,
+                    LEDGER_KEYS_KEY,
                     index
-                ) to keyEncodingService.encodeAsString(identityKey)
+                ) to keyEncodingService.encodeAsString(ledgerKey)
             }
 
         @JvmStatic

--- a/components/membership/membership-group-read/src/main/kotlin/net/corda/membership/read/MembershipGroupReader.kt
+++ b/components/membership/membership-group-read/src/main/kotlin/net/corda/membership/read/MembershipGroupReader.kt
@@ -43,9 +43,9 @@ interface MembershipGroupReader {
      *
      * If the member is not found then the null value is returned.
      *
-     * @param publicKeyHash Public key hash for the member to lookup.
+     * @param ledgerKeyHash Hash of the ledger key belonging to the member to be looked up.
      */
-    fun lookup(publicKeyHash: PublicKeyHash): MemberInfo?
+    fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo?
 
     /**
      * Looks up a group member matching the [MemberX500Name] as visible by the member represented

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsTest.kt
@@ -16,7 +16,7 @@ import net.corda.membership.impl.MemberInfoExtension
 import net.corda.membership.impl.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_NAME
-import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_OWNING_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.impl.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.impl.MemberInfoExtension.Companion.SOFTWARE_VERSION
@@ -110,7 +110,7 @@ class MemberLookupRpcOpsTest {
         memberProvidedContext = layeredPropertyMapFactory.create<MemberContextImpl>(
             sortedMapOf(
                 PARTY_NAME to name,
-                PARTY_OWNING_KEY to KNOWN_KEY,
+                PARTY_SESSION_KEY to KNOWN_KEY,
                 GROUP_ID to "DEFAULT_MEMBER_GROUP_ID",
                 *convertPublicKeys().toTypedArray(),
                 *convertEndpoints().toTypedArray(),
@@ -128,11 +128,11 @@ class MemberLookupRpcOpsTest {
     )
 
     private fun convertPublicKeys(): List<Pair<String, String>> =
-        keys.mapIndexed { index, identityKey ->
+        keys.mapIndexed { index, ledgerKey ->
             String.format(
-                MemberInfoExtension.IDENTITY_KEYS_KEY,
+                MemberInfoExtension.LEDGER_KEYS_KEY,
                 index
-            ) to keyEncodingService.encodeAsString(identityKey)
+            ) to keyEncodingService.encodeAsString(ledgerKey)
         }
 
     private fun convertEndpoints(): List<Pair<String, String>> {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -20,7 +20,7 @@ import net.corda.membership.impl.MemberContextImpl
 import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.impl.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.impl.MemberInfoExtension.Companion.groupId
-import net.corda.membership.impl.MemberInfoExtension.Companion.identityKeyHashes
+import net.corda.membership.impl.MemberInfoExtension.Companion.ledgerKeyHashes
 import net.corda.membership.impl.MemberInfoExtension.Companion.modifiedTime
 import net.corda.membership.impl.MemberInfoExtension.Companion.softwareVersion
 import net.corda.membership.impl.MemberInfoExtension.Companion.status
@@ -125,8 +125,7 @@ class StaticMemberRegistrationServiceTest {
 
     private val cryptoOpsClient: CryptoOpsClient = mock {
         on { generateKeyPair(any(), any(), any(), any(), any<Map<String, String>>()) } doReturn defaultKey
-        on { generateKeyPair(any(), any(), eq("alice-alias"), any(), any<Map<String, String>>()) } doReturn aliceKey
-        // when no keyAlias is defined in static template, we are using the HoldingIdentity's id
+        on { generateKeyPair(any(), any(), eq(aliceId), any(), any<Map<String, String>>()) } doReturn aliceKey
         on { generateKeyPair(any(), any(), eq(bobId), any(), any<Map<String, String>>()) } doReturn bobKey
         on { generateKeyPair(any(), any(), eq(charlieId), any(), any<Map<String, String>>()) } doReturn charlieKey
     }
@@ -231,10 +230,10 @@ class StaticMemberRegistrationServiceTest {
         assertNotNull(memberPublished.serial)
         assertNotNull(memberPublished.modifiedTime)
 
-        assertEquals(aliceKey, memberPublished.owningKey)
-        assertEquals(1, memberPublished.identityKeys.size)
-        assertEquals(1, memberPublished.identityKeyHashes.size)
-        assertEquals(aliceKey.calculateHash(), memberPublished.identityKeyHashes.first())
+        assertEquals(aliceKey, memberPublished.sessionInitiationKey)
+        assertEquals(1, memberPublished.ledgerKeys.size)
+        assertEquals(1, memberPublished.ledgerKeyHashes.size)
+        assertEquals(aliceKey.calculateHash(), memberPublished.ledgerKeyHashes.first())
         assertEquals(MEMBER_STATUS_ACTIVE, memberPublished.status)
         assertEquals(1, memberPublished.endpoints.size)
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -153,7 +153,7 @@ class VirtualNodeWriterProcessorTests {
     private val layeredPropertyMapFactory: LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(
         listOf(EndpointInfoConverter(), PublicKeyConverter(keyEncodingService), PublicKeyHashConverter())
     )
-    private val groupPolicyParser =  GroupPolicyParser(keyEncodingService, layeredPropertyMapFactory)
+    private val groupPolicyParser =  GroupPolicyParser(layeredPropertyMapFactory)
 
     private val publisherError = CordaMessageAPIIntermittentException("Error.")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.110-beta+
+cordaApiVersion=5.0.0.111-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22

--- a/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapImpl.kt
+++ b/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapImpl.kt
@@ -124,7 +124,7 @@ class LayeredPropertyMapImpl(
         // then convert it to a map one by one and pass it to the converter
         // 1 -> [corda.endpoints.1.url=localhost, corda.endpoints.1.protocolVersion=1]
         // 2 -> [corda.endpoints.2.url=localhost, corda.endpoints.2.protocolVersion=1]
-        // 1 -> [corda.identityKeys.1=ABC]
+        // 1 -> [corda.ledgerKeys.1=ABC]
         val result = entryList.groupBy {
             getIndexedPrefix(it.key, normalisedPrefix)
         }.toSortedMap(indexedPrefixComparator).map { groupedEntry ->

--- a/libs/membership/ledger-identity/src/main/kotlin/net/corda/membership/ledger/identity/converter/PartyConverter.kt
+++ b/libs/membership/ledger-identity/src/main/kotlin/net/corda/membership/ledger/identity/converter/PartyConverter.kt
@@ -21,7 +21,7 @@ class PartyConverter @Activate constructor(
 ) : CustomPropertyConverter<Party> {
     companion object {
         private const val NAME = "name"
-        private const val OWNING_KEY = "owningKey"
+        private const val SESSION_KEY = "sessionInitiationKey"
     }
 
     override val type: Class<Party>
@@ -32,8 +32,8 @@ class PartyConverter @Activate constructor(
             name = context.value(NAME)?.let {
                 MemberX500Name.parse(it)
             } ?: throw ValueNotFoundException("'$NAME' is null or missing"),
-            owningKey = context.value(OWNING_KEY)?.let {
+            owningKey = context.value(SESSION_KEY)?.let {
                 keyEncodingService.decodePublicKey(it)
-            } ?: throw ValueNotFoundException("'$OWNING_KEY' is null or missing")
+            } ?: throw ValueNotFoundException("'$SESSION_KEY' is null or missing")
         )
 }

--- a/libs/membership/ledger-identity/src/main/kotlin/net/corda/membership/ledger/identity/converter/PartyConverter.kt
+++ b/libs/membership/ledger-identity/src/main/kotlin/net/corda/membership/ledger/identity/converter/PartyConverter.kt
@@ -21,7 +21,7 @@ class PartyConverter @Activate constructor(
 ) : CustomPropertyConverter<Party> {
     companion object {
         private const val NAME = "name"
-        private const val SESSION_KEY = "sessionInitiationKey"
+        private const val SESSION_KEY = "session.key"
     }
 
     override val type: Class<Party>

--- a/libs/membership/ledger-identity/src/test/kotlin/net/corda/membership/ledger/identity/converter/PartyConverterTest.kt
+++ b/libs/membership/ledger-identity/src/test/kotlin/net/corda/membership/ledger/identity/converter/PartyConverterTest.kt
@@ -33,7 +33,7 @@ class PartyConverterTest {
                 MemberInfoExtension.PARTY_NAME to partyName,
                 MemberInfoExtension.PARTY_SESSION_KEY to KEY,
                 MemberInfoExtension.NOTARY_SERVICE_PARTY_NAME to notaryName,
-                MemberInfoExtension.NOTARY_SERVICE_PARTY_KEY to KEY
+                MemberInfoExtension.NOTARY_SERVICE_PARTY_SESSION_KEY to KEY
             )
         )
 

--- a/libs/membership/ledger-identity/src/test/kotlin/net/corda/membership/ledger/identity/converter/PartyConverterTest.kt
+++ b/libs/membership/ledger-identity/src/test/kotlin/net/corda/membership/ledger/identity/converter/PartyConverterTest.kt
@@ -21,7 +21,7 @@ class PartyConverterTest {
         private const val PARTY = "corda.party"
         private const val partyName = "O=Alice,L=London,C=GB"
         private const val notaryName = "O=Notary,L=London,C=GB"
-        private const val NOTARY_SERVICE_PARTY = "corda.notaryServiceParty"
+        private const val NOTARY_SERVICE_PARTY = "corda.notaryService"
         private const val KEY = "12345"
         private val key = Mockito.mock(PublicKey::class.java)
 
@@ -33,7 +33,7 @@ class PartyConverterTest {
                 MemberInfoExtension.PARTY_NAME to partyName,
                 MemberInfoExtension.PARTY_SESSION_KEY to KEY,
                 MemberInfoExtension.NOTARY_SERVICE_PARTY_NAME to notaryName,
-                MemberInfoExtension.NOTARY_SERVICE_PARTY_SESSION_KEY to KEY
+                MemberInfoExtension.NOTARY_SERVICE_SESSION_KEY to KEY
             )
         )
 

--- a/libs/membership/ledger-identity/src/test/kotlin/net/corda/membership/ledger/identity/converter/PartyConverterTest.kt
+++ b/libs/membership/ledger-identity/src/test/kotlin/net/corda/membership/ledger/identity/converter/PartyConverterTest.kt
@@ -31,7 +31,7 @@ class PartyConverterTest {
         val memberContext = layeredPropertyMapFactory.create<MemberContextImpl>(
             sortedMapOf(
                 MemberInfoExtension.PARTY_NAME to partyName,
-                MemberInfoExtension.PARTY_OWNING_KEY to KEY,
+                MemberInfoExtension.PARTY_SESSION_KEY to KEY,
                 MemberInfoExtension.NOTARY_SERVICE_PARTY_NAME to notaryName,
                 MemberInfoExtension.NOTARY_SERVICE_PARTY_KEY to KEY
             )

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
@@ -26,11 +26,11 @@ class MemberInfoExtension {
 
         /** Key name for party property. */
         const val PARTY_NAME = "corda.party.name"
-        const val PARTY_SESSION_KEY = "corda.party.sessionInitiationKey"
+        const val PARTY_SESSION_KEY = "corda.party.session.key"
 
         /** Key name for notary service property. */
-        const val NOTARY_SERVICE_PARTY_NAME = "corda.notaryServiceParty.name"
-        const val NOTARY_SERVICE_PARTY_SESSION_KEY = "corda.notaryServiceParty.sessionInitiationKey"
+        const val NOTARY_SERVICE_PARTY_NAME = "corda.notaryService.name"
+        const val NOTARY_SERVICE_SESSION_KEY = "corda.notaryService.session.key"
 
         /** Key name for serial property. */
         const val SERIAL = "corda.serial"

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
@@ -13,24 +13,24 @@ import java.time.Instant
 
 class MemberInfoExtension {
     companion object {
-        /** Key name for identity keys property. */
-        const val IDENTITY_KEYS = "corda.identityKeys"
-        const val IDENTITY_KEYS_KEY = "corda.identityKeys.%s"
+        /** Key name for ledger keys property. */
+        const val LEDGER_KEYS = "corda.ledgerKeys"
+        const val LEDGER_KEYS_KEY = "corda.ledgerKeys.%s"
 
-        /** Key name for identity key hashes property. */
-        const val IDENTITY_KEY_HASHES = "corda.identityKeyHashes"
-        const val IDENTITY_KEY_HASHES_KEY = "corda.identityKeyHashes.%s"
+        /** Key name for ledger key hashes property. */
+        const val LEDGER_KEY_HASHES = "corda.ledgerKeyHashes"
+        const val LEDGER_KEY_HASHES_KEY = "corda.ledgerKeyHashes.%s"
 
         /** Key name for platform version property. */
         const val PLATFORM_VERSION = "corda.platformVersion"
 
         /** Key name for party property. */
         const val PARTY_NAME = "corda.party.name"
-        const val PARTY_OWNING_KEY = "corda.party.owningKey"
+        const val PARTY_SESSION_KEY = "corda.party.sessionInitiationKey"
 
         /** Key name for notary service property. */
         const val NOTARY_SERVICE_PARTY_NAME = "corda.notaryServiceParty.name"
-        const val NOTARY_SERVICE_PARTY_KEY = "corda.notaryServiceParty.owningKey"
+        const val NOTARY_SERVICE_PARTY_KEY = "corda.notaryServiceParty.sessionInitiationKey"
 
         /** Key name for serial property. */
         const val SERIAL = "corda.serial"
@@ -127,10 +127,10 @@ class MemberInfoExtension {
         val MemberInfo.modifiedTime: Instant?
             get() = mgmProvidedContext.parse(MODIFIED_TIME)
 
-        /** Collection of identity key hashes for member's node. */
+        /** Collection of ledger key hashes for member's node. */
         @JvmStatic
-        val MemberInfo.identityKeyHashes: Collection<PublicKeyHash>
-            get() = memberProvidedContext.parseSet(IDENTITY_KEY_HASHES)
+        val MemberInfo.ledgerKeyHashes: Collection<PublicKeyHash>
+            get() = memberProvidedContext.parseSet(LEDGER_KEY_HASHES)
 
         /** Denotes whether this [MemberInfo] represents an MGM node. */
         @JvmStatic

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
@@ -30,7 +30,7 @@ class MemberInfoExtension {
 
         /** Key name for notary service property. */
         const val NOTARY_SERVICE_PARTY_NAME = "corda.notaryServiceParty.name"
-        const val NOTARY_SERVICE_PARTY_KEY = "corda.notaryServiceParty.sessionInitiationKey"
+        const val NOTARY_SERVICE_PARTY_SESSION_KEY = "corda.notaryServiceParty.sessionInitiationKey"
 
         /** Key name for serial property. */
         const val SERIAL = "corda.serial"

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoImpl.kt
@@ -1,9 +1,9 @@
 package net.corda.membership.impl
 
-import net.corda.membership.impl.MemberInfoExtension.Companion.IDENTITY_KEYS
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEYS
 import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_NAME
-import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_OWNING_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.impl.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.impl.MemberInfoExtension.Companion.STATUS
@@ -26,14 +26,13 @@ class MemberInfoImpl(
         require(endpoints.isNotEmpty()) { "Node must have at least one address." }
         require(platformVersion > 0) { "Platform version must be at least 1." }
         require(softwareVersion.isNotEmpty()) { "Node software version must not be blank." }
-        require(owningKey in identityKeys) { "Identity key must be in the key list." }
     }
 
     override val name: MemberX500Name get() = memberProvidedContext.parse(PARTY_NAME)
 
-    override val owningKey: PublicKey get() = memberProvidedContext.parse(PARTY_OWNING_KEY)
+    override val sessionInitiationKey: PublicKey get() = memberProvidedContext.parse(PARTY_SESSION_KEY)
 
-    override val identityKeys: List<PublicKey> get() = memberProvidedContext.parseList(IDENTITY_KEYS)
+    override val ledgerKeys: List<PublicKey> get() = memberProvidedContext.parseList(LEDGER_KEYS)
 
     override val platformVersion: Int get() = memberProvidedContext.parse(PLATFORM_VERSION)
 

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/converter/PublicKeyConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/converter/PublicKeyConverter.kt
@@ -22,7 +22,7 @@ class PublicKeyConverter @Activate constructor(
         get() = PublicKey::class.java
 
     /**
-     * Select the single element in case the structure is like 'corda.identityKeys.1'
+     * Select the single element in case the structure is like 'corda.ledgerKeys.1'
      */
     override fun convert(context: ConversionContext): PublicKey? =
         context.value()?.let { keyEncodingService.decodePublicKey(it) }

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/GroupPolicyParserTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/GroupPolicyParserTest.kt
@@ -183,6 +183,7 @@ class GroupPolicyParserTest {
             it.assertThat(mgmInfo.name.toString())
                 .isEqualTo("CN=Corda Network MGM, OU=MGM, O=Corda Network, L=London, C=GB")
             it.assertThat(mgmInfo.certificate.size).isEqualTo(3)
+            it.assertThat(mgmInfo.sessionInitiationKey).isNotNull
             it.assertThat(mgmInfo.ledgerKeys.size).isEqualTo(0)
             it.assertThat(mgmInfo.ledgerKeyHashes.size).isEqualTo(0)
             it.assertThat(mgmInfo.endpoints.size).isEqualTo(2)

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/GroupPolicyParserTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/GroupPolicyParserTest.kt
@@ -5,8 +5,8 @@ import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
 import net.corda.membership.exceptions.BadGroupPolicyException
 import net.corda.membership.impl.MemberInfoExtension.Companion.certificate
 import net.corda.membership.impl.MemberInfoExtension.Companion.endpoints
-import net.corda.membership.impl.MemberInfoExtension.Companion.identityKeyHashes
 import net.corda.membership.impl.MemberInfoExtension.Companion.isMgm
+import net.corda.membership.impl.MemberInfoExtension.Companion.ledgerKeyHashes
 import net.corda.membership.impl.MemberInfoExtension.Companion.softwareVersion
 import net.corda.membership.impl.converter.EndpointInfoConverter
 import net.corda.membership.impl.converter.PublicKeyConverter
@@ -79,7 +79,7 @@ class GroupPolicyParserTest {
 
     @BeforeEach
     fun setUp() {
-        groupPolicyParser = GroupPolicyParser(keyEncodingService, layeredPropertyMapFactory)
+        groupPolicyParser = GroupPolicyParser(layeredPropertyMapFactory)
     }
 
     @Test
@@ -183,8 +183,8 @@ class GroupPolicyParserTest {
             it.assertThat(mgmInfo.name.toString())
                 .isEqualTo("CN=Corda Network MGM, OU=MGM, O=Corda Network, L=London, C=GB")
             it.assertThat(mgmInfo.certificate.size).isEqualTo(3)
-            it.assertThat(mgmInfo.identityKeys.size).isEqualTo(1)
-            it.assertThat(mgmInfo.identityKeyHashes.size).isEqualTo(1)
+            it.assertThat(mgmInfo.ledgerKeys.size).isEqualTo(0)
+            it.assertThat(mgmInfo.ledgerKeyHashes.size).isEqualTo(0)
             it.assertThat(mgmInfo.endpoints.size).isEqualTo(2)
             it.assertThat(mgmInfo.platformVersion).isEqualTo(5000)
             it.assertThat(mgmInfo.softwareVersion).isEqualTo("5.0.0")

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/MemberInfoTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/MemberInfoTest.kt
@@ -6,12 +6,12 @@ import net.corda.data.membership.SignedMemberInfo
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.layeredpropertymap.toWire
 import net.corda.membership.impl.MemberInfoExtension.Companion.GROUP_ID
-import net.corda.membership.impl.MemberInfoExtension.Companion.IDENTITY_KEYS
-import net.corda.membership.impl.MemberInfoExtension.Companion.IDENTITY_KEYS_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEYS
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
 import net.corda.membership.impl.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.impl.MemberInfoExtension.Companion.MODIFIED_TIME
 import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_NAME
-import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_OWNING_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.impl.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.SERIAL
@@ -64,7 +64,7 @@ class MemberInfoTest {
             EndpointInfoImpl("https://localhost:10000", EndpointInfo.DEFAULT_PROTOCOL_VERSION),
             EndpointInfoImpl("https://google.com", 10)
         )
-        private val identityKeys = listOf(key, key)
+        private val ledgerKeys = listOf(key, key)
         private val testObjects = listOf(
             DummyObjectWithNumberAndText(1, "dummytext1"),
             DummyObjectWithNumberAndText(2, "dummytext2")
@@ -91,7 +91,7 @@ class MemberInfoTest {
             memberProvidedContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
                 sortedMapOf(
                     PARTY_NAME to "O=Alice,L=London,C=GB",
-                    PARTY_OWNING_KEY to KEY,
+                    PARTY_SESSION_KEY to KEY,
                     GROUP_ID to "DEFAULT_MEMBER_GROUP_ID",
                     *convertPublicKeys().toTypedArray(),
                     *convertEndpoints().toTypedArray(),
@@ -125,7 +125,7 @@ class MemberInfoTest {
         }
 
         private fun convertPublicKeys(): List<Pair<String, String>> =
-            identityKeys.mapIndexed { i, identityKey -> String.format(IDENTITY_KEYS_KEY, i) to keyEncodingService.encodeAsString(identityKey) }
+            ledgerKeys.mapIndexed { i, ledgerKey -> String.format(LEDGER_KEYS_KEY, i) to keyEncodingService.encodeAsString(ledgerKey) }
 
         private fun convertTestObjects(): List<Pair<String, String>> {
             val result = mutableListOf<Pair<String, String>>()
@@ -209,9 +209,9 @@ class MemberInfoTest {
         }
 
         assertEquals(memberInfo, recreatedMemberInfo)
-        assertEquals(memberInfo?.identityKeys, recreatedMemberInfo?.identityKeys)
+        assertEquals(memberInfo?.ledgerKeys, recreatedMemberInfo?.ledgerKeys)
         assertEquals(memberInfo?.name, recreatedMemberInfo?.name)
-        assertEquals(memberInfo?.owningKey, recreatedMemberInfo?.owningKey)
+        assertEquals(memberInfo?.sessionInitiationKey, recreatedMemberInfo?.sessionInitiationKey)
         assertEquals(memberInfo?.endpoints, recreatedMemberInfo?.endpoints)
         assertEquals(memberInfo?.modifiedTime, recreatedMemberInfo?.modifiedTime)
         assertEquals(memberInfo?.isActive, recreatedMemberInfo?.isActive)
@@ -247,9 +247,9 @@ class MemberInfoTest {
 
     @Test
     fun `parsing value fails when casting is impossible`() {
-        val keys = memberInfo?.identityKeys
-        assertEquals(identityKeys, keys)
-        assertFailsWith<ValueNotFoundException> { memberInfo?.memberProvidedContext?.parseList<EndpointInfo>(IDENTITY_KEYS) }
+        val keys = memberInfo?.ledgerKeys
+        assertEquals(ledgerKeys, keys)
+        assertFailsWith<ValueNotFoundException> { memberInfo?.memberProvidedContext?.parseList<EndpointInfo>(LEDGER_KEYS) }
     }
 
     @Test

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/PublicKeyConverterTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/PublicKeyConverterTest.kt
@@ -19,8 +19,8 @@ import kotlin.test.assertNull
 
 class PublicKeyConverterTest {
     companion object {
-        private const val IDENTITY_KEY = "12345"
-        private val identityKey = mock<PublicKey>()
+        private const val LEDGER_KEY = "12345"
+        private val ledgerKey = mock<PublicKey>()
     }
 
     private lateinit var keyEncodingService: KeyEncodingService
@@ -29,8 +29,8 @@ class PublicKeyConverterTest {
     @BeforeEach
     fun setup() {
         keyEncodingService = mock {
-            on { decodePublicKey(IDENTITY_KEY) } doReturn identityKey
-            on { encodeAsString(identityKey) } doReturn IDENTITY_KEY
+            on { decodePublicKey(LEDGER_KEY) } doReturn ledgerKey
+            on { encodeAsString(ledgerKey) } doReturn LEDGER_KEY
         }
         converters = listOf(PublicKeyConverter(keyEncodingService))
     }
@@ -38,53 +38,53 @@ class PublicKeyConverterTest {
     @Test
     fun `converting public key should work for single element`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKey" to IDENTITY_KEY),
+            sortedMapOf("corda.ledgerKey" to LEDGER_KEY),
             converters
         )
-        val result = memberContext.parse<PublicKey>("corda.identityKey")
-        assertEquals(identityKey, result)
+        val result = memberContext.parse<PublicKey>("corda.ledgerKey")
+        assertEquals(ledgerKey, result)
     }
 
     @Test
     fun `converting list of public key should work`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKeys.0" to IDENTITY_KEY),
+            sortedMapOf("corda.ledgerKeys.0" to LEDGER_KEY),
             converters
         )
-        val result = memberContext.parseList<PublicKey>("corda.identityKeys")
+        val result = memberContext.parseList<PublicKey>("corda.ledgerKeys")
         assertEquals(1, result.size)
-        assertEquals(identityKey, result[0])
+        assertEquals(ledgerKey, result[0])
     }
 
     @Test
     fun `converting PublicKey fails when the keys is null`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
             sortedMapOf(
-                "corda.identityKey" to null
+                "corda.ledgerKey" to null
             ),
             converters
         )
-        assertFailsWith<ValueNotFoundException> { memberContext.parse<PublicKey>("corda.identityKey") }
+        assertFailsWith<ValueNotFoundException> { memberContext.parse<PublicKey>("corda.ledgerKey") }
     }
 
     @Test
     fun `converting list of PublicKeys fails when the keys is null`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKeys.0" to null),
+            sortedMapOf("corda.ledgerKeys.0" to null),
             converters
         )
         assertFailsWith<ValueNotFoundException> {
-            memberContext.parseList<PublicKey>("corda.identityKeys")
+            memberContext.parseList<PublicKey>("corda.ledgerKeys")
         }
     }
 
     @Test
     fun `converting to nullable PublicKey works`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKey" to null),
+            sortedMapOf("corda.ledgerKey" to null),
             converters
         )
-        val result = memberContext.parseOrNull<PublicKey>("corda.identityKey")
+        val result = memberContext.parseOrNull<PublicKey>("corda.ledgerKey")
         assertNull(result)
     }
 }

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/PublicKeyHashConverterTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/impl/PublicKeyHashConverterTest.kt
@@ -16,59 +16,59 @@ import kotlin.test.assertNull
 
 class PublicKeyHashConverterTest {
     companion object {
-        private const val IDENTITY_KEY_HASH = "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"
-        private val identityKeyHash = PublicKeyHash.parse(IDENTITY_KEY_HASH)
+        private const val LEDGER_KEY_HASH = "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD"
+        private val ledgerKeyHash = PublicKeyHash.parse(LEDGER_KEY_HASH)
         private val converters = listOf(PublicKeyHashConverter())
     }
 
     @Test
     fun `converting hash should work for single element`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKeyHash" to IDENTITY_KEY_HASH),
+            sortedMapOf("corda.ledgerKeyHash" to LEDGER_KEY_HASH),
             converters
         )
-        val result = memberContext.parse<PublicKeyHash>("corda.identityKeyHash")
-        assertEquals(identityKeyHash, result)
+        val result = memberContext.parse<PublicKeyHash>("corda.ledgerKeyHash")
+        assertEquals(ledgerKeyHash, result)
     }
 
     @Test
     fun `converting list of hashes should work`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKeyHashes.0" to IDENTITY_KEY_HASH),
+            sortedMapOf("corda.ledgerKeyHashes.0" to LEDGER_KEY_HASH),
             converters
         )
-        val result = memberContext.parseSet<PublicKeyHash>("corda.identityKeyHashes")
+        val result = memberContext.parseSet<PublicKeyHash>("corda.ledgerKeyHashes")
         assertEquals(1, result.size)
-        assertTrue(result.contains(identityKeyHash))
+        assertTrue(result.contains(ledgerKeyHash))
     }
 
     @Test
     fun `converting hash fails when the keys is null`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKeyHash" to null),
+            sortedMapOf("corda.ledgerKeyHash" to null),
             converters
         )
-        assertFailsWith<ValueNotFoundException> { memberContext.parse<PublicKey>("corda.identityKeyHash") }
+        assertFailsWith<ValueNotFoundException> { memberContext.parse<PublicKey>("corda.ledgerKeyHash") }
     }
 
     @Test
     fun `converting list of hashes fails when the keys is null`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKeyHashes.0" to null),
+            sortedMapOf("corda.ledgerKeyHashes.0" to null),
             converters
         )
         assertFailsWith<ValueNotFoundException> {
-            memberContext.parseSet<PublicKey>("corda.identityKeyHashes")
+            memberContext.parseSet<PublicKey>("corda.ledgerKeyHashes")
         }
     }
 
     @Test
     fun `converting to nullable hash works`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.identityKeyHash" to null),
+            sortedMapOf("corda.ledgerKeyHash" to null),
             converters
         )
-        val result = memberContext.parseOrNull<PublicKey>("corda.identityKeyHash")
+        val result = memberContext.parseOrNull<PublicKey>("corda.ledgerKeyHash")
         assertNull(result)
     }
 }

--- a/libs/membership/membership-impl/src/test/resources/SampleDynamicGroupPolicy.json
+++ b/libs/membership/membership-impl/src/test/resources/SampleDynamicGroupPolicy.json
@@ -25,7 +25,7 @@
   },
   "mgmInfo": {
     "corda.party.name": "C=GB, L=London, O=Corda Network, OU=MGM, CN=Corda Network MGM",
-    "corda.party.sessionInitiationKey": "-----BEGIN PUBLIC KEY-----\n{truncated for readability}\n-----END PUBLIC KEY-----",
+    "corda.session.key": "-----BEGIN PUBLIC KEY-----\n{truncated for readability}\n-----END PUBLIC KEY-----",
     "corda.session.certificate.0":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",
     "corda.session.certificate.1":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",
     "corda.session.certificate.2":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",

--- a/libs/membership/membership-impl/src/test/resources/SampleDynamicGroupPolicy.json
+++ b/libs/membership/membership-impl/src/test/resources/SampleDynamicGroupPolicy.json
@@ -25,7 +25,7 @@
   },
   "mgmInfo": {
     "corda.party.name": "C=GB, L=London, O=Corda Network, OU=MGM, CN=Corda Network MGM",
-    "corda.session.key": "-----BEGIN PUBLIC KEY-----\n{truncated for readability}\n-----END PUBLIC KEY-----",
+    "corda.party.sessionInitiationKey": "-----BEGIN PUBLIC KEY-----\n{truncated for readability}\n-----END PUBLIC KEY-----",
     "corda.session.certificate.0":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",
     "corda.session.certificate.1":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",
     "corda.session.certificate.2":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",

--- a/libs/membership/membership-impl/src/test/resources/SampleDynamicGroupPolicy.json
+++ b/libs/membership/membership-impl/src/test/resources/SampleDynamicGroupPolicy.json
@@ -25,7 +25,7 @@
   },
   "mgmInfo": {
     "corda.party.name": "C=GB, L=London, O=Corda Network, OU=MGM, CN=Corda Network MGM",
-    "corda.session.key": "-----BEGIN PUBLIC KEY-----\n{truncated for readability}\n-----END PUBLIC KEY-----",
+    "corda.party.session.key": "-----BEGIN PUBLIC KEY-----\n{truncated for readability}\n-----END PUBLIC KEY-----",
     "corda.session.certificate.0":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",
     "corda.session.certificate.1":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",
     "corda.session.certificate.2":"-----BEGIN CERTIFICATE-----\n{truncated for readability}\n-----END CERTIFICATE-----",

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedEncryptionSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedEncryptionSessionTest.kt
@@ -26,18 +26,18 @@ class AuthenticatedEncryptionSessionTest {
 
     // party A
     private val partyAMaxMessageSize = 1_000_000
-    private val partyALedgerKey = keyPairGenerator.generateKeyPair()
+    private val partyASessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolA = AuthenticationProtocolInitiator(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
         partyAMaxMessageSize,
-        partyALedgerKey.public,
+        partyASessionKey.public,
         groupId
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
-    private val partyBLedgerKey = keyPairGenerator.generateKeyPair()
+    private val partyBSessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB =
         AuthenticationProtocolResponder(
             sessionId,
@@ -60,29 +60,29 @@ class AuthenticatedEncryptionSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBLedgerKey.private)
+            signature.initSign(partyBSessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBLedgerKey.public,
+            partyBSessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -139,29 +139,29 @@ class AuthenticatedEncryptionSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBLedgerKey.private)
+            signature.initSign(partyBSessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBLedgerKey.public,
+            partyBSessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -224,29 +224,29 @@ class AuthenticatedEncryptionSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBLedgerKey.private)
+            signature.initSign(partyBSessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBLedgerKey.public,
+            partyBSessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedEncryptionSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedEncryptionSessionTest.kt
@@ -26,18 +26,18 @@ class AuthenticatedEncryptionSessionTest {
 
     // party A
     private val partyAMaxMessageSize = 1_000_000
-    private val partyAIdentityKey = keyPairGenerator.generateKeyPair()
+    private val partyALedgerKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolA = AuthenticationProtocolInitiator(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
         partyAMaxMessageSize,
-        partyAIdentityKey.public,
+        partyALedgerKey.public,
         groupId
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
-    private val partyBIdentityKey = keyPairGenerator.generateKeyPair()
+    private val partyBLedgerKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB =
         AuthenticationProtocolResponder(
             sessionId,
@@ -60,29 +60,29 @@ class AuthenticatedEncryptionSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBIdentityKey.private)
+            signature.initSign(partyBLedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBIdentityKey.public,
+            partyBLedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -139,29 +139,29 @@ class AuthenticatedEncryptionSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBIdentityKey.private)
+            signature.initSign(partyBLedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBIdentityKey.public,
+            partyBLedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -224,29 +224,29 @@ class AuthenticatedEncryptionSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBIdentityKey.private)
+            signature.initSign(partyBLedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBIdentityKey.public,
+            partyBLedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedSessionTest.kt
@@ -26,18 +26,18 @@ class AuthenticatedSessionTest {
 
     // party A
     private val partyAMaxMessageSize = 1_000_000
-    private val partyALedgerKey = keyPairGenerator.generateKeyPair()
+    private val partyASessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolA = AuthenticationProtocolInitiator(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATION_ONLY),
         partyAMaxMessageSize,
-        partyALedgerKey.public,
+        partyASessionKey.public,
         groupId
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
-    private val partyBLedgerKey = keyPairGenerator.generateKeyPair()
+    private val partyBSessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB = AuthenticationProtocolResponder(
         sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize
     )
@@ -58,29 +58,29 @@ class AuthenticatedSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBLedgerKey.private)
+            signature.initSign(partyBSessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBLedgerKey.public,
+            partyBSessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -130,29 +130,29 @@ class AuthenticatedSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBLedgerKey.private)
+            signature.initSign(partyBSessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBLedgerKey.public,
+            partyBSessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -193,29 +193,29 @@ class AuthenticatedSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBLedgerKey.private)
+            signature.initSign(partyBSessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBLedgerKey.public,
+            partyBSessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticatedSessionTest.kt
@@ -26,18 +26,18 @@ class AuthenticatedSessionTest {
 
     // party A
     private val partyAMaxMessageSize = 1_000_000
-    private val partyAIdentityKey = keyPairGenerator.generateKeyPair()
+    private val partyALedgerKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolA = AuthenticationProtocolInitiator(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATION_ONLY),
         partyAMaxMessageSize,
-        partyAIdentityKey.public,
+        partyALedgerKey.public,
         groupId
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
-    private val partyBIdentityKey = keyPairGenerator.generateKeyPair()
+    private val partyBLedgerKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB = AuthenticationProtocolResponder(
         sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize
     )
@@ -58,29 +58,29 @@ class AuthenticatedSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBIdentityKey.private)
+            signature.initSign(partyBLedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBIdentityKey.public,
+            partyBLedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -130,29 +130,29 @@ class AuthenticatedSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBIdentityKey.private)
+            signature.initSign(partyBLedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBIdentityKey.public,
+            partyBLedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
@@ -193,29 +193,29 @@ class AuthenticatedSessionTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBIdentityKey.private)
+            signature.initSign(partyBLedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
-            partyBIdentityKey.public,
+            partyBLedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticationProtocolFailureTest.kt
@@ -28,18 +28,18 @@ class AuthenticationProtocolFailureTest {
 
     // party A
     private val partyAMaxMessageSize = 1_000_000
-    private val partyAIdentityKey = keyPairGenerator.generateKeyPair()
+    private val partyALedgerKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolA = AuthenticationProtocolInitiator(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATION_ONLY),
         partyAMaxMessageSize,
-        partyAIdentityKey.public,
+        partyALedgerKey.public,
         groupId
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
-    private val partyBIdentityKey = keyPairGenerator.generateKeyPair()
+    private val partyBLedgerKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB =
         AuthenticationProtocolResponder(
             sessionId,
@@ -62,11 +62,11 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         val modifiedInitiatorHandshakeMessage = InitiatorHandshakeMessage(
             initiatorHandshakeMessage.header,
@@ -74,7 +74,7 @@ class AuthenticationProtocolFailureTest {
         )
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                modifiedInitiatorHandshakeMessage, partyAIdentityKey.public, ECDSA_SHA256_SIGNATURE_SPEC
+                modifiedInitiatorHandshakeMessage, partyALedgerKey.public, ECDSA_SHA256_SIGNATURE_SPEC
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -96,15 +96,15 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: initiator creating different signature than the one expected.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage, partyAIdentityKey.public, ECDSA_SHA256_SIGNATURE_SPEC
+                initiatorHandshakeMessage, partyALedgerKey.public, ECDSA_SHA256_SIGNATURE_SPEC
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -128,11 +128,11 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: the provided public key does not match the one given by the initiator at step 1.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage, wrongPublicKey, ECDSA_SHA256_SIGNATURE_SPEC
@@ -157,29 +157,29 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyAIdentityKey.private)
+            signature.initSign(partyALedgerKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder creating different signature than the one expected.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBIdentityKey.private)
+            signature.initSign(partyBLedgerKey.private)
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBIdentityKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
 
         assertThatThrownBy {
             authenticationProtocolA.validatePeerHandshakeMessage(
-                responderHandshakeMessage, partyBIdentityKey.public, ECDSA_SHA256_SIGNATURE_SPEC
+                responderHandshakeMessage, partyBLedgerKey.public, ECDSA_SHA256_SIGNATURE_SPEC
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -191,7 +191,7 @@ class AuthenticationProtocolFailureTest {
             sessionId,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             partyAMaxMessageSize,
-            partyAIdentityKey.public,
+            partyALedgerKey.public,
             sessionId
         )
         val authenticationProtocolB = AuthenticationProtocolResponder(

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticationProtocolFailureTest.kt
@@ -28,18 +28,18 @@ class AuthenticationProtocolFailureTest {
 
     // party A
     private val partyAMaxMessageSize = 1_000_000
-    private val partyALedgerKey = keyPairGenerator.generateKeyPair()
+    private val partyASessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolA = AuthenticationProtocolInitiator(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATION_ONLY),
         partyAMaxMessageSize,
-        partyALedgerKey.public,
+        partyASessionKey.public,
         groupId
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
-    private val partyBLedgerKey = keyPairGenerator.generateKeyPair()
+    private val partyBSessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB =
         AuthenticationProtocolResponder(
             sessionId,
@@ -62,11 +62,11 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         val modifiedInitiatorHandshakeMessage = InitiatorHandshakeMessage(
             initiatorHandshakeMessage.header,
@@ -74,7 +74,7 @@ class AuthenticationProtocolFailureTest {
         )
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                modifiedInitiatorHandshakeMessage, partyALedgerKey.public, ECDSA_SHA256_SIGNATURE_SPEC
+                modifiedInitiatorHandshakeMessage, partyASessionKey.public, ECDSA_SHA256_SIGNATURE_SPEC
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -96,15 +96,15 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: initiator creating different signature than the one expected.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage, partyALedgerKey.public, ECDSA_SHA256_SIGNATURE_SPEC
+                initiatorHandshakeMessage, partyASessionKey.public, ECDSA_SHA256_SIGNATURE_SPEC
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -128,11 +128,11 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: the provided public key does not match the one given by the initiator at step 1.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage, wrongPublicKey, ECDSA_SHA256_SIGNATURE_SPEC
@@ -157,29 +157,29 @@ class AuthenticationProtocolFailureTest {
 
         // Step 3: initiator sending handshake message and responder validating it.
         val signingCallbackForA = { data: ByteArray ->
-            signature.initSign(partyALedgerKey.private)
+            signature.initSign(partyASessionKey.private)
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             ECDSA_SHA256_SIGNATURE_SPEC,
         )
 
         // Step 4: responder creating different signature than the one expected.
         val signingCallbackForB = { data: ByteArray ->
-            signature.initSign(partyBLedgerKey.private)
+            signature.initSign(partyBSessionKey.private)
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBLedgerKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
 
         assertThatThrownBy {
             authenticationProtocolA.validatePeerHandshakeMessage(
-                responderHandshakeMessage, partyBLedgerKey.public, ECDSA_SHA256_SIGNATURE_SPEC
+                responderHandshakeMessage, partyBSessionKey.public, ECDSA_SHA256_SIGNATURE_SPEC
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -191,7 +191,7 @@ class AuthenticationProtocolFailureTest {
             sessionId,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             partyAMaxMessageSize,
-            partyALedgerKey.public,
+            partyASessionKey.public,
             sessionId
         )
         val authenticationProtocolB = AuthenticationProtocolResponder(

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     runtimeOnly project(':components:virtual-node:virtual-node-write-service-impl')
     runtimeOnly project(':components:membership:certificates-service-impl')
 
-    runtimeOnly project(':libs:crypto:crypto-impl')
     runtimeOnly project(':libs:db:db-orm-impl')
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly project(':libs:messaging:messaging-impl')

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     runtimeOnly project(':components:virtual-node:virtual-node-write-service-impl')
     runtimeOnly project(':components:membership:certificates-service-impl')
 
+    runtimeOnly project(':libs:crypto:crypto-impl')
     runtimeOnly project(':libs:db:db-orm-impl')
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly project(':libs:messaging:messaging-impl')

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -202,7 +202,7 @@ class MemberProcessorTestUtils {
         }
 
         fun lookUpFromPublicKey(groupReader: MembershipGroupReader, member: MemberInfo?) = eventually {
-            val result = groupReader.lookup(PublicKeyHash.calculate(member!!.owningKey))
+            val result = groupReader.lookup(PublicKeyHash.calculate(member!!.sessionInitiationKey))
             assertNotNull(result)
             result!!
         }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -46,7 +46,7 @@ class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
             throw IllegalStateException("TEST MODULE: Membership not supported")
         }
 
-        override fun lookup(publicKeyHash: PublicKeyHash): MemberInfo? {
+        override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? {
             return null
         }
 


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-4557
The following key properties exposed by the `MemberInfo` interface have changed -

`owningKey` changed to `sessionInitiationKey`
`identityKeys` changed to `ledgerKeys`

Relates to https://github.com/corda/corda-api/pull/394