### PR TITLE
CORE-4998 Cleanup flow mapper in-memory state

### DIFF
--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/PublishConfig.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/PublishConfig.kt
@@ -35,7 +35,7 @@ class PublishConfig(private val context: TaskContext) : Task {
         for (componentKey in configFileConfig.getConfig("corda").root().keys) {
             val componentPath = "corda.${componentKey}"
             val configAsJson = configFileConfig.getConfig(componentPath).root().render(ConfigRenderOptions.concise())
-            val content = Configuration(configAsJson, "5.0", ConfigurationSchemaVersion(1,0))
+            val content = Configuration(configAsJson, "5", ConfigurationSchemaVersion(1,0))
             val record = Record(CONFIG_TOPIC, componentPath, content)
 
             context.publish(record)

--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
@@ -51,7 +51,7 @@ class StartFlow(private val context: TaskContext) : Task {
         val rpcStartFlow = StartFlow(context, jsonArgs)
         return Record(
             Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC,
-            context.statusKey,
+            context.statusKey.toString(),
             FlowMapperEvent(rpcStartFlow)
         )
     }

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
@@ -77,15 +77,15 @@ class FlowMapperListener(
      * Set up a cleanup timer for this key
      */
     private fun setupCleanupTimer(eventKey: String, expiryTime: Long) {
-        scheduledTasks[eventKey] = executorService.schedule(
-            {
-                log.debug { "Clearing up mapper state for key $eventKey" }
-                publisher?.publish(listOf(Record(FLOW_MAPPER_EVENT_TOPIC, eventKey, FlowMapperEvent(
-                    ExecuteCleanup()
-                ))))
-            },
-            expiryTime - clock.millis(),
-            TimeUnit.MILLISECONDS
-        )
+        scheduledTasks.computeIfAbsent(eventKey) {
+            executorService.schedule(
+                {
+                    log.debug { "Clearing up mapper state for key $eventKey" }
+                    publisher?.publish(listOf(Record(FLOW_MAPPER_EVENT_TOPIC, eventKey, FlowMapperEvent(ExecuteCleanup()))))
+                },
+                expiryTime - clock.millis(),
+                TimeUnit.MILLISECONDS
+            )
+        }
     }
 }

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
@@ -7,7 +7,14 @@ import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import net.corda.data.flow.FlowKey
 
+/**
+ * The [FlowMapperMessageProcessor] receives states and events that are keyed by strings. These strings can be either:
+ *
+ * - `toString`ed [FlowKey]s representing flow starts.
+ * - Session ids representing sessions.
+ */
 class FlowMapperMessageProcessor(
     private val flowMapperEventExecutorFactory: FlowMapperEventExecutorFactory
 ) : StateAndEventProcessor<String, FlowMapperState, FlowMapperEvent> {
@@ -21,7 +28,7 @@ class FlowMapperMessageProcessor(
         event: Record<String, FlowMapperEvent>
     ): StateAndEventProcessor.Response<FlowMapperState> {
         val key = event.key
-        logger.debug { "Received event: key: $key event: $event " }
+        logger.debug { "Received event: key: $key event: ${event.value}" }
         val value = event.value ?: return StateAndEventProcessor.Response(state, emptyList())
         val executor = flowMapperEventExecutorFactory.create(key, value, state)
         val result = executor.execute()

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -79,7 +79,7 @@ class FlowRPCOpsImpl @Activate constructor(
         val status = messageFactory.createStartFlowStatus(clientRequestId, vNode, flowClassName)
 
         val records = listOf(
-            Record(FLOW_MAPPER_EVENT_TOPIC, status.key, startEvent),
+            Record(FLOW_MAPPER_EVENT_TOPIC, status.key.toString(), startEvent),
             Record(FLOW_STATUS_TOPIC, status.key, status),
         )
 

--- a/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
+++ b/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
@@ -52,9 +52,9 @@ This document should be maintained so that we can ensure that we have quick visi
 - Given two sessions receiving a session close event for one resumes the flow with an error (not fully implemented, assert WAIT_FOR_FINAL_ACK session as well)
 - Given two sessions receiving a session data event for one and a close for another resumes the flow with an error
 - Given a non-receive request type receiving a session data event does not resume the flow and sends a session acks ✅
-- Given two sessions receiving a single session error event does not resume the flow ✅
-- Given two sessions receiving a session data event for one and a session error event for the other resumes the flow with an error ✅
-- Given two sessions receiving a session error event first for one and a session data event for the other resumes the flow with an error ✅
+- Given two sessions receiving a single session error event does not resume the flow and schedules session cleanup ✅
+- Given two sessions receiving a session data event for one and a session error event for the other resumes the flow with an error and schedules session cleanup ✅
+- Given two sessions receiving a session error event first for one and a session data event for the other resumes the flow with an error and schedules session cleanup ✅
 - Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error ✅
 - Given two sessions receiving session close events for both sessions resumes the flow with an error ✅
 - Given two sessions receiving a session data and then close event for one session and a session data event for the other resumes the flow  ✅
@@ -62,6 +62,7 @@ This document should be maintained so that we can ensure that we have quick visi
 ## Closing
 
 - Calling 'close' on initiated sessions sends session close events ✅
+- Calling 'close' on an initiated and closing session sends session close events ✅
 - Calling 'close' on an initiated and closed session sends a session close event to the initiated session ✅
 - Calling 'close' on an initiated and errored session sends a session close event to the initiated session ✅
 - Calling 'close' on a closed and errored session schedules a wakeup event and sends no session close events ✅
@@ -70,24 +71,24 @@ This document should be maintained so that we can ensure that we have quick visi
 - Receiving a wakeup or session ack event does not resume the flow and resends any unacknowledged events ✅ (Still requires the resends to be asserted)
 - Receiving a session event for an unrelated session does not resume the flow and sends a session ack ✅
 - Receiving a session data event instead of a close resumes the flow with an error ✅
-- Given two sessions receiving a single session close event does not resume the flow and sends a session ack ✅
-- Given two sessions receiving all session close events resumes the flow and sends session acks ✅
-- Given two sessions where one has already received a session close event calling 'close' and then receiving a session close event for the other session does not resume the flow and sends a session ack ✅
+- Given two sessions receiving a single session close event does not resume the flow sends a session ack and schedules session cleanup ✅
+- Given two sessions receiving all session close events resumes the flow sends session acks and schedules session cleanup ✅
 - Given two sessions where one enters WAIT_FOR_FINAL_ACK after calling 'close' resumes the flow after receiving a session ack and session close ✅ (test done twice but order switched around)
-- Given two sessions have already received their session close events when the flow calls 'close' for both sessions at once the flow resumes after receiving session acks from each ✅
-- Given two sessions have already received their session close events when the flow calls 'close' for each session individually the flow resumes after receiving session acks respectively ✅
+- Given two sessions have already received their session close events when the flow calls 'close' for both sessions at once the flow resumes after receiving session acks from each and schedules session cleanup ✅
+- Given two sessions have already received their session close events when the flow calls 'close' for each session individually the flow resumes after receiving session acks respectively and schedules session cleanup ✅
 - Given two closed sessions when the flow calls 'close' for both sessions a wakeup event is scheduled and no session close events are sent ✅
 - Given a non-close request type receiving a session close event does not resume the flow and sends a session ack ✅
 - Given a flow resumes after receiving session data events calling 'close' on the sessions sends session close events and no session ack for the session that resumed the flow ✅
-- Given two sessions receiving a single session error event does not resume the flow ✅
-- Given two sessions receiving two session error events resumes the flow with an error ✅
-- Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error ✅
-- Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error ✅
-- Given two sessions receiving session data events for both sessions resumes the flow with an error ✅
+- Given two sessions receiving a single session error event does not resume the flow and schedules session cleanup ✅
+- Given two sessions receiving two session error events resumes the flow with an error and schedules session cleanup ✅
+- Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup ✅
+- Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup ✅
+- Given two sessions receiving session data events for both sessions resumes the flow with an error and schedules session cleanup ✅
 
-## SubFlow session closing
+## SubFlow finishing
 
 - Given a subFlow contains only initiated sessions when the subFlow finishes session close events are sent ✅
+- Given a subFlow contains an initiated and closing session when the subFlow finishes session close events are sent ✅
 - Given a subFlow contains an initiated and closed session when the subFlow finishes a single session close event is sent ✅
 - Given a subFlow contains only closed sessions when the subFlow finishes a wakeup event is scheduled ✅
 - Given a subFlow contains no sessions when the subFlow finishes a wakeup event is scheduled ✅
@@ -98,26 +99,37 @@ This document should be maintained so that we can ensure that we have quick visi
 - Receiving a session close event for one session and a data for another resumes the flow with an error
 - Receiving a session event for an unrelated session does not resume the flow and sends a session ack ✅
 - Receiving a session data event instead of a close resumes the flow with an error ✅
-- Given two sessions receiving a single session close event does not resume the flow and sends a session ack ✅
-- Given two sessions receiving all session close events resumes the flow and sends session acks ✅
-- Given two sessions where one has already received a session close event calling 'close' and then receiving a session close event for the other session does not resume the flow and sends a session ack ✅
+- Given two sessions receiving a single session close event does not resume the flow sends a session ack and schedules session cleanup ✅
+- Given two sessions receiving all session close events resumes the flow sends session acks and schedules session cleanup ✅
 - Given two sessions where one enters WAIT_FOR_FINAL_ACK after calling 'close' resumes the flow after receiving a session ack and session close ✅ (test done twice but order switched around)
-- Given two sessions receiving a single session error event does not resume the flow ✅
-- Given two sessions receiving two session error events resumes the flow with an error ✅
-- Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error ✅
+- Given two sessions receiving a single session error event does not resume the flow and schedules session cleanup ✅
+- Given two sessions receiving two session error events resumes the flow with an error and schedules session cleanup ✅
+- Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup ✅
 - Given an initiated top level flow with an initiated session when it finishes and calls SubFlowFinished a session close event is sent ✅
-- Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error ✅
-- Given two sessions receiving session data events for both sessions resumes the flow with an error ✅
+- Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup ✅
+- Given two sessions receiving session data events for both sessions resumes the flow with an error and schedules session cleanup ✅
 - Given an initiated top level flow with a closed session when it finishes and calls SubFlowFinished a wakeup event is scheduled and does not send a session close event ✅
 - Given an initiated top level flow with an errored session when it finishes and calls SubFlowFinished a wakeup event is scheduled and no session close event is sent ✅
 
 ## SubFlow failing
 
-- Given a subFlow contains only initiated sessions when the subFlow fails a wakeup event is scheduled and session error events are sent ✅
-- Given a subFlow contains an initiated and closed session when the subFlow fails a wakeup event is scheduled and a single session error event is sent to the initiated session ✅
+- Given a subFlow contains only initiated sessions when the subFlow fails a wakeup event is scheduled session error events are sent and session cleanup is scheduled ✅
+- Given a subFlow contains an initiated and closed session when the subFlow fails a wakeup event is scheduled a single session error event is sent to the initiated session and session cleanup is scheduled ✅
 - Given a subFlow contains only closed sessions when the subFlow fails a wakeup event is scheduled and no session error events are sent ✅
 - Given a subFlow contains only errored sessions when the subFlow fails a wakeup event is scheduled and no session error events are sent ✅
 - Given a subFlow contains no sessions when the subFlow fails a wakeup event is scheduled ✅
-- Given an initiated top level flow with an initiated session when it finishes and calls SubFlowFailed a session error event is sent ✅
+- Given an initiated top level flow with an initiated session when it finishes and calls SubFlowFailed a session error event is sent and session cleanup is scheduled ✅
 - Given an initiated top level flow with a closed session when it finishes and calls SubFlowFailed a wakeup event is scheduled and does not send a session error event ✅
 - Given an initiated top level flow with an errored session when it finishes and calls SubFlowFailed a wakeup event is scheduled and no session error event is sent` ✅
+
+## Flow finishing
+
+- A flow finishing removes the flow's checkpoint publishes a completed flow status and schedules flow cleanup ✅
+- An initiated flow finishing removes the flow's checkpoint publishes a completed flow status and schedules flow cleanup ✅
+- Given the flow has a WAIT_FOR_FINAL_ACK session receiving a session close event and then finishing the flow schedules flow and session cleanup ✅
+
+## Flow failing
+
+- A flow failing removes the flow's checkpoint publishes a failed flow status and schedules flow cleanup ✅
+- An initiated flow failing removes the flow's checkpoint publishes a failed flow status and schedules flow cleanup ✅
+- Given the flow has a WAIT_FOR_FINAL_ACK session receiving a session close event and then failing the flow schedules flow and session cleanup ✅

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
@@ -35,6 +35,8 @@ interface OutputAssertions {
         initiatedIdentity: HoldingIdentity? = null
     )
 
+    fun scheduleFlowMapperCleanupEvents(vararg key: String)
+
     fun flowDidNotResume()
 
     fun flowResumedWith(value: Any)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
@@ -104,6 +104,30 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
+    fun `Calling 'close' on an initiated and closing session sends session close events`() {
+        given {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
+
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_2))
+
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
+        }
+
+        `when` {
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_2, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                sessionCloseEvents(SESSION_ID_1, SESSION_ID_2)
+            }
+        }
+    }
+
+    @Test
     fun `Calling 'close' on an initiated and closed session sends a session close event to the initiated session`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
@@ -329,7 +353,7 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
-    fun `Given two sessions receiving a single session close event does not resume the flow and sends a session ack`() {
+    fun `Given two sessions receiving a single session close event does not resume the flow sends a session ack and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -349,12 +373,13 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
                 sessionAckEvents(SESSION_ID_1)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving all session close events resumes the flow and sends session acks`() {
+    fun `Given two sessions receiving all session close events resumes the flow sends session acks and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -377,59 +402,13 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
                 sessionAckEvents(SESSION_ID_1)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
                 sessionAckEvents(SESSION_ID_2)
-            }
-        }
-    }
-
-    /**
-     * Given two sessions where:
-     *
-     * - `SESSION_ID_1` has already received a session close event.
-     * - `close` is called.
-     * - `SESSION_ID_2` receives a session close event.
-     *
-     * The flow does not resume and sends `SESSION_ID_2` a session ack.
-     */
-    @Test
-    fun `Given two sessions where one has already received a session close event calling close and then receiving a session close event for the other session does not resume the flow and sends a session ack`() {
-        given {
-            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
-                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
-
-            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
-                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_2))
-
-            sessionAckEventReceived(FLOW_ID1, SESSION_ID_2, receivedSequenceNum = 1)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
-        }
-
-        `when` {
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-                .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
-
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 2)
-
-            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 2)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
-        }
-
-        then {
-            expectOutputForFlow(FLOW_ID1) {
-                sessionCloseEvents(SESSION_ID_1, SESSION_ID_2)
-            }
-
-            expectOutputForFlow(FLOW_ID1) {
-                sessionAckEvents(SESSION_ID_2)
-            }
-
-            expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(Unit)
-                sessionAckEvents()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
@@ -471,11 +450,13 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
                 sessionAckEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
                 sessionAckEvents()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
         }
     }
