### PR TITLE
CORE-5338: Remove the timeout parameter from `getPartitions` in consumer implementations

### DIFF
--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -163,7 +163,7 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
         )
     }
 
-    override fun getPartitions(topic: String, timeout: Duration): List<CordaTopicPartition> {
+    override fun getPartitions(topic: String): List<CordaTopicPartition> {
         return dbAccess.getTopicPartitionMapFor(topic).toList()
     }
 

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -200,9 +200,9 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
     }
 
 
-    override fun getPartitions(topic: String, timeout: Duration): List<CordaTopicPartition> {
+    override fun getPartitions(topic: String): List<CordaTopicPartition> {
         val listOfPartitions: List<PartitionInfo> = try {
-            consumer.partitionsFor(config.topicPrefix + topic, timeout)
+            consumer.partitionsFor(config.topicPrefix + topic)
         } catch (ex: Exception) {
             when (ex) {
                 is AuthenticationException,

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -263,7 +263,7 @@ class CordaKafkaConsumerImplTest {
     @Test
     fun testGetPartitionsNullPointerException() {
         assertThatExceptionOfType(CordaMessageAPIIntermittentException::class.java).isThrownBy {
-            cordaKafkaConsumer.getPartitions("topic", Duration.ZERO)
+            cordaKafkaConsumer.getPartitions("topic")
         }.withMessageContaining("Partitions for topic topic are null. Kafka may not have completed startup.")
     }
 

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
@@ -149,11 +149,10 @@ interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
      * Get metadata about the partitions for a given topic.
      *
      * @param topic The topic to get partition metadata for
-     * @param timeout The maximum of time to await topic metadata
      *
      * @return The list of [CordaTopicPartition]s
      */
-    fun getPartitions(topic: String, timeout: Duration): List<CordaTopicPartition>
+    fun getPartitions(topic: String): List<CordaTopicPartition>
 
     /**
      * Sets the default [CordaConsumerRebalanceListener] for this [CordaConsumer], if one is desired.

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
@@ -108,8 +108,7 @@ internal class CompactedSubscriptionImpl<K : Any, V : Any>(
                     ::onError
                 ).use {
                     val partitions = it.getPartitions(
-                        config.topic,
-                        config.pollTimeout
+                        config.topic
                     )
                     it.assign(partitions)
                     lifecycleCoordinator.updateStatus(LifecycleStatus.UP)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/builder/StateAndEventBuilderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/builder/StateAndEventBuilderImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.subscription.consumer.builder
 
-import java.util.concurrent.ConcurrentHashMap
 import net.corda.messagebus.api.configuration.ConsumerConfig
 import net.corda.messagebus.api.configuration.ProducerConfig
 import net.corda.messagebus.api.constants.ConsumerRoles
@@ -24,6 +23,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 @Component(service = [StateAndEventBuilder::class])
 internal class StateAndEventBuilderImpl @Activate constructor(
@@ -83,11 +83,10 @@ internal class StateAndEventBuilderImpl @Activate constructor(
         stateConsumer: CordaConsumer<K, S>,
         eventConsumer: CordaConsumer<K, E>
     ) {
-        val consumerTimeout = config.pollTimeout
         val statePartitions =
-            stateConsumer.getPartitions(getStateAndEventStateTopic(config.topic), consumerTimeout)
+            stateConsumer.getPartitions(getStateAndEventStateTopic(config.topic))
         val eventPartitions =
-            eventConsumer.getPartitions(config.topic, consumerTimeout)
+            eventConsumer.getPartitions(config.topic)
         if (statePartitions.size != eventPartitions.size) {
             val errorMsg = "Mismatch between state and event partitions."
             log.debug {

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImplTest.kt
@@ -303,7 +303,7 @@ class CompactedSubscriptionImplTest {
         doAnswer(onPoll).whenever(consumerMock).poll(any())
         doAnswer {
             listOf(CordaTopicPartition(config.topic, 0))
-        }.whenever(consumerMock).getPartitions(any(), any())
+        }.whenever(consumerMock).getPartitions(any())
 
         return Pair(consumerMock, cordaConsumerBuilder)
     }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/RPCSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/RPCSubscriptionImplTest.kt
@@ -94,7 +94,7 @@ class RPCSubscriptionImplTest {
 
         doAnswer {
             listOf(CordaTopicPartition(config.topic, 0))
-        }.whenever(kafkaConsumer).getPartitions(any(), any())
+        }.whenever(kafkaConsumer).getPartitions(any())
 
         doReturn(lifecycleCoordinator).`when`(lifecycleCoordinatorFactory).createCoordinator(any(), any())
     }


### PR DESCRIPTION
The patterns library bus API has a timeout parameter for `getPartitions`. Everywhere this was used in the patterns lib implementation, the timeout was given as the poll timeout, which is quite short (default 500ms). Kafka however exposes two versions of this API: one with an explicit timeout parameter, and one which uses the default timeout configuration value provided by Kafka (https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#consumerconfigs_default.api.timeout.ms). For other APIs on the consumer that have the same property, we use the implicit version and do not ask for a timeout. This PR aligns the `getPartitions` API with the behaviour for these other APIs. This has the effect of raising the default timeout from 500ms to 1 minute, which should be enough to eliminate the intermittent API exceptions that are often seen on startup.