### PR TITLE
CORE-5389: implement pagination for FindAll, sharing implementation w…

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/FindAllAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/FindAllAcceptanceTest.kt
@@ -47,7 +47,7 @@ class FindAllAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                entityRequestSent(FindAll(className))
+                entityRequestSent(FindAll(className, 0, Int.MAX_VALUE))
             }
         }
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/FindAllRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/FindAllRequestHandler.kt
@@ -27,7 +27,7 @@ class FindAllRequestHandler @Activate constructor(
     }
 
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.FindAll): FlowEventContext<Any> {
-        val findAllRequest = FindAll(request.className)
+        val findAllRequest = FindAll(request.className, 0, Int.MAX_VALUE)
         val checkpoint = context.checkpoint
         val entityRequest =
             EntityRequest(Instant.now(), checkpoint.flowId, checkpoint.holdingIdentity.toAvro(), findAllRequest)

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -71,6 +71,10 @@ import java.time.temporal.ChronoUnit
 import java.util.Calendar
 import java.util.UUID
 
+sealed class QuerySetup {
+    data class NamedQuery(val params: Map<String, String>, val query: String = "Dog.summon"): QuerySetup()
+    data class All(val className: String): QuerySetup()
+}
 
 /**
  * To use Postgres rather than in-memory (HSQL):
@@ -457,7 +461,7 @@ class PersistenceServiceInternalTests {
     fun `find all`() {
         val expected = persistDogs(ctx, 1)
 
-        val results = assertFindAll(DOG_CLASS_NAME)
+        val results = assertQuery(QuerySetup.All(DOG_CLASS_NAME))
 
         assertThat(results.size).isGreaterThanOrEqualTo(expected)
 
@@ -468,9 +472,58 @@ class PersistenceServiceInternalTests {
         }
     }
 
+
+    @Test
+    fun `find all with pagination`() {
+        val expected = persistDogs(ctx, 1)
+
+        val results1 = assertQuery(QuerySetup.All(DOG_CLASS_NAME), 0, 2)
+        val results2 = assertQuery(QuerySetup.All(DOG_CLASS_NAME), 2, 2)
+        val resultsBalance = assertQuery(QuerySetup.All(DOG_CLASS_NAME), 4, Int.MAX_VALUE)
+
+        assertThat(results1.size).isEqualTo(2)
+        assertThat(results2.size).isEqualTo(2)
+        assertThat(resultsBalance.size).isEqualTo(expected - 4)
+
+        // And check the types we've returned
+        val dogClass = ctx.entitySandboxService.getClass(ctx.virtualNodeInfo.holdingIdentity, DOG_CLASS_NAME)
+        results1.forEach {
+            assertThat(it).isInstanceOf(dogClass)
+        }
+        results2.forEach {
+            assertThat(it).isInstanceOf(dogClass)
+        }
+        resultsBalance.forEach {
+            assertThat(it).isInstanceOf(dogClass)
+        }
+
+        results1.forEach {
+            assertThat(results2.map { x -> x.toString()}).doesNotContain(it.toString())
+            assertThat(resultsBalance.map { x -> x.toString()}).doesNotContain(it.toString())
+        }
+        results2.forEach {
+            assertThat(results1.map { x -> x.toString()}).doesNotContain(it.toString())
+            assertThat(resultsBalance.map { x -> x.toString()}).doesNotContain(it.toString())
+        }
+        resultsBalance.forEach {
+            assertThat(results1.map { x -> x.toString()}).doesNotContain(it.toString())
+            assertThat(results2.map { x -> x.toString()}).doesNotContain(it.toString())
+        }
+    }
+
+
+    @Test
+    fun `find all with negative pagination produces error`() {
+        persistDogs(ctx, 1)
+        assertQuery(QuerySetup.All(DOG_CLASS_NAME), -12, 2, expectFailure = "Invalid negative offset -12")
+        assertQuery(QuerySetup.All(DOG_CLASS_NAME), 0, -42, expectFailure = "Invalid negative limit -42")
+    }
+
     /**
      * AT THE TIME OF WRITING - if 'find all' returns a set of results and the size
      * of that set of results exceeds a kafka packet size, then we return an error response.
+     * The caller may use pagination to workaround this, provided individual result rows fit in
+     * Kafka message.
      */
     @Test
     fun `find all exceeds kakfa packet size`() {
@@ -480,7 +533,7 @@ class PersistenceServiceInternalTests {
             if (it.array().size > 50) throw KafkaMessageSizeException("Too large")
             it
         }
-        val request = createRequest(ctx.virtualNodeInfo.holdingIdentity, FindAll(DOG_CLASS_NAME))
+        val request = createRequest(ctx.virtualNodeInfo.holdingIdentity,FindAll(DOG_CLASS_NAME, 0, Int.MAX_VALUE))
 
         val responses = assertFailureResponses(processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), request))))
 
