### PR TITLE
CORE-5134 Add Helm Chart for Link Manager

### DIFF
--- a/applications/p2p-link-manager/README.md
+++ b/applications/p2p-link-manager/README.md
@@ -32,10 +32,19 @@ Below is a list of command line arguments you can use:
   -h, --help   Display help and exit
   -i, --instance-id=<instanceId>
                The unique instance ID (default to random number)
-  -k, --kafka-servers=<kafkaServers>
-               A comma-separated list of addresses of Kafka brokers (default: localhost:9092)
-      --topic-prefix=<topicPrefix>
+  -m, --messagingParams=<String=String>
+               Messaging parameters for the link manager.
+      --topicPrefix=<topicPrefix>
                The topic prefix (default: )
+```
+By default, the link-manager will try and connect to a Kafka broker on localhost:9092.
+To override this use option `-m` (to connect to a Kafka Broker on (kafka-broker:1000):
+```bash
+java -jar ./applications/p2p-link-manager/build/bin/corda-p2p-link-manager*.jar -mbootstrap.servers=kafka-broker:1000
+```
+These -m options are passed into the Kafka client. For example to use TLS to connect to the Kafka broker the following -m options can be used:
+```bash
+java -jar ./applications/p2p-link-manager/build/bin/corda-p2p-link-manager*.jar -msecurity.protocol=SSL -mssl.truststore.location=/certs/ca.crt -mssl.truststore.type=PEM
 ```
 
 ### Running the Docker image

--- a/applications/p2p-link-manager/README.md
+++ b/applications/p2p-link-manager/README.md
@@ -38,7 +38,7 @@ Below is a list of command line arguments you can use:
                The topic prefix (default: )
 ```
 By default, the link-manager will try and connect to a Kafka broker on localhost:9092.
