### PR TITLE
CORE-5751 Add TLS support to the Application Simulator

### DIFF
--- a/applications/tools/p2p-test/app-simulator/README.md
+++ b/applications/tools/p2p-test/app-simulator/README.md
@@ -118,7 +118,7 @@ To build the Docker image, run:
 ### Running the JAR
 To run the JAR, use:
 ```
-java -jar applications/tools/p2p-test/app-simulator/build/bin/corda-app-simulator*.jar --kafka-servers broker1:9093 --simulator-config ~/Desktop/simulator.conf
+java -jar applications/tools/p2p-test/app-simulator/build/bin/corda-app-simulator*.jar --simulator-config ~/Desktop/simulator.conf
 ```
 
 The simulator configuration file can differ depending on the mode, as explained above.
@@ -127,15 +127,28 @@ Below is a list of command line arguments you can use:
 ```bash
   -h, --help   Display help and exit
   -i, --instance-id=<instanceId>
-               The instance ID. Defaults to the value of the env. variable INSTANCE_ID or a random number, if that hasn't been set.
-  -k, --kafka-servers=<kafkaServers>
-               A comma-separated list of addresses of Kafka brokers. Default to localhost:9092
+               The instance ID. Defaults to the value of the env. variable
+                 INSTANCE_ID or a random number, if that hasn't been set.
+  -m, --messagingParams=<String=String>
+               Messaging parameters for the simulator.
       --receive-topic=<receiveTopic>
-               Topic to receive messages from. Defaults to p2p.in, if not specified.
+               Topic to receive messages from. Defaults to p2p.in, if not
+                 specified.
       --send-topic=<sendTopic>
-               Topic to send the messages to. Defaults to p2p.out, if not specified.
+               Topic to send the messages to. Defaults to p2p.out, if not
+                 specified.
       --simulator-config=<simulatorConfig>
-               File containing configuration parameters for simulator. Default to config.conf
+               File containing configuration parameters for simulator. Default
+                 to config.conf
+```
+By default, the simulator will try and connect to a Kafka broker on localhost:9092.
+To override this use option `-m`. For example, to connect to a Kafka Broker on `kafka-broker:1000`:
+```bash
+java -jar applications/tools/p2p-test/app-simulator/build/bin/corda-app-simulator*.jar -mbootstrap.servers=kafka-broker:1000
+```
+These -m options are passed into the Kafka client. For example to use TLS to connect to the Kafka broker the following -m options can be used:
+```bash
+java -jar ./applications/p2p-link-manager/build/bin/corda-p2p-link-manager*.jar -msecurity.protocol=SSL -mssl.truststore.location=/certs/ca.crt -mssl.truststore.type=PEM
 ```
 
 ### Running the Docker image
@@ -150,7 +163,7 @@ docker run \
 
 Below is a list of environment variables you can use:
 * `KAFKA_SERVERS` - The list of Kafka server (default to `localhost:9092`)
-* `INSTANCE_ID` - The Link Manager instance ID (default to random number)
+* `INSTANCE_ID` - The simulator instance ID (default to random number)
 
 ## Database metadata
 

--- a/applications/tools/p2p-test/app-simulator/build.gradle
+++ b/applications/tools/p2p-test/app-simulator/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api"
     implementation "net.corda:corda-base"
     implementation project(":libs:configuration:configuration-core")
+    implementation project(":libs:configuration:configuration-merger")
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle:lifecycle")
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
@@ -41,4 +42,5 @@ dependencies {
     runtimeOnly project(":libs:messaging:messaging-impl")
     runtimeOnly project(":libs:schema-registry:schema-registry-impl")
     runtimeOnly project(":libs:lifecycle:lifecycle-impl")
+
 }

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
@@ -164,7 +164,15 @@ class AppSimulator @Activate constructor(
         clients: Int,
         instanceId: String,
     ) {
-        val receiver = Receiver(subscriptionFactory, configMerger, receiveTopic, APP_RECEIVED_MESSAGES_TOPIC, bootConfig, clients, instanceId)
+        val receiver = Receiver(
+            subscriptionFactory,
+            configMerger,
+            receiveTopic,
+            APP_RECEIVED_MESSAGES_TOPIC,
+            bootConfig,
+            clients,
+            instanceId
+        )
         receiver.start()
         resources.add(receiver)
     }

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
@@ -3,7 +3,12 @@ package net.corda.p2p.app.simulator
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
 import net.corda.data.identity.HoldingIdentity
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.libs.configuration.merger.ConfigMerger
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.osgi.api.Application
@@ -11,6 +16,8 @@ import net.corda.osgi.api.Shutdown
 import net.corda.schema.Schemas.P2P.Companion.P2P_IN_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_TOPIC
 import net.corda.schema.TestSchema.Companion.APP_RECEIVED_MESSAGES_TOPIC
