### PR TITLE
CORE-4868 - correct version handling for merging CPK entities

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
@@ -1,13 +1,11 @@
 package net.corda.chunking.db.impl.tests
 
 import com.google.common.jimfs.Jimfs
-import net.corda.chunking.ChunkWriter
 import net.corda.chunking.ChunkWriterFactory
 import net.corda.chunking.RequestId
 import net.corda.chunking.datamodel.ChunkEntity
 import net.corda.chunking.datamodel.ChunkingEntities
 import net.corda.chunking.db.impl.AllChunksReceived
-import net.corda.chunking.db.impl.ChunkDbWriterImpl
 import net.corda.chunking.db.impl.persistence.DatabaseChunkPersistence
 import net.corda.chunking.toAvro
 import net.corda.data.chunking.Chunk
@@ -55,6 +53,9 @@ import javax.persistence.EntityManagerFactory
 import javax.persistence.NoResultException
 import javax.persistence.NonUniqueResultException
 import javax.persistence.PersistenceException
+import net.corda.libs.cpi.datamodel.CpiCpkEntity
+import net.corda.libs.cpi.datamodel.CpiCpkKey
+import net.corda.libs.cpi.datamodel.CpkKey
 import net.corda.libs.cpi.datamodel.CpkMetadataEntity
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -177,14 +178,21 @@ internal class DatabaseChunkPersistenceTest {
         return chunks
     }
 
