### PR TITLE
NOTICK - Wrap incoming unauthenticated messages in app message

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessor.kt
@@ -64,7 +64,7 @@ internal class InboundMessageProcessor(
                     processSessionMessage(message)
                 }
                 is UnauthenticatedMessage -> {
-                    listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), payload))
+                    listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(payload)))
                 }
                 else -> {
                     logger.error("Received unknown payload type ${message.payload::class.java.simpleName}. The message was discarded.")

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessorTest.kt
@@ -752,7 +752,8 @@ class InboundMessageProcessorTest {
 
         assertThat(records).hasSize(1).anySatisfy {
             assertThat(it.topic).isEqualTo(P2P_IN_TOPIC)
-            assertThat(it.value).isSameAs(unauthenticatedMessage)
+            assertThat(it.value).isInstanceOf(AppMessage::class.java)
+            assertThat((it.value as AppMessage).message).isEqualTo(unauthenticatedMessage)
         }
     }
 }


### PR DESCRIPTION
Incoming unauthenticated messages were not being wrapped in app message, as they should have been.