### PR TITLE
CORE-5748 Rename `lookup` for ledger key hash to match session key lookup

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeMembershipGroupReaderProvider.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeMembershipGroupReaderProvider.kt
@@ -56,7 +56,7 @@ class FakeMembershipGroupReaderProvider : MembershipGroupReaderProvider {
             TODO("Not yet implemented")
         }
 
-        override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? {
+        override fun lookupByLedgerKey(ledgerKeyHash: PublicKeyHash): MemberInfo? {
             TODO("Not yet implemented")
         }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/MemberLookupImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/MemberLookupImpl.kt
@@ -24,7 +24,7 @@ class MemberLookupImpl @Activate constructor(
     }
 
     override fun lookup(key: PublicKey): MemberInfo? {
-        return getGroupReader().lookup(key.calculateHash())
+        return getGroupReader().lookupByLedgerKey(key.calculateHash())
     }
 
     override fun lookup(name: MemberX500Name): MemberInfo? {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MemberLookupImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MemberLookupImplTest.kt
@@ -37,7 +37,7 @@ class MemberLookupImplTest {
         val keyHash = PublicKeyHash.calculate(key)
         val member1 = mock<MemberInfo>()
 
-        whenever(membershipGroupReader.lookup(keyHash)).thenReturn(member1)
+        whenever(membershipGroupReader.lookupByLedgerKey(keyHash)).thenReturn(member1)
 
         val target = MemberLookupImpl(flowFiberService)
 

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
@@ -30,7 +30,7 @@ class MembershipGroupReaderImpl(
 
     override fun lookup(): Collection<MemberInfo> = memberList.filter { it.isActive }
 
-    override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? =
+    override fun lookupByLedgerKey(ledgerKeyHash: PublicKeyHash): MemberInfo? =
         memberList.singleOrNull { it.isActive && ledgerKeyHash in it.ledgerKeyHashes }
 
     override fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo? =

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -94,25 +94,25 @@ class MembershipGroupReaderImplTest {
     @Test
     fun `lookup known member with active status based on ledger public key hash`() {
         mockMemberList(listOf(activeMemberInfo))
-        assertEquals(activeMemberInfo, membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
+        assertEquals(activeMemberInfo, membershipGroupReaderImpl.lookupByLedgerKey(mockLedgerKeyHash))
     }
 
     @Test
     fun `lookup known member with non active status based on ledger public key hash`() {
         mockMemberList(listOf(suspendedMemberInfo))
-        assertNull(membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
+        assertNull(membershipGroupReaderImpl.lookupByLedgerKey(mockLedgerKeyHash))
     }
 
     @Test
     fun `lookup non-existing member based on ledger public key hash`() {
         mockMemberList(emptyList())
-        assertNull(membershipGroupReaderImpl.lookup(mockLedgerKeyHash))
+        assertNull(membershipGroupReaderImpl.lookupByLedgerKey(mockLedgerKeyHash))
     }
 
     @Test
     fun `lookup member based on ledger public key hash using session key fails`() {
         mockMemberList(listOf(activeMemberInfo))
-        assertNull(membershipGroupReaderImpl.lookup(mockSessionKeyHash))
+        assertNull(membershipGroupReaderImpl.lookupByLedgerKey(mockSessionKeyHash))
     }
 
     @Test

--- a/components/membership/membership-group-read/src/main/kotlin/net/corda/membership/read/MembershipGroupReader.kt
+++ b/components/membership/membership-group-read/src/main/kotlin/net/corda/membership/read/MembershipGroupReader.kt
@@ -45,7 +45,7 @@ interface MembershipGroupReader {
      *
      * @param ledgerKeyHash Hash of the ledger key belonging to the member to be looked up.
      */
-    fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo?
+    fun lookupByLedgerKey(ledgerKeyHash: PublicKeyHash): MemberInfo?
 
     /**
      * Looks up a group member matching the [MemberX500Name] as visible by the member represented

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupReaderProvider.kt
@@ -101,7 +101,7 @@ class TestGroupReader @Activate constructor(
         )
     )
 
-    override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? {
+    override fun lookupByLedgerKey(ledgerKeyHash: PublicKeyHash): MemberInfo? {
         with(UNIMPLEMENTED_FUNCTION) {
             logger.warn(this)
             throw UnsupportedOperationException(this)

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -46,7 +46,7 @@ class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
             throw IllegalStateException("TEST MODULE: Membership not supported")
         }
 
-        override fun lookup(ledgerKeyHash: PublicKeyHash): MemberInfo? {
+        override fun lookupByLedgerKey(ledgerKeyHash: PublicKeyHash): MemberInfo? {
             return null
         }
 


### PR DESCRIPTION
Rename `lookup` for ledger key hash to match session key lookup

https://r3-cev.atlassian.net/browse/CORE-5748