### PR TITLE
CORE-4985 Add Open Telemetry agent to p2p-link-manager

### DIFF
--- a/applications/p2p-link-manager/build.gradle
+++ b/applications/p2p-link-manager/build.gradle
@@ -48,4 +48,6 @@ dependencies {
     implementation project(":libs:configuration:configuration-merger")
     implementation project(":libs:messaging:messaging")
     implementation project(":components:configuration:configuration-read-service")
+
+    image "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
 }


### PR DESCRIPTION
At least as currently written, the Helm chart expects all worker images to contain the Open Telemetry agent.