### PR TITLE
NOTICK: sandbox graphviz visitor

### DIFF
--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -10,6 +10,7 @@ import net.corda.sandbox.internal.classtag.StaticTag
 import net.corda.sandbox.internal.sandbox.CpkSandbox
 import net.corda.sandbox.internal.sandbox.Sandbox
 import net.corda.sandbox.internal.utilities.BundleUtils
+import net.corda.sandbox.internal.utilities.dot.SandboxVisitor
 import net.corda.v5.base.util.contextLogger
 import org.osgi.framework.Bundle
 import java.util.Collections.unmodifiableMap
@@ -28,7 +29,6 @@ internal class SandboxGroupImpl(
     private val classTagFactory: ClassTagFactory,
     private val bundleUtils: BundleUtils
 ) : SandboxGroupInternal {
-
     companion object {
         val logger = contextLogger()
     }
@@ -145,5 +145,11 @@ internal class SandboxGroupImpl(
             throw SandboxException("Attempted to create evolvable class tag for cpk private bundle ${bundle.symbolicName}.")
         }
         return classTagFactory.createSerialisedTag(isStaticTag, bundle, cpkSandbox)
+    }
+
+    /** Visit all sandboxes */
+    internal fun accept(visitor: SandboxVisitor) {
+        cpkSandboxes.forEach { it.accept(visitor) }
+        publicSandboxes.forEach { it.accept(visitor) }
     }
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -12,6 +12,7 @@ import net.corda.sandbox.internal.sandbox.CpkSandboxImpl
 import net.corda.sandbox.internal.sandbox.Sandbox
 import net.corda.sandbox.internal.sandbox.SandboxImpl
 import net.corda.sandbox.internal.utilities.BundleUtils
