### PR TITLE
CORE-5301 removing corda osgi lib from plugins

### DIFF
--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -8,8 +8,6 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
-
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -8,6 +8,8 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -8,8 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
-
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation "net.corda:corda-api:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'javax.persistence:javax.persistence-api'
 

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -9,7 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'javax.persistence:javax.persistence-api'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -9,7 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'javax.persistence:javax.persistence-api'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -9,7 +9,6 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation 'javax.persistence:javax.persistence-api'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -9,7 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'javax.persistence:javax.persistence-api'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-api:$cordaApiVersion"
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'javax.persistence:javax.persistence-api'
 

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -9,6 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation 'javax.persistence:javax.persistence-api'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -9,7 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -9,6 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -9,7 +9,6 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -9,7 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -9,7 +9,7 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation "net.corda:corda-api:$cordaApiVersion"
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation platform("net.corda:corda-api:$cordaApiVersion")
+    implementation "net.corda:corda-api:$cordaApiVersion"
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -8,8 +8,6 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
-
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -8,6 +8,8 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     kapt "org.pf4j:pf4j:$pf4jVersion"

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -8,7 +8,7 @@ plugins {
 group 'net.corda.cli.deployment'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(":libs:virtual-node:virtual-node-endpoints-maintenance")
     implementation project(":libs:virtual-node:cpi-upload-endpoints")
     implementation project(":libs:http-rpc:http-rpc")
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation project(":libs:virtual-node:virtual-node-endpoints-maintenance")
     implementation project(":libs:virtual-node:cpi-upload-endpoints")
     implementation project(":libs:http-rpc:http-rpc")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(":libs:virtual-node:virtual-node-endpoints-maintenance")
     implementation project(":libs:virtual-node:cpi-upload-endpoints")
     implementation project(":libs:http-rpc:http-rpc")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(":libs:virtual-node:virtual-node-endpoints-maintenance")
     implementation project(":libs:virtual-node:cpi-upload-endpoints")
     implementation project(":libs:http-rpc:http-rpc")
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(":libs:virtual-node:virtual-node-endpoints-maintenance")
     implementation project(":libs:virtual-node:cpi-upload-endpoints")
     implementation project(":libs:http-rpc:http-rpc")
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"


### PR DESCRIPTION
Removing unnecessary dependency on the `net.corda.kotlin:kotlin-stdlib-jdk8-osgi` lib