### PR TITLE
CORE-5397: Change OpenAPI input params wrapping logic

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
@@ -77,7 +77,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
 
         val mediaType = requestBody.content["application/json"]
         assertNotNull(mediaType)
-        assertEquals("#/components/schemas/DaysOfTheYearRequest", mediaType.schema.`$ref`)
+        assertEquals("#/components/schemas/DaysOfTheYearWrapperRequest", mediaType.schema.`$ref`)
 
         val responseOk = path.post.responses["200"]
         assertNotNull(responseOk)
@@ -117,14 +117,14 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             val postParams = post.parameters
             assertTrue(postParams.isEmpty())
             assertEquals(
-                "#/components/schemas/CreateRequest",
+                "#/components/schemas/CreationParams",
                 post.requestBody.content["application/json"]?.schema?.`$ref`
             )
 
             val putParams = put.parameters
             assertTrue(putParams.isEmpty())
             assertEquals(
-                "#/components/schemas/UpdateRequest",
+                "#/components/schemas/UpdateParams",
                 put.requestBody.content["application/json"]?.schema?.`$ref`
             )
 
@@ -181,21 +181,13 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             val requestBodyJson = post.requestBody.content["application/json"]
             assertNotNull(requestBodyJson)
             val ref = requestBodyJson.schema.`$ref`
-            assertThat(ref).isEqualTo("#/components/schemas/PostTakesNullableReturnsNullableRequest")
+            assertThat(ref).isEqualTo("#/components/schemas/SomeInfo")
             val successResponse = post.responses["200"]
             assertNotNull(successResponse)
             val content = successResponse.content["application/json"]
             assertNotNull(content)
             val schema = content.schema
             assertTrue(schema.nullable, "The schema should have the nullable property")
-        }
-
-        with(openAPI.components.schemas["PostTakesNullableReturnsNullableRequest"]) {
-            assertNotNull(this)
-            assertThat(this.nullable).isTrue
-            val someInfo = this.properties["someInfo"]
-            assertNotNull(someInfo)
-            assertThat(someInfo.`$ref`).isEqualTo("#/components/schemas/SomeInfo")
         }
 
         with(openAPI.components.schemas["SomeInfo"]) {

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
@@ -133,10 +133,14 @@ private fun List<EndpointParameter>.toMediaType(
             Schema<Any>().properties(this.toProperties(schemaModelProvider))
                 .type(DataType.OBJECT.toString().lowercase())
         )
-    } else if (isSingleRef || multiParams) {
+    } else if (isSingleRef) {
+        MediaType().schema(
+            SchemaModelToOpenApiSchemaConverter.convert(schemaModelProvider.toSchemaModel(this.first()))
+        )
+    } else if (multiParams) {
         MediaType().schema(
             SchemaModelToOpenApiSchemaConverter.convert(
-                schemaModelProvider.toSchemaModel(this, methodName + "Request")
+                schemaModelProvider.toSchemaModel(this, methodName + "WrapperRequest")
             )
         )
     } else {

--- a/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/apigen/processing/ResourceToOpenApiSpecMapperTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/apigen/processing/ResourceToOpenApiSpecMapperTest.kt
@@ -192,7 +192,7 @@ class ResourceToOpenApiSpecMapperTest {
             assertTrue(components.schemas.containsKey("PingPongData"))
 
             assertEquals(
-                "#/components/schemas/PingRequest",
+                "#/components/schemas/PingPongData",
                 this.paths["/health/ping"]!!.post.requestBody.content["application/json"]!!.schema.`$ref`
             )
         }

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -186,7 +186,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/GenerateCsrRequest"
+                "$ref" : "#/components/schemas/GenerateCsrWrapperRequest"
               }
             }
           },
@@ -225,7 +225,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/UpdateclusterconfigurationRequest"
+                "$ref" : "#/components/schemas/UpdateConfigParameters"
               }
             }
           },
@@ -539,7 +539,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/StartFlowRequest"
+                "$ref" : "#/components/schemas/StartFlowParameters"
               }
             }
           },
@@ -1165,7 +1165,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/GenerateKeyPairRequest"
+                "$ref" : "#/components/schemas/GenerateKeyPairWrapperRequest"
               }
             }
           },