+import net.corda.schema.configuration.BootConfig
+import net.corda.schema.configuration.MessagingConfig
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.util.contextLogger
@@ -33,7 +40,9 @@ class AppSimulator @Activate constructor(
     @Reference(service = PublisherFactory::class)
     private val publisherFactory: PublisherFactory,
     @Reference(service = SubscriptionFactory::class)
-    private val subscriptionFactory: SubscriptionFactory
+    private val subscriptionFactory: SubscriptionFactory,
+    @Reference(service = ConfigMerger::class)
+    private val configMerger: ConfigMerger,
 ) : Application {
 
     companion object {
@@ -71,15 +80,31 @@ class AppSimulator @Activate constructor(
                 return
             }
 
+            val parsedMessagingParams = parameters.messagingParams.mapKeys { (key, _) ->
+                "${BootConfig.BOOT_KAFKA_COMMON}.${key.trim()}"
+            }.toMutableMap()
+            parsedMessagingParams.computeIfAbsent("${BootConfig.BOOT_KAFKA_COMMON}.bootstrap.servers") {
+                System.getenv("KAFKA_SERVERS") ?: "localhost:9092"
+            }
+            val bootConfig = SmartConfigFactory.create(SmartConfigImpl.empty()).create(
+                ConfigFactory.parseMap(parsedMessagingParams)
+                    .withValue(
+                        BootConfig.TOPIC_PREFIX,
+                        ConfigValueFactory.fromAnyRef("")
+                    ).withValue(
+                        MessagingConfig.Bus.BUS_TYPE,
+                        ConfigValueFactory.fromAnyRef("KAFKA")
+                    )
+            )
             try {
-                runSimulator(parameters, parameters.kafkaServers)
+                runSimulator(parameters, bootConfig)
             } catch (e: Throwable) {
                 consoleLogger.error("Could not run: ${e.message}")
             }
         }
     }
 