@@ -489,6 +542,7 @@ class PersistenceServiceInternalTests {
         val failure = response.responseType as EntityResponseFailure
         assertThat(failure.exception.errorType).contains("KafkaMessageSizeException")
     }
+
     @Test
     fun `find exceeds kakfa packet size`() {
         val dogId = UUID.randomUUID()
@@ -541,7 +595,7 @@ class PersistenceServiceInternalTests {
     @Test
     fun `find all with composite key`() {
         val expected = persistCats(ctx, 1)
-        val results = assertFindAll(CAT_CLASS_NAME)
+        val results = assertQuery(QuerySetup.All(CAT_CLASS_NAME))
 
         // Of the expected size - if it fails here - check we're cleaning up elsewhere.
         assertThat(results.size).isGreaterThanOrEqualTo(expected)
@@ -585,59 +639,80 @@ class PersistenceServiceInternalTests {
     @Test
     fun `find with named query with many results`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf("name" to "%o%"), query="Dog.summonLike")
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf("name" to "%o%"), query="Dog.summonLike"))
         assertThat(r.size).isEqualTo(4)
     }
 
     @Test
     fun `find with named query with 1 result`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf("name" to "Rover 1"), query="Dog.summon")
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf("name" to "Rover 1"), query="Dog.summon"))
         assertThat(r.size).isEqualTo(1)
     }
 
     @Test
     fun `find with named query and missing owner`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf(), query="Dog.independent")
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.independent"))
         assertThat(r.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `update produces error`() {
+        persistDogs(ctx, 1)
+        assertQuery(
+            QuerySetup.NamedQuery(mapOf(), query = "Dog.release"),
+            expectFailure = "Not supported for DML operations"
+        )
     }
 
     @Test
     fun `find with named query and incorrectly named parameter`() {
         persistDogs(ctx, 1)
-        assertNamedQueryDog(mapOf("handle" to "Rover 1"), query="Dog.summon", expectFailure="Could not locate named parameter [handle], expecting one of [name]")
+        assertQuery(
+            QuerySetup.NamedQuery(mapOf("handle" to "Rover 1"), query = "Dog.summon"),
+            expectFailure = "Could not locate named parameter [handle], expecting one of [name]"
+        )
     }
 
     @Test
-    fun `find with incorrectly named query and incorrectly named parameter`() {
+    fun `find with incorrectly named parameter`() {
         persistDogs(ctx, 1)
-        assertNamedQueryDog(mapOf("name" to "Rover 1"), query="Dog.findByOwner", expectFailure="No query defined for that name [Dog.findByOwner]")
+        assertQuery(
+            QuerySetup.NamedQuery(mapOf("name" to "Rover 1"), query = "Dog.findByOwner"),
+            expectFailure = "No query defined for that name [Dog.findByOwner]"
+        )
     }
-
 
     @Test
     fun `find with named query with all results`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf(), query="Dog.all")
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.all"))
         assertThat(r.size).isEqualTo(8)
     }
 
     @Test
     fun `find with named query and zero limit returns no results`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf(), query="Dog.all", limit=0)
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.all"), limit=0)
         assertThat(r.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `find with named query and negative pagination produces error`() {
+        persistDogs(ctx, 1)
+        assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.all"), -12, 2, expectFailure = "Invalid negative offset -12")
+        assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.all"), 0, -42, expectFailure = "Invalid negative limit -42")
     }
 
     @Test
     fun `find with named query with pagination`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf(), query="Dog.all", 0, 2)
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.all"), 0, 2)
         assertThat(r.size).isEqualTo(2)
         assertThat(r[0].toString()).contains("Butch 1")
         assertThat(r[1].toString()).contains("Eddie 1")
