### PR TITLE
CORE-5248 - Default to message bus emulation in combined-worker

### DIFF
--- a/.run/Combined Worker Local-debug-suspend.run.xml
+++ b/.run/Combined Worker Local-debug-suspend.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Combined Worker Local (suspend debug agent 5005)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005 -Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
-    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
+    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <method v="2">

--- a/.run/Combined Worker Local-debug.run.xml
+++ b/.run/Combined Worker Local-debug.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Combined Worker Local (debug agent 5005)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
-    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
+    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <method v="2">

--- a/.run/Combined Worker Local-no-debug.run.xml
+++ b/.run/Combined Worker Local-no-debug.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Combined Worker Local (no debug)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
-    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
+    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <method v="2">

--- a/applications/workers/release/combined-worker/README.md
+++ b/applications/workers/release/combined-worker/README.md
@@ -16,14 +16,72 @@ docker run --rm -p 5432:5432 --name postgresql -e POSTGRESQL_DATABASE=cordaclust
 ```
 
 DB schema will be created automatically when worker is started.
-TODO: DB bootstraping might change as CLI could be used instead
+NOTE: DB bootstrapping might change as CLI could be used instead
 
-### Message Bus
+## Start the worker
 
-#### Kafka
+### From the command line
+Build the worker using:
+```bash
+./gradlew :applications:workers:release:combined-worker:clean :applications:workers:release:combined-worker:appJar
+```
 
-TODO: Database message bus should be used instead, this is just temporary work-around (which is the reason why all containers are not created together).
-Note that topics were taken from k8s cluster and might be out of sync.
+Run the worker using:
+```bash
+java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
+  ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
+  --instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 \
+  -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt \
+  -ddatabase.user=user -ddatabase.pass=password \
+  -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
+```
+
+### From IntelliJ IDE
+
+Use one of the following run configuratons:
+
+- `Combined Worker Local (no debug)` (no debug agent attached)
+- `Combined Worker Local (debug agent 5005)` (debug agent attached and exposed on port 5005)
+- `Combined Worker Local (suspend debug agent 5005)` (debug agent attached, exposed on port 5005 and suspended on start)
+
+## Interact with the worker
+
+The worker will expose the HTTP API on port 8888: https://localhost:8888/api/v1/swagger
+The status endpoint is also exposed: http://localhost:7000/status
+
+## Smoketests
+
+Run the [smoketests](/applications/workers/workers-smoketest/) to validate the combined worker.
+
+Note that some tests require an empty environment (e.g. CPI upload).
+
+## Logs
+
+Logs are output to disk, using the `osgi-framework-bootstrap/src/main/resources/log4j2.xml` configuration.
+Logging level for 3rd party libs has been defaulted to WARN to reduce the log size/increase the usefulness in normal running,
+but it may be useful to change this on a case-by-case basis when debugging.
+
+## Message Bus
+
+### Message bus emulation
+
+By default, the combined-worker uses the DB Message Bus emulation. This means that Kafka is not required, instead the message API will be supported by the postgres DB created above.
+
+### Kafka
+
+If using a "real", Kafka, message bus is preferred, for example for debugging or troubleshooting message library issues, this can be done by changing the runtime dependency in `build.gradle`:
+
+```
+runtimeOnly project(':libs:messaging:db-message-bus-impl')
+```
+
+to:
+
+```
+runtimeOnly project(':libs:messaging:kafka-message-bus-impl')
+```
+
+You then also need to provide a Kafka installation and set it up, which can be done like so:
 
 Create file `docker-compose.yml`:
 ```
@@ -72,40 +130,3 @@ cp ../corda-runtime-os/tools/plugins/topic-config/build/libs/topic-config-cli-pl
  ./build/generatedScripts/corda-cli.sh topic -b=localhost:9092 create connect
  cd ../corda-runtime-os/
 ```
-
-## Start the worker
-### From the command line
-Build the worker using:
-```bash
-./gradlew :applications:workers:release:combined-worker:clean :applications:workers:release:combined-worker:appJar
-```
-
-Run the worker using:
-```bash
-java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
-  ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
-  --instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 \
-  -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt \
-  -ddatabase.user=user -ddatabase.pass=password \
-  -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
-```
-
-### From IntelliJ IDE
-From IntelliJ menu choose: `Run` -> `Run...` -> `Combined Worker Local-debug`
-
-## Interact with the worker
-
-The worker will expose the HTTP API on port 8888: https://localhost:8888/api/v1/swagger 
-The status endpoint is also exposed: http://localhost:7000/status
-
-## Smoketests
-
-Run the [smoketests](/applications/workers/workers-smoketest/) to validate the combined worker.
-
-Note that some tests require an empty environment (e.g. CPI upload).
-
-## Logs
-
-Logs are output to disk, using the `osgi-framework-bootstrap/src/main/resources/log4j2.xml` configuration.
-Logging level for 3rd party libs has been defaulted to WARN to reduce the log size/increase the usefulness in normal running, 
-but it may be useful to change this on a case-by-case basis when debugging.

--- a/applications/workers/release/combined-worker/README.md
+++ b/applications/workers/release/combined-worker/README.md
@@ -30,6 +30,16 @@ Run the worker using:
 ```bash
 java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
   ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
