### PR TITLE
CORE-5151 Use LinkManager Processor in LinkManagerApp

### DIFF
--- a/applications/p2p-link-manager/build.gradle
+++ b/applications/p2p-link-manager/build.gradle
@@ -11,48 +11,33 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation project(':components:link-manager')
-    implementation project(':components:domino-logic')
-    implementation project(':components:p2p-test:stub-crypto-processor')
+    implementation project(':processors:link-manager-processor')
     implementation project(':osgi-framework-api')
+    implementation project(":libs:utilities")
+    implementation project(":libs:configuration:configuration-core")
+    implementation project(":libs:configuration:configuration-merger")
+    implementation project(":libs:messaging:messaging")
+    implementation project(":libs:messaging:message-bus")
+    implementation project(":components:configuration:configuration-read-service")
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
+
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'
-    implementation project(":components:membership:group-policy")
-    implementation project(":components:crypto:crypto-client")
-    implementation project(":components:membership:membership-group-read")
+
+    runtimeOnly project(":libs:lifecycle:lifecycle-impl")
+    runtimeOnly project(":components:configuration:configuration-read-service-impl")
+    runtimeOnly project(":libs:messaging:kafka-message-bus-impl")
 
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-
-    runtimeOnly project(":libs:schema-registry:schema-registry-impl")
-    runtimeOnly project(":libs:messaging:messaging-impl")
-    runtimeOnly project(":libs:messaging:kafka-message-bus-impl")
-    runtimeOnly project(":libs:lifecycle:lifecycle-impl")
-    runtimeOnly project(":components:configuration:configuration-read-service-impl")
-    runtimeOnly project(":components:membership:group-policy-impl")
-    runtimeOnly project(":components:virtual-node:cpi-info-read-service-impl")
-    runtimeOnly project(":libs:membership:membership-impl")
-    runtimeOnly project(":libs:layered-property-map")
-    runtimeOnly project(':libs:crypto:cipher-suite-impl')
-    runtimeOnly project(":components:membership:membership-group-read-impl")
-    implementation project(':components:virtual-node:virtual-node-info-read-service')
-    implementation project(":components:virtual-node:cpi-info-read-service")
-
-    runtimeOnly project(":components:crypto:crypto-client-impl")
-    implementation project(":libs:utilities")
-    implementation project(":libs:configuration:configuration-core")
-    implementation project(":libs:configuration:configuration-merger")
-    implementation project(":libs:messaging:messaging")
-    implementation project(":components:configuration:configuration-read-service")
 
     dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
 }

--- a/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/LinkManagerApp.kt
+++ b/applications/p2p-link-manager/src/main/kotlin/net.corda.applications.linkmanager/LinkManagerApp.kt
@@ -1,126 +1,35 @@
 package net.corda.applications.linkmanager
 
 import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigValueFactory
-import kotlin.concurrent.thread
-import net.corda.configuration.read.ConfigurationReadService
-import net.corda.cpiinfo.read.CpiInfoReadService
-import net.corda.crypto.client.CryptoOpsClient
-import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
-import net.corda.libs.configuration.merger.ConfigMerger
-import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.membership.grouppolicy.GroupPolicyProvider
-import net.corda.membership.read.MembershipGroupReaderProvider
-import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
-import net.corda.p2p.linkmanager.LinkManager
-import net.corda.p2p.linkmanager.ThirdPartyComponentsMode
-import net.corda.schema.configuration.MessagingConfig.Subscription.POLL_TIMEOUT
-import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.processors.p2p.linkmanager.LinkManagerProcessor
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 @Component
 @Suppress("LongParameterList")
 class LinkManagerApp @Activate constructor(
     @Reference(service = Shutdown::class)
     private val shutDownService: Shutdown,
-    @Reference(service = ConfigurationReadService::class)
-    private val configurationReadService: ConfigurationReadService,
-    @Reference(service = SubscriptionFactory::class)
-    private val subscriptionFactory: SubscriptionFactory,
-    @Reference(service = PublisherFactory::class)
-    private val publisherFactory: PublisherFactory,
-    @Reference(service = LifecycleCoordinatorFactory::class)
-    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    @Reference(service = ConfigMerger::class)
-    private val configMerger: ConfigMerger,
-    @Reference(service = GroupPolicyProvider::class)
-    private val groupPolicyProvider: GroupPolicyProvider,
-    @Reference(service = VirtualNodeInfoReadService::class)
-    private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
-    @Reference(service = CpiInfoReadService::class)
-    private val cpiInfoReadService: CpiInfoReadService,
-    @Reference(service = CryptoOpsClient::class)
-    private val cryptoOpsClient: CryptoOpsClient,
-    @Reference(service = MembershipGroupReaderProvider::class)
-    private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
+    @Reference(service = LinkManagerProcessor::class)
+    private val linkManagerProcessor: LinkManagerProcessor,
     ) : Application {
-
-    companion object {
-        private val consoleLogger: Logger = LoggerFactory.getLogger("Console")
-    }
-    private var linkManager: LinkManager? = null
 
     override fun startup(args: Array<String>) {
         val arguments = CliArguments.parse(args)
-
+        val bootConfig = SmartConfigFactory.create(ConfigFactory.empty()).create(arguments.bootConfiguration)
         if (arguments.helpRequested) {
             shutDownService.shutdown(FrameworkUtil.getBundle(this::class.java))
         } else {
-
-            // TODO - move to common worker and pick up secrets params
-            consoleLogger.info("Starting the configuration service")
-            val secretsConfig = ConfigFactory.empty()
-            val bootConfig = SmartConfigFactory.create(secretsConfig).create(arguments.bootConfiguration)
-            configurationReadService.start()
-            configurationReadService.bootstrapConfig(bootConfig)
-
-            consoleLogger.info("Starting link manager")
-            val messagingConfig = getMessagingConfig(bootConfig)
-            val thirdPartyComponentsMode = when(arguments.withoutStubs) {
-                true -> ThirdPartyComponentsMode.REAL
-                false -> ThirdPartyComponentsMode.STUB
-            }
-            linkManager = LinkManager(
-                subscriptionFactory,
-                publisherFactory,
-                lifecycleCoordinatorFactory,
-                configurationReadService,
-                messagingConfig,
-                groupPolicyProvider,
-                virtualNodeInfoReadService,
-                cpiInfoReadService,
-                cryptoOpsClient,
-                membershipGroupReaderProvider,
-                thirdPartyComponentsMode,
-            ).also { linkmanager ->
-                linkmanager.start()
-
-                thread(isDaemon = true) {
-                    while (!linkmanager.isRunning) {
-                        consoleLogger.info("Waiting for link manager to start...")
-                        Thread.sleep(1000)
-                    }
-                    consoleLogger.info("Link manager is running")
-                }
-            }
+            linkManagerProcessor.start(bootConfig, !arguments.withoutStubs)
         }
-    }
-
-    private fun getMessagingConfig(bootConfig: SmartConfig): SmartConfig {
-        return configMerger.getMessagingConfig(bootConfig).withValue(
-            // The default value of poll timeout is quite high (6 seconds), so setting it to something lower.
-            // Specifically, state & event subscriptions have an issue where they are polling with high timeout on events topic,
-            // leading to slow syncing upon startup. See: https://r3-cev.atlassian.net/browse/CORE-3163
-            POLL_TIMEOUT,
-            ConfigValueFactory.fromAnyRef(100)
-        )
     }
 
     override fun shutdown() {
-        if (linkManager != null) {
-            consoleLogger.info("Closing link manager")
-            linkManager?.stop()
-            consoleLogger.info("Link manager closed")
-        }
+        linkManagerProcessor.stop()
     }
-
 }

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/LinkManager.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/LinkManager.kt
@@ -13,5 +13,5 @@ class LinkManager(
 
     override val imageName = "p2p-link-manager"
 
-    override val readyLog = ".*Waiting for link manager to start.*".toRegex()
+    override val readyLog = ".*LinkManager-1 - Starting child.*".toRegex()
 }

