### PR TITLE
CORE-5674 Retry topic creation

### DIFF
--- a/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
+++ b/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
@@ -21,13 +21,13 @@ class CreateConnectTest {
     @Test
     fun `validate new topic with no config`() {
         assertThat(command().getTopics(listOf(Create.TopicConfig("topic", emptyList(), emptyList(), emptyMap()))))
-            .containsExactly(NewTopic("topic", 1, 1).configs(emptyMap()))
+            .containsEntry("topic", NewTopic("topic", 1, 1).configs(emptyMap()))
     }
 
     @Test
     fun `validate new topic with config`() {
         assertThat(command().getTopics(listOf(Create.TopicConfig("topic", emptyList(), emptyList(), mapOf("key" to "value")))))
-            .containsExactly(NewTopic("topic", 1, 1).configs(mapOf("key" to "value")))
+            .containsEntry("topic", NewTopic("topic", 1, 1).configs(mapOf("key" to "value")))
     }
 
     @Test


### PR DESCRIPTION
There doesn't appear to be a reliable way to check for topics that are
still pending deletion so, instead, we'll just retry the creation if it
fails due to a topic already existing. Testing locally we seem to go
round the loop 2 or 3 times before everything then deletes successfully.

As recommended by Confluent, we're also dropping the message retention
time before deleting the topics.