### PR TITLE
CORE-5030: Only remove successfully deleted bundles from their sandbox.

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -131,7 +131,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
         stop()
         coordinator.close()
         sandboxGroupContextService?.close()
-        cpkReadService.stop()
+        cpkReadService.close()
     }
 
     private fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
@@ -157,13 +157,15 @@ class SandboxGroupContextComponentImpl @Activate constructor(
                 SANDBOX_CACHE_SIZE_DEFAULT
             }
 
-            if(null == sandboxGroupContextService)
+            val service = sandboxGroupContextService ?: run {
                 initCache(cacheSize)
-            else if (sandboxGroupContextService!!.cache.cacheSize != cacheSize) {
+                sandboxGroupContextService ?: throw IllegalStateException("SandboxGroupContextService not initialized")
+            }
+            if (service.cache.cacheSize != cacheSize) {
                 // this means the cache size has been reconfigured, which means we need to recreate the cache
                 logger.info("Re-creating Sandbox cache with size: $cacheSize")
-                val oldCache = sandboxGroupContextService!!.cache
-                sandboxGroupContextService!!.cache = SandboxGroupContextCacheImpl(cacheSize)
+                val oldCache = service.cache
+                service.cache = SandboxGroupContextCacheImpl(cacheSize)
                 oldCache.close()
             }
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -78,8 +79,11 @@ class SandboxBundleIsolationTest {
             sandboxFactory.createSandboxGroupFor(CPI_ONE)
         }
         try {
-            assertEquals(sandboxFactory.group1.metadata.keys.names, copyOne.metadata.keys.names)
-            assertNotEquals(sandboxFactory.group1.metadata.keys.ids, copyOne.metadata.keys.ids)
+            assertAll(
+                { assertTrue(copyOne.metadata.keys.stream().allMatch { bundle -> bundle.state == Bundle.ACTIVE }) },
+                { assertEquals(sandboxFactory.group1.metadata.keys.names, copyOne.metadata.keys.names) },
+                { assertNotEquals(sandboxFactory.group1.metadata.keys.ids, copyOne.metadata.keys.ids) }
+            )
         } finally {
             sandboxFactory.destroySandboxGroup(copyOne)
         }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/Sandbox.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/Sandbox.kt
@@ -33,7 +33,9 @@ internal interface Sandbox {
     /**
      * Uninstalls all the sandbox's bundles.
      *
-     * Returns the bundles that could not be uninstalled.
+     * Returns at most two lists of bundles.
+     * The bundles for `true` are no longer installed,
+     * whereas the bundles for `false` are still installed.
      */
-    fun unload(): List<Bundle>
+    fun unload(): Map<Boolean, List<Bundle>>
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
@@ -52,16 +52,16 @@ internal open class SandboxImpl(
         }
     }
 
-    override fun unload() = allBundles.mapNotNull { bundle ->
+    override fun unload() = allBundles.groupBy { bundle ->
         try {
             bundle.uninstall()
-            null
+            true
         } catch (e: IllegalStateException) {
             logger.warn("Bundle ${bundle.symbolicName} is not installed", e)
-            null
+            true
         } catch (e: Exception) {
             logger.warn("Bundle ${bundle.symbolicName} could not be uninstalled", e)
-            bundle
+            false
         }
     }
 

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
@@ -3,7 +3,9 @@ package net.corda.sandbox.internal.utilities
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
+import org.osgi.framework.FrameworkListener
 import org.osgi.framework.FrameworkUtil
+import org.osgi.framework.wiring.FrameworkWiring
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -39,4 +41,11 @@ internal class BundleUtils @Activate constructor(
 
     /** Returns the list of all installed bundles. */
     val allBundles get() = bundleContext.bundles.toList()
+
+    /**
+     * Force the update or removal of bundles.
+     */
+    fun refreshBundles(bundles: Collection<Bundle>, refreshListener: FrameworkListener) {
+        systemBundle.adapt(FrameworkWiring::class.java).refreshBundles(bundles, refreshListener)
+    }
 }

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextService.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextService.kt
@@ -66,7 +66,8 @@ interface SandboxGroupContextService: AutoCloseable {
 
     /**
      * This function registers instances of the service classes
-     * identified within the [SandboxGroup]'s [CPK.Metadata].
+     * identified within the [SandboxGroup][net.corda.sandbox.SandboxGroup]'s
+     * [CpkMetadata].
      * Each OSGi service will be a singleton containing an extra
      * `corda.sandbox=true` service property.
      *
@@ -80,7 +81,7 @@ interface SandboxGroupContextService: AutoCloseable {
      * service also implements [VirtualNodeContext.serviceMarkerType].
      *
      * You should register these metadata services as part of the
-     * [ServiceContextGroupInitializer].
+     * [SandboxGroupContextInitializer].
      *
      * @param sandboxGroupContext
      * @param serviceNames A lambda to extract the service class names from the CPK metadata.
@@ -100,7 +101,7 @@ interface SandboxGroupContextService: AutoCloseable {
     /**
      * This function registers any [DigestAlgorithmFactory][net.corda.v5.cipher.suite.DigestAlgorithmFactory]
      * instances that exist inside the [SandboxGroup][net.corda.sandbox.SandboxGroup]'s CPKs.
-     * The [DigestAlgorithmFactoryProvider][net.corda.crypto.DigestAlgorithmFactoryProvider]
+     * The [DigestAlgorithmFactoryProvider][net.corda.crypto.core.DigestAlgorithmFactoryProvider]
      * component will discover these services when the sandbox uses its
      * [DigestService][net.corda.v5.crypto.DigestService] for the first time.
      *


### PR DESCRIPTION
Delete bundles first, and then remove them from their IDs from the sandboxes. Do not unsandbox bundles which cannot be deleted for any reason.