### PR TITLE
NOTICK-editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 140


### PR DESCRIPTION
Added editorconfig to apply the 140 character boundary width, which aligns with the coding standards documentation.

https://engineering.r3.com/guilds/guild-of-kotlin-engineers/coding-standards/public-api-coding-standards/

> Wrap at 140 characters