### PR TITLE
CORE-5959 Cpi status returns 400 for bad request

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -275,6 +275,18 @@ class VirtualNodeRpcTest {
     }
 
     @Test
+    @Order(65)
+    fun `cpi status returns 400 for unknown request id`() {
+        cluster {
+            endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+            assertWithRetry {
+                command { cpiStatus("THIS_WILL_NEVER_BE_A_CPI_STATUS") }
+                condition { it.code == 400 }
+            }
+        }
+    }
+
+    @Test
     @Order(80)
     fun `can force upload same CPI`() {
         cluster {

--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
@@ -17,6 +17,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import net.corda.httprpc.HttpFileUpload
+import net.corda.httprpc.exception.InvalidInputDataException
 
 @Component(service = [PluggableRPCOps::class])
 class CpiUploadRPCOpsImpl @Activate constructor(
@@ -58,7 +59,7 @@ class CpiUploadRPCOpsImpl @Activate constructor(
     override fun status(id: String): CpiUploadRPCOps.Status {
         logger.info("Upload status request for CPI id: $id")
         requireRunning()
-        val status = cpiUploadManager.status(id) ?: throw InternalServerException("No such requestId=$id")
+        val status = cpiUploadManager.status(id) ?: throw InvalidInputDataException("No such requestId=$id")
 
         // Errors are passed back to the Javalin code via exceptions.
         if (status.exception != null) {


### PR DESCRIPTION
A bad request id should return 400 - "bad request error" when an
invalid request id is used.