### PR TITLE
NOTICK - Add missing algorithm in public key reader

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/PublicKeyReader.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/PublicKeyReader.kt
@@ -12,7 +12,7 @@ internal class PublicKeyReader {
     companion object {
         internal fun PublicKey.toKeyAlgorithm(): KeyAlgorithm {
             return when (this.algorithm) {
-                "EC" -> KeyAlgorithm.ECDSA
+                "EC", "ECDSA" -> KeyAlgorithm.ECDSA
                 "RSA" -> KeyAlgorithm.RSA
                 else -> throw UnsupportedAlgorithm(this)
             }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/PublicKeyReaderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/PublicKeyReaderTest.kt
@@ -7,9 +7,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import java.io.StringWriter
 import java.security.Key
 import java.security.KeyPairGenerator
+import java.security.PublicKey
 
 class PublicKeyReaderTest {
     @Test
@@ -49,8 +52,17 @@ class PublicKeyReaderTest {
     }
 
     @Test
-    fun `toKeyAlgorithm return EC for ECDSA key`() {
+    fun `toKeyAlgorithm return ECDSA for EC key`() {
         val key = KeyPairGenerator.getInstance("EC").genKeyPair().public
+
+        assertThat(key.toKeyAlgorithm()).isEqualTo(KeyAlgorithm.ECDSA)
+    }
+
+    @Test
+    fun `toKeyAlgorithm return ECDSA for ECDSA key`() {
+        val key = mock<PublicKey> {
+            on { algorithm } doReturn "ECDSA"
+        }
 
         assertThat(key.toKeyAlgorithm()).isEqualTo(KeyAlgorithm.ECDSA)
     }


### PR DESCRIPTION
Add missing algorithm in public key reader.

This was working so far, but now that `MemberInfo`s are picked up from the membership components, we are seeing the following error on the link manager:
```
14:45:27.276 [durable processing thread outbound_message_processor_group-p2p.out] ERROR EVENT_LOG-outbound_message_processor_group-p2p.out-6 - Failed to read and process records from topic p2p.out, group outbound_message_processor_gro │
│ net.corda.messaging.api.exception.CordaMessageAPIFatalException: Failed to process records from topic p2p.out, group outbound_message_processor_group, producerClientId EVENT_LOG-outbound_message_processor_group-p2p.out-6. Unexpected e │
│     at net.corda.messaging.subscription.EventLogSubscriptionImpl.processDurableRecords(EventLogSubscriptionImpl.kt:288) ~[?:?]                                                                                                             │
│     at net.corda.messaging.subscription.EventLogSubscriptionImpl.pollAndProcessRecords(EventLogSubscriptionImpl.kt:203) ~[?:?]                                                                                                             │
│     at net.corda.messaging.subscription.EventLogSubscriptionImpl.runConsumeLoop(EventLogSubscriptionImpl.kt:165) ~[?:?]                                                                                                                    │
│     at net.corda.messaging.subscription.EventLogSubscriptionImpl$start$2$1.invoke(EventLogSubscriptionImpl.kt:101) ~[?:?]                                                                                                                  │
│     at net.corda.messaging.subscription.EventLogSubscriptionImpl$start$2$1.invoke(EventLogSubscriptionImpl.kt:101) ~[?:?]                                                                                                                  │
│     at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30) ~[p2p-link-manager.jar:?]                                                                                                                                             │
│ Caused by: net.corda.p2p.test.stub.crypto.processor.UnsupportedAlgorithm: Unsupported algorithm ECDSA                                                                                                                                      │
│     at net.corda.p2p.linkmanager.PublicKeyReader$Companion.toKeyAlgorithm$link_manager(PublicKeyReader.kt:17) ~[?:?]                                                                                                                       │
│     at net.corda.p2p.linkmanager.ForwardingMembershipGroupReader.toLinkManagerMemberInfo(ForwardingMembershipGroupReader.kt:62) ~[?:?]                                                                                                     │
│     at net.corda.p2p.linkmanager.ForwardingMembershipGroupReader.getMemberInfo(ForwardingMembershipGroupReader.kt:32) ~[?:?]                                                                                                               │
│     at net.corda.p2p.linkmanager.messaging.MessageConverter$Companion.linkOutFromUnauthenticatedMessage(MessageConverter.kt:152) ~[?:?]                                                                                                    │
│     at net.corda.p2p.linkmanager.OutboundMessageProcessor.processUnauthenticatedMessage(OutboundMessageProcessor.kt:109) ~[?:?]                                                                                                            │
│     at net.corda.p2p.linkmanager.OutboundMessageProcessor.processEvent(OutboundMessageProcessor.kt:95) ~[?:?]                                                                                                                              │
│     at net.corda.p2p.linkmanager.OutboundMessageProcessor.onNext(OutboundMessageProcessor.kt:71) ~[?:?]                                                                                                                                    │
│     at net.corda.messaging.subscription.EventLogSubscriptionImpl.processDurableRecords(EventLogSubscriptionImpl.kt:269) ~[?:?]                                                                                                             │
│     ... 5 more
```

The reason for that is that `CipherSchemeMetadataImpl.decodePublicKey(encodedKey: String)` decodes the key using BouncyCastle (`JcaPEMKeyConverter`), which translates the algorithm identifier `1.2.840.10045.2.1` into `ECDSA`, instead of `EC` (BouncyCastle supports both).  