### PR TITLE
CORE-5108: Unregister ConfigurationReadService when closing SecurityConfigHandler.

### DIFF
--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ComponentConfigHandler.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ComponentConfigHandler.kt
@@ -19,7 +19,7 @@ class ComponentConfigHandler(private val coordinator: LifecycleCoordinator, priv
     override fun onNewConfiguration(changedKeys: Set<String>, config: Map<String, SmartConfig>) {
         if (requiredKeys.all { it in config.keys } and changedKeys.any { it in requiredKeys }) {
             val keys = if (snapshotPosted) {
-                changedKeys.filter { it in requiredKeys }.toSet()
+                changedKeys.filterTo(LinkedHashSet()) { it in requiredKeys }
             } else {
                 snapshotPosted = true
                 requiredKeys

--- a/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityConfigHandlerImpl.kt
+++ b/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityConfigHandlerImpl.kt
@@ -38,11 +38,12 @@ class SecurityConfigHandlerImpl @Activate constructor(
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<SecurityConfigHandler>(::eventHandler)
+    private val configReadServiceHandle: AutoCloseable
     private var configHandle: AutoCloseable? = null
 
     init {
         log.debug("Initializing SecurityConfigHandler")
-        coordinator.followStatusChangesByName(
+        configReadServiceHandle = coordinator.followStatusChangesByName(
             setOf(
                 LifecycleCoordinatorName.forComponent<ConfigurationReadService>()
             )
@@ -64,6 +65,7 @@ class SecurityConfigHandlerImpl @Activate constructor(
 
     @Deactivate
     override fun close() {
+        configReadServiceHandle.close()
         coordinator.close()
     }
 

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
@@ -131,7 +131,7 @@ class LifecycleCoordinatorImpl(
      * See [LifecycleCoordinator].
      */
     override fun postEvent(event: LifecycleEvent) {
-        if (_isClosed.get()) {
+        if (isClosed) {
             logger.error("An attempt was made to use coordinator $name after it has been closed. Event: $event")
             throw LifecycleException("No events can be posted to a closed coordinator. Event: $event")
         }
@@ -191,7 +191,7 @@ class LifecycleCoordinatorImpl(
      */
     override fun followStatusChangesByName(coordinatorNames: Set<LifecycleCoordinatorName>): RegistrationHandle {
         val coordinators = try {
-            coordinatorNames.map { registry.getCoordinator(it) }.toSet()
+            coordinatorNames.mapTo(LinkedHashSet(), registry::getCoordinator)
         } catch (e: LifecycleRegistryException) {
             logger.error("Failed to register on coordinator as an invalid name was provided. ${e.message}", e)
             throw LifecycleException("Failed to register on a coordinator as an invalid name was provided", e)

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorSchedulerFactoryImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorSchedulerFactoryImpl.kt
@@ -1,14 +1,47 @@
 package net.corda.lifecycle.impl
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import java.util.concurrent.Executors
 import net.corda.lifecycle.LifecycleCoordinatorScheduler
 import net.corda.lifecycle.LifecycleCoordinatorSchedulerFactory
+import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.ServiceScope
+import org.osgi.service.component.annotations.Deactivate
 
-@Component(service = [LifecycleCoordinatorSchedulerFactory::class], scope = ServiceScope.SINGLETON)
-class LifecycleCoordinatorSchedulerFactoryImpl : LifecycleCoordinatorSchedulerFactory {
+@Component(service = [LifecycleCoordinatorSchedulerFactory::class], immediate = true)
+class LifecycleCoordinatorSchedulerFactoryImpl @Activate constructor(): LifecycleCoordinatorSchedulerFactory {
+    /**
+     * The executor on which events are processed. Note that all events should be processed on an executor thread,
+     * but they may be posted from any thread. Different events may be processed on different executor threads.
+     *
+     * The coordinator guarantees that the event processing task is only scheduled once. This means that event
+     * processing is effectively single threaded in the sense that no event processing will happen concurrently.
+     *
+     * By sharing a thread pool among coordinators, it should be possible to reduce resource usage when in a stable
+     * state.
+     */
+    private val executor = Executors.newCachedThreadPool(
+        ThreadFactoryBuilder()
+            .setNameFormat("lifecycle-coordinator-%d")
+            .setDaemon(true)
+            .build()
+    )
+
+    private val timerExecutor = Executors.newSingleThreadScheduledExecutor(
+        ThreadFactoryBuilder()
+            .setNameFormat("lifecycle-coordinator-timer-%d")
+            .setDaemon(true)
+            .build()
+    )
+
     override fun create(): LifecycleCoordinatorScheduler {
-        return LifecycleCoordinatorSchedulerImpl()
+        return LifecycleCoordinatorSchedulerImpl(executor, timerExecutor)
+    }
+
+    @Suppress("unused")
+    @Deactivate
+    fun done() {
+        timerExecutor.shutdown()
+        executor.shutdown()
     }
 }
-

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorSchedulerImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorSchedulerImpl.kt
@@ -1,36 +1,15 @@
 package net.corda.lifecycle.impl
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import net.corda.lifecycle.LifecycleCoordinatorScheduler
-import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
-class LifecycleCoordinatorSchedulerImpl : LifecycleCoordinatorScheduler {
-
-    /**
-     * The executor on which events are processed. Note that all events should be processed on an executor thread,
-     * but they may be posted from any thread. Different events may be processed on different executor threads.
-     *
-     * The coordinator guarantees that the event processing task is only scheduled once. This means that event
-     * processing is effectively single threaded in the sense that no event processing will happen concurrently.
-     *
-     * By sharing a thread pool among coordinators, it should be possible to reduce resource usage when in a stable
-     * state.
-     */
-    private val executor = Executors.newCachedThreadPool(
-        ThreadFactoryBuilder()
-            .setNameFormat("lifecycle-coordinator-%d")
-            .setDaemon(true)
-            .build()
-    )
-
-    private val timerExecutor = Executors.newSingleThreadScheduledExecutor(
-        ThreadFactoryBuilder()
-            .setNameFormat("lifecycle-coordinator-timer-%d")
-            .setDaemon(true)
-            .build()
-    )
+class LifecycleCoordinatorSchedulerImpl(
+    private val executor: ExecutorService,
+    private val timerExecutor: ScheduledExecutorService
+) : LifecycleCoordinatorScheduler {
 
     override fun execute(task: Runnable) {
         executor.execute(task)

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImplTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImplTest.kt
@@ -18,6 +18,7 @@ import net.corda.lifecycle.impl.LifecycleProcessor.Companion.STOPPED_REASON
 import net.corda.lifecycle.impl.registry.LifecycleRegistryCoordinatorAccess
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -28,6 +29,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
@@ -58,6 +60,15 @@ internal class LifecycleCoordinatorImplTest {
     interface PostEvent : LifecycleEvent
 
     interface ThrowException : LifecycleEvent
+
+    private val timerExecutor = Executors.newSingleThreadScheduledExecutor()
+    private val executor = Executors.newSingleThreadExecutor()
+
+    @AfterEach
+    fun done() {
+        timerExecutor.shutdown()
+        executor.shutdown()
+    }
 
     @Test
     fun burstEvents() {
@@ -1158,7 +1169,7 @@ internal class LifecycleCoordinatorImplTest {
 
     private fun createCoordinator(
         registry: LifecycleRegistryCoordinatorAccess = mock(),
-        scheduler: LifecycleCoordinatorScheduler = LifecycleCoordinatorSchedulerImpl(),
+        scheduler: LifecycleCoordinatorScheduler = LifecycleCoordinatorSchedulerImpl(executor, timerExecutor),
         processor: LifecycleEventHandler
     ): LifecycleCoordinator {
         return LifecycleCoordinatorImpl(


### PR DESCRIPTION
Close the `Registration` for `ConfigurationReadService` when closing `SecurityConfigHandler`. Also refactor `LifecycleCoordinatorSchedulerFactoryImpl` so that all `LifecycleCoorinatorSchedulerImpl` instances share common `ExecutorService` and `ScheduledExecutorService` instances. (This is apparently what was supposed to happen anyway.)