### PR TITLE
CORE-5271 - refactor chunk persistence

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/ChunkWriteToDbProcessorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/ChunkWriteToDbProcessorTest.kt
@@ -3,7 +3,7 @@ package net.corda.chunking.db.impl.tests
 import net.corda.chunking.RequestId
 import net.corda.chunking.db.impl.AllChunksReceived
 import net.corda.chunking.db.impl.ChunkWriteToDbProcessor
-import net.corda.chunking.db.impl.persistence.DatabaseChunkPersistence
+import net.corda.chunking.db.impl.persistence.database.DatabaseChunkPersistence
 import net.corda.chunking.db.impl.persistence.StatusPublisher
 import net.corda.data.chunking.Chunk
 import net.corda.messaging.api.records.Record

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
@@ -1,40 +1,29 @@
 package net.corda.chunking.db.impl.tests
 
 import com.google.common.jimfs.Jimfs
+import java.nio.file.FileSystem
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.UUID
+import javax.persistence.EntityManagerFactory
+import javax.persistence.NoResultException
+import javax.persistence.NonUniqueResultException
 import net.corda.chunking.ChunkWriterFactory
 import net.corda.chunking.RequestId
 import net.corda.chunking.datamodel.ChunkEntity
 import net.corda.chunking.datamodel.ChunkingEntities
 import net.corda.chunking.db.impl.AllChunksReceived
-import net.corda.chunking.db.impl.persistence.DatabaseChunkPersistence
+import net.corda.chunking.db.impl.persistence.database.DatabaseChunkPersistence
 import net.corda.chunking.toAvro
 import net.corda.data.chunking.Chunk
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
-import net.corda.libs.cpi.datamodel.CpiCpkEntity
-import net.corda.libs.cpi.datamodel.CpiCpkKey
 import net.corda.libs.cpi.datamodel.CpiEntities