-    private fun mockCpk(name: String, fileChecksum: SecureHash = newRandomSecureHash()) = mock<Cpk>().also { cpk ->
+    private fun updatedCpk(cpkId: CpkIdentifier, newFileChecksum: SecureHash = newRandomSecureHash()) =
+        mockCpk(cpkId.name, newFileChecksum, cpkId.signerSummaryHash)
+
+    private fun mockCpk(
+        name: String,
+        fileChecksum: SecureHash = newRandomSecureHash(),
+        cpkSignerSummaryHash: SecureHash? = newRandomSecureHash()
+    ) = mock<Cpk>().also { cpk ->
         val cpkId = CpkIdentifier(
             name = name,
             version = "cpk-version",
-            signerSummaryHash = newRandomSecureHash()
+            signerSummaryHash = cpkSignerSummaryHash
         )
 
-        val cpkManifest = CpkManifest(CpkFormatVersion(1,0))
+        val cpkManifest = CpkManifest(CpkFormatVersion(1, 0))
 
         val cordappManifest = CordappManifest(
             "", "", -1, -1,
@@ -203,7 +211,7 @@ internal class DatabaseChunkPersistenceTest {
             type = CpkType.UNKNOWN,
             fileChecksum = fileChecksum,
             cordappCertificates = emptySet(),
-            timestamp = Instant.now(),
+            timestamp = Instant.now()
         )
         whenever(cpk.path).thenReturn(mockCpkContent.writeToPath())
         whenever(cpk.originalFileName).thenReturn(name)
@@ -221,8 +229,6 @@ internal class DatabaseChunkPersistenceTest {
 
         return mockCpiWithId(cpks, id)
     }
-
-
 
     private fun mockCpiWithId(cpks: Collection<Cpk>, cpiId: CpiIdentifier): Cpi {
         val metadata = mock<CpiMetadata>().also {
@@ -459,32 +465,20 @@ internal class DatabaseChunkPersistenceTest {
         val cpk1Checksum = newRandomSecureHash()
         val cpk2Checksum = newRandomSecureHash()
 
-        val sharedCpk = mockCpk(
-            "${UUID.randomUUID()}.cpk",
-            sharedCpkChecksum
-        )
-        val cpi1 = mockCpi(listOf(
-            sharedCpk,
-            mockCpk(
-                "${UUID.randomUUID()}.cpk",
-                cpk1Checksum
-            ),
-        ))
+        val sharedCpk = mockCpk("${UUID.randomUUID()}.cpk", sharedCpkChecksum)
+        val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpk1Checksum)
+        val cpi1 = mockCpi(listOf(sharedCpk, cpk1))
 
         persistence.persistMetadataAndCpks(
             cpi1,
             "test.cpi",
             newRandomSecureHash(),
             UUID.randomUUID().toString(),
-            "123456")
+            "123456"
+        )
 
-        val cpi2 = mockCpi(listOf(
-            sharedCpk,
-            mockCpk(
-                "${UUID.randomUUID()}.cpk",
-                cpk2Checksum
-            ),
-        ))
+        val cpk2 = mockCpk("${UUID.randomUUID()}.cpk", cpk2Checksum)
+        val cpi2 = mockCpi(listOf(sharedCpk, cpk2))
 
         assertDoesNotThrow {
             persistence.persistMetadataAndCpks(
@@ -492,46 +486,39 @@ internal class DatabaseChunkPersistenceTest {
                 "test.cpi",
                 newRandomSecureHash(),
                 UUID.randomUUID().toString(),
-                "123456")
+                "123456"
+            )
         }
 
-        loadAndAssertCpkEntity(sharedCpkChecksum, 0)
-        loadAndAssertCpkEntity(cpk1Checksum, 0)
-        loadAndAssertCpkEntity(cpk2Checksum, 0)
-    }
-
-    private fun loadAndAssertCpkEntity(sharedCpkChecksum: SecureHash, entityVersion: Int): String {
-        val queryForCpk = "FROM ${CpkMetadataEntity::class.simpleName} where cpkFileChecksum = :cpkFileChecksum"
-        val queryResult = entityManagerFactory.createEntityManager().transaction {
-            it.createQuery(queryForCpk, CpkMetadataEntity::class.java)
-                .setParameter("cpkFileChecksum", sharedCpkChecksum.toString())
-                .resultList
-        }!!
-        assertThat(queryResult).isNotNull
-        assertThat(queryResult.size).isEqualTo(1)
-        assertThat(queryResult[0].cpkFileChecksum).isEqualTo(sharedCpkChecksum.toString())
-        assertThat(queryResult[0].entityVersion).isEqualTo(entityVersion) // CPK was not edited and was shared between CPIs
-        return queryForCpk
+        findAndAssertCpk(cpi1.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi1.metadata.cpiId, cpk1.metadata.cpkId, cpk1Checksum.toString(), 0, 0, 0)
+        findAndAssertCpk(cpi2.metadata.cpiId, cpk2.metadata.cpkId, cpk2Checksum.toString(), 0, 0, 0)
     }
 
     @Test
     fun `database chunk persistence can force update a CPI`() {
-        val cpiChecksum = newRandomSecureHash()
         val cpkChecksum = newRandomSecureHash()
         val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpkChecksum)
-        val cpks = listOf(cpk1)
-        val cpi = mockCpi(cpks)
-
+        val cpi = mockCpi(listOf(cpk1))
         val cpiFileName = "test${UUID.randomUUID()}.cpi"
-        val cpiMetadataEntity = persistence.persistMetadataAndCpks(cpi, cpiFileName, cpiChecksum, UUID.randomUUID().toString(), "abcdef")
-        assertThat(cpiMetadataEntity.entityVersion).isEqualTo(1)
 
+        val cpiMetadataEntity =
+            persistence.persistMetadataAndCpks(cpi, cpiFileName, newRandomSecureHash(), UUID.randomUUID().toString(), "abcdef")
+
+        assertThat(cpiMetadataEntity.entityVersion).isEqualTo(1)
+        assertThat(cpiMetadataEntity.cpks.size).isEqualTo(1)
+        assertThat(cpiMetadataEntity.cpks.first().entityVersion).isEqualTo(0)
+
+        // make same assertions but after loading the entity again
         val initialLoadedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                cpi.metadata.cpiId.name,
-                cpi.metadata.cpiId.version,
-                cpi.metadata.cpiId.signerSummaryHash.toString(),
-            ))
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    cpi.metadata.cpiId.name,
+                    cpi.metadata.cpiId.version,
+                    cpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
         }!!
 
         // adding cpk to cpi accounts for 1 modification
