### PR TITLE
CORE-5459 Find nearest initiating flow when initiating session

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -245,4 +245,52 @@ class FlowTests {
         flowResult = result.getRpcFlowResult()
         assertThat(flowResult.result).isEqualTo("dog '${id}' deleted")
     }
+
+    @Test
+    fun `SubFlow - Create an initiated session in an initiating flow and pass it to a inline subflow`() {
+
+        val requestBody = RpcSmokeTestInput().apply {
+            command = "subflow_passed_in_initiated_session"
+            data = mapOf(
+                "sessions" to "${X500_SESSION_USER1};${X500_SESSION_USER2}",
+                "messages" to "m1;m2"
+            )
+        }
+
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
+
+        val flowResult = result.getRpcFlowResult()
+        assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result.flowResult).isNotNull
+        assertThat(result.flowError).isNull()
+        assertThat(flowResult.command).isEqualTo("subflow_passed_in_initiated_session")
+        assertThat(flowResult.result)
+            .isEqualTo("${X500_SESSION_USER1}=echo:m1; ${X500_SESSION_USER2}=echo:m2")
+    }
+
+    @Test
+    fun `SubFlow - Create an uninitiated session in an initiating flow and pass it to a inline subflow`() {
+
+        val requestBody = RpcSmokeTestInput().apply {
+            command = "subflow_passed_in_non_initiated_session"
+            data = mapOf(
+                "sessions" to "${X500_SESSION_USER1};${X500_SESSION_USER2}",
+                "messages" to "m1;m2"
+            )
+        }
+
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
+
+        val flowResult = result.getRpcFlowResult()
+        assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result.flowResult).isNotNull
+        assertThat(result.flowError).isNull()
+        assertThat(flowResult.command).isEqualTo("subflow_passed_in_non_initiated_session")
+        assertThat(flowResult.result)
+            .isEqualTo("${X500_SESSION_USER1}=echo:m1; ${X500_SESSION_USER2}=echo:m2")
+    }
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlow.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlow.kt
@@ -1,10 +1,13 @@
 package net.corda.flow.testing.fakes
 
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RPCRequestData
 import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
 