-To override this use option `-m` (to connect to a Kafka Broker on (kafka-broker:1000):
+To override this use option `-m`. For example, to connect to a Kafka Broker on `kafka-broker:1000`:
 ```bash
 java -jar ./applications/p2p-link-manager/build/bin/corda-p2p-link-manager*.jar -mbootstrap.servers=kafka-broker:1000
 ```

--- a/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
+++ b/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/CliArguments.kt
@@ -35,13 +35,13 @@ internal class CliArguments {
     var helpRequested = false
 
     @Option(
-        names = ["-k", "--kafka-servers"],
-        description = ["A comma-separated list of addresses of Kafka brokers (default: \${DEFAULT-VALUE})"]
+        names = ["-m", "--messagingParams"],
+        description = ["Messaging parameters for the link manager."]
     )
-    var kafkaServers = System.getenv("KAFKA_SERVERS") ?: "localhost:9092"
+    var messagingParams = emptyMap<String, String>()
 
     @Option(
-        names = ["--topic-prefix"],
+        names = ["--topicPrefix"],
         description = ["The topic prefix (default: \${DEFAULT-VALUE})"]
     )
     var topicPrefix = System.getenv("TOPIC_PREFIX") ?: ""
@@ -53,8 +53,12 @@ internal class CliArguments {
     var instanceId = System.getenv("INSTANCE_ID")?.toInt() ?: Random.nextInt()
 
     val bootConfiguration: Config by lazy {
-        ConfigFactory.empty()
-            .withValue("$BOOT_KAFKA_COMMON.bootstrap.servers", ConfigValueFactory.fromAnyRef(kafkaServers))
+        val parsedMessagingParams = messagingParams.mapKeys { (key, _) -> "$BOOT_KAFKA_COMMON.${key.trim()}" }.toMutableMap()
+        parsedMessagingParams.computeIfAbsent("$BOOT_KAFKA_COMMON.bootstrap.servers") {
+            System.getenv("KAFKA_SERVERS") ?: "localhost:9092"
+        }
+        ConfigFactory
+            .parseMap(parsedMessagingParams)
             .withValue(
                 TOPIC_PREFIX,
                 ConfigValueFactory.fromAnyRef(topicPrefix)

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -66,7 +66,7 @@ imagePullSecrets:
 Worker name
 */}}
 {{- define "corda.workerName" -}}
-"{{ include "corda.fullname" . }}-{{ .worker }}-worker"
+"{{ include "corda.fullname" . }}-{{ .worker | kebabcase | replace "p-2p" "p2p" }}-worker"
 {{- end }}
 
 {{/*

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -30,7 +30,7 @@ spec:
                     - key: "app.kubernetes.io/component"
                       operator: In
                       values:
-                        - flow-worker
+                        - p2plinkmanager
                 topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ include "corda.workerName" . }}

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -1,4 +1,4 @@
-{{- $_ := set . "worker" "p2plinkmanager" }}
+{{- $_ := set . "worker" "p2pLinkManager" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "corda.workerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.workers.p2plinkmanager.replicaCount }}
+  replicas: {{ .Values.workers.p2pLinkManager.replicaCount }}
   selector:
     matchLabels:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
@@ -30,7 +30,7 @@ spec:
                     - key: "app.kubernetes.io/component"
                       operator: In
                       values:
-                        - p2plinkmanager
+                        - p2pLinkManager
                 topologyKey: "kubernetes.io/hostname"
       containers:
       - name: {{ include "corda.workerName" . }}
@@ -46,7 +46,7 @@ spec:
         volumeMounts:
         {{- include "corda.workerVolumeMounts" . | nindent 10 }}
         # Add health port when porting Link Manager to common worker framework CORE-4424
-        {{- if .Values.workers.p2plinkmanager.debug.enabled }}
+        {{- if .Values.workers.p2pLinkManager.debug.enabled }}
         ports:
           - name: debug
             containerPort: 5005

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -1,0 +1,59 @@
+{{- $_ := set . "worker" "p2plinkmanager" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "corda.workerName" . }}
+  labels:
+    {{- include "corda.workerLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.workers.p2plinkmanager.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "corda.workerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "corda.workerSelectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app.kubernetes.io/component"
+                      operator: In
+                      values:
+                        - flow-worker
+                topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: {{ include "corda.workerName" . }}
+        image: {{ include "corda.workerImage" . }}
+        imagePullPolicy:  {{ .Values.imagePullPolicy }}
+        securityContext:
+         allowPrivilegeEscalation: false
+        {{- include "corda.workerResources" . | nindent 8 }}
+        env:
+        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+        args:
+        {{- include "corda.workerKafkaArgs" . | nindent 10 }}
+        volumeMounts:
+        {{- include "corda.workerVolumeMounts" . | nindent 10 }}
+        # Add health port when porting Link Manager to common worker framework CORE-4424
+        {{- if .Values.workers.p2plinkmanager.debug.enabled }}
+        ports:
+          - name: debug
+            containerPort: 5005
+        {{- end }}
+      volumes:
+      {{- include "corda.workerVolumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -253,3 +253,28 @@ workers:
       loadBalancerSourceRanges: []
       # -- the annotations for RPC worker service
       annotations: {}
+
+  # P2P Link Manager worker configuration
+  p2plinkmanager:
+    # p2p-link-manager worker image configuration
+    image:
+      # -- p2p-link-manager worker image registry, defaults to image.registry
+      registry: ""
+      # -- p2p-link-manager worker image repository
+      repository: "corda-os-p2p-link-manager"
+      # -- p2p-link-manager worker image tag, defaults to image.tag
+      tag: ""
+    # -- p2p-link-manager worker replica count
+    replicaCount: 1
+    # p2p-link-manager worker debug configuration
+    debug:
+      # -- run p2p-link-manager worker with debug enabled
+      enabled: false
+      # -- if debug is enabled, suspend the p2p-link-manager worker until the debugger is attached
+      suspend: false
+    # resource limits and requests configuration for the p2p-link-manager worker containers.
+    resources:
+      # -- the CPU/memory resource requests for the p2p-link-manager worker containers
+      requests: {}
+      # -- the CPU/memory resource limits for the p2p-link-manager worker containers
+      limits: {}

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -255,7 +255,7 @@ workers:
       annotations: {}
 
   # P2P Link Manager worker configuration
-  p2plinkmanager:
+  p2pLinkManager:
     # p2p-link-manager worker image configuration
     image:
       # -- p2p-link-manager worker image registry, defaults to image.registry


### PR DESCRIPTION
Changed the Link Manager command line arguments to be compatible with the Helm Charts i.e. the same as the common worker:
1. Removed the option `--kafka-servers` instead we accept a list of arguments prefixed with -m. So for example instead of `--kafka-servers=localhost:9092` use `-mbootstrap.servers=localhost:9092`. By passing in multiple options TLS can be turned on for Kafka.
2. Changed `--topic-prefix` to `--topicPrefix`.

Currently the link manager does not use the common worker framework (this will be done as a part of CORE-4424). For this reason there is no health port exposed. Hence the Link Manager will pod will be ready even if it has invalid config.

Testing
===
I followed these instructions:
https://github.com/corda/corda-runtime-os/wiki/Local-development-with-Kubernetes

The install Corda command completed successfully. Running:
```
william.vigor@22LDN-MAC13TJGH5 corda-runtime-os % kubectl get pods -n corda
NAME                                           READY   STATUS      RESTARTS   AGE
corda-create-topics--1-hrblz                   0/1     Completed   0          95m
corda-crypto-worker-8479fc5659-msj9h           1/1     Running     0          92m
corda-db-worker-977d5f46f-md79w                1/1     Running     0          92m
corda-flow-worker-5dc5664c9d-rd6rq             1/1     Running     0          92m
corda-membership-worker-6897fbbd9c-8zn4g       1/1     Running     0          92m
corda-p2plinkmanager-worker-5f9999bc57-7p8qg   1/1     Running     0          92m
corda-rpc-worker-695b85f65b-28frc              1/1     Running     0          92m
corda-setup-db--1-phzqk                        0/1     Completed   0          93m
prereqs-kafka-0                                1/1     Running     0          127m
prereqs-postgresql-0                           1/1     Running     0          127m
prereqs-zookeeper-0                            1/1     Running     0          127m
```

We can see a `corda-p2plinkmanager-worker`. Looking at the logs we can see it is started:
```
14:32:58.377 [Thread-3] INFO  Console - Link manager is running
```

I also did a p2p deployment with the p2p Kubernetes deployment to check that that still works by checking the Link Manager's successfully start.