### PR TITLE
NOTICK: Reduce usage of afterEvaluate when publishing applications.

### DIFF
--- a/applications/tools/p2p-test/fake-ca/build.gradle
+++ b/applications/tools/p2p-test/fake-ca/build.gradle
@@ -43,9 +43,7 @@ publishing {
         maven(MavenPublication) {
             groupId project.group
             artifactId appJarBaseName
-            afterEvaluate {
-                artifacts = [ appJar ]
-            }
+            artifact appJar
         }
     }
 }

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -458,11 +458,11 @@ pluginManager.withPlugin('maven-publish') {
         publications {
             maven(MavenPublication) {
                 artifactId appJarBaseName
+                artifact appJar
 
                 afterEvaluate { proj ->
                     groupId proj.group
                     version proj.version
-                    artifacts = [ appJar ]
                 }
             }
         }

--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -9,7 +9,7 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
     pluginManager.withPlugin('java') {
         publishing {
             publications {
-                maven(MavenPublication) {
+                maven(MavenPublication) { mvn ->
                     afterEvaluate {
                         artifactId = tasks.named('jar', Jar).flatMap { it.archiveBaseName }.get()
                         groupId group.toString()
@@ -23,6 +23,10 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
                         try {
                             artifact tasks.named('javadocJar', Jar)
                         } catch (UnknownTaskException ignored) {
+                        }
+
+                        mvn.artifacts = mvn.artifacts.findAll { a ->
+                            !(a instanceof MavenArtifact) || a.classifier != 'ignore'
                         }
                     }
                 }


### PR DESCRIPTION
Gradle's `afterEvaluate` handler is _**PURE EVIL**_, so avoid using it unless we really need to. (We can _never_ guarantee the order in which two `afterEvaluate` handlers execute.)

Update the "external" publication task not to publish artifacts whose classifier is "ignore", which allows us to select easily between the `jar` and `appJar` task outputs as the main Maven artifact.