### PR TITLE
NOTICK: Allow Gradle to run on Java 17, while still building for Java 11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,8 +256,8 @@ void configureKotlinForOSGi(Configuration configuration) {
 }
 
 logger.quiet("********************** CORDA FLOW WORKER BUILD **********************")
-if (JavaVersion.current() != javaVersion) {
-    throw new GradleException("The java version used ${JavaVersion.current()} is not the expected version ${javaVersion}.")
+if (!JavaVersion.current().isCompatibleWith(javaVersion)) {
+    throw new GradleException("The java version used ${JavaVersion.current()} is not compatible with the expected version ${javaVersion}.")
 }
 logger.quiet("SDK version: {}", JavaVersion.current())
 logger.quiet("JAVA HOME {}", System.getProperty("java.home"))


### PR DESCRIPTION
We already use Gradle toolchains to build and test for Java 11, so we can allow Gradle itself to run on a more recent JDK.