### PR TITLE
NOTICK - Helm value files with sensible defaults for local development.

### DIFF
--- a/debug.yaml
+++ b/debug.yaml
@@ -13,26 +13,26 @@
 workers:
   crypto:
     replicaCount: 1
-    #debug:
-    #  enabled: true
-    #  suspend: true
+#    debug:
+#      enabled: true
+#      suspend: true
   db:
     replicaCount: 1
-    debug:
-      enabled: true
-      suspend: true
+#    debug:
+#      enabled: true
+#      suspend: true
   flow:
     replicaCount: 1
-    #debug:
-    #  enabled: true
-    #  suspend: true
+#    debug:
+#      enabled: true
+#      suspend: true
   membership:
     replicaCount: 1
-    #debug:
-    #  enabled: true
-    #  suspend: true
+#    debug:
+#      enabled: true
+#      suspend: true
   rpc:
     replicaCount: 1
-    #debug:
-    #  enabled: true
-    #  suspend: true
+#    debug:
+#      enabled: true
+#      suspend: true

--- a/debug.yaml
+++ b/debug.yaml
@@ -1,0 +1,38 @@
+# values file suitable for local deployment of a debuggable corda cluster.
+# Uncomment values for workers to debug.
+#
+# First use `./gradlew publishOSGiImage --parallel` to create local docker images
+# Then deploy using:
+#
+#  helm upgrade --install corda -n corda \
+#  charts/corda \
+#  --values values.yaml \
+#  --values debug.yaml \
+#  --wait
+#
+workers:
+  crypto:
+    replicaCount: 1
+    #debug:
+    #  enabled: true
+    #  suspend: true
+  db:
+    replicaCount: 1
+    debug:
+      enabled: true
+      suspend: true
+  flow:
+    replicaCount: 1
+    #debug:
+    #  enabled: true
+    #  suspend: true
+  membership:
+    replicaCount: 1
+    #debug:
+    #  enabled: true
+    #  suspend: true
+  rpc:
+    replicaCount: 1
+    #debug:
+    #  enabled: true
+    #  suspend: true

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,30 @@
+# values file suitable for local deployment of the corda helm chart.
+#
+# First use `./gradlew publishOSGiImage --parallel` to create local docker images
+# Then deploy using:
+#
+#  helm upgrade --install corda -n corda \
+#  charts/corda \
+#  --values values.yaml \
+#  --values debug.yaml \
+#  --wait
+#
+# See `debug.yaml` for debug settings
+imagePullPolicy: IfNotPresent
+image:
+  registry: corda-os-docker-dev.software.r3.com
+  tag: latest-local
+
+kafka:
+  bootstrapServers: prereqs-kafka:9092
+  replicas: 1
+  tls:
+    enabled: true
+    truststore:
+      secretRef:
+        name: prereqs-kafka-0-tls
+
+db:
+  cluster:
+    host: prereqs-postgresql.corda # NOTE: corda here is the current namespace, change in case you are deploying to a different 
+    existingSecret: prereqs-postgresql


### PR DESCRIPTION
Adding helm files that have sensible defaults to be used in local development so that they can be kept up-to-date with any changes.

Downsides of this is that anybody having different ones locally may get a conflict, but maybe the suggested setup should be to have `<file>.local.yaml` versions if wanted and we can add those to `.gitignore`