### PR TITLE
CORE-5594 Remove default admin credentials

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                }
                 sh '''
                     export SASL_SECRET=$(kubectl get secret -n $NAMESPACE prereqs-kafka-jaas -o=jsonpath='{.data.client-passwords}' | base64 --decode)
-                    helm install corda ./charts/corda -f .ci/e2eTests/corda.yaml --set kafka.sasl.password=$SASL_SECRET --set image.tag=$BASE_IMAGE --set bootstrap.initialAdminUser.password=admin -n $NAMESPACE --wait --timeout 600s
+                    helm install corda ./charts/corda -f .ci/e2eTests/corda.yaml --set kafka.sasl.password=$SASL_SECRET --set image.tag=$BASE_IMAGE -n $NAMESPACE --wait --timeout 600s
                 '''
             }
             post {

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                }
                 sh '''
                     export SASL_SECRET=$(kubectl get secret -n $NAMESPACE prereqs-kafka-jaas -o=jsonpath='{.data.client-passwords}' | base64 --decode)
-                    helm install corda ./charts/corda -f .ci/e2eTests/corda.yaml --set kafka.sasl.password=$SASL_SECRET --set image.tag=$BASE_IMAGE -n $NAMESPACE --wait --timeout 600s
+                    helm install corda ./charts/corda -f .ci/e2eTests/corda.yaml --set kafka.sasl.password=$SASL_SECRET --set image.tag=$BASE_IMAGE --set bootstrap.initialAdminUser.password=admin -n $NAMESPACE --wait --timeout 600s
                 '''
             }
             post {

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -1,6 +1,10 @@
 imagePullSecrets:
   - docker-registry-cred
 
+bootstrap:
+  initialAdminUser:
+    password: "admin"
+
 kafka:
   bootstrapServers: prereqs-kafka:9092
   tls:

--- a/charts/corda/templates/NOTES.txt
+++ b/charts/corda/templates/NOTES.txt
@@ -1,2 +1,8 @@
-1. Expose the RPC endpoint on localhost by running this command:
-kubectl port-forward --namespace {{ .Release.Namespace }} deployment/{{ include "corda.fullname" . }}-rpc-worker 8888
+1. Extract the credentials for the initial admin user:
+kubectl get secret {{ include "corda.initialAdminUserSecretName" . }} -o jsonpath='{ .data.{{ include "corda.initialAdminUserSecretUsernameKey" . }} }' | base64 --decode
+kubectl get secret {{ include "corda.initialAdminUserSecretName" . }} -o jsonpath='{ .data.{{ include "corda.initialAdminUserSecretPasswordKey" . }} }' | base64 --decode
+
+2. Expose the APC endpoint on localhost by running this command:
+kubectl port-forward --namespace {{ .Release.Namespace }} deployment/{{ include "corda.fullname" . }}-rpc-worker 8888 &
+
+3. The API endpoint definition can then be accessed via: https://localhost:8888/api/v1/swagger

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -195,6 +195,27 @@ Kafka bootstrap servers
 {{- end }}
 
 {{/*
+Initial admin user secret name
+*/}}
+{{- define "corda.initialAdminUserSecretName" -}}
+{{ .Values.bootstrap.initialAdminUser.secretRef.name | default (printf "%s-initial-admin-user" (include "corda.fullname" .)) }}
+{{- end }}
+
+{{/*
+Initial admin user secret username key
+*/}}
+{{- define "corda.initialAdminUserSecretUsernameKey" -}}
+{{ .Values.bootstrap.initialAdminUser.secretRef.usernameKey }}
+{{- end }}
+
+{{/*
+Initial admin user secret password key
+*/}}
+{{- define "corda.initialAdminUserSecretPasswordKey" -}}
+{{ .Values.bootstrap.initialAdminUser.secretRef.passwordKey }}
+{{- end }}
+
+{{/*
 Worker Kafka arguments
 */}}
 {{- define "corda.workerKafkaArgs" -}}

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -1,6 +1,6 @@
+{{- if .Values.bootstrap.db.enabled }}
 apiVersion: batch/v1
 kind: Job
-{{- if .Values.bootstrap.auto }}
 metadata:
   name: corda-setup-db
   labels:
@@ -118,21 +118,21 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          args: [ 'initial-config', 'create-user-config', '-l', '/tmp/working_dir', 'create-dev-config']
+          args: [ 'initial-config', 'create-user-config', '-u', '$(INITIAL_ADMIN_USER_USERNAME)', '-p', '$(INITIAL_ADMIN_USER_PASSWORD)', '-l', '/tmp/working_dir']
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
           env:
-            - name: SALT
+            - name: INITIAL_ADMIN_USER_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
-                  key: salt
-            - name: PASSPHRASE
+                  name: {{ include "corda.initialAdminUserSecretName" . }}
+                  key: {{ include "corda.initialAdminUserSecretUsernameKey" . }}
+            - name: INITIAL_ADMIN_USER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ printf "%s-db-worker" (include "corda.fullname" .) }}
-                  key: passphrase
+                  name: {{ include "corda.initialAdminUserSecretName" . }}
+                  key: {{ include "corda.initialAdminUserSecretPasswordKey" . }}
         - name: apply-initial-rpc-admin
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/charts/corda/templates/initial-admin-user-secret.yaml
+++ b/charts/corda/templates/initial-admin-user-secret.yaml
@@ -1,0 +1,22 @@
+{{- $name := include "corda.initialAdminUserSecretName" . }}
+{{- $usernameKey := include "corda.initialAdminUserSecretUsernameKey" . }}
+{{- $passwordKey := include "corda.initialAdminUserSecretPasswordKey" . }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  annotations:
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook": pre-install
+  labels:
+    {{- include "corda.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- if $existingSecret }}
+  {{ $usernameKey }}: {{ index $existingSecret.data $usernameKey }}
+  {{ $passwordKey }}: {{ index $existingSecret.data $passwordKey }}
+{{- else }}
+  {{ $usernameKey }}: {{ required "Must specify bootstrap.initialAdminUser.secretRef or bootstrap.initialAdminUser.username" .Values.bootstrap.initialAdminUser.username | b64enc | quote }}
+  {{ $passwordKey }}: {{ .Values.bootstrap.initialAdminUser.password | default (randAlphaNum 12) | b64enc | quote }}
+{{- end }}

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.bootstrap.kafka.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -26,9 +27,9 @@ spec:
             '-n', '{{ .Values.kafka.topicPrefix }}',
             {{- end }}
             'create',
-            '-r', '{{ .Values.kafka.replicas }}',
-            '-p', '{{ .Values.kafka.partitions }}',
-            'connect'{{- if .Values.kafka.cleanup }},
+            '-r', '{{ .Values.bootstrap.kafka.replicas }}',
+            '-p', '{{ .Values.bootstrap.kafka.partitions }}',
+            'connect'{{- if .Values.bootstrap.kafka.cleanup }},
             '-d'
             {{- end }}
           ]
@@ -94,3 +95,4 @@ spec:
         {{- end }}
       restartPolicy: Never
   backoffLimit: 0
+{{- end }}

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -70,14 +70,8 @@ db:
 kafka:
   # -- comma-separated list of Kafka bootstrap servers (required)
   bootstrapServers: ""
-  # -- Kafka topic partitions
-  partitions: 10
-  # -- Kafka topic replicas
-  replicas: 3
   # -- prefix to use for Kafka topic names (to support the use of a single Kafka cluster by multiple Corda clusters)
   topicPrefix: ""
-  # -- Specifies whether existing topics with the given prefix should be deleted before trying to create new ones (deletes all existing topics if no prefix is given)
-  cleanup: false
   # TLS configuration for client connections to Kafka
   tls:
     # -- indicates whether TLS should be used for client connections to Kafka
@@ -105,21 +99,54 @@ kafka:
     # -- enable/disable SASL for client connection to Kafka 
     enabled: false
 
-# Configuration for the bootstrapper
+# Configuration for cluster bootstrap
 bootstrap:
-  auto: true
+
+  # Configuration for the initial user created with admin permissions
+  initialAdminUser:
+    # -- Username for the initial admin user
+    username: "admin"
+    # -- Password for the initial admin user; generated if not specified
+    password: ""
+    # Reference to a Kubernetes secret that holds the initial admin user credentials to be used in preference to any provided via username and password
+    secretRef:
+      # -- If specified, the name of an existing secret that contains the initial admin user credentials to be used in preference to any provided via username and password
+      name: ""
+      # -- The key name for the secret entry containing the initial admin user's username
+      usernameKey: "username"
+      # -- The key name for the secret entry containing the initial admin user's password
+      passwordKey: "password"
+
+  # Configuration for database bootstrap
+  db:
+    # -- Indicates whether DB bootstrap is enabled as part of installation
+    enabled: true
+
+  # Configuration for Kafka bootstrap
+  kafka:
+    # -- Indicates whether Kafka bootstrap is enabled as part of installation
+    enabled: true
+    # -- Specifies whether existing topics with the given prefix should be deleted before trying to create new ones (deletes all existing topics if no prefix is given)
+    cleanup: false
+    # -- Kafka topic partitions
+    partitions: 10
+    # -- Kafka topic replicas
+    replicas: 3
+
+  # Configuration for CLI image used for bootstrap
   image:
-    # -- cli image registry
+    # -- CLI image registry; defaults to image.registry
     registry: ""
-    # -- cli image repository
+    # -- CLI image repository
     repository: "corda-os-plugins"
-    # -- cli default tag
+    # -- CLI default tag; defaults to image.tag
     tag: ""
-  # resource limits and requests configuration for the bootstrapper
+
+  # resource limits and requests configuration for the bootstrap containers
   resources:
-    # -- the CPU/memory resource requests for the bootstrapper
+    # -- the CPU/memory resource requests for the bootstrap containers
     requests: { }
-    # -- the CPU/memory resource limits for the bootstrapper
+    # -- the CPU/memory resource limits for the bootstrap containers
     limits: { }
 
 # worker configuration

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/RbacConfigSubcommand.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/RbacConfigSubcommand.kt
@@ -49,20 +49,4 @@ class RbacConfigSubcommand : Runnable {
         }
     }
 
-    @Suppress("Unused")
-    @CommandLine.Command(
-        name = "create-dev-config",
-        description = ["Create a config with standard admin user/password and self-signed cert"]
-    )
-    fun createDevConfig() {
-        if (user == null) {
-            user = "admin"
-        }
-
-        if (password == null) {
-            password = "admin"
-        }
-        run()
-    }
-
 }

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginUser.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginUser.kt
@@ -9,24 +9,6 @@ import picocli.CommandLine
 class TestInitialConfigPluginUser {
 
     @Test
-    fun testDevSetupScript() {
-        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
-        val app = InitialConfigPlugin.PluginEntryPoint()
-
-        val outText = tapSystemOutNormalized {
-            CommandLine(
-                app
-            ).setColorScheme(colorScheme).execute("create-user-config", "create-dev-config")
-        }
-
-        // can only compare the first bit as timestamp and salted hash will change.
-        assertThat(outText).startsWith(
-            "insert into RPC_RBAC.rpc_user (enabled, full_name, hashed_password, id, login_name, " +
-                "salt_value, update_ts, version) values (true, 'Default Admin',"
-        )
-    }
-
-    @Test
     fun testSetupScript() {
         val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
         val app = InitialConfigPlugin.PluginEntryPoint()

--- a/values.yaml
+++ b/values.yaml
@@ -17,9 +17,12 @@ image:
   registry: corda-os-docker-dev.software.r3.com
   tag: latest-local
 
+bootstrap:
+  kafka:
+    replicas: 1
+
 kafka:
   bootstrapServers: prereqs-kafka:9092
-  replicas: 1
   tls:
     enabled: true
     truststore:

--- a/values.yaml
+++ b/values.yaml
@@ -18,6 +18,8 @@ image:
   tag: latest-local
 
 bootstrap:
+  initialAdminUser:
+    password: "admin"
   kafka:
     replicas: 1
 


### PR DESCRIPTION
Provides three mechanisms for providing credentials:

1. By default, the username is "admin" and the password is a generated
   12-character alphanumeric. The notes outputed on chart install have
   been updated to indicate how the generated password can be retrieved
   from the generated secret.

2. The bootstrap.initialAdminUser.admin/password values can be used to
   specify the credentials to use. The E2E tests will specify the
   password via this route until the tests are updated to allow the
   password to be overridden. Developers will likely also use this route
   and the wiki will be updated once merged.

3. A secret can be created that contains the credentials to be used. The
   name of the secret is specified via
   bootstrap.initialAdminUser.secretRef.name and the keys to the
   username/password via
   boostrap.initialAdminUser.secretRef.usernameKey/passwordKey.

Note that a few other values have been moved under bootstrap so that the
db and kafka values are only those that apply to both automatic and
manual boostrapping. Most notably, kafka.replicas is now
bootstrap.kafka.replicas and the default values.yaml has been updated to
reflect this.

The create-dev-config sub-command has been removed from the
create-user-config CLI command.