### PR TITLE
NOTICKET: Fix P2P deployment

### DIFF
--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Utilities.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Utilities.kt
@@ -50,7 +50,7 @@ fun Config.toConfigurationRecord(
     componentName: String,
     topic: String = Schemas.Config.CONFIG_TOPIC
 ): Record<String, Configuration> {
-    val content = Configuration(this.root().render(ConfigRenderOptions.concise()), "1.0", ConfigurationSchemaVersion(1,0))
+    val content = Configuration(this.root().render(ConfigRenderOptions.concise()), "1", ConfigurationSchemaVersion(1,0))
     val recordKey = "$packageName.$componentName"
     return Record(topic, recordKey, content)
 }

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/builder/CordaKafkaConsumerBuilderImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/builder/CordaKafkaConsumerBuilderImpl.kt
@@ -66,7 +66,9 @@ class CordaKafkaConsumerBuilderImpl @Activate constructor(
         val currentBundle = FrameworkUtil.getBundle(KafkaProducer::class.java)
 
         return try {
-            Thread.currentThread().contextClassLoader = OsgiDelegatedClassLoader(currentBundle)
+            if (currentBundle != null) {
+                Thread.currentThread().contextClassLoader = OsgiDelegatedClassLoader(currentBundle)
+            }
             KafkaConsumer(
                 kafkaProperties,
                 CordaAvroDeserializerImpl(avroSchemaRegistry, onSerializationError, kClazz),

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
@@ -55,7 +55,9 @@ class KafkaCordaProducerBuilderImpl @Activate constructor(
         val currentBundle = FrameworkUtil.getBundle(KafkaProducer::class.java)
 
         return try {
-            Thread.currentThread().contextClassLoader = OsgiDelegatedClassLoader(currentBundle)
+            if (currentBundle != null) {
+                Thread.currentThread().contextClassLoader = OsgiDelegatedClassLoader(currentBundle)
+            }
             KafkaProducer(
                 kafkaProperties,
                 CordaAvroSerializerImpl(avroSchemaRegistry),


### PR DESCRIPTION
There are two issues with the P2P deployment:
1. The publisher assumes that it is in an OSGi context. This change will make it work regardless.
2. The configuration version had changed to an integer number. This change will make it version 1 instead of 1.0.