@@ -539,22 +526,29 @@ internal class DatabaseChunkPersistenceTest {
         assertThat(initialLoadedCpi.cpks.size).isEqualTo(1)
         assertThat(initialLoadedCpi.cpks.first().entityVersion).isEqualTo(0)
 
-
-        val updatedCpiChecksum = newRandomSecureHash()
         val updatedCpkChecksum = newRandomSecureHash()
         val updatedCpks = listOf(cpk1, mockCpk("${UUID.randomUUID()}.cpk", updatedCpkChecksum))
         // cpi with different CPKs but same ID
         val updatedCpi = mockCpiWithId(updatedCpks, cpi.metadata.cpiId)
 
-        val updatedCpiMetadataEntity = persistence.updateMetadataAndCpks(updatedCpi, cpiFileName, updatedCpiChecksum, UUID.randomUUID().toString(), "abcdef")
-        assertThat(updatedCpiMetadataEntity.entityVersion).isEqualTo(3)
+        val returnedCpiMetadataEntity =
+            persistence.updateMetadataAndCpks(updatedCpi, cpiFileName, newRandomSecureHash(), UUID.randomUUID().toString(), "abcdef")
 
+        assertThat(returnedCpiMetadataEntity.entityVersion).isEqualTo(3)
+        val firstReturnedCpk = returnedCpiMetadataEntity.cpks.first { it.cpkFileChecksum == cpkChecksum.toString() }
+        val secondReturnedCpk = returnedCpiMetadataEntity.cpks.first { it.cpkFileChecksum == updatedCpkChecksum.toString() }
+        assertThat(firstReturnedCpk.entityVersion).isEqualTo(1)
+        assertThat(secondReturnedCpk.entityVersion).isEqualTo(0)
+
+        // make same assertions but after loading the entity again
         val updatedLoadedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                updatedCpi.metadata.cpiId.name,
-                updatedCpi.metadata.cpiId.version,
-                updatedCpi.metadata.cpiId.signerSummaryHash.toString(),
-            ))
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    updatedCpi.metadata.cpiId.name,
+                    updatedCpi.metadata.cpiId.version,
+                    updatedCpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
         }!!
 
         assertThat(updatedLoadedCpi.cpks.size).isEqualTo(2)
@@ -576,11 +570,13 @@ internal class DatabaseChunkPersistenceTest {
         persistence.persistMetadataAndCpks(cpi, "test.cpi", cpiChecksum, UUID.randomUUID().toString(), "abcdef")
 
         val loadedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                cpi.metadata.cpiId.name,
-                cpi.metadata.cpiId.version,
-                cpi.metadata.cpiId.signerSummaryHash.toString(),
-            ))
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    cpi.metadata.cpiId.name,
+                    cpi.metadata.cpiId.version,
+                    cpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
         }!!
 
         // adding cpk to cpi accounts for 1 modification
@@ -592,11 +588,13 @@ internal class DatabaseChunkPersistenceTest {
         persistence.updateMetadataAndCpks(cpi, "test.cpi", cpiChecksum, UUID.randomUUID().toString(), "abcdef")
 
         val updatedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                cpi.metadata.cpiId.name,
-                cpi.metadata.cpiId.version,
-                cpi.metadata.cpiId.signerSummaryHash.toString(),
-            ))
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    cpi.metadata.cpiId.name,
+                    cpi.metadata.cpiId.version,
+                    cpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
         }!!
 
         assertThat(updatedCpi.insertTimestamp).isAfter(loadedCpi.insertTimestamp)
