### PR TITLE
NOTICK: Adjust packaging library dependencies.

### DIFF
--- a/libs/packaging/packaging-core/build.gradle
+++ b/libs/packaging/packaging-core/build.gradle
@@ -3,15 +3,16 @@ plugins {
     id 'corda.common-library'
 }
 
-description "Packaging Interfaces and Data Classes"
+description 'Packaging Interfaces and Data Classes'
 
 dependencies {
-    compileOnly "org.osgi:osgi.core"
+    compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:osgi.annotation'
 
     api platform("net.corda:corda-api:$cordaApiVersion")
-    api "net.corda:corda-avro-schema"
-    api "net.corda:corda-crypto"
+    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'net.corda:corda-avro-schema'
+    api 'net.corda:corda-crypto'
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/packaging/packaging-verify/build.gradle
+++ b/libs/packaging/packaging-verify/build.gradle
@@ -1,33 +1,24 @@
-import aQute.bnd.version.MavenVersion
-
-import java.security.cert.CertificateFactory
-
 plugins {
     id 'corda.common-library'
-    id 'org.jetbrains.kotlin.jvm'
     id 'corda.common-publishing'
 }
 
 description 'Corda Packaging Verify'
 
 dependencies {
-    compileOnly "org.osgi:osgi.core"
-    compileOnly "org.osgi:osgi.annotation"
-    compileOnly "org.osgi:org.osgi.service.component.annotations"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    compileOnly 'org.osgi:osgi.annotation'
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     api platform("net.corda:corda-api:$cordaApiVersion")
 
-    api "net.corda:corda-base"
-    api "net.corda:corda-crypto"
-    api "net.corda:corda-cipher-suite"
+    api 'net.corda:corda-base'
+    api 'net.corda:corda-crypto'
+    api 'net.corda:corda-cipher-suite'
 
-    implementation project(":libs:packaging:packaging")
-    implementation project(":libs:packaging:packaging-core")
+    implementation project(':libs:packaging:packaging')
+    implementation project(':libs:packaging:packaging-core')
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
 
     testImplementation project(':testing:test-utilities')
-
-    testImplementation "org.osgi:osgi.core"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -2,7 +2,6 @@ import aQute.bnd.version.MavenVersion
 
 plugins {
     id 'corda.common-library'
-    id 'org.jetbrains.kotlin.jvm'
     id 'corda.common-publishing'
 }
 
@@ -16,10 +15,6 @@ allprojects {
 }
 
 configurations {
-    flowsCPK {
-        canBeConsumed = false
-        transitive = false
-    }
     contractCPK {
         canBeConsumed = false
     }
@@ -36,20 +31,18 @@ configurations {
 }
 
 dependencies {
-    compileOnly "org.osgi:osgi.core"
     compileOnly "org.osgi:osgi.annotation"
-    compileOnly "org.osgi:org.osgi.service.component.annotations"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
 
     api platform("net.corda:corda-api:$cordaApiVersion")
 
-    api "net.corda:corda-base"
-    api "net.corda:corda-crypto"
-    api "net.corda:corda-cipher-suite"
+    api 'net.corda:corda-base'
+    api 'net.corda:corda-crypto'
+    api 'net.corda:corda-cipher-suite'
+    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     implementation project(":libs:packaging:packaging-core")
 
-    testImplementation "org.osgi:osgi.core"
+    testImplementation 'org.osgi:osgi.core'
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
@@ -64,8 +57,12 @@ dependencies {
 }
 
 tasks.named('test', Test) {
-    inputs.files(configurations.flowsCPK, configurations.contractCPK, configurations.workflowCPK)
-    .withPropertyName("CPK_CONFIG").withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(
+        configurations.contractCPK,
+        configurations.workflowCPK,
+        configurations.workflowLibs,
+        configurations.workflow
+    ).withPropertyName("CPK_CONFIG").withPathSensitivity(PathSensitivity.RELATIVE)
 
     doFirst {
         systemProperties([
@@ -73,7 +70,7 @@ tasks.named('test', Test) {
             'net.corda.packaging.test.contract.cpk' : configurations.contractCPK.singleFile.toURI(),
             'net.corda.packaging.test.workflow.cpk' : configurations.workflowCPK.singleFile.toURI(),
             'net.corda.packaging.test.contract.bundle.symbolic.name': contractSymbolicName,
-            'net.corda.packaging.test.contract.bundle.version' : MavenVersion.parseMavenString(version.toString()).OSGiVersion.toString(),
+            'net.corda.packaging.test.contract.bundle.version' : MavenVersion.parseMavenString(version.toString()).OSGiVersion,
             'net.corda.packaging.test.workflow.cordapp' : configurations.workflow.singleFile.toURI()
         ])
     }


### PR DESCRIPTION
Remove unnecessary OSGi dependencies, and add explicit dependencies on Kotlin's standard library. Also ensure that `Test` task declares all of its input files.