@@ -1590,7 +1590,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/StartRegistrationRequest"
+                "$ref" : "#/components/schemas/MemberRegistrationRequest"
               }
             }
           },
@@ -1667,7 +1667,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/SetupHostedIdentitiesRequest"
+                "$ref" : "#/components/schemas/SetupHostedIdentitiesWrapperRequest"
               }
             }
           },
@@ -1697,7 +1697,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CreatePermissionRequest"
+                "$ref" : "#/components/schemas/CreatePermissionType"
               }
             }
           },
@@ -1829,7 +1829,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CreateRoleRequest"
+                "$ref" : "#/components/schemas/CreateRoleType"
               }
             }
           },
@@ -1866,7 +1866,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/AddPermissionRequest"
+                "$ref" : "#/components/schemas/AddPermissionWrapperRequest"
               }
             }
           },
@@ -1932,7 +1932,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/RemovePermissionRequest"
+                "$ref" : "#/components/schemas/RemovePermissionWrapperRequest"
               }
             }
           },
@@ -2098,7 +2098,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CreateUserRequest"
+                "$ref" : "#/components/schemas/CreateUserType"
               }
             }
           },
@@ -2135,7 +2135,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/AddRoleRequest"
+                "$ref" : "#/components/schemas/AddRoleWrapperRequest"
               }
             }
           },
@@ -2238,7 +2238,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/RemoveRoleRequest"
+                "$ref" : "#/components/schemas/RemoveRoleWrapperRequest"
               }
             }
           },
@@ -2299,7 +2299,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CreatevirtualnodeRequest"
+                "$ref" : "#/components/schemas/CreateVirtualNodeParameters"
               }
             }
           },
@@ -2357,7 +2357,7 @@
   },
   "components" : {
     "schemas" : {
-      "AddPermissionRequest" : {
+      "AddPermissionWrapperRequest" : {
         "required" : [ "permissionId", "roleId" ],
         "properties" : {
           "permissionId" : {
@@ -2373,10 +2373,10 @@
             "example" : "string"
           }
         },
-        "description" : "AddPermissionRequest",
+        "description" : "AddPermissionWrapperRequest",
         "nullable" : false
       },
-      "AddRoleRequest" : {
+      "AddRoleWrapperRequest" : {
         "required" : [ "loginName", "roleId" ],
         "properties" : {
           "loginName" : {
@@ -2392,7 +2392,7 @@
             "example" : "string"
           }
         },
-        "description" : "AddRoleRequest",
+        "description" : "AddRoleWrapperRequest",
         "nullable" : false
       },
       "CpiIdentifier" : {
@@ -2557,16 +2557,6 @@
           }
         }
       },
-      "CreatePermissionRequest" : {
-        "required" : [ "createPermissionType" ],
-        "properties" : {
-          "createPermissionType" : {
-            "$ref" : "#/components/schemas/CreatePermissionType"
-          }
-        },
-        "description" : "CreatePermissionRequest",
-        "nullable" : false
-      },
       "CreatePermissionType" : {
         "required" : [ "permissionString", "permissionType" ],
         "type" : "object",
@@ -2594,16 +2584,6 @@
         },
         "description" : "Details of the permission to be created"
       },
-      "CreateRoleRequest" : {
-        "required" : [ "createRoleType" ],
-        "properties" : {
-          "createRoleType" : {
-            "$ref" : "#/components/schemas/CreateRoleType"
-          }
-        },
-        "description" : "CreateRoleRequest",
-        "nullable" : false
-      },
       "CreateRoleType" : {
         "required" : [ "roleName" ],
         "type" : "object",
@@ -2620,16 +2600,6 @@
           }
         },
         "description" : "Details of the role to be created"
-      },
-      "CreateUserRequest" : {
-        "required" : [ "createUserType" ],
-        "properties" : {
-          "createUserType" : {
-            "$ref" : "#/components/schemas/CreateUserType"
-          }
-        },
-        "description" : "CreateUserRequest",
-        "nullable" : false
       },
       "CreateUserType" : {
         "required" : [ "enabled", "fullName", "loginName" ],
@@ -2755,16 +2725,6 @@
           }
         }
       },
