### PR TITLE
CORE-5333 activate local Gradle cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -139,7 +139,7 @@ kotlin.build.report.output=file,build_scan
 gradleEnterpriseVersion = 3.8.1
 gradleDataPlugin = 1.6.2
 gradleTestRetryPluginVersion = 1.3.2
-org.gradle.caching = false
+org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
 #snyk version
 snykVersion = 0.4

--- a/settings.gradle
+++ b/settings.gradle
@@ -396,7 +396,8 @@ gradleEnterprise {
     }
     buildCache {
         local {
-            enabled = false
+            enabled = true
+            removeUnusedEntriesAfterDays = 14  // Garbage collect if a cache item is not used in 2 weeks.
         }
         remote(HttpBuildCache) {
             url = "${gradleEnterpriseUrl}/cache/"
@@ -410,7 +411,7 @@ gradleEnterprise {
                 enabled = true
             } else {
                 push = false
-                enabled = true
+                enabled = false
             }
         }
     }


### PR DESCRIPTION
- disable remote cache for local users ( this is only CI -> CI for now anyway ) , enable local cache.
- set local cache garbage collection to 2 weeks
- Note: cache location is in $GRADLE_USER_HOME/caches
- can be disabled via command line if required by adding --no-build-cache or changing the property org.gradle.caching in gradle.properties to false

No action is needed by end user, gradle will use the cached outputs of a task if appropriate.