### PR TITLE
CORE-5100: Retrieve the correct sandbox in the `FlowFiberExecutionContextFactoryImpl`

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
@@ -24,7 +24,7 @@ class FlowFiberExecutionContextFactoryImpl @Activate constructor(
     ): FlowFiberExecutionContext {
         val checkpoint = context.checkpoint
         val sandbox = try {
-            flowSandboxService.get(checkpoint.flowStartContext.initiatedBy.toCorda())
+            flowSandboxService.get(checkpoint.flowStartContext.identity.toCorda())
         } catch (e: Exception) {
             throw FlowTransientException("Failed to create the sandbox: ${e.message}", context, e)
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowFiberExecutionContextFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowFiberExecutionContextFactoryImplTest.kt
@@ -34,7 +34,7 @@ class FlowFiberExecutionContextFactoryImplTest {
     @Test
     fun `create fiber execution context returns initialized context instance`() {
         val flowStartContext = FlowStartContext().apply {
-            initiatedBy = BOB_X500_HOLDING_IDENTITY
+            identity = BOB_X500_HOLDING_IDENTITY
         }
 
         val context = buildFlowEventContext<Any>(Wakeup())


### PR DESCRIPTION
We were retrieving the sandbox using the `initiatedBy` identity rather than our identity here, which results in the wrong sandbox being retrieved when a flow is started via a session init.