### PR TITLE
CORE-4464: Do not include `org.slf4j` inside plugin Jar

### DIFF
--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -16,8 +16,6 @@ dependencies {
     kapt "org.pf4j:pf4j:$pf4jVersion"
     kapt "info.picocli:picocli-codegen:$picocliVersion"
 
-    implementation platform("net.corda:corda-api:$cordaApiVersion")
-
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
     testImplementation "org.pf4j:pf4j:$pf4jVersion"
@@ -50,6 +48,7 @@ def plugin = tasks.register('plugin', Jar) {
         exclude "META-INF/*.RSA"
         exclude "module-info.class"
         exclude "META-INF/versions/*/module-info.class"
+        exclude "org/slf4j/**"
 
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }


### PR DESCRIPTION
That way we can rely on SLF4J packaged inside Plugin Host and avoid errors like:
```
11:07:34.656 [main] ERROR org.pf4j.AbstractPluginManager - Unable to start plugin 'virtual-node@5.0.0.0-SNAPSHOT'
java.lang.LinkageError: loader constraint violation: when resolving method "org.slf4j.impl.StaticLoggerBinder.getLoggerFactory()Lorg/slf4j/ILoggerFactory;" the class loader org.pf4j.PluginClassLoader @45d2ade3 (instance of org.pf4j.PluginClassLoader, child of 'app' jdk.internal.loader.ClassLoaders$AppClassLoader) of the current class, org/slf4j/LoggerFactory, and the class loader 'app' (instance of jdk.internal.loader.ClassLoaders$AppClassLoader) for the method's defining class, org/slf4j/impl/StaticLoggerBinder, have different Class objects for the type org/slf4j/ILoggerFactory used in the signature
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:423) ~[corda-cli-0.0.1-SNAPSHOT.jar:?]
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362) ~[corda-cli-0.0.1-SNAPSHOT.jar:?]
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388) ~[corda-cli-0.0.1-SNAPSHOT.jar:?]
        at net.corda.cli.plugins.vnode.VirtualNodeCliPlugin.<clinit>(VirtualNodeCliPlugin.kt:16) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:490) ~[?:?]
        at org.pf4j.DefaultPluginFactory.create(DefaultPluginFactory.java:64) ~[corda-cli-0.0.1-SNAPSHOT.jar:?]
        at org.pf4j.PluginWrapper.getPlugin(PluginWrapper.java:81) ~[corda-cli-0.0.1-SNAPSHOT.jar:?]
        at org.pf4j.AbstractPluginManager.startPlugins(AbstractPluginManager.java:358) [corda-cli-0.0.1-SNAPSHOT.jar:?]
        at net.corda.cli.application.Boot.run(Boot.kt:52) [corda-cli-0.0.1-SNAPSHOT.jar:?]
        at net.corda.cli.application.BootKt.main(Boot.kt:17) [corda-cli-0.0.1-SNAPSHOT.jar:?]
 ```