### PR TITLE
CORE-2281: Add dynamic member registration service

### DIFF
--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -1,13 +1,15 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
+    id 'corda.osgi-test-conventions'
 }
 
-description 'Registration service implemenations'
+description 'Registration service implementations'
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
+    compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
@@ -45,4 +47,17 @@ dependencies {
     testImplementation project(":libs:crypto:cipher-suite-impl")
     testImplementation project(":testing:layered-property-map-testkit")
     testImplementation project(":testing:test-utilities")
+
+    integrationTestImplementation project(':testing:db-message-bus-testkit')
+
+    integrationTestRuntimeOnly project(':components:configuration:configuration-read-service-impl')
+    integrationTestRuntimeOnly project(':components:crypto:crypto-client-impl')
+    integrationTestRuntimeOnly project(':components:db:db-connection-manager-impl')
+    integrationTestRuntimeOnly project(':components:membership:membership-group-read-impl')
+    integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
+    integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
+    integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
+
+    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
 }

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -249,8 +249,8 @@ class MemberRegistrationIntegrationTest {
             "corda.session.key.signature.spec" to "CORDA.ECDSA.SECP256R1",
             URL_KEY to URL_VALUE,
             PROTOCOL_KEY to PROTOCOL_VALUE,
-            "corda.ledgerKeys.0.id" to ledgerKeyId,
-            "corda.ledgerKeys.0.signature.spec" to "CORDA.ECDSA.SECP256R1",
+            "corda.ledger.keys.0.id" to ledgerKeyId,
+            "corda.ledger.keys.0.signature.spec" to "CORDA.ECDSA.SECP256R1",
         )
     }
 

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -1,0 +1,273 @@
+package net.corda.membership.impl.registration
+
+import com.typesafe.config.ConfigFactory
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.CordaAvroDeserializer
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.KeyValuePairList
+import net.corda.data.config.Configuration
+import net.corda.data.config.ConfigurationSchemaVersion
+import net.corda.data.membership.p2p.MembershipRegistrationRequest
+import net.corda.data.membership.state.RegistrationState
+import net.corda.db.messagebus.testkit.DBSetup
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.StartEvent
+import net.corda.lifecycle.createCoordinator
+import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.impl.registration.dummy.TestCryptoOpsClient
+import net.corda.membership.impl.registration.dummy.TestGroupPolicy
+import net.corda.membership.impl.registration.dummy.TestGroupPolicyProvider
+import net.corda.membership.impl.registration.dummy.TestGroupReaderProvider
+import net.corda.membership.registration.RegistrationProxy
+import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.publisher.config.PublisherConfig
+import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.messaging.api.records.Record
+import net.corda.messaging.api.subscription.config.SubscriptionConfig
+import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.p2p.app.AppMessage
+import net.corda.p2p.app.UnauthenticatedMessage
+import net.corda.schema.Schemas
+import net.corda.schema.configuration.BootConfig
+import net.corda.schema.configuration.ConfigKeys
+import net.corda.schema.configuration.MessagingConfig
+import net.corda.test.util.eventually
+import net.corda.v5.base.concurrent.getOrThrow
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.crypto.publicKeyId
+import net.corda.virtualnode.HoldingIdentity
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.extension.ExtendWith
+import org.osgi.test.common.annotation.InjectService
+import org.osgi.test.junit5.service.ServiceExtension
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+
+@ExtendWith(ServiceExtension::class, DBSetup::class)
+class MemberRegistrationIntegrationTest {
+    private companion object {
+        @InjectService(timeout = 5000)
+        lateinit var publisherFactory: PublisherFactory
+
+        @InjectService(timeout = 5000)
+        lateinit var subscriptionFactory: SubscriptionFactory
+
+        @InjectService(timeout = 5000)
+        lateinit var configurationReadService: ConfigurationReadService
+
+        @InjectService(timeout = 5000)
+        lateinit var lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
+
+        @InjectService(timeout = 5000)
+        lateinit var cryptoOpsClient: TestCryptoOpsClient
+
+        @InjectService(timeout = 5000)
+        lateinit var serializationFactory: CordaAvroSerializationFactory
+
+        @InjectService(timeout = 5000)
+        lateinit var membershipGroupReaderProvider: TestGroupReaderProvider
+
+        @InjectService(timeout = 5000)
+        lateinit var groupPolicyProvider: TestGroupPolicyProvider
+
+        @InjectService(timeout = 5000)
+        lateinit var registrationProxy: RegistrationProxy
+
+        lateinit var keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList>
+        lateinit var requestDeserializer: CordaAvroDeserializer<MembershipRegistrationRequest>
+
+        val logger = contextLogger()
+        val bootConfig = SmartConfigFactory.create(ConfigFactory.empty())
+            .create(
+                ConfigFactory.parseString(
+                    """
+                ${BootConfig.INSTANCE_ID} = 1
+                ${MessagingConfig.Bus.BUS_TYPE} = INMEMORY
+                """
+                )
+            )
+        const val messagingConf = """
+            componentVersion="5.1"
+            subscription {
+                consumer {
+                    close.timeout = 6000
+                    poll.timeout = 6000
+                    thread.stop.timeout = 6000
+                    processor.retries = 3
+                    subscribe.retries = 3
+                    commit.retries = 3
+                }
+                producer {
+                    close.timeout = 6000
+                }
+            }
+        """
+        val schemaVersion = ConfigurationSchemaVersion(1, 0)
+        val memberName = MemberX500Name("Alice", "London", "GB")
+        val mgmName = MemberX500Name("Corda MGM", "London", "GB")
+
+        const val groupId = "dummy_group"
+        const val URL_KEY = "corda.endpoints.0.connectionURL"
+        const val URL_VALUE = "localhost:1080"
+        const val PROTOCOL_KEY = "corda.endpoints.0.protocolVersion"
+        const val PROTOCOL_VALUE = "1"
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp() {
+            val coordinator = lifecycleCoordinatorFactory.createCoordinator<MemberRegistrationIntegrationTest> { e, c ->
+                if (e is StartEvent) {
+                    logger.info("Starting test coordinator")
+                    c.followStatusChangesByName(
+                        setOf(
+                            LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+                            LifecycleCoordinatorName.forComponent<CryptoOpsClient>(),
+                            LifecycleCoordinatorName.forComponent<RegistrationProxy>(),
+                            LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
+                        )
+                    )
+                } else if (e is RegistrationStatusChangeEvent) {
+                    logger.info("Test coordinator is ${e.status}")
+                    c.updateStatus(e.status)
+                }
+            }.also { it.start() }
+
+            keyValuePairListDeserializer = serializationFactory.createAvroDeserializer({}, KeyValuePairList::class.java)
+            requestDeserializer =
+                serializationFactory.createAvroDeserializer({}, MembershipRegistrationRequest::class.java)
+
+            setupConfig()
+            groupPolicyProvider.start()
+            registrationProxy.start()
+            cryptoOpsClient.start()
+            membershipGroupReaderProvider.start()
+
+            configurationReadService.bootstrapConfig(bootConfig)
+
+            eventually {
+                logger.info("Waiting for required services to start...")
+                Assertions.assertThat(coordinator.isRunning).isTrue
+                logger.info("Required services started.")
+            }
+        }
+
+        fun setupConfig() {
+            val publisher = publisherFactory.createPublisher(PublisherConfig("clientId"), bootConfig)
+            publisher.publish(
+                listOf(
+                    Record(
+                        Schemas.Config.CONFIG_TOPIC,
+                        ConfigKeys.MESSAGING_CONFIG,
+                        Configuration(messagingConf, messagingConf, 0, schemaVersion)
+                    )
+                )
+            )
+            configurationReadService.start()
+            configurationReadService.bootstrapConfig(bootConfig)
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDown() {
+            configurationReadService.stop()
+        }
+    }
+
+    @Test
+    fun `dynamic member registration service publishes unauthenticated message to be sent to the MGM`() {
+        groupPolicyProvider.putGroupPolicy(TestGroupPolicy())
+
+        val member = HoldingIdentity(memberName.toString(), groupId)
+        val context = buildTestContext(member)
+        val completableResult = CompletableFuture<Pair<RegistrationState?, Record<String, AppMessage>>>()
+        // Set up subscription to gather results of processing p2p message
+        val registrationRequestSubscription = subscriptionFactory.createStateAndEventSubscription(
+            SubscriptionConfig("membership_p2p_test_receiver", Schemas.P2P.P2P_OUT_TOPIC),
+            getTestProcessor { s, e ->
+                completableResult.complete(Pair(s, e))
+            },
+            messagingConfig = bootConfig
+        ).also { it.start() }
+
+        registrationProxy.use {
+            it.register(member, context)
+        }
+
+        // Wait for latch to countdown, so we know when processing has completed and results have been collected
+        val result = assertDoesNotThrow {
+            completableResult.getOrThrow(Duration.ofSeconds(5))
+        }
+        registrationRequestSubscription.close()
+
+        // Assert results
+        assertSoftly {
+            it.assertThat(result).isNotNull
+            it.assertThat(result?.first).isNull()
+            it.assertThat(result?.second).isNotNull
+            with(result!!.second) {
+                it.assertThat(topic).isEqualTo(Schemas.P2P.P2P_OUT_TOPIC)
+                it.assertThat(key).isEqualTo(member.id)
+                it.assertThat(value)
+                    .isNotNull
+                    .isInstanceOf(AppMessage::class.java)
+                with(value!!["message"] as UnauthenticatedMessage) {
+                    it.assertThat(this.header.destination.x500Name).isEqualTo(mgmName.toString())
+                    it.assertThat(this.header.destination.groupId).isEqualTo(groupId)
+                    it.assertThat(this.header.source.x500Name).isEqualTo(memberName.toString())
+                    it.assertThat(this.header.source.groupId).isEqualTo(groupId)
+                    val deserializedContext = requestDeserializer.deserialize(payload.array())!!.run {
+                        keyValuePairListDeserializer.deserialize(memberContext.array())!!
+                    }
+                    with(deserializedContext.items) {
+                        it.assertThat(first { pair -> pair.key == URL_KEY }.value).isEqualTo(URL_VALUE)
+                        it.assertThat(first { pair -> pair.key == PROTOCOL_KEY }.value).isEqualTo(PROTOCOL_VALUE)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun buildTestContext(member: HoldingIdentity): Map<String, String> {
+        val sessionKeyId =
+            cryptoOpsClient.generateKeyPair(member.id, "SESSION_INIT", member.id + "session", "CORDA.ECDSA.SECP256R1")
+                .publicKeyId()
+        val ledgerKeyId =
+            cryptoOpsClient.generateKeyPair(member.id, "LEDGER", member.id + "ledger", "CORDA.ECDSA.SECP256R1")
+                .publicKeyId()
+        return mapOf(
+            "corda.session.key.id" to sessionKeyId,
+            "corda.session.key.signature.spec" to "CORDA.ECDSA.SECP256R1",
+            URL_KEY to URL_VALUE,
+            PROTOCOL_KEY to PROTOCOL_VALUE,
+            "corda.ledgerKeys.0.id" to ledgerKeyId,
+            "corda.ledgerKeys.0.signature.spec" to "CORDA.ECDSA.SECP256R1",
+        )
+    }
+
+    private fun getTestProcessor(resultCollector: (RegistrationState?, Record<String, AppMessage>) -> Unit): StateAndEventProcessor<String, RegistrationState, AppMessage> {
+        class TestProcessor : StateAndEventProcessor<String, RegistrationState, AppMessage> {
+            override fun onNext(
+                state: RegistrationState?,
+                event: Record<String, AppMessage>
+            ): StateAndEventProcessor.Response<RegistrationState> {
+                resultCollector(state, event)
+                return StateAndEventProcessor.Response(null, emptyList())
+            }
+
+            override val keyClass = String::class.java
+            override val stateValueClass = RegistrationState::class.java
+            override val eventValueClass = AppMessage::class.java
+        }
+        return TestProcessor()
+    }
+}

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestCryptoOpsClient.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestCryptoOpsClient.kt
@@ -1,0 +1,194 @@
+package net.corda.membership.impl.registration.dummy
+
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.crypto.wire.CryptoSigningKey
+import net.corda.data.crypto.wire.ops.rpc.queries.CryptoKeyOrderBy
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import net.corda.utilities.time.UTCClock
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.cipher.suite.CipherSchemeMetadata
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.crypto.publicKeyId
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+import java.nio.ByteBuffer
+import java.security.KeyPairGenerator
+import java.security.PublicKey
+import java.util.concurrent.ConcurrentHashMap
+
+interface TestCryptoOpsClient : CryptoOpsClient
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [CryptoOpsClient::class, TestCryptoOpsClient::class])
+class TestCryptoOpsClientImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = CipherSchemeMetadata::class)
+    private val schemeMetadata: CipherSchemeMetadata,
+) : TestCryptoOpsClient {
+    companion object {
+        val logger = contextLogger()
+        private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
+        private val keys: ConcurrentHashMap<String, CryptoSigningKey> = ConcurrentHashMap()
+    }
+
+    private val coordinator =
+        coordinatorFactory.createCoordinator(LifecycleCoordinatorName.forComponent<CryptoOpsClient>()) { event, coordinator ->
+            if (event is StartEvent) {
+                coordinator.updateStatus(LifecycleStatus.UP)
+            }
+        }
+
+    override fun getSupportedSchemes(tenantId: String, category: String): List<String> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun filterMyKeys(tenantId: String, candidateKeys: Collection<PublicKey>): Collection<PublicKey> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun generateKeyPair(
+        tenantId: String,
+        category: String,
+        alias: String,
+        scheme: String,
+        context: Map<String, String>
+    ): PublicKey {
+        val keyScheme = schemeMetadata.findKeyScheme(scheme)
+        val keyPairGenerator = KeyPairGenerator.getInstance(
+            keyScheme.algorithmName,
+            schemeMetadata.providers.getValue(keyScheme.providerName)
+        )
+        keyPairGenerator.initialize(keyScheme.algSpec, schemeMetadata.secureRandom)
+        val publicKey = keyPairGenerator.generateKeyPair().public
+        val keyId = publicKey.publicKeyId()
+        keys[keyId] = CryptoSigningKey(
+            keyId,
+            tenantId,
+            category,
+            alias,
+            alias,
+            ByteBuffer.wrap(publicKey.encoded),
+            scheme,
+            alias,
+            1,
+            "1",
+            UTCClock().instant()
+        )
+        return publicKey
+    }
+
+    override fun generateKeyPair(
+        tenantId: String,
+        category: String,
+        alias: String,
+        externalId: String,
+        scheme: String,
+        context: Map<String, String>
+    ): PublicKey {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun freshKey(tenantId: String, category: String, scheme: String, context: Map<String, String>): PublicKey {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun freshKey(
+        tenantId: String,
+        category: String,
+        externalId: String,
+        scheme: String,
+        context: Map<String, String>
+    ): PublicKey {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun sign(
+        tenantId: String,
+        publicKey: PublicKey,
+        signatureSpec: SignatureSpec,
+        data: ByteArray,
+        context: Map<String, String>
+    ) = DigitalSignature.WithKey(publicKey, byteArrayOf(1), emptyMap())
+
+    override fun sign(
+        tenantId: String,
+        publicKey: PublicKey,
+        digest: DigestAlgorithmName,
+        data: ByteArray,
+        context: Map<String, String>
+    ): DigitalSignature.WithKey {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun lookup(
+        tenantId: String,
+        skip: Int,
+        take: Int,
+        orderBy: CryptoKeyOrderBy,
+        filter: Map<String, String>
+    ): List<CryptoSigningKey> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun lookup(tenantId: String, ids: List<String>): List<CryptoSigningKey> {
+        val result = mutableListOf<CryptoSigningKey>()
+        ids.forEach {
+            result.add(keys[it] ?: throw IllegalArgumentException("No key found under ID: $it."))
+        }
+        return result
+    }
+
+    override fun createWrappingKey(
+        configId: String,
+        failIfExists: Boolean,
+        masterKeyAlias: String,
+        context: Map<String, String>
+    ) {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override val isRunning: Boolean
+        get() = coordinator.status == LifecycleStatus.UP
+
+    override fun start() {
+        logger.info("TestCryptoOpsClient starting.")
+        coordinator.start()
+    }
+
+    override fun stop() {
+        logger.info("TestCryptoOpsClient starting.")
+        coordinator.stop()
+    }
+}

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupPolicyProvider.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupPolicyProvider.kt
@@ -1,0 +1,89 @@
+package net.corda.membership.impl.registration.dummy
+
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.lib.grouppolicy.GroupPolicy
+import net.corda.v5.base.util.contextLogger
+import net.corda.virtualnode.HoldingIdentity
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+
+interface TestGroupPolicyProvider : GroupPolicyProvider {
+    fun putGroupPolicy(groupPolicy: GroupPolicy)
+}
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [GroupPolicyProvider::class, TestGroupPolicyProvider::class])
+class TestGroupPolicyProviderImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+) : TestGroupPolicyProvider {
+    companion object {
+        val logger = contextLogger()
+        private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
+    }
+
+    private val coordinator =
+        coordinatorFactory.createCoordinator(LifecycleCoordinatorName.forComponent<GroupPolicyProvider>()) { event, coordinator ->
+            if (event is StartEvent) {
+                coordinator.updateStatus(LifecycleStatus.UP)
+            }
+        }
+
+    private lateinit var policy: GroupPolicy
+
+    override fun putGroupPolicy(groupPolicy: GroupPolicy) {
+        policy = groupPolicy
+    }
+
+    override fun getGroupPolicy(holdingIdentity: HoldingIdentity) = policy
+
+    override fun registerListener(callback: (HoldingIdentity, GroupPolicy) -> Unit) {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override val isRunning: Boolean
+        get() = coordinator.status == LifecycleStatus.UP
+
+    override fun start() {
+        logger.info("TestGroupPolicyProvider starting.")
+        coordinator.start()
+    }
+
+    override fun stop() {
+        logger.info("TestGroupPolicyProvider stopping.")
+        coordinator.stop()
+    }
+
+}
+
+class TestGroupPolicy : GroupPolicy {
+    companion object {
+        private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
+    }
+    override val fileFormatVersion: Int
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val groupId: String
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val registrationProtocol: String
+        get() = "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService"
+    override val synchronisationProtocol: String
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val protocolParameters: GroupPolicy.ProtocolParameters
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val p2pParameters: GroupPolicy.P2PParameters
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val mgmInfo: GroupPolicy.MGMInfo
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val cipherSuite: GroupPolicy.CipherSuite
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+
+}

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupReaderProvider.kt
@@ -1,0 +1,124 @@
+package net.corda.membership.impl.registration.dummy
+
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import net.corda.membership.lib.CPIWhiteList
+import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.impl.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.membership.lib.impl.MemberInfoExtension.Companion.IS_MGM
+import net.corda.membership.lib.impl.MemberInfoExtension.Companion.PARTY_NAME
+import net.corda.membership.lib.impl.MemberInfoExtension.Companion.PLATFORM_VERSION
+import net.corda.membership.lib.impl.MemberInfoExtension.Companion.SOFTWARE_VERSION
+import net.corda.membership.read.MembershipGroupReader
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.crypto.PublicKeyHash
+import net.corda.v5.membership.GroupParameters
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+
+interface TestGroupReaderProvider : MembershipGroupReaderProvider
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [MembershipGroupReaderProvider::class, TestGroupReaderProvider::class])
+class TestGroupReaderProviderImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = MemberInfoFactory::class)
+    val memberInfoFactory: MemberInfoFactory,
+) : TestGroupReaderProvider {
+    companion object {
+        val logger = contextLogger()
+        private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
+    }
+
+    private val coordinator = coordinatorFactory.createCoordinator(
+        LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),
+    ) { event, coordinator ->
+        if (event is StartEvent) {
+            coordinator.updateStatus(LifecycleStatus.UP)
+        }
+    }
+
+    override fun getGroupReader(holdingIdentity: HoldingIdentity): MembershipGroupReader =
+        TestGroupReader(memberInfoFactory)
+
+    override val isRunning: Boolean
+        get() = coordinator.status == LifecycleStatus.UP
+
+    override fun start() {
+        logger.info("TestGroupReaderProvider starting.")
+        coordinator.start()
+    }
+
+    override fun stop() {
+        logger.info("TestGroupReaderProvider starting.")
+        coordinator.stop()
+    }
+}
+
+class TestGroupReader @Activate constructor(
+    @Reference(service = MemberInfoFactory::class)
+    private val memberInfoFactory: MemberInfoFactory,
+) : MembershipGroupReader {
+    companion object {
+        val logger = contextLogger()
+        private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
+    }
+
+    override val groupId: String
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val owningMember: MemberX500Name
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val groupParameters: GroupParameters
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+    override val cpiWhiteList: CPIWhiteList
+        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+
+    private val name = MemberX500Name("Corda MGM", "London", "GB")
+    private val group = "dummy_group"
+
+    override fun lookup(): Collection<MemberInfo> = listOf(
+        memberInfoFactory.create(
+            sortedMapOf(
+                PARTY_NAME to name.toString(),
+                GROUP_ID to group,
+                "corda.endpoints.0.connectionURL" to "localhost:1081",
+                "corda.endpoints.0.protocolVersion" to "1",
+                PLATFORM_VERSION to "5000",
+                SOFTWARE_VERSION to "5.0.0",
+            ),
+            sortedMapOf(
+                IS_MGM to "true",
+            )
+        )
+    )
+
+    override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun lookup(name: MemberX500Name): MemberInfo? {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo? {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+}

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -198,7 +198,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                 val serializedMemberContext = keyValuePairListSerializer.serialize(memberContext)
                     ?: throw IllegalArgumentException("Failed to serialize the member context for this request.")
                 val publicKey =
-                    keyEncodingService.decodePublicKey(memberContext.items.first { it.key == PARTY_SESSION_KEY }.value.toByteArray())
+                    keyEncodingService.decodePublicKey(memberContext.items.first { it.key == PARTY_SESSION_KEY }.value)
                 val memberSignature = cryptoOpsClient.sign(
                     member.id,
                     publicKey,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -1,0 +1,422 @@
+package net.corda.membership.impl.registration.dynamic.member
+
+import net.corda.configuration.read.ConfigChangedEvent
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.CordaAvroSerializer
+import net.corda.data.KeyValuePair
+import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureWithKey
+import net.corda.data.crypto.wire.CryptoSigningKey
+import net.corda.data.membership.p2p.MembershipRegistrationRequest
+import net.corda.libs.configuration.helper.getConfig
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleEvent
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.RegistrationHandle
+import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.StartEvent
+import net.corda.lifecycle.StopEvent
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEYS
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.PARTY_SESSION_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.PLATFORM_VERSION
+import net.corda.membership.impl.MemberInfoExtension.Companion.PROTOCOL_VERSION
+import net.corda.membership.impl.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.impl.MemberInfoExtension.Companion.SESSION_KEY_HASH
+import net.corda.membership.impl.MemberInfoExtension.Companion.SOFTWARE_VERSION
+import net.corda.membership.impl.MemberInfoExtension.Companion.URL_KEY
+import net.corda.membership.impl.MemberInfoExtension.Companion.groupId
+import net.corda.membership.impl.MemberInfoExtension.Companion.isMgm
+import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.toWire
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.membership.registration.MemberRegistrationService
+import net.corda.membership.registration.MembershipRequestRegistrationOutcome
+import net.corda.membership.registration.MembershipRequestRegistrationResult
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.publisher.config.PublisherConfig
+import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.messaging.api.records.Record
+import net.corda.p2p.app.AppMessage
+import net.corda.p2p.app.UnauthenticatedMessage
+import net.corda.p2p.app.UnauthenticatedMessageHeader
+import net.corda.schema.Schemas
+import net.corda.schema.configuration.ConfigKeys
+import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.cipher.suite.schemes.EDDSA_ED25519_TEMPLATE
+import net.corda.v5.cipher.suite.schemes.GOST3410_GOST3411_TEMPLATE
+import net.corda.v5.crypto.ECDSA_SECP256K1_CODE_NAME
+import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
+import net.corda.v5.crypto.RSA_CODE_NAME
+import net.corda.v5.crypto.SM2_CODE_NAME
+import net.corda.v5.crypto.SPHINCS256_CODE_NAME
+import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.crypto.calculateHash
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.slf4j.Logger
+import java.nio.ByteBuffer
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@Component(service = [MemberRegistrationService::class])
+class DynamicMemberRegistrationService @Activate constructor(
+    @Reference(service = PublisherFactory::class)
+    private val publisherFactory: PublisherFactory,
+    @Reference(service = ConfigurationReadService::class)
+    private val configurationReadService: ConfigurationReadService,
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = CryptoOpsClient::class)
+    private val cryptoOpsClient: CryptoOpsClient,
+    @Reference(service = KeyEncodingService::class)
+    private val keyEncodingService: KeyEncodingService,
+    @Reference(service = CordaAvroSerializationFactory::class)
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    @Reference(service = MembershipGroupReaderProvider::class)
+    private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
+) : MemberRegistrationService {
+    /**
+     * Private interface used for implementation swapping in response to lifecycle events.
+     */
+    private interface InnerRegistrationService : AutoCloseable {
+        fun register(member: HoldingIdentity, context: Map<String, String>): MembershipRequestRegistrationResult
+    }
+
+    private companion object {
+        val logger: Logger = contextLogger()
+
+        const val PUBLICATION_TIMEOUT_SECONDS = 30L
+        const val SESSION_KEY_ID = "${PARTY_SESSION_KEY}.id"
+        const val SESSION_KEY_SIGNATURE_SPEC = "${PARTY_SESSION_KEY}.signature.spec"
+        const val LEDGER_KEY_ID = "${LEDGER_KEYS_KEY}.id"
+        const val LEDGER_KEY_SIGNATURE_SPEC = "${LEDGER_KEYS_KEY}.signature.spec"
+        const val REGISTRATION_ID = "corda.registration.id"
+        const val MEMBERSHIP_P2P_SUBSYSTEM = "membership"
+        const val PLATFORM_VERSION_CONST = "5000"
+        const val SOFTWARE_VERSION_CONST = "5.0.0"
+        const val SERIAL_CONST = "1"
+
+        val defaultCodeNameToSpec = mapOf(
+            ECDSA_SECP256K1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
+            ECDSA_SECP256R1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
+            EDDSA_ED25519_TEMPLATE to SignatureSpec.EDDSA_ED25519,
+            GOST3410_GOST3411_TEMPLATE to SignatureSpec.GOST3410_GOST3411,
+            RSA_CODE_NAME to SignatureSpec.RSA_SHA512,
+            SM2_CODE_NAME to SignatureSpec.SM2_SM3,
+            SPHINCS256_CODE_NAME to SignatureSpec.SPHINCS256_SHA512,
+        )
+    }
+
+    // for watching the config changes
+    private var configHandle: AutoCloseable? = null
+
+    // for checking the components' health
+    private var componentHandle: RegistrationHandle? = null
+
+    private var _publisher: Publisher? = null
+
+    /**
+     * Publisher for Kafka messaging. Recreated after every [MESSAGING_CONFIG] change.
+     */
+    private val publisher: Publisher
+        get() = _publisher ?: throw IllegalArgumentException("Publisher is not initialized.")
+
+    // Component lifecycle coordinator
+    private val coordinator = coordinatorFactory.createCoordinator(lifecycleCoordinatorName, ::handleEvent)
+
+    private val registrationRequestSerializer: CordaAvroSerializer<MembershipRegistrationRequest> =
+        cordaAvroSerializationFactory.createAvroSerializer { }
+
+    private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> =
+        cordaAvroSerializationFactory.createAvroSerializer { }
+
+    private var impl: InnerRegistrationService = InactiveImpl
+
+    override val isRunning: Boolean
+        get() = coordinator.isRunning
+
+    override fun start() {
+        logger.info("DynamicMemberRegistrationService started.")
+        coordinator.start()
+    }
+
+    override fun stop() {
+        logger.info("DynamicMemberRegistrationService stopped.")
+        coordinator.stop()
+    }
+
+    private fun activate(coordinator: LifecycleCoordinator) {
+        impl = ActiveImpl()
+        coordinator.updateStatus(LifecycleStatus.UP)
+    }
+
+    private fun deactivate(coordinator: LifecycleCoordinator) {
+        coordinator.updateStatus(LifecycleStatus.DOWN)
+        impl.close()
+        impl = InactiveImpl
+    }
+
+    override fun register(
+        member: HoldingIdentity,
+        context: Map<String, String>,
+    ): MembershipRequestRegistrationResult = impl.register(member, context)
+
+    private object InactiveImpl : InnerRegistrationService {
+        override fun register(
+            member: HoldingIdentity,
+            context: Map<String, String>
+        ): MembershipRequestRegistrationResult =
+            MembershipRequestRegistrationResult(
+                MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
+                "Registration failed. Reason: DynamicMemberRegistrationService is not running."
+            )
+
+        override fun close() = Unit
+    }
+
+    private inner class ActiveImpl : InnerRegistrationService {
+        override fun register(
+            member: HoldingIdentity,
+            context: Map<String, String>,
+        ): MembershipRequestRegistrationResult {
+            try {
+                val registrationId = UUID.randomUUID().toString()
+                val memberContext = buildMemberContext(context, registrationId, member.id)
+                val serializedMemberContext = keyValuePairListSerializer.serialize(memberContext)
+                val publicKey = keyEncodingService.decodePublicKey(context[PARTY_SESSION_KEY].toString())
+                val memberSignature = cryptoOpsClient.sign(
+                    member.id,
+                    publicKey,
+                    SignatureSpec(context[SESSION_KEY_SIGNATURE_SPEC].toString()),
+                    serializedMemberContext!!
+                ).bytes.run {
+                    CryptoSignatureWithKey(
+                        ByteBuffer.wrap(publicKey.encoded),
+                        ByteBuffer.wrap(this),
+                        KeyValuePairList(emptyList())
+                    )
+                }
+                val mgm = membershipGroupReaderProvider.getGroupReader(member).lookup().firstOrNull { it.isMgm }
+                    ?: throw IllegalArgumentException("Failed to look up MGM information.")
+                val messageHeader = UnauthenticatedMessageHeader(
+                    net.corda.data.identity.HoldingIdentity(mgm.name.toString(), mgm.groupId),
+                    member.toAvro(),
+                    MEMBERSHIP_P2P_SUBSYSTEM
+                )
+                val message = MembershipRegistrationRequest(
+                    registrationId,
+                    ByteBuffer.wrap(serializedMemberContext),
+                    memberSignature
+                )
+                val record = buildUnauthenticatedP2PRequest(
+                    messageHeader,
+                    ByteBuffer.wrap(registrationRequestSerializer.serialize(message)),
+                    member.id // holding identity ID is used as topic key to be able to ensure serial processing of registration for the same member.
+                )
+                publisher.publish(listOf(record)).first().get(PUBLICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            } catch (e: Exception) {
+                logger.warn("Registration failed.", e)
+                return MembershipRequestRegistrationResult(
+                    MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
+                    "Registration failed. Reason: ${e.message}"
+                )
+            }
+            return MembershipRequestRegistrationResult(MembershipRequestRegistrationOutcome.SUBMITTED)
+        }
+
+        override fun close() {
+            publisher.close()
+        }
+
+        private fun buildMemberContext(
+            context: Map<String, String>,
+            registrationId: String,
+            tenantId: String
+        ): KeyValuePairList {
+            validateContext(context)
+            return KeyValuePairList(
+                context.filterNot { it.key.startsWith(LEDGER_KEYS) || it.key.startsWith(PARTY_SESSION_KEY) }.toWire().items
+                + generateSessionKeyData(context, tenantId).items
+                + generateLedgerKeyData(context, tenantId).items
+                + listOf(
+                    KeyValuePair(REGISTRATION_ID, registrationId),
+                    // temporarily hardcoded
+                    KeyValuePair(PLATFORM_VERSION, PLATFORM_VERSION_CONST),
+                    KeyValuePair(SOFTWARE_VERSION, SOFTWARE_VERSION_CONST),
+                    KeyValuePair(SERIAL, SERIAL_CONST),
+                )
+            )
+        }
+
+        private fun validateContext(context: Map<String, String>) {
+            context[SESSION_KEY_ID] ?: throw IllegalArgumentException("No session key was provided.")
+            context.keys.filter { URL_KEY.format("[0-9]+").toRegex().matches(it) }.apply {
+                require(isNotEmpty()) { "No endpoint URL was provided." }
+                require(isOrdered(this, 2)) { "Provided endpoint URLs are incorrectly numbered." }
+            }
+            context.keys.filter { PROTOCOL_VERSION.format("[0-9]+").toRegex().matches(it) }.apply {
+                require(isNotEmpty()) { "No endpoint protocol was provided." }
+                require(isOrdered(this, 2)) { "Provided endpoint protocols are incorrectly numbered." }
+            }
+            context.keys.filter { LEDGER_KEY_ID.format("[0-9]+").toRegex().matches(it) }.apply {
+                require(isNotEmpty()) { "No ledger key was provided." }
+                require(isOrdered(this, 2)) { "Provided ledger keys are incorrectly numbered." }
+            }
+        }
+
+        /**
+         * Checks if [keys] are numbered correctly (0, 1, ..., n).
+         *
+         * @param keys List of property keys to validate.
+         * @param position Position of numbering in each of the provided [keys]. For example, [position] is 2 in
+         * "corda.endpoints.0.connectionURL".
+         */
+        private fun isOrdered(keys: List<String>, position: Int): Boolean =
+            keys.map { it.split(".")[position].toInt() }
+                .sorted()
+                .run {
+                    indices.forEach { index ->
+                        if (this[index] != index) return false
+                    }
+                    true
+                }
+
+        private fun getKeysFromIds(keyIds: List<String>, tenantId: String): List<CryptoSigningKey> =
+            with(cryptoOpsClient) {
+                lookup(tenantId, keyIds).apply {
+                    require(isNotEmpty()) { throw IllegalArgumentException("No key found for tenant: $tenantId under ID: $keyIds.") }
+                    // TODO check if keys for all IDs were found?
+                }
+            }
+
+        private fun getSignatureSpec(key: CryptoSigningKey, specFromContext: String?): SignatureSpec {
+            if (specFromContext != null) {
+                return SignatureSpec(specFromContext)
+            }
+            return defaultCodeNameToSpec[key.schemeCodeName]
+                ?: throw IllegalArgumentException("Could not find a suitable signature spec for ${key.schemeCodeName}. Specify signature spec for key with ID: ${key.id} explicitly in the context.")
+        }
+
+        private fun generateLedgerKeyData(context: Map<String, String>, tenantId: String): KeyValuePairList {
+            val ledgerKeys =
+                getKeysFromIds(context.filter { LEDGER_KEY_ID.format("[0-9]+").toRegex().matches(it.key) }.values.toList(), tenantId)
+            val ledgerPublicKeys = ledgerKeys.map { keyEncodingService.decodePublicKey(it.publicKey.array()) }
+            return KeyValuePairList(
+                ledgerPublicKeys.mapIndexed { index, ledgerKey ->
+                    KeyValuePair(String.format(LEDGER_KEYS_KEY, index), keyEncodingService.encodeAsString(ledgerKey))
+                    KeyValuePair(String.format(LEDGER_KEY_HASHES_KEY, index), ledgerKey.calculateHash().value)
+                    KeyValuePair(
+                        String.format(LEDGER_KEY_SIGNATURE_SPEC, index),
+                        getSignatureSpec(ledgerKeys[index], context[String.format(LEDGER_KEY_SIGNATURE_SPEC, index)]).signatureName
+                    )
+                }
+            )
+        }
+
+        private fun generateSessionKeyData(context: Map<String, String>, tenantId: String): KeyValuePairList {
+            val sessionKey = getKeysFromIds(listOf(context[SESSION_KEY_ID]!!), tenantId).first()
+            val sessionPublicKey = keyEncodingService.decodePublicKey(sessionKey.publicKey.array())
+            return KeyValuePairList(
+                listOf(
+                    KeyValuePair(PARTY_SESSION_KEY, keyEncodingService.encodeAsString(sessionPublicKey)),
+                    KeyValuePair(SESSION_KEY_HASH, sessionPublicKey.calculateHash().value),
+                    KeyValuePair(SESSION_KEY_SIGNATURE_SPEC, getSignatureSpec(sessionKey, context[SESSION_KEY_SIGNATURE_SPEC]).signatureName
+                    )
+                )
+            )
+        }
+
+        private fun buildUnauthenticatedP2PRequest(
+            messageHeader: UnauthenticatedMessageHeader,
+            payload: ByteBuffer,
+            topicKey: String,
+        ): Record<String, AppMessage> {
+            return Record(
+                Schemas.P2P.P2P_OUT_TOPIC,
+                topicKey,
+                AppMessage(
+                    UnauthenticatedMessage(
+                        messageHeader,
+                        payload
+                    )
+                )
+            )
+        }
+    }
+
+    private fun handleEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
+        logger.info("Received event $event.")
+        when (event) {
+            is StartEvent -> handleStartEvent(coordinator)
+            is StopEvent -> handleStopEvent(coordinator)
+            is RegistrationStatusChangeEvent -> handleRegistrationChangeEvent(event, coordinator)
+            is ConfigChangedEvent -> handleConfigChange(event, coordinator)
+        }
+    }
+
+    private fun handleStartEvent(coordinator: LifecycleCoordinator) {
+        logger.info("Handling start event.")
+        componentHandle?.close()
+        componentHandle = coordinator.followStatusChangesByName(
+            setOf(
+                LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+                LifecycleCoordinatorName.forComponent<CryptoOpsClient>(),
+                LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),
+            )
+        )
+    }
+
+    private fun handleStopEvent(coordinator: LifecycleCoordinator) {
+        logger.info("Handling stop event.")
+        deactivate(coordinator)
+        componentHandle?.close()
+        componentHandle = null
+        configHandle?.close()
+        configHandle = null
+        _publisher?.close()
+        _publisher = null
+    }
+
+    private fun handleRegistrationChangeEvent(
+        event: RegistrationStatusChangeEvent,
+        coordinator: LifecycleCoordinator,
+    ) {
+        logger.info("Handling registration changed event.")
+        when (event.status) {
+            LifecycleStatus.UP -> {
+                configHandle?.close()
+                configHandle = configurationReadService.registerComponentForUpdates(
+                    coordinator,
+                    setOf(ConfigKeys.BOOT_CONFIG, MESSAGING_CONFIG)
+                )
+            }
+            else -> {
+                deactivate(coordinator)
+                configHandle?.close()
+            }
+        }
+    }
+
+    // re-creates the publisher with the new config, sets the lifecycle status to UP when the publisher is ready for the first time
+    private fun handleConfigChange(event: ConfigChangedEvent, coordinator: LifecycleCoordinator) {
+        logger.info("Handling config changed event.")
+        _publisher?.close()
+        _publisher = publisherFactory.createPublisher(
+            PublisherConfig("dynamic-member-registration-service"),
+            event.config.getConfig(MESSAGING_CONFIG)
+        )
+        _publisher?.start()
+        activate(coordinator)
+    }
+}

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -278,7 +278,7 @@ class DynamicMemberRegistrationService @Activate constructor(
             }
             context.keys.filter { LEDGER_KEY_ID.format("[0-9]+").toRegex().matches(it) }.apply {
                 require(isNotEmpty()) { "No ledger key ID was provided." }
-                require(isOrdered(this, 2)) { "Provided ledger key IDs are incorrectly numbered." }
+                require(isOrdered(this, 3)) { "Provided ledger key IDs are incorrectly numbered." }
             }
         }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -30,7 +30,7 @@ import net.corda.membership.lib.impl.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.impl.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.lib.impl.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.lib.impl.MemberInfoExtension.Companion.URL_KEY
-import net.corda.membership.lib.impl.MemberInfoExtension.Companion.groupId
+import net.corda.membership.lib.impl.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.membership.lib.impl.MemberInfoExtension.Companion.isMgm
 import net.corda.membership.lib.toWire
 import net.corda.membership.read.MembershipGroupReaderProvider
@@ -214,7 +214,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                 val mgm = membershipGroupReaderProvider.getGroupReader(member).lookup().firstOrNull { it.isMgm }
                     ?: throw IllegalArgumentException("Failed to look up MGM information.")
                 val messageHeader = UnauthenticatedMessageHeader(
-                    net.corda.data.identity.HoldingIdentity(mgm.name.toString(), mgm.groupId),
+                    mgm.holdingIdentity.toAvro(),
                     member.toAvro(),
                     MEMBERSHIP_P2P_SUBSYSTEM
                 )

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -118,7 +118,15 @@ class DynamicMemberRegistrationServiceTest {
     private val cryptoOpsClient: CryptoOpsClient = mock {
         on { lookup(memberId, listOf(SESSION_KEY_ID)) } doReturn listOf(sessionCryptoSigningKey)
         on { lookup(memberId, listOf(LEDGER_KEY_ID)) } doReturn listOf(ledgerCryptoSigningKey)
-        on { sign(any(), any(), any<SignatureSpec>(), any(), eq(CryptoOpsClient.EMPTY_CONTEXT)) }.doReturn(mockSignature)
+        on {
+            sign(
+                any(),
+                any(),
+                any<SignatureSpec>(),
+                any(),
+                eq(CryptoOpsClient.EMPTY_CONTEXT)
+            )
+        }.doReturn(mockSignature)
     }
 
     private val componentHandle: RegistrationHandle = mock()
@@ -251,7 +259,8 @@ class DynamicMemberRegistrationServiceTest {
             val publishedMessage = publishedMessageList.first()
             it.assertThat(publishedMessage.topic).isEqualTo(Schemas.P2P.P2P_OUT_TOPIC)
             it.assertThat(publishedMessage.key).isEqualTo(memberId)
-            val unauthenticatedMessagePublished = (publishedMessage.value as AppMessage).message as UnauthenticatedMessage
+            val unauthenticatedMessagePublished =
+                (publishedMessage.value as AppMessage).message as UnauthenticatedMessage
             it.assertThat(unauthenticatedMessagePublished.header.source).isEqualTo(member.toAvro())
             it.assertThat(unauthenticatedMessagePublished.header.destination).isEqualTo(mgm.toAvro())
             it.assertThat(unauthenticatedMessagePublished.payload).isEqualTo(ByteBuffer.wrap(REQUEST_BYTES))
@@ -299,7 +308,7 @@ class DynamicMemberRegistrationServiceTest {
         SoftAssertions.assertSoftly {
             it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
             it.assertThat(result.message)
-                .isEqualTo("Registration failed. Reason: Provided ledger keys are incorrectly numbered.")
+                .isEqualTo("Registration failed. Reason: Provided ledger key IDs are incorrectly numbered.")
         }
         registrationService.stop()
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -1,0 +1,391 @@
+package net.corda.membership.impl.registration.dynamic.member
+
+import com.typesafe.config.ConfigFactory
+import net.corda.configuration.read.ConfigChangedEvent
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.CordaAvroSerializer
+import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSigningKey
+import net.corda.data.membership.p2p.MembershipRegistrationRequest
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleEventHandler
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.RegistrationHandle
+import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.StartEvent
+import net.corda.lifecycle.StopEvent
+import net.corda.membership.impl.MemberInfoExtension.Companion.groupId
+import net.corda.membership.impl.MemberInfoExtension.Companion.isMgm
+import net.corda.membership.read.MembershipGroupReader
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.membership.registration.MembershipRequestRegistrationOutcome
+import net.corda.membership.registration.MembershipRequestRegistrationResult
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.publisher.config.PublisherConfig
+import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas
+import net.corda.schema.configuration.ConfigKeys
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.membership.MGMContext
+import net.corda.v5.membership.MemberContext
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.nio.ByteBuffer
+import java.security.PublicKey
+import java.util.concurrent.CompletableFuture
+
+class DynamicMemberRegistrationServiceTest {
+    companion object {
+        private const val SESSION_KEY = "1234"
+        private const val SESSION_KEY_ID = "1"
+        private const val LEDGER_KEY = "5678"
+        private const val LEDGER_KEY_ID = "2"
+        private const val PUBLISHER_CLIENT_ID = "dynamic-member-registration-service"
+    }
+
+    private val memberName = MemberX500Name("Alice", "London", "GB")
+    private val member = HoldingIdentity(memberName.toString(), "dummy_group")
+    private val memberId = member.id
+    private val sessionKey: PublicKey = mock {
+        on { encoded } doReturn SESSION_KEY.toByteArray()
+    }
+    private val sessionCryptoSigningKey: CryptoSigningKey = mock {
+        on { publicKey } doReturn ByteBuffer.wrap(SESSION_KEY.toByteArray())
+    }
+    private val ledgerKey: PublicKey = mock {
+        on { encoded } doReturn LEDGER_KEY.toByteArray()
+    }
+    private val ledgerCryptoSigningKey: CryptoSigningKey = mock {
+        on { publicKey } doReturn ByteBuffer.wrap(LEDGER_KEY.toByteArray())
+    }
+    private val mockPublisher = mock<Publisher>().apply {
+        whenever(publish(any())).thenReturn(listOf(CompletableFuture.completedFuture(Unit)))
+    }
+
+    private val publisherFactory: PublisherFactory = mock {
+        on { createPublisher(any(), any()) } doReturn mockPublisher
+    }
+    private val keyEncodingService: KeyEncodingService = mock {
+        on { decodePublicKey(SESSION_KEY.toByteArray()) } doReturn sessionKey
+        on { decodePublicKey(LEDGER_KEY.toByteArray()) } doReturn ledgerKey
+
+        on { encodeAsString(any()) } doReturn SESSION_KEY
+        on { encodeAsString(ledgerKey) } doReturn LEDGER_KEY
+    }
+    private val mockSignature: DigitalSignature.WithKey = mock{
+//        on { bytes } doReturn "1111".toByteArray()
+    }
+    private val cryptoOpsClient: CryptoOpsClient = mock {
+        on { lookup(memberId, listOf(SESSION_KEY_ID)) } doReturn listOf(sessionCryptoSigningKey)
+        on { lookup(memberId, listOf(LEDGER_KEY_ID)) } doReturn listOf(ledgerCryptoSigningKey)
+        on { sign(any(), any(), eq(any<SignatureSpec>()), any()) } doReturn mockSignature
+    }
+
+    private val componentHandle: RegistrationHandle = mock()
+    private val configHandle: AutoCloseable = mock()
+    private val testConfig =
+        SmartConfigFactory.create(ConfigFactory.empty()).create(ConfigFactory.parseString("instanceId=1"))
+    private val dependentComponents = setOf(
+        LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+        LifecycleCoordinatorName.forComponent<CryptoOpsClient>(),
+        LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),
+    )
+
+    private var coordinatorIsRunning = false
+    private var coordinatorStatus: KArgumentCaptor<LifecycleStatus> = argumentCaptor()
+    private val coordinator: LifecycleCoordinator = mock {
+        on { followStatusChangesByName(eq(dependentComponents)) } doReturn componentHandle
+        on { isRunning } doAnswer { coordinatorIsRunning }
+        on { start() } doAnswer {
+            coordinatorIsRunning = true
+            lifecycleHandlerCaptor.firstValue.processEvent(StartEvent(), mock)
+        }
+        on { stop() } doAnswer {
+            coordinatorIsRunning = false
+            lifecycleHandlerCaptor.firstValue.processEvent(StopEvent(), mock)
+        }
+        doNothing().whenever(it).updateStatus(coordinatorStatus.capture(), any())
+        on { status } doAnswer { coordinatorStatus.firstValue }
+    }
+
+    private val lifecycleHandlerCaptor: KArgumentCaptor<LifecycleEventHandler> = argumentCaptor()
+    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory = mock {
+        on { createCoordinator(any(), lifecycleHandlerCaptor.capture()) } doReturn coordinator
+    }
+    private val configurationReadService: ConfigurationReadService = mock {
+        on { registerComponentForUpdates(eq(coordinator), any()) } doReturn configHandle
+    }
+    private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> = mock {
+        on { serialize(any()) } doReturn "2222".toByteArray()
+    }
+    private val registrationRequestSerializer: CordaAvroSerializer<MembershipRegistrationRequest> = mock {
+        on { serialize(any()) } doReturn "3333".toByteArray()
+    }
+    private val serializationFactory: CordaAvroSerializationFactory = mock {
+        on { createAvroSerializer<KeyValuePairList> {  } } doReturn keyValuePairListSerializer
+        on { createAvroSerializer<MembershipRegistrationRequest> {  } } doReturn registrationRequestSerializer
+    }
+    private val memberProvidedContext: MemberContext = mock()
+    private val mgmProvidedContext: MGMContext = mock()
+    private val mgm: MemberInfo = mock {
+        on { memberProvidedContext } doReturn memberProvidedContext
+        on { mgmProvidedContext } doReturn mgmProvidedContext
+        on { name } doReturn MemberX500Name("Corda MGM", "London", "GB")
+        on { groupId } doReturn "ABCD"
+        on { isMgm } doReturn true
+    }
+    private val groupReader: MembershipGroupReader = mock {
+        on { lookup() } doReturn listOf(mgm)
+    }
+    private val membershipGroupReaderProvider: MembershipGroupReaderProvider = mock {
+        on { getGroupReader(any()) } doReturn groupReader
+    }
+    private val registrationService = DynamicMemberRegistrationService(
+        publisherFactory,
+        configurationReadService,
+        lifecycleCoordinatorFactory,
+        cryptoOpsClient,
+        keyEncodingService,
+        serializationFactory,
+        membershipGroupReaderProvider,
+    )
+
+    private val context = mapOf(
+        "corda.session.key.id" to SESSION_KEY_ID,
+        "corda.session.key.signature.spec" to "CORDA.ECDSA.SECP256R1",
+        "corda.endpoints.0.connectionURL" to "localhost:1080",
+        "corda.endpoints.0.protocolVersion" to "1",
+        "corda.ledgerKeys.0.id" to LEDGER_KEY_ID,
+        "corda.ledgerKeys.0.signature.spec" to "CORDA.ECDSA.SECP256R1",
+    )
+
+    private fun postStartEvent() {
+        lifecycleHandlerCaptor.firstValue.processEvent(StartEvent(), coordinator)
+    }
+
+    private fun postStopEvent() {
+        lifecycleHandlerCaptor.firstValue.processEvent(StopEvent(), coordinator)
+    }
+
+    private fun postRegistrationStatusChangeEvent(
+        status: LifecycleStatus,
+        handle: RegistrationHandle = componentHandle
+    ) {
+        lifecycleHandlerCaptor.firstValue.processEvent(
+            RegistrationStatusChangeEvent(
+                handle,
+                status
+            ),
+            coordinator
+        )
+    }
+
+    private fun postConfigChangedEvent() {
+        lifecycleHandlerCaptor.firstValue.processEvent(
+            ConfigChangedEvent(
+                setOf(ConfigKeys.BOOT_CONFIG, ConfigKeys.MESSAGING_CONFIG),
+                mapOf(
+                    ConfigKeys.BOOT_CONFIG to testConfig,
+                    ConfigKeys.MESSAGING_CONFIG to testConfig
+                )
+            ), coordinator
+        )
+    }
+
+    @Test
+    fun `starting the service succeeds`() {
+        registrationService.start()
+        Assertions.assertThat(registrationService.isRunning).isTrue
+        verify(coordinator).start()
+    }
+
+    @Test
+    fun `stopping the service succeeds`() {
+        registrationService.start()
+        registrationService.stop()
+        Assertions.assertThat(registrationService.isRunning).isFalse
+        verify(coordinator).stop()
+    }
+
+    @Test
+    fun `registration successfully builds unauthenticated message and publishes it`() {
+        postConfigChangedEvent()
+        registrationService.start()
+        val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
+        val result = registrationService.register(member, context)
+        verify(mockPublisher, times(1)).publish(capturedPublishedList.capture())
+        val publishedMessageList = capturedPublishedList.firstValue
+        SoftAssertions.assertSoftly {
+            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
+            it.assertThat(publishedMessageList.size).isEqualTo(1)
+            val publishedMessage = publishedMessageList.first()
+            it.assertThat(publishedMessage.topic).isEqualTo(Schemas.P2P.P2P_OUT_TOPIC)
+            it.assertThat(publishedMessage.key).isEqualTo(memberId)
+//            val unauthenticatedMessagePublished = publishedMessage.value as UnauthenticatedMessage
+//            val deserializedContext = keyValuePairListDeserializer.deserialize(this.memberContext.array())
+//            it.assertThat(mgmPublished.name.toString()).isEqualTo(memberName.toString())
+        }
+        registrationService.stop()
+    }
+
+    @Test
+    fun `registration fails when coordinator is not running`() {
+        val registrationResult = registrationService.register(member, mock())
+        Assertions.assertThat(registrationResult).isEqualTo(
+            MembershipRequestRegistrationResult(
+                MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
+                "Registration failed. Reason: DynamicMemberRegistrationService is not running."
+            )
+        )
+    }
+
+    @Test
+    fun `registration fails when one or more context properties are missing`() {
+        postConfigChangedEvent()
+        val testProperties = mutableMapOf<String, String>()
+        registrationService.start()
+        context.entries.apply {
+            for (index in indices) {
+                val result = registrationService.register(member, testProperties)
+                SoftAssertions.assertSoftly {
+                    it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                }
+                elementAt(index).let { testProperties.put(it.key, it.value) }
+            }
+        }
+        registrationService.stop()
+    }
+
+    @Test
+    fun `registration fails when one or more context properties are numbered incorrectly`() {
+        postConfigChangedEvent()
+        val testProperties =
+            context + mapOf(
+                "corda.ledgerKeys.100.id" to "9999"
+            )
+        registrationService.start()
+        val result = registrationService.register(member, testProperties)
+        SoftAssertions.assertSoftly {
+            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+            it.assertThat(result.message)
+                .isEqualTo("Registration failed. Reason: Provided ledger keys are incorrectly numbered.")
+        }
+        registrationService.stop()
+    }
+
+    @Test
+    fun `component handle created on start and closed on stop`() {
+        postStartEvent()
+
+        verify(componentHandle, never()).close()
+        verify(coordinator).followStatusChangesByName(eq(dependentComponents))
+
+        postStartEvent()
+
+        verify(componentHandle).close()
+        verify(coordinator, times(2)).followStatusChangesByName(eq(dependentComponents))
+
+        postStopEvent()
+        verify(componentHandle, times(2)).close()
+    }
+
+    @Test
+    fun `status set to down after stop`() {
+        postStopEvent()
+
+        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+        verify(componentHandle, never()).close()
+        verify(configHandle, never()).close()
+        verify(mockPublisher, never()).close()
+    }
+
+    @Test
+    fun `registration status UP creates config handle and closes it first if it exists`() {
+        postStartEvent()
+        postRegistrationStatusChangeEvent(LifecycleStatus.UP)
+
+        val configArgs = argumentCaptor<Set<String>>()
+        verify(configHandle, never()).close()
+        verify(configurationReadService).registerComponentForUpdates(
+            eq(coordinator),
+            configArgs.capture()
+        )
+        Assertions.assertThat(configArgs.firstValue)
+            .isEqualTo(setOf(ConfigKeys.BOOT_CONFIG, ConfigKeys.MESSAGING_CONFIG))
+
+        postRegistrationStatusChangeEvent(LifecycleStatus.UP)
+        verify(configHandle).close()
+        verify(configurationReadService, times(2)).registerComponentForUpdates(eq(coordinator), any())
+
+        postStopEvent()
+        verify(configHandle, times(2)).close()
+    }
+
+    @Test
+    fun `registration status DOWN sets status to DOWN`() {
+        postRegistrationStatusChangeEvent(LifecycleStatus.DOWN)
+
+        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+    }
+
+    @Test
+    fun `registration status ERROR sets status to DOWN`() {
+        postRegistrationStatusChangeEvent(LifecycleStatus.ERROR)
+
+        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+    }
+
+    @Test
+    fun `config changed event creates publisher`() {
+        postConfigChangedEvent()
+
+        val configCaptor = argumentCaptor<PublisherConfig>()
+        verify(mockPublisher, never()).close()
+        verify(publisherFactory).createPublisher(
+            configCaptor.capture(),
+            any()
+        )
+        verify(mockPublisher).start()
+        verify(coordinator).updateStatus(eq(LifecycleStatus.UP), any())
+
+        with(configCaptor.firstValue) {
+            Assertions.assertThat(clientId).isEqualTo(PUBLISHER_CLIENT_ID)
+        }
+
+        postConfigChangedEvent()
+        verify(mockPublisher).close()
+        verify(publisherFactory, times(2)).createPublisher(
+            configCaptor.capture(),
+            any()
+        )
+        verify(mockPublisher, times(2)).start()
+        verify(coordinator, times(2)).updateStatus(eq(LifecycleStatus.UP), any())
+
+        postStopEvent()
+        verify(mockPublisher, times(3)).close()
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -109,6 +109,7 @@ class DynamicMemberRegistrationServiceTest {
     }
     private val keyEncodingService: KeyEncodingService = mock {
         on { decodePublicKey(SESSION_KEY.toByteArray()) } doReturn sessionKey
+        on { decodePublicKey(SESSION_KEY) } doReturn sessionKey
         on { decodePublicKey(LEDGER_KEY.toByteArray()) } doReturn ledgerKey
 
         on { encodeAsString(any()) } doReturn SESSION_KEY

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -194,8 +194,8 @@ class DynamicMemberRegistrationServiceTest {
         "corda.session.key.signature.spec" to "CORDA.ECDSA.SECP256R1",
         "corda.endpoints.0.connectionURL" to "localhost:1080",
         "corda.endpoints.0.protocolVersion" to "1",
-        "corda.ledgerKeys.0.id" to LEDGER_KEY_ID,
-        "corda.ledgerKeys.0.signature.spec" to "CORDA.ECDSA.SECP256R1",
+        "corda.ledger.keys.0.id" to LEDGER_KEY_ID,
+        "corda.ledger.keys.0.signature.spec" to "CORDA.ECDSA.SECP256R1",
     )
 
     private fun postStartEvent() {
@@ -302,7 +302,7 @@ class DynamicMemberRegistrationServiceTest {
         postConfigChangedEvent()
         val testProperties =
             context + mapOf(
-                "corda.ledgerKeys.100.id" to "9999"
+                "corda.ledger.keys.100.id" to "9999"
             )
         registrationService.start()
         val result = registrationService.register(member, testProperties)

--- a/components/membership/registration-impl/test.bndrun
+++ b/components/membership/registration-impl/test.bndrun
@@ -1,0 +1,41 @@
+-tester: biz.aQute.tester.junit-platform
+-runfw: org.apache.felix.framework;
+-runee: JavaSE-11
+-runtrace: true
+#-runjdb: 5006
+
+-runsystempackages: \
+    sun.security.x509
+
+-runrequires: \
+    bnd.identity;id='net.corda.registration-impl',\
+    bnd.identity;id='net.corda.membership-group-read-impl',\
+    bnd.identity;id='net.corda.cipher-suite-impl',\
+    bnd.identity;id='net.corda.crypto-client-impl',\
+    bnd.identity;id='${project.archivesBaseName}-tests',\
+    bnd.identity;id='net.corda.messaging-impl',\
+    bnd.identity;id='net.corda.membership-impl',\
+    bnd.identity;id='net.corda.lifecycle-impl',\
+    bnd.identity;id='net.corda.configuration-read-service-impl',\
+    bnd.identity;id='net.corda.db-message-bus-impl',\
+    bnd.identity;id='net.corda.schema-registry-impl',\
+    bnd.identity;id='net.corda.db-admin-impl',\
+    bnd.identity;id='net.corda.db-orm-impl',\
+    bnd.identity;id='net.corda.db-connection-manager-impl',\
+    bnd.identity;id='net.corda.configuration-read-service-impl',\
+    bnd.identity;id='junit-jupiter-engine',\
+    bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='net.bytebuddy.byte-buddy',\
+    bnd.identity;id='org.hsqldb.hsqldb',\
+
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1
+
+-runproperties: \
+    org.osgi.framework.bsnversion=multiple,\
+    org.slf4j.simpleLogger.defaultLogLevel=info,\
+    org.slf4j.simpleLogger.showShortLogName=true,\
+    org.slf4j.simpleLogger.showThreadName=false,\
+    org.slf4j.simpleLogger.showDateTime=true,\
+    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z'

--- a/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapImpl.kt
+++ b/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapImpl.kt
@@ -124,7 +124,7 @@ class LayeredPropertyMapImpl(
         // then convert it to a map one by one and pass it to the converter
         // 1 -> [corda.endpoints.1.url=localhost, corda.endpoints.1.protocolVersion=1]
         // 2 -> [corda.endpoints.2.url=localhost, corda.endpoints.2.protocolVersion=1]
-        // 1 -> [corda.ledgerKeys.1=ABC]
+        // 1 -> [corda.ledger.keys.1=ABC]
         val result = entryList.groupBy {
             getIndexedPrefix(it.key, normalisedPrefix)
         }.toSortedMap(indexedPrefixComparator).map { groupedEntry ->

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/MemberInfoExtension.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/MemberInfoExtension.kt
@@ -15,8 +15,8 @@ import java.time.Instant
 class MemberInfoExtension {
     companion object {
         /** Key name for ledger keys property. */
-        const val LEDGER_KEYS = "corda.ledgerKeys"
-        const val LEDGER_KEYS_KEY = "corda.ledgerKeys.%s"
+        const val LEDGER_KEYS = "corda.ledger.keys"
+        const val LEDGER_KEYS_KEY = "corda.ledger.keys.%s"
 
         /** Key name for ledger key hashes property. */
         const val LEDGER_KEY_HASHES = "corda.ledgerKeyHashes"

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/PublicKeyConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/PublicKeyConverter.kt
@@ -22,7 +22,7 @@ class PublicKeyConverter @Activate constructor(
         get() = PublicKey::class.java
 
     /**
-     * Select the single element in case the structure is like 'corda.ledgerKeys.1'
+     * Select the single element in case the structure is like 'corda.ledger.keys.1'
      */
     override fun convert(context: ConversionContext): PublicKey? =
         context.value()?.let { keyEncodingService.decodePublicKey(it) }

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/PublicKeyConverterTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/PublicKeyConverterTest.kt
@@ -3,6 +3,7 @@ package net.corda.membership.lib.impl.converter
 import net.corda.layeredpropertymap.CustomPropertyConverter
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.membership.lib.impl.MemberContextImpl
+import net.corda.membership.lib.impl.MemberInfoExtension
 import net.corda.v5.base.exceptions.ValueNotFoundException
 import net.corda.v5.base.util.parse
 import net.corda.v5.base.util.parseList
@@ -38,20 +39,20 @@ class PublicKeyConverterTest {
     @Test
     fun `converting public key should work for single element`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.ledgerKey" to LEDGER_KEY),
+            sortedMapOf(MemberInfoExtension.LEDGER_KEYS to LEDGER_KEY),
             converters
         )
-        val result = memberContext.parse<PublicKey>("corda.ledgerKey")
+        val result = memberContext.parse<PublicKey>(MemberInfoExtension.LEDGER_KEYS)
         assertEquals(ledgerKey, result)
     }
 
     @Test
     fun `converting list of public key should work`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.ledgerKeys.0" to LEDGER_KEY),
+            sortedMapOf(String.format(MemberInfoExtension.LEDGER_KEYS_KEY, 0) to LEDGER_KEY),
             converters
         )
-        val result = memberContext.parseList<PublicKey>("corda.ledgerKeys")
+        val result = memberContext.parseList<PublicKey>(MemberInfoExtension.LEDGER_KEYS)
         assertEquals(1, result.size)
         assertEquals(ledgerKey, result[0])
     }
@@ -60,31 +61,31 @@ class PublicKeyConverterTest {
     fun `converting PublicKey fails when the keys is null`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
             sortedMapOf(
-                "corda.ledgerKey" to null
+                MemberInfoExtension.LEDGER_KEYS to null
             ),
             converters
         )
-        assertFailsWith<ValueNotFoundException> { memberContext.parse<PublicKey>("corda.ledgerKey") }
+        assertFailsWith<ValueNotFoundException> { memberContext.parse<PublicKey>(MemberInfoExtension.LEDGER_KEYS) }
     }
 
     @Test
     fun `converting list of PublicKeys fails when the keys is null`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.ledgerKeys.0" to null),
+            sortedMapOf(String.format(MemberInfoExtension.LEDGER_KEYS_KEY, 0) to null),
             converters
         )
         assertFailsWith<ValueNotFoundException> {
-            memberContext.parseList<PublicKey>("corda.ledgerKeys")
+            memberContext.parseList<PublicKey>(MemberInfoExtension.LEDGER_KEYS)
         }
     }
 
     @Test
     fun `converting to nullable PublicKey works`() {
         val memberContext = LayeredPropertyMapMocks.create<MemberContextImpl>(
-            sortedMapOf("corda.ledgerKey" to null),
+            sortedMapOf(MemberInfoExtension.LEDGER_KEYS to null),
             converters
         )
-        val result = memberContext.parseOrNull<PublicKey>("corda.ledgerKey")
+        val result = memberContext.parseOrNull<PublicKey>(MemberInfoExtension.LEDGER_KEYS)
         assertNull(result)
     }
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-2281
1. Introduces dynamic registration protocol service that builds a registration request and publishes `UnauthenticatedMessage` with the request to `P2P_OUT`
2. Unit and integration tests
3. Key name update for ledger keys (from `corda.ledgerKeys.%s` to `corda.ledger.keys.%s`)

Wiki page for dynamic member registration created [here](https://github.com/corda/corda-runtime-os/wiki/Member-Onboarding-(Dynamic-Networks)).