### PR TITLE
CORE-4890 Publish Cpi Info version to Kafka after consulting the DB

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
@@ -486,7 +486,8 @@ internal class DatabaseChunkPersistenceTest {
         val cpks = listOf(cpk1)
         val cpi = mockCpi(cpks)
 
-        persistence.persistMetadataAndCpks(cpi, "test.cpi", cpiChecksum, UUID.randomUUID().toString(), "abcdef")
+        val cpiMetadataEntity = persistence.persistMetadataAndCpks(cpi, "test.cpi", cpiChecksum, UUID.randomUUID().toString(), "abcdef")
+        assertThat(cpiMetadataEntity.entityVersion).isEqualTo(1)
 
         val updatedCpiChecksum = SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
         val updatedCpkChecksum = SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
@@ -494,7 +495,8 @@ internal class DatabaseChunkPersistenceTest {
         // cpi with different CPKs but same ID
         val updatedCpi = mockCpiWithId(updatedCpks, cpi.metadata.cpiId)
 
-        persistence.updateMetadataAndCpks(updatedCpi, "test.cpi", updatedCpiChecksum, UUID.randomUUID().toString(), "abcdef")
+        val updatedCpiMetadataEntity = persistence.updateMetadataAndCpks(updatedCpi, "test.cpi", updatedCpiChecksum, UUID.randomUUID().toString(), "abcdef")
+        assertThat(updatedCpiMetadataEntity.entityVersion > 1).isTrue
 
         val loadedCpi = entityManagerFactory.createEntityManager().transaction {
             it.find(CpiMetadataEntity::class.java, CpiMetadataEntityKey(

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/ChunkPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/ChunkPersistence.kt
@@ -3,6 +3,7 @@ package net.corda.chunking.db.impl.persistence
 import net.corda.chunking.RequestId
 import net.corda.chunking.db.impl.AllChunksReceived
 import net.corda.data.chunking.Chunk
+import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 import net.corda.libs.packaging.Cpi
 import net.corda.v5.crypto.SecureHash
 
@@ -68,7 +69,7 @@ interface ChunkPersistence {
         checksum: SecureHash,
         requestId: RequestId,
         groupId: String
-    )
+    ): CpiMetadataEntity
 
     /**
      * When CPI has previously been saved, delete all the stale data and update in place.
@@ -84,7 +85,7 @@ interface ChunkPersistence {
         cpiFileName: String,
         checksum: SecureHash,
         requestId: RequestId,
-        groupId: String)
+        groupId: String): CpiMetadataEntity
 
     /** Get the group id for a given CPI */
     fun getGroupId(cpiName: String, cpiVersion: String, signerSummaryHash: String): String?

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -46,7 +46,7 @@ class CpiValidatorImpl(
         }
 
         publisher.update(requestId, "Persisting CPI")
-        validationFunctions.persistToDatabase(persistence, cpi, fileInfo, requestId)
+        val cpiMetadataEntity = validationFunctions.persistToDatabase(persistence, cpi, fileInfo, requestId)
 
         publisher.update(requestId, "Notifying flow workers")
         val timestamp = Instant.now()
@@ -55,8 +55,7 @@ class CpiValidatorImpl(
             fileInfo.checksum,
             cpi.cpks.map { it.metadata },
             cpi.metadata.groupPolicy,
-            // TODO the below version should be populated from the DB as per https://r3-cev.atlassian.net/browse/CORE-4890
-            version = 0,
+            version = cpiMetadataEntity.entityVersion,
             timestamp
         )
         cpiInfoWriteService.put(cpiMetadata.cpiId, cpiMetadata)

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -14,6 +14,7 @@ import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.persistence.PersistenceException
+import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 
 internal class ValidationFunctions(
     private val cpiCacheDir: Path,
@@ -89,7 +90,7 @@ internal class ValidationFunctions(
         cpi: Cpi,
         fileInfo: FileInfo,
         requestId: RequestId
-    ) {
+    ): CpiMetadataEntity {
         // Cannot compare the CPI.metadata.hash to our checksum above
         // because two different digest algorithms might have been used to create them.
         // We'll publish to the database using the de-chunking checksum.
@@ -102,7 +103,7 @@ internal class ValidationFunctions(
                 cpi.metadata.cpiId.version,
                 cpi.metadata.cpiId.signerSummaryHashForDbQuery)
 
-            if (cpiExists && fileInfo.forceUpload) {
+            return if (cpiExists && fileInfo.forceUpload) {
                 log.info("Force uploading CPI: ${cpi.metadata.cpiId.name} v${cpi.metadata.cpiId.version}")
                 chunkPersistence.updateMetadataAndCpks(cpi, fileInfo.name, fileInfo.checksum, requestId, groupId)
             } else if (!cpiExists) {


### PR DESCRIPTION
Uses `CpiMetadataEntity.entityVersion` to populate Cpi Metadata Avro object's entity version.