### PR TITLE
CORE-2528: Do not include query param if `null` and not required

### DIFF
--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
@@ -581,4 +581,29 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
         }
     }
 
+    @Test
+    @Timeout(100)
+    fun `optional query parameter call`() {
+        val client = HttpRpcClient(
+            baseAddress = "http://localhost:$port/api/v1/",
+            TestHealthCheckAPI::class.java,
+            HttpRpcClientConfig()
+                .enableSSL(false)
+                .minimumServerProtocolVersion(1)
+                .username(userAlice.username)
+                .password(requireNotNull(userAlice.password)),
+        )
+
+        client.use {
+            val connection = client.start()
+
+            with(connection.proxy) {
+                assertThat(hello("name", 1)).isEqualTo(""""Hello 1 : name"""")
+                assertThat(hello("name", null)).isEqualTo(""""Hello null : name"""")
+                assertThat(hello2("world", "name")).isEqualTo(""""Hello queryParam: world, pathParam : name"""")
+                assertThat(hello2(null, "name")).isEqualTo(""""Hello queryParam: null, pathParam : name"""")
+            }
+        }
+    }
+
 }

--- a/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/processing/QueryParametersResolver.kt
+++ b/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/processing/QueryParametersResolver.kt
@@ -4,14 +4,20 @@ import net.corda.httprpc.annotations.HttpRpcQueryParameter
 import net.corda.httprpc.tools.annotations.extensions.name
 import net.corda.v5.base.util.uncheckedCast
 import java.lang.reflect.Method
+import java.lang.reflect.Parameter
 
-internal fun Method.queryParametersFrom(allParameters: Array<out Any?>): Map<String, Any?> =
-    this.parameters
+internal fun Method.queryParametersFrom(allParameters: Array<out Any?>): Map<String, Any?> {
+    val queryParameters: List<Pair<Parameter, Any?>> = parameters
         .mapIndexed { index, parameter -> parameter to allParameters[index] }
         .filter { it.first.annotations.any { annotation -> annotation is HttpRpcQueryParameter } }
+    // Do not include into the map if it is `null` and not required
+    val requiredQueryParameters = queryParameters
+        .filterNot { it.second == null && !it.first.getAnnotation(HttpRpcQueryParameter::class.java).required }
+    return requiredQueryParameters
         .associate {
             it.first.getAnnotation(HttpRpcQueryParameter::class.java).name(it.first) to it.second.encodeQueryParam()
         }
+}
 
 private fun Any?.encodeQueryParam(): Any? {
     return if (this == null) {

--- a/libs/http-rpc/http-rpc-client/src/test/kotlin/net/corda/httprpc/client/processing/QueryParametersResolverTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/test/kotlin/net/corda/httprpc/client/processing/QueryParametersResolverTest.kt
@@ -20,8 +20,7 @@ class QueryParametersResolverTest {
     fun `queryParametersResolver_withQueryParametersMethodAndNullQueryParam_returnsPopulatedMap`() {
         val result = TestHealthCheckAPI::hello2.javaMethod!!.queryParametersFrom(arrayOf(null, null))
 
-        assertTrue(result.contains("id"))
-        assertEquals(null, result["id"])
+        assertTrue(result.isEmpty())
     }
 
     @Test

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
@@ -154,6 +154,14 @@ class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
     }
 
     @Test
+    fun `GET hello name returns string without optional query param`() {
+
+        val helloResponse = client.call(GET, WebRequest<Any>("health/hello/world"), userName, password)
+        assertEquals(HttpStatus.SC_OK, helloResponse.responseStatus)
+        assertEquals(""""Hello null : world"""", helloResponse.body)
+    }
+
+    @Test
     fun `GET hello2 name returns string greeting name`() {
 
         val fullUrl = "health/hello2/pathString?id=id"


### PR DESCRIPTION
It is HTTP RPC Client change only, as HTTP Server already support not required parameters correctly.
Integration test coverage been extended to expose previously failing scenario.