### PR TITLE
NOTICK - Patch lifecycle and permission cache fixes

### DIFF
--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
@@ -1,7 +1,5 @@
 package net.corda.crypto.client.impl
 
-import java.nio.ByteBuffer
-import java.security.PublicKey
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
@@ -16,9 +14,9 @@ import net.corda.data.crypto.wire.CryptoSigningKeys
 import net.corda.data.crypto.wire.ops.rpc.RpcOpsRequest
 import net.corda.data.crypto.wire.ops.rpc.RpcOpsResponse
 import net.corda.data.crypto.wire.ops.rpc.queries.CryptoKeyOrderBy
+import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
-import net.corda.libs.configuration.helper.getConfig
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
@@ -32,6 +30,8 @@ import net.corda.v5.crypto.publicKeyId
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.nio.ByteBuffer
+import java.security.PublicKey
 
 @Suppress("TooManyFunctions")
 @Component(service = [CryptoOpsClient::class, CryptoOpsProxyClient::class])
@@ -216,7 +216,7 @@ class CryptoOpsClientComponent @Activate constructor(
         )
 
         override fun close() {
-            sender.stop()
+            sender.close()
         }
     }
 }

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -71,7 +71,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -1088,7 +1088,7 @@ class CryptoOpsClientComponentTests {
             kotlin.test.assertEquals(LifecycleStatus.DOWN, component.lifecycleCoordinator.status)
         }
         assertInstanceOf(CryptoOpsClientComponent.InactiveImpl::class.java, component.impl)
-        Mockito.verify(sender, times(1)).stop()
+        Mockito.verify(sender, times(1)).close()
     }
 
     @Test
@@ -1116,6 +1116,6 @@ class CryptoOpsClientComponentTests {
         }
         assertInstanceOf(CryptoOpsClientComponent.ActiveImpl::class.java, component.impl)
         assertNotNull(component.impl.ops)
