### PR TITLE
NOTICK: Move osgiRun extension out of dependencies handler.

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -1,10 +1,15 @@
 plugins {
     id 'corda.common-publishing'
-    id 'corda.common-app'
     id 'corda.quasar-app'
 }
 
 description 'Combined Worker'
+
+osgiRun {
+    frameworkProperties.putAll(
+        'org.osgi.framework.security': 'osgi'
+    )
+}
 
 dependencies {
     // for BundleManager
@@ -41,17 +46,8 @@ dependencies {
 
     runtimeOnly project(':libs:messaging:kafka-message-bus-impl')
 
-    testImplementation 'org.osgi:osgi.core'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
-
     runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
         exclude group: 'org.apache.felix'
         exclude group: 'org.osgi'
-    }
-
-    osgiRun {
-        frameworkProperties.putAll(
-                'org.osgi.framework.security': 'osgi'
-        )
     }
 }

--- a/applications/workers/release/db-worker/build.gradle
+++ b/applications/workers/release/db-worker/build.gradle
@@ -5,6 +5,12 @@ plugins {
 
 description 'DB Worker'
 
+osgiRun {
+    frameworkProperties.putAll(
+        'org.osgi.framework.security': 'osgi'
+    )
+}
+
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
@@ -33,12 +39,6 @@ dependencies {
     runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
         exclude group: 'org.apache.felix'
         exclude group: 'org.osgi'
-    }
-
-    osgiRun {
-        frameworkProperties.putAll(
-                'org.osgi.framework.security': 'osgi'
-        )
     }
 
     image "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"

--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -5,6 +5,12 @@ plugins {
 
 description 'Flow Worker'
 
+osgiRun {
+    frameworkProperties.putAll(
+        'org.osgi.framework.security': 'osgi'
+    )
+}
+
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
@@ -36,10 +42,4 @@ dependencies {
     }
 
     image "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
-
-    osgiRun {
-        frameworkProperties.putAll(
-                'org.osgi.framework.security': 'osgi'
-        )
-    }
 }

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -1,5 +1,3 @@
-import aQute.bnd.gradle.Bundle
-
 plugins {
     id 'org.jetbrains.kotlin.jvm'
 }


### PR DESCRIPTION
It is an unfortunate "feature" of Gradle that its scripts are completely unstructured, and putting things in bizarre places doesn't trigger an error.