### PR TITLE
CORE-5271 - avoid loading CpkFileEntity's data binary data when updating existing CPKs

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -301,10 +301,39 @@ internal class DatabaseCpiPersistenceTest {
             )
         }
 
-        findAndAssertCpk(cpi1.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 0, 0)
-        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 0, 0)
-        findAndAssertCpk(cpi1.metadata.cpiId, cpk1.metadata.cpkId, cpk1Checksum.toString(), 0, 0, 0)
-        findAndAssertCpk(cpi2.metadata.cpiId, cpk2.metadata.cpkId, cpk2Checksum.toString(), 0, 0, 0)
+        // no updates to existing CPKs have occurred hence why all entity versions are 0
+        findAndAssertCpk(
+            cpiId = cpi1.metadata.cpiId,
+            cpkId = sharedCpk.metadata.cpkId,
+            expectedCpkFileChecksum = sharedCpkChecksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
+        findAndAssertCpk(
+            cpiId = cpi2.metadata.cpiId,
+            cpkId = sharedCpk.metadata.cpkId,
+            expectedCpkFileChecksum = sharedCpkChecksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
+        findAndAssertCpk(
+            cpiId = cpi1.metadata.cpiId,
+            cpkId = cpk1.metadata.cpkId,
+            expectedCpkFileChecksum = cpk1Checksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
+        findAndAssertCpk(
+            cpiId = cpi2.metadata.cpiId,
+            cpkId = cpk2.metadata.cpkId,
+            expectedCpkFileChecksum = cpk2Checksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
     }
 
     @Test
@@ -468,8 +497,23 @@ internal class DatabaseCpiPersistenceTest {
             emptyList()
         )
 
-        findAndAssertCpk(cpi.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpk.metadata.fileChecksum.toString(), 0, 0, 0)
-        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpk.metadata.fileChecksum.toString(), 0, 0, 0)
+        // no updates to existing CPKs have occurred hence why all entity versions are 0
+        findAndAssertCpk(
+            cpiId = cpi.metadata.cpiId,
+            cpkId = sharedCpk.metadata.cpkId,
+            expectedCpkFileChecksum = sharedCpk.metadata.fileChecksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
+        findAndAssertCpk(
+            cpiId = cpi2.metadata.cpiId,
+            cpkId = sharedCpk.metadata.cpkId,
+            expectedCpkFileChecksum = sharedCpk.metadata.fileChecksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
     }
 
     @Test
@@ -501,8 +545,23 @@ internal class DatabaseCpiPersistenceTest {
 
         assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, cpk.metadata.fileChecksum.toString(), 0, 0, 0)
-        findAndAssertCpk(cpi.metadata.cpiId, newCpk.metadata.cpkId, newCpk.metadata.fileChecksum.toString(), 0, 0, 0)
+        // no updates to existing CPKs have occurred hence why all entity versions are 0. We are updating a CPI by adding a new CPK to it
+        findAndAssertCpk(
+            cpiId = cpi.metadata.cpiId,
+            cpkId = cpk.metadata.cpkId,
+            expectedCpkFileChecksum = cpk.metadata.fileChecksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
+        findAndAssertCpk(
+            cpiId = cpi.metadata.cpiId,
+            cpkId = newCpk.metadata.cpkId,
+            expectedCpkFileChecksum = newCpk.metadata.fileChecksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
     }
 
     @Test
@@ -535,7 +594,15 @@ internal class DatabaseCpiPersistenceTest {
 
         assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, newChecksum.toString(), 1, 1, 1)
+        // we have updated an existing CPK with a new checksum (and data) hence why its entityVersion has incremented.
+        findAndAssertCpk(
+            cpiId = cpi.metadata.cpiId,
+            cpkId = cpk.metadata.cpkId,
+            expectedCpkFileChecksum = newChecksum.toString(),
+            expectedMetadataEntityVersion = 1,
+            expectedFileEntityVersion = 1,
+            expectedCpiCpkEntityVersion = 1
+        )
     }
 
     @Test
@@ -553,7 +620,14 @@ internal class DatabaseCpiPersistenceTest {
             emptyList()
         )
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, firstCpkChecksum.toString(), 0, 0, 0)
+        findAndAssertCpk(
+            cpiId = cpi.metadata.cpiId,
+            cpkId = cpk.metadata.cpkId,
+            expectedCpkFileChecksum = firstCpkChecksum.toString(),
+            expectedMetadataEntityVersion = 0,
+            expectedFileEntityVersion = 0,
+            expectedCpiCpkEntityVersion = 0
+        )
 
         // a new cpi object, but with same cpk
         val secondCpkChecksum = newRandomSecureHash()
@@ -569,7 +643,15 @@ internal class DatabaseCpiPersistenceTest {
             emptyList()
         )
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, secondCpkChecksum.toString(), 1, 1, 1)
+        // we have updated an existing CPK hence why the entity versions are incremented.
+        findAndAssertCpk(
+            cpiId = cpi.metadata.cpiId,
+            cpkId = cpk.metadata.cpkId,
+            expectedCpkFileChecksum = secondCpkChecksum.toString(),
+            expectedMetadataEntityVersion = 1,
+            expectedFileEntityVersion = 1,
+            expectedCpiCpkEntityVersion = 1
+        )
 
         // a new cpi object, but with same cpk
         val thirdChecksum = newRandomSecureHash()
@@ -585,7 +667,15 @@ internal class DatabaseCpiPersistenceTest {
             emptyList()
         )
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, thirdChecksum.toString(), 2, 2, 2)
+        // We have updated the same CPK again hence why the entity versions are incremented again.
+        findAndAssertCpk(
+            cpiId = cpi.metadata.cpiId,
+            cpkId = cpk.metadata.cpkId,
+            expectedCpkFileChecksum = thirdChecksum.toString(),
+            expectedMetadataEntityVersion = 2,
+            expectedFileEntityVersion = 2,
+            expectedCpiCpkEntityVersion = 2
+        )
     }
 
     private fun findAndAssertCpk(

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -301,8 +301,8 @@ internal class DatabaseCpiPersistenceTest {
             )
         }
 
