### PR TITLE
CORE-4880 Persist cpk Liquibase scripts

### DIFF
--- a/components/chunking/chunk-db-write-impl/build.gradle
+++ b/components/chunking/chunk-db-write-impl/build.gradle
@@ -3,6 +3,13 @@ plugins {
     id 'corda.common-publishing'
 }
 
+configurations {
+    cpis {
+        canBeConsumed = false
+        transitive = false
+    }
+}
+
 description 'Chunk database writer impl'
 
 dependencies {
@@ -24,6 +31,8 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(':libs:db:db-core')
     implementation project(':libs:db:db-orm')
+    implementation project(':libs:db:db-admin')
+
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:virtual-node:cpi-datamodel")
@@ -41,12 +50,26 @@ dependencies {
     testImplementation project(':libs:db:db-admin-impl')
     testImplementation project(':libs:db:db-orm-impl')
     testImplementation project(':testing:db-testkit')
+    testImplementation project(':testing:test-utilities')
 
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
     testRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     testRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
+
+    cpis project(path: ':testing:cpbs:extendable-cpb', configuration: 'cordaCPB')
+}
+
+def testResources = tasks.named('processTestResources', ProcessResources) {
+    from(configurations.cpis) {
+        rename "(.*)-\\Q${version}\\E-package.cpb", "\$1.cpb"
+        into 'META-INF'
+    }
+}
+
+tasks.named('test', Test) {
+    dependsOn testResources
 }
 
 tasks.named('jar', Jar) {

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
@@ -20,6 +20,7 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
 import net.corda.utilities.PathProvider
 import net.corda.utilities.TempPathProvider
+import net.corda.utilities.time.UTCClock
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -95,8 +96,14 @@ class ChunkDbWriterFactoryImpl(
         val statusPublisher = StatusPublisher(statusTopic, publisher)
         val cpiCacheDir = tempPathProvider.getOrCreate(bootConfig, CPI_CACHE_DIR)
         val cpiPartsDir = tempPathProvider.getOrCreate(bootConfig, CPI_PARTS_DIR)
-        val validator =
-            CpiValidatorImpl(statusPublisher, persistence, cpiInfoWriteService, cpiCacheDir, cpiPartsDir)
+        val validator = CpiValidatorImpl(
+            statusPublisher,
+            persistence,
+            cpiInfoWriteService,
+            cpiCacheDir,
+            cpiPartsDir,
+            UTCClock()
+        )
         val processor = ChunkWriteToDbProcessor(statusPublisher, persistence, validator)
         val subscriptionConfig = SubscriptionConfig(GROUP_NAME, uploadTopic)
         return try {

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/JarWalker.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/JarWalker.kt
@@ -1,0 +1,60 @@
+package net.corda.chunking.db.impl.cpi.liquibase
+
+import java.io.ByteArrayInputStream
+import java.io.FilterInputStream
+import java.io.InputStream
+import java.util.jar.JarInputStream
+
+
+/**
+ * Simple class to traverse a jar input stream, and call 'onEntry' for each entry.
+ */
+object JarWalker {
+    /**
+     * Don't descend into lots of nested jars - we own the CPK format,
+     * we expect a jar immediately inside the CPK at the 'root' level of the archive.
+     *
+     * Allow for a `cpi`, that contains a `cpb`, that contain the "final" `jar`
+     */
+    private const val maxDepth = 2
+
+    /**
+     * Walk a jar-like archive and call the [onEntry] callback.
+     *
+     * We call this method on a CPK, and then again, on the `jar` inside it.
+     */
+    fun walk(inputStream: InputStream, onEntry: (String, InputStream) -> Unit) = walk(0, inputStream, onEntry)
+
+    @Suppress("NestedBlockDepth")
+    private fun walk(depth: Int, inputStream: InputStream, onEntry: (String, InputStream) -> Unit) {
+        // We don't own the input stream, so we don't close it.
+        // Instead, read bytes into a buffer that we *do own*.
+        // As long as no-one loads a multi-Gb jar we're fine (this is the same
+        // jar loading code as the cpk/cpi loaders so that's doomed too).
+        val buffer = inputStream.readAllBytes()
+
+        // We "own" the CPK format, the actual "jar" is at the top level.
+        if (depth > maxDepth) return
+
+        ByteArrayInputStream(buffer).use {
+            JarInputStream(it).use { jarInputStream ->
+                while (true) {
+                    val entry = jarInputStream.nextJarEntry ?: break
+
+                    // We *might* want to additionally filter on the jar here as well
+                    // to ensure it's a Cordapp one.
+                    if (entry.name.lowercase().endsWith(".jar") || entry.name.lowercase().endsWith(".cpk")) {
+                        walk(depth + 1, UncloseableInputStream(jarInputStream), onEntry)
+                    } else {
+                        onEntry(entry.name, UncloseableInputStream(jarInputStream))
+                    }
+                }
+            }
+        }
+    }
+
+    /** We don't want any method to close the jar input stream other than "us". */
+    internal class UncloseableInputStream(source: InputStream) : FilterInputStream(source) {
+        override fun close() {}
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractor.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractor.kt
@@ -1,0 +1,48 @@
+package net.corda.chunking.db.impl.cpi.liquibase
+
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.Cpk
+import net.corda.v5.base.util.contextLogger
+import java.nio.file.Files
+
+class LiquibaseExtractor {
+    companion object {
+        private val log = contextLogger()
+    }
+
+    /**
+     * Extract liquibase scripts from the CPI and persist them to the database.
+     *
+     * @return list of entities to be inserted into db containing liquibase scripts
+     */
+    fun extractLiquibaseEntitiesFromCpi(cpi: Cpi) : List<CpkDbChangeLogEntity> {
+        val entities = mutableListOf<CpkDbChangeLogEntity>()
+        log.info("Extracting liquibase files from for CPI: ${cpi.metadata.cpiId}")
+        cpi.cpks.forEach { entities += extractLiquibaseFromCpk(it) }
+
+        if (entities.isEmpty()) {
+            log.warn("Extracting liquibase finished although none were found for ${cpi.metadata.cpiId}")
+        }
+
+        return entities
+    }
+
+    /**
+     * Extract liquibase scripts from a CPK and persist them to the database.
+     *
+     * @return the extracted entities containing the liquibase scripts
+     */
+    private fun extractLiquibaseFromCpk(cpk: Cpk) : List<CpkDbChangeLogEntity> {
+        val entities = mutableListOf<CpkDbChangeLogEntity>()
+
+        log.info("Extracting liquibase files from ${cpk.metadata.cpkId}")
+        // We expect [Cpk.path] to be non-null here because it has been previously extracted to local disk above.
+        Files.newInputStream(cpk.path!!).use {
+            entities += LiquibaseExtractorHelpers().getEntities(cpk, it)
+        }
+        log.info("Extracting liquibase files finished for ${cpk.metadata.cpkId}")
+
+        return entities
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractorHelpers.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractorHelpers.kt
@@ -1,0 +1,116 @@
+package net.corda.chunking.db.impl.cpi.liquibase
+
+import net.corda.chunking.db.impl.persistence.PersistenceUtils.signerSummaryHashForDbQuery
+import net.corda.db.admin.LiquibaseXmlConstants.DB_CHANGE_LOG_ROOT_ELEMENT
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogKey
+import net.corda.libs.packaging.Cpk
+import net.corda.v5.base.util.contextLogger
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.StringReader
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamException
+import javax.xml.stream.events.XMLEvent
+
+/**
+ * Some helper methods to extract the Liquibase XML from a [Cpk]
+ */
+@Suppress("unused_parameter")
+class LiquibaseExtractorHelpers {
+    companion object {
+        private const val MIGRATION_FOLDER = "migration"
+        private val log = contextLogger()
+    }
+
+    /**
+     * For the given [content] string, test that:
+     *
+     * * it is XML
+     * * it starts with the Liquibase root element `databaseChangeLog`
+     * * the root element has the `xmlns` attribute set.
+     */
+    @Suppress("NestedBlockDepth")
+    fun isLiquibaseXml(content: String): Boolean {
+        val reader = XMLInputFactory.newInstance().createXMLStreamReader(StringReader(content))
+
+        try {
+            while (reader.hasNext()) {
+                when (reader.next()) {
+                    XMLEvent.START_ELEMENT -> {
+                        if (reader.name.localPart == DB_CHANGE_LOG_ROOT_ELEMENT) {
+                            val xmlns = reader.getAttributeValue(null, "xmlns")
+                            if (xmlns != null) return true
+                        }
+                    }
+                }
+            }
+        } catch (e: XMLStreamException) {
+            log.error("Unexpected content in possible liquibase XML file", e)
+            return false
+        } catch (e: Exception) {
+            log.error("Unexpected exception when parsing possible liquibase XML file", e)
+            return false
+        }
+
+        return false
+    }
+
+
+    /**
+     * For the given [Cpk] extract all Liquibase scripts that exist and convert
+     * them into entities that we can persist to the database.
+     */
+    fun getEntities(cpk: Cpk, inputStream: InputStream): List<CpkDbChangeLogEntity> {
+        log.info("Processing ${cpk.metadata.cpkId} for Liquibase files")
+        val entities = mutableListOf<CpkDbChangeLogEntity>()
+        JarWalker.walk(inputStream) { path, it ->
+            if (!isMigrationFile(path)) return@walk
+            val content = validateXml(path, it) ?: return@walk
+            entities.add(createEntity(cpk, path, content))
+        }
+        log.info("Processing ${cpk.metadata.cpkId} for Liquibase files finished")
+        return entities
+    }
+
+    /**
+     * Is the file in `resources/migration` folder and has file extension `.xml` ?
+     */
+    private fun isMigrationFile(path: String) = path.lowercase()
+        .endsWith(".xml") && (path.startsWith(MIGRATION_FOLDER) || path.startsWith("/$MIGRATION_FOLDER"))
+
+    /**
+     * Validate the (expected) XML in the [inputStream] is Liquibase
+     *
+     * @return the XML as a [String] or null if it is invalid
+     */
+    private fun validateXml(path: String, inputStream: InputStream): String? {
+        val content = try {
+            BufferedReader(inputStream.reader()).readText()
+        } catch (e: Exception) {
+            log.warn("Could not read as text: $path", e)
+            return null
+        }
+
+        if (content.isEmpty() || content.isBlank()) {
+            log.debug("Skipping empty XML string for $path")
+            return null
+        }
+
+        if (!isLiquibaseXml(content)) {
+            log.error("Could not read Liquibase file $path")
+            return null
+        }
+
+        return content
+    }
+
+    /**
+     * Create db entity containing the Liquibase script for the given [Cpk]
+     */
+    private fun createEntity(cpk: Cpk, path: String, xmlContent: String): CpkDbChangeLogEntity {
+        val cpkId = cpk.metadata.cpkId
+        val id = CpkDbChangeLogKey(cpkId.name, cpkId.version, cpkId.signerSummaryHashForDbQuery, path)
+        return CpkDbChangeLogEntity(id, cpk.metadata.fileChecksum.toString(), xmlContent)
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/ChunkPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/ChunkPersistence.kt
@@ -4,6 +4,7 @@ import net.corda.chunking.RequestId
 import net.corda.chunking.db.impl.AllChunksReceived
 import net.corda.data.chunking.Chunk
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.packaging.Cpi
 import net.corda.v5.crypto.SecureHash
 
@@ -62,13 +63,16 @@ interface ChunkPersistence {
      * @param checksum the checksum of the CPI file
      * @param requestId the request id for the CPI that is being uploaded
      * @param groupId the group id from the group policy file
+     * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
      */
+    @Suppress("LongParameterList")
     fun persistMetadataAndCpks(
         cpi: Cpi,
         cpiFileName: String,
         checksum: SecureHash,
         requestId: RequestId,
-        groupId: String
+        groupId: String,
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
     ): CpiMetadataEntity
 
     /**
@@ -79,13 +83,17 @@ interface ChunkPersistence {
      * @param checksum the checksum of the CPI file
      * @param requestId the request id for the CPI that is being uploaded
      * @param groupId the group id from the group policy file
+     * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
      */
+    @Suppress("LongParameterList")
     fun updateMetadataAndCpks(
         cpi: Cpi,
         cpiFileName: String,
         checksum: SecureHash,
         requestId: RequestId,
-        groupId: String): CpiMetadataEntity
+        groupId: String,
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
+    ): CpiMetadataEntity
 
     /** Get the group id for a given CPI */
     fun getGroupId(cpiName: String, cpiVersion: String, signerSummaryHash: String): String?

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -6,17 +6,19 @@ import net.corda.chunking.db.impl.persistence.StatusPublisher
 import net.corda.cpiinfo.write.CpiInfoWriteService
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiMetadata
+import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import java.nio.file.Path
-import java.time.Instant
 
-class CpiValidatorImpl(
+@Suppress("LongParameterList")
+class CpiValidatorImpl constructor(
     private val publisher: StatusPublisher,
     private val persistence: ChunkPersistence,
     private val cpiInfoWriteService: CpiInfoWriteService,
     cpiCacheDir: Path,
-    cpiPartsDir: Path
+    cpiPartsDir: Path,
+    private val clock: Clock
 ) : CpiValidator {
     companion object {
         private val log = contextLogger()
@@ -28,6 +30,7 @@ class CpiValidatorImpl(
         //  Each function may throw a [ValidationException]
         log.debug("Validating $requestId")
 
+        // Assemble the CPI locally and return information about it
         publisher.update(requestId, "Validating upload")
         val fileInfo = validationFunctions.getFileInfo(persistence, requestId)
 
@@ -45,18 +48,26 @@ class CpiValidatorImpl(
             validationFunctions.checkGroupIdDoesNotExistForThisCpi(persistence, cpi)
         }
 
+        publisher.update(requestId, "Extracting Liquibase files from CPKs in CPI")
+        val cpkDbChangeLogEntities = validationFunctions.extractLiquibaseScriptsFromCpi(cpi)
+
         publisher.update(requestId, "Persisting CPI")
-        val cpiMetadataEntity = validationFunctions.persistToDatabase(persistence, cpi, fileInfo, requestId)
+        val cpiMetadataEntity = validationFunctions.persistToDatabase(
+            persistence,
+            cpi,
+            fileInfo,
+            requestId,
+            cpkDbChangeLogEntities
+        )
 
         publisher.update(requestId, "Notifying flow workers")
-        val timestamp = Instant.now()
         val cpiMetadata = CpiMetadata(
             cpi.metadata.cpiId,
             fileInfo.checksum,
             cpi.cpks.map { it.metadata },
             cpi.metadata.groupPolicy,
             version = cpiMetadataEntity.entityVersion,
-            timestamp
+            timestamp = clock.instant()
         )
         cpiInfoWriteService.put(cpiMetadata.cpiId, cpiMetadata)
 

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/FileInfo.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/FileInfo.kt
@@ -4,7 +4,14 @@ import net.corda.data.chunking.PropertyKeys
 import net.corda.v5.crypto.SecureHash
 import java.nio.file.Path
 
-/** Simple class containing information about the file produced from combining [net.corda.data.chunking.Chunk] objects */
+/**
+ * Simple class containing information about the file produced from combining [net.corda.data.chunking.Chunk] objects
+ *
+ * @param name the original file name
+ * @param path the path to the file.  NB. the _file name_ may not match the [name] parameter
+ * @param checksum the checksum of the file
+ * @param properties a bag of miscellaneous properties
+ * */
 internal data class FileInfo(val name: String, val path: Path, val checksum: SecureHash, val properties: Map<String, String?>?) {
     val forceUpload: Boolean get() {
         return properties?.get(PropertyKeys.FORCE_UPLOAD)?.let { java.lang.Boolean.parseBoolean(it) } ?: false

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -2,8 +2,11 @@ package net.corda.chunking.db.impl.validation
 
 import net.corda.chunking.ChunkReaderFactory
 import net.corda.chunking.RequestId
+import net.corda.chunking.db.impl.cpi.liquibase.LiquibaseExtractor
 import net.corda.chunking.db.impl.persistence.ChunkPersistence
 import net.corda.chunking.db.impl.persistence.PersistenceUtils.signerSummaryHashForDbQuery
+import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.CpiReader
 import net.corda.libs.packaging.core.exception.PackagingException
@@ -14,7 +17,6 @@ import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import javax.persistence.PersistenceException
-import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 
 internal class ValidationFunctions(
     private val cpiCacheDir: Path,
@@ -89,7 +91,8 @@ internal class ValidationFunctions(
         chunkPersistence: ChunkPersistence,
         cpi: Cpi,
         fileInfo: FileInfo,
-        requestId: RequestId
+        requestId: RequestId,
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
     ): CpiMetadataEntity {
         // Cannot compare the CPI.metadata.hash to our checksum above
         // because two different digest algorithms might have been used to create them.
@@ -101,14 +104,15 @@ internal class ValidationFunctions(
             val cpiExists = chunkPersistence.cpiExists(
                 cpi.metadata.cpiId.name,
                 cpi.metadata.cpiId.version,
-                cpi.metadata.cpiId.signerSummaryHashForDbQuery)
+                cpi.metadata.cpiId.signerSummaryHashForDbQuery
+            )
 
             return if (cpiExists && fileInfo.forceUpload) {
                 log.info("Force uploading CPI: ${cpi.metadata.cpiId.name} v${cpi.metadata.cpiId.version}")
-                chunkPersistence.updateMetadataAndCpks(cpi, fileInfo.name, fileInfo.checksum, requestId, groupId)
+                chunkPersistence.updateMetadataAndCpks(cpi, fileInfo.name, fileInfo.checksum, requestId, groupId, cpkDbChangeLogEntities)
             } else if (!cpiExists) {
                 log.info("Uploading CPI: ${cpi.metadata.cpiId.name} v${cpi.metadata.cpiId.version}")
-                chunkPersistence.persistMetadataAndCpks(cpi, fileInfo.name, fileInfo.checksum, requestId, groupId)
+                chunkPersistence.persistMetadataAndCpks(cpi, fileInfo.name, fileInfo.checksum, requestId, groupId, cpkDbChangeLogEntities)
             } else {
                 throw ValidationException(
                     "CPI has already been inserted with cpks for " +
@@ -162,8 +166,17 @@ internal class ValidationFunctions(
             cpi.metadata.cpiId.version,
             cpi.metadata.cpiId.signerSummaryHashForDbQuery
         )
+
         if (groupIdInDatabase != null) {
             throw ValidationException("CPI already uploaded with groupId = $groupIdInDatabase")
         }
     }
+
+    /**
+     * Extract liquibase scripts from the CPI and persist them to the database.
+     *
+     * @return list of entities containing liquibase scripts ready for insertion into database
+     */
+    fun extractLiquibaseScriptsFromCpi(cpi: Cpi): List<CpkDbChangeLogEntity> =
+        LiquibaseExtractor().extractLiquibaseEntitiesFromCpi(cpi)
 }

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessorSimpleTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessorSimpleTest.kt
@@ -67,12 +67,5 @@ class ChunkWriteToDbProcessorSimpleTest {
 
         processor.onNext(listOf(Record(topic, requestId, chunk)))
         verify(persistence).persistChunk(chunk)
-
-        // TODO
-//        assertThat(records.isNotEmpty()).isTrue
-//
-//        assertThat(requestId).isEqualTo(key.requestId)
-//        assertThat(exceptionMessage).isEqualTo(chunkAck.exception.errorMessage)
-//        assertThat(CordaRuntimeException::class.java.name).isEqualTo(chunkAck.exception.errorType)
     }
 }

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/JarWalkerTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/JarWalkerTest.kt
@@ -1,0 +1,48 @@
+package net.corda.chunking.db.impl.cpi
+
+import net.corda.chunking.db.impl.cpi.liquibase.JarWalker
+import net.corda.test.util.InMemoryZipFile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class JarWalkerTest {
+    companion object {
+        private const val text = "some words"
+    }
+
+    private fun nonEmptyJar() = InMemoryZipFile().also {
+        it.addEntry("resources/words1.txt", text.toByteArray())
+        it.addEntry("resources/words2.txt", text.toByteArray())
+    }
+
+    private fun emptyJar() = InMemoryZipFile()
+
+    @Test
+    fun `empty jar has zero entries`() {
+        var entryCount = 0
+        emptyJar().inputStream().use { JarWalker.walk(it) { _, _ -> entryCount++ } }
+        assertThat(entryCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `non empty jar has two entries`() {
+        var entryCount = 0
+        nonEmptyJar().inputStream().use { JarWalker.walk(it) { _, _ -> entryCount++ } }
+        assertThat(entryCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `non empty jar returns content correctly`() {
+        var entryCount = 0
+
+        // I'm assuming the entries are in order
+        nonEmptyJar().inputStream().use {
+            JarWalker.walk(it) { path, inputStream ->
+                entryCount++
+                assertThat(inputStream.readAllBytes()).isEqualTo(text.toByteArray())
+                assertThat(path).isEqualTo("resources/words$entryCount.txt")
+            }
+        }
+        assertThat(entryCount).isEqualTo(2)
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
@@ -1,0 +1,232 @@
+package net.corda.chunking.db.impl.cpi
+
+import net.corda.chunking.db.impl.cpi.liquibase.LiquibaseExtractor
+import net.corda.chunking.db.impl.cpi.liquibase.LiquibaseExtractorHelpers
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.CpiReader
+import net.corda.libs.packaging.Cpk
+import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.test.util.InMemoryZipFile
+import net.corda.v5.crypto.SecureHash
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.FileNotFoundException
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class LiquibaseExtractorHelpersTest {
+    companion object {
+        const val EXTENDABLE_CPB = "/META-INF/extendable-cpb.cpb"
+        private fun getInputStream(resourceName: String): InputStream {
+            return this::class.java.getResource(resourceName)?.openStream()
+                ?: throw FileNotFoundException("No such resource: '$resourceName'")
+        }
+
+        @Suppress("MaxLineLength")
+        private val liquibase = """
+        <?xml version="1.1" encoding="UTF-8" standalone="no"?>
+        <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+            <include file="migration/dbms-example-migration-v1.0.xml"/>
+        </databaseChangeLog>""".trimIndent()
+
+        private val notLiquibase = """
+                <?xml version="1.1" encoding="UTF-8" standalone="no"?>
+                <hello></hello>""".trimIndent()
+
+        private const val notXml = "this is not xml"
+    }
+
+    private lateinit var testDir: Path
+
+    @BeforeAll
+    fun setup(@TempDir tempDir: Path) {
+        testDir = tempDir
+    }
+
+    private fun jarWithLiquibase() = InMemoryZipFile().also {
+        it.addEntry("migration/anything.xml", liquibase.toByteArray())
+    }
+
+    private fun jarWithoutLiquibase() = InMemoryZipFile().also {
+        it.addEntry("migration/anything.xml", notLiquibase.toByteArray())
+    }
+
+    private fun jarWithBrokenLiquibase() = InMemoryZipFile().also {
+        it.addEntry("migration/anything.xml", notXml.toByteArray())
+    }
+
+    private fun jarWithOtherXmlResource() = InMemoryZipFile().also {
+        it.addEntry("some/other/migration/anything.xml", notXml.toByteArray())
+    }
+
+    private fun cpkWithNestedJar() = InMemoryZipFile().also {
+        it.addEntry("foo.jar", jarWithLiquibase().toByteArray())
+    }
+
+    private fun mockCpk(name: String, version: String, signerHash: SecureHash, fileChecksum: SecureHash): Cpk {
+        val cpkId = CpkIdentifier(name, version, signerHash)
+        val mockMetadata = mock<CpkMetadata>().also {
+            whenever(it.cpkId).thenReturn(cpkId)
+            whenever(it.fileChecksum).thenReturn(fileChecksum)
+        }
+        return mock<Cpk>().also { whenever(it.metadata).thenReturn(mockMetadata) }
+    }
+
+    @Test
+    fun `liquibase extractor can persist liquibase script`() {
+        val cpk = mockCpk(
+            "Test",
+            "1.0",
+            SecureHash.create("ALGO:1234567890"),
+            SecureHash.create("ALGO:0987654321")
+        )
+
+        val obj = LiquibaseExtractorHelpers()
+        val entities = jarWithLiquibase().inputStream().use { obj.getEntities(cpk, it) }
+
+        assertThat(entities.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `liquibase extractor can persist liquibase script in nested jar`() {
+        val cpk = mockCpk(
+            "Test",
+            "1.0",
+            SecureHash.create("ALGO:1234567890"),
+            SecureHash.create("ALGO:0987654321")
+        )
+
+        val obj = LiquibaseExtractorHelpers()
+        val entities = cpkWithNestedJar().inputStream().use { obj.getEntities(cpk, it) }
+
+        assertThat(entities.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `liquibase extractor does not persist non liquibase script`() {
+        val cpk = mockCpk(
+            "Test",
+            "1.1",
+            SecureHash.create("ALGO:1234567890"),
+            SecureHash.create("ALGO:0987654321")
+        )
+
+        val obj = LiquibaseExtractorHelpers()
+        val entities = jarWithoutLiquibase().inputStream().use { obj.getEntities(cpk, it) }
+
+        assertThat(entities.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `liquibase extractor does not persist broken XML`() {
+        val cpk = mockCpk(
+            "Test",
+            "1.2",
+            SecureHash.create("ALGO:1234567890"),
+            SecureHash.create("ALGO:0987654321")
+        )
+
+        val obj = LiquibaseExtractorHelpers()
+        val entities = jarWithBrokenLiquibase().inputStream().use { obj.getEntities(cpk, it) }
+
+        assertThat(entities.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `liquibase extractor does not persist XML in other migration folder`() {
+        val cpk = mockCpk(
+            "Test",
+            "1.2",
+            SecureHash.create("ALGO:1234567890"),
+            SecureHash.create("ALGO:0987654321")
+        )
+
+
+        val obj = LiquibaseExtractorHelpers()
+        val entities = jarWithOtherXmlResource().inputStream().use { obj.getEntities(cpk, it) }
+
+        assertThat(entities.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `liquibase XML accepted`() {
+        assertThat(LiquibaseExtractorHelpers().isLiquibaseXml(liquibase)).isTrue
+    }
+
+    @Test
+    fun `liquibase XML rejected`() {
+        assertThat(LiquibaseExtractorHelpers().isLiquibaseXml(notLiquibase)).isFalse
+    }
+
+    @Test
+    fun `not XML rejected`() {
+        assertThat(LiquibaseExtractorHelpers().isLiquibaseXml(notXml)).isFalse
+    }
+
+    @Test
+    fun `empty string that is not not XML rejected`() {
+        assertThat(LiquibaseExtractorHelpers().isLiquibaseXml("")).isFalse
+    }
+
+    @Test
+    fun `test real cpb`() {
+        val cpk = mockCpk(
+            "Test",
+            "1.2",
+            SecureHash.create("ALGO:1234567890"),
+            SecureHash.create("ALGO:0987654321")
+        )
+
+        val obj = LiquibaseExtractorHelpers()
+
+        // Note:  INCORRECT USAGE on purpose (we just want some CPKs to test)
+        // We're testing a **CPI**, not a *CPK**, so we're persisting
+        // the scripts using the "mock cpk" as the db key.
+
+        val entities = getInputStream(EXTENDABLE_CPB).use { obj.getEntities(cpk, it) }
+
+        // "extendable-cpb" contains cats.cpk (3) and dogs.cpk (2) liquibase files.
+        val expectedLiquibaseFileCount = 5
+
+        assertThat(entities.size).isEqualTo(expectedLiquibaseFileCount)
+    }
+
+    @Test
+    fun `test real cpb and parse it`() {
+        val obj = LiquibaseExtractorHelpers()
+        val cpi: Cpi = getInputStream(EXTENDABLE_CPB).use { CpiReader.readCpi(it, testDir) }
+
+        val entities = mutableListOf<CpkDbChangeLogEntity>()
+        cpi.cpks.forEach { cpk ->
+            Files.newInputStream(cpk.path!!).use {
+                entities += obj.getEntities(cpk, it)
+            }
+        }
+
+        // "extendable-cpb" contains cats.cpk (3) and dogs.cpk (2) liquibase files.
+        val expectedLiquibaseFileCount = 5
+        assertThat(entities.size).isEqualTo(expectedLiquibaseFileCount)
+    }
+
+    @Test
+    fun `test real cpb via validation function`() {
+        val cpi: Cpi = getInputStream(EXTENDABLE_CPB).use { CpiReader.readCpi(it, testDir) }
+
+        val obj = LiquibaseExtractor()
+        assertThat(obj.extractLiquibaseEntitiesFromCpi(cpi).isNotEmpty()).isTrue
+
+        val expectedLiquibaseFileCount = 5
+        assertThat(obj.extractLiquibaseEntitiesFromCpi(cpi).size).isEqualTo(expectedLiquibaseFileCount)
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorTest.kt
@@ -1,0 +1,67 @@
+package net.corda.chunking.db.impl.cpi
+
+import net.corda.chunking.db.impl.cpi.liquibase.LiquibaseExtractor
+import net.corda.db.admin.LiquibaseXmlConstants
+import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.CpiReader
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import java.io.FileNotFoundException
+import java.io.InputStream
+import java.nio.file.Path
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class LiquibaseExtractorTest {
+    companion object {
+        const val EXTENDABLE_CPB = "/META-INF/extendable-cpb.cpb"
+        private fun getInputStream(resourceName: String): InputStream {
+            return this::class.java.getResource(resourceName)?.openStream()
+                ?: throw FileNotFoundException("No such resource: '$resourceName'")
+        }
+    }
+
+    private lateinit var testDir: Path
+
+    @BeforeAll
+    fun setup(@TempDir tempDir: Path) {
+        testDir = tempDir
+    }
+
+    @Test
+    fun `test real cpb via validation function`() {
+        val cpi: Cpi = getInputStream(EXTENDABLE_CPB).use { CpiReader.readCpi(it, testDir) }
+        val obj = LiquibaseExtractor()
+        assertThat(obj.extractLiquibaseEntitiesFromCpi(cpi).isNotEmpty()).isTrue
+
+        val expectedLiquibaseFileCount = 5
+        assertThat(obj.extractLiquibaseEntitiesFromCpi(cpi).size).isEqualTo(expectedLiquibaseFileCount)
+    }
+
+    @Test
+    fun `check content`() {
+        val cpi: Cpi = getInputStream(EXTENDABLE_CPB).use { CpiReader.readCpi(it, testDir) }
+        val obj = LiquibaseExtractor()
+        val entities = obj.extractLiquibaseEntitiesFromCpi(cpi)
+        assertThat(entities.isNotEmpty()).isTrue
+
+        val expectedLiquibaseFileCount = 5
+        assertThat(entities.size).isEqualTo(expectedLiquibaseFileCount)
+
+        entities.forEach {
+            assertThat(it.id.cpkSignerSummaryHash.isNotEmpty()).isTrue
+            assertThat(it.id.cpkName.isNotEmpty()).isTrue
+            assertThat(it.id.cpkVersion.isNotEmpty()).isTrue
+            assertThat(it.id.filePath.isNotEmpty()).isTrue
+            assertThat(it.content.isNotEmpty()).isTrue
+            assertThat(it.fileChecksum.isNotEmpty()).isTrue
+
+            //  Cursory check of XML -
+            assertThat(it.content).contains("<?xml")
+            assertThat(it.content).contains(LiquibaseXmlConstants.DB_CHANGE_LOG_ROOT_ELEMENT)
+            assertThat(it.content).contains("xmlns")
+        }
+    }
+}

--- a/libs/packaging/packaging-verify/build.gradle
+++ b/libs/packaging/packaging-verify/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation project(":libs:packaging:packaging-core")
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
 
+    testImplementation project(':testing:test-utilities')
+
     testImplementation "org.osgi:osgi.core"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/TestUtils.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/TestUtils.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.verify
 
 import net.corda.libs.packaging.hash
+import net.corda.test.util.InMemoryZipFile
 import net.corda.v5.crypto.SecureHash
 import java.io.FileNotFoundException
 import java.io.InputStream

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1VerifierTest.kt
@@ -4,7 +4,7 @@ import net.corda.libs.packaging.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.DependencyResolutionException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.ALICE
 import net.corda.libs.packaging.verify.TestUtils.BOB

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
@@ -4,7 +4,7 @@ import net.corda.libs.packaging.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.DependencyResolutionException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.ALICE
 import net.corda.libs.packaging.verify.TestUtils.BOB

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/TestCpbV1Builder.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/TestCpbV1Builder.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpb
 
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.addFile
 import net.corda.libs.packaging.verify.TestUtils.signedBy

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/TestCpbV2Builder.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/TestCpbV2Builder.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpb
 
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.addFile
 import net.corda.libs.packaging.verify.TestUtils.signedBy

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1VerifierTest.kt
@@ -4,7 +4,7 @@ import net.corda.libs.packaging.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.DependencyResolutionException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.ALICE
 import net.corda.libs.packaging.verify.TestUtils.BOB

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2VerifierTest.kt
@@ -3,7 +3,7 @@ package net.corda.libs.packaging.verify.internal.cpi
 import net.corda.libs.packaging.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils.ALICE
 import net.corda.libs.packaging.verify.TestUtils.BOB
 import net.corda.libs.packaging.verify.TestUtils.ROOT_CA

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/TestCpiV2Builder.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/TestCpiV2Builder.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpi
 
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.addFile
 import net.corda.libs.packaging.verify.TestUtils.signedBy

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1VerifierTest.kt
@@ -3,7 +3,7 @@ package net.corda.libs.packaging.verify.internal.cpk
 import net.corda.libs.packaging.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils.ALICE
 import net.corda.libs.packaging.verify.TestUtils.BOB
 import net.corda.libs.packaging.verify.TestUtils.ROOT_CA

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2VerifierTest.kt
@@ -3,7 +3,7 @@ package net.corda.libs.packaging.verify.internal.cpk
 import net.corda.libs.packaging.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils.ALICE
 import net.corda.libs.packaging.verify.TestUtils.BOB
 import net.corda.libs.packaging.verify.TestUtils.ROOT_CA

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/TestCpkV1Builder.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/TestCpkV1Builder.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpk
 
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.addFile
 import net.corda.libs.packaging.verify.TestUtils.signedBy

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/TestCpkV1MainBundleBuilder.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/TestCpkV1MainBundleBuilder.kt
@@ -2,7 +2,7 @@ package net.corda.libs.packaging.verify.internal.cpk
 
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_VERSION_ATTRIBUTE
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.addFile
 import net.corda.libs.packaging.verify.TestUtils.signedBy

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/TestCpkV2Builder.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/TestCpkV2Builder.kt
@@ -2,7 +2,7 @@ package net.corda.libs.packaging.verify.internal.cpk
 
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_VERSION_ATTRIBUTE
-import net.corda.libs.packaging.verify.InMemoryZipFile
+import net.corda.test.util.InMemoryZipFile
 import net.corda.libs.packaging.verify.TestUtils
 import net.corda.libs.packaging.verify.TestUtils.addFile
 import net.corda.libs.packaging.verify.TestUtils.signedBy

--- a/testing/test-utilities/src/main/java/net/corda/test/util/InMemoryZipFile.kt
+++ b/testing/test-utilities/src/main/java/net/corda/test/util/InMemoryZipFile.kt
@@ -1,4 +1,4 @@
-package net.corda.libs.packaging.verify
+package net.corda.test.util
 
 import jdk.security.jarsigner.JarSigner
 import java.io.ByteArrayInputStream


### PR DESCRIPTION
Persist any Liquibase script found in a cpk in to the database.

Perform a cursory check that we can parse the XML, find the root element
and that it has an `xmlns` attribute set.

Added unit tests.

Moved InMemoryZipFile to testing project.