### PR TITLE
CORE-5913: Rename return types for `CpiUploadRPCOps`

### DIFF
--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
@@ -28,7 +28,7 @@ class CpiUploadRPCOpsImpl @Activate constructor(
     private val cpiInfoReadService: CpiInfoReadService
 ) : CpiUploadRPCOps, PluggableRPCOps<CpiUploadRPCOps>, Lifecycle {
     companion object {
-        val logger = contextLogger()
+        private val logger = contextLogger()
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<CpiUploadRPCOps>(
@@ -47,15 +47,15 @@ class CpiUploadRPCOpsImpl @Activate constructor(
 
     override fun stop() = coordinator.close()
 
-    override fun cpi(upload: HttpFileUpload): CpiUploadRPCOps.UploadResponse {
+    override fun cpi(upload: HttpFileUpload): CpiUploadRPCOps.CpiUploadResponse {
         logger.info("Uploading CPI: ${upload.fileName}")
         requireRunning()
         val cpiUploadRequestId = cpiUploadManager.uploadCpi(upload.fileName, upload.content)
-        return CpiUploadRPCOps.UploadResponse(cpiUploadRequestId.requestId)
+        return CpiUploadRPCOps.CpiUploadResponse(cpiUploadRequestId.requestId)
     }
 
     // We're mostly returning the enumeration to a string in this version
-    override fun status(id: String): CpiUploadRPCOps.Status {
+    override fun status(id: String): CpiUploadRPCOps.CpiUploadStatus {
         logger.info("Upload status request for CPI id: $id")
         requireRunning()
         val status = cpiUploadManager.status(id) ?: throw InternalServerException("No such requestId=$id")
@@ -66,7 +66,7 @@ class CpiUploadRPCOpsImpl @Activate constructor(
         }
 
         val checksum = if (status.checksum != null) toShortHash(status.checksum.toCorda()) else ""
-        return CpiUploadRPCOps.Status(status.message, checksum)
+        return CpiUploadRPCOps.CpiUploadStatus(status.message, checksum)
     }
 
     override fun getAllCpis(): GetCPIsResponse {

--- a/components/virtual-node/virtual-node-rpcops-maintenance-impl/src/main/kotlin/net/corda/libs/virtualnode/maintenance/rpcops/impl/v1/VirtualNodeMaintenanceRPCOpsImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-maintenance-impl/src/main/kotlin/net/corda/libs/virtualnode/maintenance/rpcops/impl/v1/VirtualNodeMaintenanceRPCOpsImpl.kt
@@ -105,14 +105,14 @@ class VirtualNodeMaintenanceRPCOpsImpl @Activate constructor(
         }
     }
 
-    override fun forceCpiUpload(upload: HttpFileUpload): CpiUploadRPCOps.UploadResponse {
+    override fun forceCpiUpload(upload: HttpFileUpload): CpiUploadRPCOps.CpiUploadResponse {
         logger.info("Force uploading CPI: ${upload.fileName}")
         requireRunning()
         val cpiUploadRequestId = cpiUploadManager.uploadCpi(
             upload.fileName, upload.content,
             mapOf(PropertyKeys.FORCE_UPLOAD to true.toString())
         )
-        return CpiUploadRPCOps.UploadResponse(cpiUploadRequestId.requestId)
+        return CpiUploadRPCOps.CpiUploadResponse(cpiUploadRequestId.requestId)
     }
 
     // Lookup and update the virtual node for the given virtual node short ID.

--- a/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRPCOps.kt
+++ b/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRPCOps.kt
@@ -14,22 +14,22 @@ import net.corda.httprpc.HttpFileUpload
 )
 interface CpiUploadRPCOps : RpcOps {
     /** Simple class to return some information back to the caller regarding the upload request */
-    data class UploadResponse(val id: String)
+    data class CpiUploadResponse(val id: String)
 
     /**
      * HTTP POST resource to upload a CPI to Kafka.
      *
-     * Please note that this method will not close [cpiContent] input stream, the caller must close it.
+     * Please note that this method will not close [HttpFileUpload.content] input stream, the caller must close it.
      */
     @HttpRpcPOST(
         title = "CPI API",
         description = "CPI management endpoints.",
         responseDescription = "The request Id calculated for a CPI upload request"
     )
-    fun cpi(upload: HttpFileUpload): UploadResponse
+    fun cpi(upload: HttpFileUpload): CpiUploadResponse
 
     /** Simple class to return the status of the upload request */
-    data class Status(val status: String, val cpiFileChecksum: String)
+    data class CpiUploadStatus(val status: String, val cpiFileChecksum: String)
 
     /**
      * Get the status of the upload.
@@ -41,7 +41,7 @@ interface CpiUploadRPCOps : RpcOps {
     fun status(
         @HttpRpcPathParameter(description = "The requestId")
         id: String,
-    ): Status
+    ): CpiUploadStatus
 
     /**
      * Lists all CPIs uploaded to the cluster.

--- a/libs/virtual-node/virtual-node-endpoints-maintenance/src/main/kotlin/net/corda/libs/virtualnode/maintenance/endpoints/v1/VirtualNodeMaintenanceRPCOps.kt
+++ b/libs/virtual-node/virtual-node-endpoints-maintenance/src/main/kotlin/net/corda/libs/virtualnode/maintenance/endpoints/v1/VirtualNodeMaintenanceRPCOps.kt
@@ -35,7 +35,7 @@ interface VirtualNodeMaintenanceRPCOps : RpcOps {
         description = "Uploads a CPI",
         responseDescription = "The request Id calculated for a CPI upload request"
     )
-    fun forceCpiUpload(upload: HttpFileUpload): CpiUploadRPCOps.UploadResponse
+    fun forceCpiUpload(upload: HttpFileUpload): CpiUploadRPCOps.CpiUploadResponse
 
     /**
      * Updates a virtual nodes state.

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -376,7 +376,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UploadResponse"
+                  "$ref" : "#/components/schemas/CpiUploadResponse"
                 }
               }
             }
@@ -442,7 +442,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Status"
+                  "$ref" : "#/components/schemas/CpiUploadStatus"
                 }
               }
             }
@@ -1338,7 +1338,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/UploadResponse"
+                  "$ref" : "#/components/schemas/CpiUploadResponse"
                 }
               }
             }
@@ -2530,6 +2530,33 @@
           }
         }
       },
+      "CpiUploadResponse" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          }
+        }
+      },
+      "CpiUploadStatus" : {
+        "required" : [ "cpiFileChecksum", "status" ],
+        "type" : "object",
+        "properties" : {
+          "cpiFileChecksum" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          }
+        }
+      },
       "CpkIdentifier" : {
         "required" : [ "name", "version" ],
         "type" : "object",
@@ -3314,22 +3341,6 @@
           }
         }
       },
-      "Status" : {
-        "required" : [ "cpiFileChecksum", "status" ],
-        "type" : "object",
-        "properties" : {
-          "cpiFileChecksum" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          }
-        }
-      },
       "UpdateConfigParameters" : {
         "required" : [ "config", "schemaVersion", "section", "version" ],
         "type" : "object",
@@ -3399,17 +3410,6 @@
         },
         "description" : "UpdatevirtualnodestateWrapperRequest",
         "nullable" : false
-      },
-      "UploadResponse" : {
-        "required" : [ "id" ],
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          }
-        }
       },
       "UserPermissionSummaryResponseType" : {
         "required" : [ "enabled", "lastUpdateTimestamp", "loginName", "permissions" ],


### PR DESCRIPTION
Before the change in OpenAPI we had a type called `Status` which was rather non-descriptive and unclear what kind of status is that.