### PR TITLE
CORE-5451 Expose member lookup based on session key

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeMembershipGroupReaderProvider.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeMembershipGroupReaderProvider.kt
@@ -63,5 +63,9 @@ class FakeMembershipGroupReaderProvider : MembershipGroupReaderProvider {
         override fun lookup(name: MemberX500Name): MemberInfo? {
             TODO("Not yet implemented")
         }
+
+        override fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo? {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.read.reader
 
 import net.corda.membership.impl.MemberInfoExtension.Companion.ledgerKeyHashes
+import net.corda.membership.impl.MemberInfoExtension.Companion.sessionKeyHash
 import net.corda.membership.lib.CPIWhiteList
 import net.corda.membership.impl.read.cache.MembershipGroupReadCache
 import net.corda.membership.read.MembershipGroupReader
@@ -31,6 +32,11 @@ class MembershipGroupReaderImpl(
 
     override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? =
         memberList.singleOrNull { it.isActive && ledgerKeyHash in it.ledgerKeyHashes }
+
+    override fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo? =
+        memberList.singleOrNull {
+            it.isActive && sessionKeyHash == it.sessionKeyHash
+        }
 
     override fun lookup(name: MemberX500Name) = memberList.singleOrNull { it.isActive && it.name == name }
 }

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
@@ -34,9 +34,7 @@ class MembershipGroupReaderImpl(
         memberList.singleOrNull { it.isActive && ledgerKeyHash in it.ledgerKeyHashes }
 
     override fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo? =
-        memberList.singleOrNull {
-            it.isActive && sessionKeyHash == it.sessionKeyHash
-        }
+        memberList.singleOrNull { it.isActive && sessionKeyHash == it.sessionKeyHash }
 
     override fun lookup(name: MemberX500Name) = memberList.singleOrNull { it.isActive && it.name == name }
 }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.read.reader
 
 import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEY_HASHES
+import net.corda.membership.impl.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.impl.read.TestProperties
 import net.corda.membership.impl.read.TestProperties.Companion.GROUP_ID_1
 import net.corda.membership.impl.read.cache.MemberListCache
@@ -30,26 +31,33 @@ class MembershipGroupReaderImplTest {
     private val membershipGroupCache: MembershipGroupReadCache = mock<MembershipGroupReadCache>().apply {
         whenever(this.memberListCache).thenReturn(memberCache)
     }
-    private val knownKey: PublicKey = mock()
-    private val knownKeyAsByteArray = "1234".toByteArray()
-    private val knownKeyHash = PublicKeyHash.parse(knownKeyAsByteArray.sha256Bytes())
+    private val mockLedgerKey: PublicKey = mock()
+    private val mockLedgerKeyAsByteArray = "1234".toByteArray()
+    private val mockLedgerKeyHash = PublicKeyHash.parse(mockLedgerKeyAsByteArray.sha256Bytes())
+    private val mockSessionKey: PublicKey = mock()
+    private val mockSessionKeyAsByteArray = "5678".toByteArray()
+    private val mockSessionKeyHash = PublicKeyHash.parse(mockSessionKeyAsByteArray.sha256Bytes())
+    private val mockedMemberProvidedContext = mock<MemberContext> {
+        on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
+        on { parse(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
+    }
     private val suspendedMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
-        on { ledgerKeys } doReturn listOf(knownKey)
-        val mockedMemberProvidedContext = mock<MemberContext> {
-            on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(knownKeyHash)
-        }
+        on { ledgerKeys } doReturn listOf(mockLedgerKey)
+        on { sessionInitiationKey } doReturn mockSessionKey
         on { memberProvidedContext } doReturn mockedMemberProvidedContext
         on { isActive } doReturn false
     }
 
+    private val mockedActiveMemberProvidedContext = mock<MemberContext> {
+        on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
+        on { parse(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
+    }
     private val activeMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
-        on { ledgerKeys } doReturn listOf(knownKey)
-        val mockedMemberProvidedContext = mock<MemberContext> {
-            on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(knownKeyHash)
-        }
-        on { memberProvidedContext } doReturn mockedMemberProvidedContext
+        on { ledgerKeys } doReturn listOf(mockLedgerKey)
+        on { sessionInitiationKey } doReturn mockSessionKey
+        on { memberProvidedContext } doReturn mockedActiveMemberProvidedContext
         on { isActive } doReturn true
     }
 
@@ -86,19 +94,49 @@ class MembershipGroupReaderImplTest {
     @Test
     fun `lookup known member with active status based on public key hash`() {
         mockMemberList(listOf(activeMemberInfo))
-        assertEquals(activeMemberInfo, membershipGroupReaderImpl.lookup(knownKeyHash))
+        assertEquals(activeMemberInfo, membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
     }
 
     @Test
     fun `lookup known member with non active status based on public key hash`() {
         mockMemberList(listOf(suspendedMemberInfo))
-        assertNull(membershipGroupReaderImpl.lookup(knownKeyHash))
+        assertNull(membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
     }
 
     @Test
     fun `lookup non-existing member based on public key hash`() {
         mockMemberList(emptyList())
-        assertNull(membershipGroupReaderImpl.lookup(knownKeyHash))
+        assertNull(membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
+    }
+
+    @Test
+    fun `lookup member based on public key hash using session key fails`() {
+        mockMemberList(listOf(activeMemberInfo))
+        assertNull(membershipGroupReaderImpl.lookup(mockSessionKeyHash))
+    }
+
+    @Test
+    fun `lookup known member with active status based on session public key hash`() {
+        mockMemberList(listOf(activeMemberInfo))
+        assertEquals(activeMemberInfo, membershipGroupReaderImpl.lookupBySessionKey(mockSessionKeyHash))
+    }
+
+    @Test
+    fun `lookup known member with non active status based on session public key hash`() {
+        mockMemberList(listOf(suspendedMemberInfo))
+        assertNull(membershipGroupReaderImpl.lookupBySessionKey(mockSessionKeyHash))
+    }
+
+    @Test
+    fun `lookup non-existing member based on session public key hash`() {
+        mockMemberList(emptyList())
+        assertNull(membershipGroupReaderImpl.lookupBySessionKey(mockSessionKeyHash))
+    }
+
+    @Test
+    fun `lookup member based on public key hash using ledger key fails`() {
+        mockMemberList(listOf(activeMemberInfo))
+        assertNull(membershipGroupReaderImpl.lookupBySessionKey(mockLedgerKeyHash))
     }
 
     @Test

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -37,7 +37,7 @@ class MembershipGroupReaderImplTest {
     private val mockSessionKey: PublicKey = mock()
     private val mockSessionKeyAsByteArray = "5678".toByteArray()
     private val mockSessionKeyHash = PublicKeyHash.parse(mockSessionKeyAsByteArray.sha256Bytes())
-    private val mockedMemberProvidedContext = mock<MemberContext> {
+    private val mockedSuspendedMemberProvidedContext = mock<MemberContext> {
         on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
         on { parse(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
     }
@@ -45,7 +45,7 @@ class MembershipGroupReaderImplTest {
         on { name } doReturn aliceName
         on { ledgerKeys } doReturn listOf(mockLedgerKey)
         on { sessionInitiationKey } doReturn mockSessionKey
-        on { memberProvidedContext } doReturn mockedMemberProvidedContext
+        on { memberProvidedContext } doReturn mockedSuspendedMemberProvidedContext
         on { isActive } doReturn false
     }
 
@@ -92,25 +92,25 @@ class MembershipGroupReaderImplTest {
     }
 
     @Test
-    fun `lookup known member with active status based on public key hash`() {
+    fun `lookup known member with active status based on ledger public key hash`() {
         mockMemberList(listOf(activeMemberInfo))
         assertEquals(activeMemberInfo, membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
     }
 
     @Test
-    fun `lookup known member with non active status based on public key hash`() {
+    fun `lookup known member with non active status based on ledger public key hash`() {
         mockMemberList(listOf(suspendedMemberInfo))
         assertNull(membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
     }
 
     @Test
-    fun `lookup non-existing member based on public key hash`() {
+    fun `lookup non-existing member based on ledger public key hash`() {
         mockMemberList(emptyList())
         assertNull(membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
     }
 
     @Test
-    fun `lookup member based on public key hash using session key fails`() {
+    fun `lookup member based on ledger public key hash using session key fails`() {
         mockMemberList(listOf(activeMemberInfo))
         assertNull(membershipGroupReaderImpl.lookup(mockSessionKeyHash))
     }
@@ -134,7 +134,7 @@ class MembershipGroupReaderImplTest {
     }
 
     @Test
-    fun `lookup member based on public key hash using ledger key fails`() {
+    fun `lookup member based on session public key hash using ledger key fails`() {
         mockMemberList(listOf(activeMemberInfo))
         assertNull(membershipGroupReaderImpl.lookupBySessionKey(mockLedgerKeyHash))
     }

--- a/components/membership/membership-group-read/src/main/kotlin/net/corda/membership/read/MembershipGroupReader.kt
+++ b/components/membership/membership-group-read/src/main/kotlin/net/corda/membership/read/MembershipGroupReader.kt
@@ -56,4 +56,14 @@ interface MembershipGroupReader {
      * @param name MemberX500Name of the member to lookup.
      */
     fun lookup(name: MemberX500Name): MemberInfo?
+
+    /**
+     * Looks up a group member matching the public key SHA-256 hash as visible by the member represented
+     * by [owningMember] having active membership status within the group represented by [groupId].
+     *
+     * If the member is not found then the null value is returned.
+     *
+     * @param sessionKeyHash Hash of the session key belonging to the member to be looked up.
+     */
+    fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo?
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -21,6 +21,7 @@ import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.impl.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.impl.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.impl.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.impl.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.impl.MemberInfoExtension.Companion.URL_KEY
@@ -179,6 +180,7 @@ class StaticMemberRegistrationService @Activate constructor(
                 *generateLedgerKeys(encodedMemberKey).toTypedArray(),
                 *generateLedgerKeyHashes(memberKey).toTypedArray(),
                 *convertEndpoints(staticMemberInfo).toTypedArray(),
+                SESSION_KEY_HASH to memberKey.calculateHash().toString(),
                 SOFTWARE_VERSION to staticMemberInfo.softwareVersion,
                 PLATFORM_VERSION to staticMemberInfo.platformVersion,
                 SERIAL to staticMemberInfo.serial,

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/impl/MemberInfoExtension.kt
@@ -28,6 +28,9 @@ class MemberInfoExtension {
         const val PARTY_NAME = "corda.name"
         const val PARTY_SESSION_KEY = "corda.session.key"
 
+        /** Key name for the session key hash **/
+        const val SESSION_KEY_HASH = "corda.sessionKeyHash"
+
         /** Key name for notary service property. */
         const val NOTARY_SERVICE_PARTY_NAME = "corda.notaryService.name"
         const val NOTARY_SERVICE_SESSION_KEY = "corda.notaryService.session.key"
@@ -137,6 +140,11 @@ class MemberInfoExtension {
         @JvmStatic
         val MemberInfo.ledgerKeyHashes: Collection<PublicKeyHash>
             get() = memberProvidedContext.parseSet(LEDGER_KEY_HASHES)
+
+        /** Collection of ledger key hashes for member's node. */
+        @JvmStatic
+        val MemberInfo.sessionKeyHash: PublicKeyHash
+            get() = memberProvidedContext.parse(SESSION_KEY_HASH)
 
         /** Denotes whether this [MemberInfo] represents an MGM node. */
         @JvmStatic

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
@@ -46,7 +46,7 @@ import net.corda.processor.member.MemberProcessorTestUtils.Companion.getGroupPol
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.getRegistrationResult
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.groupId
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.isStarted
-import net.corda.processor.member.MemberProcessorTestUtils.Companion.lookUpFromPublicKey
+import net.corda.processor.member.MemberProcessorTestUtils.Companion.lookUpBySessionKey
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.lookup
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.lookupFails
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.makeBootstrapConfig
@@ -437,8 +437,8 @@ class MemberProcessorIntegrationTest {
 
         assertLookupSize(bobReader, 2)
 
-        assertEquals(aliceMemberInfo, lookUpFromPublicKey(aliceGroupReader, aliceMemberInfo))
-        assertEquals(bobMemberInfo, lookUpFromPublicKey(aliceGroupReader, bobMemberInfo))
+        assertEquals(aliceMemberInfo, lookUpBySessionKey(aliceGroupReader, aliceMemberInfo))
+        assertEquals(bobMemberInfo, lookUpBySessionKey(aliceGroupReader, bobMemberInfo))
 
     }
 }

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -43,6 +43,7 @@ import java.lang.IllegalStateException
 import java.util.UUID
 import net.corda.test.util.time.TestClock
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
+import net.corda.v5.crypto.calculateHash
 import java.time.Instant
 
 class MemberProcessorTestUtils {
@@ -211,8 +212,10 @@ class MemberProcessorTestUtils {
             assertNull(lookupResult)
         }
 
-        fun lookUpFromPublicKey(groupReader: MembershipGroupReader, member: MemberInfo?) = eventually {
-            val result = groupReader.lookup(PublicKeyHash.calculate(member!!.sessionInitiationKey))
+        fun lookUpBySessionKey(groupReader: MembershipGroupReader, member: MemberInfo?) = eventually {
+            val result = member?.let {
+                groupReader.lookupBySessionKey(it.sessionInitiationKey.calculateHash())
+            }
             assertNotNull(result)
             result!!
         }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -53,5 +53,9 @@ class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
         override fun lookup(name: MemberX500Name): MemberInfo? {
             return null
         }
+
+        override fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo? {
+            return null
+        }
     }
 }


### PR DESCRIPTION
Extends the membership group reader implementation to expose a lookup of member info based on session initiation key. This works in the same way as the ledger key lookup except uses a single key instead of a list. Key hash must be set in the member context for faster lookups. New lookup called `lookupBySessionKey` to avoid duplicate function signature.