### PR TITLE
NOTICK: Publish source jars artifacts, and fix inter-project dependencies for applications

### DIFF
--- a/applications/tools/p2p-test/fake-ca/build.gradle
+++ b/applications/tools/p2p-test/fake-ca/build.gradle
@@ -5,6 +5,12 @@ plugins {
 
 description "P2P Testing tools - Fake CA"
 
+configurations {
+    app {
+        canBeResolved = false
+    }
+}
+
 dependencies {
     implementation platform('org.jetbrains.kotlin:kotlin-bom')
     implementation project(':libs:crypto:certificate-generation')
@@ -38,12 +44,22 @@ def appJar = tasks.register('appJar', Jar) {
     with jar.get()
 }
 
+artifacts {
+    archives appJar
+    app appJar
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
             groupId project.group
             artifactId appJarBaseName
             artifact appJar
+
+            try {
+                artifact tasks.named('sourcesJar', Jar)
+            } catch (UnknownTaskException ignored) {
+            }
         }
     }
 }

--- a/applications/tools/p2p-test/p2p-layer-deployment/build.gradle
+++ b/applications/tools/p2p-test/p2p-layer-deployment/build.gradle
@@ -6,6 +6,12 @@ plugins {
 
 description "P2P Testing tools - P2P layer deployment"
 
+configurations {
+    deployments {
+        canBeConsumed = false
+    }
+}
+
 dependencies {
     implementation platform('org.jetbrains.kotlin:kotlin-bom')
     implementation project(':libs:crypto:certificate-generation')
@@ -21,44 +27,33 @@ dependencies {
     testImplementation "com.typesafe:config:$typeSafeConfigVersion"
     testRuntimeOnly project(':applications:tools:p2p-test:p2p-setup')
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+
+    deployments project(path: ':applications:tools:p2p-test:p2p-setup', configuration: 'app')
+    deployments project(path: ':applications:tools:kafka-setup', configuration: 'app')
 }
+
 application {
     mainClass = 'net.corda.p2p.deployment.GoKt'
 }
 
-def binaryProjects = [
-        'p2p-test:p2p-setup',
-        'kafka-setup'
-]
+def jarsDir = layout.buildDirectory.dir('jars')
 
-binaryProjects.forEach {name->
-    def shortName = name.split(':').last()
-    def copyJars = tasks.register("copyJars$shortName", Copy) {
-        def project = ":applications:tools:$name"
-        def task = rootProject.findProject(project).tasks.getByName('appJar')
-        dependsOn(task)
-        from task.outputs.files.first()
-        into "$buildDir/jars/"
-        rename {
-            "${shortName}.jar"
-        }
-    }
-    processResources.dependsOn(copyJars)
+def copyJars = tasks.register('copyJars', Copy) {
+    from configurations.deployments
+    into jarsDir
+
+    rename "corda-(.*)-\\Q${version}\\E\\.jar", '\$1.jar'
 }
-jacocoTestReport {
-    dependsOn test
-    afterEvaluate {
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, includes: [
-                    "net/corda/**",
-            ])
-        }))
-    }
-}
+
 sourceSets {
     main {
         resources {
-            srcDirs "$buildDir/jars"
+            srcDirs files(jarsDir).builtBy(copyJars)
         }
     }
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn tasks.named('test', Test)
+    classDirectories.setFrom sourceSets.main.output.classesDirs
 }

