### PR TITLE
CORE-5145 Merkle tree tweaks

### DIFF
--- a/libs/crypto/merkle/src/integrationTest/kotlin/net/corda/crypto/merkle/tests/MerkleTreeFactoryTest.kt
+++ b/libs/crypto/merkle/src/integrationTest/kotlin/net/corda/crypto/merkle/tests/MerkleTreeFactoryTest.kt
@@ -28,7 +28,7 @@ class MerkleTreeFactoryTest {
         nonceHashDigestProvider = merkleTreeFactory.createHashDigestProvider(
             HASH_DIGEST_PROVIDER_NONCE_NAME,
             digestAlgorithm,
-            mapOf(HASH_DIGEST_PROVIDER_ENTROPY_OPTION to 123.toByteArray())
+            mapOf(HASH_DIGEST_PROVIDER_ENTROPY_OPTION to "1".repeat(32).toByteArray())
         )
     }
 

--- a/libs/crypto/merkle/src/main/kotlin/net/corda/crypto/merkle/MerkleTreeFactoryImpl.kt
+++ b/libs/crypto/merkle/src/main/kotlin/net/corda/crypto/merkle/MerkleTreeFactoryImpl.kt
@@ -63,6 +63,10 @@ class MerkleTreeFactoryImpl @Activate constructor(
                 require(entropy is ByteArray){
                     "NonceHashDigestProvider needs a ByteArray $HASH_DIGEST_PROVIDER_ENTROPY_OPTION option"
                 }
+                require(entropy.size == NonceHashDigestProvider.EXPECTED_ENTROPY_LENGTH){
+                    "NonceHashDigestProvider needs a ${NonceHashDigestProvider.EXPECTED_ENTROPY_LENGTH} long " +
+                    "ByteArray $HASH_DIGEST_PROVIDER_ENTROPY_OPTION option"
+                }
                 return NonceHashDigestProvider(digestAlgorithmName, digestService, entropy)
             }
             else ->

--- a/libs/crypto/merkle/src/main/kotlin/net/corda/crypto/merkle/MerkleTreeHashDigestProviders.kt
+++ b/libs/crypto/merkle/src/main/kotlin/net/corda/crypto/merkle/MerkleTreeHashDigestProviders.kt
@@ -13,7 +13,7 @@ import java.nio.charset.Charset
 import java.security.SecureRandom
 
 private fun createNonce(random: SecureRandom): ByteArray {
-    val nonce = ByteArray(16)
+    val nonce = ByteArray(NonceHashDigestProvider.EXPECTED_ENTROPY_LENGTH)
     random.nextBytes(nonce)
     return nonce
 }
@@ -75,6 +75,9 @@ open class NonceHashDigestProvider(
     private val digestService: DigestService,
     val entropy: ByteArray,
     ) : MerkleTreeHashDigestProviderWithSizeProofSupport {
+    companion object{
+        val EXPECTED_ENTROPY_LENGTH = 32
+    }
     constructor(
         digestAlgorithmName: DigestAlgorithmName = DigestAlgorithmName.SHA2_256D,
         digestService: DigestService,

--- a/libs/crypto/merkle/src/main/kotlin/net/corda/crypto/merkle/MerkleTreeHashDigestProviders.kt
+++ b/libs/crypto/merkle/src/main/kotlin/net/corda/crypto/merkle/MerkleTreeHashDigestProviders.kt
@@ -53,6 +53,12 @@ class TweakableHashDigestProvider(
         require(!leafPrefix.contentEquals(nodePrefix)) {
             "Hash prefix for nodes must be different to that for leaves"
         }
+        require(leafPrefix.size > 0) {
+            "Leaf prefix cannot be empty"
+        }
+        require(nodePrefix.size > 0) {
+            "Node prefix cannot be empty"
+        }
     }
 
     override fun leafNonce(index: Int): ByteArray? = null

--- a/libs/crypto/merkle/src/test/kotlin/net/corda/crypto/merkle/MerkleTreeTest.kt
+++ b/libs/crypto/merkle/src/test/kotlin/net/corda/crypto/merkle/MerkleTreeTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.security.SecureRandom
@@ -59,6 +60,19 @@ class MerkleTreeTest {
 
         @JvmStatic
         fun merkleProofTestSizes(): List<Int> = (1 until 16).toList()
+    }
+
+    @Test
+    fun `Tweakable hash digest provider argument min length tests`() {
+        assertDoesNotThrow {
+            TweakableHashDigestProvider(digestAlgorithm, digestService, "0".toByteArray(), "1".toByteArray())
+        }
+        assertThrows(IllegalArgumentException::class.java)  {
+            TweakableHashDigestProvider(digestAlgorithm, digestService, "".toByteArray(), "1".toByteArray())
+        }
+        assertThrows(IllegalArgumentException::class.java)  {
+            TweakableHashDigestProvider(digestAlgorithm, digestService, "0".toByteArray(), "".toByteArray())
+        }
     }
 
     @Test


### PR DESCRIPTION
 * Update Nonce Hash Digest Provider's expected entropy length.
 * Enforce Tweakable Hash Digest Provider's arguments min length.

API: https://github.com/corda/corda-api/pull/484