### PR TITLE
CORE-5948: Allow pipeline state modification after deletion of the flow state

### DIFF
--- a/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
+++ b/components/flow/flow-service/flow-pipeline-acceptance-test-coverage.md
@@ -127,6 +127,7 @@ This document should be maintained so that we can ensure that we have quick visi
 - A flow finishing removes the flow's checkpoint publishes a completed flow status and schedules flow cleanup ✅
 - An initiated flow finishing removes the flow's checkpoint publishes a completed flow status and schedules flow cleanup ✅
 - Given the flow has a WAIT_FOR_FINAL_ACK session receiving a session close event and then finishing the flow schedules flow and session cleanup ✅
+- A flow finishing when previously in a retry state publishes a completed flow status and schedules flow cleanup ✅
 
 ## Flow failing
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExampleData.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExampleData.kt
@@ -15,6 +15,10 @@ const val ALICE_X500 = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
 val ALICE_X500_NAME = MemberX500Name.parse(ALICE_X500)
 val ALICE_HOLDING_IDENTITY = net.corda.data.identity.HoldingIdentity(ALICE_X500, HOLDING_IDENTITY_GROUP)
 
+const val CHARLIE_X500 = "CN=Charlie, O=Charlie Corp, L=LDN, C=GB"
+val CHARLIE_X500_NAME = MemberX500Name.parse(CHARLIE_X500)
+val CHARLIE_HOLDING_IDENTITY = net.corda.data.identity.HoldingIdentity(CHARLIE_X500, HOLDING_IDENTITY_GROUP)
+
 const val CPI1 = "cpi1"
 const val CPK1 = "cpk1"
 const val FLOW_ID1 = "f1"

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
@@ -73,9 +73,6 @@ class SendAcceptanceTest : FlowServiceTestBase() {
         `when` {
             sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, sequenceNum = 1, receivedSequenceNum = 1)
                 .suspendsWith(FlowIORequest.Send(mapOf(SESSION_ID_1 to DATA_MESSAGE_1)))
-
-            wakeupEventReceived(FLOW_ID1)
-                .suspendsWith(FlowIORequest.FlowFailed(Exception()))
         }
 
         then {
@@ -83,7 +80,14 @@ class SendAcceptanceTest : FlowServiceTestBase() {
                 hasPendingUserException()
                 wakeUpEvent()
             }
+        }
 
+        `when` {
+            wakeupEventReceived(FLOW_ID1)
+                .suspendsWith(FlowIORequest.FlowFailed(Exception()))
+        }
+
+        then {
             expectOutputForFlow(FLOW_ID1) {
                 flowResumedWithError<FlowException>()
                 noPendingUserException()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
@@ -1,7 +1,6 @@
 package net.corda.flow.pipeline.impl
 
 import net.corda.crypto.manager.CryptoManager
-import java.time.Instant
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
@@ -19,6 +18,7 @@ import net.corda.v5.base.util.minutes
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.time.Instant
 
 @Component(service = [FlowGlobalPostProcessor::class])
 class FlowGlobalPostProcessorImpl @Activate constructor(
@@ -95,10 +95,7 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
          * If a platform error was previously reported to the user the error should now be cleared. If we have reached
          * the post-processing step we can assume the pending error has been processed.
          */
-        val checkpoint = context.checkpoint
-        if (checkpoint.doesExist) {
-            checkpoint.clearPendingPlatformError()
-        }
+        context.checkpoint.clearPendingPlatformError()
     }
 
     /**

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -174,12 +174,10 @@ class FlowCheckpointImpl(
     }
 
     override fun markForRetry(flowEvent: FlowEvent, exception: Exception) {
-        checkFlowNotDeleted()
         pipelineStateManager.retry(flowEvent, exception)
     }
 
     override fun markRetrySuccess() {
-        checkFlowNotDeleted()
         pipelineStateManager.markRetrySuccess()
     }
 
@@ -188,7 +186,6 @@ class FlowCheckpointImpl(
     }
 
     override fun setFlowSleepDuration(sleepTimeMs: Int) {
-        checkFlowNotDeleted()
         pipelineStateManager.setFlowSleepDuration(sleepTimeMs)
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
@@ -621,9 +621,18 @@ class FlowCheckpointImplTest {
         flowCheckpoint.markDeleted()
 
         assertThrows<IllegalStateException> { flowCheckpoint.putSessionState(SessionState()) }
-        assertThrows<IllegalStateException> { flowCheckpoint.markForRetry(FlowEvent(), RuntimeException()) }
-        assertThrows<IllegalStateException> { flowCheckpoint.markRetrySuccess() }
-        assertThrows<IllegalStateException> { flowCheckpoint.setFlowSleepDuration(1) }
+    }
+
+    @Test
+    fun `checkpoint pipeline state can be modified even if the checkpoint is marked for deletion`() {
+        val checkpoint = setupAvroCheckpoint()
+        val flowCheckpoint = createFlowCheckpoint(checkpoint)
+        flowCheckpoint.markDeleted()
+        flowCheckpoint.markForRetry(FlowEvent(), RuntimeException())
+        assertThat(flowCheckpoint.inRetryState).isTrue
+        flowCheckpoint.markRetrySuccess()
+        assertThat(flowCheckpoint.inRetryState).isFalse
+        flowCheckpoint.setFlowSleepDuration(1)
     }
 
     @Test


### PR DESCRIPTION
The flow checkpoint will get marked as deleted when the flow completes. If the flow was in the retrying state though, it will then attempt to mark the retry as successful, which causes a failure as the checkpoint is marked as deleted.

With the new split between pipeline and flow state, updating the pipeline state becomes irrelevant once the checkpoint has been marked as deleted anyway, so allowing this to happen does no harm. This might also be relevant if some transient error were to occur after the flow has been marked for deletion, so it is safer to take this approach than to check before access every time.