### PR TITLE
CORE-4989 Add support for JSON format logs

### DIFF
--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -5,6 +5,9 @@ bootstrap:
   initialAdminUser:
     password: "admin"
 
+logging:
+  format: text
+
 kafka:
   bootstrapServers: prereqs-kafka:9092
   tls:

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -184,7 +184,9 @@ Worker environment variables
       -Dotel.metrics.exporter=logging
       -Dotel.traces.exporter=logging
       {{- end -}}
-    {{- end -}}
+    {{- end }}
+- name: LOG4J_CONFIG_FILE
+  value: "log4j2-console{{ if eq .Values.logging.format "json" }}-json{{ end }}.xml"
 {{- end }}
 
 {{/*

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -28,6 +28,11 @@ resources:
   # -- the default CPU/memory resource request for the Corda containers
   requests: {}
 
+# Logging configuration
+logging:
+  # -- log format; "json" or "text"
+  format: "json"
+
 # Open Telemetry configuration
 openTelemetry:
   # -- enables the Open Telemetry Java agent for the Corda workers

--- a/libs/http-rpc/http-rpc-common/src/main/kotlin/net/corda/httprpc/durablestream/DurableStreamHelper.kt
+++ b/libs/http-rpc/http-rpc-common/src/main/kotlin/net/corda/httprpc/durablestream/DurableStreamHelper.kt
@@ -24,7 +24,7 @@ object DurableStreamHelper {
     @JvmStatic
     fun <T> withDurableStreamContext
             (block: DurableStreamContext.() -> DurableStreamContextExecutionOutcome<T>): FiniteDurableCursorBuilder<T> {
-        val durableStreamContext = requireNotNull(rpcContext().invocation.durableStreamContext) {
+        val durableStreamContext = requireNotNull(rpcContext()?.invocation?.durableStreamContext) {
             "Durable stream context should always be set for durable streams invocation."
         }
         val (positionedValues, remainingElementsCountEstimate, isLastResult) = block(durableStreamContext)

--- a/libs/http-rpc/http-rpc-common/src/main/kotlin/net/corda/httprpc/security/RpcAuthContext.kt
+++ b/libs/http-rpc/http-rpc-common/src/main/kotlin/net/corda/httprpc/security/RpcAuthContext.kt
@@ -12,18 +12,10 @@ data class RpcAuthContext(
 val CURRENT_RPC_CONTEXT: ThreadLocal<RpcAuthContext> = CurrentRpcContext()
 
 /**
- * Returns a context specific to the current RPC call. Note that trying to call this function outside of an RPC will
- * throw. If you'd like to use the context outside of the call (e.g. in another thread) then pass the returned reference
- * around explicitly.
- * The [RpcAuthContext] includes permissions.
- */
-fun rpcContext(): RpcAuthContext = CURRENT_RPC_CONTEXT.get()
-
-/**
  * Returns a context specific to the current RPC call or <code>null</code> if not set.
  * The [RpcAuthContext] includes permissions.
  */
-fun nullableRpcContext(): RpcAuthContext? = CURRENT_RPC_CONTEXT.get()
+fun rpcContext(): RpcAuthContext? = CURRENT_RPC_CONTEXT.get()
 
 internal class CurrentRpcContext : ThreadLocal<RpcAuthContext>() {
 

--- a/libs/http-rpc/http-rpc-common/src/main/kotlin/net/corda/httprpc/security/RpcAuthContext.kt
+++ b/libs/http-rpc/http-rpc-common/src/main/kotlin/net/corda/httprpc/security/RpcAuthContext.kt
@@ -19,6 +19,12 @@ val CURRENT_RPC_CONTEXT: ThreadLocal<RpcAuthContext> = CurrentRpcContext()
  */
 fun rpcContext(): RpcAuthContext = CURRENT_RPC_CONTEXT.get()
 
+/**
+ * Returns a context specific to the current RPC call or <code>null</code> if not set.
+ * The [RpcAuthContext] includes permissions.
+ */
+fun nullableRpcContext(): RpcAuthContext? = CURRENT_RPC_CONTEXT.get()
+
 internal class CurrentRpcContext : ThreadLocal<RpcAuthContext>() {
 
     override fun remove() {

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
@@ -19,6 +19,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import java.lang.IllegalArgumentException
 import javax.security.auth.login.FailedLoginException
 
@@ -80,6 +81,8 @@ internal object ContextUtils {
 
     fun RouteInfo.invokeHttpMethod(): (Context) -> Unit {
         return { ctx ->
+            MDC.put("http.method", ctx.method())
+            MDC.put("http.path", ctx.path())
             log.info("Servicing ${ctx.method()} request to '${ctx.path()}")
             log.debug { "Invoke method \"${this.method.method.name}\" for route info." }
             log.trace { "Get parameter values." }
@@ -102,6 +105,8 @@ internal object ContextUtils {
                 log.warn("Error invoking path '${this.fullPath}'.", e)
                 throw HttpExceptionMapper.mapToResponse(e)
             } finally {
+                MDC.remove("http.method")
+                MDC.remove("http.path")
                 if(ctx.isMultipartFormData()) {
                     cleanUpMultipartRequest(ctx)
                 }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
@@ -9,7 +9,7 @@ import net.corda.httprpc.security.AuthorizingSubject
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.httprpc.security.InvocationContext
 import net.corda.httprpc.security.RpcAuthContext
-import net.corda.httprpc.security.nullableRpcContext
+import net.corda.httprpc.security.rpcContext
 import net.corda.httprpc.server.impl.apigen.processing.RouteInfo
 import net.corda.httprpc.server.impl.internal.HttpExceptionMapper
 import net.corda.httprpc.server.impl.internal.ParameterRetrieverFactory
@@ -84,7 +84,7 @@ internal object ContextUtils {
         return { ctx ->
             MDC.put("http.method", ctx.method())
             MDC.put("http.path", ctx.path())
-            MDC.put("http.user", nullableRpcContext()?.principal ?: "<anonymous>")
+            MDC.put("http.user", rpcContext()?.principal ?: "<anonymous>")
             log.info("Servicing ${ctx.method()} request to '${ctx.path()}")
             log.debug { "Invoke method \"${this.method.method.name}\" for route info." }
             log.trace { "Get parameter values." }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
@@ -4,11 +4,7 @@ import io.javalin.core.util.Header
 import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.UnauthorizedResponse
-import net.corda.httprpc.security.Actor
-import net.corda.httprpc.security.AuthorizingSubject
-import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
-import net.corda.httprpc.security.InvocationContext
-import net.corda.httprpc.security.RpcAuthContext
+import net.corda.httprpc.security.*
 import net.corda.httprpc.server.impl.apigen.processing.RouteInfo
 import net.corda.httprpc.server.impl.internal.HttpExceptionMapper
 import net.corda.httprpc.server.impl.internal.ParameterRetrieverFactory
@@ -83,6 +79,7 @@ internal object ContextUtils {
         return { ctx ->
             MDC.put("http.method", ctx.method())
             MDC.put("http.path", ctx.path())
+            MDC.put("http.user", rpcContext().principal)
             log.info("Servicing ${ctx.method()} request to '${ctx.path()}")
             log.debug { "Invoke method \"${this.method.method.name}\" for route info." }
             log.trace { "Get parameter values." }
@@ -107,6 +104,7 @@ internal object ContextUtils {
             } finally {
                 MDC.remove("http.method")
                 MDC.remove("http.path")
+                MDC.remove("http.user")
                 if(ctx.isMultipartFormData()) {
                     cleanUpMultipartRequest(ctx)
                 }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
@@ -4,7 +4,12 @@ import io.javalin.core.util.Header
 import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.UnauthorizedResponse
-import net.corda.httprpc.security.*
+import net.corda.httprpc.security.Actor
+import net.corda.httprpc.security.AuthorizingSubject
+import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
+import net.corda.httprpc.security.InvocationContext
+import net.corda.httprpc.security.RpcAuthContext
+import net.corda.httprpc.security.rpcContext
 import net.corda.httprpc.server.impl.apigen.processing.RouteInfo
 import net.corda.httprpc.server.impl.internal.HttpExceptionMapper
 import net.corda.httprpc.server.impl.internal.ParameterRetrieverFactory

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
@@ -9,7 +9,7 @@ import net.corda.httprpc.security.AuthorizingSubject
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.httprpc.security.InvocationContext
 import net.corda.httprpc.security.RpcAuthContext
-import net.corda.httprpc.security.rpcContext
+import net.corda.httprpc.security.nullableRpcContext
 import net.corda.httprpc.server.impl.apigen.processing.RouteInfo
 import net.corda.httprpc.server.impl.internal.HttpExceptionMapper
 import net.corda.httprpc.server.impl.internal.ParameterRetrieverFactory
@@ -84,7 +84,7 @@ internal object ContextUtils {
         return { ctx ->
             MDC.put("http.method", ctx.method())
             MDC.put("http.path", ctx.path())
-            MDC.put("http.user", rpcContext().principal)
+            MDC.put("http.user", nullableRpcContext()?.principal ?: "<anonymous>")
             log.info("Servicing ${ctx.method()} request to '${ctx.path()}")
             log.debug { "Invoke method \"${this.method.method.name}\" for route info." }
             log.trace { "Get parameter values." }

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     implementation "org.slf4j:jul-to-slf4j:$slf4jVersion"
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 
+    // Jackson dependencies for JSON formatted logs
+    runtimeOnly "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    runtimeOnly "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"
     testImplementation "org.apache.sling:org.apache.sling.testing.osgi-mock.junit5:$slingVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"

--- a/osgi-framework-bootstrap/src/main/resources/log4j2-console-json.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2-console-json.xml
@@ -2,7 +2,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} %X - %msg%n"/>
+            <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" />
         </Console>
     </Appenders>
     <Loggers>

--- a/osgi-framework-bootstrap/src/main/resources/log4j2.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} %X - %msg%n"/>
         </Console>
 
         <RollingFile name="App"

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,9 @@ image:
   registry: corda-os-docker-dev.software.r3.com
   tag: latest-local
 
+logging:
+  format: text
+
 bootstrap:
   initialAdminUser:
     password: "admin"


### PR DESCRIPTION
Add supports for JSON format logs. These are the default when using the Helm chart but, for direct consumption for developers, the `values.yaml` and E2E tests override back to the current plain text format.

I've picked on a bit of RPC code to add some MDC to, just because it's a part I know. The JSON format logs include the MDC in the `contextMap` field. I've updated the text format to also output the MDC map e.g.:

```
09:02:01.082 [qtp1334128993-196] INFO  net.corda.cpi.upload.endpoints.v1.CpiUploadRPCOpsImpl {http.method=GET, http.path=/api/v1/cpi} - Get all CPIs request
```