### PR TITLE
CORE-5921 Align signature file naming behavior in cli package plugin with `jarsigner`

### DIFF
--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpb.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpb.kt
@@ -45,9 +45,6 @@ class CreateCpb : Runnable {
 
         private const val CPB_CURRENT_FORMAT_VERSION = "2.0"
 
-        /** Name of signature within Cpb file */
-        const val CPB_SIGNER_NAME = "CPB-SIG"
-
         private val CPB_NAME_ATTRIBUTE = Attributes.Name("Corda-CPB-Name")
 
         private val CPB_VERSION_ATTRIBUTE = Attributes.Name("Corda-CPB-Version")
@@ -69,7 +66,7 @@ class CreateCpb : Runnable {
                 signingOptions.keyStoreFileName,
                 signingOptions.keyStorePass,
                 signingOptions.keyAlias,
-                CPB_SIGNER_NAME,
+                signingOptions.sigFile,
                 signingOptions.tsaUrl
             )
         } finally {

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpi.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpi.kt
@@ -21,11 +21,6 @@ import picocli.CommandLine
  */
 private const val META_INF_GROUP_POLICY_JSON = "META-INF/GroupPolicy.json"
 
-/**
- * Name of signature within jar file
- */
-private const val SIGNER_NAME = "CPI-SIG"
-
 private const val CPI_EXTENSION = ".cpi"
 
 /**
@@ -116,7 +111,7 @@ class CreateCpi : Runnable {
                 signingOptions.keyStoreFileName,
                 signingOptions.keyStorePass,
                 signingOptions.keyAlias,
-                SIGNER_NAME,
+                signingOptions.sigFile,
                 signingOptions.tsaUrl
             )
         } finally {

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/SignCpx.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/SignCpx.kt
@@ -15,10 +15,6 @@ class SignCpx : Runnable {
     @CommandLine.Parameters(index = "0", paramLabel = "CPI or CPB or CPK", description=["path of the input CPI or CPB or CPK"])
     lateinit var cpxFile: String
 
-    // TODO check how jarsigner works so that we have the equivalent. If overwriting it at least just log something.
-    @CommandLine.Option(names = ["--sig-file"], description = ["Signature file name"])
-    var sigFile: String = CPx_SIGNER_NAME
-
     @CommandLine.Option(
         names = ["--multiple-signatures"],
         arity = "1",
@@ -31,11 +27,6 @@ class SignCpx : Runnable {
     @CommandLine.Mixin
     var signingOptions = SigningOptions()
 
-    internal companion object {
-        /** Name of signature within Cpx file */
-         const val CPx_SIGNER_NAME = "CPX-SIG"
-    }
-
     override fun run() {
         val cpxFilePath = requireFileExists(cpxFile)
         val signedCpxPath = requireFileDoesNotExist(outputSignedCpxFile)
@@ -47,7 +38,7 @@ class SignCpx : Runnable {
                 signingOptions.keyStoreFileName,
                 signingOptions.keyStorePass,
                 signingOptions.keyAlias,
-                sigFile,
+                signingOptions.sigFile,
                 signingOptions.tsaUrl
             )
         } else {
@@ -60,7 +51,7 @@ class SignCpx : Runnable {
                     signingOptions.keyStoreFileName,
                     signingOptions.keyStorePass,
                     signingOptions.keyAlias,
-                    sigFile,
+                    signingOptions.sigFile,
                     signingOptions.tsaUrl
                 )
             } finally {

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/signing/SigningOptions.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/signing/SigningOptions.kt
@@ -17,4 +17,27 @@ class SigningOptions {
 
     @CommandLine.Option(names = ["--tsa", "-t"], description = ["Time Stamping Authority (TSA) URL"])
     var tsaUrl: String? = null
+
+    @CommandLine.Option(names = ["--sig-file"], description = ["Base file name for signature related files"])
+    private var _sigFile: String? = null
+
+    // The following has the same behavior as jarsigner in terms of signature files naming.
+    val sigFile: String
+        get() =
+            _sigFile ?: keyAlias.run {
+                var str = this
+                if (str.length > 8) {
+                    str = str.substring(0, 8).uppercase()
+                }
+                val strBuilder = StringBuilder()
+                for (c in str) {
+                    @Suppress("ComplexCondition")
+                    if (c in 'A'..'Z' || c in 'a'..'z' || c == '-' || c == '_')
+                        strBuilder.append(c)
+                    else
+                        strBuilder.append('_')
+                }
+                str = strBuilder.toString()
+                str
+            }
 }

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpbTest.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpbTest.kt
@@ -23,6 +23,8 @@ class CreateCpbTest {
     private val app = CreateCpb()
 
     internal companion object {
+        const val CPB_SIGNER_NAME = "CPB-SIG"
+
         const val CREATED_CPB_NAME = "cpb-test-outcome.cpb"
 
         private val testKeyStore = Path.of(this::class.java.getResource("/signingkeys.pfx")?.toURI()
@@ -70,7 +72,8 @@ class CreateCpbTest {
                 "--file=$outcomeCpb",
                 "--keystore=$testKeyStore",
                 "--storepass=keystore password",
-                "--key=signing key 1"
+                "--key=signing key 1",
+                "--sig-file=$CPB_SIGNER_NAME"
             )
 
         checkCpbContainsEntries(
@@ -102,7 +105,8 @@ class CreateCpbTest {
                     "--file=never-generated-cpb.cpb",
                     "--keystore=$testKeyStore",
                     "--storepass=keystore password",
-                    "--key=signing key 1"
+                    "--key=signing key 1",
+                    "--sig-file=$CPB_SIGNER_NAME"
                 )
         }
 
@@ -135,12 +139,13 @@ class CreateCpbTest {
                 "--file=$outcomeCpb",
                 "--keystore=$testKeyStore",
                 "--storepass=keystore password",
-                "--key=signing key 1"
+                "--key=signing key 1",
+                "--sig-file=$CPB_SIGNER_NAME"
             )
 
         checkCpbContainsEntries(
             outcomeCpb,
-            listOf("META-INF/CPB-SIG.SF", "META-INF/CPB-SIG.RSA")
+            listOf("META-INF/$CPB_SIGNER_NAME.SF", "META-INF/$CPB_SIGNER_NAME.RSA")
         )
     }
 }

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
@@ -27,6 +27,10 @@ class CreateCpiTest {
     lateinit var tempDir: Path
     private lateinit var testCpb: Path
 
+    companion object {
+        private const val SIGNER_NAME = "CPI-SIG"
+    }
+
     private val app = CreateCpi()
     private val testGroupPolicy = Path.of(this::class.java.getResource("/TestGroupPolicy.json")?.toURI()
         ?: error("TestGroupPolicy.json not found"))
@@ -109,6 +113,7 @@ class CreateCpiTest {
                 "--keystore=${testKeyStore}",
                 "--storepass=keystore password",
                 "--key=signing key 1",
+                "--sig-file=$SIGNER_NAME"
             )
         }
 
@@ -130,6 +135,7 @@ class CreateCpiTest {
                 "-s=${testKeyStore}",
                 "-p=keystore password",
                 "-k=signing key 1",
+                "--sig-file=$SIGNER_NAME"
             )
         }
 
@@ -151,6 +157,7 @@ class CreateCpiTest {
                 "-s=${testKeyStore}",
                 "-p=keystore password",
                 "-k=signing key 1",
+                "--sig-file=$SIGNER_NAME"
             )
         }
 
