### PR TITLE
NOTICK - Remove scheme check from gateway server

### DIFF
--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -90,6 +90,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
 import org.mockito.kotlin.mock
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
+import java.net.http.HttpRequest.BodyPublisher
 import java.net.http.HttpClient as JavaHttpClient
 import java.net.http.HttpRequest as JavaHttpRequest
 import java.net.http.HttpResponse.BodyHandlers
@@ -209,7 +210,9 @@ class GatewayIntegrationTest : TestBase() {
                     .build()
 
                 val request = JavaHttpRequest.newBuilder()
-                    .uri(serverAddress)
+                    .POST(java.net.http.HttpRequest.BodyPublishers.noBody())
+                    .uri(URI("$serverAddress/gateway/send"))
+                    .header("Content-type", "application/json")
                     .build()
 
                 val response = httpClient.send(request, BodyHandlers.discarding())

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpHelper.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpHelper.kt
@@ -73,9 +73,6 @@ class HttpHelper {
         fun HttpRequest.validate(): HttpResponseStatus {
             try {
                 val uri = URI.create(this.uri()).normalize()
-                if (uri.scheme != SCHEME) {
-                    return HttpResponseStatus.BAD_REQUEST
-                }
 
                 if (uri.path != ENDPOINT) {
                     return HttpResponseStatus.NOT_FOUND


### PR DESCRIPTION
## Changes
Removing the scheme check from the gateway server, because checks for TLS are already happening at a level above (so this is not really needed to check that it's a TLS connection) and it's causing issues with clients that might be sending an absolute path as part of the HTTP request (`POST /gateway/send HTTP/1.1` instead of `POST https://www.alice.net:3001/gateway/send HTTP/1.1`) which is something reasonable. I also adjusted one of the tests we had for invalid requests as before it was falling into this case (I believe by accident).

Note when someone tries to connect without TLS, the connection will fail with the following error in the server which is the same behaviour as before:
```
[WARN] 13:55:25.777 [nioEventLoopGroup-5-1] http.HttpServer. - Handshake failure not an SSL/TLS record: 474554202f676174657761792f73656e6420485454502f312e310d0a436f6e6e656374696f6e3a20557067726164652c2048545450322d53657474696e67730d0a436f6e74656e742d4c656e6774683a20300d0a486f73743a207777772e616c6963652e6e65743a333030310d0a48545450322d53657474696e67733a204141454141454141414149414141414241414d414141426b414151424141414141415541414541410d0a557067726164653a206832630d0a557365722d4167656e743a204a6176612d687474702d636c69656e742f31312e302e390d0a0d0a {}
```