### PR TITLE
CORE-5333 remove logic regarding excluding cpk specific modules from build cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,20 +310,15 @@ subprojects {
         }
     }
     
-    // NOTE: Needed to ensure we do not normalize projects which apply CPK plugin
-    afterEvaluate {
-        if (!pluginManager.hasPlugin("net.corda.plugins.cordapp-cpk")) {
-            // we do this to allow for Gradle task caching. OSGI attribute Bnd-LastModified breaks gradle caching as it is a timestamp
-            // below block tells Gradle to ignore specifically the Bnd-LastModified attribute of the manifest when checking if
-            // a task is up-to-date, this has no impact on publishing or production of jar.
-            normalization {
-                runtimeClasspath {
-                    metaInf {
-                        ignoreAttribute("Bnd-LastModified")
-                    }
-                }
-            }
-        }
+    // we do this to allow for Gradle task caching. OSGI attribute Bnd-LastModified breaks gradle caching as it is a timestamp
+    // below block tells Gradle to ignore specifically the Bnd-LastModified attribute of the manifest when checking if
+    // a task is up-to-date, this has no impact on publishing or production of jar.
+    normalization {
+	runtimeClasspath {
+	    metaInf {
+		ignoreAttribute("Bnd-LastModified")
+	    }
+	}
     }
 
     tasks.named("detekt").configure {

--- a/build.gradle
+++ b/build.gradle
@@ -314,11 +314,11 @@ subprojects {
     // below block tells Gradle to ignore specifically the Bnd-LastModified attribute of the manifest when checking if
     // a task is up-to-date, this has no impact on publishing or production of jar.
     normalization {
-	runtimeClasspath {
-	    metaInf {
-		ignoreAttribute("Bnd-LastModified")
-	    }
-	}
+        runtimeClasspath {
+            metaInf {
+                ignoreAttribute("Bnd-LastModified")
+            }
+        }
     }
 
     tasks.named("detekt").configure {


### PR DESCRIPTION
Initially we added this check as we suspected this was causing very sporadic issues with some tests related to CPKs , this was never proved to be the case 100%, revesting this area currently and feeling is this should be reactivated and we can monitor as needed.  
