### PR TITLE
CORE-5491 Switch the membership worker to no longer be a quasar app

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -11,6 +11,13 @@ osgiRun {
     )
 }
 
+quasar {
+    excludePackages.addAll([
+        'org.eclipse.jetty**',
+        'net.corda.membership**'
+    ])
+}
+
 dependencies {
     // for BundleManager
     compileOnly "org.osgi:osgi.core"

--- a/applications/workers/release/member-worker/build.gradle
+++ b/applications/workers/release/member-worker/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'corda.common-publishing'
-    id 'corda.quasar-app'
+    id 'corda.common-app'
 }
 
 description 'Member Worker'


### PR DESCRIPTION
Changed the membership worker so that it is no longer a quasar app.

Updated the combined worker to skip instrumentation of membership packages as it is not needed. Additionally add ignore for `org.eclipse.jetty` as an instrumentation error appeared here after removing the membership error.