### PR TITLE
CORE-4985 Add k8s attributes to workers for Open Telemetry

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -136,9 +136,29 @@ resources:
 {{- end }}
 
 {{/*
-Worker JAVA_TOOL_OPTIONS
+Worker environment variables
 */}}
-{{- define "corda.workerJavaToolOptions" -}}
+{{- define "corda.workerEnv" -}}
+- name: K8S_NODE_NAME
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: spec.nodeName
+- name: K8S_POD_NAME
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: metadata.name
+- name: K8S_POD_UID
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: metadata.uid
+- name: K8S_NAMESPACE
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: metadata.namespace
 - name: JAVA_TOOL_OPTIONS
   value: {{- if ( get .Values.workers .worker ).debug.enabled }}
       -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend={{ if ( get .Values.workers .worker ).debug.suspend }}y{{ else }}n{{ end }}
@@ -148,7 +168,7 @@ Worker JAVA_TOOL_OPTIONS
     {{- end -}}
     {{- if .Values.openTelemetry.enabled }}
       -javaagent:/opt/override/opentelemetry-javaagent-1.15.0.jar
-      -Dotel.resource.attributes=service.name={{ .worker }}-worker
+      -Dotel.resource.attributes=service.name={{ .worker }}-worker,k8s.namespace.name=$(K8S_NAMESPACE),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
       -Dotel.instrumentation.common.default-enabled=false
       -Dotel.instrumentation.runtime-metrics.enabled=true
       {{- if .Values.openTelemetry.endpoint }}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -40,7 +40,7 @@ spec:
           allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
-        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+        {{- include "corda.workerEnv" . | nindent 10 }}
           - name: DATABASE_PASS
             valueFrom:
               secretKeyRef:

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -40,7 +40,7 @@ spec:
           allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }} 
         env:
-        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+        {{- include "corda.workerEnv" . | nindent 10 }}
           - name: DATABASE_PASS
             valueFrom:
               secretKeyRef:

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -40,7 +40,7 @@ spec:
           allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
-        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+        {{- include "corda.workerEnv" . | nindent 10 }}
         args:
         {{- include "corda.workerKafkaArgs" . | nindent 10 }}
         volumeMounts:

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -28,7 +28,7 @@ spec:
           allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
-        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+        {{- include "corda.workerEnv" . | nindent 10 }}
         args:
         {{- include "corda.workerKafkaArgs" . | nindent 10 }}
         volumeMounts:

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -40,7 +40,7 @@ spec:
          allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
-        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+        {{- include "corda.workerEnv" . | nindent 10 }}
         args:
         {{- include "corda.workerKafkaArgs" . | nindent 10 }}
         volumeMounts:

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -66,7 +66,7 @@ spec:
           allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
-        {{- include "corda.workerJavaToolOptions" . | nindent 10 }}
+        {{- include "corda.workerEnv" . | nindent 10 }}
         args:
         {{- include "corda.workerKafkaArgs" . | nindent 10 }}
         volumeMounts:


### PR DESCRIPTION
To allow us to aggregate metrics coming directly from the worker with those coming via the Open Telemetry collector agent, it is desirable that they are identifiable by their Kubernetes namespace/pod.