### PR TITLE
NOTICK: Explicitly mark member variables as `@Volatile`

### DIFF
--- a/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
+++ b/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
@@ -49,18 +49,23 @@ class PermissionStorageReaderServiceEventHandler(
     }
 
     @VisibleForTesting
+    @Volatile
     internal var registrationHandle: RegistrationHandle? = null
 
     @VisibleForTesting
+    @Volatile
     internal var permissionStorageReader: PermissionStorageReader? = null
 
     @VisibleForTesting
+    @Volatile
     internal var publisher: Publisher? = null
 
     @VisibleForTesting
+    @Volatile
     internal var crsSub: AutoCloseable? = null
 
     @VisibleForTesting
+    @Volatile
     internal var reconciliationTaskIntervalMs: Long? = null
 
     private val timerKey = PermissionStorageReaderServiceEventHandler::class.simpleName!!

--- a/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
+++ b/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
@@ -44,9 +44,11 @@ class PermissionStorageWriterServiceEventHandler(
     }
 
     @VisibleForTesting
+    @Volatile
     internal var subscription: RPCSubscription<PermissionManagementRequest, PermissionManagementResponse>? = null
 
     @VisibleForTesting
+    @Volatile
     internal var crsSub: AutoCloseable? = null
 
     override fun processEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {


### PR DESCRIPTION
As they may change as a result of configuration update.