### PR TITLE
CORE-5146: Upgrade to Bnd 6.3.1 and Corda Gradle plugins 6.0.0-BETA17.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,8 @@ cordaRuntimeRevision=0
 
 # Plugin dependency versions
 avroGradlePluginVersion=1.1.0
-bndVersion=6.3.0
-cordaGradlePluginsVersion=6.0.0-BETA16
+bndVersion=6.3.1
+cordaGradlePluginsVersion=6.0.0-BETA17
 detektPluginVersion=1.19.+
 internalPublishVersion=1.+
 internalDockerVersion=1.+


### PR DESCRIPTION
Upgrade to Bnd 6.3.1 to avoid potential `ClassCastException` introduced by Bnd 6.3.0.