### PR TITLE
CORE-5029 Arm64 host support

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -1,5 +1,6 @@
 import com.google.cloud.tools.jib.api.*
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath
+import com.google.cloud.tools.jib.api.buildplan.Platform
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
@@ -201,6 +202,13 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('LOG4J_CONFIG_FILE', 'log4j2-console.xml')
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
+
+        if (System.properties['os.arch'] == "aarch64") {
+            logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")
+            Set<Platform> platformSet = new HashSet<Platform>()
+            platformSet.add(new Platform("arm64", "linux"))
+            builder.setPlatforms(platformSet)
+        }
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()
 

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -107,6 +107,20 @@ CLI image
 {{- end }}
 
 {{/*
+DB client image
+*/}}
+{{- define "corda.dbClientImage" -}}
+"{{- if .Values.db.clientImage.registry }}{{.Values.db.clientImage.registry}}/{{- end }}{{ .Values.db.clientImage.repository }}:{{ .Values.db.clientImage.tag }}"
+{{- end }}
+
+{{/*
+Kafka client image
+*/}}
+{{- define "corda.kafkaClientImage" -}}
+"{{- if .Values.kafka.clientImage.registry }}{{.Values.kafka.clientImage.registry}}/{{- end }}{{ .Values.kafka.clientImage.repository }}:{{ .Values.kafka.clientImage.tag }}"
+{{- end }}
+
+{{/*
 Worker JAVA_TOOL_OPTIONS
 */}}
 {{- define "corda.workerJavaToolOptions" -}}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -88,6 +88,7 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -90,4 +90,4 @@ spec:
       {{- include "corda.workerVolumes" . | nindent 8 }}
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: {{ .Values.node.arch }}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -88,6 +88,6 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: {{ .Values.node.arch }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -31,7 +31,7 @@ spec:
             - mountPath: /tmp/working_dir
               name: working-volume
         - name: apply-db-schemas
-          image: {{ .Values.db.clientImage }}
+          image: {{ include "corda.dbClientImage" . }}
           command: [ 'sh', '-c', 'for f in /tmp/working_dir/*.sql; do psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -60,7 +60,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-rbac-db-config
-          image: {{ .Values.db.clientImage }}
+          image: {{ include "corda.dbClientImage" . }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -89,7 +89,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-crypto-db-config
-          image: {{ .Values.db.clientImage }}
+          image: {{ include "corda.dbClientImage" . }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -118,7 +118,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-rpc-admin
-          image: {{ .Values.db.clientImage }}
+          image: {{ include "corda.dbClientImage" . }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/rbac-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -130,7 +130,7 @@ spec:
                   name: {{ include "corda.clusterDbSecretName" . }}
                   key: password
         - name: create-db-users-and-grant
-          image: {{ .Values.db.clientImage }}
+          image: {{ include "corda.dbClientImage" . }}
           command: [ '/bin/sh', '-e', '-c' ]
           args:
             - |

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -31,7 +31,7 @@ spec:
             - mountPath: /tmp/working_dir
               name: working-volume
         - name: apply-db-schemas
-          image: bitnami/postgresql:14.2.0-debian-10-r88
+          image: {{ .Values.db.clientImage }}
           command: [ 'sh', '-c', 'for f in /tmp/working_dir/*.sql; do psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -60,7 +60,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-rbac-db-config
-          image: bitnami/postgresql:14.2.0-debian-10-r88
+          image: {{ .Values.db.clientImage }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -89,7 +89,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-crypto-db-config
-          image: bitnami/postgresql:14.2.0-debian-10-r88
+          image: {{ .Values.db.clientImage }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -118,7 +118,7 @@ spec:
                   name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
                   key: passphrase
         - name: apply-initial-rpc-admin
-          image: bitnami/postgresql:14.2.0-debian-10-r88
+          image: {{ .Values.db.clientImage }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/rbac-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -130,7 +130,7 @@ spec:
                   name: {{ include "corda.clusterDbSecretName" . }}
                   key: password
         - name: create-db-users-and-grant
-          image: bitnami/postgresql:14.2.0-debian-10-r88
+          image: {{ .Values.db.clientImage }}
           command: [ '/bin/sh', '-e', '-c' ]
           args:
             - |

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -88,6 +88,7 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -90,4 +90,4 @@ spec:
       {{- include "corda.workerVolumes" . | nindent 8 }}
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: {{ .Values.node.arch }}

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -88,6 +88,6 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: {{ .Values.node.arch }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -68,6 +68,7 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -68,6 +68,6 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: {{ .Values.node.arch }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -70,4 +70,4 @@ spec:
       {{- include "corda.workerVolumes" . | nindent 8 }}
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: {{ .Values.node.arch }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -58,4 +58,4 @@ spec:
       {{- include "corda.workerVolumes" . | nindent 8 }}
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: {{ .Values.node.arch }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -56,6 +56,6 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: {{ .Values.node.arch }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -56,6 +56,7 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -102,6 +102,7 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -104,4 +104,4 @@ spec:
       {{- include "corda.workerVolumes" . | nindent 8 }}
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
+        kubernetes.io/arch: {{ .Values.node.arch }}

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -102,6 +102,6 @@ spec:
         {{- end }}
       volumes:
       {{- include "corda.workerVolumes" . | nindent 8 }}
-      nodeSelector:
-        kubernetes.io/os: linux
-        kubernetes.io/arch: {{ .Values.node.arch }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -13,7 +13,7 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: run-topic-script
-          image: bitnami/kafka:3.1.0-debian-10-r89
+          image: {{ .Values.kafka.clientImage }}
           resources:
             requests:
               cpu: 2000m

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -13,7 +13,7 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: run-topic-script
-          image: {{ .Values.kafka.clientImage }}
+          image: {{ include "corda.kafkaClientImage" . }}
           resources:
             requests:
               cpu: 2000m
@@ -39,7 +39,7 @@ spec:
             {{- end }}
       initContainers:
         - name: create-trust-store
-          image: {{ .Values.kafka.clientImage }}
+          image: {{ include "corda.kafkaClientImage" . }}
           command:
             - /bin/bash
             - -c

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -39,7 +39,7 @@ spec:
             {{- end }}
       initContainers:
         - name: create-trust-store
-          image: bitnami/kafka:3.1.0-debian-10-r89
+          image: {{ .Values.kafka.clientImage }}
           command:
             - /bin/bash
             - -c

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -84,11 +84,11 @@ kafka:
       # -- if TLS is enabled, the password for the truststore for client connections to Kafka, if any
       password: ""
   clientImage:
-    # -- registry for image containing a Kafka client, used to set up the db
+    # -- registry for image containing a Kafka client, used to set up Kafka
     registry: ""
-    # -- repository for image containing a Kafka client, used to set up the db
+    # -- repository for image containing a Kafka client, used to set up Kafka
     repository: bitnami/kafka
-    # -- tag for image containing a Kafka client, used to set up the db
+    # -- tag for image containing a Kafka client, used to set up Kafka
     tag: 3.1.0-debian-10-r89
 
 # Configuration for the bootstrapper

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -28,6 +28,9 @@ resources:
   # -- the CPU/memory resource request for the Corda worker containers
   requests: {}
 
+# -- node labels for pod assignment, see https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
 # Database configuration
 db:
   # Cluster database configuration
@@ -46,10 +49,12 @@ db:
     password: ""
     # -- the name of an existing secret containing the cluster database password with a key of 'password'
     existingSecret: ""
-  # image containing a db client, used to set up the db
   clientImage:
+    # -- registry for image containing a db client, used to set up the db
     registry: ""
+    # -- repository for image containing a db client, used to set up the db
     repository: bitnami/postgresql
+    # -- tag for image containing a db client, used to set up the db
     tag: 14.2.0-debian-10-r88
 
 # Kafka configuration
@@ -78,10 +83,12 @@ kafka:
       type: "PEM"
       # -- if TLS is enabled, the password for the truststore for client connections to Kafka, if any
       password: ""
-  # image containing a Kafka client, used to set up Kafka
   clientImage:
+    # -- registry for image containing a Kafka client, used to set up the db
     registry: ""
+    # -- repository for image containing a Kafka client, used to set up the db
     repository: bitnami/kafka
+    # -- tag for image containing a Kafka client, used to set up the db
     tag: 3.1.0-debian-10-r89
 
 # Configuration for the bootstrapper

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -51,7 +51,10 @@ db:
     # -- the name of an existing secret containing the cluster database password with a key of 'password'
     existingSecret: ""
   # image containing a db client, used to set up the db
-  clientImage: bitnami/postgresql:14.2.0-debian-10-r88
+  clientImage:
+    registry: ""
+    repository: bitnami/postgresql
+    tag: 14.2.0-debian-10-r88
 
 # Kafka configuration
 kafka:
@@ -80,7 +83,10 @@ kafka:
       # -- if TLS is enabled, the password for the truststore for client connections to Kafka, if any
       password: ""
   # image containing a Kafka client, used to set up Kafka
-  clientImage: bitnami/kafka:3.1.0-debian-10-r89
+  clientImage:
+    registry: ""
+    repository: bitnami/kafka
+    tag: 3.1.0-debian-10-r89
 
 # Configuration for the bootstrapper
 bootstrap:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -15,10 +15,6 @@ image:
   # -- worker image tag, defaults to Chart appVersion
   tag: ""
 
-# default node architecture to run the Corda containers on
-node:
-  arch: amd64
-
 # -- image pull secrets
 imagePullSecrets: []
 

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -15,6 +15,10 @@ image:
   # -- worker image tag, defaults to Chart appVersion
   tag: ""
 
+# default node architecture to run the Corda containers on
+node:
+  arch: amd64
+
 # -- image pull secrets
 imagePullSecrets: []
 
@@ -46,6 +50,8 @@ db:
     password: ""
     # -- the name of an existing secret containing the cluster database password with a key of 'password'
     existingSecret: ""
+  # image containing a db client, used to set up the db
+  clientImage: bitnami/postgresql:14.2.0-debian-10-r88
 
 # Kafka configuration
 kafka:
@@ -73,6 +79,8 @@ kafka:
       type: "PEM"
       # -- if TLS is enabled, the password for the truststore for client connections to Kafka, if any
       password: ""
+  # image containing a Kafka client, used to set up Kafka
+  clientImage: bitnami/kafka:3.1.0-debian-10-r89
 
 # Configuration for the bootstrapper
 bootstrap:


### PR DESCRIPTION
1. Building on a host which reports 'aarch64' as the platform architecture will result in arm64 Docker images being produced instead of amd64 ones, as long as the base image supports that.
2. Hard coded images and other arch specific items are moved to values so they can be overridden by the developer.