### PR TITLE
NOTICK - Improve checking of status endpoint in case status goes up/down/up.

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
@@ -33,34 +33,33 @@ class ClusterBootstrapTest {
             healthChecks.map {
                 async {
                     val response = tryUntil(Duration.ofSeconds(120)) { checkReady(it.key, it.value) }
-                    if (response in 200..299)
+                    if (response)
                         println("${it.key} is ready")
                     else
                         softly.fail("Problem with ${it.key} (${it.value}), \"status\" returns: $response")
                 }
             }.awaitAll()
 
-            // TODO: http request to insert config and validate it has been persisted.
-
             softly.assertAll()
         }
     }
 
-    private fun tryUntil(timeOut: Duration, function: () -> HttpResponse<String>): Int {
-        var statusCode = -1
+    private fun tryUntil(timeOut: Duration, function: () -> HttpResponse<String>): Boolean {
         val startTime = Instant.now()
-        while (statusCode < 200 && Instant.now() < startTime.plusNanos(timeOut.toNanos())) {
+        while (Instant.now() < startTime.plusNanos(timeOut.toNanos())) {
             try {
                 val response = function()
-                statusCode = response.statusCode()
+                val statusCode = response.statusCode()
                 if (statusCode in 200..299)
-                    return statusCode
+                    return true
+                else
+                    println("Returned status $statusCode.")
             } catch (connectionException: IOException) {
                 println("Cannot connect.")
             }
             Thread.sleep(1000)
         }
-        return statusCode
+        return false
     }
 
     private fun checkReady(name: String, endpoint: String): HttpResponse<String> {


### PR DESCRIPTION
The status endpoint smoketests seem flaky (https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os-e2e-tests/detail/release%2Fos%2F5.0/309/tests).

The status can go down before it goes up, so this change doesn't assume the intial response is > 200