### PR TITLE
NOTICK: Fix publishing for application jars.

### DIFF
--- a/applications/examples/amqp-custom-serializer-poc/build.gradle
+++ b/applications/examples/amqp-custom-serializer-poc/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'corda.common-publishing'
     id 'corda.common-app'
 }
 

--- a/applications/examples/amqp-evolution-poc/build.gradle
+++ b/applications/examples/amqp-evolution-poc/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'corda.common-publishing'
     id 'corda.common-app'
 }
 

--- a/applications/tools/p2p-test/fake-ca/build.gradle
+++ b/applications/tools/p2p-test/fake-ca/build.gradle
@@ -15,9 +15,17 @@ dependencies {
     implementation 'net.corda:corda-cipher-suite'
 }
 
-task appJar(type: Jar) {
-    destinationDirectory = file("$buildDir/bin")
-    archiveBaseName = "corda-${project.name}"
+def jar = tasks.named('jar', Jar) {
+    archiveClassifier = 'ignore'
+}
+
+def appJarBaseName = "corda-${project.name}"
+
+def appJar = tasks.register('appJar', Jar) {
+    dependsOn jar
+
+    destinationDirectory = layout.buildDirectory.dir('bin')
+    archiveBaseName = appJarBaseName
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
     manifest {
@@ -27,14 +35,17 @@ task appJar(type: Jar) {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    with jar
+    with jar.get()
 }
 
 publishing {
     publications {
         maven(MavenPublication) {
             groupId project.group
-            artifact appJar
+            artifactId appJarBaseName
+            afterEvaluate {
+                artifacts = [ appJar ]
+            }
         }
     }
 }

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -73,7 +73,9 @@ dependencies {
     systemPackages project(":osgi-framework-api")
 }
 
-TaskProvider<Jar> jarTask = tasks.named('jar', Jar)
+TaskProvider<Jar> jarTask = tasks.named('jar', Jar) {
+    archiveClassifier = 'ignore'
+}
 
 @CompileStatic
 private def addSystemPackagesExtra(
@@ -406,7 +408,7 @@ def appJar = tasks.register('appJar', Jar) {
     finalizedBy verifyApp
 
     archiveBaseName = appJarBaseName
-    destinationDirectory = layout.buildDirectory.dir("bin")
+    destinationDirectory = layout.buildDirectory.dir('bin')
 
     exclude "META-INF/MANIFEST.MF"
     exclude "META-INF/*.SF"
@@ -454,13 +456,13 @@ artifacts {
 pluginManager.withPlugin('maven-publish') {
     publishing {
         publications {
-            mavenAppJar(MavenPublication) {
+            maven(MavenPublication) {
                 artifactId appJarBaseName
 
                 afterEvaluate { proj ->
                     groupId proj.group
                     version proj.version
-                    artifact appJar
+                    artifacts = [ appJar ]
                 }
             }
         }

--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -9,21 +9,32 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
     pluginManager.withPlugin('java') {
         publishing {
             publications {
-                register('maven', MavenPublication) {
+                maven(MavenPublication) {
                     afterEvaluate {
                         artifactId = tasks.named('jar', Jar).flatMap { it.archiveBaseName }.get()
                         groupId group.toString()
                         from components.findByName('cordapp') ?: components.findByName('kotlin') ?: components.java
-                    }
-                    if (project.hasProperty("sourceJar")) {
-                        maven.artifact(tasks.getByName("sourcesJar"))
-                    }
-                    if (project.hasProperty("javaDoc")) {
-                        maven.artifact(tasks.getByName("javadocJar"))
-                    }
 
+                        try {
+                            artifact tasks.named('sourcesJar', Jar)
+                        } catch (UnknownTaskException ignored) {
+                        }
+
+                        try {
+                            artifact tasks.named('javadocJar', Jar)
+                        } catch (UnknownTaskException ignored) {
+                        }
+                    }
                 }
             }
         }
+    }
+
+    tasks.withType(GenerateModuleMetadata).configureEach {
+        enabled = false
+    }
+
+    tasks.register('install') {
+        dependsOn 'publishToMavenLocal'
     }
 }


### PR DESCRIPTION
If a project has multiple `MavenPublication` objects, all with the same `groupId` and `artifactId`, then their contents will overwrite each other when publishing to a Maven repository. We cannot possibly want this, so create only _one_ publication called "maven" and then use [`MavenPublication.setArtifacts`](https://docs.gradle.org/current/javadoc/org/gradle/api/publish/maven/MavenPublication.html#setArtifacts-java.lang.Iterable-) to overwrite its contents, if required.

I really don't understand how this could have been working before, unless we were either being lucky, or were publishing application jars under the wrong names?

Update the `corda.common-publishing` plugin to include any `sourcesJar` and `javadocJar` artifacts, should they exist.

And we don't need to publish two POC applications in the first place.