### PR TITLE
CORE-5422: When creating K8s label if the branch name is over 60 characters, shorten it due to k8s Character limits regarding labels - causes Job failure 

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -156,8 +156,8 @@ pipeline {
     }
 }
 
-// K8s labels can not be greater than 63 charecters 
-// Helper method to sanitize edge cases of very long brnach names
+// K8s labels can not be greater than 63 characters 
+// Helper method to sanitize edge cases of very long branch names
 def sanitizedBranchName(){
     return env.BRANCH_NAME.length() > 60 ? env.BRANCH_NAME.substring(0,60).replace('/','-') : env.BRANCH_NAME.replace('/','-')
 }

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                 sh """
                     kubectl create ns $NAMESPACE
                     kubectl label ns $NAMESPACE namespace-type=corda-e2e --overwrite=true
-                    kubectl label ns $NAMESPACE branch=${env.BRANCH_NAME.length() > 60 ? env.BRANCH_NAME.substring(0,60).replace('/','-') : env.BRANCH_NAME.replace('/','-') } --overwrite=true
+                    kubectl label ns $NAMESPACE branch=${sanitizedBranchName()} --overwrite=true
                 """
             }
         }
@@ -154,4 +154,10 @@ pipeline {
             sh 'kubectl delete ns "${NAMESPACE}"'
         }
     }
+}
+
+// K8s labels can not be greater than 63 charecters 
+// Helper method to sanitize edge cases of very long brnach names
+def sanitizedBranchName(){
+    return env.BRANCH_NAME.length() > 60 ? env.BRANCH_NAME.substring(0,60).replace('/','-') : env.BRANCH_NAME.replace('/','-')
 }

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                 sh """
                     kubectl create ns $NAMESPACE
                     kubectl label ns $NAMESPACE namespace-type=corda-e2e --overwrite=true
-                    kubectl label ns $NAMESPACE branch=${env.BRANCH_NAME.replace('/','-')} --overwrite=true
+                    kubectl label ns $NAMESPACE branch=${env.BRANCH_NAME.length() > 60 ? env.BRANCH_NAME.substring(0,60).replace('/','-') : env.BRANCH_NAME.replace('/','-') } --overwrite=true
                 """
             }
         }


### PR DESCRIPTION
As observed in example below long branch names can cause issues when creating a label based on the branch.

First check length if it's over 60 characters drop the rest of the string otherwise use the branch as normal.  
K8s limit is 63 charecters.

**Failing example:**
https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-e2e-tests/job/WillV%2FCORE-3153-Replace-Stub-Crypto-Processor-With-Real-Implementation/1/


**Subsequent Pass ( Tested with replay)**
https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-e2e-tests/job/WillV%2FCORE-3153-Replace-Stub-Crypto-Processor-With-Real-Implementation/2/

