### PR TITLE
CORE-4881 - DBChange from database source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ node_modules/
 /testing/soak/GroupPolicy.json
 /testing/soak/*.cpi
 /testing/soak/*.csv
+
+values.yaml
+debug.yaml

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbChangeLog.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbChangeLog.kt
@@ -1,0 +1,44 @@
+package net.corda.virtualnode.write.db.impl.writer
+
+import net.corda.db.admin.DbChange
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import java.io.InputStream
+
+/**
+ * DB Change Log for all CPKs for a Virtual Node, as used by Liquibase during VNode creation.
+ *
+ * @property changeLogs map of Change Log Entities per CPK
+ * @constructor Create empty Virtual node db change log
+ */
+class VirtualNodeDbChangeLog(
+    private val changeLogs: List<CpkDbChangeLogEntity>
+): DbChange {
+    companion object {
+        const val MASTER_CHANGE_LOG = "db.changelog-master.xml"
+    }
+
+    private val all by lazy {
+        changeLogs.associate {
+            "${it.id.cpkName}-${it.id.filePath}" to it.content
+        }
+    }
+
+    override val masterChangeLogFiles: List<String>
+        get() = changeLogs
+            // TODO - ensure validation that a CPK with changelog files has at least 1 master file
+            //  must happen during CPI installation.
+            .filter {
+                it.id.filePath == MASTER_CHANGE_LOG
+            }.map {
+                "${it.id.cpkName}-${it.id.filePath}"
+            }
+
+    override val changeLogFileList: Set<String>
+        get() = all.keys
+
+    override fun fetch(path: String): InputStream {
+        return all[path]?.byteInputStream()
+            ?: throw CordaRuntimeException("Cannot find changelog file: $path")
+    }
+}

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbChangeLog.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbChangeLog.kt
@@ -8,7 +8,7 @@ import java.io.InputStream
 /**
  * DB Change Log for all CPKs for a Virtual Node, as used by Liquibase during VNode creation.
  *
- * @property changeLogs map of Change Log Entities per CPK
+ * @property changeLogs list of all [CpkDbChangeLogEntity] for all CPKs to be DB migrated.
  * @constructor Create empty Virtual node db change log
  */
 class VirtualNodeDbChangeLog(

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeDbChangeLogTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeDbChangeLogTest.kt
@@ -1,0 +1,110 @@
+package net.corda.virtualnode.write.db.impl.tests.writer
+
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogKey
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class VirtualNodeDbChangeLogTest {
+    private val masterFile1 = CpkDbChangeLogEntity(
+        CpkDbChangeLogKey(
+            "CPK1",
+            "1.0",
+            "hash",
+            VirtualNodeDbChangeLog.MASTER_CHANGE_LOG
+        ),
+        "cpk1-checksum",
+        "migration1"
+    )
+    private val otherFile1 = CpkDbChangeLogEntity(
+        CpkDbChangeLogKey(
+            "CPK1",
+            "1.0",
+            "hash",
+            "another-one.xml"
+        ),
+        "cpk1-checksum",
+        "migration2"
+    )
+    private val masterFile2 = CpkDbChangeLogEntity(
+        CpkDbChangeLogKey(
+            "CPK2",
+            "1.0",
+            "hash",
+            VirtualNodeDbChangeLog.MASTER_CHANGE_LOG
+        ),
+        "cpk1-checksum",
+        "migration3"
+    )
+
+    @Test
+    fun `find all master changelog files`() {
+        val changeLog = VirtualNodeDbChangeLog(
+            listOf(
+                masterFile1,
+                otherFile1,
+                masterFile2,
+            )
+        )
+
+        val masterFiles = changeLog.masterChangeLogFiles
+
+        assertThat(masterFiles).containsAll(
+            listOf("CPK1-${masterFile1.id.filePath}", "CPK2-${masterFile2.id.filePath}")
+        )
+    }
+
+    @Test
+    fun `find all changelog files`() {
+        val changeLog = VirtualNodeDbChangeLog(
+            listOf(
+                masterFile1,
+                otherFile1,
+                masterFile2,
+            )
+        )
+
+        val files = changeLog.changeLogFileList
+
+        assertThat(files).containsAll(
+            listOf(
+                "CPK1-${masterFile1.id.filePath}",
+                "CPK1-${otherFile1.id.filePath}",
+                "CPK2-${masterFile2.id.filePath}"
+            )
+        )
+    }
+
+    @Test
+    fun `fetch changelog file contents`() {
+        val changeLog = VirtualNodeDbChangeLog(
+            listOf(
+                masterFile1,
+                otherFile1,
+            )
+        )
+
+        changeLog.fetch("CPK1-${masterFile1.id.filePath}").reader().use {
+            assertThat(it.readText()).isEqualTo(masterFile1.content)
+        }
+        changeLog.fetch("CPK1-${otherFile1.id.filePath}").reader().use {
+            assertThat(it.readText()).isEqualTo(otherFile1.content)
+        }
+    }
+
+    @Test
+    fun `fetch throws when changelog does not exist`() {
+        val changeLog = VirtualNodeDbChangeLog(
+            listOf(
+                masterFile1,
+            )
+        )
+
+        assertThrows<CordaRuntimeException> {
+            changeLog.fetch("CPK1-${otherFile1.id.filePath}")
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.121-alpha-1655478379509
+cordaApiVersion=5.0.0.121-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.120-beta+
+cordaApiVersion=5.0.0.120-alpha-1655459668143
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.120-alpha-1655459668143
+cordaApiVersion=5.0.0.121-alpha-1655478379509
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.22

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
@@ -9,8 +9,8 @@ import net.corda.libs.cpi.datamodel.CpiCpkKey
 import net.corda.libs.cpi.datamodel.CpiEntities
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 import net.corda.libs.cpi.datamodel.CpiMetadataEntityKey
-import net.corda.libs.cpi.datamodel.CpkMetadataEntity
 import net.corda.libs.cpi.datamodel.CpkFileEntity
+import net.corda.libs.cpi.datamodel.CpkKey
 import net.corda.libs.cpi.datamodel.findAllCpiMetadata
 import net.corda.libs.cpi.datamodel.findCpkChecksumsNotIn
 import net.corda.libs.cpi.datamodel.findCpkDataEntity
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.TestInstance
 import java.util.UUID
 import javax.persistence.EntityManagerFactory
 import kotlin.streams.toList
-import net.corda.libs.cpi.datamodel.CpkKey
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CpiEntitiesIntegrationTest {
@@ -55,20 +54,20 @@ class CpiEntitiesIntegrationTest {
     fun `can persist cpi and cpks`() {
         val cpiId = UUID.randomUUID()
         val cpkId = UUID.randomUUID().toString()
-        val signerSummaryHash = randomChecksumString()
+        val signerSummaryHash = TestObject.randomChecksumString()
         val cpkData = CpkFileEntity(
             CpkKey(cpkId, "1.2.3", signerSummaryHash),
             "cpk-checksum-$cpkId",
             ByteArray(2000),
         )
         val cpkMeta =
-            CpkMetadataEntityFactory.create(
+            TestObject.createCpk(
                 cpkData.fileChecksum,
                 cpkId,
                 "1.2.3",
                 signerSummaryHash,
             )
-        val cpi = CpiMetadataEntityFactory.create(cpiId, listOf(Pair("test-cpk", cpkMeta)))
+        val cpi = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpkMeta)))
 
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -107,13 +106,13 @@ class CpiEntitiesIntegrationTest {
             ByteArray(2000),
         )
         val cpkMeta =
-            CpkMetadataEntityFactory.create(
+            TestObject.createCpk(
                 cpkData.fileChecksum,
                 "test-cpk",
                 "1.2.3",
-                randomChecksumString(),
+                TestObject.randomChecksumString(),
             )
-        val cpi = CpiMetadataEntityFactory.create(cpiId, listOf(Pair("test-cpk", cpkMeta)))
+        val cpi = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpkMeta)))
 
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -129,13 +128,13 @@ class CpiEntitiesIntegrationTest {
         // Create another CPK
         val cpkName2 = "test-cpk2"
         val cpkVer2 = "2.2.3"
-        val cpk2SignerSummaryHash = randomChecksumString()
+        val cpk2SignerSummaryHash = TestObject.randomChecksumString()
         val cpkData2 = CpkFileEntity(
             CpkKey(cpkName2, cpkVer2, cpk2SignerSummaryHash),
             "cpk-checksum-${UUID.randomUUID()}",
             ByteArray(2000),
         )
-        val cpkMetadataEntity2 = CpkMetadataEntityFactory.create(
+        val cpkMetadataEntity2 = TestObject.createCpk(
             cpkData2.fileChecksum,
             cpkName2,
             cpkVer2,
@@ -199,20 +198,20 @@ class CpiEntitiesIntegrationTest {
         val cpiId = UUID.randomUUID()
         val cpkId = UUID.randomUUID().toString()
         val cpkVer = "1.2.3"
-        val cpkSSH = randomChecksumString()
+        val cpkSSH = TestObject.randomChecksumString()
         val cpkData = CpkFileEntity(
             CpkKey(cpkId, cpkVer, cpkSSH),
             "cpk-checksum-$cpkId",
             ByteArray(2000),
         )
         val cpkMeta1 =
-            CpkMetadataEntityFactory.create(
+            TestObject.createCpk(
                 cpkData.fileChecksum,
                 cpkId,
                 cpkVer,
                 cpkSSH,
             )
-        val cpi1 = CpiMetadataEntityFactory.create(cpiId, listOf(Pair("test-cpk", cpkMeta1)))
+        val cpi1 = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpkMeta1)))
 
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -228,20 +227,20 @@ class CpiEntitiesIntegrationTest {
 
         val cpk2Name = "test-cpk2"
         val cpk2Ver = "2.2.3"
-        val cpk2SSH = randomChecksumString()
+        val cpk2SSH = TestObject.randomChecksumString()
         // Create another CPK
         val cpkData2 = CpkFileEntity(
             CpkKey(cpk2Name, cpk2Ver, cpk2SSH),
             "cpk-checksum-${UUID.randomUUID()}",
             ByteArray(2000),
         )
-        val cpkMeta2 = CpkMetadataEntityFactory.create(
+        val cpkMeta2 = TestObject.createCpk(
             cpkData2.fileChecksum,
             cpk2Name,
             cpk2Ver,
             cpk2SSH,
         )
-        val cpi2 = CpiMetadataEntityFactory.create(cpiId, listOf(Pair("test-cpk1", cpkMeta1), Pair("test-cpk2", cpkMeta2)))
+        val cpi2 = TestObject.createCpi(cpiId, listOf(Pair("test-cpk1", cpkMeta1), Pair("test-cpk2", cpkMeta2)))
 
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -271,7 +270,7 @@ class CpiEntitiesIntegrationTest {
 
     @Test
     fun `on findCpkChecksumsNotIn an empty set returns all results`() {
-        val cpkChecksums = List(3) { randomChecksumString() }
+        val cpkChecksums = List(3) { TestObject.randomChecksumString() }
 
         val emFactory = EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -291,7 +290,7 @@ class CpiEntitiesIntegrationTest {
 
     @Test
     fun `on findCpkChecksumsNotIn a checksum set returns all but this set`() {
-        val cpkChecksums = List(3) { randomChecksumString() }
+        val cpkChecksums = List(3) { TestObject.randomChecksumString() }
 
         val emFactory = EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -312,7 +311,7 @@ class CpiEntitiesIntegrationTest {
     @Test
     fun `finds CPK data entity`() {
         val cpkChecksums = listOf(
-            randomChecksumString()
+            TestObject.randomChecksumString()
         )
 
         val emFactory = EntityManagerFactoryFactoryImpl().create(
@@ -344,10 +343,10 @@ class CpiEntitiesIntegrationTest {
             val cpiId = UUID.randomUUID()
             val cpkName = "test-cpk$i"
             val cpkVersion = "$i.2.3"
-            val cpkSSH = randomChecksumString()
+            val cpkSSH = TestObject.randomChecksumString()
             val cpkMetadataEntity =
-                CpkMetadataEntityFactory.create(
-                    randomChecksumString(),
+                TestObject.createCpk(
+                    TestObject.randomChecksumString(),
                     cpkName,
                     cpkVersion,
                     cpkSSH,
@@ -357,7 +356,7 @@ class CpiEntitiesIntegrationTest {
                 cpkMetadataEntity.cpkFileChecksum,
                 ByteArray(2000),
             )
-            val cpi = CpiMetadataEntityFactory.create(cpiId, listOf(Pair("test-cpk.cpk$i", cpkMetadataEntity)))
+            val cpi = TestObject.createCpi(cpiId, listOf(Pair("test-cpk.cpk$i", cpkMetadataEntity)))
 
             emFactory.use { em ->
                 em.transaction {
@@ -402,12 +401,6 @@ class CpiEntitiesIntegrationTest {
         println("**** [END] findAllCpiMetadata query as stream ****")
     }
 
-    private fun randomChecksumString(): String {
-        return "SHA-256:" + List(64) {
-            (('a'..'z') + ('A'..'Z') + ('0'..'9')).random()
-        }.joinToString("")
-    }
-
     private fun insertCpkChecksums(cpkChecksums: List<String>, emFactory: EntityManagerFactory):
             List<CpkFileEntity> {
         val cpkFiles = mutableListOf<CpkFileEntity>()
@@ -415,9 +408,9 @@ class CpiEntitiesIntegrationTest {
             cpkChecksums.forEach {
                 val cpkName = "file.cpk"
                 val cpkVer = "1.2.3"
-                val cpkSSH = randomChecksumString()
+                val cpkSSH = TestObject.randomChecksumString()
 
-                val cpkMeta = CpkMetadataEntityFactory.create(it, cpkName, cpkVer, cpkSSH)
+                val cpkMeta = TestObject.createCpk(it, cpkName, cpkVer, cpkSSH)
                 val cpkData = CpkFileEntity(
                     CpkKey(cpkName, cpkVer, cpkSSH),
                     it,
@@ -431,36 +424,4 @@ class CpiEntitiesIntegrationTest {
         }
         return cpkFiles
     }
-}
-
-private object CpiMetadataEntityFactory {
-    fun create(
-        cpiId: UUID,
-        cpks: List<Pair<String, CpkMetadataEntity>>,
-    ) =
-        CpiMetadataEntity.create(
-            "test-cpi-$cpiId",
-            "1.0",
-            "test-cpi-hash",
-            "test-cpi-$cpiId.cpi",
-            "test-cpi.cpi-$cpiId-hash",
-            "{group-policy-json}",
-            "group-id",
-            "file-upload-request-id-$cpiId",
-            cpks
-        )
-}
-
-private object CpkMetadataEntityFactory {
-    fun create(
-        cpkFileChecksum: String,
-        name: String,
-        version: String,
-        signerSummaryHash: String,
-    ) = CpkMetadataEntity(
-        CpkKey(name, version, signerSummaryHash),
-        cpkFileChecksum,
-        "1.0",
-        "{}"
-    )
 }

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
@@ -1,0 +1,180 @@
+package net.corda.libs.cpi.datamodel.tests
+
+import net.corda.db.admin.impl.ClassloaderChangeLog
+import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
+import net.corda.db.schema.DbSchema
+import net.corda.db.testkit.DbUtils
+import net.corda.libs.cpi.datamodel.CpiEntities
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogKey
+import net.corda.libs.cpi.datamodel.findCpkDbChangeLog
+import net.corda.orm.EntityManagerConfiguration
+import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
+import net.corda.orm.utils.transaction
+import net.corda.orm.utils.use
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CpkDbChangeLogEntityTest {
+    private val dbConfig: EntityManagerConfiguration =
+        DbUtils.getEntityManagerConfiguration("cpk_changelog_db")
+
+    init {
+        val dbChange = ClassloaderChangeLog(
+            linkedSetOf(
+                ClassloaderChangeLog.ChangeLogResourceFiles(
+                    DbSchema::class.java.packageName,
+                    listOf("net/corda/db/schema/config/db.changelog-master.xml"),
+                    DbSchema::class.java.classLoader
+                )
+            )
+        )
+        dbConfig.dataSource.connection.use { connection ->
+            LiquibaseSchemaMigratorImpl().updateDb(connection, dbChange)
+        }
+    }
+
+    @AfterAll
+    private fun cleanUp() {
+        dbConfig.close()
+    }
+
+    @Test
+    fun `can persist changelogs`() {
+        val (cpi, cpk) = TestObject.createCpiWithCpk()
+
+        val changeLog1 = CpkDbChangeLogEntity(
+            CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master"),
+            "master-checksum",
+            "master-content"
+        )
+        val changeLog2 = CpkDbChangeLogEntity(
+            CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "other"),
+            "other-checksum",
+            "other-content"
+        )
+
+        EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            CpiEntities.classes.toList(),
+            dbConfig
+        ).use { em ->
+            em.transaction {
+                it.persist(cpi)
+                it.persist(changeLog1)
+                it.persist(changeLog2)
+                it.flush()
+            }
+        }
+
+        EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            CpiEntities.classes.toList(),
+            dbConfig
+        ).use {
+            val loadedDbLogEntity = it.find(
+                CpkDbChangeLogEntity::class.java,
+                CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master")
+            )
+
+            assertThat(changeLog1.content).isEqualTo(loadedDbLogEntity.content)
+        }
+    }
+
+    @Test
+    fun `can persist changelogs to existing CPI`() {
+        val (cpi, cpk) = TestObject.createCpiWithCpk()
+
+        val changeLog1 = CpkDbChangeLogEntity(
+            CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master"),
+            "master-checksum",
+            "master-content"
+        )
+
+        EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            CpiEntities.classes.toList(),
+            dbConfig
+        ).use { em ->
+            em.transaction {
+                it.persist(cpi)
+                it.flush()
+            }
+        }
+
+        EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            CpiEntities.classes.toList(),
+            dbConfig
+        ).use { em ->
+            em.transaction {
+                it.persist(changeLog1)
+                it.flush()
+            }
+        }
+
+        EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            CpiEntities.classes.toList(),
+            dbConfig
+        ).use {
+            val loadedDbLogEntity = it.find(
+                CpkDbChangeLogEntity::class.java,
+                CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master")
+            )
+
+            assertThat(changeLog1.content).isEqualTo(loadedDbLogEntity.content)
+        }
+    }
+
+    @Test
+    fun `findCpkDbChangeLog returns all for cpk`() {
+        val (cpi1, cpk1) = TestObject.createCpiWithCpk()
+        val (cpi2, cpk2) = TestObject.createCpiWithCpk()
+
+        val changeLog1 = CpkDbChangeLogEntity(
+            CpkDbChangeLogKey(cpk1.id.cpkName, cpk1.id.cpkVersion, cpk1.id.cpkSignerSummaryHash, "master"),
+            "master-checksum",
+            "master-content"
+        )
+        val changeLog2 = CpkDbChangeLogEntity(
+            CpkDbChangeLogKey(cpk1.id.cpkName, cpk1.id.cpkVersion, cpk1.id.cpkSignerSummaryHash, "other"),
+            "other-checksum",
+            "other-content"
+        )
+        val changeLog3 = CpkDbChangeLogEntity(
+            CpkDbChangeLogKey(cpk2.id.cpkName, cpk2.id.cpkVersion, cpk2.id.cpkSignerSummaryHash, "master"),
+            "master-checksum",
+            "master-content"
+        )
+
+        EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            CpiEntities.classes.toList(),
+            dbConfig
+        ).use { em ->
+            em.transaction {
+                it.persist(cpi1)
+                it.persist(cpi2)
+                it.persist(changeLog1)
+                it.persist(changeLog2)
+                it.persist(changeLog3)
+                it.flush()
+            }
+        }
+
+        val changeLogs = EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            CpiEntities.classes.toList(),
+            dbConfig
+        ).use { em ->
+            em.findCpkDbChangeLog(cpk1.id.cpkName, cpk1.id.cpkVersion, cpk1.id.cpkSignerSummaryHash)
+        }
+
+        assertThat(changeLogs.size).isEqualTo(2)
+        assertThat(changeLogs.map { it.id }).containsAll(listOf(changeLog1.id, changeLog2.id))
+    }
+}

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/TestObject.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/TestObject.kt
@@ -1,0 +1,59 @@
+package net.corda.libs.cpi.datamodel.tests
+
+import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpkKey
+import net.corda.libs.cpi.datamodel.CpkMetadataEntity
+import java.util.UUID
+
+object TestObject {
+    fun randomChecksumString(): String {
+        return "SHA-256:" + List(64) {
+            (('a'..'z') + ('A'..'Z') + ('0'..'9')).random()
+        }.joinToString("")
+    }
+
+    fun createCpi(
+        cpiId: UUID,
+        cpks: List<Pair<String, CpkMetadataEntity>>,
+    ) =
+        CpiMetadataEntity.create(
+            "test-cpi-$cpiId",
+            "1.0",
+            "test-cpi-hash",
+            "test-cpi-$cpiId.cpi",
+            "test-cpi.cpi-$cpiId-hash",
+            "{group-policy-json}",
+            "group-id",
+            "file-upload-request-id-$cpiId",
+            cpks
+        )
+
+    fun createCpk(
+        cpkFileChecksum: String,
+        name: String,
+        version: String,
+        signerSummaryHash: String,
+    ) = CpkMetadataEntity(
+        CpkKey(name, version, signerSummaryHash),
+        cpkFileChecksum,
+        "1.0",
+        "{}"
+    )
+
+    fun createCpiWithCpk(): Pair<CpiMetadataEntity, CpkMetadataEntity> {
+        val cpiId = UUID.randomUUID()
+        val cpk = createCpk(
+            randomChecksumString(),
+            "test-cpk-$cpiId",
+            "1.0",
+            "test-cpk=hash"
+        )
+        val cpi = createCpi(
+            cpiId,
+            listOf(
+                Pair("test-cpk-$cpiId.cpk", cpk)
+            )
+        )
+        return Pair(cpi, cpk)
+    }
+}

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiEntities.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiEntities.kt
@@ -6,5 +6,6 @@ object CpiEntities {
         CpkFileEntity::class.java,
         CpiCpkEntity::class.java,
         CpkMetadataEntity::class.java,
+        CpkDbChangeLogEntity::class.java,
     )
 }

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogEntity.kt
@@ -1,0 +1,68 @@
+package net.corda.libs.cpi.datamodel
+
+import net.corda.db.schema.DbSchema
+import java.io.Serializable
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.EmbeddedId
+import javax.persistence.Entity
+import javax.persistence.EntityManager
+import javax.persistence.Table
+import javax.persistence.Version
+
+/**
+ * Representation of a DB ChangeLog (Liquibase) file associated with a CPK.
+ */
+@Entity
+@Table(name = "cpk_db_change_log", schema = DbSchema.CONFIG)
+class CpkDbChangeLogEntity(
+    @EmbeddedId
+    var id: CpkDbChangeLogKey,
+    @Column(name = "cpk_file_checksum", nullable = false, unique = true)
+    val fileChecksum: String,
+    @Column(name = "content", nullable = false)
+    val content: String,
+) {
+    @Version
+    @Column(name = "entity_version", nullable = false)
+    var entityVersion: Int = 0
+
+    @Column(name = "is_deleted", nullable = false)
+    var isDeleted: Boolean = false
+
+    // this TS is managed on the DB itself
+    @Column(name = "insert_ts", insertable = false, updatable = false)
+    val insertTimestamp: Instant? = null
+}
+
+/**
+ * Composite primary key for a Cpk Change Log Entry.
+ */
+@Embeddable
+data class CpkDbChangeLogKey(
+    @Column(name = "cpk_name", nullable = false)
+    var cpkName: String,
+    @Column(name = "cpk_version", nullable = false)
+    var cpkVersion: String,
+    @Column(name = "cpk_signer_summary_hash", nullable = false)
+    var cpkSignerSummaryHash: String,
+    @Column(name = "file_path", nullable = false)
+    val filePath: String,
+) : Serializable
+
+fun EntityManager.findCpkDbChangeLog(
+    cpkName: String,
+    cpkVersion: String,
+    cpkSignerSummaryHash: String
+): List<CpkDbChangeLogEntity> {
+    return createQuery(
+        "FROM ${CpkDbChangeLogEntity::class.simpleName} d " +
+                "WHERE d.id.cpkName = :name AND d.id.cpkVersion = :version AND d.id.cpkSignerSummaryHash = :summaryHash",
+        CpkDbChangeLogEntity::class.java
+    )
+        .setParameter("name", cpkName)
+        .setParameter("version", cpkVersion)
+        .setParameter("summaryHash", cpkSignerSummaryHash)
+        .resultList
+}


### PR DESCRIPTION
Introduce an implementation of DbChange that supports DB Change Log files loaded from the DB (through JPA entities).

Integration will happen in a follow-up change.

API change needed: https://github.com/corda/corda-api/pull/425