### PR TITLE
CORE-5568: Retry when creating Kafka Consumers/Producers

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaRetryUtils.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaRetryUtils.kt
@@ -1,0 +1,41 @@
+package net.corda.messagebus.kafka.utils
+
+import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import org.apache.kafka.common.KafkaException
+import org.slf4j.Logger
+import java.util.function.Supplier
+
+internal object KafkaRetryUtils {
+    /**
+     * Performs a given Kafka action retrying multiple times and sleeping between retries.
+     * If number of retries been exhausted [CordaMessageAPIFatalException] is thrown providing details.
+     */
+    fun <T> executeKafkaActionWithRetry(
+        retryCount: Int = 3,
+        sleepMs: Long = 5000,
+        action: Supplier<T>,
+        errorMessage: Supplier<String>,
+        log: Logger
+    ): T {
+        require(retryCount > 0) { "Retry count should be positive. Current value: $retryCount" }
+        require(sleepMs > 0) { "Sleep internal must be positive. Current value: $sleepMs" }
+
+        var retryCountCurr = retryCount
+        var lastException: KafkaException? = null
+        while (retryCountCurr > 0) {
+            try {
+                return action.get()
+            } catch (ex: KafkaException) {
+                lastException = ex
+                retryCountCurr--
+                log.warn("Cannot perform Kafka action. Will retry $retryCountCurr more times", ex)
+                if (retryCountCurr > 0) {
+                    Thread.sleep(sleepMs)
+                }
+            }
+        }
+        val message = errorMessage.get()
+        log.error(message, lastException)
+        throw CordaMessageAPIFatalException(message, lastException)
+    }
+}


### PR DESCRIPTION
Creation of Consumers/Producers might fail if a Worker is started too fast before K8s DNS services are fully operational, therefore it is prudent to retry multiple times before throwing a fatal error.

Evidence:
Sometimes in the log it is possible to see the following:
```
08:37:26.159 [compacted subscription thread CONFIGURATION_READ-config.topic] WARN  org.apache.kafka.clients.ClientUtils - Couldn't resolve server prereqs-kafka:9092 from bootstrap.servers as DNS resolution failed for prereqs-kafka
```
I.e. a worker can start faster than DNS server.