-        findAndAssertCpk(cpi1.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
-        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi1.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 0, 0)
+        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpkChecksum.toString(), 0, 0, 0)
         findAndAssertCpk(cpi1.metadata.cpiId, cpk1.metadata.cpkId, cpk1Checksum.toString(), 0, 0, 0)
         findAndAssertCpk(cpi2.metadata.cpiId, cpk2.metadata.cpkId, cpk2Checksum.toString(), 0, 0, 0)
     }
@@ -468,22 +468,8 @@ internal class DatabaseCpiPersistenceTest {
             emptyList()
         )
 
-        findAndAssertCpk(
-            cpi.metadata.cpiId,
-            sharedCpk.metadata.cpkId,
-            sharedCpk.metadata.fileChecksum.toString(),
-            0,
-            1,
-            0
-        )
-        findAndAssertCpk(
-            cpi2.metadata.cpiId,
-            sharedCpk.metadata.cpkId,
-            sharedCpk.metadata.fileChecksum.toString(),
-            0,
-            1,
-            0
-        )
+        findAndAssertCpk(cpi.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpk.metadata.fileChecksum.toString(), 0, 0, 0)
+        findAndAssertCpk(cpi2.metadata.cpiId, sharedCpk.metadata.cpkId, sharedCpk.metadata.fileChecksum.toString(), 0, 0, 0)
     }
 
     @Test
@@ -515,7 +501,7 @@ internal class DatabaseCpiPersistenceTest {
 
         assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, cpk.metadata.fileChecksum.toString(), 0, 1, 0)
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, cpk.metadata.fileChecksum.toString(), 0, 0, 0)
         findAndAssertCpk(cpi.metadata.cpiId, newCpk.metadata.cpkId, newCpk.metadata.fileChecksum.toString(), 0, 0, 0)
     }
 
@@ -549,7 +535,7 @@ internal class DatabaseCpiPersistenceTest {
 
         assertThat(cpi.metadata.cpiId).isEqualTo(updatedCpi.metadata.cpiId)
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, newChecksum.toString(), 1, 2, 1)
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, newChecksum.toString(), 1, 1, 1)
     }
 
     @Test
@@ -583,7 +569,7 @@ internal class DatabaseCpiPersistenceTest {
             emptyList()
         )
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, secondCpkChecksum.toString(), 1, 2, 1)
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, secondCpkChecksum.toString(), 1, 1, 1)
 
         // a new cpi object, but with same cpk
         val thirdChecksum = newRandomSecureHash()
@@ -599,7 +585,7 @@ internal class DatabaseCpiPersistenceTest {
             emptyList()
         )
 
