### PR TITLE
NOTICK - Adjust values.yaml to not use the namespace in domain names

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,8 @@
 #  --wait
 #
 # See `debug.yaml` for debug settings
+# NOTE: The below assumes you deploy Kafka and the PostgreSQL database in the same namespace, so that domain names containing just the service name are resolved (i.e. prereqs-postgresql instead of prereqs-postgresql.<namespace>)
+#       If that is not the case, you might need to add the namespace as a suffix.
 imagePullPolicy: IfNotPresent
 image:
   registry: corda-os-docker-dev.software.r3.com
@@ -26,5 +28,5 @@ kafka:
 
 db:
   cluster:
-    host: prereqs-postgresql.corda # NOTE: corda here is the current namespace, change in case you are deploying to a different 
+    host: prereqs-postgresql
     existingSecret: prereqs-postgresql


### PR DESCRIPTION
Adjust values.yaml to not use the namespace in domain names. This allows to use the same `values.yaml` to deploy multiple Corda clusters in different namespaces to facilitate automation.