### PR TITLE
NOTICK: Fix failing test on Windows

### DIFF
--- a/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
+++ b/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
@@ -53,7 +53,9 @@ class HostedIdentityEntryFactoryTest {
     private val sessionKey = mock<CryptoSigningKey> {
         on { publicKey } doReturn ByteBuffer.wrap(publicKeyBytes)
     }
-    private val certificatePem = HostedIdentityEntryFactoryTest::class.java.getResource("/certificates/$VALID_NODE.pem")!!.readText()
+    private val certificatePem =
+        HostedIdentityEntryFactoryTest::class.java.getResource("/certificates/$VALID_NODE.pem")!!.readText()
+            .replace("\n", System.lineSeparator())
     private val rootPem = HostedIdentityEntryFactoryTest::class.java.getResource("/certificates/root.pem")!!.readText()
     private val certificatePublicKey = certificatePem.let {
         CertificateFactory.getInstance("X.509").generateCertificate(it.byteInputStream()).publicKey


### PR DESCRIPTION
When writing a PEM in Windows it adds a carridge return to any new line. This should fix the failing test.