### PR TITLE
CORE-4697: Prevent consumers auto creating topics even if the setting is set in the brokers

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
@@ -20,6 +20,8 @@ consumer = ${common} {
     isolation.level = read_committed
     # Force consumers to commit their offsets manually. Again required for transactionality.
     enable.auto.commit = false
+    # Ensure that consumers cannot automatically create topics, even if the broker does allow it.
+    allow.auto.create.topics = false
 }
 
 # Properties that should be enforced for all producers.


### PR DESCRIPTION
The auto create topics configuration needs to be set on the broker for this to happen. However, if this is set then the consumers in Corda will currently auto create topics. All our deployment options should be creating topics up front, so this change should act as an extra guard to prevent auto creation if a mistake is made when setting up the broker.