@@ -522,12 +503,13 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
                 sessionAckEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions have already received their session close events when the flow calls 'close' for both sessions at once the flow resumes after receiving session acks from each`() {
+    fun `Given two sessions have already received their session close events when the flow calls 'close' for both sessions at once the flow resumes after receiving session acks from each and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -555,20 +537,23 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 sessionCloseEvents(SESSION_ID_1, SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents()
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions have already received their session close events when the flow calls 'close' for each session individually the flow resumes after receiving session acks respectively`() {
+    fun `Given two sessions have already received their session close events when the flow calls 'close' for each session individually the flow resumes after receiving session acks respectively and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -597,15 +582,18 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 sessionCloseEvents(SESSION_ID_1)
+                scheduleFlowMapperCleanupEvents()
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
                 sessionCloseEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
@@ -706,7 +694,7 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
-    fun `Given two sessions receiving a single session error event does not resume the flow and sends a session ack`() {
+    fun `Given two sessions receiving a single session error event does not resume the flow and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -725,12 +713,13 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving two session error events resumes the flow with an error and sends session acks`() {
+    fun `Given two sessions receiving two session error events resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -751,16 +740,18 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error`() {
+    fun `Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -781,17 +772,19 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
                 sessionAckEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error`() {
+    fun `Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -817,12 +810,13 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
                 sessionAckEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving session data events for both sessions resumes the flow with an error`() {
+    fun `Given two sessions receiving session data events for both sessions resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -843,10 +837,12 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowFailedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowFailedAcceptanceTest.kt
@@ -1,0 +1,100 @@
+package net.corda.flow.testing.tests
+
+import net.corda.data.flow.FlowKey
+import net.corda.data.flow.output.FlowStates
+import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.exceptions.FlowProcessingExceptionTypes.FLOW_FAILED
+import net.corda.flow.testing.context.FlowServiceTestBase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.osgi.test.junit5.service.ServiceExtension
+
+@ExtendWith(ServiceExtension::class)
+@Execution(ExecutionMode.SAME_THREAD)
+class FlowFailedAcceptanceTest : FlowServiceTestBase() {
+
+    private companion object {
+        val EXCEPTION = RuntimeException("Job's done")
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        given {
+            virtualNode(CPI1, ALICE_HOLDING_IDENTITY)
+            virtualNode(CPI1, BOB_HOLDING_IDENTITY)
+            cpkMetadata(CPI1, CPK1)
+            sandboxCpk(CPK1)
+            membershipGroupFor(ALICE_HOLDING_IDENTITY)
+            membershipGroupFor(BOB_HOLDING_IDENTITY)
+
+            sessionInitiatingIdentity(ALICE_HOLDING_IDENTITY)
+            sessionInitiatedIdentity(BOB_HOLDING_IDENTITY)
+
+            initiatingToInitiatedFlow(PROTOCOL, FAKE_FLOW_NAME, FAKE_FLOW_NAME)
+        }
+    }
+
+    @Test
+    fun `A flow failing removes the flow's checkpoint publishes a failed flow status and schedules flow cleanup`() {
+        `when` {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.FlowFailed(EXCEPTION))
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                nullStateRecord()
+                flowStatus(FlowStates.FAILED, errorType = FLOW_FAILED, errorMessage = EXCEPTION.message)
+                scheduleFlowMapperCleanupEvents(FlowKey(REQUEST_ID1, ALICE_HOLDING_IDENTITY).toString())
+            }
+        }
+    }
+
+    @Test
+    fun `An initiated flow failing removes the flow's checkpoint publishes a failed flow status and schedules flow cleanup`() {
+        `when` {
+            sessionInitEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, CPI1, PROTOCOL)
+                .suspendsWith(FlowIORequest.FlowFailed(EXCEPTION))
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                nullStateRecord()
+                flowStatus(FlowStates.FAILED, errorType = FLOW_FAILED, errorMessage = EXCEPTION.message)
+                scheduleFlowMapperCleanupEvents(FlowKey(INITIATED_SESSION_ID_1, BOB_HOLDING_IDENTITY).toString())
+            }
+        }
+    }
+
+    @Test
+    fun `Given the flow has a WAIT_FOR_FINAL_ACK session receiving a session close event and then failing the flow schedules flow and session cleanup`() {
+        given {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
+
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
+
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1)))
+        }
+
+        `when` {
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 2)
+                .suspendsWith(FlowIORequest.FlowFailed(EXCEPTION))
+        }
+
+
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                nullStateRecord()
+                flowStatus(FlowStates.FAILED, errorType = FLOW_FAILED, errorMessage = EXCEPTION.message)
+                scheduleFlowMapperCleanupEvents(FlowKey(REQUEST_ID1, ALICE_HOLDING_IDENTITY).toString(), SESSION_ID_1)
+            }
+        }
+    }
+}

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowFinishedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowFinishedAcceptanceTest.kt
@@ -1,0 +1,99 @@
+package net.corda.flow.testing.tests
+
+import net.corda.data.flow.FlowKey
+import net.corda.data.flow.output.FlowStates
+import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.testing.context.FlowServiceTestBase
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.osgi.test.junit5.service.ServiceExtension
+
+@ExtendWith(ServiceExtension::class)
+@Execution(ExecutionMode.SAME_THREAD)
+class FlowFinishedAcceptanceTest : FlowServiceTestBase() {
+
+    private companion object {
+        const val DONE = "Job's done"
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        given {
+            virtualNode(CPI1, ALICE_HOLDING_IDENTITY)
+            virtualNode(CPI1, BOB_HOLDING_IDENTITY)
+            cpkMetadata(CPI1, CPK1)
+            sandboxCpk(CPK1)
+            membershipGroupFor(ALICE_HOLDING_IDENTITY)
+            membershipGroupFor(BOB_HOLDING_IDENTITY)
+
+            sessionInitiatingIdentity(ALICE_HOLDING_IDENTITY)
+            sessionInitiatedIdentity(BOB_HOLDING_IDENTITY)
+
+            initiatingToInitiatedFlow(PROTOCOL, FAKE_FLOW_NAME, FAKE_FLOW_NAME)
+        }
+    }
+
+    @Test
+    fun `A flow finishing removes the flow's checkpoint publishes a completed flow status and schedules flow cleanup`() {
+        `when` {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.FlowFinished(DONE))
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                nullStateRecord()
+                flowStatus(FlowStates.COMPLETED, result = DONE)
+                scheduleFlowMapperCleanupEvents(FlowKey(REQUEST_ID1, ALICE_HOLDING_IDENTITY).toString())
+            }
+        }
+    }
+
+    @Test
+    fun `An initiated flow finishing removes the flow's checkpoint publishes a completed flow status and schedules flow cleanup`() {
+        `when` {
+            sessionInitEventReceived(FLOW_ID1, INITIATED_SESSION_ID_1, CPI1, PROTOCOL)
+                .suspendsWith(FlowIORequest.FlowFinished(DONE))
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                nullStateRecord()
+                flowStatus(FlowStates.COMPLETED, result = DONE)
+                scheduleFlowMapperCleanupEvents(FlowKey(INITIATED_SESSION_ID_1, BOB_HOLDING_IDENTITY).toString())
+            }
+        }
+    }
+
+    @Test
+    fun `Given the flow has a WAIT_FOR_FINAL_ACK session receiving a session close event and then finishing the flow schedules flow and session cleanup`() {
+        given {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
+
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.ForceCheckpoint)
+
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1)))
+        }
+
+        `when` {
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 2)
+                .suspendsWith(FlowIORequest.FlowFinished(DONE))
+        }
+
+
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                nullStateRecord()
+                flowStatus(FlowStates.COMPLETED, result = DONE)
+                scheduleFlowMapperCleanupEvents(FlowKey(REQUEST_ID1, ALICE_HOLDING_IDENTITY).toString(), SESSION_ID_1)
+            }
+        }
+    }
+}

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ReceiveAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ReceiveAcceptanceTest.kt
@@ -375,7 +375,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
-    fun `Given two sessions receiving a single session error event does not resume the flow`() {
+    fun `Given two sessions receiving a single session error event does not resume the flow and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -395,12 +395,13 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving a session data event for one and a session error event for the other resumes the flow with an error`() {
+    fun `Given two sessions receiving a session data event for one and a session error event for the other resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -426,12 +427,13 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving a session error event first for one and a session data event for the other resumes the flow with an error`() {
+    fun `Given two sessions receiving a session error event first for one and a session data event for the other resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -452,6 +454,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
 
             expectOutputForFlow(FLOW_ID1) {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFinishedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFinishedAcceptanceTest.kt
@@ -100,6 +100,30 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
+    fun `Calling 'close' on an initiated and closing session sends session close events`() {
+        given {
+            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
+
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_2))
+
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
+        }
+
+        `when` {
+            sessionAckEventReceived(FLOW_ID1, SESSION_ID_2, receivedSequenceNum = 1)
+                .suspendsWith(FlowIORequest.SubFlowFinished(initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                sessionCloseEvents(SESSION_ID_1, SESSION_ID_2)
+            }
+        }
+    }
+
+    @Test
     fun `Given a subFlow contains an initiated and closed session when the subFlow finishes a single session close event is sent`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
@@ -351,7 +375,7 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
-    fun `Given two sessions receiving a single session close event does not resume the flow and sends a session ack`() {
+    fun `Given two sessions receiving a single session close event does not resume the flow sends a session ack and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -371,12 +395,13 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
                 sessionAckEvents(SESSION_ID_1)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving all session close events resumes the flow and sends session acks`() {
+    fun `Given two sessions receiving all session close events resumes the flow sends session acks and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -399,59 +424,13 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
                 sessionAckEvents(SESSION_ID_1)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
                 sessionAckEvents(SESSION_ID_2)
-            }
-        }
-    }
-
-    /**
-     * Given two sessions where:
-     *
-     * - `SESSION_ID_1` has already received a session close event.
-     * - The subFlow finished.
-     * - `SESSION_ID_2` receives a session close event.
-     *
-     * The flow does not resume and sends `SESSION_ID_2` a session ack.
-     */
-    @Test
-    fun `Given two sessions where one has already received a session close event calling close and then receiving a session close event for the other session does not resume the flow and sends a session ack`() {
-        given {
-            startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
-                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
-
-            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 1)
-                .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_2))
-
-            sessionAckEventReceived(FLOW_ID1, SESSION_ID_2, receivedSequenceNum = 1)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
-        }
-
-        `when` {
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
-                .suspendsWith(FlowIORequest.SubFlowFinished(initiatingFlowStackItem(SESSION_ID_1, SESSION_ID_2)))
-
-            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_2, sequenceNum = 1, receivedSequenceNum = 2)
-
-            sessionAckEventReceived(FLOW_ID1, SESSION_ID_1, receivedSequenceNum = 2)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
-        }
-
-        then {
-            expectOutputForFlow(FLOW_ID1) {
-                sessionCloseEvents(SESSION_ID_1, SESSION_ID_2)
-            }
-
-            expectOutputForFlow(FLOW_ID1) {
-                sessionAckEvents(SESSION_ID_2)
-            }
-
-            expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(Unit)
-                sessionAckEvents()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
@@ -493,11 +472,13 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
                 sessionAckEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
                 sessionAckEvents()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
         }
     }