-        val r2 = assertNamedQueryDog(mapOf(), query="Dog.all", 2, 2)
+        val r2 = assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.all"), 2, 2)
         assertThat(r.size).isEqualTo(2)
         assertThat(r2[0].toString()).contains("Gromit 1")
         assertThat(r2[1].toString()).contains("Lassie 1")
@@ -646,21 +721,21 @@ class PersistenceServiceInternalTests {
     @Test
     fun `find with named query with excessive pagination`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf(), query="Dog.all", 0, 1000)
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf(), query="Dog.all"), 0, 1000)
         assertThat(r.size).isEqualTo(8)
     }
 
     @Test
     fun `find with named query with 0 results`() {
         persistDogs(ctx, 1)
-        val r = assertNamedQueryDog(mapOf("name" to "Topcat"), query="Dog.summon")
+        val r = assertQuery(QuerySetup.NamedQuery(mapOf("name" to "Topcat"), query="Dog.summon"))
         assertThat(r.size).isEqualTo(0)
     }
 
 
     @Test
     fun `find with named query result which hits Kafka message size limit`() {
-        assertNamedQueryDog(mapOf(), query="Dog.all", expectFailure="Too large", sizeLimit = 10)
+        assertQuery(QuerySetup.NamedQuery(mapOf(), "Dog.all"), expectFailure="Too large", sizeLimit = 10)
     }
 
 
@@ -759,37 +834,25 @@ class PersistenceServiceInternalTests {
         return EntityRequest(Instant.now(), UUID.randomUUID().toString(), holdingId.toAvro(), entity)
     }
 
-    /** Find all for class name and assert
-     * @return the list of results (NOT the list of record/responses)
-     * */
-    private fun assertFindAll(className: String): List<*> {
-        val processor = EntityMessageProcessor(ctx.entitySandboxService, UTCClock(), this::noOpPayloadCheck)
-        val request = createRequest(ctx.virtualNodeInfo.holdingIdentity, FindAll(className))
-
-        val responses =
-            assertSuccessResponses(processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), request))))
-
-        assertThat(responses.size).withFailMessage("can only use this helper method with 1 result").isEqualTo(1)
-        val flowEvent = responses.first().value  as FlowEvent
-        val entityResponse = flowEvent.payload as EntityResponse
-
-        return assertThatResponseIsAList(entityResponse)
-    }
-
-    private fun assertNamedQueryDog(
-        params: Map<String, String>, query: String = "Dog.summon",
+    private fun assertQuery(
+        querySetup: QuerySetup,
         offset: Int = 0, limit: Int = Int.MAX_VALUE,
         expectFailure: String? = null, sizeLimit: Int = Int.MAX_VALUE
     ): List<*> {
-        val paramsSerialized = params.mapValues { ctx.serialize(it.value) }
+        val rec = when(querySetup) {
+            is QuerySetup.NamedQuery -> {
+                val paramsSerialized = querySetup.params.mapValues { ctx.serialize(it.value) }
+                FindWithNamedQuery(querySetup.query, paramsSerialized, offset, limit)
+            }
+            is QuerySetup.All -> {
+                FindAll(querySetup.className, offset, limit)
+            }
+        }
         val processor = EntityMessageProcessor(ctx.entitySandboxService, UTCClock()) {
             if (sizeLimit != Int.MAX_VALUE && it.array().size > sizeLimit) throw KafkaMessageSizeException("Too large")
             it
         }
-        val request = createRequest(
-            ctx.virtualNodeInfo.holdingIdentity,
-            FindWithNamedQuery(query, paramsSerialized, offset, limit)
-        )
+        val request = createRequest(ctx.virtualNodeInfo.holdingIdentity, rec)
         val records = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), request)))
         assertThat(records.size).withFailMessage("can only use this helper method with 1 result").isEqualTo(1)
         val record = records.first()

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
@@ -9,6 +9,7 @@ import net.corda.data.persistence.FindEntity
 import net.corda.data.persistence.FindWithNamedQuery
 import net.corda.data.persistence.MergeEntity
 import net.corda.data.persistence.PersistEntity
