### PR TITLE
NOTICK: Remove the Windows \r if git added it

### DIFF
--- a/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
+++ b/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
@@ -55,6 +55,7 @@ class HostedIdentityEntryFactoryTest {
     }
     private val certificatePem =
         HostedIdentityEntryFactoryTest::class.java.getResource("/certificates/$VALID_NODE.pem")!!.readText()
+            .replace("\r", "")
             .replace("\n", System.lineSeparator())
     private val rootPem = HostedIdentityEntryFactoryTest::class.java.getResource("/certificates/root.pem")!!.readText()
     private val certificatePublicKey = certificatePem.let {


### PR DESCRIPTION
Looks like git sometimes adds `\r\n` during checkout on Windows. This caused the Windows pipeline [to break](https://ci02.dev.r3.com/job/Corda5/job/Nightlys/job/Corda-Runtime-OS/job/Windows/job/release%252Fos%252F5.0/71/display/redirect).

This change will remove the `\r` from the file before going any further.

Looks like it [passes](https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNightlys%2FCorda-Runtime-OS%2FWindows/detail/PR-1557/1/pipeline).