-    private fun runSimulator(parameters: CliParameters, kafkaServers: String) {
+    private fun runSimulator(parameters: CliParameters, bootConfig: SmartConfig) {
         val sendTopic = parameters.sendTopic ?: P2P_OUT_TOPIC
         val receiveTopic = parameters.receiveTopic ?: P2P_IN_TOPIC
         val simulatorConfig = ConfigFactory.parseFile(parameters.simulatorConfig).withFallback(DEFAULT_CONFIG)
@@ -88,13 +113,13 @@ class AppSimulator @Activate constructor(
         val simulatorMode = simulatorConfig.getEnum(SimulationMode::class.java, "simulatorMode")
         when (simulatorMode) {
             SimulationMode.SENDER -> {
-                runSender(simulatorConfig, publisherFactory, sendTopic, kafkaServers, clients, parameters.instanceId)
+                runSender(simulatorConfig, publisherFactory, sendTopic, bootConfig, clients, parameters.instanceId)
             }
             SimulationMode.RECEIVER -> {
-                runReceiver(subscriptionFactory, receiveTopic, kafkaServers, clients, parameters.instanceId)
+                runReceiver(subscriptionFactory, receiveTopic, bootConfig, clients, parameters.instanceId)
             }
             SimulationMode.DB_SINK -> {
-                runSink(simulatorConfig, subscriptionFactory, kafkaServers, clients, parameters.instanceId)
+                runSink(simulatorConfig, subscriptionFactory, bootConfig, clients, parameters.instanceId)
             }
             else -> throw IllegalStateException("Invalid value for simulator mode: $simulatorMode")
         }
@@ -105,7 +130,7 @@ class AppSimulator @Activate constructor(
         simulatorConfig: Config,
         publisherFactory: PublisherFactory,
         sendTopic: String,
-        kafkaServers: String,
+        bootConfig: SmartConfig,
         clients: Int,
         instanceId: String,
     ) {
@@ -113,10 +138,11 @@ class AppSimulator @Activate constructor(
         val loadGenerationParams = readLoadGenParams(simulatorConfig)
         val sender = Sender(
             publisherFactory,
+            configMerger,
             connectionDetails,
             loadGenerationParams,
             sendTopic,
-            kafkaServers,
+            bootConfig,
             clients,
             instanceId,
             clock
@@ -134,11 +160,11 @@ class AppSimulator @Activate constructor(
     private fun runReceiver(
         subscriptionFactory: SubscriptionFactory,
         receiveTopic: String,
-        kafkaServers: String,
+        bootConfig: SmartConfig,
         clients: Int,
         instanceId: String,
     ) {
-        val receiver = Receiver(subscriptionFactory, receiveTopic, APP_RECEIVED_MESSAGES_TOPIC, kafkaServers, clients, instanceId)
+        val receiver = Receiver(subscriptionFactory, configMerger, receiveTopic, APP_RECEIVED_MESSAGES_TOPIC, bootConfig, clients, instanceId)
         receiver.start()
         resources.add(receiver)
     }
@@ -146,7 +172,7 @@ class AppSimulator @Activate constructor(
     private fun runSink(
         simulatorConfig: Config,
         subscriptionFactory: SubscriptionFactory,
-        kafkaServers: String,
+        bootConfig: SmartConfig,
         clients: Int,
         instanceId: String,
     ) {
@@ -156,7 +182,7 @@ class AppSimulator @Activate constructor(
             shutdownOSGiFramework()
             return
         }
-        val sink = Sink(subscriptionFactory, connectionDetails, kafkaServers, clients, instanceId)
+        val sink = Sink(subscriptionFactory, configMerger, connectionDetails, bootConfig, clients, instanceId)
         sink.start()
         resources.add(sink)
     }
@@ -218,10 +244,10 @@ class AppSimulator @Activate constructor(
 
 class CliParameters {
     @CommandLine.Option(
-        names = ["-k", "--kafka-servers"],
-        description = ["A comma-separated list of addresses of Kafka brokers. Default to \${DEFAULT-VALUE}"]
+        names = ["-m", "--messagingParams"],
+        description = ["Messaging parameters for the simulator."]
     )
-    var kafkaServers = System.getenv("KAFKA_SERVERS") ?: "localhost:9092"
+    var messagingParams = emptyMap<String, String>()
 
     @CommandLine.Option(
         names = ["-i", "--instance-id"],

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
@@ -5,10 +5,11 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.typesafe.config.ConfigValueFactory
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.merger.ConfigMerger
 import java.io.Closeable
 import java.time.Duration
 import java.time.Instant
-import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
@@ -18,16 +19,14 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
-import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
-import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
-import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
 import net.corda.v5.base.util.contextLogger
 
 @Suppress("LongParameterList")
 class Receiver(private val subscriptionFactory: SubscriptionFactory,
+               private val configMerger: ConfigMerger,
                private val receiveTopic: String,
                private val metadataTopic: String,
-               private val kafkaServers: String,
+               private val bootConfig: SmartConfig,
                private val clients: Int,
                private val instanceId: String,
     ): Closeable {
@@ -42,11 +41,9 @@ class Receiver(private val subscriptionFactory: SubscriptionFactory,
     fun start() {
         (1..clients).forEach { client ->
             val subscriptionConfig = SubscriptionConfig("app-simulator-receiver", receiveTopic, )
-            val messagingConfig = SmartConfigImpl.empty()
-                .withValue(KAFKA_BOOTSTRAP_SERVERS, ConfigValueFactory.fromAnyRef(kafkaServers))
-                .withValue(BUS_TYPE, ConfigValueFactory.fromAnyRef("KAFKA"))
-                .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(""))
-                .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef("$instanceId-$client".hashCode()))
+            val configWithInstanceId = bootConfig.withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef("$instanceId-$client".hashCode()))
+            val messagingConfig = configMerger.getMessagingConfig(configWithInstanceId)
+
             val subscription = subscriptionFactory.createEventLogSubscription(subscriptionConfig,
                 InboundMessageProcessor(metadataTopic), messagingConfig, null)
             subscription.start()

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
@@ -18,6 +18,7 @@ import net.corda.schema.TestSchema.Companion.APP_RECEIVED_MESSAGES_TOPIC
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.v5.base.util.contextLogger
 
+@Suppress("LongParameterList")
 class Sink(private val subscriptionFactory: SubscriptionFactory,
            private val configMerger: ConfigMerger,
            private val dbParams: DBParams,


### PR DESCRIPTION
Modified the AppSimulator to take -m options to work in the same way as the LinkManager, Gateway and the common worker framework. To set the kafka to connect to a broker on kafka-broker:1000 use `-mbootstrap.servers=kafka-broker:1000`. To enable TLS add the following options: `-msecurity.protocol=SSL`, `-mssl.truststore.location=/certs/ca.crt` and `-mssl.truststore.type=PEM`. Where /certs/ca.crt is the trust store.

I have manually tested this by:
---

1. Deploying the prerequisite and corda helm charts.
2. Extracting the kafka trust root from Kubernetes:
```
kubectl get secret prereqs-kafka-0-tls -o go-template='{{ index .data "ca.crt" }}' -n corda | base64 -D > ca.crt
```
3. Start kubefwd so the app simulator can talk to Kafka from outside of the cluster:
```
sudo kubefwd svc -n corda
```
4. Sending a message with the App Simulator to the LinkManager.
```
java -jar ./applications/tools/p2p-test/app-simulator/build/bin/corda-app-simulator-5.0.0.0-SNAPSHOT.jar -mbootstrap.servers=prereqs-kafka:9092 -msecurity.protocol=SSL -mssl.truststore.location=./ca.crt -mssl.truststore.type=PEM   --simulator-config simulator_sender.conf
```
Where simulator_sender.conf contains:
```
{
    parallelClients: 1,
    simulatorMode: "SENDER",
    loadGenerationParams: {
        peerX500Name: "C=GB, L=London, O=Bob",
        peerGroupId: "<group-id>",
        ourX500Name: "C=GB, L=London, O=Alice",
        ourGroupId: "<group-id>",
        loadGenerationType: "ONE_OFF",
        batchSize: 1,
        totalNumberOfMessages: 1,
        interBatchDelay: 0ms,
        messageSizeBytes: 10000
    }
}
```

5. If we look in the LinkManager logs we see:
```
10:36:05.825 [pool-6-thread-1] WARN  net.corda.p2p.linkmanager.sessions.SessionManagerImpl - Could not find the group information in the GroupPolicyProvider for {"x500Name": "C=GB, L=London, O=Alice", "groupId": "<group-id>"}. The sessionInit message was not sent.
```

So the App Simulator and LinkManager have communicated successfully.

Should you wish to use the app simulator in receiver/sink mode, then it is necessary to create the topic `p2p.app.received_msg`. This can be done using Kafka-topics (can be installed using `brew install kafka`):
```
kafka-topics --create --bootstrap-server="prereqs-kafka:9092"  --command-config=./config.properties  --topic "p2p.app.received_msg"  --partitions 10
```

Where config.properties contains:
```
security.protocol=SSL
ssl.truststore.location=ca.crt
ssl.truststore.type=PEM
```

You can also use the database deployed by the prerequisite step with the following config file:
```
{
	dbParams: {
        username: "user",
        password: "MYPASSWORD",
        host: "prereqs-postgresql:5432",
        db: "cordacluster"
    },
    parallelClients: 1
    simulatorMode: "DB_SINK"
}
```
Where MYPASSWORD can be extracted from the cluster using:
```
kubectl get secret --namespace corda prereqs-postgresql -o jsonpath="{.data.password}" | base64 --decode
```