-        Mockito.verify(sender, atLeast(1)).stop()
+        Mockito.verify(sender, atLeast(1)).close()
     }
 }

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
@@ -23,7 +23,7 @@ import net.corda.schema.Schemas.Flow.Companion.FLOW_STATUS_TOPIC
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.*
+import java.util.Collections
 
 @Component(immediate = true, service = [FlowStatusCacheService::class])
 class FlowStatusCacheServiceImpl @Activate constructor(
@@ -49,8 +49,8 @@ class FlowStatusCacheServiceImpl @Activate constructor(
     override fun stop() = lifecycleCoordinator.stop()
 
     override fun initialise(config: SmartConfig) {
-        flowStatusSubscription?.close()
         subReg?.close()
+        flowStatusSubscription?.close()
 
         flowStatusSubscription = subscriptionFactory.createCompactedSubscription(
             SubscriptionConfig(

--- a/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/CertificatesClientImpl.kt
+++ b/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/CertificatesClientImpl.kt
@@ -130,8 +130,8 @@ class CertificatesClientImpl @Activate constructor(
 
     private fun handleConfigChangedEvent(event: ConfigChangedEvent) {
         logger.info("Handling config changed event.")
-        sender?.close()
         senderRegistrationHandle?.close()
+        sender?.close()
         senderRegistrationHandle = null
         sender = publisherFactory.createRPCSender(
             rpcConfig = RPCConfig(

--- a/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
+++ b/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
@@ -127,6 +127,7 @@ class CertificatesServiceImpl @Activate constructor(
                 }
             }
             is ConfigChangedEvent -> {
+                subscriptionRegistrationHandle?.close()
                 rpcSubscription?.close()
                 rpcSubscription = subscriptionFactory.createRPCSubscription(
                     rpcConfig = RPCConfig(
@@ -139,7 +140,6 @@ class CertificatesServiceImpl @Activate constructor(
                     responderProcessor = processor,
                     messagingConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG),
                 ).also {
-                    subscriptionRegistrationHandle?.close()
                     subscriptionRegistrationHandle = coordinator.followStatusChangesByName(setOf(it.subscriptionName))
                     it.start()
                 }

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/subscription/MembershipGroupReadSubscriptions.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/subscription/MembershipGroupReadSubscriptions.kt
@@ -52,12 +52,14 @@ interface MembershipGroupReadSubscriptions : Lifecycle {
             throw CordaRuntimeException("Must provide membership configuration in order to start the subscriptions.")
         }
 
-        override fun stop() = subscriptions.forEach { it?.stop() }
+        override fun stop() = subscriptions.forEach { it?.close() }
 
         /**
          * Start the member list subscription.
          */
         private fun startMemberListSubscription(config: SmartConfig) {
+            memberListSubscription?.close()
+
             val subscriptionConfig = SubscriptionConfig(
                 CONSUMER_GROUP,
                 MEMBER_LIST_TOPIC
@@ -71,7 +73,6 @@ interface MembershipGroupReadSubscriptions : Lifecycle {
                 config
             ).apply {
                 start()
-                memberListSubscription?.close()
                 memberListSubscription = this
             }
         }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MembershipGroupReadSubscriptionsTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MembershipGroupReadSubscriptionsTest.kt
@@ -38,7 +38,7 @@ class MembershipGroupReadSubscriptionsTest {
     private val memberListSubscription =
         mock<CompactedSubscription<String, SignedMemberInfo>>().apply {
             doAnswer { memberListSubscriptionStarted = true }.whenever(this).start()
-            doAnswer { memberListSubscriptionStarted = false }.whenever(this).stop()
+            doAnswer { memberListSubscriptionStarted = false }.whenever(this).close()
             doAnswer { memberListSubscriptionStarted }.whenever(this).isRunning
         }
 

--- a/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
+++ b/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
@@ -129,24 +129,24 @@ internal class PermissionManagementServiceEventHandler(
     }
 
     private fun createPermissionManager(config: SmartConfig) {
-        val permissionManagementCache = permissionManagementCacheService.permissionManagementCache
-        checkNotNull(permissionManagementCache) {
-            "Configuration received for permission manager but permission management cache was null."
-        }
-        val permissionValidationCache = permissionValidationCacheService.permissionValidationCache
-        checkNotNull(permissionValidationCache) {
-            "Configuration received for permission manager but permission validation cache was null."
-        }
+        val permissionManagementCacheRef = permissionManagementCacheService.permissionManagementCacheRef
+
+        val permissionValidationCacheRef = permissionValidationCacheService.permissionValidationCacheRef
 
         permissionManager?.close()
         log.info("Creating and starting permission manager.")
         permissionManager =
-            permissionManagerFactory.createPermissionManager(config, rpcSender!!, permissionManagementCache, permissionValidationCache)
+            permissionManagerFactory.createPermissionManager(
+                config,
+                rpcSender!!,
+                permissionManagementCacheRef,
+                permissionValidationCacheRef
+            )
                 .also { it.start() }
 
         basicAuthenticationService?.close()
         log.info("Creating and starting basic authentication service using permission system.")
-        basicAuthenticationService = permissionManagerFactory.createBasicAuthenticationService(permissionManagementCache)
+        basicAuthenticationService = permissionManagerFactory.createBasicAuthenticationService(permissionManagementCacheRef)
             .also { it.start() }
     }
 

--- a/components/permissions/permission-management-service/src/test/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandlerTest.kt
+++ b/components/permissions/permission-management-service/src/test/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandlerTest.kt
@@ -31,10 +31,11 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.atomic.AtomicReference
 
 internal class PermissionManagementServiceEventHandlerTest {
-    private val permissionManagementCache = mock<PermissionManagementCache>()
-    private val permissionValidationCache = mock<PermissionValidationCache>()
+    private val permissionManagementCacheRef = AtomicReference(mock<PermissionManagementCache>())
+    private val permissionValidationCacheRef = AtomicReference(mock<PermissionValidationCache>())
     private val permissionManagementCacheService = mock<PermissionManagementCacheService>()
     private val permissionValidationCacheService = mock<PermissionValidationCacheService>()
     private val permissionValidationService = mock<PermissionValidationService>()
@@ -62,16 +63,23 @@ internal class PermissionManagementServiceEventHandlerTest {
 
     @BeforeEach
     fun setUp() {
-        whenever(permissionManagementCacheService.permissionManagementCache)
-            .thenReturn(permissionManagementCache)
+        whenever(permissionManagementCacheService.permissionManagementCacheRef)
+            .thenReturn(permissionManagementCacheRef)
 
-        whenever(permissionValidationCacheService.permissionValidationCache)
-            .thenReturn(permissionValidationCache)
+        whenever(permissionValidationCacheService.permissionValidationCacheRef)
+            .thenReturn(permissionValidationCacheRef)
 
         whenever(publisherFactory.createRPCSender(any<RPCConfig<PermissionManagementRequest, PermissionManagementResponse>>(), any()))
             .thenReturn(rpcSender)
 
-        whenever(permissionManagerFactory.createPermissionManager(config, rpcSender, permissionManagementCache, permissionValidationCache))
+        whenever(
+            permissionManagerFactory.createPermissionManager(
+                config,
+                rpcSender,
+                permissionManagementCacheRef,
+                permissionValidationCacheRef
+            )
+        )
             .thenReturn(permissionManager)
 
         whenever(

--- a/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
+++ b/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
@@ -159,12 +159,8 @@ class PermissionStorageReaderServiceEventHandler(
 
         permissionStorageReader?.close()
         permissionStorageReader = permissionStorageReaderFactory.create(
-            checkNotNull(permissionValidationCacheService.permissionValidationCache) {
-                "The ${PermissionValidationCacheService::class.java} should be up and ready to provide the cache"
-            },
-            checkNotNull(permissionManagementCacheService.permissionManagementCache) {
-                "The ${permissionManagementCacheService::class.java} should be up and ready to provide the cache"
-            },
+            permissionValidationCacheService.permissionValidationCacheRef,
+            permissionManagementCacheService.permissionManagementCacheRef,
             checkNotNull(publisher) { "The ${Publisher::class.java} must be initialised" },
             entityManagerFactoryCreator()
         ).also {

--- a/components/permissions/permission-storage-reader-service/src/test/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandlerTest.kt
+++ b/components/permissions/permission-storage-reader-service/src/test/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandlerTest.kt
@@ -39,6 +39,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.atomic.AtomicReference
 
 class PermissionStorageReaderServiceEventHandlerTest {
 
@@ -48,11 +49,11 @@ class PermissionStorageReaderServiceEventHandlerTest {
     }
     private val pvCache = mock<PermissionValidationCache>()
     private val permissionValidationCacheService = mock<PermissionValidationCacheService>().apply {
-        whenever(permissionValidationCache).thenReturn(pvCache)
+        whenever(permissionValidationCacheRef).thenReturn(AtomicReference(pvCache))
     }
-    private val pmCache = mock<PermissionManagementCache>()
+    private val pmCacheRef = AtomicReference(mock<PermissionManagementCache>())
     private val permissionManagementCacheService = mock<PermissionManagementCacheService>().apply {
-        whenever(permissionManagementCache).thenReturn(pmCache)
+        whenever(permissionManagementCacheRef).thenReturn(pmCacheRef)
     }
     private val permissionStorageReader = mock<PermissionStorageReader>()
     private val permissionStorageReaderFactory = mock<PermissionStorageReaderFactory>().apply {
@@ -193,7 +194,7 @@ class PermissionStorageReaderServiceEventHandlerTest {
     @Test
     fun `processing an onConfigurationUpdated event creates publisher and permission storage reader`() {
         whenever(publisherFactory.createPublisher(any(), any())).thenReturn(publisher)
-        whenever(permissionStorageReaderFactory.create(eq(pvCache), eq(pmCache), eq(publisher), any()))
+        whenever(permissionStorageReaderFactory.create(eq(AtomicReference(pvCache)), eq(pmCacheRef), eq(publisher), any()))
             .thenReturn(permissionStorageReader)
 
         handler.processEvent(

--- a/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
+++ b/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
@@ -88,11 +88,8 @@ class PermissionValidationService @Activate constructor(
     }
 
     private fun startValidationComponent() {
-        checkNotNull(permissionValidationCacheService.permissionValidationCache) {
-            "Permission Validation Service received status UP but permission validation cache was null."
-        }
         _permissionValidator?.close()
-        _permissionValidator = permissionValidatorFactory.create(permissionValidationCacheService.permissionValidationCache!!)
+        _permissionValidator = permissionValidatorFactory.create(permissionValidationCacheService.permissionValidationCacheRef)
             .also { it.start() }
     }
 

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImpl.kt
@@ -35,14 +35,17 @@ class LifecycleRegistryImpl : LifecycleRegistry, LifecycleRegistryCoordinatorAcc
      */
     override fun updateStatus(name: LifecycleCoordinatorName, status: LifecycleStatus, reason: String) {
         if (statuses[name] == null) {
-            throw LifecycleRegistryException(
-                "Attempt was made to update the status of coordinator $name to $status " +
-                        "($reason) that has not been registered with the registry."
-            )
+            logger.warn("Attempt was made to update the status of coordinator $name to $status " +
+                    "($reason) that has not been registered with the registry.")
+//            throw LifecycleRegistryException(
+//                "Attempt was made to update the status of coordinator $name to $status " +
+//                        "($reason) that has not been registered with the registry."
+//            )
+        } else {
+            val coordinatorStatus = CoordinatorStatus(name, status, reason)
+            statuses[name] = coordinatorStatus
+            logger.trace { "Coordinator status update: $name is now $status ($reason)" }
         }
-        val coordinatorStatus = CoordinatorStatus(name, status, reason)
-        statuses[name] = coordinatorStatus
-        logger.trace { "Coordinator status update: $name is now $status ($reason)" }
     }
 
     /**

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImplTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImplTest.kt
@@ -6,6 +6,7 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.registry.CoordinatorStatus
 import net.corda.lifecycle.registry.LifecycleRegistryException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
@@ -49,6 +50,7 @@ class LifecycleRegistryImplTest {
     }
 
     @Test
+    @Disabled
     fun `exception is thrown when an update is attempted to a coordinator that is not registered`() {
         val registry = LifecycleRegistryImpl()
         initialRegistrySetup(registry)

--- a/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/PermissionGroupManagerImpl.kt
+++ b/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/PermissionGroupManagerImpl.kt
@@ -6,9 +6,10 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.permissions.management.cache.PermissionManagementCache
 import net.corda.libs.permissions.manager.PermissionGroupManager
 import net.corda.messaging.api.publisher.RPCSender
+import java.util.concurrent.atomic.AtomicReference
 
 class PermissionGroupManagerImpl(
     private val config: SmartConfig,
     private val rpcSender: RPCSender<PermissionManagementRequest, PermissionManagementResponse>,
-    private val permissionManagementCache: PermissionManagementCache,
+    private val permissionManagementCacheRef: AtomicReference<PermissionManagementCache?>,
 ) : PermissionGroupManager

--- a/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/PermissionRoleManagerImpl.kt
+++ b/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/PermissionRoleManagerImpl.kt
@@ -15,12 +15,13 @@ import net.corda.libs.permissions.manager.request.CreateRoleRequestDto
 import net.corda.libs.permissions.manager.request.GetRoleRequestDto
 import net.corda.libs.permissions.manager.response.RoleResponseDto
 import net.corda.messaging.api.publisher.RPCSender
+import java.util.concurrent.atomic.AtomicReference
 
 
 class PermissionRoleManagerImpl(
     config: SmartConfig,
     private val rpcSender: RPCSender<PermissionManagementRequest, PermissionManagementResponse>,
-    private val permissionManagementCache: PermissionManagementCache,
+    private val permissionManagementCacheRef: AtomicReference<PermissionManagementCache?>,
 ) : PermissionRoleManager {
 
     private val writerTimeout = config.getEndpointTimeout()
@@ -43,6 +44,9 @@ class PermissionRoleManagerImpl(
     }
 
     override fun getRole(roleRequestDto: GetRoleRequestDto): RoleResponseDto? {
+        val permissionManagementCache = checkNotNull(permissionManagementCacheRef.get()) {
+            "Permission management cache is null."
+        }
         val cachedRole: Role = permissionManagementCache.getRole(roleRequestDto.roleId) ?: return null
         return cachedRole.convertToResponseDto()
     }

--- a/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationService.kt
+++ b/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationService.kt
@@ -6,9 +6,10 @@ import net.corda.permissions.password.PasswordHash
 import net.corda.permissions.password.PasswordService
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import java.util.concurrent.atomic.AtomicReference
 
 class RbacBasicAuthenticationService(
-    private val permissionManagementCache: PermissionManagementCache,
+    private val permissionManagementCacheRef: AtomicReference<PermissionManagementCache?>,
     private val passwordService: PasswordService
 ) : BasicAuthenticationService {
 
@@ -18,6 +19,9 @@ class RbacBasicAuthenticationService(
 
     override fun authenticateUser(loginName: String, password: CharArray): Boolean {
         logger.debug { "Checking authentication for user $loginName." }
+        val permissionManagementCache = checkNotNull(permissionManagementCacheRef.get()) {
+            "Permission management cache is null."
+        }
         val user = permissionManagementCache.getUser(loginName) ?: return false
 
         if (user.saltValue == null || user.hashedPassword == null) {

--- a/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
+++ b/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
@@ -42,11 +42,13 @@ import net.corda.libs.permissions.manager.request.AddRoleToUserRequestDto
 import net.corda.libs.permissions.manager.request.RemoveRoleFromUserRequestDto
 import net.corda.schema.configuration.ConfigKeys
 import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.atomic.AtomicReference
 
 class PermissionUserManagerImplTest {
 
     private val rpcSender = mock<RPCSender<PermissionManagementRequest, PermissionManagementResponse>>()
     private val permissionManagementCache = mock<PermissionManagementCache>()
+    private val permissionManagementCacheRef = AtomicReference(permissionManagementCache)
     private val permissionValidationCache = mock<PermissionValidationCache>()
     private val passwordService = mock<PasswordService>()
 
@@ -77,8 +79,10 @@ class PermissionUserManagerImplTest {
     private val permissionManagementResponseWithoutPassword = PermissionManagementResponse(avroUserWithoutPassword)
     private val config = mock<SmartConfig>()
 
-    private val manager =
-        PermissionUserManagerImpl(config, rpcSender, permissionManagementCache, permissionValidationCache, passwordService)
+    private val manager = PermissionUserManagerImpl(
+            config, rpcSender, permissionManagementCacheRef,
+            AtomicReference(permissionValidationCache), passwordService
+        )
 
     private val defaultTimeout = Duration.ofSeconds(30)
 
@@ -211,7 +215,8 @@ class PermissionUserManagerImplTest {
         whenever(passwordService.saltAndHash(eq("mypassword"))).thenReturn(PasswordHash("randomSalt", "hashedPass"))
         whenever(future.getOrThrow(Duration.ofMillis(12345L))).thenReturn(permissionManagementResponse)
 
-        val manager = PermissionUserManagerImpl(config, rpcSender, permissionManagementCache, permissionValidationCache, passwordService)
+        val manager = PermissionUserManagerImpl(config, rpcSender, permissionManagementCacheRef,
+            AtomicReference(permissionValidationCache), passwordService)
 
         val result = manager.createUser(createUserRequestDto)
 

--- a/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationServiceTest.kt
+++ b/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationServiceTest.kt
@@ -23,13 +23,15 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.atomic.AtomicReference
 
 class RbacBasicAuthenticationServiceTest {
 
     companion object {
         private val passwordService: PasswordService = mock()
-        private val permissionManagementCache: PermissionManagementCache = mock()
-        private val rbacBasicAuthenticationService = RbacBasicAuthenticationService(permissionManagementCache, passwordService)
+        private val permissionManagementCache = mock<PermissionManagementCache>()
+        private val rbacBasicAuthenticationService =
+            RbacBasicAuthenticationService(AtomicReference(permissionManagementCache), passwordService)
 
         private val virtualNode = "f39d810f-6ee6-4742-ab7c-d1fe274ab85e"
         private val permissionString = "flow/start/com.myapp.MyFlow"

--- a/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/factory/PermissionManagerFactory.kt
+++ b/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/factory/PermissionManagerFactory.kt
@@ -8,6 +8,7 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.permissions.management.cache.PermissionManagementCache
 import net.corda.libs.permissions.validation.cache.PermissionValidationCache
 import net.corda.libs.permissions.manager.BasicAuthenticationService
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * The [PermissionManagerFactory] constructs instances of [PermissionManager].
@@ -19,21 +20,21 @@ interface PermissionManagerFactory {
      * @param config the configuration for the permission manager.
      * @param rpcSender the [RPCSender] responsible for posting requests of type [PermissionManagementRequest] and accepting responses of
      * type [PermissionManagementResponse].
-     * @param permissionManagementCache the permission management cache holding permission data used for permission management read
+     * @param permissionManagementCacheRef the permission management cache holding permission data used for permission management read
      * operations.
-     * @param permissionValidationCache the cache holding data used for permission validation
+     * @param permissionValidationCacheRef the cache holding data used for permission validation
      */
     fun createPermissionManager(
         config: SmartConfig,
         rpcSender: RPCSender<PermissionManagementRequest, PermissionManagementResponse>,
-        permissionManagementCache: PermissionManagementCache,
-        permissionValidationCache: PermissionValidationCache
+        permissionManagementCacheRef: AtomicReference<PermissionManagementCache?>,
+        permissionValidationCacheRef: AtomicReference<PermissionValidationCache?>
     ): PermissionManager
 
     /**
      * Create a service for performing basic authentication utilizing the permission management cache.
      */
     fun createBasicAuthenticationService(
-        permissionManagementCache: PermissionManagementCache
+        permissionManagementCacheRef: AtomicReference<PermissionManagementCache?>
     ): BasicAuthenticationService
 }

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/factory/PermissionStorageReaderFactoryImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/factory/PermissionStorageReaderFactoryImpl.kt
@@ -10,20 +10,21 @@ import org.osgi.service.component.annotations.Component
 import javax.persistence.EntityManagerFactory
 import net.corda.libs.permissions.management.cache.PermissionManagementCache
 import net.corda.libs.permissions.storage.reader.impl.summary.PermissionSummaryReconcilerImpl
+import java.util.concurrent.atomic.AtomicReference
 
 @Component(service = [PermissionStorageReaderFactory::class])
 class PermissionStorageReaderFactoryImpl : PermissionStorageReaderFactory {
 
     override fun create(
-        permissionValidationCache: PermissionValidationCache,
-        permissionManagementCache: PermissionManagementCache,
+        permissionValidationCacheRef: AtomicReference<PermissionValidationCache?>,
+        permissionManagementCacheRef: AtomicReference<PermissionManagementCache?>,
         publisher: Publisher,
         entityManagerFactory: EntityManagerFactory
     ): PermissionStorageReader {
 
         return PermissionStorageReaderImpl(
-            permissionValidationCache,
-            permissionManagementCache,
+            permissionValidationCacheRef,
+            permissionManagementCacheRef,
             PermissionRepositoryImpl(entityManagerFactory),
             publisher,
             PermissionSummaryReconcilerImpl()

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/PermissionStorageReaderImplTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/PermissionStorageReaderImplTest.kt
@@ -35,6 +35,7 @@ import net.corda.data.permissions.summary.UserPermissionSummary as AvroUserPermi
 import net.corda.libs.permissions.storage.reader.summary.PermissionSummaryReconciler
 import net.corda.schema.Schemas.Permissions.Companion.PERMISSIONS_USER_SUMMARY_TOPIC
 import org.mockito.kotlin.any
+import java.util.concurrent.atomic.AtomicReference
 import net.corda.data.permissions.Group as AvroGroup
 import net.corda.data.permissions.Permission as AvroPermission
 import net.corda.data.permissions.PermissionType as AvroPermissionType
@@ -315,8 +316,10 @@ class PermissionStorageReaderImplTest {
     private val publisher = mock<Publisher>()
     private val reconciler = mock<PermissionSummaryReconciler>()
 
-    private val processor =
-        PermissionStorageReaderImpl(permissionValidationCache, permissionManagementCache, permissionRepository, publisher, reconciler)
+    private val processor = PermissionStorageReaderImpl(
+            AtomicReference(permissionValidationCache),
+            AtomicReference(permissionManagementCache), permissionRepository, publisher, reconciler
+        )
 
     @Test
     fun `starting the reader publishes stored users, groups, roles and permissions`() {

--- a/libs/permissions/permission-storage-reader/src/main/kotlin/net/corda/libs/permissions/storage/reader/factory/PermissionStorageReaderFactory.kt
+++ b/libs/permissions/permission-storage-reader/src/main/kotlin/net/corda/libs/permissions/storage/reader/factory/PermissionStorageReaderFactory.kt
@@ -5,12 +5,13 @@ import net.corda.libs.permissions.storage.reader.PermissionStorageReader
 import net.corda.messaging.api.publisher.Publisher
 import javax.persistence.EntityManagerFactory
 import net.corda.libs.permissions.management.cache.PermissionManagementCache
+import java.util.concurrent.atomic.AtomicReference
 
 interface PermissionStorageReaderFactory {
 
     fun create(
-        permissionValidationCache: PermissionValidationCache,
-        permissionManagementCache: PermissionManagementCache,
+        permissionValidationCacheRef: AtomicReference<PermissionValidationCache?>,
+        permissionManagementCacheRef: AtomicReference<PermissionManagementCache?>,
         publisher: Publisher,
         entityManagerFactory: EntityManagerFactory
     ): PermissionStorageReader

--- a/libs/permissions/permission-validation-impl/src/main/kotlin/net/corda/libs/permission/impl/PermissionValidatorImpl.kt
+++ b/libs/permissions/permission-validation-impl/src/main/kotlin/net/corda/libs/permission/impl/PermissionValidatorImpl.kt
@@ -6,9 +6,10 @@ import net.corda.libs.permission.PermissionValidator
 import net.corda.libs.permissions.validation.cache.PermissionValidationCache
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import java.util.concurrent.atomic.AtomicReference
 
 class PermissionValidatorImpl(
-    private val permissionValidationCache: PermissionValidationCache
+    private val permissionValidationCacheRef: AtomicReference<PermissionValidationCache?>
 ) : PermissionValidator {
 
     companion object {
@@ -30,6 +31,11 @@ class PermissionValidatorImpl(
 
     override fun authorizeUser(loginName: String, permission: String): Boolean {
         logger.debug { "Checking permissions for $permission for user $loginName" }
+
+        val permissionValidationCache = checkNotNull(permissionValidationCacheRef.get()) {
+            "Permission validation cache is null."
+        }
+
         val permissionSummary = permissionValidationCache.getPermissionSummary(loginName)
 
         if (permissionSummary == null) {

--- a/libs/permissions/permission-validation-impl/src/main/kotlin/net/corda/libs/permission/impl/factory/PermissionValidatorFactoryImpl.kt
+++ b/libs/permissions/permission-validation-impl/src/main/kotlin/net/corda/libs/permission/impl/factory/PermissionValidatorFactoryImpl.kt
@@ -4,11 +4,12 @@ import net.corda.libs.permission.factory.PermissionValidatorFactory
 import net.corda.libs.permission.impl.PermissionValidatorImpl
 import net.corda.libs.permissions.validation.cache.PermissionValidationCache
 import org.osgi.service.component.annotations.Component
+import java.util.concurrent.atomic.AtomicReference
 
 @Component(service = [PermissionValidatorFactory::class])
 class PermissionValidatorFactoryImpl : PermissionValidatorFactory {
 
-    override fun create(permissionValidationCache: PermissionValidationCache): PermissionValidatorImpl {
-        return PermissionValidatorImpl(permissionValidationCache)
+    override fun create(permissionValidationCacheRef: AtomicReference<PermissionValidationCache?>): PermissionValidatorImpl {
+        return PermissionValidatorImpl(permissionValidationCacheRef)
     }
 }

--- a/libs/permissions/permission-validation-impl/src/test/kotlin/net/corda/libs/permission/impl/PermissionValidatorImplTest.kt
+++ b/libs/permissions/permission-validation-impl/src/test/kotlin/net/corda/libs/permission/impl/PermissionValidatorImplTest.kt
@@ -10,11 +10,12 @@ import net.corda.libs.permissions.validation.cache.PermissionValidationCache
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.concurrent.atomic.AtomicReference
 
 class PermissionValidatorImplTest {
 
     private val permissionValidationCache: PermissionValidationCache = mock()
-    private val permissionValidator = PermissionValidatorImpl(permissionValidationCache)
+    private val permissionValidator = PermissionValidatorImpl(AtomicReference(permissionValidationCache))
     private val permissionString = "flow/start/com.myapp.MyFlow"
     private val permissionUrlRequest = "POST:https://host:1234/node-rpc/5e0a07a6-c25d-413a-be34-647a792f4f58/${permissionString}"
 

--- a/libs/permissions/permission-validation/src/main/kotlin/net/corda/libs/permission/factory/PermissionValidatorFactory.kt
+++ b/libs/permissions/permission-validation/src/main/kotlin/net/corda/libs/permission/factory/PermissionValidatorFactory.kt
@@ -2,11 +2,12 @@ package net.corda.libs.permission.factory
 
 import net.corda.libs.permissions.validation.cache.PermissionValidationCache
 import net.corda.libs.permission.PermissionValidator
+import java.util.concurrent.atomic.AtomicReference
 
 interface PermissionValidatorFactory {
 
     /**
      * Create an instance of the [PermissionValidator]
      */
-    fun create(permissionValidationCache: PermissionValidationCache): PermissionValidator
+    fun create(permissionValidationCacheRef: AtomicReference<PermissionValidationCache?>): PermissionValidator
 }


### PR DESCRIPTION
**RPC RBAC changes:**
`PermissionManagementCache` and `PermissionValidationCache` re-created every time when config changes. There are other listeners of the config changes which assume that said caches been already created. This may not be always the case as config listeners are being notified in the arbitrary order.
To rectify the issue, said caches are wrapped into `AtomicReference` allowing them to be initialized at some point in the future. 

**Lifecycle changes:**
Various components updated to close registrations before coordinators as a workaround for an issue in the lifecycle code where doing the reverse results in exceptions. A few subscriptions needed to be closed instead of stopped when they are no longer in use. Finally, a race condition in the lifecycle code can cause registry failures on closing objects; this is rectified by changing the error to a warning.