### PR TITLE
CORE-5141 Add support to deploy Corda with Confluent Cloud Kafka cluster

### DIFF
--- a/charts/corda/templates/kafka-sasl-secret.yaml
+++ b/charts/corda/templates/kafka-sasl-secret.yaml
@@ -7,19 +7,14 @@ metadata:
     {{- include "corda.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- if eq .Values.kafka.sasl.mechanism "PLAIN" }}
   jaas.conf: |
     KafkaClient {
+        {{- if eq .Values.kafka.sasl.mechanism "PLAIN" }}
         org.apache.kafka.common.security.plain.PlainLoginModule required
+        {{- else }}
+        org.apache.kafka.common.security.scram.ScramLoginModule required
+        {{- end }}
         username={{ .Values.kafka.sasl.username | quote }}
         password={{ .Values.kafka.sasl.password | quote }};
     };
-  {{- else }}
-  jaas.conf: |
-    KafkaClient {
-        org.apache.kafka.common.security.scram.ScramLoginModule required
-        username={{ .Values.kafka.sasl.username }}
-        password={{ .Values.kafka.sasl.password }};
-    };
-  {{- end }}
 {{- end }}

--- a/charts/corda/templates/kafka-sasl-secret.yaml
+++ b/charts/corda/templates/kafka-sasl-secret.yaml
@@ -7,10 +7,19 @@ metadata:
     {{- include "corda.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if eq .Values.kafka.sasl.mechanism "PLAIN" }}
+  jaas.conf: |
+    KafkaClient {
+        org.apache.kafka.common.security.plain.PlainLoginModule required
+        username={{ .Values.kafka.sasl.username | quote }}
+        password={{ .Values.kafka.sasl.password | quote }};
+    };
+  {{- else }}
   jaas.conf: |
     KafkaClient {
         org.apache.kafka.common.security.scram.ScramLoginModule required
         username={{ .Values.kafka.sasl.username }}
         password={{ .Values.kafka.sasl.password }};
     };
+  {{- end }}
 {{- end }}

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -51,11 +51,10 @@ spec:
                 {{- if .Values.kafka.tls.enabled }}
                 {{- if .Values.kafka.sasl.enabled }}
                 echo "security.protocol=SASL_SSL\n" >> /tmp/working_dir/config.properties
+                echo "sasl.mechanism={{ .Values.kafka.sasl.mechanism }}\n" >> /tmp/working_dir/config.properties
                 {{- if eq .Values.kafka.sasl.mechanism "PLAIN" }}
-                echo "sasl.mechanism=PLAIN\n" >> /tmp/working_dir/config.properties
                 echo "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
                 {{- else }}
-                echo "sasl.mechanism={{ .Values.kafka.sasl.mechanism }}\n" >> /tmp/working_dir/config.properties
                 echo "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
                 {{- end }}
                 {{- else }}

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -43,7 +43,6 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           command:
-
             - /bin/bash
             - -c
           args:

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -43,21 +43,22 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           command:
+
             - /bin/bash
             - -c
           args:
             - |
                 touch /tmp/working_dir/config.properties
-                {{- if .Values.kafka.confluentCloud }}
-                echo "security.protocol=SASL_SSL\n" >> /tmp/working_dir/config.properties
-                echo "sasl.mechanism=PLAIN\n" >> /tmp/working_dir/config.properties
-                echo "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
-                {{- else }}
                 {{- if .Values.kafka.tls.enabled }}
                 {{- if .Values.kafka.sasl.enabled }}
                 echo "security.protocol=SASL_SSL\n" >> /tmp/working_dir/config.properties
+                {{- if eq .Values.kafka.sasl.mechanism "PLAIN" }}
+                echo "sasl.mechanism=PLAIN\n" >> /tmp/working_dir/config.properties
+                echo "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
+                {{- else }}
                 echo "sasl.mechanism={{ .Values.kafka.sasl.mechanism }}\n" >> /tmp/working_dir/config.properties
                 echo "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
+                {{- end }}
                 {{- else }}
                 echo "security.protocol=SSL\n" >> /tmp/working_dir/config.properties
                 {{- end }}
@@ -74,7 +75,6 @@ spec:
 
                 echo "sasl.mechanism={{ .Values.kafka.sasl.mechanism }}\n" >> /tmp/working_dir/config.properties
                 echo "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
-                {{- end }}
                 {{- end }}
                 {{- end }}
           volumeMounts:

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -48,6 +48,11 @@ spec:
           args:
             - |
                 touch /tmp/working_dir/config.properties
+                {{- if .Values.kafka.confluentCloud }}
+                echo "security.protocol=SASL_SSL\n" >> /tmp/working_dir/config.properties
+                echo "sasl.mechanism=PLAIN\n" >> /tmp/working_dir/config.properties
+                echo "sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
+                {{- else }}
                 {{- if .Values.kafka.tls.enabled }}
                 {{- if .Values.kafka.sasl.enabled }}
                 echo "security.protocol=SASL_SSL\n" >> /tmp/working_dir/config.properties
@@ -69,6 +74,7 @@ spec:
 
                 echo "sasl.mechanism={{ .Values.kafka.sasl.mechanism }}\n" >> /tmp/working_dir/config.properties
                 echo "sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{{ .Values.kafka.sasl.username }}\" password=\"{{ .Values.kafka.sasl.password }}\" ;\n">> /tmp/working_dir/config.properties
+                {{- end }}
                 {{- end }}
                 {{- end }}
           volumeMounts:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -104,6 +104,8 @@ kafka:
     mechanism: "SCRAM-SHA-256"
     # -- enable/disable SASL for client connection to Kafka 
     enabled: false
+  # Specifies whether the Kafka cluster to connect to is deployed in Confluent Cloud or not
+  confluentCloud: false
 
 # Configuration for the bootstrapper
 bootstrap:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -105,7 +105,6 @@ kafka:
     # -- enable/disable SASL for client connection to Kafka 
     enabled: false
   # Specifies whether the Kafka cluster to connect to is deployed in Confluent Cloud or not
-  confluentCloud: false
 
 # Configuration for the bootstrapper
 bootstrap:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -104,7 +104,6 @@ kafka:
     mechanism: "SCRAM-SHA-256"
     # -- enable/disable SASL for client connection to Kafka 
     enabled: false
-  # Specifies whether the Kafka cluster to connect to is deployed in Confluent Cloud or not
 
 # Configuration for the bootstrapper
 bootstrap:


### PR DESCRIPTION
Update Helm chart to support authenticating to Kafka using SASL "PLAIN" mechanism, as it's the supported method for Kafka clusters deployed in Confluent Cloud.

https://r3-cev.atlassian.net/browse/CORE-5141