### PR TITLE
CORE-4429 Update Link Manager to be compatable with new JSON Schema

### DIFF
--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/LinkManagerConfiguration.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/LinkManagerConfiguration.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import net.corda.data.config.Configuration
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_ALGORITHM_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.ReplayAlgorithm
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
@@ -107,7 +108,7 @@ class LinkManagerConfiguration : Callable<Collection<Record<String, Configuratio
         val replayAlgorithmInnerConfig = when (replayAlgorithm) {
             ReplayAlgorithm.Constant -> {
                 ConfigFactory.empty().withValue(
-                    LinkManagerConfiguration.REPLAY_PERIOD_KEY,
+                    LinkManagerConfiguration.MESSAGE_REPLAY_PERIOD_KEY,
                     ConfigValueFactory.fromAnyRef(messageReplayPeriodMilliSecs)
                 )
             }
@@ -121,7 +122,10 @@ class LinkManagerConfiguration : Callable<Collection<Record<String, Configuratio
                 )
             }
         }
-        val configuration = baseConfiguration.withValue(replayAlgorithm.configKeyName(), replayAlgorithmInnerConfig.root())
+        val configuration = baseConfiguration.withValue(
+            REPLAY_ALGORITHM_KEY,
+            ConfigFactory.empty().withValue(replayAlgorithm.configKeyName(), replayAlgorithmInnerConfig.root()).root()
+        )
 
         return listOf(
             configuration.toConfigurationRecord(

--- a/applications/tools/p2p-test/p2p-setup/src/test/kotlin/net/corda/p2p/setup/LinkManagerConfigurationTest.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/test/kotlin/net/corda/p2p/setup/LinkManagerConfigurationTest.kt
@@ -6,15 +6,14 @@ import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companio
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MAX_MESSAGE_SIZE_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MAX_REPLAYING_MESSAGES_PER_PEER
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_PERIOD_CUTOFF_KEY
-import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_PERIOD_KEY
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MESSAGE_REPLAY_PERIOD_KEY
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_ALGORITHM_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.SESSIONS_PER_PEER_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.SESSION_TIMEOUT_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.ReplayAlgorithm.Constant
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.ReplayAlgorithm.ExponentialBackoff
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Test
-
 
 class LinkManagerConfigurationTest {
 
@@ -54,8 +53,8 @@ class LinkManagerConfigurationTest {
             it.assertThat(config.getValue(HEARTBEAT_MESSAGE_PERIOD_KEY).unwrapped()).isEqualTo(HEARTBEAT_MESSAGE_REPLAY_PERIOD.toInt())
             it.assertThat(config.getValue(SESSION_TIMEOUT_KEY).unwrapped()).isEqualTo(SESSION_TIMEOUT.toInt())
             it.assertThat(config.getValue(SESSIONS_PER_PEER_KEY).unwrapped()).isEqualTo(SESSIONS_PER_PEER.toInt())
-            val innerConfig = config.getConfig(Constant.configKeyName())
-            it.assertThat(innerConfig.getValue(REPLAY_PERIOD_KEY).unwrapped()).isEqualTo(MESSAGE_REPLAY_PERIOD.toInt())
+            val innerConfig = config.getConfig(REPLAY_ALGORITHM_KEY).getConfig(Constant.configKeyName())
+            it.assertThat(innerConfig.getValue(MESSAGE_REPLAY_PERIOD_KEY).unwrapped()).isEqualTo(MESSAGE_REPLAY_PERIOD.toInt())
         }
     }
 
@@ -81,7 +80,7 @@ class LinkManagerConfigurationTest {
             it.assertThat(config.getValue(HEARTBEAT_MESSAGE_PERIOD_KEY).unwrapped()).isEqualTo(HEARTBEAT_MESSAGE_REPLAY_PERIOD.toInt())
             it.assertThat(config.getValue(SESSION_TIMEOUT_KEY).unwrapped()).isEqualTo(SESSION_TIMEOUT.toInt())
             it.assertThat(config.getValue(SESSIONS_PER_PEER_KEY).unwrapped()).isEqualTo(SESSIONS_PER_PEER.toInt())
-            val innerConfig = config.getConfig(ExponentialBackoff.configKeyName())
+            val innerConfig = config.getConfig(REPLAY_ALGORITHM_KEY).getConfig(ExponentialBackoff.configKeyName())
             it.assertThat(innerConfig.getValue(BASE_REPLAY_PERIOD_KEY).unwrapped()).isEqualTo(MESSAGE_REPLAY_PERIOD_BASE.toInt())
             it.assertThat(innerConfig.getValue(REPLAY_PERIOD_CUTOFF_KEY).unwrapped()).isEqualTo(MESSAGE_REPLAY_CUT_OFF.toInt())
         }

--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
@@ -61,14 +61,20 @@ class LinkManagerIntegrationTest {
     private val replayPeriod = 2000
     private fun createLinkManagerConfiguration(replayPeriod: Int): Config {
         val innerConfig = ConfigFactory.empty()
-            .withValue(LinkManagerConfiguration.REPLAY_PERIOD_KEY, ConfigValueFactory.fromAnyRef(replayPeriod))
+            .withValue(LinkManagerConfiguration.MESSAGE_REPLAY_PERIOD_KEY, ConfigValueFactory.fromAnyRef(replayPeriod))
         return ConfigFactory.empty()
             .withValue(MAX_MESSAGE_SIZE_KEY, ConfigValueFactory.fromAnyRef(1000000))
             .withValue(MAX_REPLAYING_MESSAGES_PER_PEER, ConfigValueFactory.fromAnyRef(100))
             .withValue(HEARTBEAT_MESSAGE_PERIOD_KEY, ConfigValueFactory.fromAnyRef(2000))
             .withValue(SESSION_TIMEOUT_KEY, ConfigValueFactory.fromAnyRef(10000))
             .withValue(SESSIONS_PER_PEER_KEY, ConfigValueFactory.fromAnyRef(4))
-            .withValue(LinkManagerConfiguration.ReplayAlgorithm.Constant.configKeyName(), innerConfig.root())
+            .withValue(
+                LinkManagerConfiguration.REPLAY_ALGORITHM_KEY,
+                ConfigFactory.empty().withValue(
+                    LinkManagerConfiguration.ReplayAlgorithm.Constant.configKeyName(),
+                    innerConfig.root()
+                ).root()
+            )
     }
 
     private val bootstrapConfig = SmartConfigFactory.create(ConfigFactory.empty())

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -26,7 +26,8 @@ import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.HEARTBEAT_MESSAGE_PERIOD_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MAX_MESSAGE_SIZE_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MAX_REPLAYING_MESSAGES_PER_PEER
-import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_PERIOD_KEY
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_ALGORITHM_KEY
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MESSAGE_REPLAY_PERIOD_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.SESSIONS_PER_PEER_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.SESSION_TIMEOUT_KEY
 import net.corda.lifecycle.impl.LifecycleCoordinatorFactoryImpl
@@ -385,11 +386,16 @@ class P2PLayerEndToEndTest {
                 .withValue(HEARTBEAT_MESSAGE_PERIOD_KEY, ConfigValueFactory.fromAnyRef(Duration.ofSeconds(2)))
                 .withValue(SESSION_TIMEOUT_KEY, ConfigValueFactory.fromAnyRef(Duration.ofSeconds(10)))
                 .withValue(SESSIONS_PER_PEER_KEY, ConfigValueFactory.fromAnyRef(4))
-                .withValue(LinkManagerConfiguration.ReplayAlgorithm.Constant.configKeyName(), replayConfig.root())
+                .withValue(
+                    REPLAY_ALGORITHM_KEY,
+                    ConfigFactory.empty().withValue(
+                        LinkManagerConfiguration.ReplayAlgorithm.Constant.configKeyName(),
+                        replayConfig.root()
+                    ).root())
         }
         private val replayConfig by lazy {
             ConfigFactory.empty()
-                .withValue(REPLAY_PERIOD_KEY, ConfigValueFactory.fromAnyRef(Duration.ofSeconds(2)))
+                .withValue(MESSAGE_REPLAY_PERIOD_KEY, ConfigValueFactory.fromAnyRef(Duration.ofSeconds(2)))
         }
 
         private fun readKeyStore(fileName: String): ByteArray {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/ReplaySchedulerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/ReplaySchedulerTest.kt
@@ -84,9 +84,14 @@ class ReplaySchedulerTest {
             clock = mockTimeFacilitiesProvider.clock
         )
         val inner = ConfigFactory.empty()
-            .withValue(LinkManagerConfiguration.REPLAY_PERIOD_KEY, ConfigValueFactory.fromAnyRef(replayPeriod))
+            .withValue(LinkManagerConfiguration.MESSAGE_REPLAY_PERIOD_KEY, ConfigValueFactory.fromAnyRef(replayPeriod))
         val config = ConfigFactory.empty()
-            .withValue(LinkManagerConfiguration.ReplayAlgorithm.Constant.configKeyName(), inner.root())
+            .withValue(
+                LinkManagerConfiguration.REPLAY_ALGORITHM_KEY,
+                ConfigFactory.empty().withValue(
+                    LinkManagerConfiguration.ReplayAlgorithm.Constant.configKeyName(), inner.root()
+                ).root()
+            )
             .withValue(LinkManagerConfiguration.MAX_REPLAYING_MESSAGES_PER_PEER, ConfigValueFactory.fromAnyRef(MAX_REPLAYING_MESSAGES)
         )
         val replaySchedulerConfig = replayScheduler.fromConfig(config)
@@ -109,7 +114,12 @@ class ReplaySchedulerTest {
             .withValue(LinkManagerConfiguration.BASE_REPLAY_PERIOD_KEY, ConfigValueFactory.fromAnyRef(replayPeriod))
             .withValue(LinkManagerConfiguration.REPLAY_PERIOD_CUTOFF_KEY, ConfigValueFactory.fromAnyRef(cutOff))
         val config = ConfigFactory.empty()
-            .withValue(LinkManagerConfiguration.ReplayAlgorithm.ExponentialBackoff.configKeyName(), inner.root())
+            .withValue(
+                LinkManagerConfiguration.REPLAY_ALGORITHM_KEY,
+                ConfigFactory.empty().withValue(
+                    LinkManagerConfiguration.ReplayAlgorithm.ExponentialBackoff.configKeyName(), inner.root()
+                ).root()
+            )
             .withValue(LinkManagerConfiguration.MAX_REPLAYING_MESSAGES_PER_PEER, ConfigValueFactory.fromAnyRef(MAX_REPLAYING_MESSAGES))
         val replaySchedulerConfig = replayScheduler.fromConfig(config)
                 as ReplayScheduler.ReplaySchedulerConfig.ExponentialBackoffReplaySchedulerConfig

--- a/libs/configuration/configuration-schema/p2p/src/main/kotlin/net/corda/libs/configuration/schema/p2p/LinkManagerConfiguration.kt
+++ b/libs/configuration/configuration-schema/p2p/src/main/kotlin/net/corda/libs/configuration/schema/p2p/LinkManagerConfiguration.kt
@@ -3,24 +3,25 @@ package net.corda.libs.configuration.schema.p2p
 class LinkManagerConfiguration {
 
     companion object {
-        const val PACKAGE_NAME = "net.corda.p2p.linkmanager"
+        const val PACKAGE_NAME = "corda.p2p"
         const val COMPONENT_NAME = "linkManager"
         const val CONFIG_KEY = "$PACKAGE_NAME.$COMPONENT_NAME"
 
         const val MAX_MESSAGE_SIZE_KEY = "maxMessageSize"
-        const val REPLAY_PERIOD_KEY = "replayPeriod"
+        const val MESSAGE_REPLAY_PERIOD_KEY = "messageReplayPeriod"
         const val BASE_REPLAY_PERIOD_KEY = "baseReplayPeriod"
         const val REPLAY_PERIOD_CUTOFF_KEY = "replayPeriodCutoff"
-        const val MAX_REPLAYING_MESSAGES_PER_PEER = "maxMessages"
+        const val MAX_REPLAYING_MESSAGES_PER_PEER = "maxReplayingMessages"
         const val HEARTBEAT_MESSAGE_PERIOD_KEY = "heartbeatMessagePeriod"
         const val SESSION_TIMEOUT_KEY = "sessionTimeout"
         const val SESSIONS_PER_PEER_KEY = "sessionsPerPeer"
+        const val REPLAY_ALGORITHM_KEY = "replayAlgorithm"
     }
 
     enum class ReplayAlgorithm {
         Constant, ExponentialBackoff;
         fun configKeyName(): String {
-            return this.name + this.declaringClass.simpleName
+            return this.name.replaceFirstChar { it.lowercase() }
         }
     }
 }


### PR DESCRIPTION
Changed the LinkManager to be compatible with the JSON config schema. To make the defaulting logic work I added an extra layer of inner config which specifies the `ReplayAlgorithm`. So the config changes from:
```
{
  "heartbeatMessagePeriod" : 2000,
  "maxMessageSize" : 1000000, 
  "maxMessages" : 100,
  "exponentialBackoff" {
    "baseReplayPeriod" : 2000, 
    "replayPeriodCutoff" : 10000
 },
 "sessionTimeout" : 10000,
 "sessionsPerPeer" : 4
}
```
to:
```
{
  "heartbeatMessagePeriod" : 2000,
  "maxMessageSize" : 1000000, 
  "maxReplayingMessages" : 100,
  "replayAlgorithm" { 
    "exponentialBackoff" {
       "baseReplayPeriod" : 2000, 
       "replayPeriodCutoff" : 10000
     }
  },
 "sessionTimeout" : 10000,
 "sessionsPerPeer" : 4
}
```
Merge https://github.com/corda/corda-api/pull/437 first.

Testing
======
1. Create a K8s namespace
`kubectl create namespace corda`
2. Deploy pre-requisites (with TLS turned off) run from top level of `corda-dev-helm` repo:
```
helm repo add bitnami https://charts.bitnami.com/bitnami
helm dependency build charts/corda-dev
helm upgrade --install prereqs -n corda \
  charts/corda-dev \
  --set kafka.replicaCount=1,kafka.zookeeper.replicaCount=1 \
  --render-subchart-notes \
 --values values.yaml \
  --timeout 10m \
  --wait
```
where `values.yaml` contains:
```
kafka:
  auth:
    clientProtocol: plaintext
```
3. Deploy Corda into K8's run from top level of `corda-runtime-os` repo:
```
helm upgrade --install corda -n corda \
  charts/corda \
  --values values.yaml \
  --wait
```
where `values.yaml` contains:
```
imagePullPolicy: IfNotPresent
image:
  registry: corda-os-docker-dev.software.r3.com
  tag: latest-local

kafka:
  bootstrapServers: prereqs-kafka:9092
  replicas: 1
  tls:
    enabled: false
    truststore:
      secretRef:
        name: prereqs-kafka-0-tls

db:
  cluster:
    host: prereqs-postgresql.corda # NOTE: corda here is the current namespace, change in case you are deploying to a different
    existingSecret: prereqs-postgresql
```
4. Expose the RPC workers end point.
```
kubectl port-forward --namespace corda deployment/corda-rpc-worker 8888
```
5. Start `kubefwd` so the LinkManager can talk to Kafka from outside of K8s
```
kubefwd svc -n corda
```
6. Start the LinkManager connecting to Kafka:
```
java -jar applications/p2p-link-manager/build/bin/corda-p2p-link-manager-5.0.0.0-SNAPSHOT.jar --kafka-servers=prereqs-kafka:9092
```
The Link Manager starts using the default config inside `logs/app.log`:
```
2022-06-22 09:34:14.605 [compacted subscription thread CONFIGURATION_READ-config.topic] INFO  net.corda.configuration.read.impl.ConfigProcessor - Received configuration for key corda.p2p.linkManager: {
    "heartbeatMessagePeriod" : 2000,
    "maxMessageSize" : 1000000,
    "maxReplayingMessages" : 100,
    "replayAlgorithm" : {
        "constant" : {
            "messageReplayPeriod" : 2000
        }
    },
    "sessionTimeout" : 10000,
    "sessionsPerPeer" : 4
}
```
We also see:
```
2022-06-22 09:34:14.611 [lifecycle-coordinator-18] INFO  ReplayScheduler-1 - Received valid config for ReplayScheduler-1.
```
etc.

Updating the Config
----

The LinkManager accepts config changes, when running. These can be made using the RPC workers end point.
For example to push the default config:
```
curl --insecure -u admin:admin  -X PUT -d @config.json  https://localhost:8888/api/v1/config
```
Where `config.json` contains:
```
{
  "request": {
      "config": "{ }",
      "schemaVersion": {
          "major": 1,
          "minor": 0
      },
      "section": "corda.p2p.linkManager",
      "version": 0
  }
}
```
We get a response back with the defaults filled in:
```
Handling connection for 8888
{"section":"corda.p2p.linkManager","config":"{\"heartbeatMessagePeriod\":2000,\"maxMessageSize\":1000000,\"maxReplayingMessages\":100,\"replayAlgorithm\":{\"constant\":{\"messageReplayPeriod\":2000}},\"sessionTimeout\":10000,\"sessionsPerPeer\":4}","schemaVersion":{"major":1,"minor":0},"version":1}%
```
As the config is the same as before, we see in the logs:
```
2022-06-22 09:58:35.854 [lifecycle-coordinator-26] INFO  ReplayScheduler-1 - Config applied with no update.
```
To turn on exponential backoff we can use the same command where `config.json` contains:
```
{
  "request": {
      "config": "{ \"replayAlgorithm\": { \"exponentialBackoff\": {} } }",
      "schemaVersion": {
          "major": 1,
          "minor": 0
      },
      "section": "corda.p2p.linkManager",
      "version": 1
  }
}
```
We get a response with the defaults for exponentialBackoff:
```
{"section":"corda.p2p.linkManager","config":"{\"heartbeatMessagePeriod\":2000,\"maxMessageSize\":1000000,\"maxReplayingMessages\":100,\"replayAlgorithm\":{\"exponentialBackoff\":{\"baseReplayPeriod\":2000,\"replayPeriodCutoff\":10000}},\"sessionTimeout\":10000,\"sessionsPerPeer\":4}","schemaVersion":{"major":1,"minor":0},"version":2}%
```
Note we had to increment the version in the request. Any default can be overriden by specifying it in the request. 