### PR TITLE
NOTICK: Add `slf4j-simple` as an optional dependency

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -30,8 +30,6 @@ dependencies {
 
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly "org.apache.commons:commons-lang3:$commonsLangVersion"
-    runtimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
-    runtimeOnly "org.slf4j:slf4j-api:$slf4jVersion"
 
     testRuntimeOnly 'org.osgi:osgi.core'
 }

--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly "org.apache.commons:commons-lang3:$commonsLangVersion"
     runtimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+    runtimeOnly "org.slf4j:slf4j-api:$slf4jVersion"
 
     testRuntimeOnly 'org.osgi:osgi.core'
 }

--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly "org.apache.commons:commons-lang3:$commonsLangVersion"
+    runtimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     testRuntimeOnly 'org.osgi:osgi.core'
 }

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -73,6 +73,7 @@ dependencies {
     systemPackages "net.corda.kotlin:kotlin-stdlib-jdk7-osgi:$kotlinVersion"
     systemPackages "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
     systemPackages "org.slf4j:slf4j-api:$slf4jVersion"
+    systemPackages "org.slf4j:slf4j-simple:$slf4jVersion"
     systemPackages project(":osgi-framework-api")
 }
 


### PR DESCRIPTION
To silence the warning from Javalin at start-up time.

Or else the following warning is produced:
```
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 12:51:34.290 [main] INFO  io.javalin.Javalin - 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]        __                      __ _            __ __
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]       / /____ _ _   __ ____ _ / /(_)____      / // /
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]  __  / // __ `/| | / // __ `// // // __ \    / // /_
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] / /_/ // /_/ / | |/ // /_/ // // // / / /   /__  __/
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] \____/ \__,_/  |___/ \__,_//_//_//_/ /_/      /_/
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]           https://javalin.io/documentation
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 12:51:34.300 [main] INFO  org.eclipse.jetty.util.log - Logging initialized @17505ms to org.eclipse.jetty.util.log.Slf4jLog
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] Missing dependency 'Slf4j simple'. Add the dependency.
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] pom.xml:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] <dependency>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <groupId>org.slf4j</groupId>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <artifactId>slf4j-simple</artifactId>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <version>1.7.31</version>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] </dependency>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] build.gradle:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.31'
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] Find the latest version here:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] https://search.maven.org/search?q=g%3Aorg.slf4j+AND+a%3Aslf4j-simple
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] OR
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] Missing dependency 'Slf4j simple with Provider'. Add the dependency.
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] pom.xml:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] <dependency>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <groupId>org.slf4j</groupId>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <artifactId>slf4j-api</artifactId>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <version>1.8.0-beta4</version>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] </dependency>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] build.gradle:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.8.0-beta4'
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] Find the latest version here:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] https://search.maven.org/search?q=g%3Aorg.slf4j+AND+a%3Aslf4j-api
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] ------------------------------------------------------------------- and
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] Missing dependency 'Slf4j simple with Provider'. Add the dependency.
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] pom.xml:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] <dependency>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <groupId>org.slf4j</groupId>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <artifactId>slf4j-simple</artifactId>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker]     <version>1.8.0-beta4</version>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] </dependency>
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] build.gradle:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.8.0-beta4'
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] 
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] Find the latest version here:
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] https://search.maven.org/search?q=g%3Aorg.slf4j+AND+a%3Aslf4j-simple
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
[pod/corda-db-worker-745f6bbd79-7c2tl/corda-db-worker] -------------------------------------------------------------------
```
Javalin is a non-OSGi compliant library and uses `Class.forName(...)` call to load the optional dependencies.