### PR TITLE
CORE-5131 Don't delete bootstrap jobs

### DIFF
--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -7,7 +7,6 @@ metadata:
     {{- include "corda.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "corda.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:


### PR DESCRIPTION
To aid problem determination, don't delete the bootstrap jobs as, at least for now, successful completion of the job doesn't necessarily correspond to success.