### PR TITLE
CORE-4355: Move JarReader and JarVerifier into packaging-verify

### DIFF
--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarReader.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarReader.kt
@@ -12,7 +12,7 @@ import java.util.jar.Manifest
  * Stores JAR in memory, validates it and allows access to [Manifest] and [Entry]s.
  * Validation checks that JAR was not tampered and that signatures lead to [trustedCerts].
  */
-internal class JarReader private constructor(val jarName: String, jarBytes: ByteArray, val trustedCerts: Collection<X509Certificate>) {
+class JarReader(val jarName: String, jarBytes: ByteArray, val trustedCerts: Collection<X509Certificate>) {
     val manifest: Manifest
     val entries: List<Entry>
     val codeSigners: List<CodeSigner>

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarReader.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarReader.kt
@@ -1,4 +1,4 @@
-package net.corda.libs.packaging
+package net.corda.libs.packaging.verify
 
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import java.io.ByteArrayInputStream
@@ -12,7 +12,7 @@ import java.util.jar.Manifest
  * Stores JAR in memory, validates it and allows access to [Manifest] and [Entry]s.
  * Validation checks that JAR was not tampered and that signatures lead to [trustedCerts].
  */
-class JarReader(val jarName: String, jarBytes: ByteArray, val trustedCerts: Collection<X509Certificate>) {
+internal class JarReader private constructor(val jarName: String, jarBytes: ByteArray, val trustedCerts: Collection<X509Certificate>) {
     val manifest: Manifest
     val entries: List<Entry>
     val codeSigners: List<CodeSigner>
@@ -44,5 +44,11 @@ class JarReader(val jarName: String, jarBytes: ByteArray, val trustedCerts: Coll
             }
         }
         entries = jarEntries
+    }
+}
+
+private fun InputStream.readAllBytesAndClose(): ByteArray {
+    return this.use {
+        it.readAllBytes()
     }
 }

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarVerifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarVerifier.kt
@@ -1,7 +1,8 @@
-package net.corda.libs.packaging
+package net.corda.libs.packaging.verify
 
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
+import net.corda.libs.packaging.signerInfo
 import java.io.InputStream
 import java.security.CodeSigner
 import java.security.cert.X509Certificate
@@ -24,7 +25,7 @@ import java.util.jar.Manifest
  * @param inputStream Input stream for reading JAR
  * @param trustedCerts Trusted certificates
  */
-class JarVerifier(
+internal class JarVerifier(
     val jarName: String,
     private val inputStream: InputStream,
     private val trustedCerts: Collection<X509Certificate>

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarVerifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/JarVerifier.kt
@@ -25,7 +25,7 @@ import java.util.jar.Manifest
  * @param inputStream Input stream for reading JAR
  * @param trustedCerts Trusted certificates
  */
-internal class JarVerifier(
+class JarVerifier(
     val jarName: String,
     private val inputStream: InputStream,
     private val trustedCerts: Collection<X509Certificate>

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/VerifyCertificates.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/VerifyCertificates.kt
@@ -1,0 +1,27 @@
+package net.corda.libs.packaging.verify
+
+import java.security.CodeSigner
+import java.security.cert.CertPathValidator
+import java.security.cert.PKIXParameters
+import java.security.cert.TrustAnchor
+import java.security.cert.X509Certificate
+
+/** Verifies that signatures lead to trusted certificate */
+internal fun verifyCertificates(codeSigners: List<CodeSigner>, trustedCerts: Collection<X509Certificate>) {
+    require(codeSigners.isNotEmpty()) {
+        "Code signers not set"
+    }
+    require(trustedCerts.isNotEmpty()) {
+        "Trusted certificates not set"
+    }
+
+    val params = trustedCerts
+        .mapTo(HashSet()) { TrustAnchor(it, null) }
+        .let(::PKIXParameters)
+    params.isRevocationEnabled = false
+
+    val certPathValidator = CertPathValidator.getInstance("PKIX")
+    codeSigners.forEach {
+        certPathValidator.validate(it.signerCertPath, params)
+    }
+}

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/VerifierFactory.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/VerifierFactory.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants.CPB_FORMAT_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPI_FORMAT_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_FORMAT_ATTRIBUTE
@@ -39,7 +39,7 @@ object VerifierFactory {
     }
 
     /** Creates CPK verifier for specified format */
-    fun createCpkVerifier(format: String?, jarReader: JarReader): CpkVerifier {
+    private fun createCpkVerifier(format: String?, jarReader: JarReader): CpkVerifier {
         return when (format) {
             FORMAT_1 -> CpkV1Verifier(jarReader)
             FORMAT_2 -> CpkV2Verifier(jarReader)
@@ -63,7 +63,7 @@ object VerifierFactory {
     }
 
     /** Creates CPB verifier for specified format */
-    fun createCpbVerifier(format: String?, jarReader: JarReader): CpbVerifier {
+    private fun createCpbVerifier(format: String?, jarReader: JarReader): CpbVerifier {
         return when (format) {
             null, FORMAT_1 -> CpbV1Verifier(jarReader)
             FORMAT_2 -> CpbV2Verifier(jarReader)
@@ -86,7 +86,7 @@ object VerifierFactory {
     }
 
     /** Creates CPI verifier for specified format */
-    fun createCpiVerifier(format: String?, jarReader: JarReader): CpiVerifier {
+    private fun createCpiVerifier(format: String?, jarReader: JarReader): CpiVerifier {
         return when (format) {
             null, FORMAT_1 -> CpiV1Verifier(jarReader)
             FORMAT_2 -> CpiV2Verifier(jarReader)

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/VerifierFactory.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/VerifierFactory.kt
@@ -39,7 +39,7 @@ object VerifierFactory {
     }
 
     /** Creates CPK verifier for specified format */
-    private fun createCpkVerifier(format: String?, jarReader: JarReader): CpkVerifier {
+    fun createCpkVerifier(format: String?, jarReader: JarReader): CpkVerifier {
         return when (format) {
             FORMAT_1 -> CpkV1Verifier(jarReader)
             FORMAT_2 -> CpkV2Verifier(jarReader)
@@ -63,7 +63,7 @@ object VerifierFactory {
     }
 
     /** Creates CPB verifier for specified format */
-    private fun createCpbVerifier(format: String?, jarReader: JarReader): CpbVerifier {
+    fun createCpbVerifier(format: String?, jarReader: JarReader): CpbVerifier {
         return when (format) {
             null, FORMAT_1 -> CpbV1Verifier(jarReader)
             FORMAT_2 -> CpbV2Verifier(jarReader)
@@ -86,7 +86,7 @@ object VerifierFactory {
     }
 
     /** Creates CPI verifier for specified format */
-    private fun createCpiVerifier(format: String?, jarReader: JarReader): CpiVerifier {
+    fun createCpiVerifier(format: String?, jarReader: JarReader): CpiVerifier {
         return when (format) {
             null, FORMAT_1 -> CpiV1Verifier(jarReader)
             FORMAT_2 -> CpiV2Verifier(jarReader)

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1Verifier.kt
@@ -19,7 +19,7 @@ import java.util.jar.Manifest
 /**
  * Verifies CPB format 1.0
  */
-internal class CpbV1Verifier(private val packageType: String, jarReader: JarReader): CpbVerifier {
+class CpbV1Verifier internal constructor(private val packageType: String, jarReader: JarReader): CpbVerifier {
     private val name = jarReader.jarName
     private val manifest: Manifest = jarReader.manifest
     private val cpkVerifiers: List<CpkV1Verifier>

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1Verifier.kt
@@ -1,7 +1,7 @@
 package net.corda.libs.packaging.verify.internal.cpb
 
 import net.corda.libs.packaging.CpkDependencyResolver
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants.CPB_FORMAT_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPB_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPB_VERSION_ATTRIBUTE
@@ -19,7 +19,7 @@ import java.util.jar.Manifest
 /**
  * Verifies CPB format 1.0
  */
-class CpbV1Verifier internal constructor (private val packageType: String, jarReader: JarReader): CpbVerifier {
+internal class CpbV1Verifier(private val packageType: String, jarReader: JarReader): CpbVerifier {
     private val name = jarReader.jarName
     private val manifest: Manifest = jarReader.manifest
     private val cpkVerifiers: List<CpkV1Verifier>

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2Verifier.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpb
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants.CPB_FORMAT_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPB_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPB_VERSION_ATTRIBUTE
@@ -17,7 +17,7 @@ import java.util.jar.Manifest
 /**
  * Verifies CPB format 2.0
  */
-class CpbV2Verifier(jarReader: JarReader): CpbVerifier {
+internal class CpbV2Verifier(jarReader: JarReader): CpbVerifier {
     private val name = jarReader.jarName
     private val manifest: Manifest = jarReader.manifest
     private val cpkVerifiers: List<CpkV2Verifier>

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2Verifier.kt
@@ -17,7 +17,7 @@ import java.util.jar.Manifest
 /**
  * Verifies CPB format 2.0
  */
-internal class CpbV2Verifier(jarReader: JarReader): CpbVerifier {
+class CpbV2Verifier(jarReader: JarReader): CpbVerifier {
     private val name = jarReader.jarName
     private val manifest: Manifest = jarReader.manifest
     private val cpkVerifiers: List<CpkV2Verifier>

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1Verifier.kt
@@ -1,12 +1,12 @@
 package net.corda.libs.packaging.verify.internal.cpi
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.verify.internal.cpb.CpbV1Verifier
 
 /**
  * Verifies CPI format 1.0
  */
-class CpiV1Verifier(jarReader: JarReader): CpiVerifier {
+internal class CpiV1Verifier(jarReader: JarReader): CpiVerifier {
     // CPB and CPI format 1 are same
     private val verifier = CpbV1Verifier("CPI", jarReader)
 

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1Verifier.kt
@@ -6,7 +6,7 @@ import net.corda.libs.packaging.verify.internal.cpb.CpbV1Verifier
 /**
  * Verifies CPI format 1.0
  */
-internal class CpiV1Verifier(jarReader: JarReader): CpiVerifier {
+class CpiV1Verifier(jarReader: JarReader): CpiVerifier {
     // CPB and CPI format 1 are same
     private val verifier = CpbV1Verifier("CPI", jarReader)
 

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2Verifier.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpi
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants.CPB_FILE_EXTENSION
 import net.corda.libs.packaging.PackagingConstants.CPI_FORMAT_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPI_GROUP_POLICY_ENTRY
@@ -17,7 +17,7 @@ import java.util.jar.Manifest
 /**
  * Verifies CPI format 2.0
  */
-class CpiV2Verifier(jarReader: JarReader): CpiVerifier {
+internal class CpiV2Verifier(jarReader: JarReader): CpiVerifier {
     private val name = jarReader.jarName
     private val manifest: Manifest = jarReader.manifest
     private val cpbVerifier: CpbV2Verifier

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2Verifier.kt
@@ -17,7 +17,7 @@ import java.util.jar.Manifest
 /**
  * Verifies CPI format 2.0
  */
-internal class CpiV2Verifier(jarReader: JarReader): CpiVerifier {
+class CpiV2Verifier(jarReader: JarReader): CpiVerifier {
     private val name = jarReader.jarName
     private val manifest: Manifest = jarReader.manifest
     private val cpbVerifier: CpbV2Verifier

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1MainBundle.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1MainBundle.kt
@@ -16,7 +16,7 @@ import net.corda.libs.packaging.verify.internal.requireAttribute
 /**
  * Verifies Main Bundle from CPK format 1.0
  */
-internal class CpkV1MainBundle(jarReader: JarReader) {
+class CpkV1MainBundle(jarReader: JarReader) {
     private val name = jarReader.jarName
     internal val manifest = jarReader.manifest
     private val codeSigners = jarReader.codeSigners

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1MainBundle.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1MainBundle.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpk
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_VERSION_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_DEPENDENCIES_FILE_ENTRY
@@ -16,7 +16,7 @@ import net.corda.libs.packaging.verify.internal.requireAttribute
 /**
  * Verifies Main Bundle from CPK format 1.0
  */
-class CpkV1MainBundle(jarReader: JarReader) {
+internal class CpkV1MainBundle(jarReader: JarReader) {
     private val name = jarReader.jarName
     internal val manifest = jarReader.manifest
     private val codeSigners = jarReader.codeSigners

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1Verifier.kt
@@ -16,7 +16,7 @@ import java.util.jar.JarEntry
 /**
  * Verifies CPK format 1.0
  */
-internal class CpkV1Verifier(jarReader: JarReader): CpkVerifier {
+class CpkV1Verifier(jarReader: JarReader): CpkVerifier {
     val name = jarReader.jarName
     private val manifest = jarReader.manifest
     val codeSigners = jarReader.codeSigners

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1Verifier.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpk
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_VERSION_ATTRIBUTE
@@ -16,7 +16,7 @@ import java.util.jar.JarEntry
 /**
  * Verifies CPK format 1.0
  */
-class CpkV1Verifier(jarReader: JarReader): CpkVerifier {
+internal class CpkV1Verifier(jarReader: JarReader): CpkVerifier {
     val name = jarReader.jarName
     private val manifest = jarReader.manifest
     val codeSigners = jarReader.codeSigners

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2Verifier.kt
@@ -13,7 +13,7 @@ import net.corda.libs.packaging.verify.internal.requireAttributeValueIn
 /**
  * Verifies CPK format 2.0
  */
-internal class CpkV2Verifier(jarReader: JarReader): CpkVerifier {
+class CpkV2Verifier(jarReader: JarReader): CpkVerifier {
     val name = jarReader.jarName
     private val manifest = jarReader.manifest
     val codeSigners = jarReader.codeSigners

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2Verifier.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpk
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_VERSION_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_DEPENDENCIES_FILE_ENTRY
@@ -13,7 +13,7 @@ import net.corda.libs.packaging.verify.internal.requireAttributeValueIn
 /**
  * Verifies CPK format 2.0
  */
-class CpkV2Verifier(jarReader: JarReader): CpkVerifier {
+internal class CpkV2Verifier(jarReader: JarReader): CpkVerifier {
     val name = jarReader.jarName
     private val manifest = jarReader.manifest
     val codeSigners = jarReader.codeSigners

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1VerifierTest.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpb
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.DependencyResolutionException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpb
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.DependencyResolutionException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1VerifierTest.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpi
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.DependencyResolutionException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV2VerifierTest.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpi
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
 import net.corda.test.util.InMemoryZipFile

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1VerifierTest.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpk
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
 import net.corda.test.util.InMemoryZipFile

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV2VerifierTest.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.packaging.verify.internal.cpk
 
-import net.corda.libs.packaging.JarReader
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.InvalidSignatureException
 import net.corda.test.util.InMemoryZipFile


### PR DESCRIPTION
In trying to use `JarReader` for reading format version 2, I found that it is tied to verification. It performs signature verification that cannot be turned off. 

I attempted to split the functionality but it resulted in a lot of duplicate code within packaging-verify (read jar, then verify at every usage).

As a result I'm moving it back into packaging-verify and making it internal. It is a good fit for packaging-verify which is what it was built for.