### PR TITLE
CORE-5928 Support for system services

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -66,6 +66,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
                 "net.corda.crypto",
                 "net.corda.kotlin-stdlib-jdk7.osgi-bundle",
                 "net.corda.kotlin-stdlib-jdk8.osgi-bundle",
+                "net.corda.ledger-consensual",
                 "net.corda.membership",
                 "net.corda.persistence",
                 "net.corda.serialization",

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -31,6 +31,7 @@ import org.osgi.service.component.runtime.ServiceComponentRuntime
 import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO
 import java.security.AccessControlContext
 import java.security.AccessControlException
+import java.util.Collections.singleton
 import java.util.Hashtable
 
 private typealias ServiceDefinition = Pair<ServiceObjects<out Any>, List<Class<*>>>

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxConstants.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxConstants.kt
@@ -1,0 +1,3 @@
+package net.corda.sandbox
+
+const val CORDA_SYSTEM = "corda.system"

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/Constants.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/Constants.kt
@@ -1,7 +1,8 @@
 @file:JvmName("Constants")
 package net.corda.sandboxgroupcontext
 
+import net.corda.sandbox.CORDA_SYSTEM
+
 const val CORDA_SANDBOX = "corda.sandbox"
 const val CORDA_SANDBOX_FILTER = "($CORDA_SANDBOX=true)"
-const val CORDA_SYSTEM = "corda.system"
 const val CORDA_SYSTEM_FILTER = "($CORDA_SYSTEM=true)"

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/Constants.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/Constants.kt
@@ -3,3 +3,5 @@ package net.corda.sandboxgroupcontext
 
 const val CORDA_SANDBOX = "corda.sandbox"
 const val CORDA_SANDBOX_FILTER = "($CORDA_SANDBOX=true)"
+const val CORDA_SYSTEM = "corda.system"
+const val CORDA_SYSTEM_FILTER = "($CORDA_SYSTEM=true)"

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -51,6 +51,7 @@ class SandboxSetupImpl @Activate constructor(
             "net.corda.crypto",
             "net.corda.kotlin-stdlib-jdk7.osgi-bundle",
             "net.corda.kotlin-stdlib-jdk8.osgi-bundle",
+            "net.corda.ledger-consensual",
             "net.corda.membership",
             "net.corda.persistence",
             "net.corda.serialization",


### PR DESCRIPTION
Adding support to mark a service implementation as `corda.system=true` which will be loaded unconditionally and the interface won't be checked to adhere the API package rules, allowing to provide system services that are available in the sandbox without the CPI being aware of the dependency.