### PR TITLE
CORE-5897 - Switch TTL from Long to Instant type

### DIFF
--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sender.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sender.kt
@@ -133,11 +133,11 @@ class Sender(private val publisherFactory: PublisherFactory,
         }
     }
 
-    private fun calculateTtl(expireAfterTime: Duration?): Long? {
+    private fun calculateTtl(expireAfterTime: Duration?): Instant? {
         return if(expireAfterTime == null) {
             null
         } else {
-            expireAfterTime.toMillis() + clock.instant().toEpochMilli()
+            Instant.ofEpochMilli(expireAfterTime.toMillis() + clock.instant().toEpochMilli())
         }
     }
 

--- a/components/flow/flow-p2p-filter-service/src/integrationTest/kotlin/net/corda/flow/p2p/filter/integration/FlowFilterServiceIntegrationTest.kt
+++ b/components/flow/flow-p2p-filter-service/src/integrationTest/kotlin/net/corda/flow/p2p/filter/integration/FlowFilterServiceIntegrationTest.kt
@@ -94,7 +94,7 @@ class FlowFilterServiceIntegrationTest {
         val flowEventSerializer = cordaAvroSerializationFactory.createAvroSerializer<FlowEvent> { }
 
         val identity = HoldingIdentity(testId, testId)
-        val flowHeader = AuthenticatedMessageHeader(identity, identity, 1, "", "", "flowSession")
+        val flowHeader = AuthenticatedMessageHeader(identity, identity, Instant.ofEpochMilli(1), "", "", "flowSession")
         val version = listOf(1)
         val sessionEvent = SessionEvent(
             MessageDirection.OUTBOUND,
@@ -121,7 +121,7 @@ class FlowFilterServiceIntegrationTest {
             )
         )
 
-        val invalidHeader = AuthenticatedMessageHeader(identity, identity, 1, "", "", "other")
+        val invalidHeader = AuthenticatedMessageHeader(identity, identity, Instant.ofEpochMilli(1), "", "", "other")
         val invalidEvent = FlowEvent(testId, sessionEvent)
         val invalidRecord = Record(
             P2P_IN_TOPIC,

--- a/components/flow/flow-p2p-filter-service/src/test/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterProcessorTest.kt
+++ b/components/flow/flow-p2p-filter-service/src/test/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterProcessorTest.kt
@@ -39,7 +39,7 @@ class FlowP2PFilterProcessorTest {
     fun `validate flow session filter logic transforms sessionId and ignores other subsystems`() {
         val testValue = "test"
         val identity = HoldingIdentity(testValue, testValue)
-        val flowHeader = AuthenticatedMessageHeader(identity, identity, 1, testValue, testValue, "flowSession")
+        val flowHeader = AuthenticatedMessageHeader(identity, identity, Instant.ofEpochMilli(1), testValue, testValue, "flowSession")
         val version = listOf(1)
         val flowEvent = SessionEvent(
             MessageDirection.OUTBOUND,
@@ -61,7 +61,7 @@ class FlowP2PFilterProcessorTest {
         val flowRecord = Record(
             Schemas.P2P.P2P_IN_TOPIC, testValue, AppMessage(AuthenticatedMessage(flowHeader, ByteBuffer.wrap(flowEventMockData)))
         )
-        val otherHeader = AuthenticatedMessageHeader(identity, identity, 1, testValue, testValue, "other")
+        val otherHeader = AuthenticatedMessageHeader(identity, identity, Instant.ofEpochMilli(1), testValue, testValue, "other")
         val otherRecord = Record(
             Schemas.P2P.P2P_IN_TOPIC, testValue, AppMessage(AuthenticatedMessage(otherHeader, ByteBuffer.wrap("other".toByteArray())))
         )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessor.kt
@@ -23,6 +23,7 @@ import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Instant
 
 @Suppress("LongParameterList")
 internal class OutboundMessageProcessor(
@@ -72,9 +73,9 @@ internal class OutboundMessageProcessor(
         return records
     }
 
-    private fun ttlExpired(ttl: Long?): Boolean {
+    private fun ttlExpired(ttl: Instant?): Boolean {
         if (ttl == null) return false
-        val currentTimeInTimeMillis = clock.instant().toEpochMilli()
+        val currentTimeInTimeMillis = clock.instant()
         return currentTimeInTimeMillis >= ttl
     }
 

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -84,12 +84,13 @@ import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import org.mockito.kotlin.mock
+import java.time.Instant
 import java.util.UUID
 
 class P2PLayerEndToEndTest {
 
     companion object {
-        private const val EXPIRED_TTL = 0L
+        private val EXPIRED_TTL = Instant.ofEpochMilli(0)
         private const val SUBSYSTEM = "e2e.test.app"
         private val logger = contextLogger()
         private const val GROUP_ID = "group-1"
@@ -623,7 +624,7 @@ class P2PLayerEndToEndTest {
             ).also { it.start() }
         }
 
-        fun sendMessages(messagesToSend: Int, ourIdentity: Identity, peer: Identity, ttl: Long? = null) {
+        fun sendMessages(messagesToSend: Int, ourIdentity: Identity, peer: Identity, ttl: Instant? = null) {
             val hostAApplicationWriter = publisherFactory.createPublisher(PublisherConfig("app-layer", false), bootstrapConfig)
             val initialMessages = (1..messagesToSend).map { index ->
                 val incrementalId = index.toString()

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessorTest.kt
@@ -34,6 +34,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
+import java.time.Instant
 
 class OutboundMessageProcessorTest {
     private val myIdentity = HoldingIdentity("PartyA", "Group")
@@ -590,7 +591,7 @@ class OutboundMessageProcessorTest {
             authenticatedMsg,
             "key"
         )
-        authenticatedMessageAndKey.message.header.ttl = 0L
+        authenticatedMessageAndKey.message.header.ttl = Instant.ofEpochMilli(0)
 
         val records = processor.processReplayedAuthenticatedMessage(authenticatedMessageAndKey)
 
@@ -614,7 +615,7 @@ class OutboundMessageProcessorTest {
             AuthenticatedMessageHeader(
                 remoteIdentity,
                 localIdentity,
-                0, "MessageId", "trace-id", "system-1"
+                Instant.ofEpochMilli(0), "MessageId", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("payload".toByteArray())
         )

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -312,7 +312,7 @@ class MembershipP2PIntegrationTest {
         val messageHeader = AuthenticatedMessageHeader(
             destination,
             source,
-            requestTimestamp.plusMillis(300000L).toEpochMilli(),
+            requestTimestamp.plusMillis(300000L),
             registrationId,
             null,
             MEMBERSHIP_P2P_SUBSYSTEM
@@ -376,7 +376,7 @@ class MembershipP2PIntegrationTest {
         val messageHeader = AuthenticatedMessageHeader(
             destination,
             source,
-            requestTimestamp.plusMillis(300000L).toEpochMilli(),
+            requestTimestamp.plusMillis(300000L),
             registrationId,
             null,
             MEMBERSHIP_P2P_SUBSYSTEM

--- a/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
+++ b/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
@@ -235,7 +235,7 @@ class MembershipP2PProcessorTest {
                 AuthenticatedMessageHeader(
                     destination,
                     source,
-                    clock.instant().plusMillis(300000L).toEpochMilli(),
+                    clock.instant().plusMillis(300000L),
                     "mid",
                     null,
                     MEMBERSHIP_P2P_SUBSYSTEM

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/helpers/P2pRecordsFactory.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/helpers/P2pRecordsFactory.kt
@@ -37,7 +37,7 @@ class P2pRecordsFactory(
         val header = AuthenticatedMessageHeader.newBuilder()
             .setDestination(destination)
             .setSource(source)
-            .setTtl(clock.instant().plus(TTL).toEpochMilli())
+            .setTtl(clock.instant().plus(TTL))
             .setMessageId(UUID.randomUUID().toString())
             .setTraceId(null)
             .setSubsystem(MEMBERSHIP_P2P_SUBSYSTEM)

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/VerificationRequestHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/VerificationRequestHandler.kt
@@ -38,7 +38,7 @@ internal class VerificationRequestHandler(
             // we need to switch here the source and destination
             mgm,
             member,
-            responseTimestamp.plusMillis(TTL)?.toEpochMilli(),
+            responseTimestamp.plusMillis(TTL),
             UUID.randomUUID().toString(),
             null,
             MEMBERSHIP_P2P_SUBSYSTEM

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
@@ -45,7 +45,7 @@ class VerifyMemberHandler(
         val authenticatedMessageHeader = AuthenticatedMessageHeader(
             member,
             mgm,
-            requestTimestamp.plusMillis(TTL)?.toEpochMilli(),
+            requestTimestamp.plusMillis(TTL),
             UUID.randomUUID().toString(),
             null,
             MEMBERSHIP_P2P_SUBSYSTEM

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/helpers/P2pRecordsFactoryTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/helpers/P2pRecordsFactoryTest.kt
@@ -83,7 +83,7 @@ class P2pRecordsFactoryTest {
                 )
             )
             it.assertThat(header?.ttl).isEqualTo(
-                2000 + 5 * 60 * 1000
+                Instant.ofEpochMilli(2000 + 5 * 60 * 1000)
             )
             it.assertThat(header?.subsystem).isEqualTo(
                 MEMBERSHIP_P2P_SUBSYSTEM

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XXX-SNAPSHOT
-cordaApiVersion=5.0.0.151-alpha-1658828833596
+cordaApiVersion=5.0.0.151-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XXX-SNAPSHOT
-cordaApiVersion=5.0.0.150-beta+
+cordaApiVersion=5.0.0.151-alpha-1658828833596
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/FlowMapperHelper.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/FlowMapperHelper.kt
@@ -14,6 +14,7 @@ import net.corda.schema.Schemas
 import net.corda.schema.configuration.FlowConfig.SESSION_P2P_TTL
 import net.corda.session.manager.Constants.Companion.FLOW_SESSION_SUBSYSTEM
 import net.corda.session.manager.Constants.Companion.INITIATED_SESSION_ID_SUFFIX
+import java.time.Instant
 
 /**
  * Generate and return random ID for flowId
@@ -65,7 +66,7 @@ fun generateAppMessage(
     val header = AuthenticatedMessageHeader(
         destinationIdentity,
         sourceIdentity,
-        sessionEvent.timestamp.toEpochMilli() + flowConfig.getLong(SESSION_P2P_TTL),
+        Instant.ofEpochMilli(sessionEvent.timestamp.toEpochMilli() + flowConfig.getLong(SESSION_P2P_TTL)),
         sessionEvent.sessionId + "-" + UUID.randomUUID(),
         "",
         FLOW_SESSION_SUBSYSTEM


### PR DESCRIPTION
After some changes on `corda-api`, the TTL on `AuthenticatedMessageHeader` is an `Instant`, instead of a `Long` now. This PR adjusts all the places where it's used accordingly.

corda-api PR: https://github.com/corda/corda-api/pull/489