### PR TITLE
CORE-5752 Adjust topic dump tool to use TLS

### DIFF
--- a/applications/tools/p2p-test/dump-topic/README.md
+++ b/applications/tools/p2p-test/dump-topic/README.md
@@ -19,14 +19,29 @@ To run the JAR, use:
 ```
 java -jar \
    applications/tools/p2p-test/dump-topic/build/bin/corda-dump-topic*.jar \
-   --kafka-servers broker1:9093 \
+   -mbootstrap.servers=broker1:9093 \
    --topic p2p.out.markers \
    --values net.corda.p2p.markers.AppMessageMarker \
    --output ./p2p-deployment/reports/markers.txt
 ```
 
-The command parameters are:
-* `kafka-servers` A comma-separated list of addresses of Kafka brokers. Default to localhost:9092
-* `topic` The name of the topic to dump
-* `values` The class name of the expected value (full canonical name)
-* `output` An output file to save all the data
+The command parameters are: 
+```
+-m, --messagingParams=<String=String>
+                        Messaging parameters for the topic dumper.
+                          Default: {}
+-o, --output=<output>   The output file.
+-t, --topic=<topic>     The name of the topic to dump.
+-v, --values=<values>   The class name of the expected value (full canonical
+                          name).
+```
+By default, the topic dumper will try and connect to a Kafka broker on localhost:9092.
+To override this use option `-m`. For example, to connect to a Kafka Broker on `kafka-broker:1000`:
+```bash
+java -jar applications/tools/p2p-test/app-simulator/build/bin/corda-app-simulator*.jar -mbootstrap.servers=kafka-broker:1000
+```
+These -m options are passed into the Kafka client. For example to use TLS to connect to the Kafka broker the following -m options can be used:
+```bash
+java -jar ./applications/p2p-link-manager/build/bin/corda-p2p-link-manager*.jar -msecurity.protocol=SSL -mssl.truststore.location=/certs/ca.crt -mssl.truststore.type=PEM
+```
+

--- a/applications/tools/p2p-test/dump-topic/build.gradle
+++ b/applications/tools/p2p-test/dump-topic/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation "info.picocli:picocli:$picocliVersion"
     implementation "org.apache.avro:avro:$avroVersion"
     implementation project(":libs:configuration:configuration-core")
+    implementation project(":libs:configuration:configuration-merger")
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle:lifecycle")
     implementation 'net.corda:corda-config-schema'

--- a/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/Application.kt
+++ b/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/Application.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.app.topic.dump
 
