### PR TITLE
CORE-4357 CPI Tool v2

### DIFF
--- a/tools/plugins/package/README.md
+++ b/tools/plugins/package/README.md
@@ -40,8 +40,28 @@ jarsigner -keystore signingkeys.pfx -storepass "keystore password" -verbose -cer
     --key "signing key 1" \
     --tsa https://freetsa.org/tsr
 
-# Pipe group policy into application package
+# Pipe group policy into CPI
 ./corda-cli.sh mgm groupPolicy | ./corda-cli.sh package create \
+    --cpb mycpb.cpb \
+    --group-policy - \
+    --file output.cpi \
+    --keystore signingkeys.pfx \
+    --storepass "keystore password" \
+    --key "signing key 1" \
+    --tsa https://freetsa.org/tsr
+    
+# Build a CPI v2
+./corda-cli.sh package create-cpi \
+    --cpb mycpb.cpb \
+    --group-policy TestGroupPolicy.json \
+    --file output.cpi \
+    --keystore signingkeys.pfx \
+    --storepass "keystore password" \
+    --key "signing key 1" \
+    --tsa https://freetsa.org/tsr    
+    
+# Pipe group policy into CPI v2
+./corda-cli.sh mgm groupPolicy | ./corda-cli.sh package create-cpi \
     --cpb mycpb.cpb \
     --group-policy - \
     --file output.cpi \

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/PackagePluginWrapper.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/PackagePluginWrapper.kt
@@ -11,7 +11,7 @@ class PackagePluginWrapper(wrapper: PluginWrapper) : Plugin(wrapper) {
     @Extension
     @CommandLine.Command(
         name = "package",
-        subcommands = [CreateCpi::class, Verify::class, CreateCpb::class, SignCpx::class],
+        subcommands = [CreateCpi::class, CreateCpiV2::class, Verify::class, CreateCpb::class, SignCpx::class],
         description = ["Plugin for CPB, CPI operations."]
     )
     class PackagePlugin : CordaCliPlugin

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
@@ -1,0 +1,100 @@
+package net.corda.cli.plugins.packaging
+
+import java.nio.file.Path
+import java.util.jar.Attributes
+import net.corda.cli.plugins.packaging.TestUtils.assertContainsAllManifestAttributes
+import net.corda.cli.plugins.packaging.TestUtils.jarEntriesExistInCpx
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import picocli.CommandLine
+
+class CreateCpiV2Test {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    companion object {
+
+        // Share cpb across all tests since we only read it and not modify it to save disk writes
+        @TempDir
+        lateinit var cpbDir: Path
+
+        lateinit var cpbPath: Path
+
+        const val CPI_FILE_NAME = "output.cpi"
+        const val SIGNER_NAME = "CPI-SIG"
+
+        private val testGroupPolicy = Path.of(this::class.java.getResource("/TestGroupPolicy.json")?.toURI()
+            ?: error("TestGroupPolicy.json not found"))
+        private val testKeyStore = Path.of(this::class.java.getResource("/signingkeys.pfx")?.toURI()
+            ?: error("signingkeys.pfx not found"))
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp() {
+            // Create a single cpb to be used for all tests
+            val createCpbTest = CreateCpbTest()
+            createCpbTest.tempDir = cpbDir
+            createCpbTest.`packs CPKs into CPB`()
+            cpbPath = Path.of("$cpbDir/${CreateCpbTest.CREATED_CPB_NAME}")
+        }
+    }
+
+    @Test
+    fun `cpi v2 contains cpb, manifest, signature files and GroupPolicy file`() {
+        val outputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
+        CommandLine(CreateCpiV2()).execute (
+            "--cpb=${cpbPath}",
+            "--group-policy=${testGroupPolicy}",
+            "--cpi-name=testCpi",
+            "--cpi-version=5.0.0.0-SNAPSHOT",
+            "--file=$outputFile",
+            "--keystore=${testKeyStore}",
+            "--storepass=keystore password",
+            "--key=signing key 1",
+            "--sig-file=$SIGNER_NAME"
+        )
+
+        assertTrue(
+            jarEntriesExistInCpx(
+                outputFile,
+                listOf(
+                    "META-INF/MANIFEST.MF",
+                    "META-INF/$SIGNER_NAME.SF",
+                    "META-INF/$SIGNER_NAME.RSA",
+                    "META-INF/GroupPolicy.json",
+                    cpbPath.fileName.toString()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `cpi v2 contains manifest attributes`() {
+        val cpiOutputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
+        CommandLine(CreateCpiV2()).execute (
+            "--cpb=${cpbPath}",
+            "--group-policy=${testGroupPolicy}",
+            "--cpi-name=testCpi",
+            "--cpi-version=5.0.0.0-SNAPSHOT",
+            "--file=$cpiOutputFile",
+            "--keystore=${testKeyStore}",
+            "--storepass=keystore password",
+            "--key=signing key 1",
+            "--sig-file=$SIGNER_NAME"
+        )
+
+        assertContainsAllManifestAttributes(
+            cpiOutputFile,
+            mapOf(
+                Attributes.Name.MANIFEST_VERSION to "1.0",
+                CPI_FORMAT_ATTRIBUTE_NAME to CPI_FORMAT_ATTRIBUTE,
+                CPI_NAME_ATTRIBUTE_NAME to "testCpi",
+                CPI_VERSION_ATTRIBUTE_NAME to "5.0.0.0-SNAPSHOT",
+                CPI_UPGRADE_ATTRIBUTE_NAME to "false"
+            )
+        )
+    }
+}


### PR DESCRIPTION
Adds CPI Tool for creating CPI v2 format 

(Code for this tool is copy and paste from v1 tool with needed minor modification, so it currently adds duplication, but we will be removing v1 tool so it should be ok).

- embeds the CPB instead of modifying it.
- adds CPI manifest main attributes as described [here](https://github.com/corda/platform-eng-design/blob/e494db1d6035c755095c20dcbebcce141b46adc2/core/corda-5/corda-5.0/packaging/cpi.md#manifest-attributes).
- adds tests asserting CPI v2 format.

Please note: it does not verify the CPB before packing it into the CPI. CPB verification for both CPI v1 and v2 tools will be added with CORE-5324.