### PR TITLE
CORE-5408: Improvements to the modules packaging

### DIFF
--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
@@ -15,7 +15,7 @@ import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRPCOps
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeParameters
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeResponse
 import net.corda.libs.virtualnode.endpoints.v1.types.GetVirtualNodesResponse
-import net.corda.libs.virtualnode.endpoints.v1.types.toEndpointType
+import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
@@ -132,6 +132,22 @@ internal class VirtualNodeRPCOpsImpl @VisibleForTesting constructor(
     override fun getAllVirtualNodes(): GetVirtualNodesResponse {
         return GetVirtualNodesResponse(virtualNodeInfoReadService.getAll().map { it.toEndpointType() })
     }
+
+    private fun net.corda.virtualnode.VirtualNodeInfo.toEndpointType(): VirtualNodeInfo =
+        VirtualNodeInfo(
+            holdingIdentity,
+            cpiIdentifier.toEndpointType(),
+            vaultDdlConnectionId,
+            vaultDmlConnectionId,
+            cryptoDdlConnectionId,
+            cryptoDmlConnectionId,
+            hsmConnectionId,
+            version,
+            timestamp
+        )
+
+    private fun net.corda.libs.packaging.core.CpiIdentifier.toEndpointType(): CpiIdentifier =
+        CpiIdentifier(name, version, signerSummaryHash?.toString())
 
     /** Validates the [x500Name]. */
     private fun validateX500Name(x500Name: String) = try {

--- a/libs/virtual-node/cpi-upload-endpoints/build.gradle
+++ b/libs/virtual-node/cpi-upload-endpoints/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     api project(':libs:http-rpc:http-rpc')
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    api project(':libs:packaging:packaging-core')
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 }

--- a/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiIdentifier.kt
+++ b/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiIdentifier.kt
@@ -6,6 +6,3 @@ data class CpiIdentifier(val cpiName: String, val cpiVersion: String, val signer
             CpiIdentifier(cpiId.name, cpiId.version, cpiId.signerSummaryHash?.toString())
     }
 }
-
-fun net.corda.libs.packaging.core.CpiIdentifier.toEndpointType() : CpiIdentifier =
-    CpiIdentifier(name, version, signerSummaryHash?.toString())

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodeInfo.kt
@@ -1,7 +1,6 @@
 package net.corda.libs.virtualnode.endpoints.v1.types
 
 import net.corda.libs.cpiupload.endpoints.v1.CpiIdentifier
-import net.corda.libs.cpiupload.endpoints.v1.toEndpointType
 import net.corda.virtualnode.HoldingIdentity
 import java.time.Instant
 import java.util.UUID
@@ -24,10 +23,3 @@ data class VirtualNodeInfo(
     /** Creation timestamp */
     val timestamp: Instant,
 )
-
-fun net.corda.virtualnode.VirtualNodeInfo.toEndpointType() : VirtualNodeInfo =
-    VirtualNodeInfo(
-        holdingIdentity,
-        cpiIdentifier.toEndpointType(),
-        vaultDdlConnectionId, vaultDmlConnectionId, cryptoDdlConnectionId, cryptoDmlConnectionId, hsmConnectionId, version, timestamp
-    )


### PR DESCRIPTION
In particular, dependency: `api project(':libs:packaging:packaging-core')` is a problem as intention is to keep HTTP endpoints as lean as possible in terms of dependencies.

This might be important, if Java HTTP RPC Client is created against the interface it will not need to pull an extensive graph of transitive dependencies.