### PR TITLE
CORE-5424 - combined worker Jenkins integration fixes

### DIFF
--- a/applications/workers/release/combined-worker/README.md
+++ b/applications/workers/release/combined-worker/README.md
@@ -16,7 +16,14 @@ docker run -d -p 5432:5432 --name postgresql -e POSTGRES_DB=cordacluster -e POST
 ```
 
 DB schema will be created automatically when worker is started.
-NOTE: DB bootstrapping might change as CLI could be used instead
+
+**NOTES:**
+
+* DB bootstrapping might change as CLI could be used instead, for example. Options are being looked at by the DevEx team.
+* Currently, the bootstrapper expects a postgres connection with the a superuser with credentials `postgres`/`password` 
+(as per docker command above). If you need to use different credentials, you can specify them with the following environment variables:
+  * `CORDA_DEV_POSTGRES_USER`
+  * `CORDA_DEV_POSTGRES_PASSWORD`
 
 ## Start the worker
 
@@ -31,7 +38,7 @@ Run the worker using:
 java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
   ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
   --instanceId=0 -mbus.busType=DATABASE  \
-  -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt \
+  -spassphrase=password -ssalt=salt \
   -ddatabase.user=user -ddatabase.pass=password \
   -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
 ```
@@ -41,7 +48,7 @@ Or if you want to connect to "real" KAFKA (see below):
 java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
   ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
   --instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 \
-  -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt \
+  -spassphrase=password -ssalt=salt \
   -ddatabase.user=user -ddatabase.pass=password \
   -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
 ```

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -91,15 +91,18 @@ tasks.register('smokeTest', Test) {
     testClassesDirs = project.sourceSets["smokeTest"].output.classesDirs
     classpath = project.sourceSets["smokeTest"].runtimeClasspath
 
+    def combinedWorker = project.getProperties().getOrDefault("isCombinedWorker",false)
     systemProperty "rpcHost", project.getProperties().getOrDefault("rpcHost","https://localhost:8888/")
     systemProperty "cryptoWorkerHealthHttp",
-            project.getProperties().getOrDefault("cryptoWorkerHealthHttp","http://localhost:7001/")
+            project.getProperties().getOrDefault("cryptoWorkerHealthHttp",combinedWorker ? null : "http://localhost:7001/")
     systemProperty "dbWorkerHealthHttp",
-            project.getProperties().getOrDefault("dbWorkerHealthHttp","http://localhost:7002/")
+            project.getProperties().getOrDefault("dbWorkerHealthHttp",combinedWorker ? null : "http://localhost:7002/")
     systemProperty "flowWorkerHealthHttp",
-            project.getProperties().getOrDefault("flowWorkerHealthHttp","http://localhost:7003/")
+            project.getProperties().getOrDefault("flowWorkerHealthHttp",combinedWorker ? null : "http://localhost:7003/")
     systemProperty "rpcWorkerHealthHttp",
-            project.getProperties().getOrDefault("rpcWorkerHealthHttp","http://localhost:7004/")
+            project.getProperties().getOrDefault("rpcWorkerHealthHttp",combinedWorker ? null : "http://localhost:7004/")
+    systemProperty "combinedWorkerHealthHttp",
+            project.getProperties().getOrDefault("combinedWorkerHealthHttp",combinedWorker ? "http://localhost:7000/" : null)
 }
 
 

--- a/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/PostgresDbSetup.kt
+++ b/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/PostgresDbSetup.kt
@@ -26,9 +26,8 @@ class PostgresDbSetup: DbSetup {
         private const val DB_PORT = "5432"
         private const val DB_NAME = "cordacluster"
         private const val DB_URL = "jdbc:postgresql://$DB_HOST:$DB_PORT/$DB_NAME"
-        private const val DB_SUPERUSER = "postgres"
-        private const val DB_SUPERUSER_PASSWORD = "password"
-        private const val DB_SUPERUSER_URL = "$DB_URL?user=$DB_SUPERUSER&password=$DB_SUPERUSER_PASSWORD"
+        private const val DB_SUPERUSER_DEFAULT = "postgres"
+        private const val DB_SUPERUSER_PASSWORD_DEFAULT = "password"
         private const val DB_ADMIN = "user"
         private const val DB_ADMIN_PASSWORD = "password"
         private const val DB_ADMIN_URL = "$DB_URL?user=$DB_ADMIN&password=$DB_ADMIN_PASSWORD"
@@ -44,8 +43,18 @@ class PostgresDbSetup: DbSetup {
         )
     }
 
+
+    private val dbSuperUserUrl by lazy {
+        val superUser = System.getenv("CORDA_DEV_POSTGRES_USER") ?: DB_SUPERUSER_DEFAULT
+        val superUserPassword = System.getenv("CORDA_DEV_POSTGRES_PASSWORD") ?: DB_SUPERUSER_PASSWORD_DEFAULT
+
+        "$DB_URL?user=$superUser&password=$superUserPassword"
+    }
+
     override fun run() {
         Class.forName(DB_DRIVER)
+
+
 
         if (!dbInitialised()) {
             initDb()
@@ -59,7 +68,7 @@ class PostgresDbSetup: DbSetup {
 
     private fun dbInitialised(): Boolean {
         DriverManager
-            .getConnection(DB_SUPERUSER_URL)
+            .getConnection(dbSuperUserUrl)
             .use { connection ->
                 connection.createStatement().executeQuery(
                     "SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname = 'config' AND tablename = 'config');")
@@ -74,7 +83,7 @@ class PostgresDbSetup: DbSetup {
 
     private fun initDb() {
         DriverManager
-            .getConnection(DB_SUPERUSER_URL)
+            .getConnection(dbSuperUserUrl)
             .use { connection ->
                 connection.createStatement().execute(
                     // NOTE: this is different to the cli as this is set up to be using the official postgres image


### PR DESCRIPTION
- Pick up combinedWorkerStatus endpoint from gradle property
- Expose `isCombinedWorker` property.
- Allow postgres superadmin credentials to be set as env variables.