### PR TITLE
CORE-5483 - configuration get endpoint

### DIFF
--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/PublishConfig.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/PublishConfig.kt
@@ -35,7 +35,7 @@ class PublishConfig(private val context: TaskContext) : Task {
         for (componentKey in configFileConfig.getConfig("corda").root().keys) {
             val componentPath = "corda.${componentKey}"
             val configAsJson = configFileConfig.getConfig(componentPath).root().render(ConfigRenderOptions.concise())
-            val content = Configuration(configAsJson, 0, ConfigurationSchemaVersion(1,0))
+            val content = Configuration(configAsJson, configAsJson, 0, ConfigurationSchemaVersion(1,0))
             val record = Record(CONFIG_TOPIC, componentPath, content)
 
             context.publish(record)

--- a/applications/tools/kafka-setup/src/main/kotlin/net/corda/tools/kafka/KafkaConfigUploader.kt
+++ b/applications/tools/kafka-setup/src/main/kotlin/net/corda/tools/kafka/KafkaConfigUploader.kt
@@ -118,8 +118,10 @@ class KafkaConfigUploader @Activate constructor(
             val recordKey = "$packageKey.$componentKey"
             // TODO - the following version should be revised. `Configuration.version` is meant for DB optimistic locking.
             //val version = packageConfig.getString("$componentKey.componentVersion")
+            val conf = packageConfig.getConfig(componentKey).root().render(ConfigRenderOptions.concise())
             val content = Configuration(
-                packageConfig.getConfig(componentKey).root().render(ConfigRenderOptions.concise()),
+                conf,
+                conf,
                 0,
                 ConfigurationSchemaVersion(1, 0)
             )

--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Utilities.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Utilities.kt
@@ -50,7 +50,8 @@ fun Config.toConfigurationRecord(
     componentName: String,
     topic: String = Schemas.Config.CONFIG_TOPIC
 ): Record<String, Configuration> {
-    val content = Configuration(this.root().render(ConfigRenderOptions.concise()), 0, ConfigurationSchemaVersion(1,0))
+    val conf = this.root().render(ConfigRenderOptions.concise())
+    val content = Configuration(conf, conf, 0, ConfigurationSchemaVersion(1,0))
     val recordKey = "$packageName.$componentName"
     return Record(topic, recordKey, content)
 }

--- a/components/configuration/configuration-read-service-impl/src/integrationTest/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceImplTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/integrationTest/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceImplTest.kt
@@ -92,7 +92,7 @@ class ConfigurationReadServiceImplTest {
         // Publish new configuration and verify it gets delivered
         val flowConfig = smartConfigFactory.create(ConfigFactory.parseMap(mapOf("foo" to "bar")))
         val confString = flowConfig.root().render()
-        publisher.publish(listOf(Record(CONFIG_TOPIC, FLOW_CONFIG, Configuration(confString, 0, ConfigurationSchemaVersion(1,0)))))
+        publisher.publish(listOf(Record(CONFIG_TOPIC, FLOW_CONFIG, Configuration(confString, confString, 0, ConfigurationSchemaVersion(1,0)))))
         eventually {
             assertTrue(receivedKeys.contains(FLOW_CONFIG), "$FLOW_CONFIG key was missing from received keys")
             assertEquals(flowConfig, receivedConfig[FLOW_CONFIG], "Incorrect config")
@@ -118,7 +118,7 @@ class ConfigurationReadServiceImplTest {
         val confString = flowConfig.root().render()
         val schemaVersion = ConfigurationSchemaVersion(1,0)
         val publisher = publisherFactory.createPublisher(PublisherConfig("foo"), bootConfig)
-        publisher.publish(listOf(Record(CONFIG_TOPIC, FLOW_CONFIG, Configuration(confString, 0, schemaVersion))))
+        publisher.publish(listOf(Record(CONFIG_TOPIC, FLOW_CONFIG, Configuration(confString, confString, 0, schemaVersion))))
         eventually(duration = 5.seconds) {
             assertTrue(configurationReadService.isRunning)
         }

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -71,11 +71,16 @@ internal class ConfigProcessor(
         }
     }
 
+    fun get(key: String): Configuration? {
+        return configCache[key]?.value
+    }
+
     private fun mergeConfigs(currentData: Map<String, Configuration>): MutableMap<String, SmartConfig> {
         return if (currentData.isNotEmpty()) {
             val config = currentData.mapValues { config ->
                 config.value.toSmartConfig().also { smartConfig ->
-                    logger.info(
+                    logger.info("Received configuration for key ${config.key}")
+                    logger.debug(
                         "Received configuration for key ${config.key}: " +
                                 smartConfig.toSafeConfig().root().render(ConfigRenderOptions.concise().setFormatted(true))
                     )

--- a/components/configuration/configuration-write-service-impl/src/test/kotlin/net/corda/configuration/write/impl/tests/writer/ConfigWriterProcessorTests.kt
+++ b/components/configuration/configuration-write-service-impl/src/test/kotlin/net/corda/configuration/write/impl/tests/writer/ConfigWriterProcessorTests.kt
@@ -35,6 +35,7 @@ class ConfigWriterProcessorTests {
             section to
                     Configuration(
                         config,
+                        config,
                         version,
                         ConfigurationSchemaVersion(
                             schemaVersion.majorVersion,
@@ -66,7 +67,7 @@ class ConfigWriterProcessorTests {
 
     /** Returns a mock [Publisher] that throws an error whenever it tries to publish. */
     private fun getErroringPublishService() = mock<ConfigPublishService>().apply {
-        whenever(put(any(), any())).thenThrow(publisherError)
+        whenever(put(any(), any(), any(), any())).thenThrow(publisherError)
     }
 
     /** Calls [processor].`onNext` for the given [req], and returns the result of the future. */
@@ -106,7 +107,7 @@ class ConfigWriterProcessorTests {
         val processor = ConfigWriterProcessor(configPublishService, configEntityWriter, validator, clock)
         processRequest(processor, configMgmtReq)
 
-        verify(configPublishService).put(expectedConfigSection, expectedConfig)
+        verify(configPublishService).put(expectedConfigSection, expectedConfig.value, expectedConfig.version, expectedConfig.schemaVersion)
     }
 
     @Test
@@ -155,8 +156,8 @@ class ConfigWriterProcessorTests {
 
         val expectedEnvelope = ExceptionEnvelope(
             CordaMessageAPIIntermittentException::class.java.name,
-            "Configuration $expectedConfig was written to the database, but couldn't be published. Cause: " +
-                    "$publisherError"
+            "Configuration '${expectedConfig.first}' (${expectedConfig.second.value}) was written to the database, " +
+                    "but couldn't be published. Cause: $publisherError"
         )
         val expectedResp = configMgmtReq.run {
             ConfigurationManagementResponse(false, expectedEnvelope, section, config, schemaVersion, version)

--- a/components/configuration/configuration-write-service/src/main/kotlin/net/corda/configuration/write/publish/ConfigPublishService.kt
+++ b/components/configuration/configuration-write-service/src/main/kotlin/net/corda/configuration/write/publish/ConfigPublishService.kt
@@ -1,6 +1,7 @@
 package net.corda.configuration.write.publish
 
 import net.corda.data.config.Configuration
+import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.Lifecycle
 import net.corda.reconciliation.ReconcilerWriter
@@ -14,10 +15,9 @@ import net.corda.reconciliation.ReconcilerWriter
  */
 interface ConfigPublishService : ReconcilerWriter<String, Configuration>, Lifecycle {
     /**
-     * Publishes a new [ConfigurationDto].
+     * Publishes a new Configuration.
      */
-    @Suppress("parameter_name_changed_on_override")
-    override fun put(configSection: String, config: Configuration)
+    fun put(section: String, value: String, version: Int, schemaVersion: ConfigurationSchemaVersion)
 
     /**
      * Provides boot configuration to config publish service.

--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
@@ -228,8 +228,8 @@ class FlowMapperServiceIntegrationTest {
 
     private fun setupConfig(publisher: Publisher) {
         val bootConfig = smartConfigFactory.create(ConfigFactory.parseString(bootConf))
-        publisher.publish(listOf(Record(CONFIG_TOPIC, FLOW_CONFIG, Configuration(flowConf, 0, schemaVersion))))
-        publisher.publish(listOf(Record(CONFIG_TOPIC, MESSAGING_CONFIG, Configuration(messagingConf, 0, schemaVersion))))
+        publisher.publish(listOf(Record(CONFIG_TOPIC, FLOW_CONFIG, Configuration(flowConf, flowConf, 0, schemaVersion))))
+        publisher.publish(listOf(Record(CONFIG_TOPIC, MESSAGING_CONFIG, Configuration(messagingConf, messagingConf, 0, schemaVersion))))
         configService.start()
         configService.bootstrapConfig(bootConfig)
     }

--- a/components/flow/flow-p2p-filter-service/src/integrationTest/kotlin/net/corda/flow/p2p/filter/integration/FlowFilterServiceIntegrationTest.kt
+++ b/components/flow/flow-p2p-filter-service/src/integrationTest/kotlin/net/corda/flow/p2p/filter/integration/FlowFilterServiceIntegrationTest.kt
@@ -150,7 +150,8 @@ class FlowFilterServiceIntegrationTest {
     }
 
     private fun setupConfig(publisher: Publisher) {
-        publisher.publish(listOf(Record(CONFIG_TOPIC, MESSAGING_CONFIG, Configuration(messagingConf, 0, schemaVersion))))
+        publisher.publish(listOf(Record(CONFIG_TOPIC, MESSAGING_CONFIG,
+            Configuration(messagingConf, messagingConf, 0, schemaVersion))))
         configService.start()
         configService.bootstrapConfig(bootConfig)
     }

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
@@ -154,10 +154,11 @@ open class TestBase {
         }
 
         private fun Publisher.publishGatewayConfig(config: Config) {
+            val configSource = config.root().render(ConfigRenderOptions.concise())
             this.publish(listOf(Record(
                 CONFIG_TOPIC,
                 "p2p.gateway",
-                Configuration(config.root().render(ConfigRenderOptions.concise()), 0, ConfigurationSchemaVersion(1, 0))
+                Configuration(configSource, configSource, 0, ConfigurationSchemaVersion(1, 0))
             ))).forEach { it.get() }
         }
 

--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
@@ -94,10 +94,11 @@ class LinkManagerIntegrationTest {
         )
 
     private fun Publisher.publishLinkManagerConfig(config: Config) {
+        val configSource = config.root().render(ConfigRenderOptions.concise())
         this.publish(listOf(Record(
             Schemas.Config.CONFIG_TOPIC,
             "${LinkManagerConfiguration.PACKAGE_NAME}.${LinkManagerConfiguration.COMPONENT_NAME}",
-            Configuration(config.root().render(ConfigRenderOptions.concise()), 0, ConfigurationSchemaVersion(1, 0))
+            Configuration(configSource, configSource, 0, ConfigurationSchemaVersion(1, 0))
         ))).forEach { it.get() }
     }
 

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -436,12 +436,13 @@ class P2PLayerEndToEndTest {
             )
 
         private fun Publisher.publishConfig(key: String, config: Config) {
+            val configSource = config.root().render(ConfigRenderOptions.concise())
             this.publish(
                 listOf(
                     Record(
                         CONFIG_TOPIC,
                         key,
-                        Configuration(config.root().render(ConfigRenderOptions.concise()), 0, ConfigurationSchemaVersion(1, 0))
+                        Configuration(configSource, configSource, 0, ConfigurationSchemaVersion(1, 0))
                     )
                 )
             ).forEach { it.get() }

--- a/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
+++ b/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
@@ -103,7 +103,7 @@ class MembershipGroupReaderProviderIntegrationTest {
                     Record(
                         Schemas.Config.CONFIG_TOPIC,
                         ConfigKeys.MESSAGING_CONFIG,
-                        Configuration(messagingConf, 0, schemaVersion)
+                        Configuration(messagingConf, messagingConf, 0, schemaVersion)
                     )
                 )
             )[0]
@@ -221,7 +221,8 @@ class MembershipGroupReaderProviderIntegrationTest {
     }
 
     private fun Publisher.publishMessagingConf() =
-        publishRecord(Schemas.Config.CONFIG_TOPIC, ConfigKeys.MESSAGING_CONFIG, Configuration(messagingConf, 0, schemaVersion))
+        publishRecord(Schemas.Config.CONFIG_TOPIC, ConfigKeys.MESSAGING_CONFIG,
+            Configuration(messagingConf, messagingConf, 0, schemaVersion))
 
     private fun <K : Any, V : Any> Publisher.publishRecord(topic: String, key: K, value: V) =
         publish(listOf(Record(topic, key, value)))

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -161,7 +161,7 @@ class MembershipP2PIntegrationTest {
                     Record(
                         Schemas.Config.CONFIG_TOPIC,
                         ConfigKeys.MESSAGING_CONFIG,
-                        Configuration(messagingConf, 0, schemaVersion)
+                        Configuration(messagingConf, messagingConf, 0, schemaVersion)
                     )
                 )
             )

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -289,7 +289,7 @@ class MembershipPersistenceTest {
                     Record(
                         Schemas.Config.CONFIG_TOPIC,
                         ConfigKeys.MESSAGING_CONFIG,
-                        Configuration(messagingConf, 0, schemaVersion)
+                        Configuration(messagingConf, messagingConf, 0, schemaVersion)
                     )
                 )
             )

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,8 +37,9 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-#cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.135-beta+
+#cordaApiVersion=5.0.0.XXX-SNAPSHOT
+#cordaApiVersion=5.0.0.135-beta+
+cordaApiVersion=5.0.0.135-alpha-1656953890247
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XXX-SNAPSHOT
 #cordaApiVersion=5.0.0.135-beta+
-cordaApiVersion=5.0.0.135-alpha-1656953890247
+cordaApiVersion=5.0.0.136-alpha-1657110326612
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,8 +38,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XXX-SNAPSHOT
-#cordaApiVersion=5.0.0.135-beta+
-cordaApiVersion=5.0.0.136-alpha-1657110326612
+cordaApiVersion=5.0.0.136-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/osgi-framework-bootstrap/src/main/resources/log4j2.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2.xml
@@ -16,7 +16,7 @@
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
             <DefaultRolloverStrategy>
-                <Delete basePath="${baseDir}">
+                <Delete basePath="logs/">
                     <IfFileName glob="logs/corda.*.log">
                         <IfAny>
                             <IfAccumulatedFileSize exceeds="500 MB" />
@@ -35,10 +35,10 @@
 
         <!-- log warn only for these 3rd party libs -->
         <Logger name="org.apache.aries.spifly" level="warn" />
-        <Logger name="org.apache.kafka" level="warn" />
+        <Logger name="org.apache.kafka" level="error" />
         <Logger name="io.javalin.Javalin" level="warn" />
         <Logger name="org.eclipse.jetty" level="warn" />
-        <Logger name="org.hibernate.Version" level="warn" />
+        <Logger name="org.hibernate" level="warn" />
 
         <!-- default to warn only for OSGi logging -->
         <Logger name="net.corda.osgi.framework.OSGiFrameworkWrap" level="warn" />

--- a/osgi-framework-bootstrap/src/main/resources/log4j2.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2.xml
@@ -35,7 +35,7 @@
 
         <!-- log warn only for these 3rd party libs -->
         <Logger name="org.apache.aries.spifly" level="warn" />
-        <Logger name="org.apache.kafka" level="error" />
+        <Logger name="org.apache.kafka" level="warn" />
         <Logger name="io.javalin.Javalin" level="warn" />
         <Logger name="org.eclipse.jetty" level="warn" />
         <Logger name="org.hibernate" level="warn" />

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -191,7 +191,7 @@ class CryptoProcessorTests {
                     Record(
                         CONFIG_TOPIC,
                         MESSAGING_CONFIG,
-                        Configuration(messagingConfig.root().render(), 0, ConfigurationSchemaVersion(1, 0))
+                        Configuration(messagingConfig.root().render(), messagingConfig.root().render(), 0, ConfigurationSchemaVersion(1, 0))
                     )
                 )
             )

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -214,9 +214,9 @@ class CryptoProcessorImpl @Activate constructor(
                     softKey = KeyCredentials("soft-passphrase", "soft-salt")
                 )
             }.root().render()
-            logger.info("Crypto Worker config\n: {}", configValue)
+            logger.debug("Crypto Processor config\n: {}", configValue)
             val record =
-                Record(CONFIG_TOPIC, CRYPTO_CONFIG, Configuration(configValue, 0, ConfigurationSchemaVersion(1, 0)))
+                Record(CONFIG_TOPIC, CRYPTO_CONFIG, Configuration(configValue, configValue, 0, ConfigurationSchemaVersion(1, 0)))
             it.publish(listOf(record)).forEach { future -> future.get() }
         }
     }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigDbReconcilerReader.kt
@@ -11,6 +11,7 @@ val getAllConfigDBVersionedRecords: (EntityManager) -> Stream<VersionedRecord<St
     em.findAllConfig().map { configEntity ->
         val config = Configuration(
             configEntity.config,
+            configEntity.config,
             configEntity.version,
             ConfigurationSchemaVersion(configEntity.schemaVersionMajor, configEntity.schemaVersionMinor)
         )

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -307,7 +307,7 @@ class MemberProcessorTestUtils {
 
         private val schemaVersion = ConfigurationSchemaVersion(1, 0)
         private fun Publisher.publishConf(configKey: String, conf: String) =
-            publishRecord(Schemas.Config.CONFIG_TOPIC, configKey, Configuration(conf, 0, schemaVersion))
+            publishRecord(Schemas.Config.CONFIG_TOPIC, configKey, Configuration(conf, conf, 0, schemaVersion))
 
         private fun Publisher.publishCpiMetadata(cpiMetadata: CpiMetadata) =
             publishRecord(Schemas.VirtualNode.CPI_INFO_TOPIC, cpiMetadata.cpiId.toAvro(), cpiMetadata.toAvro())


### PR DESCRIPTION
Refactor to include pre-defaulted configuration when publishing to Kafka.
This is a prerequisite to exposing this data in an HTTP endpoint, which I prefer to implement in a follow-up PR to make the review easier.
This current PR shouldn't have any functional impact yet.

API PR: https://github.com/corda/corda-api/pull/461