### PR TITLE
NOTICK: fix SandboxGroupCtxComponent exception

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -130,7 +130,6 @@ class SandboxGroupContextComponentImpl @Activate constructor(
 
     @Deactivate
     override fun close() {
-        stop()
         coordinator.close()
         sandboxGroupContextService?.close()
         cpkReadService.close()


### PR DESCRIPTION
Remove unneeded call to stop() that calls coordinator.stop() because
next call to coordinator.close() call coordinator.stop() again which
raises an exception