### PR TITLE
CORE-5250 Running multiple processors together in All-in-one worker

### DIFF
--- a/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/JpaEntitiesRegistryImpl.kt
+++ b/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/JpaEntitiesRegistryImpl.kt
@@ -15,6 +15,8 @@ class JpaEntitiesRegistryImpl : JpaEntitiesRegistry {
     override fun get(persistenceUnitName: String): JpaEntitiesSet? = fullSet[persistenceUnitName]
 
     override fun register(persistenceUnitName: String, jpeEntities: Set<Class<*>>) {
-        fullSet.putIfAbsent(persistenceUnitName, JpaEntitiesSet.create(persistenceUnitName, jpeEntities.toSet()))
+        fullSet[persistenceUnitName] = JpaEntitiesSet.create(
+            persistenceUnitName,
+            jpeEntities.toSet() + (fullSet[persistenceUnitName]?.classes ?: emptySet()))
     }
 }

--- a/libs/db/db-orm-impl/src/test/kotlin/net/corda/orm/impl/JpaEntitiesRegistryImplTest.kt
+++ b/libs/db/db-orm-impl/src/test/kotlin/net/corda/orm/impl/JpaEntitiesRegistryImplTest.kt
@@ -10,6 +10,7 @@ class JpaEntitiesRegistryImplTest {
 
     private val classes1 = setOf(ExampleClass1::class.java, ExampleClass2::class.java)
     private val classes2 = setOf(ExampleClass3::class.java)
+    private val classes3 = setOf(ExampleClass1::class.java, ExampleClass3::class.java)
 
     @Test
     fun `when register can get`() {
@@ -37,6 +38,20 @@ class JpaEntitiesRegistryImplTest {
         }).containsExactlyInAnyOrder(
             "set1" to classes1,
             "set2" to classes2,
+        )
+    }
+
+    @Test
+    fun `when multiple register for the same persistence unit can get all`() {
+        val registry = JpaEntitiesRegistryImpl()
+
+        registry.register("set1", classes1)
+        registry.register("set1", classes3)
+
+        assertThat(registry.all.map{
+            it.persistenceUnitName to it.classes
+        }).containsExactlyInAnyOrder(
+            "set1" to setOf(ExampleClass1::class.java, ExampleClass2::class.java, ExampleClass3::class.java),
         )
     }
 }


### PR DESCRIPTION
Changed JpaEntitiesRegistryImpl to keep already registered entities when registering new ones.

Another way to fix issue it to keep registrations across all processors in sync (which would also require that processors use dependencies they don't really need)
https://github.com/corda/corda-runtime-os/blob/e611bb458c9e1ce75d7956cce0cf77fe4bd2795b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt#L103
https://github.com/corda/corda-runtime-os/blob/dc2a0c5402c4fa5ba4eb06432c9a5ff6cafd09eb/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt#L102