+  --instanceId=0 -mbus.busType=DATABASE
+  -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt \
+  -ddatabase.user=user -ddatabase.pass=password \
+  -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
+```
+
+Or if you want to connect to "real" KAFKA (see below):
+```bash
+java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
+  ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
   --instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 \
   -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt \
   -ddatabase.user=user -ddatabase.pass=password \

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -51,7 +51,9 @@ dependencies {
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
 
-    runtimeOnly project(':libs:messaging:kafka-message-bus-impl')
+//  swap these around in order to use a "real" Kafka message bus rather than the emulation.
+    runtimeOnly project(':libs:messaging:db-message-bus-impl')
+//    runtimeOnly project(':libs:messaging:kafka-message-bus-impl')
 
     runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
         exclude group: 'org.apache.felix'

--- a/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/PostgresDbSetup.kt
+++ b/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/PostgresDbSetup.kt
@@ -97,6 +97,7 @@ class PostgresDbSetup: DbSetup {
                     val schemaMigrator = LiquibaseSchemaMigratorImpl()
                     if (schema != null) {
                         createDbSchema(schema)
+                        connection.prepareStatement("SET search_path TO $schema;").execute()
                         schemaMigrator.updateDb(connection, dbChange, schema)
                     } else {
                         schemaMigrator.updateDb(connection, dbChange)


### PR DESCRIPTION
Change combined worker configuration to, but default, support the message bus emulation.

Know issues:

- Intermittent flow issues (see below). Unsure if this is unique to the combined-worker
- I have seen some DB connection issues during start-up, but cannot reliably reproduce this

I suggest we integrate this in the Jenkins build as a non-blocking gate to assess stability.

```
2022-07-07 17:47:36.695 [Thread-70] ERROR net.corda.session.manager.impl.processor.SessionAckProcessorReceive - Received SessionAck on key 38e9f2c2-1982-44b2-8224-912c75f05012-INITIATED for sessionId 38e9f2c2-1982-44b2-8224-912c75f05012-INITIATED which had null state
2022-07-07 17:47:36.702 [Thread-70] INFO  net.corda.flow.pipeline.handlers.events.SessionEventHandler - Received a SessionAck for flow [dfbdfb02-1d99-4670-bb52-785f1193fb63] that does not exist. The event will be discarded. SessionEvent: {"messageDirection": "INBOUND", "timestamp": "2022-07-07T16:47:35.440Z", "sessionId": "38e9f2c2-1982-44b2-8224-912c75f05012-INITIATED", "sequenceNum": null, "initiatingIdentity": {"x500Name": "CN=Bob, OU=Application, O=R3, L=London, C=GB", "groupId": "placeholder"}, "initiatedIdentity": {"x500Name": "CN=SU1, OU=Application, O=R3, L=London, C=GB", "groupId": "placeholder"}, "receivedSequenceNum": 2, "outOfOrderSequenceNums": [], "payload": {}}
2022-07-07 17:47:36.703 [Thread-70] WARN  net.corda.flow.pipeline.impl.FlowEventExceptionProcessorImpl - A non critical error was reported while processing the event.
net.corda.flow.pipeline.exceptions.FlowEventException: Received a SessionAck for flow [dfbdfb02-1d99-4670-bb52-785f1193fb63] that does not exist
	at net.corda.flow.pipeline.handlers.events.SessionEventHandler.discardSessionEvent(SessionEventHandler.kt:109) ~[?:?]
	at net.corda.flow.pipeline.handlers.events.SessionEventHandler.preProcess(SessionEventHandler.kt:59) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventPipelineImpl.eventPreProcessing(FlowEventPipelineImpl.kt:67) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventPipelineImpl.eventPreProcessing(FlowEventPipelineImpl.kt:30) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl.onNext(FlowEventProcessorImpl.kt:55) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl.onNext(FlowEventProcessorImpl.kt:17) ~[?:?]
	at net.corda.messaging.subscription.StateAndEventSubscriptionImpl$getUpdatesForEvent$future$1.invoke(StateAndEventSubscriptionImpl.kt:293) ~[?:?]
	at net.corda.messaging.subscription.consumer.StateAndEventConsumerImpl.waitForFunctionToFinish$lambda-7(StateAndEventConsumerImpl.kt:122) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:834) ~[?:?]
```