### PR TITLE
CORE-5788: Require sandboxes to have ServicePermission "get" for each injectable service.

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/FakeFlowEngineImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/FakeFlowEngineImpl.kt
@@ -1,0 +1,26 @@
+package net.corda.sandboxgroupcontext.test
+
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.serialization.SingletonSerializeAsToken
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import java.time.Duration
+import java.util.UUID
+
+@Component(service = [ FlowEngine::class, SingletonSerializeAsToken::class ], scope = PROTOTYPE)
+class FakeFlowEngineImpl : FlowEngine, SingletonSerializeAsToken {
+    override val flowId: UUID
+        get() = throw UnsupportedOperationException("VICTORY IS MINE!")
+    override val virtualNodeName: MemberX500Name
+        get() = throw UnsupportedOperationException("VICTORY IS MINE!")
+
+    override fun sleep(duration: Duration) {
+        throw UnsupportedOperationException("VICTORY IS MINE!")
+    }
+
+    override fun <R> subFlow(subFlow: SubFlow<R>): R {
+        throw UnsupportedOperationException("VICTORY IS MINE!")
+    }
+}

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SecurityManagerPolicyTests.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SecurityManagerPolicyTests.kt
@@ -4,7 +4,7 @@ import net.corda.securitymanager.SecurityManagerService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,9 +13,9 @@ import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
-import org.osgi.framework.FrameworkUtil
 import org.osgi.test.common.annotation.InjectBundleContext
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
@@ -32,6 +32,7 @@ class SecurityManagerPolicyTests {
         private const val CPB1 = "META-INF/sandbox-security-manager-one.cpb"
         private const val CPK1_FLOWS_PACKAGE = "com.example.securitymanager.one.flows"
         private const val CPK1_ENVIRONMENT_FLOW = "$CPK1_FLOWS_PACKAGE.EnvironmentFlow"
+        private const val CPK1_FLOW_ENGINE_FLOW = "$CPK1_FLOWS_PACKAGE.FlowEngineFlow"
         private const val CPK1_JSON_FLOW = "$CPK1_FLOWS_PACKAGE.JsonFlow"
         private const val CPK1_HTTP_FLOW = "${CPK1_FLOWS_PACKAGE}.HttpRequestFlow"
         private const val CPK1_REFLECTION_FLOW = "$CPK1_FLOWS_PACKAGE.ReflectionJavaFlow"
@@ -68,14 +69,14 @@ class SecurityManagerPolicyTests {
     }
 
     private fun applyPolicyFile(fileName: String) {
-        val url = FrameworkUtil.getBundle(this::class.java).getResource(fileName)
+        val url = this::class.java.classLoader.getResource(fileName) ?: fail("Resource $fileName not found")
         val policy = securityManagerService.readPolicy(url.openConnection().getInputStream())
         securityManagerService.updatePermissions(policy, clear = false)
     }
 
     @Test
     fun `retrieving environment fails when permission denied`() {
-        applyPolicyFile("/security_01.policy")
+        applyPolicyFile("security_01.policy")
         val sandboxGroupContext = virtualNode.loadSandbox(CPB1)
 
         assertThrows<AccessControlException> {
@@ -85,7 +86,7 @@ class SecurityManagerPolicyTests {
 
     @Test
     fun `reflection fails when permission denied`() {
-        applyPolicyFile("/security_02.policy")
+        applyPolicyFile("security_02.policy")
         val sandboxGroupContext = virtualNode.loadSandbox(CPB1)
 
         assertThrows<AccessControlException> {
@@ -95,7 +96,7 @@ class SecurityManagerPolicyTests {
 
     @Test
     fun `HTTP connection fails when permission denied`() {
-        applyPolicyFile("/security_03.policy")
+        applyPolicyFile("security_03.policy")
         val sandboxGroupContext = virtualNode.loadSandbox(CPB1)
 
         assertThrows<AccessControlException> {
@@ -105,29 +106,53 @@ class SecurityManagerPolicyTests {
 
     @Test
     fun `Reflection fails when permission denied on call stack`() {
-        applyPolicyFile("/security_04.policy")
+        applyPolicyFile("security_04.policy")
         val sandboxGroupContext = virtualNode.loadSandbox(CPB1)
 
         val exception = assertThrows<Exception> {
             virtualNode.runFlow<String>(CPK1_JSON_FLOW, sandboxGroupContext)
         }
-        Assertions.assertThat(exception.message).contains(EXPECTED_ERROR_MSG)
+        assertThat(exception.message).contains(EXPECTED_ERROR_MSG)
     }
 
     @Test
     fun `policy can be changed in runtime`() {
-        applyPolicyFile("/security_02.policy")
+        applyPolicyFile("security_02.policy")
         val sandboxGroupContext = virtualNode.loadSandbox(CPB1)
 
         assertThrows<AccessControlException> {
             virtualNode.runFlow<String>(CPK1_REFLECTION_FLOW, sandboxGroupContext)
         }
 
-        applyPolicyFile("/security_05.policy")
+        applyPolicyFile("security_05.policy")
 
-        Assertions.assertThat(
+        assertThat(
             virtualNode.runFlow<String>(CPK1_REFLECTION_FLOW, sandboxGroupContext)
         ).isEqualTo("test")
     }
 
- }
+    @Test
+    fun `policy can forbid access to injectable service`() {
+        val context1 = virtualNode.loadSandbox(CPB1)
+        try {
+            val ex = assertThrows<UnsupportedOperationException> {
+                virtualNode.runFlow<String>(CPK1_FLOW_ENGINE_FLOW, context1)
+            }
+            assertThat(ex).hasMessage("VICTORY IS MINE!")
+        } finally {
+            virtualNode.unloadSandbox(context1)
+        }
+
+        // Update the security policy to deny sandboxes access to FlowEngine.
+        applyPolicyFile("security-deny-flow-engine.policy")
+
+        val context2 = virtualNode.loadSandbox(CPB1)
+        try {
+            assertThat(
+                virtualNode.runFlow<String>(CPK1_FLOW_ENGINE_FLOW, context2)
+            ).isEqualTo("FlowEngine not found")
+        } finally {
+            virtualNode.unloadSandbox(context2)
+        }
+    }
+}

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/resources/security-deny-flow-engine.policy
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/resources/security-deny-flow-engine.policy
@@ -1,0 +1,4 @@
+DENY {
+[org.osgi.service.condpermadmin.BundleLocationCondition "FLOW/*"]
+(org.osgi.framework.ServicePermission "net.corda.v5.application.flows.FlowEngine" "get")
+} "deny access to FlowEngine"

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -93,7 +93,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     override fun getOrCreate(
         virtualNodeContext: VirtualNodeContext, initializer: SandboxGroupContextInitializer
     ): SandboxGroupContext =
-        sandboxGroupContextService?.getOrCreate(virtualNodeContext, initializer)?:
+        sandboxGroupContextService?.getOrCreate(virtualNodeContext, initializer) ?:
             throw IllegalStateException("SandboxGroupContextService is not ready.")
 
 
@@ -105,13 +105,12 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     ): AutoCloseable =
         sandboxGroupContextService?.registerMetadataServices(
             sandboxGroupContext, serviceNames, isMetadataService, serviceMarkerType
-        )?:
-            throw IllegalStateException("SandboxGroupContextService is not ready.")
+        )?: throw IllegalStateException("SandboxGroupContextService is not ready.")
 
     override fun registerCustomCryptography(
         sandboxGroupContext: SandboxGroupContext
     ): AutoCloseable =
-        sandboxGroupContextService?.registerCustomCryptography(sandboxGroupContext)?:
+        sandboxGroupContextService?.registerCustomCryptography(sandboxGroupContext) ?:
             throw IllegalStateException("SandboxGroupContextService is not ready.")
 
     override fun hasCpks(cpkChecksums: Set<SecureHash>): Boolean =

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -14,6 +14,7 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.cipher.suite.DigestAlgorithmFactory
+import net.corda.v5.crypto.SecureHash
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
 import org.osgi.framework.Constants.OBJECTCLASS
@@ -22,11 +23,14 @@ import org.osgi.framework.Constants.SCOPE_SINGLETON
 import org.osgi.framework.Constants.SERVICE_SCOPE
 import org.osgi.framework.FrameworkUtil
 import org.osgi.framework.ServiceObjects
+import org.osgi.framework.ServicePermission
+import org.osgi.framework.ServicePermission.GET
 import org.osgi.framework.ServiceRegistration
 import org.osgi.service.component.runtime.ServiceComponentRuntime
 import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO
+import java.security.AccessControlContext
+import java.security.AccessControlException
 import java.util.Hashtable
-import net.corda.v5.crypto.SecureHash
 
 private typealias ServiceDefinition = Pair<ServiceObjects<out Any>, List<Class<*>>>
 
@@ -131,6 +135,9 @@ class SandboxGroupContextServiceImpl(
      * finding any pre-existing services inside the sandbox itself.
      */
     private fun fetchCommonServices(vnc: VirtualNodeContext, bundles: Iterable<Bundle>): List<ServiceDefinition> {
+        // Access control context for the sandbox's "main" bundles.
+        // All "main" bundles are assumed to have equal access rights.
+        val accessControlContext = bundles.first().adapt(AccessControlContext::class.java)
         val serviceFilter = vnc.serviceFilter?.let { filter -> "(&$SANDBOX_FACTORY_FILTER$filter)" } ?: SANDBOX_FACTORY_FILTER
         val serviceMarkerTypeName = vnc.serviceMarkerType.name
         return bundleContext.getServiceReferences(vnc.serviceMarkerType, serviceFilter).mapNotNull { serviceRef ->
@@ -138,6 +145,7 @@ class SandboxGroupContextServiceImpl(
                 @Suppress("unchecked_cast")
                 (serviceRef.getProperty(OBJECTCLASS) as? Array<String> ?: emptyArray())
                     .filterNot(serviceMarkerTypeName::equals)
+                    .filter(accessControlContext::checkServicePermission)
                     .mapNotNullTo(ArrayList(), bundles::loadCommonService)
                     .takeIf(List<*>::isNotEmpty)
                     ?.let { injectables ->
@@ -286,6 +294,21 @@ class SandboxGroupContextServiceImpl(
             runIgnoringExceptions { (serviceFactory as ServiceObjects<Any>).ungetService(serviceObj) }
         }
     }
+}
+
+/**
+ * Check whether this [AccessControlContext] is allowed to GET service [serviceType].
+ */
+private fun AccessControlContext.checkServicePermission(serviceType: String): Boolean {
+    val sm = System.getSecurityManager()
+    if (sm != null) {
+        try {
+            sm.checkPermission(ServicePermission(serviceType, GET), this)
+        } catch (ace: AccessControlException) {
+            return false
+        }
+    }
+    return true
 }
 
 /**

--- a/testing/cpbs/sandbox-security-manager-one/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-one/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
+    cordaProvided 'org.osgi:osgi.core'
     cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/testing/cpbs/sandbox-security-manager-one/src/main/kotlin/com/example/securitymanager/one/flows/FlowEngineFlow.kt
+++ b/testing/cpbs/sandbox-security-manager-one/src/main/kotlin/com/example/securitymanager/one/flows/FlowEngineFlow.kt
@@ -1,0 +1,21 @@
+package com.example.securitymanager.one.flows
+
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.util.loggerFor
+import org.osgi.framework.BundleContext
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+
+@Component
+class FlowEngineFlow @Activate constructor(private val context: BundleContext): SubFlow<String> {
+    private val logger = loggerFor<FlowEngineFlow>()
+
+    @Suspendable
+    override fun call(): String {
+        val flowEngine = context.getServiceReference(FlowEngine::class.java)?.let(context::getService)
+        logger.info("FlowEngine={}", flowEngine)
+        return flowEngine?.flowId?.toString() ?: "FlowEngine not found"
+    }
+}

--- a/testing/cpbs/sandbox-security-manager-one/src/main/kotlin/com/example/securitymanager/one/flows/HttpRequestFlow.kt
+++ b/testing/cpbs/sandbox-security-manager-one/src/main/kotlin/com/example/securitymanager/one/flows/HttpRequestFlow.kt
@@ -12,7 +12,7 @@ class HttpRequestFlow
 @Activate constructor() : SubFlow<Int> {
 
     override fun call(): Int  {
-        var url = URL("http://example.com")
+        val url = URL("http://example.com")
         val connection = url.openConnection() as HttpURLConnection
         connection.requestMethod = "GET"
         connection.connectTimeout = 3000


### PR DESCRIPTION
Only create an OSGi service for a sandbox if Corda's security policy has granted `ServicePermission "get"` to the sandbox for that service.

This allows us to DENY access to specific services based on the sandbox type, rather than relying solely on the sandbox having a bundle wiring for the service type.