### PR TITLE
NOTICK: Simplify WeakValueHashMap.processQueue().

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/WeakValueHashMap.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/WeakValueHashMap.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.utils
 
-import net.corda.v5.base.util.uncheckedCast
 import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
@@ -86,12 +85,10 @@ class WeakValueHashMap<K, V>: MutableMap<K, V> {
        whose values have been discarded.
      */
     private fun processQueue() {
-        var ref: WeakValueRef<K, V>?
-        while (queue.poll().also { ref = uncheckedCast(it) } != null) {
-            if (ref === map[ref!!.key]) {
-                // only remove if it is the *exact* same WeakValueRef
-                map.remove(ref!!.key)
-            }
+        while (true) {
+            val ref = (queue.poll() as? WeakValueRef<*,*>) ?: break
+            // only remove if it is the *exact* same WeakValueRef
+            map.remove(ref.key, ref)
         }
     }
 }


### PR DESCRIPTION
Simplify `processQueue()` to remove the old entry in a single operation via [`MutableMap.remove(key, value)`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-mutable-map/remove.html). And get rid of unnecessary `uncheckedCast` too.
```kotlin
if (ref === map[ref!!.key]) {
```
This says that the `WeakValueRef` inside the map _must_ be the exact same object as the `WeakValueRef` taken from the reference queue. I have effectively replaced this with:
```kotlin
if (ref == map[ref.key]) {
```
_except_ that `WeakValueRef` uses the default `equals()` and `hashCode()` methods which _also_ use object identity. This would be a problem if `WeakValueRef` were to become a `data` class, of course. (Don't do that...) However, `ConcurrentHashMap.remove(key, value)` is [an _atomic_ operation](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html#remove-java.lang.Object-java.lang.Object-), which I believe is preferable to using `get()` followed by `remove(key)`.