### PR TITLE
CORE-5518 Verify Quasar instrumentation in flow worker

### DIFF
--- a/.run/Combined Worker Local-debug-suspend.run.xml
+++ b/.run/Combined Worker Local-debug-suspend.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Combined Worker Local (suspend debug agent 5005)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar" />
-    <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" />
+    <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005 -Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
     <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />

--- a/.run/Combined Worker Local-debug.run.xml
+++ b/.run/Combined Worker Local-debug.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Combined Worker Local (debug agent 5005)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar" />
-    <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" />
+    <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
     <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />

--- a/.run/Combined Worker Local-no-debug.run.xml
+++ b/.run/Combined Worker Local-no-debug.run.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Combined Worker Local (no debug)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar" />
+    <option name="VM_PARAMETERS" value="-Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
     <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -61,6 +61,10 @@ class CombinedWorker @Activate constructor(
     override fun startup(args: Array<String>) {
         logger.info("Combined worker starting.")
 
+        if (System.getProperty("co.paralleluniverse.fibers.verifyInstrumentation") == true.toString()) {
+            logger.info("Quasar's instrumentation verification is enabled")
+        }
+
         PostgresDbSetup().run()
 
         JavaSerialisationFilter.install()

--- a/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
+++ b/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
@@ -38,6 +38,11 @@ class FlowWorker @Activate constructor(
     /** Parses the arguments, then initialises and starts the [flowProcessor]. */
     override fun startup(args: Array<String>) {
         logger.info("Flow worker starting.")
+
+        if (System.getProperty("co.paralleluniverse.fibers.verifyInstrumentation") == true.toString()) {
+            logger.info("Quasar's instrumentation verification is enabled")
+        }
+
         JavaSerialisationFilter.install()
 
         val params = getParams(args, FlowWorkerParams())

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -163,6 +163,9 @@ Worker environment variables
   value: {{- if ( get .Values.workers .worker ).debug.enabled }}
       -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend={{ if ( get .Values.workers .worker ).debug.suspend }}y{{ else }}n{{ end }}
     {{- end -}}
+    {{- if ( get .Values.workers .worker ).verifyInstrumentation }}
+      -Dco.paralleluniverse.fibers.verifyInstrumentation=true
+    {{- end -}}
     {{- if .Values.kafka.sasl.enabled }}
       -Djava.security.auth.login.config=/etc/config/jaas.conf
     {{- end -}}

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -202,6 +202,8 @@ workers:
       requests: {}
       # -- the CPU/memory resource limits for the flow worker containers
       limits: {}
+    # -- run flow worker with Quasar's verifyInstrumentation enabled
+    verifyInstrumentation: false
 
   # membership worker configuration
   membership:

--- a/debug.yaml
+++ b/debug.yaml
@@ -26,6 +26,7 @@ workers:
 #    debug:
 #      enabled: true
 #      suspend: true
+    verifyInstrumentation: true
   membership:
     replicaCount: 1
 #    debug:


### PR DESCRIPTION
Setting `-Dco.paralleluniverse.fibers.verifyInstrumentation=true`
enables Quasars instrumentation verification to check for correct use of
`@Suspendable`s.

For Kafka deployments, the default value is `false` with an entry in
`debug.yaml` that sets it to `true`.

For the combined worker, the run configuration have been updated to
include the property. Otherwise, it is up to the user to include the
property when running the jar.