@@ -604,5 +602,100 @@ internal class DatabaseChunkPersistenceTest {
         assertThat(updatedCpi.entityVersion).isEqualTo(3)
         assertThat(updatedCpi.cpks.size).isEqualTo(1)
         assertThat(updatedCpi.cpks.first().entityVersion).isEqualTo(1)
+    }
+
+    @Test
+    fun `CPKs are correct after persisting a CPI with already existing CPK`() {
+        val sharedCpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val cpi = mockCpi(listOf(sharedCpk))
+
+        persistence.persistMetadataAndCpks(cpi, "test.cpi", newRandomSecureHash(), UUID.randomUUID().toString(), "group-a")
+
+        val cpi2 = mockCpi(listOf(sharedCpk))
+
+        persistence.persistMetadataAndCpks(cpi2, "test2.cpi", newRandomSecureHash(), UUID.randomUUID().toString(), "group-b")
+
+        findAndAssertCpk(cpi.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpk.metadata.fileChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpk.metadata.fileChecksum.toString(), 0, 1, 0)
+    }
+
+    @Test
+    fun `CPKs are correct after updating a CPI by adding a new CPK`() {
+        val cpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val newCpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val cpi = mockCpi(listOf(cpk))
+
+        persistence.persistMetadataAndCpks(cpi, "test.cpi", newRandomSecureHash(), UUID.randomUUID().toString(), "group-a")
+
+        // a new cpi object, but with same
+        val updatedCpi = mockCpiWithId(listOf(cpk, newCpk), cpi.metadata.cpiId)
+
+        persistence.updateMetadataAndCpks(updatedCpi, "test.cpi", newRandomSecureHash(), UUID.randomUUID().toString(), "group-b")
+
+        assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
+
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, cpk.metadata.fileChecksum.toString(), 0, 1, 1)
+        findAndAssertCpk(cpi.metadata.cpiId, newCpk.metadata.cpkId, newCpk.metadata.fileChecksum.toString(), 0, 0, 0)
+    }
+
+    @Test
+    fun `CPK version is incremented when we update a CPK in a CPI`() {
+        val cpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val newChecksum = newRandomSecureHash()
+        val updatedCpk = updatedCpk(cpk.metadata.cpkId, newChecksum)
+        val cpi = mockCpi(listOf(cpk))
+
+        persistence.persistMetadataAndCpks(cpi, "test.cpi", newRandomSecureHash(), UUID.randomUUID().toString(), "group-a")
+
+        // a new cpi object, but with same
+        val updatedCpi = mockCpiWithId(listOf(updatedCpk), cpi.metadata.cpiId)
+
+        persistence.updateMetadataAndCpks(updatedCpi, "test.cpi", newRandomSecureHash(), UUID.randomUUID().toString(), "group-b")
+
+        assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
+
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, newChecksum.toString(), 1, 2, 1)
+    }
+
+    private fun findAndAssertCpk(
+        cpiId: CpiIdentifier,
+        cpkId: CpkIdentifier,
+        expectedFileChecksum: String,
+        expectedMetadataEntityVersion: Int,
+        expectedFileEntityVersion: Int,
+        expectedCpiCpkEntityVersion: Int
+    ) {
+        val (cpkMetadata, cpkFile, cpiCpk) = entityManagerFactory.createEntityManager().transaction {
+            val cpiCpkKey = CpiCpkKey(
+                cpiId.name,
+                cpiId.version,
+                cpiId.signerSummaryHash.toString(),
+                cpkId.name,
+                cpkId.version,
+                cpkId.signerSummaryHash.toString()
+            )
+            val cpkKey = CpkKey(
+                cpkId.name,
+                cpkId.version,
+                cpkId.signerSummaryHash.toString()
+            )
+            val cpiCpk = it.find(CpiCpkEntity::class.java, cpiCpkKey)
+            val cpkMetadata = it.find(CpkMetadataEntity::class.java, cpkKey)
+            val cpkFile = it.find(CpkFileEntity::class.java, cpkKey)
+            Triple(cpkMetadata, cpkFile, cpiCpk)
+        }
+
+        assertThat(cpkMetadata.cpkFileChecksum).isEqualTo(expectedFileChecksum)
+        assertThat(cpkFile.fileChecksum).isEqualTo(expectedFileChecksum)
+
+        assertThat(cpkMetadata.entityVersion)
+            .withFailMessage("CpkMetadataEntity.entityVersion expected $expectedMetadataEntityVersion but was ${cpkMetadata.entityVersion}.")
+            .isEqualTo(expectedMetadataEntityVersion)
+        assertThat(cpkFile.entityVersion)
+            .withFailMessage("CpkFileEntity.entityVersion expected $expectedFileEntityVersion but was ${cpkFile.entityVersion}.")
+            .isEqualTo(expectedFileEntityVersion)
+        assertThat(cpiCpk.entityVersion)
+            .withFailMessage("CpiCpkEntity.entityVersion expected $expectedCpiCpkEntityVersion but was ${cpiCpk.entityVersion}.")
+            .isEqualTo(expectedCpiCpkEntityVersion)
     }
 }

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
@@ -60,14 +60,13 @@ class CpiEntitiesIntegrationTest {
             "cpk-checksum-$cpkId",
             ByteArray(2000),
         )
