### PR TITLE
CORE-5458 Catch Throwable instead of Exception

### DIFF
--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -2,9 +2,28 @@ plugins {
     id 'corda.common-publishing'
     id 'corda.osgi-test-conventions'
     id 'corda.common-library'
+    id 'net.corda.plugins.quasar-utils'
 }
 
 description "Flow service"
+
+quasar {
+    version = quasarVersion
+    suspendableAnnotation = 'net.corda.v5.base.annotations.Suspendable'
+    instrumentTests = true
+    instrumentJavaExec = false
+    excludePackages = [
+            'co.paralleluniverse.**',
+            'com.esotericsoftware.**',
+            'io.opentelemetry.**',
+            'jdk**',
+            'kotlin**',
+            'org.apache.**',
+            'org.slf4j**',
+            'net.corda.sandboxhooks.**',
+            'net.corda.osgi.**'
+    ]
+}
 
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
@@ -60,6 +79,7 @@ dependencies {
     testImplementation project(":testing:flow:flow-utilities")
 
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+    testRuntimeOnly "co.paralleluniverse:quasar-core-osgi:$quasarVersion:agent"
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project(':testing:virtual-node-info-read-service-fake')

--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -79,7 +79,6 @@ dependencies {
     testImplementation project(":testing:flow:flow-utilities")
 
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
-    testRuntimeOnly "co.paralleluniverse:quasar-core-osgi:$quasarVersion:agent"
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project(':testing:virtual-node-info-read-service-fake')

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -59,9 +59,9 @@ class FlowFiberImpl(
             suspend(FlowIORequest.InitialCheckpoint)
 
             FlowIORequest.FlowFinished(flowLogic.invoke())
-        } catch (e: Exception) {
-            log.error("Flow failed", e)
-            FlowIORequest.FlowFailed(e)
+        } catch (t: Throwable) {
+            log.error("Flow failed", t)
+            FlowIORequest.FlowFailed(t)
         }
 
         try {
@@ -164,8 +164,6 @@ class FlowFiberImpl(
             }
         }
     }
-
-    private fun Throwable.isUnrecoverable(): Boolean = this is VirtualMachineError && this !is StackOverflowError
 
     private fun initialiseThreadContext() {
         Thread.currentThread().contextClassLoader = flowLogic.javaClass.classLoader

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
@@ -27,7 +27,7 @@ class FlowFiberImplTest {
     val mockCheckpointSerializer = mock<CheckpointSerializer>()
     val mockFlowSandboxGroupContext = mock<FlowSandboxGroupContext>()
     val mockFlowFiberExecutionContext = mock<FlowFiberExecutionContext>()
-    
+
     val fiberScheduler: FiberScheduler = FiberExecutorScheduler(
         "Same thread scheduler",
         ScheduledSingleThreadExecutor()
@@ -67,6 +67,7 @@ class FlowFiberImplTest {
 
         val flowFiber = FlowFiberImpl(UUID.randomUUID(), mockFlowLogic, fiberScheduler)
         flowFiber.setUncaughtExceptionHandler { _, _ ->
+            // This is never hit if the test passes, but the test would hang without it were the test to fail
             forceCancelOngoingRunUntilWithTestFailure()
         }
         val outcome = flowFiber.runUntilNotSuspended(mockFlowFiberExecutionContext, fiberScheduler)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
@@ -62,6 +62,7 @@ class FlowFiberImplTest {
     fun `check throwing flow is handled safely`() {
         val mockFlowLogic = mock<FlowLogicAndArgs>()
         whenever(mockFlowLogic.invoke()).then {
+            @Suppress("TooGenericExceptionThrown")
             throw Throwable()
         }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
@@ -1,0 +1,108 @@
+package net.corda.flow.fiber
+
+import co.paralleluniverse.concurrent.util.ScheduledSingleThreadExecutor
+import co.paralleluniverse.fibers.FiberExecutorScheduler
+import co.paralleluniverse.fibers.FiberScheduler
+import net.corda.data.flow.FlowStackItem
+import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
+import net.corda.flow.state.FlowStack
+import net.corda.serialization.checkpoint.CheckpointSerializer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.any
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FlowFiberImplTest {
+
+    val mockFlowStack = mock<FlowStack>()
+    val mockCheckpointSerializer = mock<CheckpointSerializer>()
+    val mockFlowSandboxGroupContext = mock<FlowSandboxGroupContext>()
+    val mockFlowFiberExecutionContext = mock<FlowFiberExecutionContext>()
+
+    val threadExecutor = ScheduledSingleThreadExecutor()
+    val fiberScheduler: FiberScheduler = FiberExecutorScheduler(
+        "Same thread scheduler",
+        threadExecutor
+    )
+
+    @BeforeAll
+    fun setup() {
+        whenever(mockFlowSandboxGroupContext.checkpointSerializer).thenReturn(mockCheckpointSerializer)
+        whenever(mockFlowFiberExecutionContext.sandboxGroupContext).thenReturn(mockFlowSandboxGroupContext)
+        whenever(mockCheckpointSerializer.serialize<FlowFiberImpl>(any())).thenReturn("bytes".toByteArray())
+        whenever(mockFlowFiberExecutionContext.flowStackService).thenReturn(mockFlowStack)
+
+        expectItemInFlowStack()
+    }
+
+    @Test
+    fun `check innocuous flow is handled safely`() {
+        val mockFlowLogic = mock<FlowLogicAndArgs>()
+        whenever(mockFlowLogic.invoke()).then {
+            // do nothing, innocuous flow
+            ""
+        }
+
+        val flowFiber = FlowFiberImpl(UUID.randomUUID(), mockFlowLogic, fiberScheduler)
+        val outcome = flowFiber.runUntilNotSuspended(mockFlowFiberExecutionContext, fiberScheduler)
+
+        assertThat(outcome).isInstanceOfAny(FlowIORequest.FlowFinished::class.java)
+        verify(mockFlowLogic).invoke()
+    }
+
+    @Test
+    fun `check throwing flow is handled safely`() {
+        val mockFlowLogic = mock<FlowLogicAndArgs>()
+        whenever(mockFlowLogic.invoke()).then {
+            throw Throwable()
+        }
+
+        val flowFiber = FlowFiberImpl(UUID.randomUUID(), mockFlowLogic, fiberScheduler)
+        flowFiber.setUncaughtExceptionHandler { _, _ ->
+            forceCancelOngoingRunUntilWithTestFailure()
+        }
+        val outcome = flowFiber.runUntilNotSuspended(mockFlowFiberExecutionContext, fiberScheduler)
+
+        assertThat(outcome).isInstanceOfAny(FlowIORequest.FlowFailed::class.java)
+        verify(mockFlowLogic).invoke()
+    }
+
+    private fun forceCancelOngoingRunUntilWithTestFailure() {
+        class TestFailedDueToForceCancel : FlowIORequest<Unit>
+
+        val completableFuture = flowFuture as CompletableFuture<FlowIORequest<*>>
+        completableFuture.complete(TestFailedDueToForceCancel())
+    }
+
+    private fun expectItemInFlowStack() {
+        whenever(mockFlowStack.size).thenReturn(1)
+        val mockStackItem = mock<FlowStackItem>()
+        whenever(mockStackItem.sessionIds).thenReturn(listOf("stack item"))
+        whenever(mockFlowStack.peek()).thenReturn(mockStackItem)
+    }
+
+    lateinit var flowFuture: Future<FlowIORequest<*>>
+
+    fun FlowFiber.runUntilNotSuspended(
+        flowFiberExecutionContext: FlowFiberExecutionContext,
+        scheduler: FiberScheduler
+    ): FlowIORequest<*> {
+        flowFuture = this.startFlow(flowFiberExecutionContext)
+        while (flowFuture.get() is FlowIORequest.FlowSuspended<*>) {
+            // Sanity check that any time the FlowFiber was suspended, it was serialized
+            verify(mockCheckpointSerializer).serialize(this)
+            clearInvocations(mockCheckpointSerializer)
+            flowFuture = this.resume(flowFiberExecutionContext, FlowContinuation.Run(), scheduler)
+        }
+        return flowFuture.get()
+    }
+}

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberImplTest.kt
@@ -3,7 +3,7 @@ package net.corda.flow.fiber
 import co.paralleluniverse.concurrent.util.ScheduledSingleThreadExecutor
 import co.paralleluniverse.fibers.FiberExecutorScheduler
 import co.paralleluniverse.fibers.FiberScheduler
-import net.corda.data.flow.FlowStackItem
+import net.corda.data.flow.state.checkpoint.FlowStackItem
 import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.state.FlowStack
 import net.corda.serialization.checkpoint.CheckpointSerializer
@@ -27,11 +27,10 @@ class FlowFiberImplTest {
     val mockCheckpointSerializer = mock<CheckpointSerializer>()
     val mockFlowSandboxGroupContext = mock<FlowSandboxGroupContext>()
     val mockFlowFiberExecutionContext = mock<FlowFiberExecutionContext>()
-
-    val threadExecutor = ScheduledSingleThreadExecutor()
+    
     val fiberScheduler: FiberScheduler = FiberExecutorScheduler(
         "Same thread scheduler",
-        threadExecutor
+        ScheduledSingleThreadExecutor()
     )
 
     @BeforeAll


### PR DESCRIPTION
- Catch Throwable instead of Exception when Flows are invoked.
- Tests for Flow invocation for innocuous and throwing Flow.
