### PR TITLE
CORE-5913: Change schema version type for `ConfigRPCOps`

### DIFF
--- a/components/configuration/configuration-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/ConfigRPCOpsImplTests.kt
+++ b/components/configuration/configuration-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/ConfigRPCOpsImplTests.kt
@@ -37,7 +37,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
-/** Tests of [ConfigRPCOpsImpl]. */
+/**
+ * Tests of [ConfigRPCOpsImpl].
+ */
 class ConfigRPCOpsImplTests {
     companion object {
         private const val actor = "test_principal"

--- a/components/configuration/configuration-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/ConfigRPCOpsImplTests.kt
+++ b/components/configuration/configuration-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/ConfigRPCOpsImplTests.kt
@@ -15,6 +15,7 @@ import net.corda.httprpc.exception.HttpApiException
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.httprpc.security.RpcAuthContext
 import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.libs.configuration.endpoints.v1.types.ConfigSchemaVersion
 import net.corda.libs.configuration.endpoints.v1.types.GetConfigResponse
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigResponse
@@ -53,7 +54,7 @@ class ConfigRPCOpsImplTests {
         }
     }
 
-    private val req = UpdateConfigParameters("section", 999, "a=b", Version(888, 0))
+    private val req = UpdateConfigParameters("section", 999, "a=b", ConfigSchemaVersion(888, 0))
     private val successFuture = CompletableFuture.supplyAsync {
         ConfigurationManagementResponse(
             true, null, req.section, req.config, ConfigurationSchemaVersion(
@@ -62,7 +63,7 @@ class ConfigRPCOpsImplTests {
         )
     }
     private val successResponse = UpdateConfigResponse(
-        req.section, req.config, Version(
+        req.section, req.config, ConfigSchemaVersion(
             req.schemaVersion.major,
             req.schemaVersion.minor
         ), req.version
@@ -282,7 +283,7 @@ class ConfigRPCOpsImplTests {
             configSection,
             config.source,
             config.value,
-            Version(config.schemaVersion.majorVersion, config.schemaVersion.minorVersion),
+            ConfigSchemaVersion(config.schemaVersion.majorVersion, config.schemaVersion.minorVersion),
             config.version
         )).isEqualTo(configRPCOps.get(configSection))
     }

--- a/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/ConfigSchemaVersion.kt
+++ b/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/ConfigSchemaVersion.kt
@@ -1,0 +1,8 @@
+package net.corda.libs.configuration.endpoints.v1.types
+
+/**
+ * Represents the schema version which is used by configuration.
+ * Not to be confused with revision version of configuration which is one integer that gets incremented every time
+ * configuration is updated.
+ */
+data class ConfigSchemaVersion(val major: Int, val minor: Int)

--- a/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/GetConfigResponse.kt
+++ b/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/GetConfigResponse.kt
@@ -1,7 +1,5 @@
 package net.corda.libs.configuration.endpoints.v1.types
 
-import net.corda.v5.base.versioning.Version
-
 /**
  * The data object received via HTTP in response to a request to update cluster configuration.
  *
@@ -15,6 +13,6 @@ data class GetConfigResponse(
     val section: String,
     val sourceConfig: String,
     val configWithDefaults: String,
-    val schemaVersion: Version,
+    val schemaVersion: ConfigSchemaVersion,
     val version: Int
 )

--- a/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/UpdateConfigParameters.kt
+++ b/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/UpdateConfigParameters.kt
@@ -1,7 +1,5 @@
 package net.corda.libs.configuration.endpoints.v1.types
 
-import net.corda.v5.base.versioning.Version
-
 /**
  * The data object sent via HTTP to request a cluster configuration update.
  *
@@ -11,5 +9,5 @@ import net.corda.v5.base.versioning.Version
  * @property schemaVersion Schema version of the configuration.
  */
 data class UpdateConfigParameters(
-    val section: String, val version: Int, val config: String, val schemaVersion: Version
+    val section: String, val version: Int, val config: String, val schemaVersion: ConfigSchemaVersion
 )

--- a/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/UpdateConfigResponse.kt
+++ b/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/types/UpdateConfigResponse.kt
@@ -1,7 +1,5 @@
 package net.corda.libs.configuration.endpoints.v1.types
 
-import net.corda.v5.base.versioning.Version
-
 /**
  * The data object received via HTTP in response to a request to update cluster configuration.
  *
@@ -13,7 +11,7 @@ import net.corda.v5.base.versioning.Version
 data class UpdateConfigResponse(
     val section: String,
     val config: String,
-    val schemaVersion: Version,
+    val schemaVersion: ConfigSchemaVersion,
     val version: Int
 )
 

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -2519,6 +2519,24 @@
           }
         }
       },
+      "ConfigSchemaVersion" : {
+        "required" : [ "major", "minor" ],
+        "type" : "object",
+        "properties" : {
+          "major" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : false,
+            "example" : 0
+          },
+          "minor" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : false,
+            "example" : 0
+          }
+        }
+      },
       "CpiIdentifier" : {
         "required" : [ "cpiName", "cpiVersion" ],
         "type" : "object",
@@ -2971,7 +2989,7 @@
             "example" : "string"
           },
           "schemaVersion" : {
-            "$ref" : "#/components/schemas/Version"
+            "$ref" : "#/components/schemas/ConfigSchemaVersion"
           },
           "section" : {
             "type" : "string",
@@ -3532,7 +3550,7 @@
             "example" : "string"
           },
           "schemaVersion" : {
-            "$ref" : "#/components/schemas/Version"
+            "$ref" : "#/components/schemas/ConfigSchemaVersion"
           },
           "section" : {
             "type" : "string",
@@ -3558,7 +3576,7 @@
             "example" : "string"
           },
           "schemaVersion" : {
-            "$ref" : "#/components/schemas/Version"
+            "$ref" : "#/components/schemas/ConfigSchemaVersion"
           },
           "section" : {
             "type" : "string",
@@ -3696,24 +3714,6 @@
             "example" : "2022-06-24T10:15:30Z"
           },
           "version" : {
-            "type" : "integer",
-            "format" : "int32",
-            "nullable" : false,
-            "example" : 0
-          }
-        }
-      },
-      "Version" : {
-        "required" : [ "major", "minor" ],
-        "type" : "object",
-        "properties" : {
-          "major" : {
-            "type" : "integer",
-            "format" : "int32",
-            "nullable" : false,
-            "example" : 0
-          },
-          "minor" : {
             "type" : "integer",
             "format" : "int32",
             "nullable" : false,


### PR DESCRIPTION
It is important not to leak internal `Version` type to public API such that we could evolve them separately.

In theory this should be a non-breaking change from external API callers of view. The only visible effect in OpenAPI should be the name of the type has changed from `Version` to `ConfigSchemaVersion`.