+import net.corda.entityprocessor.impl.internal.exceptions.InvalidPaginationException
 import net.corda.entityprocessor.impl.internal.exceptions.NullParameterException
 import net.corda.utilities.time.Clock
 import net.corda.v5.application.serialization.SerializationService
@@ -17,6 +18,7 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import java.nio.ByteBuffer
 import javax.persistence.EntityManager
+import javax.persistence.Query
 import javax.persistence.criteria.Selection
 
 
@@ -151,15 +153,11 @@ class PersistenceServiceInternal(
         val all = cq.select(rootEntity as Selection<out Nothing>?)
 
         val typedQuery = entityManager.createQuery(all)
-        val innerMsg = when (val results = typedQuery.resultList) {
-            null -> EntityResponseSuccess()
-            else -> EntityResponseSuccess(payloadCheck(serializationService.toBytes(results)))
-        }
-        return EntityResponse(clock.instant(), requestId, innerMsg)
+        return findWithQuery(serializationService, typedQuery, payload.offset, payload.limit)
     }
 
     /*
-     * Find all entites that match a named query
+     * Find all entities that match a named query
      */
     fun findWithNamedQuery(
         serializationService: SerializationService,
@@ -188,11 +186,26 @@ class PersistenceServiceInternal(
             val bytes = rec.value.array()
             query.setParameter(rec.key, serializationService.deserialize<Any>(bytes))
         }
-        if (payload.offset != 0) {
-            query.firstResult = payload.offset
+        return findWithQuery(serializationService, query, payload.offset, payload.limit)
+    }
+
+
+    /*
+    * Find all entities that match a query, with pagination
+    */
+    private fun findWithQuery(
+        serializationService: SerializationService,
+        query: Query,
+        offset: Int = 0,
+        limit: Int = Int.MAX_VALUE,
+    ): EntityResponse {
+        if (offset < 0) throw InvalidPaginationException("Invalid negative offset $offset")
+        if (offset != 0) {
+            query.firstResult = offset
         }
-        if (payload.limit != Int.MAX_VALUE) {
-            query.maxResults = payload.limit
+        if (limit < 0) throw InvalidPaginationException("Invalid negative limit $limit")
+        if (limit != Int.MAX_VALUE) {
+            query.maxResults = limit
         }
         val innerMsg = when (val results = query.resultList) {
             null -> EntityResponseSuccess()

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/exceptions/InvalidPaginationException.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/exceptions/InvalidPaginationException.kt
@@ -1,0 +1,3 @@
+package net.corda.entityprocessor.impl.internal.exceptions
+
+class InvalidPaginationException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XXX-SNAPSHOT
-cordaApiVersion=5.0.0.153-beta+
+cordaApiVersion=5.0.0.154-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/testing/bundles/testing-dogs/src/main/kotlin/net/corda/testing/bundles/dogs/Dog.kt
+++ b/testing/bundles/testing-dogs/src/main/kotlin/net/corda/testing/bundles/dogs/Dog.kt
@@ -15,7 +15,8 @@ import javax.persistence.NamedQuery
     NamedQuery(name = "Dog.summon", query = "SELECT d FROM Dog d WHERE d.name = :name"),
     NamedQuery(name = "Dog.independent", query = "SELECT d FROM Dog d WHERE d.owner IS NULL"),
     NamedQuery(name = "Dog.summonLike", query = "SELECT d FROM Dog d WHERE d.name LIKE :name ORDER BY d.name"),
-    NamedQuery(name = "Dog.all", query = "SELECT d FROM Dog d ORDER BY d.name")
+    NamedQuery(name = "Dog.all", query = "SELECT d FROM Dog d ORDER BY d.name"),
+    NamedQuery(name = "Dog.release", query = "UPDATE Dog SET owner=null")
 )
 data class Dog(
     @Id


### PR DESCRIPTION
…ith FindWithNamedQuery.

We share much of the logic, both core and test fixture, between FindAll and FindWithNamedQuery.

Also, extend the persistence service query interface with:
- error checking for negative pagination parameters
- a test case that Hibernate does not allow data modification in named queries