### PR TITLE
CORE-5039: Apply key scheme from registration context

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -41,7 +41,6 @@ import net.corda.schema.Schemas.P2P.Companion.P2P_HOSTED_IDENTITIES_TOPIC
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.KeyEncodingService
-import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.calculateHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
@@ -79,6 +78,7 @@ class StaticMemberRegistrationService @Activate constructor(
         private val logger: Logger = contextLogger()
         private val endpointUrlIdentifier = ENDPOINT_URL.substringBefore("-")
         private val endpointProtocolIdentifier = ENDPOINT_PROTOCOL.substringBefore("-")
+        private const val KEY_SCHEME = "corda.key.scheme"
     }
 
     private val DUMMY_CERTIFICATE = this::class.java.getResource("/static_network_dummy_certificate.pem")!!.readText()
@@ -117,8 +117,9 @@ class StaticMemberRegistrationService @Activate constructor(
             )
         }
         try {
+            val keyScheme = context[KEY_SCHEME] ?: throw IllegalArgumentException("Key scheme must be specified.")
             val groupPolicy = groupPolicyProvider.getGroupPolicy(member)
-            val membershipUpdates = lifecycleHandler.publisher.publish(parseMemberTemplate(member, groupPolicy))
+            val membershipUpdates = lifecycleHandler.publisher.publish(parseMemberTemplate(member, groupPolicy, keyScheme))
             membershipUpdates.forEach { it.get() }
             val hostedIdentityUpdates =
                 lifecycleHandler.publisher.publish(listOf(createHostedIdentity(member, groupPolicy)))
@@ -145,7 +146,8 @@ class StaticMemberRegistrationService @Activate constructor(
     @Suppress("MaxLineLength")
     private fun parseMemberTemplate(
         registeringMember: HoldingIdentity,
-        groupPolicy: GroupPolicy
+        groupPolicy: GroupPolicy,
+        keyScheme: String,
     ): List<Record<String, PersistentMemberInfo>> {
         val records = mutableListOf<Record<String, PersistentMemberInfo>>()
 
@@ -165,7 +167,7 @@ class StaticMemberRegistrationService @Activate constructor(
 
         validateStaticMemberDeclaration(staticMemberInfo)
         // single key used as both session and ledger key
-        val memberKey = getOrGenerateKeyPair(memberId)
+        val memberKey = getOrGenerateKeyPair(memberId, keyScheme)
         val encodedMemberKey = keyEncodingService.encodeAsString(memberKey)
 
         @Suppress("SpreadOperator")
@@ -264,7 +266,7 @@ class StaticMemberRegistrationService @Activate constructor(
         }
     }
 
-    private fun getOrGenerateKeyPair(tenantId: String): PublicKey {
+    private fun getOrGenerateKeyPair(tenantId: String, scheme: String): PublicKey {
         return with(cryptoOpsClient) {
             lookup(
                 tenantId = tenantId,
@@ -280,7 +282,7 @@ class StaticMemberRegistrationService @Activate constructor(
                 tenantId = tenantId,
                 category = CryptoConsts.Categories.LEDGER,
                 alias = tenantId,
-                scheme = ECDSA_SECP256R1_CODE_NAME // @Charlie - you will have to have a way of specifying that now
+                scheme = scheme
             )
         }
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -46,6 +46,7 @@ import net.corda.schema.Schemas
 import net.corda.schema.Schemas.P2P.Companion.P2P_HOSTED_IDENTITIES_TOPIC
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.calculateHash
 import net.corda.virtualnode.HoldingIdentity
 import org.junit.jupiter.api.Test
@@ -69,6 +70,7 @@ class StaticMemberRegistrationServiceTest {
         private const val ALICE_KEY = "1234"
         private const val BOB_KEY = "2345"
         private const val CHARLIE_KEY = "6789"
+        private const val KEY_SCHEME = "corda.key.scheme"
     }
 
     private val alice = HoldingIdentity(aliceName.toString(), DUMMY_GROUP_ID)
@@ -158,6 +160,10 @@ class StaticMemberRegistrationServiceTest {
 
     private val hsmRegistrationClient: HSMRegistrationClient = mock()
 
+    private val mockContext: Map<String, String> = mock {
+        on { get(KEY_SCHEME) } doReturn ECDSA_SECP256R1_CODE_NAME
+    }
+
     private val registrationService = StaticMemberRegistrationService(
         groupPolicyProvider,
         publisherFactory,
@@ -191,7 +197,7 @@ class StaticMemberRegistrationServiceTest {
         setUpPublisher()
         registrationService.start()
         val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
-        val registrationResult = registrationService.register(alice, mock())
+        val registrationResult = registrationService.register(alice, mockContext)
         Mockito.verify(mockPublisher, times(2)).publish(capturedPublishedList.capture())
         CryptoConsts.Categories.all.forEach {
             Mockito.verify(hsmRegistrationClient, times(1)).findHSM(aliceId, it)
@@ -246,7 +252,7 @@ class StaticMemberRegistrationServiceTest {
     fun `registration fails when name field is empty in the GroupPolicy file`() {
         setUpPublisher()
         registrationService.start()
-        val registrationResult = registrationService.register(bob, mock())
+        val registrationResult = registrationService.register(bob, mockContext)
         assertEquals(
             MembershipRequestRegistrationResult(
                 NOT_SUBMITTED,
@@ -261,7 +267,7 @@ class StaticMemberRegistrationServiceTest {
     fun `registration fails when static network is empty`() {
         setUpPublisher()
         registrationService.start()
-        val registrationResult = registrationService.register(charlie, mock())
+        val registrationResult = registrationService.register(charlie, mockContext)
         assertEquals(
             MembershipRequestRegistrationResult(
                 NOT_SUBMITTED,
@@ -275,7 +281,7 @@ class StaticMemberRegistrationServiceTest {
     @Test
     fun `registration fails when coordinator is not running`() {
         setUpPublisher()
-        val registrationResult = registrationService.register(alice, mock())
+        val registrationResult = registrationService.register(alice, mockContext)
         assertEquals(
             MembershipRequestRegistrationResult(
                 NOT_SUBMITTED,
@@ -289,11 +295,26 @@ class StaticMemberRegistrationServiceTest {
     fun `registration fails when registering member is not in the static member list`() {
         setUpPublisher()
         registrationService.start()
-        val registrationResult = registrationService.register(daisy, mock())
+        val registrationResult = registrationService.register(daisy, mockContext)
         assertEquals(
             MembershipRequestRegistrationResult(
                 NOT_SUBMITTED,
                 "Registration failed. Reason: Our membership O=Daisy, L=London, C=GB is not listed in the static member list."
+            ),
+            registrationResult
+        )
+        registrationService.stop()
+    }
+
+    @Test
+    fun `registration fails when key scheme is not provided in context`() {
+        setUpPublisher()
+        registrationService.start()
+        val registrationResult = registrationService.register(alice, mock())
+        assertEquals(
+            MembershipRequestRegistrationResult(
+                NOT_SUBMITTED,
+                "Registration failed. Reason: Key scheme must be specified."
             ),
             registrationResult
         )

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -42,6 +42,7 @@ import java.time.Duration
 import java.lang.IllegalStateException
 import java.util.UUID
 import net.corda.test.util.time.TestClock
+import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import java.time.Instant
 
 class MemberProcessorTestUtils {
@@ -70,6 +71,8 @@ class MemberProcessorTestUtils {
         instanceId=1
         bus.busType = INMEMORY
     """
+
+        private const val KEY_SCHEME = "corda.key.scheme"
 
         fun makeMessagingConfig(boostrapConfig: SmartConfig): SmartConfig =
             boostrapConfig.factory.create(
@@ -180,14 +183,16 @@ class MemberProcessorTestUtils {
         fun getRegistrationResult(
             registrationProxy: RegistrationProxy,
             holdingIdentity: HoldingIdentity
-        ): MembershipRequestRegistrationResult =
-            eventually(
+        ): MembershipRequestRegistrationResult {
+            val context = mapOf(KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME)
+            return eventually(
                 waitBetween = Duration.ofMillis(1000)
             ) {
                 assertDoesNotThrow {
-                    registrationProxy.register(holdingIdentity, emptyMap())
+                    registrationProxy.register(holdingIdentity, context)
                 }
             }
+        }
 
         fun assertLookupSize(groupReader: MembershipGroupReader, expectedSize: Int) = eventually {
             groupReader.lookup().also {


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-5039

The onboarding process for static members is described on this [Wiki page](https://github.com/corda/corda-runtime-os/wiki/Member-Onboarding), along with an example of the registration context containing the key scheme.