-      "CreatevirtualnodeRequest" : {
-        "required" : [ "request" ],
-        "properties" : {
-          "request" : {
-            "$ref" : "#/components/schemas/CreateVirtualNodeParameters"
-          }
-        },
-        "description" : "CreatevirtualnodeRequest",
-        "nullable" : false
-      },
       "FlowStateErrorResponse" : {
         "required" : [ "message", "type" ],
         "type" : "object",
@@ -2835,7 +2795,7 @@
           }
         }
       },
-      "GenerateCsrRequest" : {
+      "GenerateCsrWrapperRequest" : {
         "required" : [ "certificateRole", "x500name" ],
         "properties" : {
           "certificateRole" : {
@@ -2870,10 +2830,10 @@
             "example" : "string"
           }
         },
-        "description" : "GenerateCsrRequest",
+        "description" : "GenerateCsrWrapperRequest",
         "nullable" : false
       },
-      "GenerateKeyPairRequest" : {
+      "GenerateKeyPairWrapperRequest" : {
         "required" : [ "alias", "hsmCategory", "scheme" ],
         "properties" : {
           "alias" : {
@@ -2895,7 +2855,7 @@
             "example" : "string"
           }
         },
-        "description" : "GenerateKeyPairRequest",
+        "description" : "GenerateKeyPairWrapperRequest",
         "nullable" : false
       },
       "GetCPIsResponse" : {
@@ -3261,7 +3221,7 @@
           }
         }
       },
-      "RemovePermissionRequest" : {
+      "RemovePermissionWrapperRequest" : {
         "required" : [ "permissionId", "roleId" ],
         "properties" : {
           "permissionId" : {
@@ -3277,10 +3237,10 @@
             "example" : "string"
           }
         },
-        "description" : "RemovePermissionRequest",
+        "description" : "RemovePermissionWrapperRequest",
         "nullable" : false
       },
-      "RemoveRoleRequest" : {
+      "RemoveRoleWrapperRequest" : {
         "required" : [ "loginName", "roleId" ],
         "properties" : {
           "loginName" : {
@@ -3296,7 +3256,7 @@
             "example" : "string"
           }
         },
-        "description" : "RemoveRoleRequest",
+        "description" : "RemoveRoleWrapperRequest",
         "nullable" : false
       },
       "RoleAssociationResponseType" : {
@@ -3424,7 +3384,7 @@
           }
         }
       },
-      "SetupHostedIdentitiesRequest" : {
+      "SetupHostedIdentitiesWrapperRequest" : {
         "required" : [ "certificateChainAlias" ],
         "properties" : {
           "certificateChainAlias" : {
@@ -3446,7 +3406,7 @@
             "example" : "string"
           }
         },
-        "description" : "SetupHostedIdentitiesRequest",
+        "description" : "SetupHostedIdentitiesWrapperRequest",
         "nullable" : false
       },
       "StartFlowParameters" : {
@@ -3470,26 +3430,6 @@
           }
         },
         "description" : "Information required to start a flow for this holdingId"
-      },
-      "StartFlowRequest" : {
-        "required" : [ "startFlow" ],
-        "properties" : {
-          "startFlow" : {
-            "$ref" : "#/components/schemas/StartFlowParameters"
-          }
-        },
-        "description" : "StartFlowRequest",
-        "nullable" : false
-      },
-      "StartRegistrationRequest" : {
-        "required" : [ "memberRegistrationRequest" ],
-        "properties" : {
-          "memberRegistrationRequest" : {
-            "$ref" : "#/components/schemas/MemberRegistrationRequest"
-          }
-        },
-        "description" : "StartRegistrationRequest",
-        "nullable" : false
       },
       "StartableFlowsResponse" : {
         "required" : [ "flowClassNames" ],
@@ -3572,16 +3512,6 @@
             "example" : 0
           }
         }
-      },
-      "UpdateclusterconfigurationRequest" : {
-        "required" : [ "request" ],
-        "properties" : {
-          "request" : {
-            "$ref" : "#/components/schemas/UpdateConfigParameters"
-          }
-        },
-        "description" : "UpdateclusterconfigurationRequest",
-        "nullable" : false
       },
       "UploadResponse" : {
         "required" : [ "id" ],


### PR DESCRIPTION
If there is a single reference type - use it without wrapping. Else create an artificial type named `${methodName}WrapperRequest`.