-        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, thirdChecksum.toString(), 2, 4, 2)
+        findAndAssertCpk(cpi.metadata.cpiId, cpk.metadata.cpkId, thirdChecksum.toString(), 2, 2, 2)
     }
 
     private fun findAndAssertCpk(

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
@@ -264,7 +264,8 @@ class DatabaseCpiPersistence(private val entityManagerFactory: EntityManagerFact
                         UPDATE ${CpkFileEntity::class.java.simpleName} f 
                         SET f.fileChecksum = :fileChecksum, 
                         f.data = :data,
-                        f.entityVersion = :incrementedEntityVersion 
+                        f.entityVersion = :incrementedEntityVersion, 
+                        f.insertTimestamp = CURRENT_TIMESTAMP 
                         WHERE f.entityVersion = :entityVersion 
                         AND f.id = :id
                     """.trimIndent()

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkFileEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkFileEntity.kt
@@ -8,7 +8,15 @@ import javax.persistence.Entity
 import javax.persistence.Lob
 import javax.persistence.Table
 import javax.persistence.EntityManager
+import javax.persistence.NamedQuery
 import javax.persistence.Version
+
+const val QUERY_NAME_UPDATE_CPK_FILE_DATA = "CpkFileEntity.updateFileData"
+const val QUERY_PARAM_FILE_CHECKSUM = "fileChecksum"
+const val QUERY_PARAM_DATA = "data"
+const val QUERY_PARAM_ENTITY_VERSION = "entityVersion"
+const val QUERY_PARAM_INCREMENTED_ENTITY_VERSION = "incrementedEntityVersion"
+const val QUERY_PARAM_ID = "id"
 
 /**
  * Cpk binary data
@@ -22,6 +30,16 @@ import javax.persistence.Version
  */
 @Entity
 @Table(name = "cpk_file", schema = DbSchema.CONFIG)
+@NamedQuery(
+    name = QUERY_NAME_UPDATE_CPK_FILE_DATA,
+    query = "UPDATE CpkFileEntity f" +
+            " SET f.fileChecksum = :$QUERY_PARAM_FILE_CHECKSUM," +
+            " f.data = :$QUERY_PARAM_DATA," +
+            " f.entityVersion = :$QUERY_PARAM_INCREMENTED_ENTITY_VERSION," +
+            " f.insertTimestamp = CURRENT_TIMESTAMP" +
+            " WHERE f.entityVersion = :$QUERY_PARAM_ENTITY_VERSION" +
+            " AND f.id = :$QUERY_PARAM_ID"
+)
 data class CpkFileEntity(
     @EmbeddedId
     val id: CpkKey,
@@ -36,6 +54,7 @@ data class CpkFileEntity(
     @Version
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int = 0
+
     // this TS is managed on the DB itself
     @Column(name = "insert_ts", insertable = false, updatable = false)
     var insertTimestamp: Instant? = null


### PR DESCRIPTION
We don't want to load the CpkFileEntity's binary data when we update the CPK entities.

Using `getReference()` as per jira description did not achieve lazy loading of data field, as on first access of a field of the proxy, all the fields of the class were loaded in a select:

```
val existingFileChecksum = existingCpkFileEntity.fileChecksum

// hibernate produces this:
Hibernate: 
    select
        cpkfileent0_.cpk_name as cpk_name1_3_0_,
        cpkfileent0_.cpk_signer_summary_hash as cpk_sign2_3_0_,
        cpkfileent0_.cpk_version as cpk_vers3_3_0_,
        cpkfileent0_.data as data4_3_0_,
        cpkfileent0_.entity_version as entity_v5_3_0_,
        cpkfileent0_.file_checksum as file_che6_3_0_,
        cpkfileent0_.insert_ts as insert_t7_3_0_,
        cpkfileent0_.is_deleted as is_delet8_3_0_ 
    from
        CONFIG.cpk_file cpkfileent0_ 
    where
        cpkfileent0_.cpk_name=? 
        and cpkfileent0_.cpk_signer_summary_hash=? 
        and cpkfileent0_.cpk_version=?
```

Approach is to use a dedicated query to find the relevant data required and update the entities. I also had to manually increment the entityVersion as using a query avoids hibernate's locking mechanism.

New query:
```
Hibernate: 
    select
        cpkfileent0_.cpk_name as col_0_0_,
        cpkfileent0_.cpk_signer_summary_hash as col_0_1_,
        cpkfileent0_.cpk_version as col_0_2_,
        cpkfileent0_.file_checksum as col_1_0_,
        cpkfileent0_.entity_version as col_2_0_ 
    from
        CONFIG.cpk_file cpkfileent0_ 
    where
        cpkfileent0_.cpk_name=? 
        and cpkfileent0_.cpk_signer_summary_hash=? 
        and cpkfileent0_.cpk_version=?
```