### PR TITLE
CORE-3153 - Add integration with crypto ops client in the gateway

### DIFF
--- a/applications/p2p-gateway/build.gradle
+++ b/applications/p2p-gateway/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'
+    implementation project(":components:crypto:crypto-client")
 
     implementation project(":libs:configuration:configuration-merger")
 
@@ -33,6 +34,7 @@ dependencies {
     runtimeOnly project(":libs:messaging:kafka-message-bus-impl")
     runtimeOnly project(":libs:lifecycle:lifecycle-impl")
     runtimeOnly project(":components:configuration:configuration-read-service-impl")
+    runtimeOnly project(":components:crypto:crypto-client-impl")
     implementation project(":libs:configuration:configuration-core")
     implementation project(":libs:configuration:configuration-merger")
 }

--- a/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/CliArguments.kt
+++ b/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/CliArguments.kt
@@ -51,6 +51,9 @@ internal class CliArguments {
     )
     var instanceId = System.getenv("INSTANCE_ID")?.toInt() ?: Random.nextInt()
 
+    @Option(names = ["--without-stubs"])
+    var withoutStubs = false
+
     val bootConfiguration: Config by lazy {
         ConfigFactory.empty()
             .withValue("$BOOT_KAFKA_COMMON.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))

--- a/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/GatewayApp.kt
+++ b/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/GatewayApp.kt
@@ -11,6 +11,7 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.p2p.gateway.Gateway
+import net.corda.p2p.gateway.messaging.SigningMode
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -54,12 +55,18 @@ class GatewayApp @Activate constructor(
             configurationReadService.bootstrapConfig(bootConfig)
 
             consoleLogger.info("Starting gateway")
+            val signingMode = if (arguments.withoutStubs) {
+                SigningMode.REAL
+            } else {
+                SigningMode.STUB
+            }
             gateway = Gateway(
                 configurationReadService,
                 subscriptionFactory,
                 publisherFactory,
                 lifecycleCoordinatorFactory,
-                configMerger.getMessagingConfig(bootConfig)
+                configMerger.getMessagingConfig(bootConfig),
+                signingMode
             ).also { gateway ->
                 gateway.start()
 

--- a/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/GatewayApp.kt
+++ b/applications/p2p-gateway/src/main/kotlin/net/corda/gateway/GatewayApp.kt
@@ -3,6 +3,7 @@ package net.corda.gateway
 import com.typesafe.config.ConfigFactory
 import kotlin.concurrent.thread
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.merger.ConfigMerger
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -34,6 +35,8 @@ class GatewayApp @Activate constructor(
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigMerger::class)
     private val configMerger: ConfigMerger,
+    @Reference(service = CryptoOpsClient::class)
+    private val cryptoOpsClient: CryptoOpsClient
 ) : Application {
     companion object {
         private val consoleLogger: Logger = LoggerFactory.getLogger("Console")
@@ -66,7 +69,8 @@ class GatewayApp @Activate constructor(
                 publisherFactory,
                 lifecycleCoordinatorFactory,
                 configMerger.getMessagingConfig(bootConfig),
-                signingMode
+                signingMode,
+                cryptoOpsClient
             ).also { gateway ->
                 gateway.start()
 

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -22,6 +22,10 @@ dependencies {
     api project(':components:domino-logic')
     api project(':libs:crypto:delegated-signing')
     implementation project(':components:p2p-test:stub-crypto-processor')
+    implementation project(":components:crypto:crypto-client")
+    implementation project(":components:crypto:crypto-client-impl")
+    implementation project(":components:crypto:crypto-component-core-impl")
+    implementation project(":libs:crypto:crypto-impl")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "io.netty:netty-codec-http:$nettyVersion"

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     api project(':libs:crypto:delegated-signing')
     implementation project(':components:p2p-test:stub-crypto-processor')
     implementation project(":components:crypto:crypto-client")
-    implementation project(":libs:crypto:crypto-impl")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "io.netty:netty-codec-http:$nettyVersion"

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -23,8 +23,6 @@ dependencies {
     api project(':libs:crypto:delegated-signing')
     implementation project(':components:p2p-test:stub-crypto-processor')
     implementation project(":components:crypto:crypto-client")
-    implementation project(":components:crypto:crypto-client-impl")
-    implementation project(":components:crypto:crypto-component-core-impl")
     implementation project(":libs:crypto:crypto-impl")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -88,6 +88,7 @@ import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
+import org.mockito.kotlin.mock
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
 import java.net.http.HttpClient as JavaHttpClient
 import java.net.http.HttpRequest as JavaHttpRequest
@@ -201,7 +202,8 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                SigningMode.STUB
+                SigningMode.STUB,
+                mock()
             ).use {
                 publishKeyStoreCertificatesAndKeys(alice.publisher, aliceKeyStore)
                 it.startAndWaitForStarted()
@@ -238,7 +240,8 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                SigningMode.STUB
+                SigningMode.STUB,
+                mock()
             ).use {
                 publishKeyStoreCertificatesAndKeys(alice.publisher, aliceKeyStore)
                 it.startAndWaitForStarted()
@@ -331,7 +334,8 @@ class GatewayIntegrationTest : TestBase() {
                     alice.publisherFactory,
                     alice.lifecycleCoordinatorFactory,
                     messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                    SigningMode.STUB
+                    SigningMode.STUB,
+                    mock()
                 ).use { gateway ->
                     gateway.start()
 
@@ -407,7 +411,8 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                SigningMode.STUB
+                SigningMode.STUB,
+                mock()
             ).use {
                 it.startAndWaitForStarted()
                 (1..clientNumber).map { index ->
@@ -502,7 +507,8 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                SigningMode.STUB
+                SigningMode.STUB,
+                mock()
             ).use {
                 publishKeyStoreCertificatesAndKeys(alice.publisher, aliceKeyStore)
                 startTime = Instant.now().toEpochMilli()
@@ -610,7 +616,8 @@ class GatewayIntegrationTest : TestBase() {
                     alice.publisherFactory,
                     alice.lifecycleCoordinatorFactory,
                     messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                    SigningMode.STUB
+                    SigningMode.STUB,
+                    mock()
                 ),
                 Gateway(
                     createConfigurationServiceFor(
@@ -625,7 +632,8 @@ class GatewayIntegrationTest : TestBase() {
                     bob.publisherFactory,
                     bob.lifecycleCoordinatorFactory,
                     messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                    SigningMode.STUB
+                    SigningMode.STUB,
+                    mock()
                 )
             ).onEach {
                 it.startAndWaitForStarted()
@@ -691,7 +699,8 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                SigningMode.STUB
+                SigningMode.STUB,
+                mock()
             ).use { gateway ->
                 val port = getOpenPort()
                 logger.info("Publishing good config")
@@ -819,7 +828,8 @@ class GatewayIntegrationTest : TestBase() {
                 server.publisherFactory,
                 server.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
-                SigningMode.STUB
+                SigningMode.STUB,
+                mock()
             ).use { gateway ->
                 gateway.startAndWaitForStarted()
                 val firstCertificatesAuthority = CertificateAuthorityFactory

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -56,6 +56,7 @@ import net.corda.p2p.gateway.messaging.ConnectionConfiguration
 import net.corda.p2p.gateway.messaging.GatewayConfiguration
 import net.corda.p2p.gateway.messaging.RevocationConfig
 import net.corda.p2p.gateway.messaging.RevocationConfigMode
+import net.corda.p2p.gateway.messaging.SigningMode
 import net.corda.p2p.gateway.messaging.SslConfiguration
 import net.corda.p2p.gateway.messaging.http.DestinationInfo
 import net.corda.p2p.gateway.messaging.http.HttpClient
@@ -200,6 +201,7 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                SigningMode.STUB
             ).use {
                 publishKeyStoreCertificatesAndKeys(alice.publisher, aliceKeyStore)
                 it.startAndWaitForStarted()
@@ -236,6 +238,7 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                SigningMode.STUB
             ).use {
                 publishKeyStoreCertificatesAndKeys(alice.publisher, aliceKeyStore)
                 it.startAndWaitForStarted()
@@ -328,6 +331,7 @@ class GatewayIntegrationTest : TestBase() {
                     alice.publisherFactory,
                     alice.lifecycleCoordinatorFactory,
                     messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                    SigningMode.STUB
                 ).use { gateway ->
                     gateway.start()
 
@@ -403,6 +407,7 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                SigningMode.STUB
             ).use {
                 it.startAndWaitForStarted()
                 (1..clientNumber).map { index ->
@@ -497,6 +502,7 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                SigningMode.STUB
             ).use {
                 publishKeyStoreCertificatesAndKeys(alice.publisher, aliceKeyStore)
                 startTime = Instant.now().toEpochMilli()
@@ -604,6 +610,7 @@ class GatewayIntegrationTest : TestBase() {
                     alice.publisherFactory,
                     alice.lifecycleCoordinatorFactory,
                     messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                    SigningMode.STUB
                 ),
                 Gateway(
                     createConfigurationServiceFor(
@@ -618,6 +625,7 @@ class GatewayIntegrationTest : TestBase() {
                     bob.publisherFactory,
                     bob.lifecycleCoordinatorFactory,
                     messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                    SigningMode.STUB
                 )
             ).onEach {
                 it.startAndWaitForStarted()
@@ -683,6 +691,7 @@ class GatewayIntegrationTest : TestBase() {
                 alice.publisherFactory,
                 alice.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                SigningMode.STUB
             ).use { gateway ->
                 val port = getOpenPort()
                 logger.info("Publishing good config")
@@ -810,6 +819,7 @@ class GatewayIntegrationTest : TestBase() {
                 server.publisherFactory,
                 server.lifecycleCoordinatorFactory,
                 messagingConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(instanceId.incrementAndGet())),
+                SigningMode.STUB
             ).use { gateway ->
                 gateway.startAndWaitForStarted()
                 val firstCertificatesAuthority = CertificateAuthorityFactory

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
@@ -1,6 +1,7 @@
 package net.corda.p2p.gateway
 
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -31,7 +32,8 @@ class Gateway(
     publisherFactory: PublisherFactory,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     messagingConfiguration: SmartConfig,
-    signingMode: SigningMode
+    signingMode: SigningMode,
+    cryptoOpsClient: CryptoOpsClient
 ) : LifecycleWithDominoTile {
 
     private val inboundMessageHandler = InboundMessageHandler(
@@ -40,7 +42,8 @@ class Gateway(
         publisherFactory,
         subscriptionFactory,
         messagingConfiguration,
-        signingMode
+        signingMode,
+        cryptoOpsClient
     )
     private val outboundMessageProcessor = OutboundMessageHandler(
         lifecycleCoordinatorFactory,

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
@@ -8,6 +8,7 @@ import net.corda.lifecycle.domino.logic.DominoTile
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.p2p.gateway.messaging.SigningMode
 import net.corda.p2p.gateway.messaging.internal.InboundMessageHandler
 import net.corda.p2p.gateway.messaging.internal.OutboundMessageHandler
 import net.corda.v5.base.annotations.VisibleForTesting
@@ -30,6 +31,7 @@ class Gateway(
     publisherFactory: PublisherFactory,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     messagingConfiguration: SmartConfig,
+    signingMode: SigningMode
 ) : LifecycleWithDominoTile {
 
     private val inboundMessageHandler = InboundMessageHandler(
@@ -38,6 +40,7 @@ class Gateway(
         publisherFactory,
         subscriptionFactory,
         messagingConfiguration,
+        signingMode
     )
     private val outboundMessageProcessor = OutboundMessageHandler(
         lifecycleCoordinatorFactory,

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
@@ -2,13 +2,13 @@ package net.corda.p2p.gateway.messaging.http
 
 import io.netty.handler.codec.http.HttpResponseStatus
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.lifecycle.domino.logic.util.ResourcesHolder
-import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.gateway.Gateway
 import net.corda.p2p.gateway.messaging.DynamicKeyStore
@@ -28,9 +28,9 @@ class ReconfigurableHttpServer(
     private val configurationReaderService: ConfigurationReadService,
     private val listener: HttpServerListener,
     subscriptionFactory: SubscriptionFactory,
-    publisherFactory: PublisherFactory,
     nodeConfiguration: SmartConfig,
-    signingMode: SigningMode
+    signingMode: SigningMode,
+    cryptoOpsClient: CryptoOpsClient
 ) : LifecycleWithDominoTile {
 
     @Volatile
@@ -40,10 +40,9 @@ class ReconfigurableHttpServer(
     private val dynamicKeyStore = DynamicKeyStore(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
-        publisherFactory,
         nodeConfiguration,
-        configurationReaderService,
-        signingMode
+        signingMode,
+        cryptoOpsClient
     )
 
     override val dominoTile = ComplexDominoTile(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
@@ -8,10 +8,12 @@ import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.lifecycle.domino.logic.util.ResourcesHolder
+import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.gateway.Gateway
 import net.corda.p2p.gateway.messaging.DynamicKeyStore
 import net.corda.p2p.gateway.messaging.GatewayConfiguration
+import net.corda.p2p.gateway.messaging.SigningMode
 import net.corda.p2p.gateway.messaging.toGatewayConfiguration
 import net.corda.v5.base.util.contextLogger
 import java.net.SocketAddress
@@ -26,7 +28,9 @@ class ReconfigurableHttpServer(
     private val configurationReaderService: ConfigurationReadService,
     private val listener: HttpServerListener,
     subscriptionFactory: SubscriptionFactory,
+    publisherFactory: PublisherFactory,
     nodeConfiguration: SmartConfig,
+    signingMode: SigningMode
 ) : LifecycleWithDominoTile {
 
     @Volatile
@@ -36,7 +40,10 @@ class ReconfigurableHttpServer(
     private val dynamicKeyStore = DynamicKeyStore(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
+        publisherFactory,
         nodeConfiguration,
+        configurationReaderService,
+        signingMode
     )
 
     override val dominoTile = ComplexDominoTile(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -4,6 +4,7 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import java.nio.ByteBuffer
 import java.util.UUID
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.p2p.gateway.GatewayMessage
 import net.corda.data.p2p.gateway.GatewayResponse
 import net.corda.libs.configuration.SmartConfig
@@ -41,7 +42,8 @@ internal class InboundMessageHandler(
     publisherFactory: PublisherFactory,
     subscriptionFactory: SubscriptionFactory,
     messagingConfiguration: SmartConfig,
-    signingMode: SigningMode
+    signingMode: SigningMode,
+    cryptoOpsClient: CryptoOpsClient
 ) : HttpServerListener, LifecycleWithDominoTile {
 
     companion object {
@@ -65,9 +67,9 @@ internal class InboundMessageHandler(
         configurationReaderService,
         this,
         subscriptionFactory,
-        publisherFactory,
         messagingConfiguration,
-        signingMode
+        signingMode,
+        cryptoOpsClient
     )
     override val dominoTile = ComplexDominoTile(
         this::class.java.simpleName,

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -23,6 +23,7 @@ import net.corda.p2p.crypto.InitiatorHandshakeMessage
 import net.corda.p2p.crypto.InitiatorHelloMessage
 import net.corda.p2p.crypto.ResponderHandshakeMessage
 import net.corda.p2p.crypto.ResponderHelloMessage
+import net.corda.p2p.gateway.messaging.SigningMode
 import net.corda.p2p.gateway.messaging.http.HttpRequest
 import net.corda.p2p.gateway.messaging.http.HttpServerListener
 import net.corda.p2p.gateway.messaging.http.ReconfigurableHttpServer
@@ -40,6 +41,7 @@ internal class InboundMessageHandler(
     publisherFactory: PublisherFactory,
     subscriptionFactory: SubscriptionFactory,
     messagingConfiguration: SmartConfig,
+    signingMode: SigningMode
 ) : HttpServerListener, LifecycleWithDominoTile {
 
     companion object {
@@ -63,7 +65,9 @@ internal class InboundMessageHandler(
         configurationReaderService,
         this,
         subscriptionFactory,
+        publisherFactory,
         messagingConfiguration,
+        signingMode
     )
     override val dominoTile = ComplexDominoTile(
         this::class.java.simpleName,

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
@@ -98,7 +98,6 @@ class DynamicKeyStoreTest {
         subscriptionDominoTile.close()
         dominoTile.close()
         signer.close()
-        cryptoOpsClient.close()
         blockingDominoTile.close()
     }
 

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
@@ -1,5 +1,7 @@
 package net.corda.p2p.gateway.messaging
 
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.impl.CryptoOpsClientComponent
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -7,12 +9,14 @@ import net.corda.lifecycle.domino.logic.BlockingDominoTile
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.util.SubscriptionDominoTile
 import net.corda.messaging.api.processor.CompactedProcessor
+import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.CompactedSubscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTlsCertificates
 import net.corda.p2p.test.stub.crypto.processor.StubCryptoProcessor
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_CERTIFICATES
+import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -21,6 +25,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mockConstruction
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -28,6 +33,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.InputStream
@@ -41,10 +47,21 @@ class DynamicKeyStoreTest {
     private val lifecycleCoordinatorFactory = mock<LifecycleCoordinatorFactory>()
     private val nodeConfiguration = mock<SmartConfig>()
     private val subscription = mock<CompactedSubscription<String, GatewayTlsCertificates>>()
-    private val processor = argumentCaptor<CompactedProcessor<String, GatewayTlsCertificates>>()
-    private val subscriptionFactory = mock<SubscriptionFactory> {
-        on { createCompactedSubscription(any(), processor.capture(), eq(nodeConfiguration)) } doReturn subscription
+
+    private val processorForKeystoreWithStubs = argumentCaptor<CompactedProcessor<String, GatewayTlsCertificates>>()
+    private val subscriptionFactoryForKeystoreWithStubs = mock<SubscriptionFactory> {
+        on { createCompactedSubscription(any(), processorForKeystoreWithStubs.capture(), eq(nodeConfiguration)) } doReturn subscription
     }
+
+    private val processorForKeystoreWithoutStubs = argumentCaptor<CompactedProcessor<String, GatewayTlsCertificates>>()
+    private val subscriptionFactoryForKeystoreWithoutStubs = mock<SubscriptionFactory> {
+        on { createCompactedSubscription(any(), processorForKeystoreWithoutStubs.capture(), eq(nodeConfiguration)) } doReturn subscription
+    }
+
+    private val publisherFactory = mock<PublisherFactory> {
+        on { createPublisher(any(), any()) } doReturn mock()
+    }
+    private val configurationReaderService = mock<ConfigurationReadService>()
     private val certificateFactory = mock<CertificateFactory>()
     private val dominoTile = mockConstruction(ComplexDominoTile::class.java)
     private val subscriptionDominoTile = mockConstruction(SubscriptionDominoTile::class.java) { mock, _ ->
@@ -56,18 +73,32 @@ class DynamicKeyStoreTest {
         }
         whenever(mock.dominoTile).doReturn(mockDominoTile)
     }
-    private var future: CompletableFuture<Unit>? = null
+    private val cryptoOpsClient = mockConstruction(CryptoOpsClientComponent::class.java)
+    private var futures: MutableList<CompletableFuture<Unit>> = mutableListOf()
     private val blockingDominoTile = mockConstruction(BlockingDominoTile::class.java) { mock, context ->
         @Suppress("UNCHECKED_CAST")
-        future = context.arguments()[2] as CompletableFuture<Unit>
+        futures.add(context.arguments()[2] as CompletableFuture<Unit>)
         whenever(mock.coordinatorName).doReturn(LifecycleCoordinatorName("", ""))
     }
 
-    private val dynamicKeyStore = DynamicKeyStore(
+    private val dynamicKeyStoreWithStubs = DynamicKeyStore(
         lifecycleCoordinatorFactory,
-        subscriptionFactory,
+        subscriptionFactoryForKeystoreWithStubs,
+        publisherFactory,
         nodeConfiguration,
+        configurationReaderService,
+        SigningMode.STUB,
         certificateFactory,
+    )
+
+    private val dynamicKeystoreWithoutStubs = DynamicKeyStore(
+        lifecycleCoordinatorFactory,
+        subscriptionFactoryForKeystoreWithoutStubs,
+        publisherFactory,
+        nodeConfiguration,
+        configurationReaderService,
+        SigningMode.REAL,
+        certificateFactory
     )
 
     @AfterEach
@@ -75,6 +106,7 @@ class DynamicKeyStoreTest {
         subscriptionDominoTile.close()
         dominoTile.close()
         signer.close()
+        cryptoOpsClient.close()
         blockingDominoTile.close()
     }
 
@@ -83,14 +115,19 @@ class DynamicKeyStoreTest {
 
         @Test
         fun `create resources will not complete without snapshots`() {
-            assertThat(future).isNotCompleted
+            futures.forEach {
+                assertThat(it).isNotCompleted
+            }
         }
 
         @Test
         fun `create resources will complete with snapshots`() {
-            processor.firstValue.onSnapshot(emptyMap())
+            processorForKeystoreWithStubs.firstValue.onSnapshot(emptyMap())
+            processorForKeystoreWithoutStubs.firstValue.onSnapshot(emptyMap())
 
-            assertThat(future).isCompleted
+            futures.forEach {
+                assertThat(it).isCompleted
+            }
         }
     }
 
@@ -111,24 +148,24 @@ class DynamicKeyStoreTest {
 
         @Test
         fun `onSnapshot save the correct data`() {
-            processor.firstValue.onSnapshot(
+            processorForKeystoreWithStubs.firstValue.onSnapshot(
                 mapOf(
                     "one" to GatewayTlsCertificates("id", certificates.keys.toList())
                 )
             )
 
-            assertThat(dynamicKeyStore.aliasToCertificates["one"]).containsAll(certificates.values)
+            assertThat(dynamicKeyStoreWithStubs.aliasToCertificates["one"]).containsAll(certificates.values)
         }
 
         @Test
         fun `onNext remove data with null value`() {
-            processor.firstValue.onSnapshot(
+            processorForKeystoreWithStubs.firstValue.onSnapshot(
                 mapOf(
                     "one" to GatewayTlsCertificates("id", certificates.keys.toList())
                 )
             )
 
-            processor.firstValue.onNext(
+            processorForKeystoreWithStubs.firstValue.onNext(
                 Record(
                     GATEWAY_TLS_CERTIFICATES,
                     "one",
@@ -138,12 +175,12 @@ class DynamicKeyStoreTest {
                 emptyMap()
             )
 
-            assertThat(dynamicKeyStore.aliasToCertificates["one"]).isNull()
+            assertThat(dynamicKeyStoreWithStubs.aliasToCertificates["one"]).isNull()
         }
 
         @Test
         fun `onNext add data with valid value`() {
-            processor.firstValue.onNext(
+            processorForKeystoreWithStubs.firstValue.onNext(
                 Record(
                     GATEWAY_TLS_CERTIFICATES,
                     "one",
@@ -153,7 +190,7 @@ class DynamicKeyStoreTest {
                 emptyMap()
             )
 
-            assertThat(dynamicKeyStore.aliasToCertificates["one"]).containsAll(certificates.values)
+            assertThat(dynamicKeyStoreWithStubs.aliasToCertificates["one"]).containsAll(certificates.values)
         }
     }
 
@@ -186,45 +223,71 @@ class DynamicKeyStoreTest {
                 }
             }
 
-            processor.firstValue.onSnapshot(
-                mapOf(
-                    "one" to GatewayTlsCertificates(
-                        tenantIdOne,
-                        listOf("1")
-                    ),
-                    "three" to GatewayTlsCertificates(
-                        tenantIdOne,
-                        listOf("3")
-                    ),
+            listOf(processorForKeystoreWithStubs.firstValue, processorForKeystoreWithoutStubs.firstValue).forEach {
+                it.onSnapshot(
+                    mapOf(
+                        "one" to GatewayTlsCertificates(
+                            tenantIdOne,
+                            listOf("1")
+                        ),
+                        "three" to GatewayTlsCertificates(
+                            tenantIdOne,
+                            listOf("3")
+                        ),
+                    )
                 )
-            )
+            }
         }
 
         @Test
         fun `sign with unknown publicKey will throw an exception`() {
             assertThrows<InvalidKeyException> {
-                dynamicKeyStore.sign(mock(), spec, data)
+                dynamicKeyStoreWithStubs.sign(mock(), spec, data)
             }
         }
 
         @Test
-        fun `sign with known publicKey will send the correct data`() {
-            dynamicKeyStore.sign(publicKeyOne, spec, data)
+        fun `when keystore is using stubs, sign with known publicKey will send the correct data`() {
+            dynamicKeyStoreWithStubs.sign(publicKeyOne, spec, data)
 
             verify(signer.constructed().first()).sign(tenantIdOne, publicKeyOne, spec, data)
+            verify(cryptoOpsClient.constructed().first(), never()).sign(anyString(), any(), any<SignatureSpec>(), any(), any())
         }
 
         @Test
-        fun `sign with known publicKey will return the correct data`() {
+        fun `when keystore is using stubs, sign with known publicKey will return the correct data`() {
             val returnedData = "ok".toByteArray()
             whenever(signer.constructed().first().sign(any(), any(), any(), any())).doReturn(returnedData)
 
-            assertThat(dynamicKeyStore.sign(publicKeyOne, spec, data)).isEqualTo(returnedData)
+            assertThat(dynamicKeyStoreWithStubs.sign(publicKeyOne, spec, data)).isEqualTo(returnedData)
+        }
+
+        @Test
+        fun `when keystore is not using stubs, sign with known publicKey will send the correct data`() {
+            val returnedData = "ok".toByteArray()
+            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData, emptyMap())
+            whenever(cryptoOpsClient.constructed().first().sign(anyString(), any(), any<SignatureSpec>(), any(), any()))
+                .doReturn(signatureWithKey)
+            dynamicKeystoreWithoutStubs.sign(publicKeyOne, spec, data)
+
+            verify(cryptoOpsClient.constructed().first()).sign(tenantIdOne, publicKeyOne, spec, data)
+            verify(signer.constructed().first(), never()).sign(any(), any(), any(), any())
+        }
+
+        @Test
+        fun `when keystore is not using stubs, sign with known publicKey will return the correct data`() {
+            val returnedData = "ok".toByteArray()
+            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData, emptyMap())
+            whenever(cryptoOpsClient.constructed().first().sign(anyString(), any(), any<SignatureSpec>(), any(), any()))
+                .doReturn(signatureWithKey)
+
+            assertThat(dynamicKeystoreWithoutStubs.sign(publicKeyOne, spec, data)).isEqualTo(returnedData)
+            verify(signer.constructed().first(), never()).sign(any(), any(), any(), any())
         }
 
         @Test
         fun `onNext will remove the public key`() {
-            processor.firstValue.onNext(
+            processorForKeystoreWithStubs.firstValue.onNext(
                 Record(
                     GATEWAY_TLS_CERTIFICATES,
                     "one",
@@ -235,13 +298,13 @@ class DynamicKeyStoreTest {
             )
 
             assertThrows<InvalidKeyException> {
-                dynamicKeyStore.sign(publicKeyOne, spec, data)
+                dynamicKeyStoreWithStubs.sign(publicKeyOne, spec, data)
             }
         }
 
         @Test
         fun `onNext will replace the public key`() {
-            processor.firstValue.onNext(
+            processorForKeystoreWithStubs.firstValue.onNext(
                 Record(
                     GATEWAY_TLS_CERTIFICATES,
                     "one",
@@ -255,7 +318,7 @@ class DynamicKeyStoreTest {
             )
 
             assertDoesNotThrow {
-                dynamicKeyStore.sign(publicKeyTwo, spec, data)
+                dynamicKeyStoreWithStubs.sign(publicKeyTwo, spec, data)
             }
         }
     }
@@ -265,7 +328,7 @@ class DynamicKeyStoreTest {
         @Test
         fun `keyStore creates a new keystore`() {
             mockConstruction(KeyStoreFactory::class.java).use {
-                dynamicKeyStore.keyStore
+                dynamicKeyStoreWithStubs.keyStore
 
                 verify(it.constructed().first()).createDelegatedKeyStore()
             }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
@@ -11,6 +11,7 @@ import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.util.ResourcesHolder
 import net.corda.p2p.gateway.messaging.DynamicKeyStore
 import net.corda.p2p.gateway.messaging.GatewayConfiguration
+import net.corda.p2p.gateway.messaging.SigningMode
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -71,6 +72,8 @@ class ReconfigurableHttpServerTest {
         listener,
         mock(),
         mock(),
+        mock(),
+        SigningMode.STUB
     )
 
     @AfterEach

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
@@ -72,8 +72,8 @@ class ReconfigurableHttpServerTest {
         listener,
         mock(),
         mock(),
-        mock(),
-        SigningMode.STUB
+        SigningMode.STUB,
+        mock()
     )
 
     @AfterEach

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
@@ -29,6 +29,7 @@ import net.corda.p2p.crypto.ProtocolMode
 import net.corda.p2p.crypto.ResponderHandshakeMessage
 import net.corda.p2p.crypto.ResponderHelloMessage
 import net.corda.p2p.crypto.internal.InitiatorHandshakeIdentity
+import net.corda.p2p.gateway.messaging.SigningMode
 import net.corda.p2p.gateway.messaging.http.HttpRequest
 import net.corda.p2p.gateway.messaging.http.ReconfigurableHttpServer
 import net.corda.p2p.gateway.messaging.session.SessionPartitionMapperImpl
@@ -92,7 +93,8 @@ class InboundMessageHandlerTest {
         configurationReaderService,
         publisherFactory,
         subscriptionFactory,
-        SmartConfigImpl.empty()
+        SmartConfigImpl.empty(),
+        SigningMode.STUB
     )
 
     @AfterEach

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
@@ -94,7 +94,8 @@ class InboundMessageHandlerTest {
         publisherFactory,
         subscriptionFactory,
         SmartConfigImpl.empty(),
-        SigningMode.STUB
+        SigningMode.STUB,
+        mock()
     )
 
     @AfterEach

--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation project(':components:domino-logic')
     implementation project(':components:p2p-test:stub-crypto-processor')
     implementation "net.corda:corda-cipher-suite"
+    implementation project(":components:crypto:crypto-client")
 
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"

--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation project(':components:domino-logic')
     implementation project(':components:p2p-test:stub-crypto-processor')
     implementation "net.corda:corda-cipher-suite"
-    implementation project(":components:crypto:crypto-client")
 
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
@@ -74,6 +73,7 @@ dependencies {
     nonOsgiIntegrationTestImplementation project(":testing:p2p:inmemory-messaging-impl")
     nonOsgiIntegrationTestImplementation project(':libs:messaging:message-bus')
     nonOsgiIntegrationTestImplementation project(":libs:messaging:db-message-bus-impl")
+    nonOsgiIntegrationTestImplementation project(":components:crypto:crypto-client")
 
     integrationTestImplementation project(":components:configuration:configuration-read-service-impl")
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -82,6 +82,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
+import org.mockito.kotlin.mock
 
 class P2PLayerEndToEndTest {
 
@@ -420,7 +421,8 @@ class P2PLayerEndToEndTest {
                 publisherFactory,
                 lifecycleCoordinatorFactory,
                 bootstrapConfig,
-                SigningMode.STUB
+                SigningMode.STUB,
+                mock()
             )
 
         private fun Publisher.publishConfig(key: String, config: Config) {

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -50,6 +50,7 @@ import net.corda.p2p.crypto.ProtocolMode
 import net.corda.p2p.gateway.Gateway
 import net.corda.p2p.gateway.messaging.RevocationConfig
 import net.corda.p2p.gateway.messaging.RevocationConfigMode
+import net.corda.p2p.gateway.messaging.SigningMode
 import net.corda.p2p.gateway.messaging.SslConfiguration
 import net.corda.p2p.linkmanager.LinkManager
 import net.corda.p2p.markers.AppMessageMarker
@@ -419,6 +420,7 @@ class P2PLayerEndToEndTest {
                 publisherFactory,
                 lifecycleCoordinatorFactory,
                 bootstrapConfig,
+                SigningMode.STUB
             )
 
         private fun Publisher.publishConfig(key: String, config: Config) {


### PR DESCRIPTION
Adding integration with the `CryptoOpsClient` in the gateway to delegate TLS signing to. The existing integration with our stub crypto processor is kept in place so that end-to-end testing can be performed in our existing setup and will be removed once integration with MGM/dynamic networks has been completed and tested succesfully. An option has been added to switch between stubs or the real crypto processor in the Gateway worker. The default has been set up to use the stubs, so that our end-to-end tests continue working without further changes needed.