--- a/applications/tools/p2p-test/p2p-setup/build.gradle
+++ b/applications/tools/p2p-test/p2p-setup/build.gradle
@@ -5,6 +5,12 @@ plugins {
 
 description "P2P Testing tools - P2P Setup tool"
 
+configurations {
+    app {
+        canBeResolved = false
+    }
+}
+
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-avro-schema:$cordaApiVersion"
@@ -39,8 +45,15 @@ dependencies {
 
     testRuntimeOnly "com.lmax:disruptor:$disruptorVersion"
 }
-task appJar(type: Jar) {
-    destinationDirectory = file("$buildDir/bin")
+
+def jar = tasks.named('jar', Jar) {
+    archiveClassifier = 'ignore'
+}
+
+def appJar = tasks.register('appJar', Jar) {
+    dependsOn jar
+
+    destinationDirectory = layout.buildDirectory.dir('bin')
     archiveBaseName = "corda-${project.name}"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
@@ -51,5 +64,10 @@ task appJar(type: Jar) {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    with jar
+    with jar.get()
+}
+
+artifacts {
+    archives appJar
+    app appJar
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ allprojects {
             toolchain {
                 languageVersion = of(javaVersion.majorVersion.toInteger())
             }
+
+            withSourcesJar()
         }
     }
 

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -60,6 +60,10 @@ configurations {
     compileClassPath.shouldResolveConsistentlyWith(runtimeClasspath)
     systemPackages.shouldResolveConsistentlyWith(runtimeClasspath)
     bootstrapClasspath.shouldResolveConsistentlyWith(runtimeClasspath)
+
+    app {
+        canBeResolved = false
+    }
 }
 
 dependencies {
@@ -451,6 +455,7 @@ def appJar = tasks.register('appJar', Jar) {
 
 artifacts {
     archives appJar
+    app appJar
 }
 
 pluginManager.withPlugin('maven-publish') {
@@ -463,6 +468,11 @@ pluginManager.withPlugin('maven-publish') {
                 afterEvaluate { proj ->
                     groupId proj.group
                     version proj.version
+
+                    try {
+                        artifact tasks.named('sourcesJar', Jar)
+                    } catch (UnknownTaskException ignored) {
+                    }
                 }
             }
         }

--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -7,26 +7,25 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
     logger.info("External user - using standard maven publishing")
     pluginManager.apply('maven-publish')
     pluginManager.withPlugin('java') {
-        publishing {
-            publications {
-                maven(MavenPublication) { mvn ->
-                    afterEvaluate {
-                        artifactId = tasks.named('jar', Jar).flatMap { it.archiveBaseName }.get()
-                        groupId group.toString()
-                        from components.findByName('cordapp') ?: components.findByName('kotlin') ?: components.java
+        afterEvaluate {
+            publishing {
+                if (publications.isEmpty()) {
+                    // If we haven't already created a MavenPublication then create one now.
+                    publications {
+                        maven(MavenPublication) {
+                            artifactId = tasks.named('jar', Jar).flatMap { it.archiveBaseName }.get()
+                            groupId group.toString()
+                            from components.findByName('cordapp') ?: components.findByName('kotlin') ?: components.java
 
-                        try {
-                            artifact tasks.named('sourcesJar', Jar)
-                        } catch (UnknownTaskException ignored) {
-                        }
+                            try {
+                                artifact tasks.named('sourcesJar', Jar)
+                            } catch (UnknownTaskException ignored) {
+                            }
 
-                        try {
-                            artifact tasks.named('javadocJar', Jar)
-                        } catch (UnknownTaskException ignored) {
-                        }
-
-                        mvn.artifacts = mvn.artifacts.findAll { a ->
-                            !(a instanceof MavenArtifact) || a.classifier != 'ignore'
+                            try {
+                                artifact tasks.named('javadocJar', Jar)
+                            } catch (UnknownTaskException ignored) {
+                            }
                         }
                     }
                 }

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -1,7 +1,14 @@
-import java.nio.file.Files
-import java.util.jar.JarFile
-
 description("OSGi Framework Bootstrap")
+
+configurations {
+    testBundles {
+        attributes { attrs ->
+            attrs.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+        }
+        canBeConsumed = false
+        transitive = false
+    }
+}
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
@@ -17,54 +24,19 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
+
+    testBundles project(':testing:apps:test-app')
 }
 
-private static boolean isBundle(JarFile jarFile) {
-    return jarFile.manifest.mainAttributes.getValue(org.osgi.framework.Constants.BUNDLE_MANIFESTVERSION) != null
+def copyBundles = tasks.register('copyBundles', Copy) {
+    into layout.buildDirectory.dir('resources/test/bundles')
+    from configurations.testBundles
 }
 
-private static boolean isJar(final File file) {
-    return file.name.endsWith(".jar")
-}
-
-private addBundle(
-        final File source,
-        final File target,
-        final Set<String> applicationBundleSet) {
-    Files.deleteIfExists(target.toPath())
-    Files.copy(source.toPath(), target.toPath())
-    applicationBundleSet.add("bundles/${source.name}")
-    logger.info "OSGI Bundle $source.name included as resource."
-}
-
-private addBundles(
-        final File[] files,
-        final File bundlesDir,
-        final Set<String> applicationBundleSet) {
-    if (!bundlesDir.exists()) {
-        bundlesDir.mkdirs()
-    }
-    files.each { file ->
-        if (isJar(file)) {
-            final def jarFile = new JarFile(file)
-            if (isBundle(jarFile)) {
-                addBundle(file, new File(bundlesDir, file.name), applicationBundleSet)
-            }
-        }
-    }
-}
-
-test {
-    dependsOn(':testing:apps:test-app:appJar')
-    final def appTesterProject = project(":testing:apps:test-app")
+tasks.named('test', Test) {
+    dependsOn copyBundles
     doFirst {
-        final File source = new File(appTesterProject.buildDir, "libs")
-        final File target = new File(buildDir, "resources/test/bundles")
-        if (!target.exists()) {
-            target.mkdirs()
-        }
-        final Set<String> applicationBundleSet = new TreeSet<>()
-        addBundles(source.listFiles(), target, applicationBundleSet)
+        def applicationBundleSet = configurations.testBundles.files.collect { "bundles/${it.name}" } as Set<String>
         final applicationBundlesFile = new File(project.buildDir, "resources/test/application_bundles")
         applicationBundlesFile.withWriter { writer ->
             applicationBundleSet.each { line ->


### PR DESCRIPTION
Gradle expects projects to "consume" configurations rather than have direct dependencies on each others' tasks. Provide a consumable `app` configuration for every application jar so that projects can depend on that instead.

Also enable "sources" artifacts, which we will need when we ultimately publish to Maven Central.

Update our "external publication" plugin only to create a new `MavenPublication` if one hasn't already been created elsewhere, e.g. by the `corda.common-app` plugin. This mirrors how our internal publication plugin behaves.