--- a/processors/link-manager-processor/build.gradle
+++ b/processors/link-manager-processor/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'
     implementation 'net.corda:corda-base'
+    implementation 'net.corda:corda-config-schema'
 
     implementation project(':components:configuration:configuration-read-service')
     implementation project(':components:domino-logic')

--- a/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/LinkManagerProcessor.kt
+++ b/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/LinkManagerProcessor.kt
@@ -2,7 +2,6 @@ package net.corda.processors.p2p.linkmanager
 
 import net.corda.libs.configuration.SmartConfig
 import net.corda.p2p.linkmanager.LinkManager
-import net.corda.p2p.linkmanager.ThirdPartyComponentsMode
 
 /**
  * The processor for a [LinkManager].

--- a/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/LinkManagerProcessor.kt
+++ b/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/LinkManagerProcessor.kt
@@ -2,13 +2,14 @@ package net.corda.processors.p2p.linkmanager
 
 import net.corda.libs.configuration.SmartConfig
 import net.corda.p2p.linkmanager.LinkManager
+import net.corda.p2p.linkmanager.ThirdPartyComponentsMode
 
 /**
  * The processor for a [LinkManager].
  * */
 interface LinkManagerProcessor {
 
-    fun start(bootConfig: SmartConfig)
+    fun start(bootConfig: SmartConfig, useStubComponents: Boolean)
 
     fun stop()
 }

--- a/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/internal/LinkManagerProcessorImpl.kt
+++ b/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/internal/LinkManagerProcessorImpl.kt
@@ -33,7 +33,7 @@ import org.slf4j.Logger
 
 @Suppress("LongParameterList", "Unused")
 @Component(service = [LinkManagerProcessor::class])
-class LinkManagerProcessImpl @Activate constructor(
+class LinkManagerProcessorImpl @Activate constructor(
     @Reference(service = ConfigMerger::class)
     private val configMerger: ConfigMerger,
     @Reference(service = ConfigurationReadService::class)
@@ -63,7 +63,7 @@ class LinkManagerProcessImpl @Activate constructor(
     private var registration: RegistrationHandle? = null
     private var linkManager: LinkManager? = null
 
-    private val lifecycleCoordinator = coordinatorFactory.createCoordinator<LinkManagerProcessImpl>(::eventHandler)
+    private val lifecycleCoordinator = coordinatorFactory.createCoordinator<LinkManagerProcessorImpl>(::eventHandler)
 
     override fun start(bootConfig: SmartConfig, useStubComponents: Boolean) {
         log.info("Link manager processor starting.")


### PR DESCRIPTION
Update the Link Manager Processor and use it from the Link Manager App. This significantly simplifies the LinkManagerApp.

Testing
===
1. Building all the OSGi docker images
2. Deploying the prerequisite and Corda helm charts.
3. Checking the LinkManager has started in the LinkManager container logs:
```
10:54:47.207 [lifecycle-coordinator-14] INFO  net.corda.processors.p2p.linkmanager.internal.LinkManagerProcessImpl - Link manager processor is UP
```

I also tested the P2P deployment. Sending 100 messages between two counterparties. All 100 messages were successfully delivered.