### PR TITLE
CORE-5896 Lazily initialise MGM group policy for data coming from the DB

### DIFF
--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/MGMGroupPolicyImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/MGMGroupPolicyImpl.kt
@@ -29,8 +29,26 @@ import net.corda.virtualnode.HoldingIdentity
 class MGMGroupPolicyImpl(
     holdingIdentity: HoldingIdentity,
     rootNode: JsonNode,
-    persistedProperties: LayeredPropertyMap
+    groupPolicyPropertiesQuery: () -> LayeredPropertyMap?
 ) : MGMGroupPolicy {
+
+    /**
+     * Properties are persisted when the MGM is onboarded but the group policy needs to be accessible before that.
+     * e.g. to select the registration protocol. Lazy initialisation on persisted properties is to hold off on setting
+     * values until a later time when the MGM has fully onboarded.
+     */
+    private val persistedProperties by lazy {
+        groupPolicyPropertiesQuery.invoke()
+            ?: throw BadGroupPolicyException("Could not query for group policy parameters.")
+    }
+
+    private fun getPersistedString(key: String): String? {
+        return persistedProperties.parseOrNull(
+            key,
+            String::class.java
+        )
+    }
+
     override val fileFormatVersion = rootNode.getMandatoryInt(FILE_FORMAT_VERSION)
 
     override val groupId = rootNode.getMandatoryString(GROUP_ID).let {
@@ -44,47 +62,67 @@ class MGMGroupPolicyImpl(
 
     override val synchronisationProtocol = rootNode.getMandatoryString(SYNC_PROTOCOL)
 
-    override val protocolParameters: GroupPolicy.ProtocolParameters = ProtocolParametersImpl(persistedProperties)
+    override val protocolParameters: GroupPolicy.ProtocolParameters = ProtocolParametersImpl()
 
-    override val p2pParameters: GroupPolicy.P2PParameters = P2PParametersImpl(persistedProperties)
+    override val p2pParameters: GroupPolicy.P2PParameters = P2PParametersImpl()
 
     override val mgmInfo: GroupPolicy.MGMInfo? = null
 
     override val cipherSuite: GroupPolicy.CipherSuite = CipherSuiteImpl()
 
-    internal inner class ProtocolParametersImpl(
-        persistedProperties: LayeredPropertyMap
-    ) : GroupPolicy.ProtocolParameters {
-        private val sessionKeyPolicyString = persistedProperties.parseOrNull(PropertyKeys.SESSION_KEY_POLICY, String::class.java)
+    internal inner class ProtocolParametersImpl : GroupPolicy.ProtocolParameters {
+        override val sessionKeyPolicy by lazy {
+            SessionKeyPolicy.fromString(
+                getPersistedString(
+                    PropertyKeys.SESSION_KEY_POLICY
+                )
+            ) ?: COMBINED
+        }
 
-        override val sessionKeyPolicy = SessionKeyPolicy.fromString(sessionKeyPolicyString) ?: COMBINED
         override val staticNetworkMembers: List<Map<String, Any>>? = null
     }
 
-    internal inner class P2PParametersImpl(
-        persistedProperties: LayeredPropertyMap
-    ) : GroupPolicy.P2PParameters {
-        private val sessionPkiString = persistedProperties.parseOrNull(PropertyKeys.SESSION_PKI, String::class.java)
-        private val tlsPkiString = persistedProperties.parseOrNull(PropertyKeys.TLS_PKI, String::class.java)
-        private val tlsVersionString = persistedProperties.parseOrNull(PropertyKeys.TLS_VERSION, String::class.java)
-        private val protocolModeString = persistedProperties.parseOrNull(PropertyKeys.PROTOCOL_MODE, String::class.java)
+    internal inner class P2PParametersImpl : GroupPolicy.P2PParameters {
 
-        override val sessionPki = SessionPkiMode.fromString(sessionPkiString) ?: NO_PKI
-        override val sessionTrustRoots: Collection<String>? =
-            if(!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.SESSION_TRUST_ROOTS) }) {
+        override val sessionPki by lazy {
+            SessionPkiMode.fromString(
+                getPersistedString(
+                    PropertyKeys.SESSION_PKI
+                )
+            ) ?: NO_PKI
+        }
+
+        override val sessionTrustRoots by lazy {
+            if (!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.SESSION_TRUST_ROOTS) }) {
                 null
             } else {
                 persistedProperties.parseList(PropertyKeys.SESSION_TRUST_ROOTS, String::class.java)
             }
-        override val tlsTrustRoots: Collection<String> =
-            if(!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.TLS_TRUST_ROOTS) }) {
+        }
+
+        override val tlsTrustRoots by lazy {
+            if (!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.TLS_TRUST_ROOTS) }) {
                 emptyList()
             } else {
                 persistedProperties.parseList(PropertyKeys.TLS_TRUST_ROOTS, String::class.java)
             }
-        override val tlsPki = TlsPkiMode.fromString(tlsPkiString) ?: STANDARD
-        override val tlsVersion = TlsVersion.fromString(tlsVersionString) ?: VERSION_1_3
-        override val protocolMode = ProtocolMode.fromString(protocolModeString) ?: AUTH_ENCRYPT
+        }
+
+        override val tlsPki by lazy {
+            TlsPkiMode.fromString(
+                getPersistedString(PropertyKeys.TLS_PKI)
+            ) ?: STANDARD
+        }
+        override val tlsVersion by lazy {
+            TlsVersion.fromString(
+                getPersistedString(PropertyKeys.TLS_VERSION)
+            ) ?: VERSION_1_3
+        }
+        override val protocolMode by lazy {
+            ProtocolMode.fromString(
+                getPersistedString(PropertyKeys.PROTOCOL_MODE)
+            ) ?: AUTH_ENCRYPT
+        }
     }
 
     internal inner class CipherSuiteImpl private constructor(

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/GroupPolicyTestUtils.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/GroupPolicyTestUtils.kt
@@ -113,7 +113,7 @@ fun buildGroupPolicyNode(
                 mgmInfoOverride?.let { put(MGM_INFO, it) }
                 cipherSuiteOverride?.let { put(CIPHER_SUITE, it) }
             }
-        ).also { println(it) }
+        )
     )
 }
 


### PR DESCRIPTION
Group policy data for the MGMs group policy is provided at onboarding/registration time. The group policy file needs to be accessible earlier to allow for registration protocol selection. This change updates how persisted properties are set so that they are lazily initialized so they aren't queried for until they are needed.