### PR TITLE
CORE-5574 Add P2P Processors To Combined Worker

### DIFF
--- a/applications/workers/release/combined-worker/README.md
+++ b/applications/workers/release/combined-worker/README.md
@@ -76,7 +76,7 @@ Note that some tests require an empty environment (e.g. CPI upload).
 
 Logs are output to disk, using the `osgi-framework-bootstrap/src/main/resources/log4j2.xml` configuration.
 Logging level for 3rd party libs has been defaulted to WARN to reduce the log size/increase the usefulness in normal running,
-but it may be useful to change this on a case-by-case basis when debugging. Note that the JAR bust be rebuilt
+but it may be useful to change this on a case-by-case basis when debugging. Note that the JAR must be rebuilt
 after the resource file is changed. Here is an `log4j2.xml` which logs to the console only:
 
 ```

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation project(':processors:member-processor')
     implementation project(':processors:rpc-processor')
     implementation project(':processors:uniqueness-processor')
+    implementation project(':processors:link-manager-processor')
+    implementation project(':processors:gateway-processor')
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -19,6 +19,8 @@ import net.corda.processors.db.DBProcessor
 import net.corda.processors.uniqueness.UniquenessProcessor
 import net.corda.processors.flow.FlowProcessor
 import net.corda.processors.member.MemberProcessor
+import net.corda.processors.p2p.gateway.GatewayProcessor
+import net.corda.processors.p2p.linkmanager.LinkManagerProcessor
 import net.corda.processors.rpc.RPCProcessor
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
@@ -45,6 +47,10 @@ class CombinedWorker @Activate constructor(
     private val rpcProcessor: RPCProcessor,
     @Reference(service = MemberProcessor::class)
     private val memberProcessor: MemberProcessor,
+    @Reference(service = LinkManagerProcessor::class)
+    private val linkManagerProcessor: LinkManagerProcessor,
+    @Reference(service = GatewayProcessor::class)
+    private val gatewayProcessor: GatewayProcessor,
     @Reference(service = Shutdown::class)
     private val shutDownService: Shutdown,
     @Reference(service = HealthMonitor::class)
@@ -90,6 +96,8 @@ class CombinedWorker @Activate constructor(
         flowProcessor.start(config)
         memberProcessor.start(config)
         rpcProcessor.start(config)
+        linkManagerProcessor.start(config, false)
+        gatewayProcessor.start(config, false)
     }
 
     override fun shutdown() {
@@ -101,6 +109,8 @@ class CombinedWorker @Activate constructor(
         flowProcessor.stop()
         memberProcessor.stop()
         rpcProcessor.stop()
+        linkManagerProcessor.stop()
+        gatewayProcessor.stop()
 
         healthMonitor.stop()
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProvider.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProvider.kt
@@ -2,7 +2,6 @@ package net.corda.p2p.linkmanager
 
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.identity.HoldingIdentity
-import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -11,49 +10,32 @@ import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters
 import net.corda.membership.persistence.client.MembershipQueryClient
-import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.NetworkType
 import net.corda.p2p.crypto.ProtocolMode
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 
-@Suppress("LongParameterList")
-internal class ForwardingGroupPolicyProvider(private val coordinatorFactory: LifecycleCoordinatorFactory,
-                                             private val subscriptionFactory: SubscriptionFactory,
-                                             private val messagingConfiguration: SmartConfig,
+internal class ForwardingGroupPolicyProvider(coordinatorFactory: LifecycleCoordinatorFactory,
                                              private val groupPolicyProvider: GroupPolicyProvider,
-                                             private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
-                                             private val cpiInfoReadService: CpiInfoReadService,
-                                             private val thirdPartyComponentsMode: ThirdPartyComponentsMode,
-                                             private val membershipQueryClient: MembershipQueryClient):
-    LinkManagerGroupPolicyProvider {
+                                             virtualNodeInfoReadService: VirtualNodeInfoReadService,
+                                             cpiInfoReadService: CpiInfoReadService,
+                                             membershipQueryClient: MembershipQueryClient): LinkManagerGroupPolicyProvider {
 
-    private companion object {
-        private val logger = contextLogger()
-    }
 
-    private val stubGroupPolicyProvider = StubGroupPolicyProvider(coordinatorFactory, subscriptionFactory, messagingConfiguration)
+    private val dependentChildren = setOf(
+        LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
+        LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
+        LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
+        LifecycleCoordinatorName.forComponent<MembershipQueryClient>()
+    )
 
-    private val dependentChildren = when(thirdPartyComponentsMode) {
-        ThirdPartyComponentsMode.STUB -> setOf(stubGroupPolicyProvider.dominoTile.coordinatorName)
-        ThirdPartyComponentsMode.REAL -> setOf(
-            LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
-            LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
-            LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
-            LifecycleCoordinatorName.forComponent<MembershipQueryClient>()
-        )
-    }
-    private val managedChildren = when(thirdPartyComponentsMode) {
-        ThirdPartyComponentsMode.STUB -> setOf(stubGroupPolicyProvider.dominoTile.toNamedLifecycle())
-        ThirdPartyComponentsMode.REAL -> setOf(
-            NamedLifecycle(groupPolicyProvider, LifecycleCoordinatorName.forComponent<GroupPolicyProvider>()),
-            NamedLifecycle(virtualNodeInfoReadService, LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()),
-            NamedLifecycle(cpiInfoReadService, LifecycleCoordinatorName.forComponent<CpiInfoReadService>()),
-            NamedLifecycle(membershipQueryClient, LifecycleCoordinatorName.forComponent<MembershipQueryClient>())
-        )
-    }
+    private val managedChildren = setOf(
+        NamedLifecycle(groupPolicyProvider, LifecycleCoordinatorName.forComponent<GroupPolicyProvider>()),
+        NamedLifecycle(virtualNodeInfoReadService, LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()),
+        NamedLifecycle(cpiInfoReadService, LifecycleCoordinatorName.forComponent<CpiInfoReadService>()),
+        NamedLifecycle(membershipQueryClient, LifecycleCoordinatorName.forComponent<MembershipQueryClient>())
+    )
 
     override val dominoTile = ComplexDominoTile(
         this::class.java.simpleName,
@@ -63,24 +45,13 @@ internal class ForwardingGroupPolicyProvider(private val coordinatorFactory: Lif
     )
 
     override fun getGroupInfo(holdingIdentity: HoldingIdentity): GroupPolicyListener.GroupInfo? {
-        return if (thirdPartyComponentsMode == ThirdPartyComponentsMode.REAL) {
-            groupPolicyProvider.getGroupPolicy(holdingIdentity.toCorda())?.let {
-                toGroupInfo(holdingIdentity, it)
-            }
-        } else {
-            stubGroupPolicyProvider.getGroupInfo(holdingIdentity)
-        }
+       return groupPolicyProvider.getGroupPolicy(holdingIdentity.toCorda())?.let { toGroupInfo(holdingIdentity, it) }
     }
 
     override fun registerListener(groupPolicyListener: GroupPolicyListener) {
-        when(thirdPartyComponentsMode) {
-            ThirdPartyComponentsMode.REAL -> {
-                groupPolicyProvider.registerListener { holdingIdentity, groupPolicy ->
-                    val groupInfo = toGroupInfo(holdingIdentity.toAvro(), groupPolicy)
-                    groupPolicyListener.groupAdded(groupInfo)
-                }
-            }
-            ThirdPartyComponentsMode.STUB -> stubGroupPolicyProvider.registerListener(groupPolicyListener)
+        groupPolicyProvider.registerListener { holdingIdentity, groupPolicy ->
+            val groupInfo = toGroupInfo(holdingIdentity.toAvro(), groupPolicy)
+            groupPolicyListener.groupAdded(groupInfo)
         }
     }
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
@@ -48,10 +48,11 @@ class LinkManager(
         }
     }
 
-    private val forwardingGroupPolicyProvider =
-        ForwardingGroupPolicyProvider(lifecycleCoordinatorFactory, subscriptionFactory, messagingConfiguration, groupPolicyProvider,
-            virtualNodeInfoReadService, cpiInfoReadService, thirdPartyComponentsMode, membershipQueryClient)
-
+    private val forwardingGroupPolicyProvider: LinkManagerGroupPolicyProvider = when (thirdPartyComponentsMode) {
+        ThirdPartyComponentsMode.REAL -> ForwardingGroupPolicyProvider(lifecycleCoordinatorFactory, groupPolicyProvider,
+            virtualNodeInfoReadService, cpiInfoReadService, membershipQueryClient)
+        ThirdPartyComponentsMode.STUB -> StubGroupPolicyProvider(lifecycleCoordinatorFactory, subscriptionFactory, messagingConfiguration)
+    }
     private val linkManagerCryptoProcessor: CryptoProcessor = when(thirdPartyComponentsMode) {
         ThirdPartyComponentsMode.REAL -> DelegatingCryptoService(cryptoOpsClient)
         ThirdPartyComponentsMode.STUB -> StubCryptoProcessor(lifecycleCoordinatorFactory, subscriptionFactory, messagingConfiguration)

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
@@ -73,18 +73,8 @@ class ForwardingGroupPolicyProviderTest {
     }
 
     @Test
-    fun `dependent and managed children are set properly when using stub policy provider`() {
-        createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.STUB)
-
-        assertThat(dependentChildren).hasSize(1)
-        assertThat(dependentChildren).containsExactlyInAnyOrder(stubGroupPolicyProviderCoordinatorName)
-        assertThat(managedChildren).hasSize(1)
-        assertThat(managedChildren).containsExactlyInAnyOrder(stubGroupPolicyProviderNamedLifecycle)
-    }
-
-    @Test
     fun `dependent and managed children are set properly when using the real policy provider`() {
-        createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.REAL)
+        createForwardingGroupPolicyProvider()
 
         assertThat(dependentChildren).hasSize(4)
         assertThat(dependentChildren).containsExactlyInAnyOrder(
@@ -106,16 +96,8 @@ class ForwardingGroupPolicyProviderTest {
     }
 
     @Test
-    fun `get group info delegates to the stub policy provider properly`() {
-        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.STUB)
-
-        whenever(stubGroupPolicyProvider.constructed().first().getGroupInfo(alice)).thenReturn(groupInfo)
-        assertThat(forwardingGroupPolicyProvider.getGroupInfo(alice)).isEqualTo(groupInfo)
-    }
-
-    @Test
     fun `get group info delegates to the real policy provider properly`() {
-        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.REAL)
+        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
 
         whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(groupPolicy)
         assertThat(forwardingGroupPolicyProvider.getGroupInfo(alice)).isEqualTo(groupInfo)
@@ -123,7 +105,7 @@ class ForwardingGroupPolicyProviderTest {
 
     @Test
     fun `get group info delegates to the real policy provider properly for c4 network`() {
-        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.REAL)
+        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
         whenever(groupPolicy.p2pParameters.tlsPki).thenReturn(P2PParameters.TlsPkiMode.CORDA_4)
 
         whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(groupPolicy)
@@ -132,7 +114,7 @@ class ForwardingGroupPolicyProviderTest {
 
     @Test
     fun `get group info delegates to the real policy provider properly for network with authentication only mode`() {
-        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.REAL)
+        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
         whenever(groupPolicy.p2pParameters.protocolMode).thenReturn(P2PParameters.ProtocolMode.AUTH)
 
         whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(groupPolicy)
@@ -142,7 +124,7 @@ class ForwardingGroupPolicyProviderTest {
 
     @Test
     fun `get group info returns null if real group policy provider fails to find a group policy for the holding identity`() {
-        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.REAL)
+        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
         whenever(groupPolicy.p2pParameters.protocolMode).thenReturn(P2PParameters.ProtocolMode.AUTH)
 
         whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(null)
@@ -150,17 +132,8 @@ class ForwardingGroupPolicyProviderTest {
     }
 
     @Test
-    fun `register listener delegates to the stub policy provider properly`() {
-        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.STUB)
-
-        val listener = mock<GroupPolicyListener>()
-        forwardingGroupPolicyProvider.registerListener(listener)
-        verify(stubGroupPolicyProvider.constructed().first()).registerListener(listener)
-    }
-
-    @Test
     fun `register listener delegates to the real policy provider properly`() {
-        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider(ThirdPartyComponentsMode.REAL)
+        val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
 
         val listener = mock<GroupPolicyListener>()
         forwardingGroupPolicyProvider.registerListener(listener)
@@ -171,10 +144,9 @@ class ForwardingGroupPolicyProviderTest {
         verify(listener).groupAdded(groupInfo)
     }
 
-    private fun createForwardingGroupPolicyProvider(mode: ThirdPartyComponentsMode): ForwardingGroupPolicyProvider {
+    private fun createForwardingGroupPolicyProvider(): ForwardingGroupPolicyProvider {
         return ForwardingGroupPolicyProvider(
-            mock(), mock(), mock(),
-            realGroupPolicyProvider, virtualNodeInfoReadService, cpiInfoReadService, mode, membershipQueryClient
+            mock(), realGroupPolicyProvider, virtualNodeInfoReadService, cpiInfoReadService, membershipQueryClient
         )
     }
 


### PR DESCRIPTION
Add the Link Manager and Gateway to the combined worker. Change the LinkManager and Gateway to not to instantiate Stub Components when these are unused. This change is necessary for the ready end point to become ready as previously these components would always have Lifecycle  status `DOWN`. The HealthMonitor checks every Lifecycle is `UP` before considering the worker ready.

Testing with a Static Network
===

These tests follow a mix of the instructions in this [README](https://github.com/corda/corda-runtime-os/blob/release/os/5.0/applications/workers/release/combined-worker/README.md) and these [instructions](https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4023779329/Instructions+for+testing+the+p2p+layer+with+a+static+network): 

1. Start Kafka using docker compose.
 `docker-compose -f ./testing/message-patterns/kafka-docker/single-kafka-cluster.yml up -d`

2. Deploy a Database in docker
`docker run --rm -p 5432:5432 --name postgresql -e POSTGRES_DB=cordacluster -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres:latest`

3. Build the topic creation tool CLI plugin inside :

`./gradlew :tools:plugins:topic-config:clean :tools:plugins:topic-config:cliPluginTask`

4. Copy plugin into CLI tool (checkout repo if not already checked out):
```
cd ../corda-cli-plugin-host/
./gradlew assemble
cp ../corda-runtime-os/tools/plugins/topic-config/build/libs/topic-config-cli-plugin-*.jar ./build/plugins/
```

5. Create topics with 20 partitions and 3 replicas:
```
./build/generatedScripts/corda-cli.sh topic -b=localhost:9092 create -p 20  -r 3 connect
```

6. Build combined worker with Kafka Message bus see (https://github.com/corda/corda-runtime-os/blob/release/os/5.0/applications/workers/release/combined-worker/README.md).

7. Start the combined worker

```
java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
  ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
  --instanceId=0 -mbootstrap.servers=localhost:9092  \
  -spassphrase=password -ssalt=salt \
  -ddatabase.user=user -ddatabase.pass=password \
  -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
```

8. Wait for the combined worker to start. You can check the status of all the lifecycle components using:
```
curl -v http://localhost:7000/status | jq
```
Everything should have status `UP` (not `DOWN` or `ERROR`).

9. Follow these instructions to create a [virtual node](https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4023779329/Instructions+for+testing+the+p2p+layer+with+a+static+network#Create-virtual-nodes). Ignoring the instruction to `port-forward`.

10. Run the app simulator:
```
java -jar ./applications/tools/p2p-test/app-simulator/build/bin/corda-app-simulator-5.0.0.0-SNAPSHOT.jar -mbootstrap.servers=localhost:9092 --simulator-config simulator_sender.conf
```

11. Check the p2p.in topic in the kafka-ui contains one message.