### PR TITLE
CORE-5084: Use multi-arch image for DB client

### DIFF
--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -62,9 +62,9 @@ db:
     # -- registry for image containing a db client, used to set up the db
     registry: ""
     # -- repository for image containing a db client, used to set up the db
-    repository: bitnami/postgresql
+    repository: postgres
     # -- tag for image containing a db client, used to set up the db
-    tag: 14.2.0-debian-10-r88
+    tag: 14.4
 
 # Kafka configuration
 kafka:


### PR DESCRIPTION
To support development on both ARM and AMD, switch the DB client image to use a Postgres image that supports both architectures.