### PR TITLE
CORE-5246: Replace Aries dynamic bundle with Aries dynamic framework extension.

### DIFF
--- a/applications/examples/amqp-custom-serializer-poc/build.gradle
+++ b/applications/examples/amqp-custom-serializer-poc/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     cpks project(path: ':applications:examples:amqp-custom-serializer-poc:cpk-a', configuration: 'cordaCPK')
     cpks project(path: ':applications:examples:amqp-custom-serializer-poc:cpk-b', configuration: 'cordaCPK')
 
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
 
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"

--- a/applications/examples/amqp-evolution-poc/build.gradle
+++ b/applications/examples/amqp-evolution-poc/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     cpks project(path: ':applications:examples:amqp-evolution-poc:evolution-cpk', configuration: 'cordaCPK')
 
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
 
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"

--- a/applications/examples/sandbox-app/build.gradle
+++ b/applications/examples/sandbox-app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation project(':components:virtual-node:sandbox-group-context-service')
 
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
 

--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
 
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     runtimeOnly "net.corda:corda-application"
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"

--- a/components/configuration/configuration-read-service-impl/build.gradle
+++ b/components/configuration/configuration-read-service-impl/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(":libs:messaging:db-topic-admin-impl")
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/components/crypto/crypto-db-persistence-impl/build.gradle
+++ b/components/crypto/crypto-db-persistence-impl/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     integrationTestImplementation project(":testing:db-testkit")
 
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly("org.hibernate:hibernate-core:$hibernateVersion")
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/components/flow/flow-mapper-service/build.gradle
+++ b/components/flow/flow-mapper-service/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     integrationTestRuntimeOnly project(":libs:messaging:db-message-bus-impl")
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"

--- a/components/flow/flow-mapper-service/test.bndrun
+++ b/components/flow/flow-mapper-service/test.bndrun
@@ -36,8 +36,7 @@
     bnd.identity;id='org.postgresql.jdbc',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='slf4j.simple',\
-    bnd.identity;id='junit-platform-launcher',\
-    bnd.identity;id='org.apache.aries.spifly.dynamic.bundle'
+    bnd.identity;id='junit-platform-launcher'
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/components/flow/flow-p2p-filter-service/build.gradle
+++ b/components/flow/flow-p2p-filter-service/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"

--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     integrationTestRuntimeOnly project(":components:membership:membership-group-read-impl")
     integrationTestRuntimeOnly project(":components:virtual-node:cpk-read-service-impl")
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
 }
 
 def jar = tasks.named('jar', Jar) {

--- a/components/flow/flow-service/test.bndrun
+++ b/components/flow/flow-service/test.bndrun
@@ -26,8 +26,7 @@
     bnd.identity;id='net.corda.cpi-info-read-service-fake',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
-    bnd.identity;id='slf4j.simple',\
-    bnd.identity;id='org.apache.aries.spifly.dynamic.bundle'
+    bnd.identity;id='slf4j.simple'
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -82,7 +82,7 @@ dependencies {
 
     testRuntimeOnly "com.lmax:disruptor:$disruptorVersion"
     testRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    testRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    testRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     testRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     testRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 }

--- a/components/membership/membership-group-read-impl/build.gradle
+++ b/components/membership/membership-group-read-impl/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/components/virtual-node/entity-processor-service-impl/build.gradle
+++ b/components/virtual-node/entity-processor-service-impl/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     integrationTestImplementation project(":testing:db-message-bus-testkit")
 
     // needed to import serialization libs
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project(':components:virtual-node:cpk-read-service')

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -69,7 +69,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
                 "net.corda.membership",
                 "net.corda.persistence",
                 "net.corda.serialization",
-                "org.apache.aries.spifly.dynamic.bundle",
+                "org.apache.aries.spifly.dynamic.framework.extension",
                 "org.apache.felix.framework",
                 "org.apache.felix.scr",
                 "org.hibernate.orm.core",

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ dependencyCheckVersion=0.42.+
 
 # Implementation dependency versions
 activationVersion = 1.2.0
-ariesDynamicBundleVersion = 1.3.2
+ariesDynamicFrameworkExtensionVersion = 1.3.5
 antlrVersion=2.7.7
 asmVersion=9.2
 avroVersion=1.11.0

--- a/libs/db/osgi-integration-tests/build.gradle
+++ b/libs/db/osgi-integration-tests/build.gradle
@@ -31,5 +31,5 @@ dependencies {
 
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
 }

--- a/libs/permissions/permission-datamodel/build.gradle
+++ b/libs/permissions/permission-datamodel/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     integrationTestRuntimeOnly project(":libs:db:db-orm-impl")
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
 
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation "net.corda:corda-application"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly project(':libs:crypto:crypto-core')
     integrationTestRuntimeOnly project(':libs:crypto:crypto-impl')
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")

--- a/processors/crypto-processor/build.gradle
+++ b/processors/crypto-processor/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     runtimeOnly project(":libs:schema-registry:schema-registry-impl")
 
     runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     runtimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 
     integrationTestImplementation project(":testing:db-message-bus-testkit")

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     runtimeOnly project(':libs:schema-registry:schema-registry-impl')
 
     runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     runtimeOnly "org.liquibase:liquibase-core:$liquibaseVersion"
     runtimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 

--- a/processors/member-processor/build.gradle
+++ b/processors/member-processor/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     integrationTestRuntimeOnly project(":libs:messaging:db-topic-admin-impl")
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly "org.hibernate:hibernate-core:$hibernateVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     integrationTestRuntimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
 
     kafkaIntegrationTestRuntimeOnly project(":libs:messaging:kafka-topic-admin-impl")
     kafkaIntegrationTestRuntimeOnly project(":libs:messaging:kafka-message-bus-impl")

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -54,7 +54,7 @@ class SandboxSetupImpl @Activate constructor(
             "net.corda.membership",
             "net.corda.persistence",
             "net.corda.serialization",
-            "org.apache.aries.spifly.dynamic.bundle",
+            "org.apache.aries.spifly.dynamic.framework.extension",
             "org.apache.felix.framework",
             "org.apache.felix.scr",
             "org.hibernate.orm.core",

--- a/tools/crypto-tck/build.gradle
+++ b/tools/crypto-tck/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
 
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:$ariesDynamicBundleVersion"
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 


### PR DESCRIPTION
Use the dynamic framework extension instead of the dynamic bundle, to avoid any start-up ordering problems.