+import net.corda.sandbox.internal.utilities.dot.DotSandboxVisitor
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.framework.Bundle
@@ -202,6 +203,11 @@ internal class SandboxServiceImpl @Activate constructor(
 
         bundles.forEach { bundle ->
             bundleIdToSandboxGroup[bundle.bundleId] = sandboxGroup
+        }
+
+        DotSandboxVisitor(this, System.out).also {
+            sandboxGroup.accept(it)
+            it.complete()
         }
 
         return sandboxGroup

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/CpkSandboxImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/CpkSandboxImpl.kt
@@ -2,6 +2,8 @@ package net.corda.sandbox.internal.sandbox
 
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.sandbox.SandboxException
+import net.corda.sandbox.internal.utilities.dot.SandboxVisitor
+import net.corda.sandbox.internal.utilities.dot.SandboxVisitor.*
 import org.osgi.framework.Bundle
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
 import org.osgi.framework.FrameworkUtil
@@ -45,5 +47,11 @@ internal class CpkSandboxImpl(
         return adapt(BundleWiring::class.java).getCapabilities(PACKAGE_WIRING).any { capability ->
             capability.attributes[PACKAGE_WIRING] == clazz.packageName
         }
+    }
+
+    override fun accept(visitor: SandboxVisitor) {
+        visitor.visit(this)
+        this.publicBundles.forEach { visitor.visit(PublicBundle(id, it)) }
+        this.privateBundles.forEach { visitor.visit(PrivateBundle(id, it)) }
     }
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/Sandbox.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/Sandbox.kt
@@ -1,6 +1,7 @@
 package net.corda.sandbox.internal.sandbox
 
 import net.corda.sandbox.SandboxException
+import net.corda.sandbox.internal.utilities.dot.SandboxVisitor
 import org.osgi.framework.Bundle
 import java.util.UUID
 
@@ -38,4 +39,7 @@ internal interface Sandbox {
      * whereas the bundles for `false` are still installed.
      */
     fun unload(): Map<Boolean, List<Bundle>>
+
+    /** Visit sandboxes */
+    fun accept(visitor: SandboxVisitor)
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
@@ -1,6 +1,9 @@
 package net.corda.sandbox.internal.sandbox
 
 import net.corda.sandbox.SandboxException
+import net.corda.sandbox.internal.utilities.dot.SandboxVisitor
+import net.corda.sandbox.internal.utilities.dot.SandboxVisitor.PrivateBundle
+import net.corda.sandbox.internal.utilities.dot.SandboxVisitor.PublicBundle
 import net.corda.v5.base.util.loggerFor
 import org.osgi.framework.Bundle
 import java.util.UUID
@@ -67,5 +70,11 @@ internal open class SandboxImpl(
 
     override fun toString(): String {
         return "Sandbox[ID: $id, PUBLIC: ${publicBundles.joinToString()}, PRIVATE: ${privateBundles.joinToString()}]"
+    }
+
+    override fun accept(visitor: SandboxVisitor) {
+        visitor.visit(this)
+        this.publicBundles.forEach { visitor.visit(PublicBundle(id, it)) }
+        this.privateBundles.forEach { visitor.visit(PrivateBundle(id, it)) }
     }
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/SandboxVisitor.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/SandboxVisitor.kt
@@ -1,0 +1,24 @@
+package net.corda.sandbox.internal.utilities.dot
+
+import net.corda.sandbox.internal.sandbox.Sandbox
+import org.osgi.framework.Bundle
+import java.util.UUID
+
+
+/**
+ * Trivial visitor - we visit a sandbox, which may be a regular
+ * sandbox or a cpk sandbox, and then visit private and public OSGi bundles.
+ */
+internal interface SandboxVisitor {
+    /** Using types to discriminate between public and private bundles and their sandboxes */
+    data class PrivateBundle(val thisSandboxId: UUID, val bundle: Bundle)
+
+    /** Using types to discriminate between public and private bundles and their sandboxes */
+    data class PublicBundle(val thisSandboxId: UUID, val bundle: Bundle)
+
+    fun visit(sandbox: Sandbox)
+    fun visit(bundle: PrivateBundle)
+    fun visit(bundle: PublicBundle)
+
+    fun complete()
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/DotSandboxVisitor.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/DotSandboxVisitor.kt
@@ -1,0 +1,128 @@
+package net.corda.sandbox.internal.utilities.dot
+
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.sandbox.SandboxContextService
+import net.corda.sandbox.internal.sandbox.CpkSandboxImpl
+import net.corda.sandbox.internal.sandbox.Sandbox
+import net.corda.sandbox.internal.sandbox.SandboxImpl
+import net.corda.sandbox.internal.utilities.dot.lang.AttrStatement
+import net.corda.sandbox.internal.utilities.dot.lang.Digraph
+import net.corda.sandbox.internal.utilities.dot.lang.Node
+import net.corda.sandbox.internal.utilities.dot.lang.NodeId
+import net.corda.sandbox.internal.utilities.dot.lang.Subgraph
+import org.osgi.framework.Bundle
+import java.io.OutputStream
+import java.util.UUID
+
+internal class DotSandboxVisitor(private val service: SandboxContextService, private val outputStream: OutputStream) :
+    SandboxVisitor {
+    class DecoratedBundle(val bundle: Bundle, val isVisible: Boolean)
+
+    private val bundlesBySandboxId = mutableMapOf<UUID, MutableList<DecoratedBundle>>()
+    private val sandboxIdByBundle = mutableMapOf<Bundle, UUID>()
+    private val cpkMetadataById = mutableMapOf<UUID, CpkMetadata>()
+
+    override fun visit(sandbox: Sandbox) {
+        when (sandbox) {
+            is CpkSandboxImpl -> addSandboxInfo(sandbox.id, sandbox.cpkMetadata)
+            is SandboxImpl -> { /* unused */
+            }
+            else -> println("Unknown sandbox type")
+        }
+    }
+
+    override fun visit(bundle: SandboxVisitor.PrivateBundle) = addBundle(bundle.thisSandboxId, bundle.bundle, false)
+
+    override fun visit(bundle: SandboxVisitor.PublicBundle) = addBundle(bundle.thisSandboxId, bundle.bundle, true)
+
+    private fun addBundle(sandboxId: UUID, bundle: Bundle, isVisible: Boolean) {
+        bundlesBySandboxId.computeIfAbsent(sandboxId) { mutableListOf() }.add(DecoratedBundle(bundle, isVisible))
+        sandboxIdByBundle[bundle] = sandboxId
+    }
+
+    private fun addSandboxInfo(id: UUID, cpkMetadata: CpkMetadata) {
+        cpkMetadataById[id] = cpkMetadata
+    }
+
+    override fun complete() {
+        val g = Digraph()
+        val commonAttributes = listOf("fontname" to "sans-serif", "fontsize" to "9")
+        g.attrs(commonAttributes)
+        g.add(AttrStatement(AttrStatement.Type.node, commonAttributes))
+        g.add(AttrStatement(AttrStatement.Type.edge, commonAttributes))
+
+        generateBundleNodes(g)
+        generateBundleEdges(g)
+
+        val writer = outputStream.bufferedWriter()
+        writer.write(g.render())
+        writer.flush()
+    }
+
+    /**
+     * we can have *lots* of edges, up to N*N-1 bundles if we render all of them
+     * but we will skip edges internal to a sandbox
+     */
+    private fun generateBundleEdges(g: Digraph) {
+        val allBundles = bundlesBySandboxId.flatMap { it.value }.toSet()
+        allBundles.forEach { outer ->
+            allBundles.forEach { inner ->
+                // Don't render edges in same sandbox, it's a mess.
+                if (outer != inner && !inSameSandbox(inner, outer)) {
+                    if (service.hasVisibility(outer.bundle, inner.bundle)) {
+                        g.edge(NodeId(nodeId(outer.bundle)), NodeId(nodeId(inner.bundle)))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun inSameSandbox(inner: DecoratedBundle, outer: DecoratedBundle) =
+        sandboxIdByBundle[inner.bundle]!! == sandboxIdByBundle[outer.bundle]
+
+    private fun nodeId(bundle: Bundle) = "bundle_${bundle.bundleId}".replace("-", "_")
+    private fun cpkName(cpkMetadata: CpkMetadata) =
+        "CPK name=${cpkMetadata.cpkId.name} version=${cpkMetadata.cpkId.version}"
+
+    private fun generateBundleNodes(digraph: Digraph) {
+        val allBundles = bundlesBySandboxId.flatMap { it.value }.toSet()
+        bundlesBySandboxId.keys.forEach { uuid ->
+            val attrs = listOf("color" to "orange", "style" to "filled", "label" to "${subgraphLabel(uuid)}")
+            val sandboxSubgraph = Subgraph("cluster_$uuid".replace("-", "_")).apply { attrs(attrs) }
+            digraph.add(sandboxSubgraph)
+            addNodesForSandbox(sandboxSubgraph, uuid)
+        }
+
+        // Write out the actual node "instances"
+        allBundles.forEach {
+            val colour = if (it.isVisible) "green" else "red"
+            digraph.add(
+                Node(
+                    nodeId(it.bundle),
+                    listOf("shape" to "box", "label" to it.bundle.symbolicName, "style" to "filled", "color" to colour)
+                )
+            )
+        }
+    }
+
+    private fun subgraphLabel(uuid: UUID): String = if (cpkMetadataById.keys.contains(uuid)) {
+        "$uuid\n(${cpkName(cpkMetadataById[uuid]!!)})"
+    } else {
+        "$uuid"
+    }
+
+    private fun addNodesForSandbox(sandboxSubgraph: Subgraph, uuid: UUID) {
+        val (publicBundles, privateBundles) = bundlesBySandboxId[uuid]!!.partition { it.isVisible }
+
+        val redAttrs = listOf("color" to "red3", "style" to "filled", "label" to "")
+        val greenAttrs = listOf("color" to "green3", "style" to "filled", "label" to "")
+
+        val s = Subgraph("cluster-public-$uuid".replace("-", "_")).apply { attrs(greenAttrs) }
+        sandboxSubgraph.add(s)
+        publicBundles.forEach { s.add(Node(nodeId(it.bundle))) }
+
+        val s2 = Subgraph("cluster-private-$uuid".replace("-", "_")).apply { attrs(redAttrs) }
+        sandboxSubgraph.add(s2)
+        privateBundles.forEach { s2.add(Node(nodeId(it.bundle))) }
+    }
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AList.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AList.kt
@@ -1,0 +1,23 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+/**
+ * https://graphviz.org/doc/info/lang.html
+ *
+ * ID '=' ID [ (';' | ',') ] [ a_list ]
+ *
+ * ID '=' ID == [IdStatement]
+ */
+class AList(ids: List<Pair<String, String>> = emptyList()) : Render {
+    private val statements = mutableListOf<IdStatement>()
+
+    init {
+        add(ids)
+    }
+
+    fun add(ids: List<Pair<String, String>>) = ids.forEach { statements.add(IdStatement(it.first, it.second)) }
+    fun add(stmt: IdStatement) = statements.add(stmt)
+    fun addIds(stmts: List<IdStatement>) = stmts.forEach(::add)
+    override fun render(): String =
+        if (statements.isEmpty()) "" else statements.joinToString(";") { it.render() }
+
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AttrList.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AttrList.kt
@@ -1,0 +1,18 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+class AttrList(attributes:List<Pair<String,String>> = emptyList()) : Render {
+    private val s = mutableListOf<String>()
+    init {
+        add(attributes)
+    }
+    fun add(a: AList) {
+        val ss = a.render()
+        if (ss.isNotEmpty()) {
+            s.add("[$ss]")
+        }
+    }
+    fun add(a: AttrList) = s.add("${a.render()}")
+    fun addIds(attributes: List<IdStatement>) = add(AList().apply { addIds(attributes) })
+    fun add(attributes: List<Pair<String, String>>) = add(AList(attributes))
+    override fun render(): String = s.joinToString("")
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AttrStatement.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AttrStatement.kt
@@ -1,0 +1,11 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+class AttrStatement(val type: Type, val attrList: AttrList) : Statement, AttributeList {
+    constructor(type: Type, attributes:List<Pair<String,String>>) : this(type, AttrList(attributes))
+
+    enum class Type { graph, node, edge }
+
+    override fun render(): String = "$type ${attrList.render()}"
+
+    override fun attrs(attributes: List<Pair<String, String>>) = attrList.add(attributes)
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AttributeList.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/AttributeList.kt
@@ -1,0 +1,9 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+interface AttributeList {
+    /**
+     * Add attributes specifically for this statement, i.e. something { X=Y; A=B; ... }
+     * Convenience for adding add(IdStatement(X,Y))
+     */
+    fun attrs(attributes: List<Pair<String, String>>)
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/ClusterSubgraph.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/ClusterSubgraph.kt
@@ -1,0 +1,5 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+class ClusterSubgraph(override val id: String) : Subgraph(id) {
+    override fun render(): String = "cluster_$id {\n${statements.render()}\n}"
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Digraph.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Digraph.kt
@@ -1,0 +1,28 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+/**
+ * Top-most class.  Simple implementation of https://graphviz.org/doc/info/lang.html
+ */
+class Digraph(val id: String = "") : Render, AttributeList, Statements {
+    companion object {
+        val op = "->"
+    }
+
+    private val statements = StatementList()
+    fun edgeRhs(nodeId: NodeId, rhs: List<EdgeRhs> = emptyList()) = EdgeRhs(op, nodeId, rhs)
+    fun edgeRhs(subgraph: Subgraph, rhs: List<EdgeRhs> = emptyList()) = EdgeRhs(op, subgraph, rhs)
+    override fun render(): String = "digraph $id {\n${statements.render()}\n}\n\n"
+
+    override fun add(statement: Statement) = statement.apply { statements.add(statement) }
+    override fun add(statements: List<Statement>) = statements.forEach(::add)
+
+    fun edge(nodeA: NodeId, nodeB: NodeId) : Edge = Edge(nodeA, listOf(edgeRhs(nodeB))).apply { add(this) }
+    fun edge(nodes: List<NodeId>) = Edge(nodes.first(), nodes.drop(1).map { EdgeRhs(op, it) })
+
+    override fun attrs(attributes: List<Pair<String, String>>) = attributes.forEach { add(IdStatement(it.first, it.second)) }
+}
+
+
+//class Graph(val id: String, val statements: StatementList) {
+//    fun edgeRhs(nodeLike: NodeLike, rhs: EdgeRhs? = null) = EdgeRhs("--", nodeLike, rhs)
+//}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Edge.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Edge.kt
@@ -1,0 +1,34 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+class Edge : Statement, AttributeList {
+    private val nodeId: NodeId?
+    private val subgraph: Subgraph?
+    private val rhs: List<EdgeRhs>
+    private val attrList: AttrList
+
+    constructor(nodeId: NodeId, rhs: List<EdgeRhs>, attrList: AttrList = AttrList()) {
+        this.nodeId = nodeId
+        this.subgraph = null
+        this.rhs = rhs
+        this.attrList = attrList
+    }
+
+    constructor(subgraph: Subgraph, rhs: List<EdgeRhs>, attrList: AttrList = AttrList()) {
+        this.nodeId = null
+        this.subgraph = subgraph
+        this.rhs = rhs
+        this.attrList = attrList
+    }
+
+    override fun render(): String {
+        val other = rhs.joinToString("") { it.render() }
+
+        return when {
+            nodeId != null -> "\"${nodeId.id}\"$other${attrList.render()}"
+            subgraph != null -> "${subgraph.render()}$other${attrList.render()}"
+            else -> ""
+        }
+    }
+
+    override fun attrs(attributes: List<Pair<String, String>>) = attrList.add(attributes)
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/EdgeRhs.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/EdgeRhs.kt
@@ -1,0 +1,37 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+class EdgeRhs : Render {
+    private val op: String
+    private val nodeId: NodeId?
+    private val subgraph: Subgraph?
+    private val rhs: List<EdgeRhs>
+
+    constructor(op: String, nodeId: NodeId, rhs: EdgeRhs) {
+        this.op = op
+        this.nodeId = nodeId
+        this.subgraph = null
+        this.rhs = listOf(rhs)
+    }
+    constructor(op: String, nodeId: NodeId, rhs: List<EdgeRhs> = emptyList()) {
+        this.op = op
+        this.nodeId = nodeId
+        this.subgraph = null
+        this.rhs = rhs
+    }
+
+    constructor(op: String, subgraph: Subgraph, rhs: List<EdgeRhs> = emptyList()) {
+        this.op = op
+        this.nodeId = null
+        this.subgraph = subgraph
+        this.rhs = rhs
+    }
+
+    override fun render(): String {
+        val other = rhs.joinToString("") { it.render() }
+        return when {
+            nodeId != null -> " $op \"${nodeId.id}\"$other"
+            subgraph != null -> " $op ${subgraph.render()}$other"
+            else -> ""
+        }
+    }
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/IdStatement.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/IdStatement.kt
@@ -1,0 +1,10 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+/**
+ * ID '=' ID
+ *
+ * See https://graphviz.org/doc/info/lang.html
+ */
+class IdStatement(val key: String, val value: String) : Statement {
+    override fun render(): String = "$key=\"$value\""
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Node.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Node.kt
@@ -1,0 +1,16 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+class Node(id: String, attrs: AttrList = AttrList()) : NodeId(id), Statement, AttributeList {
+    private val attrList = AttrList()
+
+    init {
+        attrList.add(attrs)
+    }
+
+    constructor(id: String, attrs: List<Pair<String, String>>) : this(id, AttrList(attrs))
+
+    override fun attrs(attributes: List<Pair<String, String>>) = attrs(AList(attributes))
+    fun attrs(attributes: AList) = attrList.add(attributes)
+    fun attrs(attributes: AttrList) = attrList.add(attributes)
+    override fun render(): String = "\"$id\" ${attrList.render()}"
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/NodeId.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/NodeId.kt
@@ -1,0 +1,3 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+open class NodeId(val id: String)

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Render.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Render.kt
@@ -1,0 +1,8 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+/**
+ * Renders current 'token' to a string.
+ */
+interface Render {
+    fun render(): String
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Statement.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Statement.kt
@@ -1,0 +1,3 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+interface Statement : Render

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/StatementList.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/StatementList.kt
@@ -1,0 +1,12 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+class StatementList() : Render {
+    private val statements = mutableListOf<Statement>()
+    fun add(statement: Statement) = statements.add(statement)
+
+    constructor(statements: List<Statement>) : this() {
+        statements.forEach(::add)
+    }
+
+    override fun render(): String = statements.joinToString(";\n") { it.render() }
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Statements.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Statements.kt
@@ -1,0 +1,18 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+/**
+ * Supports statements
+ */
+interface Statements {
+    /**
+     * Add a statement.
+     *
+     * @return the statement that was added, i.e. [statement]
+     */
+    fun add(statement: Statement) : Statement
+
+    /**
+     * Add a list of statements.
+     */
+    fun add(statements: List<Statement>)
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Subgraph.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/dot/lang/Subgraph.kt
@@ -1,0 +1,11 @@
+package net.corda.sandbox.internal.utilities.dot.lang
+
+open class Subgraph(open val id: String) : Statement, AttributeList, Statements {
+    protected val statements = StatementList()
+    override fun add(statement: Statement) = statement.apply { statements.add(statement) }
+    override fun add(statements: List<Statement>) = statements.forEach(::add)
+
+    override fun attrs(attributes: List<Pair<String, String>>) = attributes.forEach { add(IdStatement(it.first, it.second)) }
+
+    override fun render(): String = "subgraph $id {\n${statements.render()}\n}"
+}

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -494,8 +494,8 @@ class SandboxServiceImplTests {
 private data class CpkAndContents(
     val mainBundleClass: Class<*>,
     val libraryClass: Class<*>,
-    val mainBundleName: String? = "${random.nextInt()}",
-    val libraryBundleName: String? = "${random.nextInt()}",
+    val mainBundleName: String? = "Main Bundle ${random.nextInt()}",
+    val libraryBundleName: String? = "Lib Bundle ${random.nextInt()}",
     private val cpkDependencies: List<CpkIdentifier> = emptyList()
 ) {
     val bundleNames = setOf(mainBundleName, libraryBundleName)

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/utilities/dot/DotLangTest.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/utilities/dot/DotLangTest.kt
@@ -1,0 +1,85 @@
+package net.corda.sandbox.internal.utilities.dot
+
+import net.corda.sandbox.internal.utilities.dot.lang.AList
+import net.corda.sandbox.internal.utilities.dot.lang.AttrList
+import net.corda.sandbox.internal.utilities.dot.lang.AttrStatement
+import net.corda.sandbox.internal.utilities.dot.lang.ClusterSubgraph
+import net.corda.sandbox.internal.utilities.dot.lang.Digraph
+import net.corda.sandbox.internal.utilities.dot.lang.Edge
+import net.corda.sandbox.internal.utilities.dot.lang.EdgeRhs
+import net.corda.sandbox.internal.utilities.dot.lang.Node
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DotLangTest {
+    @Test
+    fun `test AList`() {
+        val a = AList()
+        assertThat(a.render()).isEqualTo("")
+        a.add(listOf("color" to "yellow"))
+        assertThat(a.render()).isEqualTo("color=\"yellow\"")
+        a.add(listOf("font" to "Times"))
+        assertThat(a.render()).isEqualTo("color=\"yellow\";font=\"Times\"")
+    }
+
+    @Test
+    fun `test AttrList`() {
+        val a = AttrList()
+        assertThat(a.render()).isEqualTo("")
+        a.add(listOf("color" to "yellow"))
+        assertThat(a.render()).isEqualTo("[color=\"yellow\"]")
+        a.add(listOf("shape" to "box", "font" to "Times"))
+        assertThat(a.render()).isEqualTo("[color=\"yellow\"][shape=\"box\";font=\"Times\"]")
+    }
+
+    @Test
+    fun `test node`() {
+        val n = Node("a", AttrList().apply { add(listOf("color" to "yellow"))})
+        assertThat(n.render()).isEqualTo("\"a\" [color=\"yellow\"]")
+    }
+
+    @Test
+    fun `test edge`() {
+        val a = Node("a", AttrList().apply { add(listOf("color" to "yellow"))})
+        val b = Node("b", AttrList().apply { add(listOf("color" to "yellow"))})
+        val c = Node("c", AttrList().apply { add(listOf("color" to "yellow"))})
+        val eb = EdgeRhs("->", b)
+        val ec = EdgeRhs("->", c)
+        assertThat(eb.render()).isEqualTo(" -> \"b\"")
+        assertThat(Edge(a, listOf(eb)).render()).isEqualTo("\"a\" -> \"b\"")
+        assertThat(Edge(a, listOf(eb,ec)).render()).isEqualTo("\"a\" -> \"b\" -> \"c\"")
+
+        val g = Digraph()
+        assertThat(g.edge(listOf(a,b,c)).render()).isEqualTo("\"a\" -> \"b\" -> \"c\"")
+    }
+
+    @Test
+    fun `digraph`() {
+        val g = Digraph("test")
+        g.attrs(listOf("fontsize" to "11", "fontname" to "sans-serif"))
+        val attrs = AttrList().apply { add(listOf("fontsize" to "10", "color" to "yellow"))}
+        g.add(AttrStatement(AttrStatement.Type.node, attrs))
+
+        val c = ClusterSubgraph("aaa")
+        val a = Node("a", attrs)
+        val b = Node("b", attrs)
+        g.edge(a, b)
+
+        c.add(listOf(a,b))
+        g.add(c)
+        val actual = g.render()
+        //digraph test {
+        //fontsize="11";
+        //fontname="sans-serif";
+        //node [fontsize="10";color="yellow"];
+        //"a" -> "b";
+        //cluster_aaa {
+        //"a" [fontsize="10";color="yellow"];
+        //"b" [fontsize="10";color="yellow"]
+        //}
+        //}
+        assertThat(actual).contains("digraph")
+        assertThat(actual).contains("cluster_aaa")
+        assertThat(actual).contains("\"a\" -> \"b\"")
+    }
+}


### PR DESCRIPTION
Do NOT merge as-is.

Adds a visitor to the sandbox classes, and a graphviz/dot visitor
that then renders bundles and sandboxes into "dot" format.

Just writes to stdout at the moment, and then can paste into
VSCode, with graphviz preview, or save as ".dot" file and
run:

    dot -Tpng simple-sandbox.dot -o simple-sandbox.png