### PR TITLE
NOTICK - VirtualNodeEntityKey data class

### DIFF
--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/VirtualNodeEntity.kt
@@ -82,7 +82,7 @@ data class VirtualNodeEntity(
 /** The composite primary key for a virtual node instance. */
 @Embeddable
 @Suppress("Unused")
-class VirtualNodeEntityKey(
+data class VirtualNodeEntityKey(
     private val holdingIdentity: HoldingIdentityEntity,
     private val cpiName: String,
     private val cpiVersion: String,


### PR DESCRIPTION
Make `VirtualNodeEntityKey` a data class so that equals and hashCode are correctly handled.

This should remove the below hibernate warning:

```
2022-07-26 13:35:51.564 [lifecycle-coordinator-8] WARN  org.hibernate.mapping.RootClass - HHH000038: Composite-id class does not override equals(): net.corda.libs.virtualnode.datamodel.VirtualNodeEntityKey
2022-07-26 13:35:51.564 [lifecycle-coordinator-8] WARN  org.hibernate.mapping.RootClass - HHH000039: Composite-id class does not override hashCode(): net.corda.libs.virtualnode.datamodel.VirtualNodeEntityKey
```