### PR TITLE
CORE-5674 Remove quotes from topic prefix

### DIFF
--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -23,7 +23,7 @@ spec:
             '-b', '{{ include "corda.kafkaBootstrapServers" . }}',
             '-k', '/tmp/working_dir/config.properties',
             {{- if .Values.kafka.topicPrefix }}
-            '-n', '"{{ .Values.kafka.topicPrefix }}"',
+            '-n', '{{ .Values.kafka.topicPrefix }}',
             {{- end }}
             'create',
             '-r', '{{ .Values.kafka.replicas }}',


### PR DESCRIPTION
Currently, the quotes are getting included in the prefix (which is invalid).