-        val cpkMeta =
-            TestObject.createCpk(
-                cpkData.fileChecksum,
-                cpkId,
-                "1.2.3",
-                signerSummaryHash,
+        val cpiCpk =
+            TestObject.createCpiCpkEntity(
+                cpiId.toString(), "1.0", "test-cpi-hash",
+                cpkId, "1.2.3", signerSummaryHash,
+                "filename", cpkData.fileChecksum,
             )
-        val cpi = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpkMeta)))
+        val cpi = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpiCpk)))
 
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -105,15 +104,13 @@ class CpiEntitiesIntegrationTest {
             "cpk-checksum-$cpkId",
             ByteArray(2000),
         )
-        val cpkMeta =
-            TestObject.createCpk(
-                cpkData.fileChecksum,
-                "test-cpk",
-                "1.2.3",
-                TestObject.randomChecksumString(),
+        val cpiCpk =
+            TestObject.createCpiCpkEntity(
+                cpiId.toString(), "1.0", "test-cpi-hash",
+                cpkId, "1.2.3", TestObject.randomChecksumString(),
+                "filename", cpkData.fileChecksum,
             )
-        val cpi = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpkMeta)))
-
+        val cpi = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpiCpk)))
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
             CpiEntities.classes.toList(),
@@ -204,14 +201,13 @@ class CpiEntitiesIntegrationTest {
             "cpk-checksum-$cpkId",
             ByteArray(2000),
         )
-        val cpkMeta1 =
-            TestObject.createCpk(
-                cpkData.fileChecksum,
-                cpkId,
-                cpkVer,
-                cpkSSH,
+        val cpiCpk1 =
+            TestObject.createCpiCpkEntity(
+                cpiId.toString(), "1.0", "test-cpi-hash",
+                cpkId, cpkVer, cpkSSH,
+                "filename", cpkData.fileChecksum,
             )
-        val cpi1 = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpkMeta1)))
+        val cpi1 = TestObject.createCpi(cpiId, listOf(Pair("test-cpk", cpiCpk1)))
 
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
@@ -234,14 +230,13 @@ class CpiEntitiesIntegrationTest {
             "cpk-checksum-${UUID.randomUUID()}",
             ByteArray(2000),
         )
