### PR TITLE
NOTICK - ensure entity manager is closed when commit throws

### DIFF
--- a/libs/db/db-orm/build.gradle
+++ b/libs/db/db-orm/build.gradle
@@ -13,4 +13,7 @@ dependencies {
 
     compileOnly "org.osgi:osgi.annotation"
     api "javax.persistence:javax.persistence-api"
+
+    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/libs/db/db-orm/src/main/kotlin/net/corda/orm/utils/EntityManagerUtils.kt
+++ b/libs/db/db-orm/src/main/kotlin/net/corda/orm/utils/EntityManagerUtils.kt
@@ -85,20 +85,21 @@ inline fun <R> EntityManager.transaction(block: (EntityManager) -> R): R {
  * @see transaction
  */
 inline fun <R> transactionExecutor(entityManager: EntityManager,  block: (EntityManager) -> R): R {
-    val currentTransaction = entityManager.transaction
-    currentTransaction.begin()
+    entityManager.use { em ->
+        val currentTransaction = em.transaction
+        currentTransaction.begin()
 
-    return try {
-        block(entityManager)
-    } catch (e: Exception) {
-        currentTransaction.setRollbackOnly()
-        throw e
-    } finally {
-        if (!currentTransaction.rollbackOnly) {
-            currentTransaction.commit()
-        } else {
-            currentTransaction.rollback()
+        return try {
+            block(em)
+        } catch (e: Exception) {
+            currentTransaction.setRollbackOnly()
+            throw e
+        } finally {
+            if (!currentTransaction.rollbackOnly) {
+                currentTransaction.commit()
+            } else {
+                currentTransaction.rollback()
+            }
         }
-        entityManager.close()
     }
 }

--- a/libs/db/db-orm/src/test/kotlin/net/corda/orm/EntityManagerUtilsTest.kt
+++ b/libs/db/db-orm/src/test/kotlin/net/corda/orm/EntityManagerUtilsTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import javax.persistence.EntityManager
 import javax.persistence.EntityTransaction
 
+@Suppress("TooGenericExceptionThrown")
 class EntityManagerUtilsTest {
 
     @Test

--- a/libs/db/db-orm/src/test/kotlin/net/corda/orm/EntityManagerUtilsTest.kt
+++ b/libs/db/db-orm/src/test/kotlin/net/corda/orm/EntityManagerUtilsTest.kt
@@ -1,0 +1,35 @@
+package net.corda.orm
+
+import net.corda.orm.utils.transactionExecutor
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import javax.persistence.EntityManager
+import javax.persistence.EntityTransaction
+
+class EntityManagerUtilsTest {
+
+    @Test
+    fun `when transaction and commit fails call close`() {
+        val tx = mock<EntityTransaction>() {
+            on { commit() } doThrow RuntimeException()
+        }
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        try {
+            transactionExecutor(em) {
+                println("do")
+            }
+        }
+        catch (e: Exception) {
+            println("Caught $e")
+        }
+
+        verify(em, times(1)).close()
+    }
+}

--- a/libs/db/db-orm/src/test/kotlin/net/corda/orm/EntityManagerUtilsTest.kt
+++ b/libs/db/db-orm/src/test/kotlin/net/corda/orm/EntityManagerUtilsTest.kt
@@ -1,7 +1,9 @@
 package net.corda.orm
 
 import net.corda.orm.utils.transactionExecutor
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
@@ -15,7 +17,7 @@ class EntityManagerUtilsTest {
     @Test
     fun `when transaction and commit fails call close`() {
         val tx = mock<EntityTransaction>() {
-            on { commit() } doThrow RuntimeException()
+            on { commit() } doThrow RuntimeException("exception when committing")
         }
         val em = mock<EntityManager>() {
             on { transaction } doReturn tx
@@ -31,5 +33,122 @@ class EntityManagerUtilsTest {
         }
 
         verify(em, times(1)).close()
+    }
+
+    @Test
+    fun `when transaction and rollback fails call close`() {
+        val tx = mock<EntityTransaction>() {
+            on { rollback() } doThrow RuntimeException("exception when rolling back")
+            on { rollbackOnly } doReturn (true)
+        }
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        try {
+            transactionExecutor(em) {
+                throw RuntimeException("exception in block")
+            }
+        }
+        catch (e: Exception) {
+            println("Caught $e")
+        }
+
+        verify(em, times(1)).close()
+    }
+
+    @Test
+    fun `when transaction close after commit`() {
+        val tx = mock<EntityTransaction>()
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        transactionExecutor(em) {
+            println("do")
+        }
+
+        verify(em, times(1)).close()
+    }
+
+    @Test
+    fun `when transaction call begin`() {
+        val tx = mock<EntityTransaction>()
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        transactionExecutor(em) {
+            println("do")
+        }
+
+        verify(tx, times(1)).begin()
+    }
+
+    @Test
+    fun `when transaction call commit`() {
+        val tx = mock<EntityTransaction>()
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        transactionExecutor(em) {
+            println("do")
+        }
+
+        verify(tx, times(1)).commit()
+    }
+
+    @Test
+    fun `when transaction and something goes wrong set rollback`() {
+        val tx = mock<EntityTransaction>()
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        try {
+            transactionExecutor(em) {
+                throw RuntimeException("exception in block")
+            }
+        }
+        catch (e: Exception) {
+            println("Caught $e")
+        }
+
+        verify(tx, times(1)).setRollbackOnly()
+    }
+
+    @Test
+    fun `when transaction and set rollback roll back and don't commit`() {
+        val tx = mock<EntityTransaction>() {
+            on { rollbackOnly } doReturn true
+        }
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        transactionExecutor(em) {
+            println("do")
+        }
+
+        verify(tx, times(1)).rollback()
+        verify(tx, times(0)).commit()
+    }
+
+    @Test
+    fun `when transaction and something goes wrong rethrow`() {
+        val tx = mock<EntityTransaction>()
+        val em = mock<EntityManager>() {
+            on { transaction } doReturn tx
+        }
+
+        val ex = RuntimeException("exception in block")
+        val thrown = assertThrows<RuntimeException> {
+            transactionExecutor(em) {
+                throw ex
+            }
+        }
+
+        assertThat(thrown).isEqualTo(ex)
     }
 }


### PR DESCRIPTION
This PR is proving/addressing a theory that the entity manager isn't closed when the `transaction` util is used and commit or rollback throws an exception.
When this happens, I believe the connection stays open instead of being returned to the pool.

Tests added to prove this.