@@ -216,7 +223,7 @@ class CreateCpiTest {
         assertEquals("""Missing required options: '--cpb=<cpbFileName>', '--group-policy=<groupPolicyFileName>', '--keystore=<keyStoreFileName>', '--storepass=<keyStorePass>', '--key=<keyAlias>'
 Usage: create -c=<cpbFileName> [-f=<outputFileName>] -g=<groupPolicyFileName>
               -k=<keyAlias> -p=<keyStorePass> -s=<keyStoreFileName>
-              [-t=<tsaUrl>]
+              [--sig-file=<_sigFile>] [-t=<tsaUrl>]
 Creates a CPI from a CPB and GroupPolicy.json file.
   -c, --cpb=<cpbFileName>   CPB file to convert into CPI
   -f, --file=<outputFileName>
@@ -231,6 +238,7 @@ Creates a CPI from a CPB and GroupPolicy.json file.
                             Keystore password
   -s, --keystore=<keyStoreFileName>
                             Keystore holding signing keys
+      --sig-file=<_sigFile> Base file name for signature related files
   -t, --tsa=<tsaUrl>        Time Stamping Authority (TSA) URL
 """, errText)
     }

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/TestUtils.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/TestUtils.kt
@@ -137,4 +137,13 @@ internal object TestUtils {
             }
         }
     }
+
+    fun jarEntriesExistInCpx(cpxPath: Path, expectedEntries: List<String>): Boolean {
+        JarInputStream(Files.newInputStream(cpxPath)).use {
+            val actualEntries = generateSequence { it.nextJarEntry?.name }.toList()
+            return expectedEntries.all {
+                actualEntries.contains(it)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Aligns signature files (.SF, .RSA) naming with `jarsigner`  across all package module any time we need to sign a Cpx.

- adds `--sig-file` option to specify signature files base name for all commands that do signing.
- if `--sig-file` is missing then key alias is used, modified if needed as per [jarsigner docs](https://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#:~:text=a%20secure%20system.-,%2Dsigfile%20file,-Specifies%20the%20base).   