### PR TITLE
CORE-5898 Fix race condition in domino logic causing the gateway to fail to start

### DIFF
--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/ComplexDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/ComplexDominoTile.kt
@@ -278,7 +278,7 @@ class ComplexDominoTile(
     }
 
     private fun handleChildStarted() {
-        if (!isRunning) {
+        if (internalState != Started) {
             if (shouldNotWaitForChildren()) {
                 logger.info("Starting resources, since all children are now up.")
                 startIfDependantChildrenAndConfigReady()


### PR DESCRIPTION
Check the internalState instead of isRunning under `handleChildStarted`. 

When we do `coordinator.updateStatus(it)` the status does not get updated straight away, the LifecycleCoordinator posts a `StatusChangeEvent` which eventually gets processed and updates the `status` (see `LifecycleCoordinatorImpl`). Thus if we stop the Tile in one event `isRunning` might still be true in the next event. This can happen if the next event gets added to the queue before the `StatusChangeEvent`.

This caused the gateway to fail to start sometimes. To fix this we instead check the internalState. This gets atomically updated, so will be seen by subsequent events.

Testing
====

I tested deploying the Corda helm charts 10 times and checked each time that the gateway starts correctly. 