-        val cpkMeta2 = TestObject.createCpk(
-            cpkData2.fileChecksum,
-            cpk2Name,
-            cpk2Ver,
-            cpk2SSH,
-        )
-        val cpi2 = TestObject.createCpi(cpiId, listOf(Pair("test-cpk1", cpkMeta1), Pair("test-cpk2", cpkMeta2)))
-
+        val cpiCpk2 =
+            TestObject.createCpiCpkEntity(
+                cpiId.toString(), "1.0", "test-cpi-hash",
+                cpk2Name, cpk2Ver, cpk2SSH,
+                "filename", cpkData2.fileChecksum,
+            )
+        val cpi2 = TestObject.createCpi(cpiId, listOf(Pair("test-cpk1", cpiCpk1), Pair("test-cpk2", cpiCpk2)))
         EntityManagerFactoryFactoryImpl().create(
             "test_unit",
             CpiEntities.classes.toList(),
@@ -345,11 +340,10 @@ class CpiEntitiesIntegrationTest {
             val cpkVersion = "$i.2.3"
             val cpkSSH = TestObject.randomChecksumString()
             val cpkMetadataEntity =
-                TestObject.createCpk(
-                    TestObject.randomChecksumString(),
-                    cpkName,
-                    cpkVersion,
-                    cpkSSH,
+                TestObject.createCpiCpkEntity(
+                    cpiId.toString(), "1.0", "test-cpi-hash",
+                    cpkName, cpkVersion, cpkSSH,
+                    "filename", TestObject.randomChecksumString(),
                 )
             val cpkData = CpkFileEntity(
                 CpkKey(cpkName, cpkVersion, cpkSSH),

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
@@ -47,12 +47,14 @@ class CpkDbChangeLogEntityTest {
         val (cpi, cpk) = TestObject.createCpiWithCpk()
 
         val changeLog1 = CpkDbChangeLogEntity(
-            CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master"),
+            CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion,
+                cpk.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
             "master-content"
         )
         val changeLog2 = CpkDbChangeLogEntity(
-            CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "other"),
+            CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion,
+                cpk.metadata.id.cpkSignerSummaryHash, "other"),
             "other-checksum",
             "other-content"
         )
@@ -77,7 +79,8 @@ class CpkDbChangeLogEntityTest {
         ).use {
             val loadedDbLogEntity = it.find(
                 CpkDbChangeLogEntity::class.java,
-                CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master")
+                CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion,
+                    cpk.metadata.id.cpkSignerSummaryHash, "master")
             )
 
             assertThat(changeLog1.content).isEqualTo(loadedDbLogEntity.content)
@@ -89,7 +92,7 @@ class CpkDbChangeLogEntityTest {
         val (cpi, cpk) = TestObject.createCpiWithCpk()
 
         val changeLog1 = CpkDbChangeLogEntity(
-            CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master"),
+            CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion, cpk.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
             "master-content"
         )
@@ -123,7 +126,7 @@ class CpkDbChangeLogEntityTest {
         ).use {
             val loadedDbLogEntity = it.find(
                 CpkDbChangeLogEntity::class.java,
-                CpkDbChangeLogKey(cpk.id.cpkName, cpk.id.cpkVersion, cpk.id.cpkSignerSummaryHash, "master")
+                CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion, cpk.metadata.id.cpkSignerSummaryHash, "master")
             )
 
             assertThat(changeLog1.content).isEqualTo(loadedDbLogEntity.content)
@@ -136,17 +139,17 @@ class CpkDbChangeLogEntityTest {
         val (cpi2, cpk2) = TestObject.createCpiWithCpk()
 
         val changeLog1 = CpkDbChangeLogEntity(
-            CpkDbChangeLogKey(cpk1.id.cpkName, cpk1.id.cpkVersion, cpk1.id.cpkSignerSummaryHash, "master"),
+            CpkDbChangeLogKey(cpk1.metadata.id.cpkName, cpk1.metadata.id.cpkVersion, cpk1.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
             "master-content"
         )
         val changeLog2 = CpkDbChangeLogEntity(
-            CpkDbChangeLogKey(cpk1.id.cpkName, cpk1.id.cpkVersion, cpk1.id.cpkSignerSummaryHash, "other"),
+            CpkDbChangeLogKey(cpk1.metadata.id.cpkName, cpk1.metadata.id.cpkVersion, cpk1.metadata.id.cpkSignerSummaryHash, "other"),
             "other-checksum",
             "other-content"
         )
         val changeLog3 = CpkDbChangeLogEntity(
-            CpkDbChangeLogKey(cpk2.id.cpkName, cpk2.id.cpkVersion, cpk2.id.cpkSignerSummaryHash, "master"),
+            CpkDbChangeLogKey(cpk2.metadata.id.cpkName, cpk2.metadata.id.cpkVersion, cpk2.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
             "master-content"
         )
@@ -171,7 +174,7 @@ class CpkDbChangeLogEntityTest {
             CpiEntities.classes.toList(),
             dbConfig
         ).use { em ->
-            em.findCpkDbChangeLog(cpk1.id.cpkName, cpk1.id.cpkVersion, cpk1.id.cpkSignerSummaryHash)
+            em.findCpkDbChangeLog(cpk1.metadata.id.cpkName, cpk1.metadata.id.cpkVersion, cpk1.metadata.id.cpkSignerSummaryHash)
         }
 
         assertThat(changeLogs.size).isEqualTo(2)

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/TestObject.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/TestObject.kt
@@ -4,6 +4,8 @@ import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 import net.corda.libs.cpi.datamodel.CpkKey
 import net.corda.libs.cpi.datamodel.CpkMetadataEntity
 import java.util.UUID
+import net.corda.libs.cpi.datamodel.CpiCpkEntity
+import net.corda.libs.cpi.datamodel.CpiCpkKey
 
 object TestObject {
     fun randomChecksumString(): String {
@@ -12,10 +14,7 @@ object TestObject {
         }.joinToString("")
     }
 
-    fun createCpi(
-        cpiId: UUID,
-        cpks: List<Pair<String, CpkMetadataEntity>>,
-    ) =
+    fun createCpi(cpiId: UUID, cpks: List<Pair<String, CpiCpkEntity>>) =
         CpiMetadataEntity.create(
             "test-cpi-$cpiId",
             "1.0",
@@ -40,20 +39,33 @@ object TestObject {
         "{}"
     )
 
-    fun createCpiWithCpk(): Pair<CpiMetadataEntity, CpkMetadataEntity> {
+    fun createCpiCpkEntity(
+        cpiName: String = "test-cpi-${UUID.randomUUID()}.cpk", cpiVersion: String, cpiSSH: String,
+        cpkName: String, cpkVersion: String, cpkSSH: String,
+        cpkFileName: String, cpkFileChecksum: String
+    ) = CpiCpkEntity(
+        CpiCpkKey(cpiName, cpiVersion, cpiSSH, cpkName, cpkVersion, cpkSSH),
+        cpkFileName,
+        cpkFileChecksum,
+        createCpk(cpkFileChecksum, cpkName, cpkVersion, cpkSSH)
+    )
+
+    fun createCpiWithCpk(): Pair<CpiMetadataEntity, CpiCpkEntity> {
         val cpiId = UUID.randomUUID()
-        val cpk = createCpk(
-            randomChecksumString(),
-            "test-cpk-$cpiId",
-            "1.0",
-            "test-cpk=hash"
+        val cpkFileChecksum = randomChecksumString()
+        val cpkId = "test-cpk-$cpiId.cpk"
+        val ssh = "test-cpk=hash"
+        val cpiCpkEntity = createCpiCpkEntity(
+            "test-cpi-$cpiId", "1.0", ssh,
+            cpkId, "1.0",  ssh,
+            "test-cpi-$cpiId.cpi", cpkFileChecksum
         )
         val cpi = createCpi(
             cpiId,
             listOf(
-                Pair("test-cpk-$cpiId.cpk", cpk)
+                Pair("test-cpk-$cpiId.cpk", cpiCpkEntity)
             )
         )
-        return Pair(cpi, cpk)
+        return Pair(cpi, cpiCpkEntity)
     }
 }

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiCpkEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiCpkEntity.kt
@@ -54,6 +54,19 @@ data class CpiCpkEntity(
     fun onUpdate() {
         insertTimestamp = Instant.now()
     }
+
+    fun update(
+        cpkFileName: String,
+        cpkFileChecksum: String,
+        metadata: CpkMetadataEntity,
+    ): CpiCpkEntity {
+        return this.copy(
+            cpkFileName = cpkFileName,
+            cpkFileChecksum = cpkFileChecksum,
+            metadata = metadata,
+        )
+    }
+
 }
 
 @Embeddable

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -92,7 +92,7 @@ data class CpiMetadataEntity(
             groupPolicy: String,
             groupId: String,
             fileUploadRequestId: String,
-            cpks: List<Pair<String, CpkMetadataEntity>>
+            cpks: List<Pair<String, CpiCpkEntity>>
         ): CpiMetadataEntity {
             return CpiMetadataEntity(
                 name,
@@ -103,19 +103,19 @@ data class CpiMetadataEntity(
                 groupPolicy,
                 groupId,
                 fileUploadRequestId,
-                cpks = cpks.map {
+                cpks = cpks.map { (originalFileName, cpiCpkEntity) ->
                     CpiCpkEntity(
                         id = CpiCpkKey(
                             name,
                             version,
                             signerSummaryHash,
-                            it.second.id.cpkName,
-                            it.second.id.cpkVersion,
-                            it.second.id.cpkSignerSummaryHash,
+                            cpiCpkEntity.metadata.id.cpkName,
+                            cpiCpkEntity.metadata.id.cpkVersion,
+                            cpiCpkEntity.metadata.id.cpkSignerSummaryHash,
                         ),
-                        cpkFileName = it.first,
-                        metadata = it.second,
-                        cpkFileChecksum = it.second.cpkFileChecksum
+                        cpkFileName = originalFileName,
+                        metadata = cpiCpkEntity.metadata,
+                        cpkFileChecksum = cpiCpkEntity.metadata.cpkFileChecksum
                     )
                 }.toSet()
             )
@@ -132,25 +132,25 @@ data class CpiMetadataEntity(
         fileUploadRequestId: String,
         fileName: String,
         fileChecksum: String,
-        cpks: List<Pair<String, CpkMetadataEntity>>
+        cpks: List<Pair<String, CpiCpkEntity>>
     ) =
         this.copy(
             fileUploadRequestId = fileUploadRequestId,
             fileName = fileName,
             fileChecksum = fileChecksum,
-            cpks = cpks.map {
+            cpks = cpks.map { (originalFileName, cpiCpkEntity) ->
                 CpiCpkEntity(
                     id = CpiCpkKey(
                         name,
                         version,
                         signerSummaryHash,
-                        it.second.id.cpkName,
-                        it.second.id.cpkVersion,
-                        it.second.id.cpkSignerSummaryHash,
+                        cpiCpkEntity.metadata.id.cpkName,
+                        cpiCpkEntity.metadata.id.cpkVersion,
+                        cpiCpkEntity.metadata.id.cpkSignerSummaryHash,
                     ),
-                    cpkFileName = it.first,
-                    metadata = it.second,
-                    cpkFileChecksum = it.second.cpkFileChecksum
+                    cpkFileName = originalFileName,
+                    metadata = cpiCpkEntity.metadata,
+                    cpkFileChecksum = cpiCpkEntity.metadata.cpkFileChecksum,
                 )
             }.toSet(),
         )

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkFileEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkFileEntity.kt
@@ -40,6 +40,18 @@ data class CpkFileEntity(
     @Column(name = "insert_ts", insertable = false, updatable = false)
     val insertTimestamp: Instant? = null
 
+    fun update(
+        fileChecksum: String,
+        data: ByteArray,
+        isDeleted: Boolean = false
+    ): CpkFileEntity {
+        return this.copy(
+            fileChecksum = fileChecksum,
+            data = data,
+            isDeleted = isDeleted
+        )
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkMetadataEntity.kt
@@ -29,6 +29,20 @@ data class CpkMetadataEntity(
     @Version
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int = 0
+
+    fun update(
+        fileChecksum: String,
+        formatVersion: String,
+        serializedMetadata: String,
+        isDeleted: Boolean
+    ): CpkMetadataEntity {
+        return this.copy(
+            cpkFileChecksum = fileChecksum,
+            formatVersion = formatVersion,
+            serializedMetadata = serializedMetadata,
+            isDeleted = isDeleted
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
before merging CPI and CPK entities we must find the entities first by their primary keys and if the entities exist, update these before merging rather than creating a new entity each time with the default entityVersion = 0