@@ -544,12 +525,13 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWith(Unit)
                 sessionAckEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving a single session error event does not resume the flow and sends a session ack`() {
+    fun `Given two sessions receiving a single session error event does not resume the flow and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -568,12 +550,13 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving two session error events resumes the flow with an error and sends session acks`() {
+    fun `Given two sessions receiving two session error events resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -594,16 +577,18 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error`() {
+    fun `Given two sessions receiving a session error event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -624,16 +609,18 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error`() {
+    fun `Given two sessions receiving a session data event for one session and a session close event for the other resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -659,12 +646,13 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
                 sessionAckEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }
 
     @Test
-    fun `Given two sessions receiving session data events for both sessions resumes the flow with an error`() {
+    fun `Given two sessions receiving session data events for both sessions resumes the flow with an error and schedules session cleanup`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.InitiateFlow(initiatedIdentityMemberName, SESSION_ID_1))
@@ -685,10 +673,12 @@ class SubFlowFinishedAcceptanceTest : FlowServiceTestBase() {
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1)
             }
 
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<CordaRuntimeException>()
+                scheduleFlowMapperCleanupEvents(SESSION_ID_2)
             }
         }
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowRecordFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowRecordFactory.kt
@@ -17,9 +17,9 @@ interface FlowRecordFactory {
     /**
      * Creates a generic [FlowEvent] record
      *
-     * @param flowId the id of the flow generating or receiving the event.
-     * @param payload the instance of the specific flow event to be carried by the record.
-     * valid types are [StartFlow], [Wakeup], [SessionEvent]
+     * @param flowId The id of the flow generating or receiving the event.
+     * @param payload The instance of the specific flow event to be carried by the record. Valid types are [StartFlow], [Wakeup],
+     * [SessionEvent].
      * @return a new instance of a [FlowEvent] record.
      */
     fun createFlowEventRecord(flowId: String, payload: Any): Record<String, FlowEvent>
@@ -27,16 +27,17 @@ interface FlowRecordFactory {
     /**
      * Creates a [FlowStatus] record
      *
-     * @param status the status to be carried by the record
-     * @return a new instance of a [FlowStatus] record.
+     * @param status The status to be carried by the record
+     * @return A new instance of a [FlowStatus] record.
      */
     fun createFlowStatusRecord(status: FlowStatus): Record<FlowKey, FlowStatus>
 
     /**
      * Creates a [FlowMapperEvent] record
      *
-     * @param sessionEvent the session event to be carried by the record
-     * @return a new instance of a [FlowMapperEvent] record.
+     * @param key The key of the created record.
+     * @param payload The instance of the specific flow mapper event to be carried by the record.
+     * @return A new instance of a [FlowMapperEvent] record.
      */
-    fun createFlowMapperSessionEventRecord(sessionEvent: SessionEvent): Record<String, FlowMapperEvent>
+    fun createFlowMapperEventRecord(key: String, payload: Any): Record<*, FlowMapperEvent>
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowRecordFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowRecordFactoryImpl.kt
@@ -2,7 +2,6 @@ package net.corda.flow.pipeline.factory.impl
 
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.FlowEvent
-import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.output.FlowStatus
 import net.corda.flow.pipeline.factory.FlowRecordFactory
@@ -31,11 +30,11 @@ class FlowRecordFactoryImpl : FlowRecordFactory {
         )
     }
 
-    override fun createFlowMapperSessionEventRecord(sessionEvent: SessionEvent): Record<String, FlowMapperEvent> {
+    override fun createFlowMapperEventRecord(key: String, payload: Any): Record<*, FlowMapperEvent> {
         return Record(
             topic = FLOW_MAPPER_EVENT_TOPIC,
-            key = sessionEvent.sessionId,
-            value = FlowMapperEvent(sessionEvent)
+            key = key,
+            value = FlowMapperEvent(payload)
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
@@ -1,14 +1,17 @@
 package net.corda.flow.pipeline.handlers.requests
 
+import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.minutes
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.time.Instant
 
 @Suppress("Unused")
 @Component(service = [FlowRequestHandler::class])
@@ -37,9 +40,14 @@ class FlowFinishedRequestHandler @Activate constructor(
         log.info("Flow [${checkpoint.flowId}] completed successfully")
 
         val status = flowMessageFactory.createFlowCompleteStatusMessage(checkpoint, request.result)
-        val record = flowRecordFactory.createFlowStatusRecord(status)
+
+        val expiryTime = Instant.now().plusMillis(1.minutes.toMillis()).toEpochMilli() // TODO Should be configurable?
+        val records = listOf(
+            flowRecordFactory.createFlowStatusRecord(status),
+            flowRecordFactory.createFlowMapperEventRecord(checkpoint.flowKey.toString(), ScheduleCleanup(expiryTime))
+        )
 
         context.checkpoint.markDeleted()
-        return context.copy(outputRecords = context.outputRecords + record)
+        return context.copy(outputRecords = context.outputRecords + records)
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -24,6 +24,7 @@ import java.time.Instant
 import kotlin.math.min
 import kotlin.math.pow
 
+@Suppress("TooManyFunctions")
 class FlowCheckpointImpl(
     private var nullableCheckpoint: Checkpoint?,
     private val config: SmartConfig,
@@ -64,6 +65,8 @@ class FlowCheckpointImpl(
         get() = checkNotNull(nullableSessionsMap)
         { "Attempt to access checkpoint before initialisation" }
 
+    private var deleted = false
+
     override val flowId: String
         get() = checkpoint.flowId
 
@@ -102,7 +105,7 @@ class FlowCheckpointImpl(
         get() = sessionMap.values.toList()
 
     override val doesExist: Boolean
-        get() = nullableCheckpoint != null
+        get() = nullableCheckpoint != null && !deleted
 
     override val currentRetryCount: Int
         get() = checkpoint.retryState?.retryCount ?: -1
@@ -149,11 +152,12 @@ class FlowCheckpointImpl(
     }
 
     override fun putSessionState(sessionState: SessionState) {
+        checkFlowNotDeleted()
         sessionMap[sessionState.sessionId] = sessionState
     }
 
     override fun markDeleted() {
-        nullableCheckpoint = null
+        deleted = true
     }
 
     override fun rollback() {
@@ -161,6 +165,7 @@ class FlowCheckpointImpl(
     }
 
     override fun markForRetry(flowEvent: FlowEvent, exception: Exception) {
+        checkFlowNotDeleted()
         if (checkpoint.retryState == null) {
             checkpoint.retryState = RetryState().apply {
                 retryCount = 1
@@ -181,15 +186,17 @@ class FlowCheckpointImpl(
     }
 
     override fun markRetrySuccess() {
+        checkFlowNotDeleted()
         checkpoint.retryState = null
     }
 
     override fun setFlowSleepDuration(sleepTimeMs: Int) {
+        checkFlowNotDeleted()
         checkpoint.maxFlowSleepDuration = min(sleepTimeMs, checkpoint.maxFlowSleepDuration)
     }
 
     override fun toAvro(): Checkpoint? {
-        if (nullableCheckpoint == null) {
+        if (nullableCheckpoint == null || deleted) {
             return null
         }
 
@@ -237,6 +244,11 @@ class FlowCheckpointImpl(
             errorType = FLOW_TRANSIENT_EXCEPTION
             errorMessage = exception.message
         }
+    }
+
+    private fun checkFlowNotDeleted() {
+        // Does not prevent changes to the Avro objects, but will give us some protection from bugs moving forward.
+        check(!deleted) { "Flow has been marked for deletion but is currently being modified" }
     }
 
     private class FlowStackImpl(val flowStackItems: MutableList<FlowStackItem>) : FlowStack {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowRecordFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowRecordFactoryImplTest.kt
@@ -4,6 +4,7 @@ import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
+import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.pipeline.factory.impl.FlowRecordFactoryImpl
@@ -17,23 +18,30 @@ import org.junit.jupiter.api.Test
 class FlowRecordFactoryImplTest {
 
     @Test
-    fun `create flow event record`(){
-        val expected = Record(FLOW_EVENT_TOPIC,"flowId", FlowEvent("flowId",3))
-        assertThat(FlowRecordFactoryImpl().createFlowEventRecord("flowId",3)).isEqualTo(expected)
+    fun `create flow event record`() {
+        val expected = Record(FLOW_EVENT_TOPIC, "flowId", FlowEvent("flowId", 3))
+        assertThat(FlowRecordFactoryImpl().createFlowEventRecord("flowId", 3)).isEqualTo(expected)
     }
 
     @Test
-    fun `create flow status record`(){
-        val status = FlowStatus().apply { key = FlowKey("id", HoldingIdentity())}
+    fun `create flow status record`() {
+        val status = FlowStatus().apply { key = FlowKey("id", HoldingIdentity()) }
         val expected = Record(FLOW_STATUS_TOPIC, status.key, status)
         assertThat(FlowRecordFactoryImpl().createFlowStatusRecord(status)).isEqualTo(expected)
     }
 
     @Test
-    fun `create flow mapper session event record`(){
-        val sessionEvent = SessionEvent().apply { sessionId = "id1"}
-        val expected = Record(FLOW_MAPPER_EVENT_TOPIC,sessionEvent.sessionId, FlowMapperEvent(sessionEvent))
-        assertThat(FlowRecordFactoryImpl().createFlowMapperSessionEventRecord(sessionEvent)).isEqualTo(expected)
+    fun `create flow mapper event record with session event`() {
+        val sessionEvent = SessionEvent().apply { sessionId = "id1" }
+        val expected = Record(FLOW_MAPPER_EVENT_TOPIC, sessionEvent.sessionId, FlowMapperEvent(sessionEvent))
+        assertThat(FlowRecordFactoryImpl().createFlowMapperEventRecord(sessionEvent.sessionId, sessionEvent)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `create flow mapper event record with schedule cleanup event`() {
+        val cleanup = ScheduleCleanup(1000)
+        val expected = Record(FLOW_MAPPER_EVENT_TOPIC, "flowKey.toString", FlowMapperEvent(cleanup))
+        assertThat(FlowRecordFactoryImpl().createFlowMapperEventRecord("flowKey.toString", cleanup)).isEqualTo(expected)
     }
 }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFailedRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFailedRequestHandlerTest.kt
@@ -1,22 +1,31 @@
 package net.corda.flow.pipeline.handlers.requests
 
 import net.corda.data.flow.FlowKey
+import net.corda.data.flow.event.mapper.FlowMapperEvent
+import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.output.FlowStatus
+import net.corda.flow.BOB_X500_HOLDING_IDENTITY
 import net.corda.flow.RequestHandlerTestContext
+import net.corda.flow.SESSION_ID_1
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.exceptions.FlowProcessingExceptionTypes.FLOW_FAILED
 import net.corda.messaging.api.records.Record
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class FlowFailedRequestHandlerTest {
 
+    private companion object {
+        val FLOW_KEY = FlowKey(SESSION_ID_1, BOB_X500_HOLDING_IDENTITY)
+    }
+
     private val testContext = RequestHandlerTestContext(Any())
     private val flowError = Exception("error message")
     private val ioRequest = FlowIORequest.FlowFailed(flowError)
-    private val flowStatus = FlowStatus()
     private val handler = FlowFailedRequestHandler(testContext.flowMessageFactory,testContext.flowRecordFactory)
 
     @Test
@@ -27,13 +36,16 @@ class FlowFailedRequestHandlerTest {
 
     @Test
     fun `post processing marks context as deleted`() {
+        whenever(testContext.flowCheckpoint.flowKey).thenReturn(FLOW_KEY)
         handler.postProcess(testContext.flowEventContext, ioRequest)
         verify(testContext.flowCheckpoint).markDeleted()
     }
 
     @Test
-    fun `post processing publishes status update`() {
-        val statusRecord = Record("", FlowKey(),FlowStatus())
+    fun `post processing publishes status update and schedules flow cleanup`() {
+        val statusRecord = Record("", FLOW_KEY, FlowStatus())
+        val cleanupRecord = Record("", FLOW_KEY.toString(), FlowMapperEvent())
+        val flowStatus = FlowStatus()
 
         whenever(testContext.flowMessageFactory.createFlowFailedStatusMessage(
             testContext.flowCheckpoint,
@@ -42,8 +54,11 @@ class FlowFailedRequestHandlerTest {
         )).thenReturn(flowStatus)
 
         whenever(testContext.flowRecordFactory.createFlowStatusRecord(flowStatus)).thenReturn(statusRecord)
+        whenever(testContext.flowRecordFactory.createFlowMapperEventRecord(eq(FLOW_KEY.toString()), any<ScheduleCleanup>()))
+            .thenReturn(cleanupRecord)
+        whenever(testContext.flowCheckpoint.flowKey).thenReturn(FLOW_KEY)
 
         val outputContext = handler.postProcess(testContext.flowEventContext, ioRequest)
-        assertThat(outputContext.outputRecords).containsOnly(statusRecord)
+        assertThat(outputContext.outputRecords).containsOnly(statusRecord, cleanupRecord)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandlerTest.kt
@@ -1,22 +1,31 @@
 package net.corda.flow.pipeline.handlers.requests
 
 import net.corda.data.flow.FlowKey
+import net.corda.data.flow.event.mapper.FlowMapperEvent
+import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.output.FlowStatus
+import net.corda.flow.BOB_X500_HOLDING_IDENTITY
 import net.corda.flow.RequestHandlerTestContext
+import net.corda.flow.SESSION_ID_1
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.messaging.api.records.Record
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class FlowFinishedRequestHandlerTest {
 
+    private companion object {
+        val FLOW_KEY = FlowKey(SESSION_ID_1, BOB_X500_HOLDING_IDENTITY)
+    }
+
     private val testContext = RequestHandlerTestContext(Any())
     private val flowResult = "ok"
     private val ioRequest = FlowIORequest.FlowFinished(flowResult)
-    private val flowStatus = FlowStatus()
-    private val handler = FlowFinishedRequestHandler(testContext.flowMessageFactory,testContext.flowRecordFactory)
+    private val handler = FlowFinishedRequestHandler(testContext.flowMessageFactory, testContext.flowRecordFactory)
 
     @Test
     fun `Updates the waiting for to nothing`() {
@@ -26,22 +35,30 @@ class FlowFinishedRequestHandlerTest {
 
     @Test
     fun `post processing marks context as deleted`() {
+        whenever(testContext.flowCheckpoint.flowKey).thenReturn(FLOW_KEY)
         handler.postProcess(testContext.flowEventContext, ioRequest)
         verify(testContext.flowCheckpoint).markDeleted()
     }
 
     @Test
-    fun `post processing publishes status update`() {
-        val record = Record("",FlowKey(), FlowStatus())
+    fun `post processing publishes status update and schedules flow cleanup`() {
+        val statusRecord = Record("", FLOW_KEY, FlowStatus())
+        val cleanupRecord = Record("", FLOW_KEY.toString(), FlowMapperEvent())
+        val flowStatus = FlowStatus()
 
-        whenever(testContext.flowMessageFactory.createFlowCompleteStatusMessage(
-            testContext.flowCheckpoint,
-            flowResult
-        )).thenReturn(flowStatus)
+        whenever(
+            testContext.flowMessageFactory.createFlowCompleteStatusMessage(
+                testContext.flowCheckpoint,
+                flowResult
+            )
+        ).thenReturn(flowStatus)
 
-        whenever(testContext.flowRecordFactory.createFlowStatusRecord(flowStatus)).thenReturn(record)
+        whenever(testContext.flowRecordFactory.createFlowStatusRecord(flowStatus)).thenReturn(statusRecord)
+        whenever(testContext.flowRecordFactory.createFlowMapperEventRecord(eq(FLOW_KEY.toString()), any<ScheduleCleanup>()))
+            .thenReturn(cleanupRecord)
+        whenever(testContext.flowCheckpoint.flowKey).thenReturn(FLOW_KEY)
 
         val outputContext = handler.postProcess(testContext.flowEventContext, ioRequest)
-        assertThat(outputContext.outputRecords).containsOnly(record)
+        assertThat(outputContext.outputRecords).containsOnly(statusRecord, cleanupRecord)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -3,7 +3,9 @@ package net.corda.flow.pipeline.impl
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
+import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.state.session.SessionState
+import net.corda.data.flow.state.session.SessionStateType
 import net.corda.flow.ALICE_X500_HOLDING_IDENTITY
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
@@ -12,29 +14,60 @@ import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.messaging.api.records.Record
 import net.corda.session.manager.SessionManager
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.provider.Arguments
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.stream.Stream
 
 class FlowGlobalPostProcessorImplTest {
 
-    private val sessionId1 = "s1"
-    private val sessionState1 = SessionState().apply { this.sessionId = sessionId1 }
+    private companion object {
+        const val SESSION_ID_1 = "s1"
+        const val SESSION_ID_2 = "s2"
+
+        @JvmStatic
+        fun sessionStatuses(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(SessionStateType.CLOSED, SessionStateType.CONFIRMED, ),
+                Arguments.of(SessionStateType.ERROR, SessionStateType.CONFIRMED),
+                Arguments.of(SessionStateType.CLOSED, SessionStateType.ERROR),
+            )
+        }
+    }
+
+    private val sessionState1 = SessionState().apply {
+        this.sessionId = SESSION_ID_1
+        this.hasScheduledCleanup = false
+    }
+    private val sessionState2 = SessionState().apply {
+        this.sessionId = SESSION_ID_2
+        this.hasScheduledCleanup = false
+    }
     private val sessionEvent1 = SessionEvent().apply {
-        this.sessionId = sessionId1
+        this.sessionId = SESSION_ID_1
         this.sequenceNum = 1
     }
     private val sessionEvent2 = SessionEvent().apply {
-        this.sessionId = sessionId1
+        this.sessionId = SESSION_ID_1
         this.sequenceNum = 2
     }
-    private val record1 = Record("t", "1", FlowMapperEvent(Any()))
-    private val record2 = Record("t", "2", FlowMapperEvent(Any()))
+    private val sessionEvent3 = SessionEvent().apply {
+        this.sessionId = SESSION_ID_2
+        this.sequenceNum = 1
+    }
+    private val sessionRecord1 = Record("t", SESSION_ID_1, FlowMapperEvent(sessionEvent1))
+    private val sessionRecord2 = Record("t", SESSION_ID_1, FlowMapperEvent(sessionEvent2))
+    private val sessionRecord3 = Record("t", SESSION_ID_2, FlowMapperEvent(sessionEvent3))
+    private val scheduleCleanupRecord1 = Record("t", SESSION_ID_1, FlowMapperEvent(ScheduleCleanup(1000)))
+    private val scheduleCleanupRecord2 = Record("t", SESSION_ID_2, FlowMapperEvent(ScheduleCleanup(1000)))
     private val sessionManager = mock<SessionManager>()
     private val flowRecordFactory = mock<FlowRecordFactory>()
     private val flowMessageFactory = mock<FlowMessageFactory>()
@@ -49,7 +82,7 @@ class FlowGlobalPostProcessorImplTest {
     @Suppress("Unused")
     @BeforeEach
     fun setup() {
-        whenever(checkpoint.sessions).thenReturn(listOf(sessionState1))
+        whenever(checkpoint.sessions).thenReturn(listOf(sessionState1, sessionState2))
         whenever(checkpoint.flowKey).thenReturn(FlowKey("flow id", ALICE_X500_HOLDING_IDENTITY))
         whenever(checkpoint.doesExist).thenReturn(true)
         whenever(
@@ -59,33 +92,105 @@ class FlowGlobalPostProcessorImplTest {
                 eq(testContext.config),
                 eq(ALICE_X500_HOLDING_IDENTITY)
             )
-        )
-            .thenReturn(sessionState1 to listOf(sessionEvent1, sessionEvent2))
+        ).thenReturn(sessionState1 to listOf(sessionEvent1, sessionEvent2))
+        whenever(
+            sessionManager.getMessagesToSend(
+                eq(sessionState2),
+                any(),
+                eq(testContext.config),
+                eq(ALICE_X500_HOLDING_IDENTITY)
+            )
+        ).thenReturn(sessionState2 to listOf(sessionEvent3))
 
-        whenever(flowRecordFactory.createFlowMapperSessionEventRecord(sessionEvent1)).thenReturn(record1)
-        whenever(flowRecordFactory.createFlowMapperSessionEventRecord(sessionEvent2)).thenReturn(record2)
+        whenever(flowRecordFactory.createFlowMapperEventRecord(sessionEvent1.sessionId, sessionEvent1)).thenReturn(sessionRecord1)
+        whenever(flowRecordFactory.createFlowMapperEventRecord(sessionEvent2.sessionId, sessionEvent2)).thenReturn(sessionRecord2)
+        whenever(flowRecordFactory.createFlowMapperEventRecord(sessionEvent3.sessionId, sessionEvent3)).thenReturn(sessionRecord3)
+        whenever(flowRecordFactory.createFlowMapperEventRecord(eq(SESSION_ID_1), any<ScheduleCleanup>())).thenReturn(scheduleCleanupRecord1)
+        whenever(flowRecordFactory.createFlowMapperEventRecord(eq(SESSION_ID_2), any<ScheduleCleanup>())).thenReturn(scheduleCleanupRecord2)
     }
 
     @Test
     fun `Adds output records containing session events to send to peers`() {
         val outputContext = flowGlobalPostProcessor.postProcess(testContext)
 
-        assertThat(outputContext.outputRecords).containsOnly(record1, record2)
+        assertThat(outputContext.outputRecords).containsOnly(sessionRecord1, sessionRecord2, sessionRecord3)
     }
 
     @Test
     fun `Updates session states`() {
         flowGlobalPostProcessor.postProcess(testContext)
-
         verify(checkpoint).putSessionState(sessionState1)
+        verify(checkpoint).putSessionState(sessionState2)
     }
 
     @Test
-    fun `Does nothing when there is no checkpoint`() {
-        whenever(checkpoint.sessions).thenReturn(emptyList())
+    fun `Does not update sessions when the checkpoint has been delete`() {
+        whenever(checkpoint.doesExist).thenReturn(false)
+        flowGlobalPostProcessor.postProcess(testContext)
+        verify(checkpoint, never()).putSessionState(sessionState1)
+        verify(checkpoint, never()).putSessionState(sessionState2)
+    }
+
+    @Test
+    fun `Adds output records containing schedule cleanup events when there are CLOSED sessions`() {
+        sessionState1.status = SessionStateType.CLOSED
+        sessionState2.status = SessionStateType.CONFIRMED
 
         val outputContext = flowGlobalPostProcessor.postProcess(testContext)
 
-        assertEquals(testContext, outputContext)
+        assertThat(outputContext.outputRecords).contains(scheduleCleanupRecord1)
+        assertThat(outputContext.outputRecords).doesNotContain(scheduleCleanupRecord2)
+        assertTrue(sessionState1.hasScheduledCleanup)
+        assertFalse(sessionState2.hasScheduledCleanup)
+    }
+
+    @Test
+    fun `Adds output records containing schedule cleanup events when there are ERRORed sessions`() {
+        sessionState1.status = SessionStateType.ERROR
+        sessionState2.status = SessionStateType.CONFIRMED
+
+        val outputContext = flowGlobalPostProcessor.postProcess(testContext)
+
+        assertThat(outputContext.outputRecords).contains(scheduleCleanupRecord1)
+        assertThat(outputContext.outputRecords).doesNotContain(scheduleCleanupRecord2)
+        assertTrue(sessionState1.hasScheduledCleanup)
+        assertFalse(sessionState2.hasScheduledCleanup)
+    }
+
+    @Test
+    fun `Adds output records containing schedule cleanup events when there are CLOSED and ERRORed sessions`() {
+        sessionState1.status = SessionStateType.CLOSED
+        sessionState2.status = SessionStateType.ERROR
+
+        val outputContext = flowGlobalPostProcessor.postProcess(testContext)
+
+        assertThat(outputContext.outputRecords).contains(scheduleCleanupRecord1, scheduleCleanupRecord2)
+        assertTrue(sessionState1.hasScheduledCleanup)
+        assertTrue(sessionState2.hasScheduledCleanup)
+    }
+
+    @Test
+    fun `Adds no output records containing schedule cleanup events when there are no CLOSED or ERRORed or sessions`() {
+        sessionState1.status = SessionStateType.WAIT_FOR_FINAL_ACK
+        sessionState2.status = SessionStateType.CONFIRMED
+
+        val outputContext = flowGlobalPostProcessor.postProcess(testContext)
+
+        assertThat(outputContext.outputRecords).doesNotContain(scheduleCleanupRecord1, scheduleCleanupRecord2)
+        assertFalse(sessionState1.hasScheduledCleanup)
+        assertFalse(sessionState2.hasScheduledCleanup)
+    }
+
+    @Test
+    fun `Adds output records containing schedule cleanup events when when the checkpoint has been deleted`() {
+        whenever(checkpoint.doesExist).thenReturn(false)
+        sessionState1.status = SessionStateType.CLOSED
+        sessionState2.status = SessionStateType.ERROR
+
+        val outputContext = flowGlobalPostProcessor.postProcess(testContext)
+
+        assertThat(outputContext.outputRecords).contains(scheduleCleanupRecord1, scheduleCleanupRecord2)
+        assertTrue(sessionState1.hasScheduledCleanup)
+        assertTrue(sessionState2.hasScheduledCleanup)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.114-beta+
+cordaApiVersion=5.0.0.115-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorReceive.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorReceive.kt
@@ -62,6 +62,7 @@ class SessionInitProcessorReceive(
                 .setReceivedEventsState(SessionProcessState(seqNum, mutableListOf(sessionEvent)))
                 .setSendEventsState(SessionProcessState(0, mutableListOf()))
                 .setStatus(SessionStateType.CONFIRMED)
+                .setHasScheduledCleanup(false)
                 .build()
 
             logger.debug { "Created new session with id $sessionId for SessionInit received on key $key. sessionState $newSessionState" }

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorSend.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorSend.kt
@@ -59,6 +59,7 @@ class SessionInitProcessorSend(
             .setReceivedEventsState(SessionProcessState(0, mutableListOf()))
             .setSendEventsState(SessionProcessState(seqNum, mutableListOf(sessionEvent)))
             .setStatus(SessionStateType.CREATED)
+            .setHasScheduledCleanup(false)
             .build()
 
         logger.debug { "Creating new session with id $newSessionId on key $key for SessionInit sent. sessionState $newSessionState" }

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/helper/SessionProcessorHelper.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/helper/SessionProcessorHelper.kt
@@ -91,6 +91,7 @@ fun generateErrorSessionStateFromSessionEvent(errorMessage: String, sessionEvent
         .setReceivedEventsState(SessionProcessState(0, listOf()))
         .setSendEventsState(SessionProcessState(0, listOf()))
         .setStatus(SessionStateType.ERROR)
+        .setHasScheduledCleanup(false)
         .build()
 
     val errorEvent = generateErrorEvent(sessionState, sessionEvent, errorMessage, errorType, instant)

--- a/testing/flow/flow-utilities/src/main/kotlin/net/corda/test/flow/util/SessionHelper.kt
+++ b/testing/flow/flow-utilities/src/main/kotlin/net/corda/test/flow/util/SessionHelper.kt
@@ -30,6 +30,7 @@ fun buildSessionState(
         .setReceivedEventsState(SessionProcessState(lastReceivedSeqNum, receivedEvents))
         .setSendEventsState(SessionProcessState(lastSentSeqNum, eventsToSend))
         .setStatus(status)
+        .setHasScheduledCleanup(false)
         .build()
 }
 


### PR DESCRIPTION
Clean up flow mapper in-memory state of flow starts and sessions.

When a flow finishes of fails, clean up its state.

When a session becomes `CLOSED` or `ERROR`ed, clean up its state.

State is cleaned up by sending a `ScheduleCleanup` record to the flow
mapper, which cleans up the in-memory state after a period of time.

`FlowCheckpointImpl` now _soft deletes_ the Avro `Checkpoint` so that
sessions can still be accessed after marking the `Checkpoint` for
deletion. This is needed if a session goes to `CLOSED` and the flow
finishes all off of a single event, otherwise the `ScheduleCleanup`
record cannot be sent for the session.

This commit also changes the flow mapper's key solely to a `String`. The
string still represents a `FlowKey` (for flow starts) or a session id
(for a session). The change calls `toString` on `FlowKey` rather than
passing in the `FlowKey` directly and letting the state and event
pattern do the conversion to a `String`. This was required to fix a bug
where the partition a state/event was read from was not the same
partition the new state was written to, which indicated a change in the
generated hash of the key. Calling `toString` made the output
consistent and preventing changing the partition.