### PR TITLE
CORE-5250 Running multiple processors together in All-in-one worker

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/scheduler/impl/FlowWakeUpSchedulerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/scheduler/impl/FlowWakeUpSchedulerImpl.kt
@@ -1,10 +1,5 @@
 package net.corda.flow.scheduler.impl
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.state.Checkpoint
 import net.corda.flow.pipeline.factory.FlowRecordFactory
@@ -18,6 +13,11 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 
 @Component(service = [FlowWakeUpScheduler::class])
 class FlowWakeUpSchedulerImpl constructor(
@@ -39,7 +39,7 @@ class FlowWakeUpSchedulerImpl constructor(
 
     override fun onConfigChange(config: Map<String, SmartConfig>) {
         publisher?.close()
-        publisher = publisherFactory.createPublisher(PublisherConfig("FlowRPCOps"), config.getConfig(MESSAGING_CONFIG))
+        publisher = publisherFactory.createPublisher(PublisherConfig("FlowWakeUpRPCOps"), config.getConfig(MESSAGING_CONFIG))
     }
 
     override fun onPartitionSynced(states: Map<String, Checkpoint>) {


### PR DESCRIPTION
Renamed publisher's client ID in FlowWakeUpSchedulerImpl as it was clashing with client ID used in FlowRPCOpsImpl (resulted with error when creating related mbeans).