### PR TITLE
NOTICK - Disable p2p tests that fail due to expired certificates temporarily

### DIFF
--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -82,6 +82,7 @@ import net.corda.v5.cipher.suite.schemes.RSA_TEMPLATE
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.jce.PrincipalUtil
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -98,6 +99,7 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
 
+@Disabled("Disable until CORE-5877 is completed and it can be enabled back.")
 class GatewayIntegrationTest : TestBase() {
     companion object {
         private val logger = contextLogger()

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/HttpTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/HttpTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.net.URI
@@ -41,6 +42,7 @@ import javax.net.ssl.X509ExtendedKeyManager
 import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
 
+@Disabled("Disable until CORE-5877 is completed and it can be enabled back.")
 class HttpTest : TestBase() {
 
     companion object {

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -71,6 +71,7 @@ import net.corda.v5.cipher.suite.schemes.RSA_TEMPLATE
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.io.StringWriter
@@ -86,6 +87,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import org.mockito.kotlin.mock
 import java.util.UUID
 
+@Disabled("Disable until CORE-5877 is completed and it can be enabled back.")
 class P2PLayerEndToEndTest {
 
     companion object {


### PR DESCRIPTION
 Disabling p2p tests that fail due to expired certificates temporarily, until we have re-generated the certificates and we can enable them back.