### PR TITLE
CORE-5279 `ChunkWriterImpl` throws from multiple `onChunk` calls in `CpkWriteServiceImpl`

### DIFF
--- a/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
@@ -181,9 +181,18 @@ class CpkWriteServiceImplTest {
         cpkWriteServiceImpl.cpkChunksPublisher = cpkChunksPublisher
 
         cpkWriteServiceImpl.putMissingCpk()
-        assertTrue(chunks.size == 2)
+
+        // assert that we can publish multiple CPKs
+        cpkWriteServiceImpl.putMissingCpk()
+
+        assertTrue(chunks.size == 4)
         assertTrue(chunks[0].data.equals(ByteBuffer.wrap(cpkData)))
+        assertTrue(chunks[1].data.limit() == 0)
+        assertTrue(chunks[2].data.equals(ByteBuffer.wrap(cpkData)))
+        assertTrue(chunks[3].data.limit() == 0)
+
         assertEquals("${cpkChecksum.toHexString()}.cpk", chunks[0].fileName)
+        assertEquals("${cpkChecksum.toHexString()}.cpk", chunks[2].fileName)
     }
 
     @Test


### PR DESCRIPTION
Calling `ChunkWriter.onChunk` more than once throws. 

Instead of making the `ChunkWriter` a nullable property to be recreated on new messaging configuration, meaning we would have to re-register the `onChunk` callback multiple times, store the messaging configuration needed in a var and use that to create a new `ChunkWriter` on new CPK chunking and publishing request.