### PR TITLE
CORE-5309 Set signer hash to null if entity value is blank

### DIFF
--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeInfoDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeInfoDbReconcilerReader.kt
@@ -29,12 +29,17 @@ fun virtualNodeEntitiesToVersionedRecords(virtualNodes: Stream<VirtualNodeEntity
             override val isDeleted = entity.isDeleted
             override val key = holdingIdentity
             override val value by lazy {
+                val signerSummaryHash = if (entity.cpiSignerSummaryHash.isNotBlank()) {
+                    SecureHash.create(entity.cpiSignerSummaryHash)
+                } else {
+                    null
+                }
                 VirtualNodeInfo(
                     holdingIdentity = holdingIdentity,
                     cpiIdentifier = CpiIdentifier(
                         entity.cpiName,
                         entity.cpiVersion,
-                        SecureHash.create(entity.cpiSignerSummaryHash)
+                        signerSummaryHash
                     ),
                     vaultDmlConnectionId = entity.holdingIdentity.vaultDMLConnectionId!!,
                     cryptoDmlConnectionId = entity.holdingIdentity.cryptoDMLConnectionId!!,


### PR DESCRIPTION
If the database signer summary hash is empty, then set the equivalent
value in Kotlin to be `null` since the field is nullable, otherwise
`SecureHash.create("")` throws an exception because it has been passed
an empty string.