### PR TITLE
NOTICK: Ensure SandboxGroupContextComponent deactivates cleanly.

### DIFF
--- a/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/ExampleFlow.kt
+++ b/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/ExampleFlow.kt
@@ -3,8 +3,8 @@ package com.example.cpk
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RPCRequestData
 import net.corda.v5.application.flows.RPCStartableFlow
-import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.serialization.JsonMarshallingService
+import net.corda.v5.application.serialization.parseJson
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.DigestAlgorithmName
@@ -31,8 +31,9 @@ class ExampleFlow : RPCStartableFlow {
 
     @Suspendable
     override fun call(requestBody: RPCRequestData): String {
-        logger.info("Invoked: JSON=${requestBody.getRequestBody()}")
-        val input = requestBody.getRequestBodyAs<FlowInput>(jsonMarshaller)
+        val json = requestBody.getRequestBody()
+        logger.info("Invoked: JSON=$json")
+        val input = jsonMarshaller.parseJson<FlowInput>(json)
         return hashOf(
             bytes = input.message?.toByteArray() ?: byteArrayOf()
         ).also { result ->

--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -36,7 +36,7 @@ class VNodeServiceImpl @Activate constructor(
     private val logger = loggerFor<VNodeService>()
 
     init {
-        sandboxGroupContextComponent.initCache(1)
+        setupSandboxCache()
     }
 
     override fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo {
@@ -49,9 +49,14 @@ class VNodeServiceImpl @Activate constructor(
         virtualNodeLoader.unloadVirtualNode(virtualNodeInfo)
         virtualNodeLoader.forgetCPI(cpiMetadata.cpiId)
         cpiLoader.removeCpiMetadata(cpiMetadata.cpiId)
+        setupSandboxCache()
     }
 
     override fun getOrCreateSandbox(holdingIdentity: HoldingIdentity): SandboxGroupContext {
         return flowSandboxService.get(holdingIdentity)
+    }
+
+    private fun setupSandboxCache() {
+        sandboxGroupContextComponent.initCache(1)
     }
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -28,6 +28,7 @@ import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.runtime.ServiceComponentRuntime
 import java.util.Collections.unmodifiableList
@@ -127,6 +128,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
 
     override fun stop() = coordinator.stop()
 
+    @Deactivate
     override fun close() {
         stop()
         coordinator.close()


### PR DESCRIPTION
Destroy the sandbox cache when the `SandboxGroupContextComponent` is deactivated. Update the `:sandbox-app` test application so that the cache is flushed after each sandbox iteration.