-import net.corda.libs.cpi.datamodel.CpiMetadataEntity
-import net.corda.libs.cpi.datamodel.CpiMetadataEntityKey
-import net.corda.libs.cpi.datamodel.CpkFileEntity
-import net.corda.libs.cpi.datamodel.CpkKey
-import net.corda.libs.cpi.datamodel.CpkMetadataEntity
-import net.corda.libs.packaging.Cpi
-import net.corda.libs.packaging.Cpk
-import net.corda.libs.packaging.core.CordappManifest
-import net.corda.libs.packaging.core.CpiIdentifier
-import net.corda.libs.packaging.core.CpiMetadata
-import net.corda.libs.packaging.core.CpkFormatVersion
-import net.corda.libs.packaging.core.CpkIdentifier
-import net.corda.libs.packaging.core.CpkManifest
-import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.libs.packaging.core.CpkType
-import net.corda.libs.packaging.core.ManifestCorDappInfo
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
-import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
@@ -42,21 +31,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
-import java.nio.file.FileSystem
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardOpenOption
-import java.time.Instant
-import java.util.Random
-import java.util.UUID
-import javax.persistence.EntityManagerFactory
-import javax.persistence.NoResultException
-import javax.persistence.NonUniqueResultException
-import javax.persistence.PersistenceException
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class DatabaseChunkPersistenceTest {
@@ -71,7 +45,7 @@ internal class DatabaseChunkPersistenceTest {
         ChunkingEntities.classes.toList() + CpiEntities.classes.toList(),
         emConfig
     )
-    private val persistence = DatabaseChunkPersistence(entityManagerFactory)
+    private val chunkPersistence = DatabaseChunkPersistence(entityManagerFactory)
     private val mockCpkContent = """
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin id mauris ut tortor 
             condimentum porttitor. Praesent commodo, ipsum vitae malesuada placerat, nisl sem 
@@ -178,72 +152,6 @@ internal class DatabaseChunkPersistenceTest {
         return chunks
     }
 
-    private fun updatedCpk(cpkId: CpkIdentifier, newFileChecksum: SecureHash = newRandomSecureHash()) =
-        mockCpk(cpkId.name, newFileChecksum, cpkId.signerSummaryHash)
-
-    private fun mockCpk(
-        name: String,
-        fileChecksum: SecureHash = newRandomSecureHash(),
-        cpkSignerSummaryHash: SecureHash? = newRandomSecureHash()
-    ) = mock<Cpk>().also { cpk ->
-        val cpkId = CpkIdentifier(
-            name = name,
-            version = "cpk-version",
-            signerSummaryHash = cpkSignerSummaryHash
-        )
-
-        val cpkManifest = CpkManifest(CpkFormatVersion(1, 0))
-
-        val cordappManifest = CordappManifest(
-            "", "", -1, -1,
-            ManifestCorDappInfo(null, null, null, null),
-            ManifestCorDappInfo(null, null, null, null),
-            emptyMap()
-        )
-
-        val metadata = CpkMetadata(
-            cpkId = cpkId,
-            manifest = cpkManifest,
-            mainBundle = "main-bundle",
-            libraries = emptyList(),
-            dependencies = emptyList(),
-            cordappManifest = cordappManifest,
-            type = CpkType.UNKNOWN,
-            fileChecksum = fileChecksum,
-            cordappCertificates = emptySet(),
-            timestamp = Instant.now()
-        )
-        whenever(cpk.path).thenReturn(mockCpkContent.writeToPath())
-        whenever(cpk.originalFileName).thenReturn(name)
-        whenever(cpk.metadata).thenReturn(metadata)
-    }
-
-    private fun mockCpi(cpks: Collection<Cpk>): Cpi {
-        // We need a random name here as the database primary key is (name, version, signerSummaryHash)
-        // and we'd end up trying to insert the same mock cpi.
-        val id = mock<CpiIdentifier> {
-            whenever(it.name).thenReturn("test " + UUID.randomUUID().toString())
-            whenever(it.version).thenReturn("1.0")
-            whenever(it.signerSummaryHash).thenReturn(SecureHash("SHA-256", ByteArray(12)))
-        }
-
-        return mockCpiWithId(cpks, id)
-    }
-
-    private fun mockCpiWithId(cpks: Collection<Cpk>, cpiId: CpiIdentifier): Cpi {
-        val metadata = mock<CpiMetadata>().also {
-            whenever(it.cpiId).thenReturn(cpiId)
-            whenever(it.groupPolicy).thenReturn("{}")
-        }
-
-        val cpi = mock<Cpi>().also {
-            whenever(it.cpks).thenReturn(cpks)
-            whenever(it.metadata).thenReturn(metadata)
-        }
-
-        return cpi
-    }
-
     @Test
     fun `database chunk persistence writes chunks`() {
         val someFile = randomFileName()
@@ -252,7 +160,7 @@ internal class DatabaseChunkPersistenceTest {
         val requestId = chunks.first().requestId
         chunks.shuffle()
 
-        chunks.forEach { persistence.persistChunk(it) }
+        chunks.forEach { chunkPersistence.persistChunk(it) }
 
         val actual = entityManagerFactory.createEntityManager().transaction {
             it.createQuery("SELECT count(c) FROM ${ChunkEntity::class.simpleName} c WHERE c.requestId = :requestId")
@@ -272,7 +180,7 @@ internal class DatabaseChunkPersistenceTest {
         chunks.removeLast()
 
         var status = AllChunksReceived.NO
-        chunks.forEach { status = persistence.persistChunk(it) }
+        chunks.forEach { status = chunkPersistence.persistChunk(it) }
         assertThat(status).isEqualTo(AllChunksReceived.NO)
     }
 
@@ -286,10 +194,10 @@ internal class DatabaseChunkPersistenceTest {
         chunks.removeLast()
 
         var status = AllChunksReceived.NO
-        chunks.forEach { status = persistence.persistChunk(it) }
+        chunks.forEach { status = chunkPersistence.persistChunk(it) }
         assertThat(status).isEqualTo(AllChunksReceived.NO)
 
-        status = persistence.persistChunk(last)
+        status = chunkPersistence.persistChunk(last)
         assertThat(status).isEqualTo(AllChunksReceived.YES)
     }
 
@@ -305,10 +213,10 @@ internal class DatabaseChunkPersistenceTest {
         chunks.removeLast()
 
         var status = AllChunksReceived.NO
-        chunks.forEach { status = persistence.persistChunk(it) }
+        chunks.forEach { status = chunkPersistence.persistChunk(it) }
         assertThat(status).isEqualTo(AllChunksReceived.NO)
 
-        status = persistence.persistChunk(last)
+        status = chunkPersistence.persistChunk(last)
         assertThat(status).isEqualTo(AllChunksReceived.YES)
     }
 
@@ -320,7 +228,7 @@ internal class DatabaseChunkPersistenceTest {
         val requestId = chunks.first().requestId
         chunks.shuffle()
 
-        chunks.forEach { persistence.persistChunk(it) }
+        chunks.forEach { chunkPersistence.persistChunk(it) }
 
         val actual = entityManagerFactory.createEntityManager().transaction {
             it.createQuery("SELECT count(c) FROM ${ChunkEntity::class.simpleName} c WHERE c.requestId = :requestId")
@@ -345,7 +253,7 @@ internal class DatabaseChunkPersistenceTest {
         // don't shuffle for this.
 
         var allChunksReceived = AllChunksReceived.NO
-        chunks.forEach { allChunksReceived = persistence.persistChunk(it) }
+        chunks.forEach { allChunksReceived = chunkPersistence.persistChunk(it) }
 
         assertThat(allChunksReceived).isEqualTo(AllChunksReceived.YES)
 
@@ -379,9 +287,9 @@ internal class DatabaseChunkPersistenceTest {
         val requestId = chunks.first().requestId
         // don't shuffle for this.
 
-        chunks.forEach { persistence.persistChunk(it) }
+        chunks.forEach { chunkPersistence.persistChunk(it) }
 
-        assertThat(persistence.checksumIsValid(requestId)).isTrue
+        assertThat(chunkPersistence.checksumIsValid(requestId)).isTrue
     }
 
     @Test
@@ -392,474 +300,8 @@ internal class DatabaseChunkPersistenceTest {
         val requestId = chunks.first().requestId
 
         chunks.last().checksum = SecureHash("rubbish", "1234567890".toByteArray()).toAvro()
-        chunks.forEach { persistence.persistChunk(it) }
+        chunks.forEach { chunkPersistence.persistChunk(it) }
 
-        assertThat(persistence.checksumIsValid(requestId)).isFalse
-    }
-
-    fun String.writeToPath(): Path {
-        val path = fs.getPath(UUID.randomUUID().toString())
-        Files.writeString(path, this)
-        return path
-    }
-
-    /**
-     * Various db tools show a persisted cpk (or bytes) as just a textual 'handle' to the blob of bytes,
-     * so explicitly test here that it's actually doing what we think it is (persisting the bytes!).
-     */
-    @Test
-    fun `database chunk persistence writes data and can be read back`() {
-        val checksum = newRandomSecureHash()
-        val cpks = listOf(mockCpk("${UUID.randomUUID()}.cpk", checksum))
-        val cpi = mockCpi(cpks)
-
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            checksum,
-            UUID.randomUUID().toString(),
-            "abcdef",
-            emptyList()
-        )
-
-        val query = "FROM ${CpkFileEntity::class.simpleName} where fileChecksum = :cpkFileChecksum"
-        val cpkDataEntity = entityManagerFactory.createEntityManager().transaction {
-            it.createQuery(query, CpkFileEntity::class.java)
-                .setParameter("cpkFileChecksum", checksum.toString())
-                .singleResult
-        }!!
-
-        assertThat(cpkDataEntity.data).isEqualTo(mockCpkContent.toByteArray())
-    }
-
-    @Test
-    fun `database chunk persistence can lookup persisted cpi by checksum`() {
-        val checksum = newRandomSecureHash()
-        assertThat(persistence.cpkExists(checksum)).isFalse
-
-        val cpks = listOf(mockCpk("${UUID.randomUUID()}.cpk", checksum))
-        val cpi = mockCpi(cpks)
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "someFileName.cpi",
-            checksum,
-            UUID.randomUUID().toString(),
-            "abcdef",
-            emptyList()
-        )
-        assertThat(persistence.cpkExists(checksum)).isTrue
-    }
-
-    private val random = Random(0)
-    private fun newRandomSecureHash(): SecureHash {
-        return SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
-    }
-
-    @Test
-    fun `database chunk persistence can write multiple cpks into database`() {
-        val cpks = listOf(
-            mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash()),
-            mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash()),
-            mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash()),
-        )
-        val checksum = newRandomSecureHash()
-
-        val cpi = mockCpi(cpks)
-
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            checksum,
-            UUID.randomUUID().toString(),
-            "123456",
-            emptyList()
-        )
-
-        assertThrows<PersistenceException> {
-            persistence.persistMetadataAndCpks(
-                cpi,
-                "test.cpi",
-                checksum,
-                UUID.randomUUID().toString(),
-                "123456",
-                emptyList()
-            )
-        }
-    }
-
-    @Test
-    fun `database chunk persistence can write multiple CPIs with shared CPKs into database`() {
-        val sharedCpkChecksum = newRandomSecureHash()
-        val cpk1Checksum = newRandomSecureHash()
-        val cpk2Checksum = newRandomSecureHash()
-
-        val sharedCpk = mockCpk("${UUID.randomUUID()}.cpk", sharedCpkChecksum)
-        val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpk1Checksum)
-        val cpi1 = mockCpi(listOf(sharedCpk, cpk1))
-
-        persistence.persistMetadataAndCpks(
-            cpi1,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "123456",
-            emptyList()
-        )
-
-        val cpk2 = mockCpk("${UUID.randomUUID()}.cpk", cpk2Checksum)
-        val cpi2 = mockCpi(listOf(sharedCpk, cpk2))
-
-        assertDoesNotThrow {
-            persistence.persistMetadataAndCpks(
-                cpi2,
-                "test.cpi",
-                newRandomSecureHash(),
-                UUID.randomUUID().toString(),
-                "123456",
-                emptyList()
-            )
-        }
-
-        findAndAssertCpk(cpi1.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
-        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
-        findAndAssertCpk(cpi1.metadata.cpiId, cpk1.metadata.cpkId, cpk1Checksum.toString(), 0, 0, 0)
-        findAndAssertCpk(cpi2.metadata.cpiId, cpk2.metadata.cpkId, cpk2Checksum.toString(), 0, 0, 0)
-    }
-
-    @Test
-    fun `database chunk persistence can force update a CPI`() {
-        val cpkChecksum = newRandomSecureHash()
-        val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpkChecksum)
-        val cpi = mockCpi(listOf(cpk1))
-        val cpiFileName = "test${UUID.randomUUID()}.cpi"
-
-        val cpiMetadataEntity =
-            persistence.persistMetadataAndCpks(
-                cpi,
-                cpiFileName,
-                newRandomSecureHash(),
-                UUID.randomUUID().toString(),
-                "abcdef",
-                emptyList()
-            )
-
-        assertThat(cpiMetadataEntity.entityVersion).isEqualTo(1)
-        assertThat(cpiMetadataEntity.cpks.size).isEqualTo(1)
-        assertThat(cpiMetadataEntity.cpks.first().entityVersion).isEqualTo(0)
-
-        // make same assertions but after loading the entity again
-        val initialLoadedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(
-                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                    cpi.metadata.cpiId.name,
-                    cpi.metadata.cpiId.version,
-                    cpi.metadata.cpiId.signerSummaryHash.toString(),
-                )
-            )
-        }!!
-
-        // adding cpk to cpi accounts for 1 modification
-        assertThat(initialLoadedCpi.entityVersion).isEqualTo(1)
-        assertThat(initialLoadedCpi.cpks.size).isEqualTo(1)
-        assertThat(initialLoadedCpi.cpks.first().entityVersion).isEqualTo(0)
-
-        val updatedCpkChecksum = newRandomSecureHash()
-        val updatedCpks = listOf(cpk1, mockCpk("${UUID.randomUUID()}.cpk", updatedCpkChecksum))
-        // cpi with different CPKs but same ID
-        val updatedCpi = mockCpiWithId(updatedCpks, cpi.metadata.cpiId)
-
-        val returnedCpiMetadataEntity =
-            persistence.updateMetadataAndCpks(
-                updatedCpi,
-                cpiFileName,
-                newRandomSecureHash(),
-                UUID.randomUUID().toString(),
-                "abcdef",
-                emptyList()
-            )
-
-        assertThat(returnedCpiMetadataEntity.entityVersion).isEqualTo(3)
-        val firstReturnedCpk = returnedCpiMetadataEntity.cpks.first { it.cpkFileChecksum == cpkChecksum.toString() }
-        val secondReturnedCpk = returnedCpiMetadataEntity.cpks.first { it.cpkFileChecksum == updatedCpkChecksum.toString() }
-        assertThat(firstReturnedCpk.entityVersion).isEqualTo(0)
-        assertThat(secondReturnedCpk.entityVersion).isEqualTo(0)
-
-        // make same assertions but after loading the entity again
-        val updatedLoadedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(
-                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                    updatedCpi.metadata.cpiId.name,
-                    updatedCpi.metadata.cpiId.version,
-                    updatedCpi.metadata.cpiId.signerSummaryHash.toString(),
-                )
-            )
-        }!!
-
-        assertThat(updatedLoadedCpi.cpks.size).isEqualTo(2)
-        assertThat(updatedLoadedCpi.entityVersion).isEqualTo(3)
-        val firstCpk = updatedLoadedCpi.cpks.first { it.cpkFileChecksum == cpkChecksum.toString() }
-        val secondCpk = updatedLoadedCpi.cpks.first { it.cpkFileChecksum == updatedCpkChecksum.toString() }
-        assertThat(firstCpk.entityVersion).isEqualTo(0)
-        assertThat(secondCpk.entityVersion).isEqualTo(0)
-    }
-
-    @Test
-    fun `database chunk persistence can force update the same CPI`() {
-        val cpiChecksum = newRandomSecureHash()
-        val cpkChecksum = newRandomSecureHash()
-        val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpkChecksum)
-        val cpks = listOf(cpk1)
-        val cpi = mockCpi(cpks)
-
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            cpiChecksum,
-            UUID.randomUUID().toString(),
-            "abcdef",
-            emptyList()
-        )
-
-        val loadedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(
-                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                    cpi.metadata.cpiId.name,
-                    cpi.metadata.cpiId.version,
-                    cpi.metadata.cpiId.signerSummaryHash.toString(),
-                )
-            )
-        }!!
-
-        // adding cpk to cpi accounts for 1 modification
-        assertThat(loadedCpi.entityVersion).isEqualTo(1)
-        assertThat(loadedCpi.cpks.size).isEqualTo(1)
-        assertThat(loadedCpi.cpks.first().entityVersion).isEqualTo(0)
-
-        // force update same CPI
-        persistence.updateMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            cpiChecksum,
-            UUID.randomUUID().toString(),
-            "abcdef",
-            emptyList()
-        )
-
-        val updatedCpi = entityManagerFactory.createEntityManager().transaction {
-            it.find(
-                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
-                    cpi.metadata.cpiId.name,
-                    cpi.metadata.cpiId.version,
-                    cpi.metadata.cpiId.signerSummaryHash.toString(),
-                )
-            )
-        }!!
-
-        assertThat(updatedCpi.insertTimestamp).isAfter(loadedCpi.insertTimestamp)
-        // merging updated cpi accounts for 1 modification + modifying cpk
-        assertThat(updatedCpi.entityVersion).isEqualTo(3)
-        assertThat(updatedCpi.cpks.size).isEqualTo(1)
-        assertThat(updatedCpi.cpks.first().entityVersion).isEqualTo(0)
-    }
-
-    @Test
-    fun `CPKs are correct after persisting a CPI with already existing CPK`() {
-        val sharedCpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
-        val cpi = mockCpi(listOf(sharedCpk))
-
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-a",
-            emptyList()
-        )
-
-        val cpi2 = mockCpi(listOf(sharedCpk))
-
-        persistence.persistMetadataAndCpks(
-            cpi2,
-            "test2.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-b",
-            emptyList()
-        )
-
-        findAndAssertCpk(
-            cpi.metadata.cpiId,
-            sharedCpk.metadata.cpkId,
-            sharedCpk.metadata.fileChecksum.toString(),
-            0,
-            1,
-            0
-        )
-        findAndAssertCpk(
-            cpi2.metadata.cpiId,
-            sharedCpk.metadata.cpkId,
-            sharedCpk.metadata.fileChecksum.toString(),
-            0,
-            1,
-            0
-        )
-    }
-
-    @Test
-    fun `CPKs are correct after updating a CPI by adding a new CPK`() {
-        val cpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
-        val newCpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
-        val cpi = mockCpi(listOf(cpk))
-
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-a",
-            emptyList()
-        )
-
-        // a new cpi object, but with same
-        val updatedCpi = mockCpiWithId(listOf(cpk, newCpk), cpi.metadata.cpiId)
-
-        persistence.updateMetadataAndCpks(
-            updatedCpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-b",
-            emptyList()
-        )
-
-        assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
-
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, cpk.metadata.fileChecksum.toString(), 0, 1, 0)
-        findAndAssertCpk(cpi.metadata.cpiId, newCpk.metadata.cpkId, newCpk.metadata.fileChecksum.toString(), 0, 0, 0)
-    }
-
-    @Test
-    fun `CPK version is incremented when we update a CPK in a CPI`() {
-        val cpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
-        val newChecksum = newRandomSecureHash()
-        val updatedCpk = updatedCpk(cpk.metadata.cpkId, newChecksum)
-        val cpi = mockCpi(listOf(cpk))
-
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-a",
-            emptyList()
-        )
-
-        // a new cpi object, but with same
-        val updatedCpi = mockCpiWithId(listOf(updatedCpk), cpi.metadata.cpiId)
-
-        persistence.updateMetadataAndCpks(
-            updatedCpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-b",
-            emptyList()
-        )
-
-        assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
-
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, newChecksum.toString(), 1, 2, 1)
-    }
-
-    @Test
-    fun `CPK version is incremented when CpiCpkEntity has non-zero entityversion`() {
-        val firstCpkChecksum = newRandomSecureHash()
-        val cpk = mockCpk("${UUID.randomUUID()}.cpk", firstCpkChecksum)
-        val cpi = mockCpi(listOf(cpk))
-
-        persistence.persistMetadataAndCpks(
-            cpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-a",
-            emptyList()
-        )
-
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, firstCpkChecksum.toString(), 0, 0, 0)
-
-        // a new cpi object, but with same cpk
-        val secondCpkChecksum = newRandomSecureHash()
-        val updatedCpk = updatedCpk(cpk.metadata.cpkId, secondCpkChecksum)
-        val updatedCpi = mockCpiWithId(listOf(updatedCpk), cpi.metadata.cpiId)
-
-        persistence.updateMetadataAndCpks(
-            updatedCpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-b",
-            emptyList()
-        )
-
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, secondCpkChecksum.toString(), 1, 2, 1)
-
-        // a new cpi object, but with same cpk
-        val thirdChecksum = newRandomSecureHash()
-        val anotherUpdatedCpk = updatedCpk(cpk.metadata.cpkId, thirdChecksum)
-        val anotherUpdatedCpi = mockCpiWithId(listOf(anotherUpdatedCpk), cpi.metadata.cpiId)
-
-        persistence.updateMetadataAndCpks(
-            anotherUpdatedCpi,
-            "test.cpi",
-            newRandomSecureHash(),
-            UUID.randomUUID().toString(),
-            "group-b",
-            emptyList()
-        )
-
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, thirdChecksum.toString(), 2, 4, 2)
-    }
-
-    private fun findAndAssertCpk(
-        cpiId: CpiIdentifier,
-        cpkId: CpkIdentifier,
-        expectedCpkFileChecksum: String,
-        expectedMetadataEntityVersion: Int,
-        expectedFileEntityVersion: Int,
-        expectedCpiCpkEntityVersion: Int
-    ) {
-        val (cpkMetadata, cpkFile, cpiCpk) = entityManagerFactory.createEntityManager().transaction {
-            val cpiCpkKey = CpiCpkKey(
-                cpiId.name,
-                cpiId.version,
-                cpiId.signerSummaryHash.toString(),
-                cpkId.name,
-                cpkId.version,
-                cpkId.signerSummaryHash.toString()
-            )
-            val cpkKey = CpkKey(
-                cpkId.name,
-                cpkId.version,
-                cpkId.signerSummaryHash.toString()
-            )
-            val cpiCpk = it.find(CpiCpkEntity::class.java, cpiCpkKey)
-            val cpkMetadata = it.find(CpkMetadataEntity::class.java, cpkKey)
-            val cpkFile = it.find(CpkFileEntity::class.java, cpkKey)
-            Triple(cpkMetadata, cpkFile, cpiCpk)
-        }
-
-        assertThat(cpkMetadata.cpkFileChecksum).isEqualTo(expectedCpkFileChecksum)
-        assertThat(cpkFile.fileChecksum).isEqualTo(expectedCpkFileChecksum)
-
-        assertThat(cpkMetadata.entityVersion)
-            .withFailMessage("CpkMetadataEntity.entityVersion expected $expectedMetadataEntityVersion but was ${cpkMetadata.entityVersion}.")
-            .isEqualTo(expectedMetadataEntityVersion)
-        assertThat(cpkFile.entityVersion)
-            .withFailMessage("CpkFileEntity.entityVersion expected $expectedFileEntityVersion but was ${cpkFile.entityVersion}.")
-            .isEqualTo(expectedFileEntityVersion)
-        assertThat(cpiCpk.entityVersion)
-            .withFailMessage("CpiCpkEntity.entityVersion expected $expectedCpiCpkEntityVersion but was ${cpiCpk.entityVersion}.")
-            .isEqualTo(expectedCpiCpkEntityVersion)
+        assertThat(chunkPersistence.checksumIsValid(requestId)).isFalse
     }
 }

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -1,0 +1,646 @@
+package net.corda.chunking.db.impl.tests
+
+import com.google.common.jimfs.Jimfs
+import java.nio.file.FileSystem
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.Random
+import java.util.UUID
+import javax.persistence.PersistenceException
+import net.corda.chunking.datamodel.ChunkingEntities
+import net.corda.chunking.db.impl.persistence.database.DatabaseCpiPersistence
+import net.corda.db.admin.impl.ClassloaderChangeLog
+import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
+import net.corda.db.schema.DbSchema
+import net.corda.db.testkit.DbUtils
+import net.corda.libs.cpi.datamodel.CpiCpkEntity
+import net.corda.libs.cpi.datamodel.CpiCpkKey
+import net.corda.libs.cpi.datamodel.CpiEntities
+import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpiMetadataEntityKey
+import net.corda.libs.cpi.datamodel.CpkFileEntity
+import net.corda.libs.cpi.datamodel.CpkKey
+import net.corda.libs.cpi.datamodel.CpkMetadataEntity
+import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.Cpk
+import net.corda.libs.packaging.core.CordappManifest
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpiMetadata
+import net.corda.libs.packaging.core.CpkFormatVersion
+import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.libs.packaging.core.CpkManifest
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.libs.packaging.core.CpkType
+import net.corda.libs.packaging.core.ManifestCorDappInfo
+import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
+import net.corda.orm.utils.transaction
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class DatabaseCpiPersistenceTest {
+    companion object {
+        private const val MIGRATION_FILE_LOCATION = "net/corda/db/schema/config/db.changelog-master.xml"
+    }
+
+    // N.B.  We're pulling in the config tables as well.
+    private val emConfig = DbUtils.getEntityManagerConfiguration("chunking_db_for_test")
+    private val entityManagerFactory = EntityManagerFactoryFactoryImpl().create(
+        "test_unit",
+        ChunkingEntities.classes.toList() + CpiEntities.classes.toList(),
+        emConfig
+    )
+    private val cpiPersistence = DatabaseCpiPersistence(entityManagerFactory)
+    private val mockCpkContent = """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin id mauris ut tortor 
+            condimentum porttitor. Praesent commodo, ipsum vitae malesuada placerat, nisl sem 
+            ornare nibh, id rutrum mi elit in metus. Sed ac tincidunt elit. Aliquam quis 
+            pellentesque lacus. Quisque commodo tristique pellentesque. Nam sodales, urna id 
+            convallis condimentum, nulla lacus vestibulum ipsum, et ultrices sem magna sed neque. 
+            Pellentesque id accumsan odio, non interdum nibh. Nullam lacinia vestibulum purus, 
+            finibus maximus enim scelerisque eu. Ut nibh lacus, semper eget cursus a, porttitor 
+            eu odio. Vivamus vel placerat eros, sed convallis est. Proin tristique ut odio at 
+            finibus. 
+        """.trimIndent()
+
+    /**
+     * Creates an in-memory database, applies the relevant migration scripts, and initialises
+     * [entityManagerFactory].
+     */
+    init {
+        val dbChange = ClassloaderChangeLog(
+            linkedSetOf(
+                ClassloaderChangeLog.ChangeLogResourceFiles(
+                    DbSchema::class.java.packageName,
+                    listOf(MIGRATION_FILE_LOCATION),
+                    DbSchema::class.java.classLoader
+                )
+            )
+        )
+        emConfig.dataSource.connection.use { connection ->
+            LiquibaseSchemaMigratorImpl().updateDb(connection, dbChange)
+        }
+    }
+
+    @Suppress("Unused")
+    @AfterAll
+    fun cleanup() {
+        emConfig.close()
+        entityManagerFactory.close()
+    }
+
+    lateinit var fs: FileSystem
+
+    @BeforeEach
+    private fun beforeEach() {
+        fs = Jimfs.newFileSystem()
+    }
+
+    @AfterEach
+    private fun afterEach() {
+        fs.close()
+    }
+
+    private fun String.writeToPath(): Path {
+        val path = fs.getPath(UUID.randomUUID().toString())
+        Files.writeString(path, this)
+        return path
+    }
+
+    private fun updatedCpk(cpkId: CpkIdentifier, newFileChecksum: SecureHash = newRandomSecureHash()) =
+        mockCpk(cpkId.name, newFileChecksum, cpkId.signerSummaryHash)
+
+    private fun mockCpk(
+        name: String,
+        fileChecksum: SecureHash = newRandomSecureHash(),
+        cpkSignerSummaryHash: SecureHash? = newRandomSecureHash()
+    ) = mock<Cpk>().also { cpk ->
+        val cpkId = CpkIdentifier(
+            name = name,
+            version = "cpk-version",
+            signerSummaryHash = cpkSignerSummaryHash
+        )
+
+        val cpkManifest = CpkManifest(CpkFormatVersion(1, 0))
+
+        val cordappManifest = CordappManifest(
+            "", "", -1, -1,
+            ManifestCorDappInfo(null, null, null, null),
+            ManifestCorDappInfo(null, null, null, null),
+            emptyMap()
+        )
+
+        val metadata = CpkMetadata(
+            cpkId = cpkId,
+            manifest = cpkManifest,
+            mainBundle = "main-bundle",
+            libraries = emptyList(),
+            dependencies = emptyList(),
+            cordappManifest = cordappManifest,
+            type = CpkType.UNKNOWN,
+            fileChecksum = fileChecksum,
+            cordappCertificates = emptySet(),
+            timestamp = Instant.now()
+        )
+        whenever(cpk.path).thenReturn(mockCpkContent.writeToPath())
+        whenever(cpk.originalFileName).thenReturn(name)
+        whenever(cpk.metadata).thenReturn(metadata)
+    }
+
+    private fun mockCpi(cpks: Collection<Cpk>): Cpi {
+        // We need a random name here as the database primary key is (name, version, signerSummaryHash)
+        // and we'd end up trying to insert the same mock cpi.
+        val id = mock<CpiIdentifier> {
+            whenever(it.name).thenReturn("test " + UUID.randomUUID().toString())
+            whenever(it.version).thenReturn("1.0")
+            whenever(it.signerSummaryHash).thenReturn(SecureHash("SHA-256", ByteArray(12)))
+        }
+
+        return mockCpiWithId(cpks, id)
+    }
+
+    private fun mockCpiWithId(cpks: Collection<Cpk>, cpiId: CpiIdentifier): Cpi {
+        val metadata = mock<CpiMetadata>().also {
+            whenever(it.cpiId).thenReturn(cpiId)
+            whenever(it.groupPolicy).thenReturn("{}")
+        }
+
+        val cpi = mock<Cpi>().also {
+            whenever(it.cpks).thenReturn(cpks)
+            whenever(it.metadata).thenReturn(metadata)
+        }
+
+        return cpi
+    }
+
+    /**
+     * Various db tools show a persisted cpk (or bytes) as just a textual 'handle' to the blob of bytes,
+     * so explicitly test here that it's actually doing what we think it is (persisting the bytes!).
+     */
+    @Test
+    fun `database cpi persistence writes data and can be read back`() {
+        val checksum = newRandomSecureHash()
+        val cpks = listOf(mockCpk("${UUID.randomUUID()}.cpk", checksum))
+        val cpi = mockCpi(cpks)
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            checksum,
+            UUID.randomUUID().toString(),
+            "abcdef",
+            emptyList()
+        )
+
+        val query = "FROM ${CpkFileEntity::class.simpleName} where fileChecksum = :cpkFileChecksum"
+        val cpkDataEntity = entityManagerFactory.createEntityManager().transaction {
+            it.createQuery(query, CpkFileEntity::class.java)
+                .setParameter("cpkFileChecksum", checksum.toString())
+                .singleResult
+        }!!
+
+        assertThat(cpkDataEntity.data).isEqualTo(mockCpkContent.toByteArray())
+    }
+
+    @Test
+    fun `database cpi persistence can lookup persisted cpi by checksum`() {
+        val checksum = newRandomSecureHash()
+        assertThat(cpiPersistence.cpkExists(checksum)).isFalse
+
+        val cpks = listOf(mockCpk("${UUID.randomUUID()}.cpk", checksum))
+        val cpi = mockCpi(cpks)
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "someFileName.cpi",
+            checksum,
+            UUID.randomUUID().toString(),
+            "abcdef",
+            emptyList()
+        )
+        assertThat(cpiPersistence.cpkExists(checksum)).isTrue
+    }
+
+    private val random = Random(0)
+    private fun newRandomSecureHash(): SecureHash {
+        return SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
+    }
+
+    @Test
+    fun `database cpi persistence can write multiple cpks into database`() {
+        val cpks = listOf(
+            mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash()),
+            mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash()),
+            mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash()),
+        )
+        val checksum = newRandomSecureHash()
+
+        val cpi = mockCpi(cpks)
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            checksum,
+            UUID.randomUUID().toString(),
+            "123456",
+            emptyList()
+        )
+
+        assertThrows<PersistenceException> {
+            cpiPersistence.persistMetadataAndCpks(
+                cpi,
+                "test.cpi",
+                checksum,
+                UUID.randomUUID().toString(),
+                "123456",
+                emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun `database cpi persistence can write multiple CPIs with shared CPKs into database`() {
+        val sharedCpkChecksum = newRandomSecureHash()
+        val cpk1Checksum = newRandomSecureHash()
+        val cpk2Checksum = newRandomSecureHash()
+
+        val sharedCpk = mockCpk("${UUID.randomUUID()}.cpk", sharedCpkChecksum)
+        val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpk1Checksum)
+        val cpi1 = mockCpi(listOf(sharedCpk, cpk1))
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi1,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "123456",
+            emptyList()
+        )
+
+        val cpk2 = mockCpk("${UUID.randomUUID()}.cpk", cpk2Checksum)
+        val cpi2 = mockCpi(listOf(sharedCpk, cpk2))
+
+        assertDoesNotThrow {
+            cpiPersistence.persistMetadataAndCpks(
+                cpi2,
+                "test.cpi",
+                newRandomSecureHash(),
+                UUID.randomUUID().toString(),
+                "123456",
+                emptyList()
+            )
+        }
+
+        findAndAssertCpk(cpi1.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi1.metadata.cpiId, cpk1.metadata.cpkId, cpk1Checksum.toString(), 0, 0, 0)
+        findAndAssertCpk(cpi2.metadata.cpiId, cpk2.metadata.cpkId, cpk2Checksum.toString(), 0, 0, 0)
+    }
+
+    @Test
+    fun `database cpi persistence can force update a CPI`() {
+        val cpkChecksum = newRandomSecureHash()
+        val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpkChecksum)
+        val cpi = mockCpi(listOf(cpk1))
+        val cpiFileName = "test${UUID.randomUUID()}.cpi"
+
+        val cpiMetadataEntity =
+            cpiPersistence.persistMetadataAndCpks(
+                cpi,
+                cpiFileName,
+                newRandomSecureHash(),
+                UUID.randomUUID().toString(),
+                "abcdef",
+                emptyList()
+            )
+
+        assertThat(cpiMetadataEntity.entityVersion).isEqualTo(1)
+        assertThat(cpiMetadataEntity.cpks.size).isEqualTo(1)
+        assertThat(cpiMetadataEntity.cpks.first().entityVersion).isEqualTo(0)
+
+        // make same assertions but after loading the entity again
+        val initialLoadedCpi = entityManagerFactory.createEntityManager().transaction {
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    cpi.metadata.cpiId.name,
+                    cpi.metadata.cpiId.version,
+                    cpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
+        }!!
+
+        // adding cpk to cpi accounts for 1 modification
+        assertThat(initialLoadedCpi.entityVersion).isEqualTo(1)
+        assertThat(initialLoadedCpi.cpks.size).isEqualTo(1)
+        assertThat(initialLoadedCpi.cpks.first().entityVersion).isEqualTo(0)
+
+        val updatedCpkChecksum = newRandomSecureHash()
+        val updatedCpks = listOf(cpk1, mockCpk("${UUID.randomUUID()}.cpk", updatedCpkChecksum))
+        // cpi with different CPKs but same ID
+        val updatedCpi = mockCpiWithId(updatedCpks, cpi.metadata.cpiId)
+
+        val returnedCpiMetadataEntity =
+            cpiPersistence.updateMetadataAndCpks(
+                updatedCpi,
+                cpiFileName,
+                newRandomSecureHash(),
+                UUID.randomUUID().toString(),
+                "abcdef",
+                emptyList()
+            )
+
+        assertThat(returnedCpiMetadataEntity.entityVersion).isEqualTo(3)
+        val firstReturnedCpk = returnedCpiMetadataEntity.cpks.first { it.cpkFileChecksum == cpkChecksum.toString() }
+        val secondReturnedCpk = returnedCpiMetadataEntity.cpks.first { it.cpkFileChecksum == updatedCpkChecksum.toString() }
+        assertThat(firstReturnedCpk.entityVersion).isEqualTo(0)
+        assertThat(secondReturnedCpk.entityVersion).isEqualTo(0)
+
+        // make same assertions but after loading the entity again
+        val updatedLoadedCpi = entityManagerFactory.createEntityManager().transaction {
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    updatedCpi.metadata.cpiId.name,
+                    updatedCpi.metadata.cpiId.version,
+                    updatedCpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
+        }!!
+
+        assertThat(updatedLoadedCpi.cpks.size).isEqualTo(2)
+        assertThat(updatedLoadedCpi.entityVersion).isEqualTo(3)
+        val firstCpk = updatedLoadedCpi.cpks.first { it.cpkFileChecksum == cpkChecksum.toString() }
+        val secondCpk = updatedLoadedCpi.cpks.first { it.cpkFileChecksum == updatedCpkChecksum.toString() }
+        assertThat(firstCpk.entityVersion).isEqualTo(0)
+        assertThat(secondCpk.entityVersion).isEqualTo(0)
+    }
+
+    @Test
+    fun `database cpi persistence can force update the same CPI`() {
+        val cpiChecksum = newRandomSecureHash()
+        val cpkChecksum = newRandomSecureHash()
+        val cpk1 = mockCpk("${UUID.randomUUID()}.cpk", cpkChecksum)
+        val cpks = listOf(cpk1)
+        val cpi = mockCpi(cpks)
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            cpiChecksum,
+            UUID.randomUUID().toString(),
+            "abcdef",
+            emptyList()
+        )
+
+        val loadedCpi = entityManagerFactory.createEntityManager().transaction {
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    cpi.metadata.cpiId.name,
+                    cpi.metadata.cpiId.version,
+                    cpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
+        }!!
+
+        // adding cpk to cpi accounts for 1 modification
+        assertThat(loadedCpi.entityVersion).isEqualTo(1)
+        assertThat(loadedCpi.cpks.size).isEqualTo(1)
+        assertThat(loadedCpi.cpks.first().entityVersion).isEqualTo(0)
+
+        // force update same CPI
+        cpiPersistence.updateMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            cpiChecksum,
+            UUID.randomUUID().toString(),
+            "abcdef",
+            emptyList()
+        )
+
+        val updatedCpi = entityManagerFactory.createEntityManager().transaction {
+            it.find(
+                CpiMetadataEntity::class.java, CpiMetadataEntityKey(
+                    cpi.metadata.cpiId.name,
+                    cpi.metadata.cpiId.version,
+                    cpi.metadata.cpiId.signerSummaryHash.toString(),
+                )
+            )
+        }!!
+
+        assertThat(updatedCpi.insertTimestamp).isAfter(loadedCpi.insertTimestamp)
+        // merging updated cpi accounts for 1 modification + modifying cpk
+        assertThat(updatedCpi.entityVersion).isEqualTo(3)
+        assertThat(updatedCpi.cpks.size).isEqualTo(1)
+        assertThat(updatedCpi.cpks.first().entityVersion).isEqualTo(0)
+    }
+
+    @Test
+    fun `CPKs are correct after persisting a CPI with already existing CPK`() {
+        val sharedCpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val cpi = mockCpi(listOf(sharedCpk))
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-a",
+            emptyList()
+        )
+
+        val cpi2 = mockCpi(listOf(sharedCpk))
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi2,
+            "test2.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-b",
+            emptyList()
+        )
+
+        findAndAssertCpk(
+            cpi.metadata.cpiId,
+            sharedCpk.metadata.cpkId,
+            sharedCpk.metadata.fileChecksum.toString(),
+            0,
+            1,
+            0
+        )
+        findAndAssertCpk(
+            cpi2.metadata.cpiId,
+            sharedCpk.metadata.cpkId,
+            sharedCpk.metadata.fileChecksum.toString(),
+            0,
+            1,
+            0
+        )
+    }
+
+    @Test
+    fun `CPKs are correct after updating a CPI by adding a new CPK`() {
+        val cpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val newCpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val cpi = mockCpi(listOf(cpk))
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-a",
+            emptyList()
+        )
+
+        // a new cpi object, but with same
+        val updatedCpi = mockCpiWithId(listOf(cpk, newCpk), cpi.metadata.cpiId)
+
+        cpiPersistence.updateMetadataAndCpks(
+            updatedCpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-b",
+            emptyList()
+        )
+
+        assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
+
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, cpk.metadata.fileChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi.metadata.cpiId, newCpk.metadata.cpkId, newCpk.metadata.fileChecksum.toString(), 0, 0, 0)
+    }
+
+    @Test
+    fun `CPK version is incremented when we update a CPK in a CPI`() {
+        val cpk = mockCpk("${UUID.randomUUID()}.cpk", newRandomSecureHash())
+        val newChecksum = newRandomSecureHash()
+        val updatedCpk = updatedCpk(cpk.metadata.cpkId, newChecksum)
+        val cpi = mockCpi(listOf(cpk))
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-a",
+            emptyList()
+        )
+
+        // a new cpi object, but with same
+        val updatedCpi = mockCpiWithId(listOf(updatedCpk), cpi.metadata.cpiId)
+
+        cpiPersistence.updateMetadataAndCpks(
+            updatedCpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-b",
+            emptyList()
+        )
+
+        assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
+
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, newChecksum.toString(), 1, 2, 1)
+    }
+
+    @Test
+    fun `CPK version is incremented when CpiCpkEntity has non-zero entityversion`() {
+        val firstCpkChecksum = newRandomSecureHash()
+        val cpk = mockCpk("${UUID.randomUUID()}.cpk", firstCpkChecksum)
+        val cpi = mockCpi(listOf(cpk))
+
+        cpiPersistence.persistMetadataAndCpks(
+            cpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-a",
+            emptyList()
+        )
+
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, firstCpkChecksum.toString(), 0, 0, 0)
+
+        // a new cpi object, but with same cpk
+        val secondCpkChecksum = newRandomSecureHash()
+        val updatedCpk = updatedCpk(cpk.metadata.cpkId, secondCpkChecksum)
+        val updatedCpi = mockCpiWithId(listOf(updatedCpk), cpi.metadata.cpiId)
+
+        cpiPersistence.updateMetadataAndCpks(
+            updatedCpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-b",
+            emptyList()
+        )
+
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, secondCpkChecksum.toString(), 1, 2, 1)
+
+        // a new cpi object, but with same cpk
+        val thirdChecksum = newRandomSecureHash()
+        val anotherUpdatedCpk = updatedCpk(cpk.metadata.cpkId, thirdChecksum)
+        val anotherUpdatedCpi = mockCpiWithId(listOf(anotherUpdatedCpk), cpi.metadata.cpiId)
+
+        cpiPersistence.updateMetadataAndCpks(
+            anotherUpdatedCpi,
+            "test.cpi",
+            newRandomSecureHash(),
+            UUID.randomUUID().toString(),
+            "group-b",
+            emptyList()
+        )
+
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, thirdChecksum.toString(), 2, 4, 2)
+    }
+
+    private fun findAndAssertCpk(
+        cpiId: CpiIdentifier,
+        cpkId: CpkIdentifier,
+        expectedCpkFileChecksum: String,
+        expectedMetadataEntityVersion: Int,
+        expectedFileEntityVersion: Int,
+        expectedCpiCpkEntityVersion: Int
+    ) {
+        val (cpkMetadata, cpkFile, cpiCpk) = entityManagerFactory.createEntityManager().transaction {
+            val cpiCpkKey = CpiCpkKey(
+                cpiId.name,
+                cpiId.version,
+                cpiId.signerSummaryHash.toString(),
+                cpkId.name,
+                cpkId.version,
+                cpkId.signerSummaryHash.toString()
+            )
+            val cpkKey = CpkKey(
+                cpkId.name,
+                cpkId.version,
+                cpkId.signerSummaryHash.toString()
+            )
+            val cpiCpk = it.find(CpiCpkEntity::class.java, cpiCpkKey)
+            val cpkMetadata = it.find(CpkMetadataEntity::class.java, cpkKey)
+            val cpkFile = it.find(CpkFileEntity::class.java, cpkKey)
+            Triple(cpkMetadata, cpkFile, cpiCpk)
+        }
+
+        assertThat(cpkMetadata.cpkFileChecksum).isEqualTo(expectedCpkFileChecksum)
+        assertThat(cpkFile.fileChecksum).isEqualTo(expectedCpkFileChecksum)
+
+        assertThat(cpkMetadata.entityVersion)
+            .withFailMessage("CpkMetadataEntity.entityVersion expected $expectedMetadataEntityVersion but was ${cpkMetadata.entityVersion}.")
+            .isEqualTo(expectedMetadataEntityVersion)
+        assertThat(cpkFile.entityVersion)
+            .withFailMessage("CpkFileEntity.entityVersion expected $expectedFileEntityVersion but was ${cpkFile.entityVersion}.")
+            .isEqualTo(expectedFileEntityVersion)
+        assertThat(cpiCpk.entityVersion)
+            .withFailMessage("CpiCpkEntity.entityVersion expected $expectedCpiCpkEntityVersion but was ${cpiCpk.entityVersion}.")
+            .isEqualTo(expectedCpiCpkEntityVersion)
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/RecreateBinaryTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/RecreateBinaryTest.kt
@@ -4,7 +4,7 @@ import com.google.common.jimfs.Jimfs
 import net.corda.chunking.ChunkReaderFactory
 import net.corda.chunking.ChunkWriterFactory
 import net.corda.chunking.datamodel.ChunkingEntities
-import net.corda.chunking.db.impl.persistence.DatabaseChunkPersistence
+import net.corda.chunking.db.impl.persistence.database.DatabaseChunkPersistence
 import net.corda.data.chunking.Chunk
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/ChunkPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/ChunkPersistence.kt
@@ -3,10 +3,6 @@ package net.corda.chunking.db.impl.persistence
 import net.corda.chunking.RequestId
 import net.corda.chunking.db.impl.AllChunksReceived
 import net.corda.data.chunking.Chunk
-import net.corda.libs.cpi.datamodel.CpiMetadataEntity
-import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
-import net.corda.libs.packaging.Cpi
-import net.corda.v5.crypto.SecureHash
 
 interface ChunkPersistence {
     /**
@@ -42,60 +38,4 @@ interface ChunkPersistence {
      * @param onChunk lambda method to be called on each chunk
      */
     fun forEachChunk(requestId: RequestId, onChunk: (chunk: Chunk) -> Unit)
-
-    /**
-     * Check if we already have a cpk persisted with this checksum
-     *
-     * @return true if checksum exists in the persistence layer
-     */
-    fun cpkExists(cpkChecksum: SecureHash): Boolean
-
-    /** Checks to see if the CPI exists in the database using the primary key
-     *
-     * @return true if CPI exists
-     */
-    fun cpiExists(cpiName: String, cpiVersion: String, signerSummaryHash: String): Boolean
-
-    /** Persist the CPI metadata and the CPKs
-     *
-     * @param cpi a [Cpi] object
-     * @param cpiFileName the original CPI file name
-     * @param checksum the checksum of the CPI file
-     * @param requestId the request id for the CPI that is being uploaded
-     * @param groupId the group id from the group policy file
-     * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
-     */
-    @Suppress("LongParameterList")
-    fun persistMetadataAndCpks(
-        cpi: Cpi,
-        cpiFileName: String,
-        checksum: SecureHash,
-        requestId: RequestId,
-        groupId: String,
-        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
-    ): CpiMetadataEntity
-
-    /**
-     * When CPI has previously been saved, delete all the stale data and update in place.
-     *
-     * @param cpi a [Cpi] object
-     * @param cpiFileName the original CPI file name
-     * @param checksum the checksum of the CPI file
-     * @param requestId the request id for the CPI that is being uploaded
-     * @param groupId the group id from the group policy file
-     * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
-     */
-    @Suppress("LongParameterList")
-    fun updateMetadataAndCpks(
-        cpi: Cpi,
-        cpiFileName: String,
-        checksum: SecureHash,
-        requestId: RequestId,
-        groupId: String,
-        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
-    ): CpiMetadataEntity
-
-    /** Get the group id for a given CPI */
-    fun getGroupId(cpiName: String, cpiVersion: String, signerSummaryHash: String): String?
-
 }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
@@ -1,0 +1,64 @@
+package net.corda.chunking.db.impl.persistence
+
+import net.corda.chunking.RequestId
+import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.packaging.Cpi
+import net.corda.v5.crypto.SecureHash
+
+interface CpiPersistence {
+    /**
+     * Check if we already have a cpk persisted with this checksum
+     *
+     * @return true if checksum exists in the persistence layer
+     */
+    fun cpkExists(cpkChecksum: SecureHash): Boolean
+
+    /** Checks to see if the CPI exists in the database using the primary key
+     *
+     * @return true if CPI exists
+     */
+    fun cpiExists(cpiName: String, cpiVersion: String, signerSummaryHash: String): Boolean
+
+    /** Persist the CPI metadata and the CPKs
+     *
+     * @param cpi a [Cpi] object
+     * @param cpiFileName the original CPI file name
+     * @param checksum the checksum of the CPI file
+     * @param requestId the request id for the CPI that is being uploaded
+     * @param groupId the group id from the group policy file
+     * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
+     */
+    @Suppress("LongParameterList")
+    fun persistMetadataAndCpks(
+        cpi: Cpi,
+        cpiFileName: String,
+        checksum: SecureHash,
+        requestId: RequestId,
+        groupId: String,
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
+    ): CpiMetadataEntity
+
+    /**
+     * When CPI has previously been saved, delete all the stale data and update in place.
+     *
+     * @param cpi a [Cpi] object
+     * @param cpiFileName the original CPI file name
+     * @param checksum the checksum of the CPI file
+     * @param requestId the request id for the CPI that is being uploaded
+     * @param groupId the group id from the group policy file
+     * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
+     */
+    @Suppress("LongParameterList")
+    fun updateMetadataAndCpks(
+        cpi: Cpi,
+        cpiFileName: String,
+        checksum: SecureHash,
+        requestId: RequestId,
+        groupId: String,
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
+    ): CpiMetadataEntity
+
+    /** Get the group id for a given CPI */
+    fun getGroupId(cpiName: String, cpiVersion: String, signerSummaryHash: String): String?
+}

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseChunkPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseChunkPersistence.kt
@@ -1,0 +1,190 @@
+package net.corda.chunking.db.impl.persistence.database
+
+import java.nio.ByteBuffer
+import java.time.Instant
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import net.corda.chunking.Checksum
+import net.corda.chunking.RequestId
+import net.corda.chunking.datamodel.ChunkEntity
+import net.corda.chunking.datamodel.ChunkPropertyEntity
+import net.corda.chunking.db.impl.AllChunksReceived
+import net.corda.chunking.db.impl.persistence.ChunkPersistence
+import net.corda.chunking.toAvro
+import net.corda.chunking.toCorda
+import net.corda.data.KeyValuePair
+import net.corda.data.KeyValuePairList
+import net.corda.data.chunking.Chunk
+import net.corda.orm.utils.transaction
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.crypto.SecureHash
+
+/**
+ * This class provides some simple APIs to interact with the database for manipulating chunks and their associated metadata.
+ */
+class DatabaseChunkPersistence(private val entityManagerFactory: EntityManagerFactory) : ChunkPersistence {
+    private companion object {
+        private fun Chunk.toDbProperties(): List<ChunkPropertyEntity> {
+            return properties?.items?.map {
+                ChunkPropertyEntity(requestId, it.key, it.value, Instant.now())
+            } ?: emptyList()
+        }
+
+        private fun EntityManager.getAvroChunkPropertiesInTransaction(requestId: RequestId): KeyValuePairList? {
+
+            val chunkProperties = createQuery(
+                """
+                SELECT c FROM ${ChunkPropertyEntity::class.simpleName} c
+                WHERE c.requestId = :requestId
+                """.trimIndent(),
+                ChunkPropertyEntity::class.java
+            )
+                .setParameter("requestId", requestId)
+                .resultList
+
+            return if (chunkProperties.isEmpty()) {
+                null
+            } else {
+                KeyValuePairList.newBuilder().setItems(
+                    chunkProperties.map { KeyValuePair(it.key, it.value) }.toList()
+                ).build()
+            }
+        }
+    }
+
+    /**
+     * Persist a chunk to the database and also check whether we have all chunks,
+     * and return [AllChunksReceived.YES] or `NO`.
+     *
+     * This occurs in a transaction so that only one process should "raise" one
+     * final message to the rest of the system to validate the complete binary.
+     */
+
+    override fun persistChunk(chunk: Chunk): AllChunksReceived {
+        // We put `null` into the data field if the array is empty, i.e. the final chunk
+        // so that we can write easier queries for the parts expected and received.
+        val data = if (chunk.data.array().isEmpty()) null else chunk.data.array()
+        val cordaSecureHash = chunk.checksum?.toCorda()
+        var status = AllChunksReceived.NO
+        entityManagerFactory.createEntityManager().transaction { em ->
+            // Persist this chunk.
+            val chunkEntity = ChunkEntity(
+                chunk.requestId,
+                chunk.fileName,
+                cordaSecureHash?.toString(),
+                chunk.partNumber,
+                chunk.offset,
+                data
+            )
+
+            em.persist(chunkEntity)
+
+            val chunkProperties = chunk.toDbProperties()
+
+            // Merge because same chunk property may already exist
+            chunkProperties.forEach {
+                em.merge(it)
+            }
+
+            // At this point we have at least one chunk.
+            val table = ChunkEntity::class.simpleName
+            val chunkCountIfComplete = em.createQuery(
+                """
+                SELECT 'hasAllChunks' FROM $table c1
+                INNER JOIN $table c2 ON c1.requestId = c2.requestId AND c2.data IS NULL
+                WHERE c1.requestId = :requestId AND c1.data IS NOT NULL
+                GROUP BY c1.requestId, c2.partNumber
+                HAVING COUNT(c1.requestId) = c2.partNumber
+                """.trimIndent()
+            )
+                .setParameter("requestId", chunk.requestId)
+                .resultList.count()
+
+            // [chunkCountIfComplete] is either 0, i.e. incomplete, or some non-zero value
+            // which is the total number chunks, if complete.
+            if (chunkCountIfComplete != 0) {
+                status = AllChunksReceived.YES
+            }
+        }
+
+        return status
+    }
+
+    /**
+     * Is the checksum for the given [requestId] valid?
+     *
+     * Assumes that all chunks have been received for the given [requestId]
+     */
+    override fun checksumIsValid(requestId: RequestId): Boolean {
+        var expectedChecksum: SecureHash? = null
+        var actualChecksum: ByteArray? = null
+
+        entityManagerFactory.createEntityManager().transaction { em ->
+            val streamingResults = em.createQuery(
+                "SELECT c FROM ${ChunkEntity::class.simpleName} c " +
+                        "WHERE c.requestId = :requestId " +
+                        "ORDER BY c.partNumber ASC",
+                ChunkEntity::class.java
+            )
+                .setParameter("requestId", requestId)
+                .resultStream
+
+            val messageDigest = Checksum.newMessageDigest()
+
+            streamingResults.use {
+                it.forEach { e ->
+                    if (e.data == null) { // zero chunk
+                        if (e.checksum == null) throw CordaRuntimeException("No checksum found in zero-sized chunk")
+                        expectedChecksum = SecureHash.create(e.checksum!!)
+                    } else { // non-zero chunk
+                        messageDigest.update(e.data!!)
+                    }
+                }
+            }
+
+            if (expectedChecksum == null) throw CordaRuntimeException("Expected checksum not set because no zero-sized chunk was found")
+
+            actualChecksum = messageDigest.digest()
+        }
+
+        return expectedChecksum!!.bytes.contentEquals(actualChecksum)
+    }
+
+    /**
+     * Gets chunks (if any) for a given [requestId] from database and calls [onChunk] for each chunk that is returned.
+     *
+     * @param requestId the requestId of the chunks
+     * @param onChunk lambda method to be called on each chunk
+     */
+    override fun forEachChunk(requestId: RequestId, onChunk: (chunk: Chunk) -> Unit) {
+        entityManagerFactory.createEntityManager().transaction { em ->
+            val table = ChunkEntity::class.simpleName
+            val streamingResults = em.createQuery(
+                """
+                SELECT c FROM $table c
+                WHERE c.requestId = :requestId
+                ORDER BY c.requestId ASC
+                """.trimIndent(),
+                ChunkEntity::class.java
+            )
+                .setParameter("requestId", requestId)
+                .resultStream
+
+            val avroChunkProperties = em.getAvroChunkPropertiesInTransaction(requestId)
+
+            streamingResults.use {
+                it.forEach { entity ->
+                    // Do the reverse of [persist] particularly for data - if null, return zero bytes.
+                    val checksum = if (entity.checksum != null) SecureHash.create(entity.checksum!!).toAvro() else null
+                    val data = if (entity.data != null) ByteBuffer.wrap(entity.data) else ByteBuffer.allocate(0)
+                    val chunk = Chunk(
+                        requestId, entity.fileName, checksum, entity.partNumber, entity.offset, data,
+                        avroChunkProperties
+                    )
+                    onChunk(chunk)
+                }
+            }
+        }
+    }
+
+}

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
@@ -1,208 +1,35 @@
-package net.corda.chunking.db.impl.persistence
+package net.corda.chunking.db.impl.persistence.database
 
-import net.corda.chunking.Checksum
-import net.corda.chunking.RequestId
-import net.corda.chunking.datamodel.ChunkEntity
-import net.corda.chunking.datamodel.ChunkPropertyEntity
-import net.corda.chunking.db.impl.AllChunksReceived
-import net.corda.chunking.db.impl.persistence.PersistenceUtils.signerSummaryHashForDbQuery
-import net.corda.chunking.toAvro
-import net.corda.chunking.toCorda
-import net.corda.data.KeyValuePair
-import net.corda.data.KeyValuePairList
-import net.corda.data.chunking.Chunk
-import net.corda.libs.cpi.datamodel.CpiMetadataEntity
-import net.corda.libs.cpi.datamodel.CpiMetadataEntityKey
-import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
-import net.corda.libs.cpi.datamodel.CpkFileEntity
-import net.corda.libs.cpi.datamodel.CpkMetadataEntity
-import net.corda.libs.packaging.Cpi
-import net.corda.libs.packaging.Cpk
-import net.corda.orm.utils.transaction
-import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
-import net.corda.v5.crypto.SecureHash
-import java.nio.ByteBuffer
 import java.nio.file.Files
-import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.LockModeType
 import javax.persistence.NonUniqueResultException
+import net.corda.chunking.RequestId
+import net.corda.chunking.db.impl.persistence.CpiPersistence
+import net.corda.chunking.db.impl.persistence.PersistenceUtils.signerSummaryHashForDbQuery
 import net.corda.chunking.db.impl.persistence.PersistenceUtils.toCpkKey
 import net.corda.libs.cpi.datamodel.CpiCpkEntity
 import net.corda.libs.cpi.datamodel.CpiCpkKey
+import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpiMetadataEntityKey
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.CpkFileEntity
 import net.corda.libs.cpi.datamodel.CpkKey
+import net.corda.libs.cpi.datamodel.CpkMetadataEntity
+import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.Cpk
+import net.corda.orm.utils.transaction
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.crypto.SecureHash
 
 /**
- * This class provides some simple APIs to interact with the database.
+ * This class provides some simple APIs to interact with the database for manipulating CPIs, CPKs and their associated metadata.
  */
-@Suppress("TooManyFunctions")
-class DatabaseChunkPersistence(private val entityManagerFactory: EntityManagerFactory) : ChunkPersistence {
+class DatabaseCpiPersistence(private val entityManagerFactory: EntityManagerFactory) : CpiPersistence {
+
     private companion object {
         val log = contextLogger()
-
-        private fun Chunk.toDbProperties(): List<ChunkPropertyEntity> {
-            return properties?.items?.map {
-                ChunkPropertyEntity(requestId, it.key, it.value, Instant.now())
-            } ?: emptyList()
-        }
-
-        private fun EntityManager.getAvroChunkPropertiesInTransaction(requestId: RequestId): KeyValuePairList? {
-
-            val chunkProperties = createQuery(
-                """
-                SELECT c FROM ${ChunkPropertyEntity::class.simpleName} c
-                WHERE c.requestId = :requestId
-                """.trimIndent(),
-                ChunkPropertyEntity::class.java
-            )
-                .setParameter("requestId", requestId)
-                .resultList
-
-            return if (chunkProperties.isEmpty()) {
-                null
-            } else {
-                KeyValuePairList.newBuilder().setItems(
-                    chunkProperties.map { KeyValuePair(it.key, it.value) }.toList()
-                ).build()
-            }
-        }
-    }
-
-    /**
-     * Persist a chunk to the database and also check whether we have all chunks,
-     * and return [AllChunksReceived.YES] or `NO`.
-     *
-     * This occurs in a transaction so that only one process should "raise" one
-     * final message to the rest of the system to validate the complete binary.
-     */
-
-    override fun persistChunk(chunk: Chunk): AllChunksReceived {
-        // We put `null` into the data field if the array is empty, i.e. the final chunk
-        // so that we can write easier queries for the parts expected and received.
-        val data = if (chunk.data.array().isEmpty()) null else chunk.data.array()
-        val cordaSecureHash = chunk.checksum?.toCorda()
-        var status = AllChunksReceived.NO
-        entityManagerFactory.createEntityManager().transaction { em ->
-            // Persist this chunk.
-            val chunkEntity = ChunkEntity(
-                chunk.requestId,
-                chunk.fileName,
-                cordaSecureHash?.toString(),
-                chunk.partNumber,
-                chunk.offset,
-                data
-            )
-
-            em.persist(chunkEntity)
-
-            val chunkProperties = chunk.toDbProperties()
-
-            // Merge because same chunk property may already exist
-            chunkProperties.forEach {
-                em.merge(it)
-            }
-
-            // At this point we have at least one chunk.
-            val table = ChunkEntity::class.simpleName
-            val chunkCountIfComplete = em.createQuery(
-                """
-                SELECT 'hasAllChunks' FROM $table c1
-                INNER JOIN $table c2 ON c1.requestId = c2.requestId AND c2.data IS NULL
-                WHERE c1.requestId = :requestId AND c1.data IS NOT NULL
-                GROUP BY c1.requestId, c2.partNumber
-                HAVING COUNT(c1.requestId) = c2.partNumber
-                """.trimIndent()
-            )
-                .setParameter("requestId", chunk.requestId)
-                .resultList.count()
-
-            // [chunkCountIfComplete] is either 0, i.e. incomplete, or some non-zero value
-            // which is the total number chunks, if complete.
-            if (chunkCountIfComplete != 0) {
-                status = AllChunksReceived.YES
-            }
-        }
-
-        return status
-    }
-
-    /**
-     * Is the checksum for the given [requestId] valid?
-     *
-     * Assumes that all chunks have been received for the given [requestId]
-     */
-    override fun checksumIsValid(requestId: RequestId): Boolean {
-        var expectedChecksum: SecureHash? = null
-        var actualChecksum: ByteArray? = null
-
-        entityManagerFactory.createEntityManager().transaction { em ->
-            val streamingResults = em.createQuery(
-                "SELECT c FROM ${ChunkEntity::class.simpleName} c " +
-                        "WHERE c.requestId = :requestId " +
-                        "ORDER BY c.partNumber ASC",
-                ChunkEntity::class.java
-            )
-                .setParameter("requestId", requestId)
-                .resultStream
-
-            val messageDigest = Checksum.newMessageDigest()
-
-            streamingResults.use {
-                it.forEach { e ->
-                    if (e.data == null) { // zero chunk
-                        if (e.checksum == null) throw CordaRuntimeException("No checksum found in zero-sized chunk")
-                        expectedChecksum = SecureHash.create(e.checksum!!)
-                    } else { // non-zero chunk
-                        messageDigest.update(e.data!!)
-                    }
-                }
-            }
-
-            if (expectedChecksum == null) throw CordaRuntimeException("Expected checksum not set because no zero-sized chunk was found")
-
-            actualChecksum = messageDigest.digest()
-        }
-
-        return expectedChecksum!!.bytes.contentEquals(actualChecksum)
-    }
-
-    /**
-     * Gets chunks (if any) for a given [requestId] from database and calls [onChunk] for each chunk that is returned.
-     *
-     * @param requestId the requestId of the chunks
-     * @param onChunk lambda method to be called on each chunk
-     */
-    override fun forEachChunk(requestId: RequestId, onChunk: (chunk: Chunk) -> Unit) {
-        entityManagerFactory.createEntityManager().transaction { em ->
-            val table = ChunkEntity::class.simpleName
-            val streamingResults = em.createQuery(
-                """
-                SELECT c FROM $table c
-                WHERE c.requestId = :requestId
-                ORDER BY c.requestId ASC
-                """.trimIndent(),
-                ChunkEntity::class.java
-            )
-                .setParameter("requestId", requestId)
-                .resultStream
-
-            val avroChunkProperties = em.getAvroChunkPropertiesInTransaction(requestId)
-
-            streamingResults.use {
-                it.forEach { entity ->
-                    // Do the reverse of [persist] particularly for data - if null, return zero bytes.
-                    val checksum = if (entity.checksum != null) SecureHash.create(entity.checksum!!).toAvro() else null
-                    val data = if (entity.data != null) ByteBuffer.wrap(entity.data) else ByteBuffer.allocate(0)
-                    val chunk = Chunk(
-                        requestId, entity.fileName, checksum, entity.partNumber, entity.offset, data,
-                        avroChunkProperties
-                    )
-                    onChunk(chunk)
-                }
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
`DatabaseChunkPersistence` is getting quite big so refactoring will split the big file into two separate concerns behind two separate interfaces, allowing multiple teams to work on implementations with fewer conflicts, and improving the logical split.

Proposal - ChunkPersistance and CpiPersistence (currently CpkEntityPersistence but I think CpiPersistence is better fit).