### PR TITLE
CORE-3150 - Add a switch for integrating with membership/crypto components

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ThirdPartyComponentsMode.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ThirdPartyComponentsMode.kt
@@ -1,0 +1,17 @@
+package net.corda.p2p.linkmanager
+
+/**
+ * This switch will exist temporarily until we complete migration with all the third-party components (e.g. membership/crypto clients).
+ * After that point, it can be removed as only the real components will be used.
+ */
+enum class ThirdPartyComponentsMode {
+    /**
+     * In this mode, the real component is used.
+     */
+    REAL,
+
+    /**
+     * In this mode, the internal (stubbed) component is used.
+     */
+    STUB
+}


### PR DESCRIPTION
Adding a switch that can be used as a toggle when integrating with the membership/crypto components in the link manager, so that we can temporarily maintain both versions until we have confirmed integration is working successfully with dynamic networks. Adding just this switch separately, so that we can create separate PRs for each component and deliver things a bit more incrementally.