+import net.corda.libs.configuration.merger.ConfigMerger
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
@@ -14,9 +15,11 @@ internal class Application @Activate constructor(
     @Reference(service = Shutdown::class)
     private val shutDownService: Shutdown,
     @Reference(service = SubscriptionFactory::class)
-    private val subscriptionFactory: SubscriptionFactory
+    private val subscriptionFactory: SubscriptionFactory,
+    @Reference(service = ConfigMerger::class)
+    private val configMerger: ConfigMerger
 ) : Application {
-    private val topicDumper = TopicDumper(subscriptionFactory)
+    private val topicDumper = TopicDumper(subscriptionFactory, configMerger)
     override fun startup(args: Array<String>) {
         val command = CommandLine(topicDumper)
         @Suppress("SpreadOperator")

--- a/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/TopicDumper.kt
+++ b/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/TopicDumper.kt
@@ -14,11 +14,9 @@ import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
-import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVERS
 import org.apache.avro.generic.IndexedRecord
 import org.osgi.framework.FrameworkUtil
 import org.slf4j.LoggerFactory
-import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.Closeable

--- a/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/TopicDumper.kt
+++ b/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/TopicDumper.kt
@@ -1,12 +1,16 @@
 package net.corda.p2p.app.topic.dump
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
+import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.libs.configuration.merger.ConfigMerger
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
@@ -14,6 +18,7 @@ import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_BOOTSTRAP_SERVER
 import org.apache.avro.generic.IndexedRecord
 import org.osgi.framework.FrameworkUtil
 import org.slf4j.LoggerFactory
+import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.Closeable
@@ -31,34 +36,35 @@ import kotlin.random.Random
     showAtFileInUsageHelp = true,
 )
 internal class TopicDumper(
-    private val subscriptionFactory: SubscriptionFactory
+    private val subscriptionFactory: SubscriptionFactory,
+    private val configMerger: ConfigMerger
 ) : Runnable, Closeable {
     companion object {
         private val logger = LoggerFactory.getLogger("Console")
     }
     @Option(
-        names = ["-k", "--kafka-servers"],
-        description = ["A comma-separated list of addresses of Kafka brokers."]
+        names = ["-m", "--messagingParams"],
+        description = ["Messaging parameters for the topic dumper."]
     )
-    private var kafkaServers = System.getenv("KAFKA_SERVERS") ?: "localhost:9092"
+    var messagingParams = emptyMap<String, String>()
 
     @Option(
         names = ["-t", "--topic"],
-        description = ["The topic to dump"],
+        description = ["The name of the topic to dump."],
         required = true,
     )
     private lateinit var topic: String
 
     @Option(
         names = ["-v", "--values"],
-        description = ["The value class"],
+        description = ["The class name of the expected value (full canonical name)."],
         required = true,
     )
     private lateinit var values: String
 
     @Option(
         names = ["-o", "--output"],
-        description = ["The output file"],
+        description = ["The output file."],
         required = true,
     )
     private lateinit var output: File
@@ -136,14 +142,26 @@ internal class TopicDumper(
 
     override fun run() {
         output.parentFile.mkdirs()
-        logger.info("Connecting to $kafkaServers")
         val subscriptionConfig = SubscriptionConfig("topic-dumper-${UUID.randomUUID()}", topic)
-        val kafkaConfig = SmartConfigImpl.empty()
-            .withValue(KAFKA_BOOTSTRAP_SERVERS, ConfigValueFactory.fromAnyRef(kafkaServers))
-            .withValue(BUS_TYPE, ConfigValueFactory.fromAnyRef("KAFKA"))
-            .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(""))
-            .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(Random.nextInt()))
-        subscription = subscriptionFactory.createDurableSubscription(subscriptionConfig, createProcessor(), kafkaConfig, null).also {
+        val parsedMessagingParams = messagingParams.mapKeys { (key, _) ->
+            "${BootConfig.BOOT_KAFKA_COMMON}.${key.trim()}"
+        }.toMutableMap()
+        parsedMessagingParams.computeIfAbsent("${BootConfig.BOOT_KAFKA_COMMON}.bootstrap.servers") {
+            "localhost:9092"
+        }
+        logger.info("Connecting to ${parsedMessagingParams["${BootConfig.BOOT_KAFKA_COMMON}.bootstrap.servers"]}")
+        val kafkaConfig = SmartConfigFactory.create(SmartConfigImpl.empty()).create(
+            ConfigFactory.parseMap(parsedMessagingParams)
+                .withValue(BUS_TYPE, ConfigValueFactory.fromAnyRef("KAFKA"))
+                .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(""))
+                .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(Random.nextInt()))
+        )
+        subscription = subscriptionFactory.createDurableSubscription(
+            subscriptionConfig,
+            createProcessor(),
+            configMerger.getMessagingConfig(kafkaConfig),
+            null
+        ).also {
             it.start()
         }
         logger.info("Started dumping $topic into $output")


### PR DESCRIPTION
Modified the topic-dump tool to take -m options to work in the same way as the LinkManager, Gateway, AppSimulator and the common worker framework. To set the kafka to connect to a broker on kafka-broker:1000 use -mbootstrap.servers=kafka-broker:1000. To enable TLS add the following options: -msecurity.protocol=SSL, -mssl.truststore.location=/certs/ca.crt and -mssl.truststore.type=PEM. Where /certs/ca.crt is the trust store.

I have manually tested this by:
---

1. Deploying the prerequisite and corda helm charts.
2. Extracting the kafka trust root from Kubernetes:
```
kubectl get secret prereqs-kafka-0-tls -o go-template='{{ index .data "ca.crt" }}' -n corda | base64 -D > ca.crt
```
3. Start kubefwd so the app simulator can talk to Kafka from outside of the cluster:
```
sudo kubefwd svc -n corda
```
4. Dump the config topic:
```
java -jar \
   applications/tools/p2p-test/dump-topic/build/bin/corda-dump-topic*.jar \
   -mbootstrap.servers=prereqs-kafka:9092 -msecurity.protocol=SSL -mssl.truststore.location=./ca.crt -mssl.truststore.type=PEM \
   --topic config.topic \
   --values net.corda.data.config.Configuration \
   --output ./config.txt
```
Eventually we see some messages:
```
william.vigor@22LDN-MAC13TJGH5 corda-runtime-os % java -jar \
   applications/tools/p2p-test/dump-topic/build/bin/corda-dump-topic*.jar \
   -mbootstrap.servers=prereqs-kafka:9092 -msecurity.protocol=SSL -mssl.truststore.location=./ca.crt -mssl.truststore.type=PEM \
   --topic config.topic \
   --values net.corda.data.config.Configuration \
   --output ./config.txt
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
15:32:24.935 [main] INFO  Console - Connecting to prereqs-kafka:9092
15:32:25.025 [main] INFO  Console - Started dumping config.topic into ./config.txt
15:32:26.028 [Thread-3] INFO  Console - Got 0 messages
15:32:27.028 [Thread-3] INFO  Console - Got 0 messages
15:32:28.028 [Thread-3] INFO  Console - Got 0 messages
15:32:29.028 [Thread-3] INFO  Console - Got 0 messages
15:32:30.027 [Thread-3] INFO  Console - Got 0 messages
15:32:31.026 [Thread-3] INFO  Console - Got 0 messages
15:32:32.030 [Thread-3] INFO  Console - Got 0 messages
15:32:33.029 [Thread-3] INFO  Console - Got 0 messages
15:32:34.031 [Thread-3] INFO  Console - Got 0 messages
15:32:35.031 [Thread-3] INFO  Console - Got 0 messages
15:32:36.031 [Thread-3] INFO  Console - Got 0 messages
15:32:37.031 [Thread-3] INFO  Console - Got 7 messages
```
If we look inside `./config.txt` after killing the topic dump tool we see config as expected.