+@InitiatingFlow("protocol")
 class FakeFlow: RPCStartableFlow {
 
     override fun call(requestBody: RPCRequestData): String {
@@ -12,6 +15,7 @@ class FakeFlow: RPCStartableFlow {
     }
 }
 
+@InitiatedBy("protocol")
 class FakeInitiatedFlow: ResponderFlow {
 
     override fun call(session: FlowSession) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandler.kt
@@ -43,9 +43,12 @@ class InitiateFlowRequestHandler @Activate constructor(
                 e
             )
         }
-        val initiator =
-            checkpoint.flowStack.peek()?.flowName ?: throw FlowFatalException("Flow stack is empty", context)
+
+        val initiator = checkpoint.flowStack.nearestFirst { it.isInitiatingFlow }?.flowName
+            ?: throw FlowFatalException("Flow stack is empty or did not contain an initiating flow in the stack", context)
+
         val (protocolName, protocolVersions) = protocolStore.protocolsForInitiator(initiator, context)
+
         checkpoint.putSessionState(
             flowSessionManager.sendInitMessage(
                 checkpoint,

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/InitiateFlowRequestHandlerTest.kt
@@ -7,11 +7,13 @@ import net.corda.data.flow.state.waiting.SessionConfirmationType
 import net.corda.flow.ALICE_X500_NAME
 import net.corda.flow.RequestHandlerTestContext
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.pipeline.sessions.FlowProtocolStore
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -45,7 +47,7 @@ class InitiateFlowRequestHandlerTest {
         whenever(testContext.flowSandboxService.get(any())).thenReturn(sandboxGroupContext)
         whenever(sandboxGroupContext.protocolStore).thenReturn(protocolStore)
         whenever(protocolStore.protocolsForInitiator(any(), any())).thenReturn(Pair("protocol", listOf(1)))
-        whenever(testContext.flowStack.peek()).thenReturn(FlowStackItem("flow", true, listOf()))
+        whenever(testContext.flowStack.nearestFirst(any())).thenReturn(FlowStackItem("flow", true, listOf()))
     }
 
     @Test
@@ -61,6 +63,14 @@ class InitiateFlowRequestHandlerTest {
     fun `Session init event sent to session manager and checkpoint updated with session state`() {
         handler.postProcess(testContext.flowEventContext, ioRequest)
         verify(testContext.flowCheckpoint).putSessionState(sessionState1)
+    }
+
+    @Test
+    fun `No initiating flow in the subflow stack throws fatal exception`() {
+        whenever(testContext.flowStack.nearestFirst(any())).thenReturn(null)
+        assertThrows<FlowFatalException> {
+            handler.postProcess(testContext.flowEventContext, ioRequest)
+        }
     }
 
     @Test

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/SubFlowSmokeTestFlows.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/flows/SubFlowSmokeTestFlows.kt
@@ -1,0 +1,86 @@
+package net.cordapp.flowworker.development.flows
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.application.messaging.receive
+import net.corda.v5.application.messaging.sendAndReceive
+import net.corda.v5.application.messaging.unwrap
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
+import net.cordapp.flowworker.development.messages.InitiatedSmokeTestMessage
+
+@InitiatingFlow("subflow-protocol")
+class InitiatingSubFlowSmokeTestFlow(
+    private val x500Name: MemberX500Name,
+    private val initiateSessionInInitiatingFlow: Boolean,
+    private val message: String
+) : SubFlow<InitiatedSmokeTestMessage> {
+
+    private companion object {
+        val log = contextLogger()
+    }
+
+    @CordaInject
+    lateinit var flowEngine: FlowEngine
+
+    @CordaInject
+    lateinit var flowMessaging: FlowMessaging
+
+    @Suspendable
+    override fun call(): InitiatedSmokeTestMessage {
+        log.info("SubFlow - Creating session for '${x500Name}'...")
+        val session = flowMessaging.initiateFlow(x500Name)
+        if (initiateSessionInInitiatingFlow) {
+            log.info("SubFlow - Creating session '${session}' now sending and waiting for response ...")
+            session.send(InitiatedSmokeTestMessage("Initiate"))
+        }
+        return flowEngine.subFlow(InlineSubFlowSmokeTestFlow(session, initiateSessionInInitiatingFlow, message))
+    }
+}
+
+class InlineSubFlowSmokeTestFlow(
+    private val session: FlowSession,
+    private val initiateSessionInInitiatingFlow: Boolean,
+    private val message: String
+) : SubFlow<InitiatedSmokeTestMessage> {
+
+    private companion object {
+        val log = contextLogger()
+    }
+
+    @Suspendable
+    override fun call(): InitiatedSmokeTestMessage {
+        if (!initiateSessionInInitiatingFlow) {
+            log.info("SubFlow - Creating session '${session}' now sending and waiting for response ...")
+            session.send(InitiatedSmokeTestMessage("Initiate"))
+        }
+        val initiatedSmokeTestMessage = session.sendAndReceive<InitiatedSmokeTestMessage>(InitiatedSmokeTestMessage(message)).unwrap { it }
+        log.info("SubFlow - Received response from session '$session'.")
+        return initiatedSmokeTestMessage
+    }
+}
+
+@InitiatedBy("subflow-protocol")
+class InitiatingSubFlowResponderSmokeTestFlow : ResponderFlow {
+
+    private companion object {
+        val log = contextLogger()
+    }
+
+    @Suspendable
+    override fun call(session: FlowSession) {
+        session.receive<InitiatedSmokeTestMessage>()
+        log.info("SubFlow - Initiated.")
+        val received = session.receive<InitiatedSmokeTestMessage>().unwrap { it }
+        log.info("SubFlow - Received message from session '$session'.")
+        session.send(InitiatedSmokeTestMessage("echo:${received.message}"))
+        log.info("SubFlow - Sent message to session '$session'.")
+    }
+}


### PR DESCRIPTION
We check whether a session is created inside or outside an initiating
flow. However, when passing a session created in an initiating flow that
has not already been interacted with/initiated into a subFlow, then we
were trying to find the matching responder of the subFlow instead of the
initiating flow. This is due to the lazy initialisation of sessions.

This caused an error as there was no matching responder flow for the
subFlow.

We now correctly find the nearest initiating flow in the flow stack when
initiating a flow for the first time.