### PR TITLE
CORE-5985 Allow MGM to have pending members in it's member cache and to look them up through the group reader

### DIFF
--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
@@ -1,13 +1,15 @@
 package net.corda.membership.impl.read.reader
 
+import net.corda.membership.impl.read.cache.MembershipGroupReadCache
+import net.corda.membership.lib.CPIWhiteList
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.ledgerKeyHashes
 import net.corda.membership.lib.MemberInfoExtension.Companion.sessionKeyHash
-import net.corda.membership.lib.CPIWhiteList
-import net.corda.membership.impl.read.cache.MembershipGroupReadCache
+import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.read.MembershipGroupReader
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.membership.GroupParameters
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 
@@ -21,20 +23,28 @@ class MembershipGroupReaderImpl(
     private val memberList: List<MemberInfo>
         get() = membershipGroupReadCache.memberListCache.get(holdingIdentity)
             ?: throw IllegalStateException(
-                "Failed to find member list for ID='${holdingIdentity.shortHash}, Group ID='${holdingIdentity.groupId}'")
+                "Failed to find member list for ID='${holdingIdentity.shortHash}, Group ID='${holdingIdentity.groupId}'"
+            )
 
     override val groupParameters: GroupParameters
         get() = TODO("Not yet implemented")
     override val cpiWhiteList: CPIWhiteList
         get() = TODO("Not yet implemented")
 
-    override fun lookup(): Collection<MemberInfo> = memberList.filter { it.isActive }
+    override fun lookup(): Collection<MemberInfo> = memberList.filter { it.isActiveOrPending() }
 
     override fun lookupByLedgerKey(ledgerKeyHash: PublicKeyHash): MemberInfo? =
-        memberList.singleOrNull { it.isActive && ledgerKeyHash in it.ledgerKeyHashes }
+        memberList.singleOrNull { it.isActiveOrPending() && ledgerKeyHash in it.ledgerKeyHashes }
 
     override fun lookupBySessionKey(sessionKeyHash: PublicKeyHash): MemberInfo? =
-        memberList.singleOrNull { it.isActive && sessionKeyHash == it.sessionKeyHash }
+        memberList.singleOrNull { it.isActiveOrPending() && sessionKeyHash == it.sessionKeyHash }
 
-    override fun lookup(name: MemberX500Name) = memberList.singleOrNull { it.isActive && it.name == name }
+    override fun lookup(name: MemberX500Name) = memberList.singleOrNull {
+        it.isActiveOrPending() && it.name == name
+    }
+
+
+    private fun MemberInfo.isActiveOrPending(): Boolean {
+        return isActive || status == MEMBER_STATUS_PENDING
+    }
 }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -1,13 +1,18 @@
 package net.corda.membership.impl.read.reader
 
-import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES
-import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.impl.read.TestProperties
 import net.corda.membership.impl.read.TestProperties.Companion.GROUP_ID_1
 import net.corda.membership.impl.read.cache.MemberListCache
 import net.corda.membership.impl.read.cache.MembershipGroupReadCache
+import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
+import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.crypto.sha256Bytes
+import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -41,24 +46,43 @@ class MembershipGroupReaderImplTest {
         on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
         on { parse(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
     }
+    private val mockedSuspendedMgmProvidedContext = mock<MGMContext> {
+        on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_SUSPENDED
+    }
     private val suspendedMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
         on { ledgerKeys } doReturn listOf(mockLedgerKey)
         on { sessionInitiationKey } doReturn mockSessionKey
         on { memberProvidedContext } doReturn mockedSuspendedMemberProvidedContext
+        on { mgmProvidedContext } doReturn mockedSuspendedMgmProvidedContext
         on { isActive } doReturn false
     }
 
     private val mockedActiveMemberProvidedContext = mock<MemberContext> {
         on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
         on { parse(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
+        on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_ACTIVE
+    }
+    private val mockedActiveMgmProvidedContext = mock<MGMContext> {
+        on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_ACTIVE
     }
     private val activeMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
         on { ledgerKeys } doReturn listOf(mockLedgerKey)
         on { sessionInitiationKey } doReturn mockSessionKey
         on { memberProvidedContext } doReturn mockedActiveMemberProvidedContext
+        on { mgmProvidedContext } doReturn mockedActiveMgmProvidedContext
         on { isActive } doReturn true
+    }
+
+    private val mockedPendingMgmProvidedContext = mock<MGMContext> {
+        on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_PENDING
+    }
+    private val pendingMemberInfo: MemberInfo = mock {
+        on { name } doReturn aliceName
+        on { memberProvidedContext } doReturn mockedActiveMemberProvidedContext
+        on { mgmProvidedContext } doReturn mockedPendingMgmProvidedContext
+        on { isActive } doReturn false
     }
 
     @BeforeEach
@@ -83,6 +107,12 @@ class MembershipGroupReaderImplTest {
     fun `lookup known member with non active status based on name`() {
         mockMemberList(listOf(suspendedMemberInfo))
         assertNull(membershipGroupReaderImpl.lookup(aliceName))
+    }
+
+    @Test
+    fun `lookup known member with pending status based on name`() {
+        mockMemberList(listOf(pendingMemberInfo))
+        assertEquals(pendingMemberInfo, membershipGroupReaderImpl.lookup(aliceName))
     }
 
     @Test


### PR DESCRIPTION
The MGM needs to be able to send authenticated messages to members who are still in a pending state.
This PR changes the group reader slightly to allow pending members to be returned. Since pending members will never be distributed, only MGMs will have access to pending members. Pending members are published to the member list after their registration requests have been approved. 