### PR TITLE
NOTICK: Set the lifecycle to UP for a few flow worker components

### DIFF
--- a/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterService.kt
+++ b/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterService.kt
@@ -3,6 +3,7 @@ package net.corda.flow.p2p.filter
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.CordaAvroSerializationFactory
+import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -14,7 +15,6 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.libs.configuration.helper.getConfig
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
@@ -73,7 +73,7 @@ class FlowP2PFilterService @Activate constructor(
             }
             is ConfigChangedEvent -> {
                 logger.info("Flow p2p filter processor component configuration received")
-                restartFlowMapperService(event)
+                restartFlowP2PFilterService(event)
             }
             is StopEvent -> {
                 logger.info("Stopping flow p2p filter component.")
@@ -88,7 +88,7 @@ class FlowP2PFilterService @Activate constructor(
     /**
      * Recreate the Flow P2P Filter service in response to new config [event]
      */
-    private fun restartFlowMapperService(event: ConfigChangedEvent) {
+    private fun restartFlowP2PFilterService(event: ConfigChangedEvent) {
         val messagingConfig = event.config.getConfig(MESSAGING_CONFIG)
 
         durableSub?.close()
@@ -101,6 +101,7 @@ class FlowP2PFilterService @Activate constructor(
         )
 
         durableSub?.start()
+        coordinator.updateStatus(LifecycleStatus.UP)
     }
 
     override val isRunning: Boolean

--- a/testing/flow/dummy-link-manager/src/main/kotlin/net/corda/flow/dummy/link/DummyLinkManagerService.kt
+++ b/testing/flow/dummy-link-manager/src/main/kotlin/net/corda/flow/dummy/link/DummyLinkManagerService.kt
@@ -2,6 +2,7 @@ package net.corda.flow.dummy.link
 
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -13,7 +14,6 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.libs.configuration.helper.getConfig
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
@@ -70,7 +70,7 @@ class DummyLinkManagerService @Activate constructor(
             }
             is ConfigChangedEvent -> {
                 logger.info("Dummy link manager component configuration received")
-                restartFlowMapperService(event)
+                restartDummyLinkManagerService(event)
             }
             is StopEvent -> {
                 logger.info("Stopping dummy link manager component.")
@@ -82,7 +82,7 @@ class DummyLinkManagerService @Activate constructor(
         }
     }
 
-    private fun restartFlowMapperService(event: ConfigChangedEvent) {
+    private fun restartDummyLinkManagerService(event: ConfigChangedEvent) {
         val messagingConfig = event.config.getConfig(MESSAGING_CONFIG)
 
         durableSub?.close()
@@ -95,6 +95,7 @@ class DummyLinkManagerService @Activate constructor(
         )
 
         durableSub?.start()
+        coordinator.updateStatus(LifecycleStatus.UP)
     }
 
     override val isRunning: Boolean


### PR DESCRIPTION
I had a few moments so took a quick look at the lifecycle of the flow worker components. A few weren't setting themselves as UP, this PR fixes that.

The flow worker does appear to cope with messaging config changes after this fix.