### PR TITLE
CORE-5989 - Switch HoldingIdentity to use MemberX500Name type

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
@@ -24,6 +24,7 @@ import net.corda.schema.configuration.FlowConfig.PROCESSING_MAX_FLOW_SLEEP_DURAT
 import net.corda.schema.configuration.FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS
 import net.corda.schema.configuration.FlowConfig.SESSION_HEARTBEAT_TIMEOUT_WINDOW
 import net.corda.schema.configuration.FlowConfig.SESSION_MESSAGE_RESEND_WINDOW
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.loggerFor
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
@@ -146,7 +147,7 @@ class CordaVNode @Activate constructor(
 
     @Suppress("SameParameterValue")
     private fun executeSandbox(clientId: String, resourceName: String) {
-        val holdingIdentity = HoldingIdentity(X500_NAME, generateRandomId())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse(X500_NAME), generateRandomId())
         val vnodeInfo = vnode.loadVirtualNode(resourceName, holdingIdentity)
         try {
             // Checkpoint: We have loaded the CPI into the framework.

--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/SetupVirtualNode.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/SetupVirtualNode.kt
@@ -13,6 +13,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import net.corda.schema.Schemas.VirtualNode.Companion.CPI_INFO_TOPIC
 import net.corda.schema.Schemas.VirtualNode.Companion.VIRTUAL_NODE_INFO_TOPIC
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.toAvro
@@ -50,7 +51,7 @@ class SetupVirtualNode(private val context: TaskContext) : Task {
 
         val virtualNodes = cpiList.flatMap { cpi ->
             x500Identities.map { x500 -> cpi to VirtualNodeInfo(
-                HoldingIdentity(x500, cpi.metadata.cpiId.name),
+                HoldingIdentity(MemberX500Name.parse(x500), cpi.metadata.cpiId.name),
                 cpi.metadata.cpiId,
                 vaultDmlConnectionId = UUID.randomUUID(),
                 cryptoDmlConnectionId = UUID.randomUUID(),

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoDBSetup.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoDBSetup.kt
@@ -10,16 +10,15 @@ import net.corda.db.testkit.TestDbInfo
 import net.corda.libs.configuration.datamodel.ConfigurationEntities
 import net.corda.libs.configuration.datamodel.DbConnectionConfig
 import net.corda.orm.utils.transaction
-import net.corda.v5.base.types.MemberX500Name
-import net.corda.virtualnode.HoldingIdentity
+import net.corda.test.util.identity.createTestHoldingIdentity
 import org.osgi.framework.FrameworkUtil
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManagerFactory
 
 object CryptoDBSetup {
-    val vNodeHoldingIdentity = HoldingIdentity(
-        MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"),
+    val vNodeHoldingIdentity = createTestHoldingIdentity(
+        "CN=Alice, O=Alice Corp, L=LDN, C=GB",
         UUID.randomUUID().toString()
     )
 

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoDBSetup.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoDBSetup.kt
@@ -10,6 +10,7 @@ import net.corda.db.testkit.TestDbInfo
 import net.corda.libs.configuration.datamodel.ConfigurationEntities
 import net.corda.libs.configuration.datamodel.DbConnectionConfig
 import net.corda.orm.utils.transaction
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.framework.FrameworkUtil
 import java.time.Instant
@@ -18,7 +19,7 @@ import javax.persistence.EntityManagerFactory
 
 object CryptoDBSetup {
     val vNodeHoldingIdentity = HoldingIdentity(
-        "CN=Alice, O=Alice Corp, L=LDN, C=GB",
+        MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"),
         UUID.randomUUID().toString()
     )
 

--- a/components/flow/flow-rpcops-service-impl/build.gradle
+++ b/components/flow/flow-rpcops-service-impl/build.gradle
@@ -29,4 +29,5 @@ dependencies {
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation project(":libs:lifecycle:lifecycle-test-impl")
+    testImplementation project(':testing:test-utilities')
 }

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRPCOpsImplTest.kt
@@ -10,9 +10,8 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.test.impl.LifecycleTest
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.VirtualNodeState
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -43,7 +42,7 @@ class FlowClassRPCOpsImplTest {
     private lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
 
     private fun getStubVirtualNode(): VirtualNodeInfo {
-        return VirtualNodeInfo(HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), ""),
+        return VirtualNodeInfo(createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", ""),
             CpiIdentifier("", "",
             SecureHash("", "bytes".toByteArray())),
             UUID.randomUUID(),

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRPCOpsImplTest.kt
@@ -10,6 +10,7 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.test.impl.LifecycleTest
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -42,7 +43,7 @@ class FlowClassRPCOpsImplTest {
     private lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
 
     private fun getStubVirtualNode(): VirtualNodeInfo {
-        return VirtualNodeInfo(HoldingIdentity("", ""),
+        return VirtualNodeInfo(HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), ""),
             CpiIdentifier("", "",
             SecureHash("", "bytes".toByteArray())),
             UUID.randomUUID(),

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -14,6 +14,7 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -38,7 +39,7 @@ class FlowRPCOpsImplTest {
     private lateinit var publisher: Publisher
 
     private fun getStubVirtualNode(): VirtualNodeInfo {
-        return VirtualNodeInfo(HoldingIdentity("", ""),
+        return VirtualNodeInfo(HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), ""),
             CpiIdentifier("", "",
             SecureHash("", "bytes".toByteArray())),
             UUID.randomUUID(),

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -14,9 +14,8 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.VirtualNodeState
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -39,7 +38,7 @@ class FlowRPCOpsImplTest {
     private lateinit var publisher: Publisher
 
     private fun getStubVirtualNode(): VirtualNodeInfo {
-        return VirtualNodeInfo(HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), ""),
+        return VirtualNodeInfo(createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", ""),
             CpiIdentifier("", "",
             SecureHash("", "bytes".toByteArray())),
             UUID.randomUUID(),

--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testImplementation project(":libs:lifecycle:lifecycle-impl")
     testImplementation project(":libs:lifecycle:registry")
     testImplementation project(":testing:flow:flow-utilities")
+    testImplementation project(':testing:test-utilities')
 
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
@@ -15,18 +15,7 @@ class FlowFiberExecutionContext(
     val holdingIdentity: HoldingIdentity,
     val membershipGroupReader: MembershipGroupReader
 ) : NonSerializable {
-    val memberX500Name: MemberX500Name = holdingIdentity.getMemberX500Name()
+    val memberX500Name: MemberX500Name = holdingIdentity.x500Name
     val flowStackService: FlowStack = flowCheckpoint.flowStack
-
-    private fun HoldingIdentity.getMemberX500Name() : MemberX500Name {
-        try {
-            return MemberX500Name.parse(x500Name)
-        } catch (e: Exception) {
-            throw IllegalStateException(
-                "Failed to convert Holding Identity x500 name '${x500Name}' to MemberX500Name",
-                e
-            )
-        }
-    }
 }
 

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -16,7 +16,6 @@ import net.corda.v5.application.messaging.FlowSession;
 import net.corda.v5.application.serialization.SerializationService;
 import net.corda.v5.base.types.MemberX500Name;
 import net.corda.v5.serialization.SerializedBytes;
-import net.corda.virtualnode.HoldingIdentity;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Future;
 
+import static net.corda.test.util.identity.IdentityUtilsKt.createTestHoldingIdentity;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -40,7 +40,7 @@ public class FlowSessionImplJavaTest {
     private final FlowFiberExecutionContext flowFiberExecutionContext = new FlowFiberExecutionContext(
             mock(FlowCheckpoint.class),
             flowSandboxGroupContext,
-            new HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "group1"),
+            createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group1"),
             mock(MembershipGroupReader.class)
     );
     private final FlowFiber flowFiber = new FakeFiber(flowFiberExecutionContext);

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -40,7 +40,7 @@ public class FlowSessionImplJavaTest {
     private final FlowFiberExecutionContext flowFiberExecutionContext = new FlowFiberExecutionContext(
             mock(FlowCheckpoint.class),
             flowSandboxGroupContext,
-            new HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group1"),
+            new HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "group1"),
             mock(MembershipGroupReader.class)
     );
     private final FlowFiber flowFiber = new FakeFiber(flowFiberExecutionContext);

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
@@ -21,7 +21,7 @@ class MockFlowFiberService : FlowFiberService {
     val flowStack: FlowStack = mock()
     private val checkpointSerializer = mock<CheckpointSerializer>()
     val sandboxGroupContext: FlowSandboxGroupContext = mock()
-    val holdingIdentity: HoldingIdentity =  HoldingIdentity(BOB_X500_NAME.toString(),"group1")
+    val holdingIdentity: HoldingIdentity =  HoldingIdentity(BOB_X500_NAME,"group1")
     private val membershipGroupReader: MembershipGroupReader = mock()
     val flowFiberExecutionContext: FlowFiberExecutionContext
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
@@ -5,7 +5,6 @@ import net.corda.flow.application.services.MockFlowFiberService
 import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 
 class FlowFiberExecutionContextTest {
@@ -18,17 +17,9 @@ class FlowFiberExecutionContextTest {
 
     @Test
     fun `getMemberX500Name returns x500name parsed from holding identity`() {
-        val holdingIdentity = HoldingIdentity(BOB_X500_NAME.toString(), "group1")
+        val holdingIdentity = HoldingIdentity(BOB_X500_NAME, "group1")
         val context = FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock())
         assertThat(context.memberX500Name).isEqualTo(BOB_X500_NAME)
     }
 
-    @Test
-    fun `getMemberX500Name throws when the x500 name is invalid`() {
-        val holdingIdentity = HoldingIdentity("x500", "group1")
-        val exception = assertThrows<IllegalStateException> {
-            FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock())
-        }
-        assertThat(exception.message).isEqualTo("Failed to convert Holding Identity x500 name 'x500' to MemberX500Name")
-    }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
@@ -7,6 +7,7 @@ import net.corda.flow.state.FlowCheckpoint
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.flows.getRequestBodyAsList
 import net.corda.v5.application.marshalling.MarshallingService
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -73,7 +74,7 @@ class RPCRequestDataImplTest {
             startArgs = args
         }
         whenever(checkpoint.flowStartContext).thenReturn(startContext)
-        val holdingIdentity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "12345")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), "12345")
         val executionContext = FlowFiberExecutionContext(checkpoint, mock(), holdingIdentity, mock())
         whenever(fiber.getExecutionContext()).thenReturn(executionContext)
         whenever(fiberService.getExecutingFiber()).thenReturn(fiber)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import net.corda.data.flow.FlowStartContext
 import net.corda.flow.state.FlowCheckpoint
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.flows.getRequestBodyAsList
 import net.corda.v5.application.marshalling.MarshallingService
-import net.corda.v5.base.types.MemberX500Name
-import net.corda.virtualnode.HoldingIdentity
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -74,7 +73,7 @@ class RPCRequestDataImplTest {
             startArgs = args
         }
         whenever(checkpoint.flowStartContext).thenReturn(startContext)
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), "12345")
+        val holdingIdentity = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "12345")
         val executionContext = FlowFiberExecutionContext(checkpoint, mock(), holdingIdentity, mock())
         whenever(fiber.getExecutionContext()).thenReturn(executionContext)
         whenever(fiberService.getExecutingFiber()).thenReturn(fiber)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
@@ -54,7 +54,7 @@ class FlowSessionManagerImplTest {
             locality = "LDN",
             country = "GB"
         )
-        val HOLDING_IDENTITY = HoldingIdentity("x500 name", "group id")
+        val HOLDING_IDENTITY = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group id")
         val COUNTERPARTY_HOLDING_IDENTITY = HoldingIdentity(X500_NAME.toString(), "group id")
 
         @JvmStatic

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/PersistenceTestHelper.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/PersistenceTestHelper.kt
@@ -6,6 +6,7 @@ import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.state.impl.FlowCheckpointImpl
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -32,7 +33,7 @@ fun <R> mockPersistenceStateInFlowContext(
 ): FlowEventContext<R> {
     val mockCheckpoint = mock<FlowCheckpointImpl>()
     val stubContext = buildFlowEventContext(mockCheckpoint, inputEventPayload, config)
-    val holdingIdentity = HoldingIdentity("x500", "group")
+    val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "group")
     whenever(mockCheckpoint.persistenceState).thenReturn(stubPersistenceState)
     whenever(mockCheckpoint.holdingIdentity).thenReturn(holdingIdentity)
     return stubContext

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/PersistenceTestHelper.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/PersistenceTestHelper.kt
@@ -6,8 +6,7 @@ import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.state.impl.FlowCheckpointImpl
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigImpl
-import net.corda.v5.base.types.MemberX500Name
-import net.corda.virtualnode.HoldingIdentity
+import net.corda.test.util.identity.createTestHoldingIdentity
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -33,7 +32,7 @@ fun <R> mockPersistenceStateInFlowContext(
 ): FlowEventContext<R> {
     val mockCheckpoint = mock<FlowCheckpointImpl>()
     val stubContext = buildFlowEventContext(mockCheckpoint, inputEventPayload, config)
-    val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "group")
+    val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
     whenever(mockCheckpoint.persistenceState).thenReturn(stubPersistenceState)
     whenever(mockCheckpoint.holdingIdentity).thenReturn(holdingIdentity)
     return stubContext

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
@@ -24,7 +24,7 @@ import org.mockito.kotlin.whenever
 
 class ForwardingGroupPolicyProviderTest {
 
-    private val alice = HoldingIdentity("alice", "group-1")
+    private val alice = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group-1")
     private val groupInfo =
         GroupPolicyListener.GroupInfo(
             alice,

--- a/components/membership/certificates-client-impl/build.gradle
+++ b/components/membership/certificates-client-impl/build.gradle
@@ -23,4 +23,5 @@ dependencies {
 
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation project(':testing:test-utilities')
 }

--- a/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
+++ b/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
@@ -12,6 +12,7 @@ import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.p2p.HostedIdentityEntry
 import net.corda.schema.Schemas.P2P.Companion.P2P_HOSTED_IDENTITIES_TOPIC
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.cipher.suite.KeyEncodingService
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -34,7 +35,7 @@ import java.security.cert.CertificateFactory
 class HostedIdentityEntryFactoryTest {
     private companion object {
         val validHoldingId = HoldingIdentity(
-            x500Name = "x500node",
+            x500Name = MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"),
             groupId = "group-1"
         )
         val publicKeyBytes = "123".toByteArray()

--- a/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
+++ b/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactoryTest.kt
@@ -11,10 +11,9 @@ import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.p2p.HostedIdentityEntry
 import net.corda.schema.Schemas.P2P.Companion.P2P_HOSTED_IDENTITIES_TOPIC
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.cipher.suite.KeyEncodingService
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -34,10 +33,7 @@ import java.security.cert.CertificateFactory
 
 class HostedIdentityEntryFactoryTest {
     private companion object {
-        val validHoldingId = HoldingIdentity(
-            x500Name = MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"),
-            groupId = "group-1"
-        )
+        val validHoldingId = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group-1")
         val publicKeyBytes = "123".toByteArray()
         const val VALID_NODE = "validNode"
         const val INVALID_NODE = "invalidNode"

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -85,11 +85,11 @@ class GroupPolicyProviderImplTest {
     }
     private val parsedMgmGroupPolicy: MGMGroupPolicy = mock()
 
-    val holdingIdentity1 = HoldingIdentity(alice.toString(), groupId1)
-    val holdingIdentity2 = HoldingIdentity(bob.toString(), groupId1)
-    val holdingIdentity3 = HoldingIdentity(alice.toString(), groupId2)
-    val holdingIdentity4 = HoldingIdentity(bob.toString(), groupId2)
-    val holdingIdentity5 = HoldingIdentity(mgm.toString(), groupId2)
+    val holdingIdentity1 = HoldingIdentity(alice, groupId1)
+    val holdingIdentity2 = HoldingIdentity(bob, groupId1)
+    val holdingIdentity3 = HoldingIdentity(alice, groupId2)
+    val holdingIdentity4 = HoldingIdentity(bob, groupId2)
+    val holdingIdentity5 = HoldingIdentity(mgm, groupId2)
 
     fun mockMetadata(resultGroupPolicy: String?) = mock<CpiMetadata> {
         on { groupPolicy } doReturn resultGroupPolicy
@@ -363,7 +363,7 @@ class GroupPolicyProviderImplTest {
         startComponentAndDependencies()
 
         // test holding identity
-        val holdingIdentity = HoldingIdentity(alice.toString(), "FOO-BAR")
+        val holdingIdentity = HoldingIdentity(alice, "FOO-BAR")
 
         doReturn(parsedGroupPolicy1).whenever(groupPolicyParser).parse(eq(holdingIdentity), eq(groupPolicy1), any())
         doThrow(BadGroupPolicyException("")).whenever(groupPolicyParser).parse(eq(holdingIdentity), eq(null), any())

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMOpsClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMOpsClientImpl.kt
@@ -28,7 +28,6 @@ import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.concurrent.getOrThrow
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
@@ -171,7 +170,7 @@ class MGMOpsClientImpl @Activate constructor(
             val reader = membershipGroupReaderProvider.getGroupReader(holdingIdentity)
 
             val filteredMembers =
-                reader.lookup(MemberX500Name.parse(holdingIdentity.x500Name))
+                reader.lookup(holdingIdentity.x500Name)
                     ?:throw CordaRuntimeException ("Could not find holding identity associated with member.")
 
             if(filteredMembers.isMgm) {

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMOpsClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMOpsClientTest.kt
@@ -36,6 +36,7 @@ import net.corda.messaging.api.publisher.RPCSender
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.schema.configuration.ConfigKeys
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -53,7 +54,6 @@ import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions
@@ -63,8 +63,8 @@ import java.util.*
 
 class MGMOpsClientTest {
     companion object {
-        private val holdingIdentity = HoldingIdentity(
-            MemberX500Name.parse("CN=Alice,O=Alice,OU=Unit1,L=London,ST=State1,C=GB"),
+        private val holdingIdentity = createTestHoldingIdentity(
+            "CN=Alice,O=Alice,OU=Unit1,L=London,ST=State1,C=GB",
             "DEFAULT_MEMBER_GROUP_ID"
         )
         private const val HOLDING_IDENTITY_STRING = "test"

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMOpsClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMOpsClientTest.kt
@@ -63,7 +63,10 @@ import java.util.*
 
 class MGMOpsClientTest {
     companion object {
-        private val holdingIdentity = HoldingIdentity("CN=Alice,O=Alice,OU=Unit1,L=London,ST=State1,C=GB", "DEFAULT_MEMBER_GROUP_ID")
+        private val holdingIdentity = HoldingIdentity(
+            MemberX500Name.parse("CN=Alice,O=Alice,OU=Unit1,L=London,ST=State1,C=GB"),
+            "DEFAULT_MEMBER_GROUP_ID"
+        )
         private const val HOLDING_IDENTITY_STRING = "test"
         private const val KNOWN_KEY = "12345"
 

--- a/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
+++ b/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
@@ -55,7 +55,7 @@ class MembershipGroupReaderProviderIntegrationTest {
     private val aliceX500Name = "C=GB, L=London, O=Alice"
     private val aliceMemberName = MemberX500Name.parse(aliceX500Name)
     private val groupId = "ABC123"
-    private val aliceHoldingIdentity = HoldingIdentity(aliceX500Name, groupId)
+    private val aliceHoldingIdentity = HoldingIdentity(aliceMemberName, groupId)
     private val bootConf = """
         $INSTANCE_ID=1
         $BUS_TYPE = INMEMORY

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImpl.kt
@@ -16,7 +16,7 @@ class MembershipGroupReaderImpl(
     private val membershipGroupReadCache: MembershipGroupReadCache
 ) : MembershipGroupReader {
     override val groupId: String = holdingIdentity.groupId
-    override val owningMember: MemberX500Name = MemberX500Name.parse(holdingIdentity.x500Name)
+    override val owningMember: MemberX500Name = holdingIdentity.x500Name
 
     private val memberList: List<MemberInfo>
         get() = membershipGroupReadCache.memberListCache.get(holdingIdentity)

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderImplTest.kt
@@ -95,7 +95,7 @@ class MembershipGroupReaderProviderImplTest {
     @Test
     fun `Get group reader throws exception if component hasn't started`() {
         val e = assertThrows<IllegalStateException> {
-            membershipGroupReaderProvider.getGroupReader(HoldingIdentity(memberName.toString(), GROUP_ID_1))
+            membershipGroupReaderProvider.getGroupReader(HoldingIdentity(memberName, GROUP_ID_1))
         }
         assertEquals(MembershipGroupReaderProviderImpl.ILLEGAL_ACCESS, e.message)
     }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberDataCacheTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberDataCacheTest.kt
@@ -20,9 +20,9 @@ class MemberDataCacheTest {
 
     private lateinit var memberDataCache: MemberDataCache<MemberData>
 
-    private val aliceIdGroup1 = HoldingIdentity(TestProperties.aliceName.toString(), GROUP_ID_1)
-    private val bobIdGroup1 = HoldingIdentity(TestProperties.bobName.toString(), GROUP_ID_1)
-    private val aliceIdGroup2 = HoldingIdentity(TestProperties.aliceName.toString(), GROUP_ID_2)
+    private val aliceIdGroup1 = HoldingIdentity(TestProperties.aliceName, GROUP_ID_1)
+    private val bobIdGroup1 = HoldingIdentity(TestProperties.bobName, GROUP_ID_1)
+    private val aliceIdGroup2 = HoldingIdentity(TestProperties.aliceName, GROUP_ID_2)
     private val memberData1 = mock<MemberData>()
     private val memberData2 = mock<MemberData>()
 

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
@@ -22,9 +22,9 @@ class MemberListCacheImplTest {
     private val bob = bobName
     private val charlie = charlieName
 
-    private val aliceIdGroup1 = HoldingIdentity(alice.toString(), GROUP_ID_1)
-    private val bobIdGroup1 = HoldingIdentity(bob.toString(), GROUP_ID_1)
-    private val aliceIdGroup2 = HoldingIdentity(alice.toString(), GROUP_ID_2)
+    private val aliceIdGroup1 = HoldingIdentity(alice, GROUP_ID_1)
+    private val bobIdGroup1 = HoldingIdentity(bob, GROUP_ID_1)
+    private val aliceIdGroup2 = HoldingIdentity(alice, GROUP_ID_2)
 
     private val memberInfo1 = mock<MemberInfo>().apply {
         whenever(name).thenReturn(bob)

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCachePerformanceTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCachePerformanceTest.kt
@@ -26,12 +26,12 @@ class MemberListCachePerformanceTest {
     private val bob = bobName
     private val charlie = charlieName
 
-    private val aliceIdGroup1 = HoldingIdentity(alice.toString(), GROUP_ID_1)
-    private val bobIdGroup1 = HoldingIdentity(bob.toString(), GROUP_ID_1)
-    private val charlieIdGroup1 = HoldingIdentity(charlie.toString(), GROUP_ID_1)
-    private val aliceIdGroup2 = HoldingIdentity(alice.toString(), GROUP_ID_2)
-    private val bobIdGroup2 = HoldingIdentity(bob.toString(), GROUP_ID_2)
-    private val charlieIdGroup2 = HoldingIdentity(charlie.toString(), GROUP_ID_2)
+    private val aliceIdGroup1 = HoldingIdentity(alice, GROUP_ID_1)
+    private val bobIdGroup1 = HoldingIdentity(bob, GROUP_ID_1)
+    private val charlieIdGroup1 = HoldingIdentity(charlie, GROUP_ID_1)
+    private val aliceIdGroup2 = HoldingIdentity(alice, GROUP_ID_2)
+    private val bobIdGroup2 = HoldingIdentity(bob, GROUP_ID_2)
+    private val charlieIdGroup2 = HoldingIdentity(charlie, GROUP_ID_2)
 
     private lateinit var memberInfoAlice: MemberInfo
     private lateinit var memberInfoBob: MemberInfo

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MembershipGroupReadCacheTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MembershipGroupReadCacheTest.kt
@@ -19,7 +19,7 @@ class MembershipGroupReadCacheTest {
     val groupReaderCache get() = membershipGroupReadCache.groupReaderCache
 
     val aliceName = TestProperties.aliceName
-    val aliceIdGroup1 = HoldingIdentity(aliceName.toString(), GROUP_ID_1)
+    val aliceIdGroup1 = HoldingIdentity(aliceName, GROUP_ID_1)
     val bob: MemberInfo = mock()
     val membershipGroupReader: MembershipGroupReader = mock()
 

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderFactoryTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderFactoryTest.kt
@@ -25,8 +25,8 @@ class MembershipGroupReaderFactoryTest {
     val alice = aliceName
     val bob = bobName
 
-    val aliceIdGroup1 = HoldingIdentity(alice.toString(), GROUP_ID_1)
-    val bobIdGroup1 = HoldingIdentity(bob.toString(), GROUP_ID_1)
+    val aliceIdGroup1 = HoldingIdentity(alice, GROUP_ID_1)
+    val bobIdGroup1 = HoldingIdentity(bob, GROUP_ID_1)
 
     val aliceReader: MembershipGroupReader = mock()
     val groupReaderCache = mock<MemberDataCache<MembershipGroupReader>>().apply {

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -26,7 +26,7 @@ class MembershipGroupReaderImplTest {
     private lateinit var membershipGroupReaderImpl: MembershipGroupReaderImpl
 
     private val aliceName = TestProperties.aliceName
-    private val aliceIdGroup1 = HoldingIdentity(aliceName.toString(), GROUP_ID_1)
+    private val aliceIdGroup1 = HoldingIdentity(aliceName, GROUP_ID_1)
     private val memberCache: MemberListCache = mock()
     private val membershipGroupCache: MembershipGroupReadCache = mock<MembershipGroupReadCache>().apply {
         whenever(this.memberListCache).thenReturn(memberCache)

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
@@ -94,7 +94,7 @@ class MemberListProcessorTest {
         ): Map<String, PersistentMemberInfo> {
             val topicData = mutableMapOf<String, PersistentMemberInfo>()
             memberInfoList.forEach { member ->
-                val holdingIdentity = HoldingIdentity(member.name.toString(), member.groupId)
+                val holdingIdentity = HoldingIdentity(member.name, member.groupId)
                 if (!selfOwned && holdingIdentity != aliceIdentity) {
                     topicData[aliceIdentity.shortHash + holdingIdentity.shortHash] = PersistentMemberInfo(
                         aliceIdentity.toAvro(),
@@ -147,11 +147,11 @@ class MemberListProcessorTest {
             whenever(keyEncodingService.decodePublicKey(knownKeyAsString)).thenReturn(knownKey)
             whenever(keyEncodingService.encodeAsString(knownKey)).thenReturn(knownKeyAsString)
             alice = createTestMemberInfo("O=Alice,L=London,C=GB", MEMBER_STATUS_PENDING)
-            aliceIdentity = HoldingIdentity(alice.name.toString(), alice.groupId)
+            aliceIdentity = HoldingIdentity(alice.name, alice.groupId)
             bob = createTestMemberInfo("O=Bob,L=London,C=GB", MEMBER_STATUS_ACTIVE)
-            bobIdentity = HoldingIdentity(bob.name.toString(), bob.groupId)
+            bobIdentity = HoldingIdentity(bob.name, bob.groupId)
             charlie = createTestMemberInfo("O=Charlie,L=London,C=GB", MEMBER_STATUS_SUSPENDED)
-            charlieIdentity = HoldingIdentity(charlie.name.toString(), charlie.groupId)
+            charlieIdentity = HoldingIdentity(charlie.name, charlie.groupId)
             memberListFromTopic = convertToTestTopicData(listOf(alice, bob, charlie))
         }
     }
@@ -178,7 +178,7 @@ class MemberListProcessorTest {
     fun `Member list cache is successfully updated with new record`() {
         memberListProcessor.onSnapshot(memberListFromTopic)
         val newMember = createTestMemberInfo("O=NewMember,L=London,C=GB", MEMBER_STATUS_ACTIVE)
-        val newMemberIdentity = HoldingIdentity(newMember.name.toString(), newMember.groupId)
+        val newMemberIdentity = HoldingIdentity(newMember.name, newMember.groupId)
         val topicData = convertToTestTopicData(listOf(newMember), true).entries.first()
         val newRecord = Record("dummy-topic", topicData.key, topicData.value)
         memberListProcessor.onNext(newRecord, null, memberListFromTopic)

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsTest.kt
@@ -26,11 +26,11 @@ import net.corda.membership.lib.impl.converter.EndpointInfoConverter
 import net.corda.crypto.impl.converter.PublicKeyConverter
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -43,7 +43,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.security.PublicKey
 import net.corda.test.util.time.TestClock
-import net.corda.v5.base.types.MemberX500Name
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertFailsWith
@@ -74,7 +73,7 @@ class MemberLookupRpcOpsTest {
         EndpointInfoImpl("https://corda5.r3.com:10001", 10)
     )
 
-    private val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "0")
+    private val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "0")
 
     private val keyEncodingService: CipherSchemeMetadata = mock {
         on { decodePublicKey(KNOWN_KEY) } doReturn knownKey

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsTest.kt
@@ -43,6 +43,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.security.PublicKey
 import net.corda.test.util.time.TestClock
+import net.corda.v5.base.types.MemberX500Name
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertFailsWith
@@ -73,7 +74,7 @@ class MemberLookupRpcOpsTest {
         EndpointInfoImpl("https://corda5.r3.com:10001", 10)
     )
 
-    private val holdingIdentity = HoldingIdentity("test", "0")
+    private val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "0")
 
     private val keyEncodingService: CipherSchemeMetadata = mock {
         on { decodePublicKey(KNOWN_KEY) } doReturn knownKey

--- a/components/membership/membership-p2p-impl/build.gradle
+++ b/components/membership/membership-p2p-impl/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:schema-registry:schema-registry-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-topic-admin-impl')
     integrationTestImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    integrationTestImplementation project(':testing:test-utilities')
 
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
     integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -47,11 +47,13 @@ import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.test.util.eventually
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.concurrent.getOrThrow
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -193,9 +195,8 @@ class MembershipP2PIntegrationTest {
     @Test
     fun `membership p2p service reads registration requests from the p2p topic and puts them on a membership topic for further processing`() {
         val groupId = UUID.randomUUID().toString()
-        val source = MemberX500Name.parse("O=Alice,C=GB,L=London")
-        val destination = MemberX500Name.parse("O=MGM,C=GB,L=London")
-        val destinationHoldingIdentity = net.corda.virtualnode.HoldingIdentity(destination, groupId)
+        val source = createTestHoldingIdentity("O=Alice,C=GB,L=London", groupId)
+        val destination = createTestHoldingIdentity("O=MGM,C=GB,L=London", groupId)
         val registrationId = UUID.randomUUID().toString()
         val fakeKey = "fakeKey"
         val fakeSig = "fakeSig"
@@ -219,8 +220,8 @@ class MembershipP2PIntegrationTest {
             KeyValuePairList(emptyList())
         )
         val messageHeader = UnauthenticatedMessageHeader(
-            HoldingIdentity(destination.toString(), groupId),
-            HoldingIdentity(source.toString(), groupId),
+            destination.toAvro(),
+            source.toAvro(),
             MEMBERSHIP_P2P_SUBSYSTEM
         )
         val message = MembershipRegistrationRequest(
@@ -256,7 +257,7 @@ class MembershipP2PIntegrationTest {
         assertThat(result?.second).isNotNull
         with(result!!.second) {
             assertThat(topic).isEqualTo(REGISTRATION_COMMAND_TOPIC)
-            assertThat(key).isEqualTo("$registrationId-${destinationHoldingIdentity.shortHash}")
+            assertThat(key).isEqualTo("$registrationId-${destination.shortHash}")
             assertThat(value)
                 .isNotNull
                 .isInstanceOf(RegistrationCommand::class.java)
@@ -265,9 +266,9 @@ class MembershipP2PIntegrationTest {
                 .isInstanceOf(StartRegistration::class.java)
 
             with(value!!.command as StartRegistration) {
-                assertThat(this.destination.x500Name).isEqualTo(destination.toString())
+                assertThat(this.destination.x500Name).isEqualTo(destination.x500Name.toString())
                 assertThat(this.destination.groupId).isEqualTo(groupId)
-                assertThat(this.source.x500Name).isEqualTo(source.toString())
+                assertThat(this.source.x500Name).isEqualTo(source.x500Name.toString())
                 assertThat(this.source.groupId).isEqualTo(groupId)
                 assertThat(memberRegistrationRequest).isNotNull
                 with(memberRegistrationRequest) {

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -193,8 +193,8 @@ class MembershipP2PIntegrationTest {
     @Test
     fun `membership p2p service reads registration requests from the p2p topic and puts them on a membership topic for further processing`() {
         val groupId = UUID.randomUUID().toString()
-        val source = MemberX500Name.parse("O=Alice,C=GB,L=London").toString()
-        val destination = MemberX500Name.parse("O=MGM,C=GB,L=London").toString()
+        val source = MemberX500Name.parse("O=Alice,C=GB,L=London")
+        val destination = MemberX500Name.parse("O=MGM,C=GB,L=London")
         val destinationHoldingIdentity = net.corda.virtualnode.HoldingIdentity(destination, groupId)
         val registrationId = UUID.randomUUID().toString()
         val fakeKey = "fakeKey"
@@ -219,8 +219,8 @@ class MembershipP2PIntegrationTest {
             KeyValuePairList(emptyList())
         )
         val messageHeader = UnauthenticatedMessageHeader(
-            HoldingIdentity(destination, groupId),
-            HoldingIdentity(source, groupId),
+            HoldingIdentity(destination.toString(), groupId),
+            HoldingIdentity(source.toString(), groupId),
             MEMBERSHIP_P2P_SUBSYSTEM
         )
         val message = MembershipRegistrationRequest(
@@ -265,9 +265,9 @@ class MembershipP2PIntegrationTest {
                 .isInstanceOf(StartRegistration::class.java)
 
             with(value!!.command as StartRegistration) {
-                assertThat(this.destination.x500Name).isEqualTo(destination)
+                assertThat(this.destination.x500Name).isEqualTo(destination.toString())
                 assertThat(this.destination.groupId).isEqualTo(groupId)
-                assertThat(this.source.x500Name).isEqualTo(source)
+                assertThat(this.source.x500Name).isEqualTo(source.toString())
                 assertThat(this.source.groupId).isEqualTo(groupId)
                 assertThat(memberRegistrationRequest).isNotNull
                 with(memberRegistrationRequest) {

--- a/components/membership/membership-p2p-impl/test.bndrun
+++ b/components/membership/membership-p2p-impl/test.bndrun
@@ -25,6 +25,7 @@
     bnd.identity;id='net.bytebuddy.byte-buddy',\
     bnd.identity;id='slf4j.simple',\
     bnd.identity;id='org.hsqldb.hsqldb',\
+    bnd.identity;id='net.corda.test-utilities',\
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -34,6 +34,7 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.schema.Schemas.Membership.Companion.MEMBERSHIP_DB_RPC_TOPIC
 import net.corda.schema.configuration.ConfigKeys
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
@@ -477,7 +478,7 @@ class MembershipPersistenceClientImplTest {
     inner class SetMemberAndRegistrationRequestAsApprovedTests {
         @Test
         fun `it returns the correct member info`() {
-            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
+            val bob = createTestHoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
             val persistentMemberInfo = PersistentMemberInfo(
                 bob.toAvro(),
                 KeyValuePairList(emptyList()),
@@ -504,7 +505,7 @@ class MembershipPersistenceClientImplTest {
 
         @Test
         fun `it returns error when there was an issue`() {
-            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
+            val bob = createTestHoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
             val registrationRequestId = "registrationRequestId"
             postConfigChangedEvent()
             mockPersistenceResponse(false)
@@ -520,7 +521,7 @@ class MembershipPersistenceClientImplTest {
 
         @Test
         fun `it returns error when the return data has the wrong type`() {
-            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
+            val bob = createTestHoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
             val registrationRequestId = "registrationRequestId"
             postConfigChangedEvent()
             mockPersistenceResponse(payload = "This should not be a string!")

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -92,7 +92,7 @@ class MembershipPersistenceClientImplTest {
 
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = "Group ID"
-    private val ourHoldingIdentity = HoldingIdentity(ourX500Name.toString(), ourGroupId)
+    private val ourHoldingIdentity = HoldingIdentity(ourX500Name, ourGroupId)
 
     private val memberProvidedContext: MemberContext = mock()
     private val mgmProvidedContext: MGMContext = mock()
@@ -477,7 +477,7 @@ class MembershipPersistenceClientImplTest {
     inner class SetMemberAndRegistrationRequestAsApprovedTests {
         @Test
         fun `it returns the correct member info`() {
-            val bob = HoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
+            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
             val persistentMemberInfo = PersistentMemberInfo(
                 bob.toAvro(),
                 KeyValuePairList(emptyList()),
@@ -504,7 +504,7 @@ class MembershipPersistenceClientImplTest {
 
         @Test
         fun `it returns error when there was an issue`() {
-            val bob = HoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
+            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
             val registrationRequestId = "registrationRequestId"
             postConfigChangedEvent()
             mockPersistenceResponse(false)
@@ -520,7 +520,7 @@ class MembershipPersistenceClientImplTest {
 
         @Test
         fun `it returns error when the return data has the wrong type`() {
-            val bob = HoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
+            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
             val registrationRequestId = "registrationRequestId"
             postConfigChangedEvent()
             mockPersistenceResponse(payload = "This should not be a string!")

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -65,7 +65,7 @@ class MembershipQueryClientImplTest {
 
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = "Group ID 1"
-    private val ourHoldingIdentity = HoldingIdentity(ourX500Name.toString(), ourGroupId)
+    private val ourHoldingIdentity = HoldingIdentity(ourX500Name, ourGroupId)
     private val ourMemberInfo: MemberInfo = mock()
     private val registrationId = "Group ID 2"
 
@@ -476,15 +476,15 @@ class MembershipQueryClientImplTest {
 
         @Test
         fun `it will returns the correct data in case of successful result`() {
-            val bob = HoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
+            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
             postConfigChangedEvent()
-            val holdingId1 = HoldingIdentity("O=Alice ,L=London, C=GB", ourGroupId)
+            val holdingId1 = HoldingIdentity(MemberX500Name.parse("O=Alice ,L=London, C=GB"), ourGroupId)
             val signature1 = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk1".toByteArray()),
                 ByteBuffer.wrap("ct1".toByteArray()),
                 KeyValuePairList(emptyList()),
             )
-            val holdingId2 = HoldingIdentity("O=Donald ,L=London, C=GB", ourGroupId)
+            val holdingId2 = HoldingIdentity(MemberX500Name.parse("O=Donald ,L=London, C=GB"), ourGroupId)
             val signature2 = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk2".toByteArray()),
                 ByteBuffer.wrap("ct2".toByteArray()),
@@ -528,7 +528,7 @@ class MembershipQueryClientImplTest {
 
         @Test
         fun `it will return error for failure`() {
-            val bob = HoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
+            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
             postConfigChangedEvent()
             whenever(rpcSender.sendRequest(any())).thenAnswer {
                 val context = with((it.arguments.first() as MembershipPersistenceRequest).context) {
@@ -553,7 +553,7 @@ class MembershipQueryClientImplTest {
         }
         @Test
         fun `it will return error for invalid reply`() {
-            val bob = HoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
+            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
             postConfigChangedEvent()
             whenever(rpcSender.sendRequest(any())).thenAnswer {
                 val context = with((it.arguments.first() as MembershipPersistenceRequest).context) {

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -35,6 +35,7 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.schema.Schemas.Membership.Companion.MEMBERSHIP_DB_RPC_TOPIC
 import net.corda.schema.configuration.ConfigKeys
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MemberInfo
@@ -56,7 +57,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
-import java.util.*
 import java.util.concurrent.CompletableFuture
 
 class MembershipQueryClientImplTest {
@@ -476,15 +476,15 @@ class MembershipQueryClientImplTest {
 
         @Test
         fun `it will returns the correct data in case of successful result`() {
-            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
+            val bob = createTestHoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
             postConfigChangedEvent()
-            val holdingId1 = HoldingIdentity(MemberX500Name.parse("O=Alice ,L=London, C=GB"), ourGroupId)
+            val holdingId1 = createTestHoldingIdentity("O=Alice ,L=London, C=GB", ourGroupId)
             val signature1 = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk1".toByteArray()),
                 ByteBuffer.wrap("ct1".toByteArray()),
                 KeyValuePairList(emptyList()),
             )
-            val holdingId2 = HoldingIdentity(MemberX500Name.parse("O=Donald ,L=London, C=GB"), ourGroupId)
+            val holdingId2 = createTestHoldingIdentity("O=Donald ,L=London, C=GB", ourGroupId)
             val signature2 = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk2".toByteArray()),
                 ByteBuffer.wrap("ct2".toByteArray()),
@@ -528,7 +528,7 @@ class MembershipQueryClientImplTest {
 
         @Test
         fun `it will return error for failure`() {
-            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
+            val bob = createTestHoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
             postConfigChangedEvent()
             whenever(rpcSender.sendRequest(any())).thenAnswer {
                 val context = with((it.arguments.first() as MembershipPersistenceRequest).context) {
@@ -553,7 +553,7 @@ class MembershipQueryClientImplTest {
         }
         @Test
         fun `it will return error for invalid reply`() {
-            val bob = HoldingIdentity(MemberX500Name.parse("O=Bob ,L=London, C=GB"), ourGroupId)
+            val bob = createTestHoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
             postConfigChangedEvent()
             whenever(rpcSender.sendRequest(any())).thenAnswer {
                 val context = with((it.arguments.first() as MembershipPersistenceRequest).context) {

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -225,11 +225,11 @@ class MembershipPersistenceTest {
 
         private val groupId = randomUUID().toString()
         private val x500Name = MemberX500Name.parse("O=Alice, C=GB, L=London")
-        private val viewOwningHoldingIdentity = HoldingIdentity(x500Name.toString(), groupId)
+        private val viewOwningHoldingIdentity = HoldingIdentity(x500Name, groupId)
         private val holdingIdentityShortHash: String = viewOwningHoldingIdentity.shortHash
 
         private val registeringX500Name = MemberX500Name.parse("O=Bob, C=GB, L=London")
-        private val registeringHoldingIdentity = HoldingIdentity(registeringX500Name.toString(), groupId)
+        private val registeringHoldingIdentity = HoldingIdentity(registeringX500Name, groupId)
 
         private val vnodeDbInfo = TestDbInfo("vnode_vault_$holdingIdentityShortHash", DbSchema.VNODE)
         private val clusterDbInfo = TestDbInfo.createConfig()
@@ -541,7 +541,7 @@ class MembershipPersistenceTest {
 
         assertThat(approveResult.status).isEqualTo(MEMBER_STATUS_ACTIVE)
         assertThat(approveResult.groupId).isEqualTo(groupId)
-        assertThat(approveResult.name.toString()).isEqualTo(registeringHoldingIdentity.x500Name)
+        assertThat(approveResult.name).isEqualTo(registeringHoldingIdentity.x500Name)
         val newMemberEntity = vnodeEmf.use {
             it.find(
                 MemberInfoEntity::class.java,
@@ -566,7 +566,7 @@ class MembershipPersistenceTest {
 
         val signatures = (1..5).associate { index ->
             val registrationId = randomUUID().toString()
-            val holdingId = HoldingIdentity("O=Bob-$index, C=GB, L=London", groupId)
+            val holdingId = HoldingIdentity(MemberX500Name.parse("O=Bob-$index, C=GB, L=London"), groupId)
             val publicKey = ByteBuffer.wrap("pk-$index".toByteArray())
             val signature = ByteBuffer.wrap("signature-$index".toByteArray())
             val context = KeyValuePairList(

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -65,6 +65,7 @@ import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.test.util.eventually
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
@@ -566,7 +567,7 @@ class MembershipPersistenceTest {
 
         val signatures = (1..5).associate { index ->
             val registrationId = randomUUID().toString()
-            val holdingId = HoldingIdentity(MemberX500Name.parse("O=Bob-$index, C=GB, L=London"), groupId)
+            val holdingId = createTestHoldingIdentity("O=Bob-$index, C=GB, L=London", groupId)
             val publicKey = ByteBuffer.wrap("pk-$index".toByteArray())
             val signature = ByteBuffer.wrap("signature-$index".toByteArray())
             val context = KeyValuePairList(

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -26,11 +26,11 @@ import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.datamodel.RegistrationRequestEntity
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.uncheckedCast
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -62,7 +62,7 @@ class MembershipPersistenceRPCProcessorTest {
     private val ourX500Name = MemberX500Name.parse("O=Alice, L=London, C=GB").toString()
     private val ourGroupId = UUID.randomUUID().toString()
     private val ourRegistrationId = UUID.randomUUID().toString()
-    private val ourHoldingIdentity = HoldingIdentity(MemberX500Name.parse(ourX500Name), ourGroupId)
+    private val ourHoldingIdentity = createTestHoldingIdentity(ourX500Name, ourGroupId)
     private val context = "context".toByteArray()
 
     private val vaultDmlConnectionId = UUID.randomUUID()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -62,7 +62,7 @@ class MembershipPersistenceRPCProcessorTest {
     private val ourX500Name = MemberX500Name.parse("O=Alice, L=London, C=GB").toString()
     private val ourGroupId = UUID.randomUUID().toString()
     private val ourRegistrationId = UUID.randomUUID().toString()
-    private val ourHoldingIdentity = HoldingIdentity(ourX500Name, ourGroupId)
+    private val ourHoldingIdentity = HoldingIdentity(MemberX500Name.parse(ourX500Name), ourGroupId)
     private val context = "context".toByteArray()
 
     private val vaultDmlConnectionId = UUID.randomUUID()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -74,7 +74,7 @@ class PersistGroupPolicyHandlerTest {
     @Test
     fun `invoke return the correct version`() {
         val context = mock<MembershipRequestContext> {
-            on { holdingIdentity } doReturn HoldingIdentity("name", "group")
+            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
         }
         val request = mock<PersistGroupPolicy> {
             on { properties } doReturn KeyValuePairList(

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -45,7 +45,7 @@ class PersistMemberInfoHandlerTest {
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = UUID.randomUUID().toString()
     private val ourHoldingIdentity = HoldingIdentity(
-        ourX500Name.toString(),
+        ourX500Name,
         ourGroupId
     )
     private val ourRegistrationId = UUID.randomUUID().toString()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -44,7 +44,7 @@ class PersistRegistrationRequestHandlerTest {
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = "cbdc24f5-35b0-4ef3-be9e-f428d273d7b1"
     private val ourHoldingIdentity = HoldingIdentity(
-        ourX500Name.toString(),
+        ourX500Name,
         ourGroupId
     )
     private val ourRegistrationId = UUID.randomUUID().toString()
@@ -153,7 +153,7 @@ class PersistRegistrationRequestHandlerTest {
             assertThat(this).isInstanceOf(MemberSignatureEntity::class.java)
             val entity = this as MemberSignatureEntity
             assertThat(entity.groupId).isEqualTo(ourHoldingIdentity.groupId)
-            assertThat(entity.memberX500Name).isEqualTo(ourHoldingIdentity.x500Name)
+            assertThat(entity.memberX500Name).isEqualTo(ourHoldingIdentity.x500Name.toString())
             assertThat(entity.publicKey).isEqualTo("123".toByteArray())
             assertThat(entity.content).isEqualTo("456".toByteArray())
             assertThat(entity.context).isEqualTo(byteArrayOf(1, 3, 4))

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
@@ -37,7 +37,7 @@ import javax.persistence.TypedQuery
 class QueryGroupPolicyHandlerTest {
     private val x500Name = MemberX500Name.parse("O=MGM,L=London,C=GB").toString()
     private val groupId = UUID.randomUUID().toString()
-    private val holdingIdentity = HoldingIdentity(x500Name, groupId)
+    private val holdingIdentity = HoldingIdentity(MemberX500Name.parse(x500Name), groupId)
 
     private val vaultDmlConnectionId = UUID.randomUUID()
     private val cryptoDmlConnectionId = UUID.randomUUID()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
@@ -11,9 +11,9 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.datamodel.GroupPolicyEntity
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -37,7 +37,7 @@ import javax.persistence.TypedQuery
 class QueryGroupPolicyHandlerTest {
     private val x500Name = MemberX500Name.parse("O=MGM,L=London,C=GB").toString()
     private val groupId = UUID.randomUUID().toString()
-    private val holdingIdentity = HoldingIdentity(MemberX500Name.parse(x500Name), groupId)
+    private val holdingIdentity = createTestHoldingIdentity(x500Name, groupId)
 
     private val vaultDmlConnectionId = UUID.randomUUID()
     private val cryptoDmlConnectionId = UUID.randomUUID()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
@@ -44,11 +44,11 @@ class QueryMemberInfoHandlerTest {
     private val otherX500Name = MemberX500Name.parse("O=Bob,L=London,C=GB")
     private val ourGroupId = UUID.randomUUID().toString()
     private val ourHoldingIdentity = HoldingIdentity(
-        ourX500Name.toString(),
+        ourX500Name,
         ourGroupId
     )
     private val otherHoldingIdentity = HoldingIdentity(
-        otherX500Name.toString(),
+        otherX500Name,
         ourGroupId
     )
     private val ourRegistrationId = UUID.randomUUID().toString()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -60,7 +60,7 @@ class QueryMemberSignatureHandlerTest {
             "", "", null
         ),
         cryptoDmlConnectionId = UUID(0, 0),
-        holdingIdentity = HoldingIdentity("", "").toCorda(),
+        holdingIdentity = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "").toCorda(),
         timestamp = clock.instant(),
     )
     private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
@@ -95,7 +95,7 @@ class QueryMemberSignatureHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group"),
         )
         val request = QueryMemberSignature(
             (1..10).map {
@@ -114,10 +114,10 @@ class QueryMemberSignatureHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group"),
         )
         val members = (1..10).map {
-            HoldingIdentity("name-$it", "group")
+            HoldingIdentity("CN=Member-$it, O=Corp, L=LDN, C=GB", "group")
         }
         val request = QueryMemberSignature(
             members
@@ -173,10 +173,10 @@ class QueryMemberSignatureHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group"),
         )
         val members = (1..10).map {
-            HoldingIdentity("name-$it", "group")
+            HoldingIdentity("CN=Member-$it, O=Corp, L=LDN, C=GB", "group")
         }
         val request = QueryMemberSignature(
             members

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -72,7 +72,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
             "", "", null
         ),
         cryptoDmlConnectionId = UUID(0, 0),
-        holdingIdentity = HoldingIdentity("", "").toCorda(),
+        holdingIdentity = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "").toCorda(),
         timestamp = clock.instant(),
     )
     private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
@@ -104,7 +104,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
 
     @Test
     fun `invoke throws exception if member can not be fund`() {
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         whenever(
             entityManager.find(
                 eq(MemberInfoEntity::class.java),
@@ -119,10 +119,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             "requestId",
         )
 
@@ -133,7 +133,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
 
     @Test
     fun `invoke throws exception if request can not be fund`() {
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         val entity = mock<MemberInfoEntity>()
         val requestId = "requestId"
         whenever(
@@ -151,10 +151,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             requestId,
         )
 
@@ -169,7 +169,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         whenever(keyValuePairListDeserializer.deserialize(mgmContextBytes)).doReturn(
             KeyValuePairList(listOf(KeyValuePair(STATUS, MEMBER_STATUS_PENDING)))
         )
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         val entity = mock<MemberInfoEntity> {
             on { mgmContext } doReturn mgmContextBytes
         }
@@ -190,10 +190,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             requestId,
         )
 
@@ -218,7 +218,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         )
         val mgmContextCapture = argumentCaptor<KeyValuePairList>()
         whenever(keyValuePairListSerializer.serialize(mgmContextCapture.capture())).doReturn(byteArrayOf(0))
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         val entity = mock<MemberInfoEntity> {
             on { mgmContext } doReturn mgmContextBytes
         }
@@ -239,10 +239,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             requestId,
         )
 
@@ -262,7 +262,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         whenever(keyValuePairListDeserializer.deserialize(mgmContextBytes)).doReturn(
             KeyValuePairList(listOf(KeyValuePair(STATUS, MEMBER_STATUS_PENDING)))
         )
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         val entity = mock<MemberInfoEntity> {
             on { mgmContext } doReturn mgmContextBytes
         }
@@ -283,10 +283,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             requestId,
         )
 
@@ -300,7 +300,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
     fun `invoke will throw an exception if mgm context can not be deserialize`() {
         val mgmContextBytes = byteArrayOf(1, 10)
         whenever(keyValuePairListDeserializer.deserialize(mgmContextBytes)).doReturn(null)
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         val entity = mock<MemberInfoEntity> {
             on { mgmContext } doReturn mgmContextBytes
         }
@@ -321,10 +321,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             requestId,
         )
 
@@ -340,7 +340,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         whenever(keyValuePairListDeserializer.deserialize(mgmContextBytes)).doReturn(
             KeyValuePairList(listOf(KeyValuePair(STATUS, MEMBER_STATUS_PENDING)))
         )
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         val entity = mock<MemberInfoEntity> {
             on { mgmContext } doReturn mgmContextBytes
         }
@@ -361,10 +361,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             requestId,
         )
 
@@ -377,7 +377,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
 
     @Test
     fun `invoke returns the correct data`() {
-        val member = HoldingIdentity("member", "group")
+        val member = HoldingIdentity("CN=Member, O=Corp, L=LDN, C=GB", "group")
         val entity = mock<MemberInfoEntity> {
             on { memberContext } doReturn byteArrayOf(1)
             on { mgmContext } doReturn byteArrayOf(2)
@@ -399,10 +399,10 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         val context = MembershipRequestContext(
             clock.instant(),
             "id",
-            HoldingIdentity("name", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
         )
         val request = UpdateMemberAndRegistrationRequestToApproved(
-            HoldingIdentity("member", "group"),
+            HoldingIdentity(member.x500Name.toString(), "group"),
             requestId,
         )
         val mgmContext = KeyValuePairList(

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -43,7 +43,7 @@ class UpdateRegistrationRequestStatusHandlerTest {
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = "cbdc24f5-35b0-4ef3-be9e-f428d273d7b1"
     private val ourHoldingIdentity = HoldingIdentity(
-        ourX500Name.toString(),
+        ourX500Name,
         ourGroupId
     )
 

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
@@ -40,7 +40,6 @@ import net.corda.membership.registration.MembershipRegistrationException
 import net.corda.membership.registration.RegistrationProxy
 import net.corda.messaging.api.processor.RPCResponderProcessor
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.parse
 import net.corda.v5.base.util.parseList
@@ -192,7 +191,7 @@ class MemberOpsServiceProcessor(
             val mgm = membershipGroupReaderProvider
                 .getGroupReader(holdingIdentity)
                 .lookup(
-                    MemberX500Name.parse(holdingIdentity.x500Name)
+                    holdingIdentity.x500Name
                 )?.also {
                     if (!it.isMgm) {
                         throw GroupPolicyGenerationException(

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -69,7 +69,7 @@ class MemberOpsServiceProcessorTest {
         val mgmX500Name = MemberX500Name.parse("O=MGM,L=London,C=GB")
         private const val MGM_GROUP_ID = "090ae2ea-3920-42d7-a5cf-a79b909d7c30"
         private val mgmHoldingIdentity = HoldingIdentity(
-            mgmX500Name.toString(),
+            mgmX500Name,
             MGM_GROUP_ID
         )
 

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -193,7 +193,7 @@ class MemberRegistrationIntegrationTest {
     fun `dynamic member registration service publishes unauthenticated message to be sent to the MGM`() {
         groupPolicyProvider.putGroupPolicy(TestGroupPolicy())
 
-        val member = HoldingIdentity(memberName.toString(), groupId)
+        val member = HoldingIdentity(memberName, groupId)
         val context = buildTestContext(member)
         val completableResult = CompletableFuture<Pair<String, AppMessage>>()
         // Set up subscription to gather results of processing p2p message

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -29,7 +29,6 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -83,7 +82,7 @@ class StartRegistrationHandler(
                 // Parse the registration request and verify contents
                 // The MemberX500Name matches the source MemberX500Name from the P2P messaging
                 validateRegistrationRequest(
-                    pendingMemberInfo.name == MemberX500Name.parse(pendingMemberHoldingId.x500Name)
+                    pendingMemberInfo.name == pendingMemberHoldingId.x500Name
                 ) { "MemberX500Name in registration request does not match member sending request over P2P." }
 
                 // The MemberX500Name is not a duplicate
@@ -164,7 +163,7 @@ class StartRegistrationHandler(
     }
 
     private fun getMGMMemberInfo(mgm: HoldingIdentity): MemberInfo {
-        val mgmMemberName = MemberX500Name.parse(mgm.x500Name)
+        val mgmMemberName = mgm.x500Name
         return membershipGroupReaderProvider.getGroupReader(mgm).lookup(mgmMemberName).apply {
             validateRegistrationRequest(this != null) {
                 "Could not find MGM matching name: [$mgmMemberName]"

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -260,7 +260,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                         + generateLedgerKeyData(context, member.shortHash).items
                         + listOf(
                     KeyValuePair(REGISTRATION_ID, registrationId),
-                    KeyValuePair(PARTY_NAME, member.x500Name),
+                    KeyValuePair(PARTY_NAME, member.x500Name.toString()),
                     KeyValuePair(GROUP_ID, member.groupId),
                     // temporarily hardcoded
                     KeyValuePair(PLATFORM_VERSION, PLATFORM_VERSION_CONST),

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -198,7 +198,7 @@ class MGMRegistrationService @Activate constructor(
                         } +
                             mapOf(
                                 GROUP_ID to member.groupId,
-                                PARTY_NAME to member.x500Name,
+                                PARTY_NAME to member.x500Name.toString(),
                                 PARTY_SESSION_KEY to sessionKey,
                                 ECDH_KEY to ecdhKey,
                                 // temporarily hardcoded

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -158,7 +158,7 @@ class StaticMemberRegistrationService @Activate constructor(
         assignSoftHsm(memberId)
 
         val staticMemberInfo = staticMemberList.firstOrNull {
-            MemberX500Name.parse(it.name!!) == MemberX500Name.parse(memberName)
+            MemberX500Name.parse(it.name!!) == memberName
         } ?: throw IllegalArgumentException("Our membership $memberName is not listed in the static member list.")
 
         validateStaticMemberDeclaration(staticMemberInfo)
@@ -169,7 +169,7 @@ class StaticMemberRegistrationService @Activate constructor(
         @Suppress("SpreadOperator")
         val memberInfo = memberInfoFactory.create(
             sortedMapOf(
-                PARTY_NAME to memberName,
+                PARTY_NAME to memberName.toString(),
                 PARTY_SESSION_KEY to encodedMemberKey,
                 GROUP_ID to groupId,
                 *generateLedgerKeys(encodedMemberKey).toTypedArray(),
@@ -188,7 +188,7 @@ class StaticMemberRegistrationService @Activate constructor(
 
         staticMemberList.forEach {
             val owningMemberName = MemberX500Name.parse(it.name!!).toString()
-            val owningMemberHoldingIdentity = HoldingIdentity(owningMemberName, groupId)
+            val owningMemberHoldingIdentity = HoldingIdentity(MemberX500Name.parse(owningMemberName), groupId)
             records.add(
                 Record(
                     MEMBER_LIST_TOPIC,
@@ -221,7 +221,7 @@ class StaticMemberRegistrationService @Activate constructor(
          * internal within the cluster. For this reason, we pass through a set of "dummy" certificates/keys.
          */
         val hostedIdentity = HostedIdentityEntry(
-            net.corda.data.identity.HoldingIdentity(memberName, groupId),
+            net.corda.data.identity.HoldingIdentity(memberName.toString(), groupId),
             memberId,
             memberId,
             listOf(DUMMY_CERTIFICATE),

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationProxyImplTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationProxyImplTest.kt
@@ -37,6 +37,7 @@ import net.corda.membership.lib.impl.grouppolicy.v1.MemberGroupPolicyImpl
 import net.corda.membership.registration.MemberRegistrationService
 import net.corda.membership.registration.MembershipRequestRegistrationOutcome
 import net.corda.membership.registration.MembershipRequestRegistrationResult
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -94,7 +95,8 @@ class RegistrationProxyImplTest {
         on { getGroupPolicy(any()) } doReturn mock()
     }
 
-    private fun createHoldingIdentity() = HoldingIdentity("O=Alice, L=London, C=GB", "ABC")
+    private fun createHoldingIdentity() = HoldingIdentity(
+        MemberX500Name.parse("O=Alice, L=London, C=GB"), "ABC")
     private fun createGroupPolicy(registrationProtocol: String) = MemberGroupPolicyImpl(
         ObjectMapper().readTree(
             """

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationProxyImplTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationProxyImplTest.kt
@@ -37,7 +37,7 @@ import net.corda.membership.lib.impl.grouppolicy.v1.MemberGroupPolicyImpl
 import net.corda.membership.registration.MemberRegistrationService
 import net.corda.membership.registration.MembershipRequestRegistrationOutcome
 import net.corda.membership.registration.MembershipRequestRegistrationResult
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.virtualnode.HoldingIdentity
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -95,8 +95,7 @@ class RegistrationProxyImplTest {
         on { getGroupPolicy(any()) } doReturn mock()
     }
 
-    private fun createHoldingIdentity() = HoldingIdentity(
-        MemberX500Name.parse("O=Alice, L=London, C=GB"), "ABC")
+    private fun createHoldingIdentity() = createTestHoldingIdentity("O=Alice, L=London, C=GB", "ABC")
     private fun createGroupPolicy(registrationProtocol: String) = MemberGroupPolicyImpl(
         ObjectMapper().readTree(
             """

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/VerificationRequestHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/VerificationRequestHandlerTest.kt
@@ -12,6 +12,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.test.util.time.TestClock
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
@@ -31,8 +32,9 @@ class VerificationRequestHandlerTest {
         val clock = TestClock(Instant.ofEpochSecond(0))
     }
 
-    private val mgm = HoldingIdentity("C=GB, L=London, O=MGM", GROUP_ID).toAvro()
-    private val member = HoldingIdentity("C=GB, L=London, O=Alice", GROUP_ID).toAvro()
+    private val mgm = HoldingIdentity(
+        MemberX500Name.parse("C=GB, L=London, O=MGM"), GROUP_ID).toAvro()
+    private val member = HoldingIdentity(MemberX500Name.parse("C=GB, L=London, O=Alice"), GROUP_ID).toAvro()
     private val requestBody = KeyValuePairList(listOf(KeyValuePair("KEY", "dummyKey")))
     private val verificationRequest = VerificationRequest(
         REGISTRATION_ID,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/VerificationRequestHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/VerificationRequestHandlerTest.kt
@@ -11,9 +11,8 @@ import net.corda.data.membership.p2p.VerificationResponse
 import net.corda.messaging.api.records.Record
 import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
-import net.corda.v5.base.types.MemberX500Name
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -32,9 +31,8 @@ class VerificationRequestHandlerTest {
         val clock = TestClock(Instant.ofEpochSecond(0))
     }
 
-    private val mgm = HoldingIdentity(
-        MemberX500Name.parse("C=GB, L=London, O=MGM"), GROUP_ID).toAvro()
-    private val member = HoldingIdentity(MemberX500Name.parse("C=GB, L=London, O=Alice"), GROUP_ID).toAvro()
+    private val mgm = createTestHoldingIdentity("C=GB, L=London, O=MGM", GROUP_ID).toAvro()
+    private val member = createTestHoldingIdentity("C=GB, L=London, O=Alice", GROUP_ID).toAvro()
     private val requestBody = KeyValuePairList(listOf(KeyValuePair("KEY", "dummyKey")))
     private val verificationRequest = VerificationRequest(
         REGISTRATION_ID,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
@@ -176,12 +176,12 @@ class ApproveRegistrationHandlerTest {
                 assertThat(value?.viewOwningMember).isEqualTo(owner.toAvro())
                 assertThat(value?.memberContext?.items).contains(
                     KeyValuePair(
-                        "member", member.x500Name
+                        "member", member.x500Name.toString()
                     )
                 )
                 assertThat(value?.mgmContext?.items).contains(
                     KeyValuePair(
-                        "mgm", member.x500Name
+                        "mgm", member.x500Name.toString()
                     )
                 )
             }
@@ -225,7 +225,7 @@ class ApproveRegistrationHandlerTest {
                 eq(checkHash),
             )
         ).doReturn(memberPackage)
-        val membersRecord = activeMembersWithoutMgm.map {
+        val membersRecord = (activeMembersWithoutMgm - memberInfo).map {
             val record = mock<Record<String, AppMessage>>()
             whenever(
                 p2pRecordsFactory.createAuthenticatedMessageRecord(
@@ -277,16 +277,16 @@ class ApproveRegistrationHandlerTest {
         val mgmContext = mock<MGMContext> {
             on { parseOrNull(eq(IS_MGM), any<Class<Boolean>>()) } doReturn isMgm
             on { parse(eq(STATUS), any<Class<String>>()) } doReturn status
-            on { entries } doReturn mapOf("mgm" to holdingIdentity.x500Name).entries
+            on { entries } doReturn mapOf("mgm" to holdingIdentity.x500Name.toString()).entries
         }
         val memberContext = mock<MemberContext> {
             on { parse(eq(MemberInfoExtension.GROUP_ID), any<Class<String>>()) } doReturn holdingIdentity.groupId
-            on { entries } doReturn mapOf("member" to holdingIdentity.x500Name).entries
+            on { entries } doReturn mapOf("member" to holdingIdentity.x500Name.toString()).entries
         }
         return mock {
             on { mgmProvidedContext } doReturn mgmContext
             on { memberProvidedContext } doReturn memberContext
-            on { name } doReturn MemberX500Name.Companion.parse(holdingIdentity.x500Name)
+            on { name } doReturn holdingIdentity.x500Name
             on { groupId } doReturn holdingIdentity.groupId
         }
     }
@@ -294,7 +294,7 @@ class ApproveRegistrationHandlerTest {
     private fun createHoldingIdentity(name: String): HoldingIdentity {
         return HoldingIdentity(
             groupId = GROUP_ID,
-            x500Name = "C=GB,L=London,O=$name"
+            x500Name = MemberX500Name.parse("C=GB,L=London,O=$name")
         )
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
@@ -29,8 +29,8 @@ import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.messaging.api.records.Record
 import net.corda.p2p.app.AppMessage
 import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.crypto.DigestService
 import net.corda.v5.crypto.SecureHash
@@ -292,9 +292,6 @@ class ApproveRegistrationHandlerTest {
     }
 
     private fun createHoldingIdentity(name: String): HoldingIdentity {
-        return HoldingIdentity(
-            groupId = GROUP_ID,
-            x500Name = MemberX500Name.parse("C=GB,L=London,O=$name")
-        )
+        return createTestHoldingIdentity("C=GB,L=London,O=$name", GROUP_ID)
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerificationResponseHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerificationResponseHandlerTest.kt
@@ -11,6 +11,7 @@ import net.corda.membership.impl.registration.dynamic.handler.MissingRegistratio
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.messaging.api.records.Record
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
@@ -29,8 +30,9 @@ class VerificationResponseHandlerTest {
         const val TOPIC = "dummyTopic"
     }
 
-    private val mgm = HoldingIdentity("C=GB, L=London, O=MGM", GROUP_ID).toAvro()
-    private val member = HoldingIdentity("C=GB, L=London, O=Alice", GROUP_ID).toAvro()
+    private val mgm = HoldingIdentity(
+        MemberX500Name.parse("C=GB, L=London, O=MGM"), GROUP_ID).toAvro()
+    private val member = HoldingIdentity(MemberX500Name.parse("C=GB, L=London, O=Alice"), GROUP_ID).toAvro()
     private val command = ProcessMemberVerificationResponse(
         VerificationResponse(
             REGISTRATION_ID,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerificationResponseHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerificationResponseHandlerTest.kt
@@ -11,8 +11,7 @@ import net.corda.membership.impl.registration.dynamic.handler.MissingRegistratio
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.types.MemberX500Name
-import net.corda.virtualnode.HoldingIdentity
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
@@ -30,9 +29,8 @@ class VerificationResponseHandlerTest {
         const val TOPIC = "dummyTopic"
     }
 
-    private val mgm = HoldingIdentity(
-        MemberX500Name.parse("C=GB, L=London, O=MGM"), GROUP_ID).toAvro()
-    private val member = HoldingIdentity(MemberX500Name.parse("C=GB, L=London, O=Alice"), GROUP_ID).toAvro()
+    private val mgm = createTestHoldingIdentity("C=GB, L=London, O=MGM", GROUP_ID).toAvro()
+    private val member = createTestHoldingIdentity("C=GB, L=London, O=Alice", GROUP_ID).toAvro()
     private val command = ProcessMemberVerificationResponse(
         VerificationResponse(
             REGISTRATION_ID,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandlerTest.kt
@@ -13,9 +13,8 @@ import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.messaging.api.records.Record
 import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
-import net.corda.v5.base.types.MemberX500Name
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
@@ -39,9 +38,8 @@ class VerifyMemberHandlerTest {
         val clock = TestClock(Instant.ofEpochSecond(0))
     }
 
-    private val mgm = HoldingIdentity(
-        MemberX500Name.parse("C=GB, L=London, O=MGM"), GROUP_ID).toAvro()
-    private val member = HoldingIdentity(MemberX500Name.parse("C=GB, L=London, O=Alice"), GROUP_ID).toAvro()
+    private val mgm = createTestHoldingIdentity("C=GB, L=London, O=MGM", GROUP_ID).toAvro()
+    private val member = createTestHoldingIdentity("C=GB, L=London, O=Alice", GROUP_ID).toAvro()
     private val command = VerifyMember()
 
     val state = RegistrationState(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandlerTest.kt
@@ -14,6 +14,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.test.util.time.TestClock
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
@@ -38,8 +39,9 @@ class VerifyMemberHandlerTest {
         val clock = TestClock(Instant.ofEpochSecond(0))
     }
 
-    private val mgm = HoldingIdentity("C=GB, L=London, O=MGM", GROUP_ID).toAvro()
-    private val member = HoldingIdentity("C=GB, L=London, O=Alice", GROUP_ID).toAvro()
+    private val mgm = HoldingIdentity(
+        MemberX500Name.parse("C=GB, L=London, O=MGM"), GROUP_ID).toAvro()
+    private val member = HoldingIdentity(MemberX500Name.parse("C=GB, L=London, O=Alice"), GROUP_ID).toAvro()
     private val command = VerifyMember()
 
     val state = RegistrationState(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -75,7 +75,7 @@ class DynamicMemberRegistrationServiceTest {
     private val memberProvidedContext: MemberContext = mock()
     private val mgmProvidedContext: MGMContext = mock()
     private val mgmName = MemberX500Name("Corda MGM", "London", "GB")
-    private val mgm = HoldingIdentity(mgmName.toString(), GROUP_NAME)
+    private val mgm = HoldingIdentity(mgmName, GROUP_NAME)
     private val mgmInfo: MemberInfo = mock {
         on { memberProvidedContext } doReturn memberProvidedContext
         on { mgmProvidedContext } doReturn mgmProvidedContext
@@ -84,7 +84,7 @@ class DynamicMemberRegistrationServiceTest {
         on { isMgm } doReturn true
     }
     private val memberName = MemberX500Name("Alice", "London", "GB")
-    private val member = HoldingIdentity(memberName.toString(), GROUP_NAME)
+    private val member = HoldingIdentity(memberName, GROUP_NAME)
     private val memberId = member.shortHash
     private val sessionKey: PublicKey = mock {
         on { encoded } doReturn SESSION_KEY.toByteArray()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -69,7 +69,7 @@ class MGMRegistrationServiceTest {
     }
 
     private val mgmName = MemberX500Name("Corda MGM", "London", "GB")
-    private val mgm = HoldingIdentity(mgmName.toString(), "dummy_group")
+    private val mgm = HoldingIdentity(mgmName, "dummy_group")
     private val mgmId = mgm.shortHash
     private val sessionKey: PublicKey = mock {
         on { encoded } doReturn SESSION_KEY.toByteArray()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -74,11 +74,11 @@ class StaticMemberRegistrationServiceTest {
         private const val KEY_SCHEME = "corda.key.scheme"
     }
 
-    private val alice = HoldingIdentity(aliceName.toString(), DUMMY_GROUP_ID)
-    private val bob = HoldingIdentity(bobName.toString(), DUMMY_GROUP_ID)
-    private val charlie = HoldingIdentity(charlieName.toString(), DUMMY_GROUP_ID)
-    private val daisy = HoldingIdentity(daisyName.toString(), DUMMY_GROUP_ID)
-    private val eric = HoldingIdentity(ericName.toString(), DUMMY_GROUP_ID)
+    private val alice = HoldingIdentity(aliceName, DUMMY_GROUP_ID)
+    private val bob = HoldingIdentity(bobName, DUMMY_GROUP_ID)
+    private val charlie = HoldingIdentity(charlieName, DUMMY_GROUP_ID)
+    private val daisy = HoldingIdentity(daisyName, DUMMY_GROUP_ID)
+    private val eric = HoldingIdentity(ericName, DUMMY_GROUP_ID)
 
     private val aliceId = alice.shortHash
     private val bobId = bob.shortHash
@@ -246,7 +246,7 @@ class StaticMemberRegistrationServiceTest {
         assertEquals(P2P_HOSTED_IDENTITIES_TOPIC, publishedHostedIdentity.topic)
         val hostedIdentityPublished = publishedHostedIdentity.value as HostedIdentityEntry
         assertEquals(alice.groupId, hostedIdentityPublished.holdingIdentity.groupId)
-        assertEquals(alice.x500Name, hostedIdentityPublished.holdingIdentity.x500Name)
+        assertEquals(alice.x500Name.toString(), hostedIdentityPublished.holdingIdentity.x500Name)
 
         assertEquals(MembershipRequestRegistrationResult(SUBMITTED), registrationResult)
     }

--- a/components/membership/synchronisation-impl/build.gradle
+++ b/components/membership/synchronisation-impl/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
     testImplementation project(":libs:membership:membership-impl")
+    testImplementation project(':testing:test-utilities')
 }

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
@@ -115,7 +115,7 @@ class MemberSynchronisationServiceImplTest {
         on { create(any()) } doReturn participant
     }
     private val memberName = MemberX500Name("Alice", "London", "GB")
-    private val member = HoldingIdentity(memberName.toString(), GROUP_NAME)
+    private val member = HoldingIdentity(memberName, GROUP_NAME)
     private val memberContextList = KeyValuePairList(listOf(KeyValuePair(PARTY_NAME, participantName.toString())))
     private val mgmContextList = KeyValuePairList(listOf())
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> = mock {

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImplTest.kt
@@ -45,7 +45,7 @@ import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.apache.commons.text.StringEscapeUtils
@@ -127,8 +127,7 @@ class SynchronisationProxyImplTest {
     }
     private lateinit var synchronisationProxy: SynchronisationProxy
 
-    private fun createHoldingIdentity() = HoldingIdentity(
-        MemberX500Name.parse("O=Alice, L=London, C=GB"), DUMMY_GROUP_ID)
+    private fun createHoldingIdentity() = createTestHoldingIdentity("O=Alice, L=London, C=GB", DUMMY_GROUP_ID)
 
     private fun createGroupPolicy(synchronisationProtocol: String): GroupPolicy {
         val r3comCert = StringEscapeUtils.escapeJson(

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImplTest.kt
@@ -45,6 +45,7 @@ import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.configuration.ConfigKeys
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.apache.commons.text.StringEscapeUtils
@@ -126,7 +127,8 @@ class SynchronisationProxyImplTest {
     }
     private lateinit var synchronisationProxy: SynchronisationProxy
 
-    private fun createHoldingIdentity() = HoldingIdentity("O=Alice, L=London, C=GB", DUMMY_GROUP_ID)
+    private fun createHoldingIdentity() = HoldingIdentity(
+        MemberX500Name.parse("O=Alice, L=London, C=GB"), DUMMY_GROUP_ID)
 
     private fun createGroupPolicy(synchronisationProtocol: String): GroupPolicy {
         val r3comCert = StringEscapeUtils.escapeJson(

--- a/components/virtual-node/entity-processor-service-impl/build.gradle
+++ b/components/virtual-node/entity-processor-service-impl/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project(':components:virtual-node:cpk-read-service')
     integrationTestImplementation project(':components:virtual-node:sandbox-group-context-service')
+    integrationTestImplementation project(':testing:test-utilities')
 
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/components/VirtualNodeService.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/components/VirtualNodeService.kt
@@ -6,6 +6,7 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -34,7 +35,7 @@ class VirtualNodeService @Activate constructor(
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
 
-        fun generateHoldingIdentity() = HoldingIdentity(X500_NAME, UUID.randomUUID().toString())
+        fun generateHoldingIdentity() = HoldingIdentity(MemberX500Name.parse(X500_NAME), UUID.randomUUID().toString())
     }
 
     private val vnodes = mutableMapOf<SandboxGroupContext, VirtualNodeInfo>()

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/components/VirtualNodeService.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/components/VirtualNodeService.kt
@@ -4,11 +4,10 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.serialization.SingletonSerializeAsToken
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import org.junit.jupiter.api.fail
 import org.osgi.service.component.annotations.Activate
@@ -35,7 +34,7 @@ class VirtualNodeService @Activate constructor(
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
 
-        fun generateHoldingIdentity() = HoldingIdentity(MemberX500Name.parse(X500_NAME), UUID.randomUUID().toString())
+        fun generateHoldingIdentity() = createTestHoldingIdentity(X500_NAME, UUID.randomUUID().toString())
     }
 
     private val vnodes = mutableMapOf<SandboxGroupContext, VirtualNodeInfo>()

--- a/components/virtual-node/entity-processor-service-impl/test.bndrun
+++ b/components/virtual-node/entity-processor-service-impl/test.bndrun
@@ -38,6 +38,7 @@
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
     bnd.identity;id='slf4j.simple'
+    bnd.identity;id='net.corda.test-utilities'
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/components/virtual-node/sandbox-group-context-service/build.gradle
+++ b/components/virtual-node/sandbox-group-context-service/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation project(':testing:test-utilities')
 
     testCompileOnly 'org.osgi:osgi.core'
     testRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
@@ -62,6 +63,7 @@ dependencies {
     integrationTestImplementation 'net.corda:corda-application'
     integrationTestImplementation project(':components:security-manager')
     integrationTestImplementation project(':testing:security-manager-utilities')
+    integrationTestImplementation project(':testing:test-utilities')
     integrationTestRuntimeOnly project(':libs:crypto:cipher-suite-impl')
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
@@ -8,6 +8,7 @@ import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -33,7 +34,7 @@ class VirtualNodeService @Activate constructor(
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
 
-        private fun generateHoldingIdentity() = HoldingIdentity(X500_NAME, UUID.randomUUID().toString())
+        private fun generateHoldingIdentity() = HoldingIdentity(MemberX500Name.parse(X500_NAME), UUID.randomUUID().toString())
     }
     init {
         // setting cache size to 2 as some tests require 2 concurrent sandboxes for validating they don't overlap

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
@@ -4,13 +4,12 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.SubFlow
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.serialization.SingletonSerializeAsToken
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import org.junit.jupiter.api.fail
 import org.osgi.framework.FrameworkUtil
@@ -34,7 +33,7 @@ class VirtualNodeService @Activate constructor(
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
 
-        private fun generateHoldingIdentity() = HoldingIdentity(MemberX500Name.parse(X500_NAME), UUID.randomUUID().toString())
+        private fun generateHoldingIdentity() = createTestHoldingIdentity(X500_NAME, UUID.randomUUID().toString())
     }
     init {
         // setting cache size to 2 as some tests require 2 concurrent sandboxes for validating they don't overlap

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -4,6 +4,7 @@ import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.impl.CloseableSandboxGroupContext
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCacheImpl
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
@@ -21,7 +22,7 @@ class SandboxGroupContextCacheTest {
         val cache = SandboxGroupContextCacheImpl(1)
 
         val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn "name"
+            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
         }
         val vnodeContext1 = mock<VirtualNodeContext> {
             on { sandboxGroupType } doReturn SandboxGroupType.FLOW
@@ -47,7 +48,7 @@ class SandboxGroupContextCacheTest {
         val cache = SandboxGroupContextCacheImpl(10)
 
         val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn "name"
+            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
         }
         val vnodeContext1 = mock<VirtualNodeContext> {
             on { sandboxGroupType } doReturn SandboxGroupType.FLOW
@@ -75,7 +76,7 @@ class SandboxGroupContextCacheTest {
         val cache = SandboxGroupContextCacheImpl(10)
 
         val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn "name"
+            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
         }
         val vnodeContext1 = mock<VirtualNodeContext> {
             on { sandboxGroupType } doReturn SandboxGroupType.FLOW
@@ -95,7 +96,7 @@ class SandboxGroupContextCacheTest {
         val cache = SandboxGroupContextCacheImpl(10)
 
         val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn "name"
+            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
         }
         val vnodeContext1 = mock<VirtualNodeContext> {
             on { sandboxGroupType } doReturn SandboxGroupType.FLOW
@@ -116,14 +117,15 @@ class SandboxGroupContextCacheTest {
         val cache = SandboxGroupContextCacheImpl(10)
 
         val vnodeContext1 = VirtualNodeContext(
-            HoldingIdentity("Alice", "group"),
+            HoldingIdentity(
+                MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), "group"),
             setOf(SecureHash.create("DUMMY:1234567890abcdef")),
             SandboxGroupType.FLOW,
             SingletonSerializeAsToken::class.java,
             "filter")
 
         val equalVnodeContext1 = VirtualNodeContext(
-            HoldingIdentity("Alice", "group"),
+            HoldingIdentity(MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), "group"),
             setOf(SecureHash.create("DUMMY:1234567890abcdef")),
             SandboxGroupType.FLOW,
             SingletonSerializeAsToken::class.java,

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -4,6 +4,7 @@ import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.impl.CloseableSandboxGroupContext
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCacheImpl
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -117,15 +118,14 @@ class SandboxGroupContextCacheTest {
         val cache = SandboxGroupContextCacheImpl(10)
 
         val vnodeContext1 = VirtualNodeContext(
-            HoldingIdentity(
-                MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), "group"),
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
             setOf(SecureHash.create("DUMMY:1234567890abcdef")),
             SandboxGroupType.FLOW,
             SingletonSerializeAsToken::class.java,
             "filter")
 
         val equalVnodeContext1 = VirtualNodeContext(
-            HoldingIdentity(MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), "group"),
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
             setOf(SecureHash.create("DUMMY:1234567890abcdef")),
             SandboxGroupType.FLOW,
             SingletonSerializeAsToken::class.java,

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
@@ -9,7 +9,7 @@ import net.corda.sandboxgroupcontext.putUniqueObject
 import net.corda.sandboxgroupcontext.service.impl.CloseableSandboxGroupContext
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCache
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextServiceImpl
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
@@ -42,8 +42,7 @@ class StubSandboxGroupContextCache: SandboxGroupContextCache {
 class SandboxGroupContextServiceImplTest {
 
     private lateinit var service: SandboxGroupContextServiceImpl
-    private val holdingIdentity = HoldingIdentity(
-        MemberX500Name.parse("CN=Foo, O=Foo Corp, L=LDN, C=GB"), "bar")
+    private val holdingIdentity = createTestHoldingIdentity("CN=Foo, O=Foo Corp, L=LDN, C=GB", "bar")
     private val mainBundle = "MAIN BUNDLE"
 
     private val scr = mock<ServiceComponentRuntime>()
@@ -143,9 +142,9 @@ class SandboxGroupContextServiceImplTest {
 
     @Test
     fun `can create objects with same keys in different VirtualNodeContexts`() {
-        val holdingIdentity1 = HoldingIdentity(MemberX500Name.parse("CN=Foo-1, O=Foo Corp, L=LDN, C=GB"), "bar")
-        val holdingIdentity2 = HoldingIdentity(MemberX500Name.parse("CN=Foo-2, O=Foo Corp, L=LDN, C=GB"), "bar")
-        val holdingIdentity3 = HoldingIdentity(MemberX500Name.parse("CN=Foo-3, O=Foo Corp, L=LDN, C=GB"), "bar")
+        val holdingIdentity1 = createTestHoldingIdentity("CN=Foo-1, O=Foo Corp, L=LDN, C=GB", "bar")
+        val holdingIdentity2 = createTestHoldingIdentity("CN=Foo-2, O=Foo Corp, L=LDN, C=GB", "bar")
+        val holdingIdentity3 = createTestHoldingIdentity("CN=Foo-3, O=Foo Corp, L=LDN, C=GB", "bar")
 
         val cpks1 = setOf(Helpers.mockTrivialCpk("MAIN1", "apple", "1.0.0"))
         val cpks2 = setOf(Helpers.mockTrivialCpk("MAIN2", "banana", "2.0.0"))
@@ -213,7 +212,7 @@ class SandboxGroupContextServiceImplTest {
 
     @Test
     fun `remove removes from cache`() {
-        val holdingIdentity1 = HoldingIdentity(MemberX500Name.parse("CN=Foo, O=Foo Corp, L=LDN, C=GB"), "bar")
+        val holdingIdentity1 = createTestHoldingIdentity("CN=Foo, O=Foo Corp, L=LDN, C=GB", "bar")
         val cpks1 = setOf(Helpers.mockTrivialCpk("MAIN1", "example", "1.0.0"))
         val ctx1 = createVirtualNodeContextForFlow(
             holdingIdentity1,

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
@@ -9,6 +9,7 @@ import net.corda.sandboxgroupcontext.putUniqueObject
 import net.corda.sandboxgroupcontext.service.impl.CloseableSandboxGroupContext
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCache
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextServiceImpl
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
@@ -41,7 +42,8 @@ class StubSandboxGroupContextCache: SandboxGroupContextCache {
 class SandboxGroupContextServiceImplTest {
 
     private lateinit var service: SandboxGroupContextServiceImpl
-    private val holdingIdentity = HoldingIdentity("foo", "bar")
+    private val holdingIdentity = HoldingIdentity(
+        MemberX500Name.parse("CN=Foo, O=Foo Corp, L=LDN, C=GB"), "bar")
     private val mainBundle = "MAIN BUNDLE"
 
     private val scr = mock<ServiceComponentRuntime>()
@@ -141,9 +143,9 @@ class SandboxGroupContextServiceImplTest {
 
     @Test
     fun `can create objects with same keys in different VirtualNodeContexts`() {
-        val holdingIdentity1 = HoldingIdentity("OU=1", "bar")
-        val holdingIdentity2 = HoldingIdentity("OU=2", "bar")
-        val holdingIdentity3 = HoldingIdentity("OU=3", "bar")
+        val holdingIdentity1 = HoldingIdentity(MemberX500Name.parse("CN=Foo-1, O=Foo Corp, L=LDN, C=GB"), "bar")
+        val holdingIdentity2 = HoldingIdentity(MemberX500Name.parse("CN=Foo-2, O=Foo Corp, L=LDN, C=GB"), "bar")
+        val holdingIdentity3 = HoldingIdentity(MemberX500Name.parse("CN=Foo-3, O=Foo Corp, L=LDN, C=GB"), "bar")
 
         val cpks1 = setOf(Helpers.mockTrivialCpk("MAIN1", "apple", "1.0.0"))
         val cpks2 = setOf(Helpers.mockTrivialCpk("MAIN2", "banana", "2.0.0"))
@@ -211,7 +213,7 @@ class SandboxGroupContextServiceImplTest {
 
     @Test
     fun `remove removes from cache`() {
-        val holdingIdentity1 = HoldingIdentity("OU=1", "bar")
+        val holdingIdentity1 = HoldingIdentity(MemberX500Name.parse("CN=Foo, O=Foo Corp, L=LDN, C=GB"), "bar")
         val cpks1 = setOf(Helpers.mockTrivialCpk("MAIN1", "example", "1.0.0"))
         val ctx1 = createVirtualNodeContextForFlow(
             holdingIdentity1,

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextTest.kt
@@ -8,6 +8,7 @@ import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.sandboxgroupcontext.putObjectByKey
 import net.corda.sandboxgroupcontext.putUniqueObject
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextImpl
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
@@ -35,7 +36,8 @@ class Cat(override val name: String, private val noise: String) : Animal {
 inline fun <reified T : Any> SandboxGroupContext.getUniqueObject() = this.get(T::class.java.name, T::class.java)
 
 class SandboxGroupContextTest {
-    private val holdingIdentity = HoldingIdentity("foo", "bar")
+    private val holdingIdentity = HoldingIdentity(
+        MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "bar")
     private val cpkMetadata: CpkMetadata = Helpers.mockTrivialCpk("MAIN_BUNDLE", "example", "1.0.0").metadata
 
     private val cpksMetadata = setOf(cpkMetadata)

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextTest.kt
@@ -8,10 +8,9 @@ import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.sandboxgroupcontext.putObjectByKey
 import net.corda.sandboxgroupcontext.putUniqueObject
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextImpl
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
-import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,8 +35,7 @@ class Cat(override val name: String, private val noise: String) : Animal {
 inline fun <reified T : Any> SandboxGroupContext.getUniqueObject() = this.get(T::class.java.name, T::class.java)
 
 class SandboxGroupContextTest {
-    private val holdingIdentity = HoldingIdentity(
-        MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "bar")
+    private val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "bar")
     private val cpkMetadata: CpkMetadata = Helpers.mockTrivialCpk("MAIN_BUNDLE", "example", "1.0.0").metadata
 
     private val cpksMetadata = setOf(cpkMetadata)

--- a/components/virtual-node/sandbox-group-context-service/test.bndrun
+++ b/components/virtual-node/sandbox-group-context-service/test.bndrun
@@ -35,6 +35,7 @@
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
     bnd.identity;id='slf4j.simple'
+    bnd.identity;id='net.corda.test-utilities'
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/components/virtual-node/virtual-node-info-read-service/build.gradle
+++ b/components/virtual-node/virtual-node-info-read-service/build.gradle
@@ -37,4 +37,5 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation project(':testing:test-utilities')
 }

--- a/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoMapTest.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoMapTest.kt
@@ -1,6 +1,7 @@
 package net.corda.virtualnode.read.impl
 
 import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -41,7 +42,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put one VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(
             holdingIdentity, cpiIdentifier
         )
@@ -57,7 +58,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put two VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(
             holdingIdentity, cpiIdentifier
         )
@@ -65,7 +66,7 @@ class VirtualNodeInfoMapTest {
             VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash), virtualNodeInfo.toAvro()
         )
 
-        val otherHoldingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val otherHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val otherVirtualNode = newVirtualNodeInfo(otherHoldingIdentity, cpiIdentifier)
         map.put(
             VirtualNodeInfoMap.Key(otherHoldingIdentity.toAvro(), otherShortHash), otherVirtualNode.toAvro()
@@ -82,13 +83,13 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put two VirtualNodeInfo with clashing ids`() {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
         map.put(
             VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash), virtualNodeInfo.toAvro()
         )
 
-        val otherHoldingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val otherHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val otherVirtualNodeInfo = newVirtualNodeInfo(otherHoldingIdentity, cpiIdentifier)
         // Put with same short hash
         assertThrows<IllegalArgumentException> {
@@ -106,8 +107,11 @@ class VirtualNodeInfoMapTest {
      */
     @Test
     fun `putting mismatched HoldingIdentity throws`() {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
-        val differentHoldingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val differentHoldingIdentity = HoldingIdentity(
+            MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"),
+            UUID.randomUUID().toString()
+        )
         val virtualNodeInfo = newVirtualNodeInfo(differentHoldingIdentity, cpiIdentifier)
         assertThrows<IllegalArgumentException> {
             map.put(
@@ -120,7 +124,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put one and remove one VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
 
         val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash)
@@ -134,12 +138,12 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put two and remove two VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
         val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash)
         map.put(key, virtualNodeInfo.toAvro())
 
-        val otherHoldingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val otherHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val otherVirtualNodeInfo = newVirtualNodeInfo(otherHoldingIdentity, cpiIdentifier)
         val otherFakeShortHash = "F000000D"
         val otherKey = VirtualNodeInfoMap.Key(otherHoldingIdentity.toAvro(), otherFakeShortHash)
@@ -165,7 +169,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `second remove returns null`() {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
         val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash)
         map.put(key, virtualNodeInfo.toAvro())
@@ -187,7 +191,7 @@ class VirtualNodeInfoMapTest {
 
         // Add a number of VirtualNodeInfo objects to the map, and keep a copy of the keys
         for (i in 0..count) {
-            val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+            val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
             val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
             // Actually use the real short hash/id of the holding identity
             val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), holdingIdentity.shortHash)
@@ -243,7 +247,7 @@ class VirtualNodeInfoMapTest {
         val count = 100
 
         for (i in 0..count) {
-            val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+            val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
             val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
             // Actually use the real short hash/id of the holding identity
             val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), holdingIdentity.shortHash)

--- a/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoMapTest.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoMapTest.kt
@@ -1,7 +1,7 @@
 package net.corda.virtualnode.read.impl
 
 import net.corda.libs.packaging.core.CpiIdentifier
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -42,7 +42,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put one VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(
             holdingIdentity, cpiIdentifier
         )
@@ -58,7 +58,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put two VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(
             holdingIdentity, cpiIdentifier
         )
@@ -66,7 +66,7 @@ class VirtualNodeInfoMapTest {
             VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash), virtualNodeInfo.toAvro()
         )
 
-        val otherHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val otherHoldingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val otherVirtualNode = newVirtualNodeInfo(otherHoldingIdentity, cpiIdentifier)
         map.put(
             VirtualNodeInfoMap.Key(otherHoldingIdentity.toAvro(), otherShortHash), otherVirtualNode.toAvro()
@@ -83,13 +83,13 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put two VirtualNodeInfo with clashing ids`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
         map.put(
             VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash), virtualNodeInfo.toAvro()
         )
 
-        val otherHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val otherHoldingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val otherVirtualNodeInfo = newVirtualNodeInfo(otherHoldingIdentity, cpiIdentifier)
         // Put with same short hash
         assertThrows<IllegalArgumentException> {
@@ -107,11 +107,8 @@ class VirtualNodeInfoMapTest {
      */
     @Test
     fun `putting mismatched HoldingIdentity throws`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
-        val differentHoldingIdentity = HoldingIdentity(
-            MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"),
-            UUID.randomUUID().toString()
-        )
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
+        val differentHoldingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(differentHoldingIdentity, cpiIdentifier)
         assertThrows<IllegalArgumentException> {
             map.put(
@@ -124,7 +121,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put one and remove one VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
 
         val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash)
@@ -138,12 +135,12 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `put two and remove two VirtualNodeInfo`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
         val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash)
         map.put(key, virtualNodeInfo.toAvro())
 
-        val otherHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val otherHoldingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val otherVirtualNodeInfo = newVirtualNodeInfo(otherHoldingIdentity, cpiIdentifier)
         val otherFakeShortHash = "F000000D"
         val otherKey = VirtualNodeInfoMap.Key(otherHoldingIdentity.toAvro(), otherFakeShortHash)
@@ -169,7 +166,7 @@ class VirtualNodeInfoMapTest {
 
     @Test
     fun `second remove returns null`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
         val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), fakeShortHash)
         map.put(key, virtualNodeInfo.toAvro())
@@ -191,7 +188,7 @@ class VirtualNodeInfoMapTest {
 
         // Add a number of VirtualNodeInfo objects to the map, and keep a copy of the keys
         for (i in 0..count) {
-            val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+            val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
             val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
             // Actually use the real short hash/id of the holding identity
             val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), holdingIdentity.shortHash)
@@ -247,7 +244,7 @@ class VirtualNodeInfoMapTest {
         val count = 100
 
         for (i in 0..count) {
-            val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+            val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
             val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, cpiIdentifier)
             // Actually use the real short hash/id of the holding identity
             val key = VirtualNodeInfoMap.Key(holdingIdentity.toAvro(), holdingIdentity.shortHash)

--- a/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
@@ -2,6 +2,7 @@ package net.corda.virtualnode.read.impl
 
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.messaging.api.records.Record
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -31,7 +32,7 @@ class VirtualNodeInfoProcessorTest {
     }
 
     private fun sendOnNextRandomMessage(processor: VirtualNodeInfoProcessor): HoldingIdentity {
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val newVirtualNodeInfo = VirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash),
             null, UUID.randomUUID(), null, UUID.randomUUID(), timestamp = Instant.now())
         processor.onNext(Record("", holdingIdentity.toAvro(), newVirtualNodeInfo.toAvro()), null, emptyMap())
@@ -52,7 +53,7 @@ class VirtualNodeInfoProcessorTest {
     fun `register client listener callback before onSnapshot is called`() {
         processor.registerCallback(listener)
 
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -64,7 +65,7 @@ class VirtualNodeInfoProcessorTest {
 
     @Test
     fun `register client listener callback after onSnapshot is called`() {
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -83,7 +84,7 @@ class VirtualNodeInfoProcessorTest {
 
         assertTrue(listener.update)
 
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
 
@@ -115,7 +116,7 @@ class VirtualNodeInfoProcessorTest {
     fun `unregister client listener callback`() {
         val closeable = processor.registerCallback(listener)
 
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -147,7 +148,7 @@ class VirtualNodeInfoProcessorTest {
 
         assertTrue(listener.update)
 
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
 
@@ -172,7 +173,7 @@ class VirtualNodeInfoProcessorTest {
     @Test
     fun `client listeners are unregistered when service closes`() {
         processor.registerCallback(listener)
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -206,7 +207,7 @@ class VirtualNodeInfoProcessorTest {
 
         // Send message
         listener.update = false
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onNext(Record("", holdingIdentity.toAvro(), virtualNodeInfo.toAvro()), null, emptyMap())
@@ -236,7 +237,7 @@ class VirtualNodeInfoProcessorTest {
         assertNotNull(virtualNodeList)
         assertTrue(virtualNodeList.isEmpty())
 
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         val shortHash = holdingIdentity.shortHash
@@ -266,7 +267,7 @@ class VirtualNodeInfoProcessorTest {
         processor.registerCallback(listener)
         processor.onSnapshot(emptyMap())
 
-        val holdingIdentity = HoldingIdentity("x500", "groupId")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
 
@@ -298,7 +299,7 @@ class VirtualNodeInfoProcessorTest {
     @Test
     fun `clear message processor`() {
         val processor = VirtualNodeInfoProcessor({ /* don't care about callback */ }, { /* don't care about callback */ })
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash))
         processor.registerCallback(listener)
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -315,7 +316,7 @@ class VirtualNodeInfoProcessorTest {
     fun `internal onSnapshot callback is called`() {
         var onSnapshot = false
         val processor = VirtualNodeInfoProcessor({ onSnapshot = true }, { /* don't care about callback */ })
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash))
 
         processor.registerCallback(listener)
@@ -329,8 +330,8 @@ class VirtualNodeInfoProcessorTest {
     fun `internal onError callback is called`() {
         var onError = false
         val processor = VirtualNodeInfoProcessor({ /* don't care */ }, { onError = true })
-        val holdingIdentity = HoldingIdentity("abc", UUID.randomUUID().toString())
-        val holdingIdentityOther = HoldingIdentity("def", UUID.randomUUID().toString())
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentityOther = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash))
 
         processor.registerCallback(listener)

--- a/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
@@ -2,7 +2,7 @@ package net.corda.virtualnode.read.impl
 
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -32,7 +32,7 @@ class VirtualNodeInfoProcessorTest {
     }
 
     private fun sendOnNextRandomMessage(processor: VirtualNodeInfoProcessor): HoldingIdentity {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val newVirtualNodeInfo = VirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash),
             null, UUID.randomUUID(), null, UUID.randomUUID(), timestamp = Instant.now())
         processor.onNext(Record("", holdingIdentity.toAvro(), newVirtualNodeInfo.toAvro()), null, emptyMap())
@@ -53,7 +53,7 @@ class VirtualNodeInfoProcessorTest {
     fun `register client listener callback before onSnapshot is called`() {
         processor.registerCallback(listener)
 
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -65,7 +65,7 @@ class VirtualNodeInfoProcessorTest {
 
     @Test
     fun `register client listener callback after onSnapshot is called`() {
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -84,7 +84,7 @@ class VirtualNodeInfoProcessorTest {
 
         assertTrue(listener.update)
 
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
 
@@ -116,7 +116,7 @@ class VirtualNodeInfoProcessorTest {
     fun `unregister client listener callback`() {
         val closeable = processor.registerCallback(listener)
 
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -148,7 +148,7 @@ class VirtualNodeInfoProcessorTest {
 
         assertTrue(listener.update)
 
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
 
@@ -173,7 +173,7 @@ class VirtualNodeInfoProcessorTest {
     @Test
     fun `client listeners are unregistered when service closes`() {
         processor.registerCallback(listener)
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -207,7 +207,7 @@ class VirtualNodeInfoProcessorTest {
 
         // Send message
         listener.update = false
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         processor.onNext(Record("", holdingIdentity.toAvro(), virtualNodeInfo.toAvro()), null, emptyMap())
@@ -237,7 +237,7 @@ class VirtualNodeInfoProcessorTest {
         assertNotNull(virtualNodeList)
         assertTrue(virtualNodeList.isEmpty())
 
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
         val shortHash = holdingIdentity.shortHash
@@ -267,7 +267,7 @@ class VirtualNodeInfoProcessorTest {
         processor.registerCallback(listener)
         processor.onSnapshot(emptyMap())
 
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "groupId")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
         val virtualNodeInfo =
             newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
 
@@ -299,7 +299,7 @@ class VirtualNodeInfoProcessorTest {
     @Test
     fun `clear message processor`() {
         val processor = VirtualNodeInfoProcessor({ /* don't care about callback */ }, { /* don't care about callback */ })
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash))
         processor.registerCallback(listener)
         processor.onSnapshot(mapOf(holdingIdentity.toAvro() to virtualNodeInfo.toAvro()))
@@ -316,7 +316,7 @@ class VirtualNodeInfoProcessorTest {
     fun `internal onSnapshot callback is called`() {
         var onSnapshot = false
         val processor = VirtualNodeInfoProcessor({ onSnapshot = true }, { /* don't care about callback */ })
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash))
 
         processor.registerCallback(listener)
@@ -330,8 +330,8 @@ class VirtualNodeInfoProcessorTest {
     fun `internal onError callback is called`() {
         var onError = false
         val processor = VirtualNodeInfoProcessor({ /* don't care */ }, { onError = true })
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
-        val holdingIdentityOther = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), UUID.randomUUID().toString())
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
+        val holdingIdentityOther = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
         val virtualNodeInfo = newVirtualNodeInfo(holdingIdentity, CpiIdentifier("ghi", "hjk", secureHash))
 
         processor.registerCallback(listener)

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
@@ -106,7 +106,7 @@ internal class VirtualNodeRPCOpsImpl @VisibleForTesting constructor(
         return when (val resolvedResponse = resp.responseType) {
             is VirtualNodeCreateResponse -> {
                 VirtualNodeInfo(
-                    HoldingIdentity(resolvedResponse.x500Name, resolvedResponse.mgmGroupId).toEndpointType(),
+                    HoldingIdentity(MemberX500Name.parse(resolvedResponse.x500Name), resolvedResponse.mgmGroupId).toEndpointType(),
                     CpiIdentifier.fromAvro(resolvedResponse.cpiIdentifier),
                     resolvedResponse.vaultDdlConnectionId,
                     resolvedResponse.vaultDmlConnectionId,
@@ -134,7 +134,7 @@ internal class VirtualNodeRPCOpsImpl @VisibleForTesting constructor(
     }
 
     private fun HoldingIdentity.toEndpointType(): HoldingIdentityEndpointType =
-        HoldingIdentityEndpointType(x500Name, groupId, shortHash, fullHash)
+        HoldingIdentityEndpointType(x500Name.toString(), groupId, shortHash, fullHash)
 
     private fun net.corda.virtualnode.VirtualNodeInfo.toEndpointType(): VirtualNodeInfo =
         VirtualNodeInfo(

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/VirtualNodeRPCOpsImplTests.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/VirtualNodeRPCOpsImplTests.kt
@@ -141,7 +141,7 @@ class VirtualNodeRPCOpsImplTests {
         val id = holdingId.toCorda()
         val successResponse =
             VirtualNodeInfoEndpointType(
-                holdingIdentity = HoldingIdentityEndpointType(id.x500Name, id.groupId, id.shortHash, id.fullHash),
+                holdingIdentity = HoldingIdentityEndpointType(id.x500Name.toString(), id.groupId, id.shortHash, id.fullHash),
                 cpiIdentifier = cpiId,
                 vaultDdlConnectionId = vaultDdlConnectionId,
                 vaultDmlConnectionId = vaultDmlConnectionId,

--- a/components/virtual-node/virtual-node-write-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-write-service-impl/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation project(":testing:test-utilities")
     testImplementation project(':libs:db:db-orm-impl')
     testImplementation project(':testing:db-testkit')
+    testImplementation project(':testing:test-utilities')
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
@@ -17,6 +17,7 @@ import net.corda.libs.virtualnode.datamodel.VirtualNodeEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntityKey
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.write.db.impl.writer.CpiMetadataLite
@@ -164,11 +165,11 @@ internal class VirtualNodeEntityRepositoryTest {
 
     @Test
     fun `can read holding identity`() {
-        val expectedHoldingIdentity = HoldingIdentity("X500 Name", "Group ID")
+        val expectedHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "Group ID")
 
         val holdingIdentityEntity = with(expectedHoldingIdentity) {
             HoldingIdentityEntity(
-                shortHash, fullHash, x500Name, groupId, null, null,
+                shortHash, fullHash, x500Name.toString(), groupId, null, null,
                 null, null, null
             )
         }
@@ -190,7 +191,7 @@ internal class VirtualNodeEntityRepositoryTest {
     fun `can save holding identity`() {
         val entityManager = entityManagerFactory.createEntityManager()
 
-        val expectedHoldingIdentity = HoldingIdentity("X500 Name 2", "Group ID")
+        val expectedHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-2, O=Bob Corp, L=LDN, C=GB"), "Group ID")
 
         // Save holding identity and DB connections
 
@@ -229,7 +230,7 @@ internal class VirtualNodeEntityRepositoryTest {
         with(holdingIdentityEntity) {
             Assertions.assertThat(holdingIdentityShortHash).isEqualTo(expectedHoldingIdentity.shortHash)
             Assertions.assertThat(holdingIdentityFullHash).isEqualTo(expectedHoldingIdentity.fullHash)
-            Assertions.assertThat(x500Name).isEqualTo(expectedHoldingIdentity.x500Name)
+            Assertions.assertThat(x500Name).isEqualTo(expectedHoldingIdentity.x500Name.toString())
             Assertions.assertThat(mgmGroupId).isEqualTo(expectedHoldingIdentity.groupId)
             Assertions.assertThat(vaultDDLConnectionId).isEqualTo(expectedConnections.vaultDdlConnectionId)
             Assertions.assertThat(vaultDMLConnectionId).isEqualTo(expectedConnections.vaultDmlConnectionId)
@@ -240,7 +241,7 @@ internal class VirtualNodeEntityRepositoryTest {
 
     @Test
     fun `can update holding identity`() {
-        val expectedHoldingIdentity = HoldingIdentity("X500 Name 3", "Group ID")
+        val expectedHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-3, O=Bob Corp, L=LDN, C=GB"), "Group ID")
 
         // Save holding identity and DB connections
 
@@ -306,7 +307,7 @@ internal class VirtualNodeEntityRepositoryTest {
         with(holdingIdentityEntity) {
             Assertions.assertThat(holdingIdentityShortHash).isEqualTo(expectedHoldingIdentity.shortHash)
             Assertions.assertThat(holdingIdentityFullHash).isEqualTo(expectedHoldingIdentity.fullHash)
-            Assertions.assertThat(x500Name).isEqualTo(expectedHoldingIdentity.x500Name)
+            Assertions.assertThat(x500Name).isEqualTo(expectedHoldingIdentity.x500Name.toString())
             Assertions.assertThat(mgmGroupId).isEqualTo(expectedHoldingIdentity.groupId)
             Assertions.assertThat(vaultDDLConnectionId).isEqualTo(expectedConnections.vaultDdlConnectionId)
             Assertions.assertThat(vaultDMLConnectionId).isEqualTo(expectedConnections.vaultDmlConnectionId)
@@ -322,7 +323,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val signerSummaryHash = "TEST:121212121212"
         val cpiId = CpiIdentifier("Test CPI 2", "1.0", SecureHash.create(signerSummaryHash))
         val cpiMetadata = CpiMetadataLite(cpiId, hexFileChecksum, "Test Group ID", "Test Group Policy")
-        val holdingIdentity = HoldingIdentity("X500 Name 4", "Group ID")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-4, O=Bob Corp, L=LDN, C=GB"), "Group ID")
 
         val cpiMetadataEntity = with(cpiMetadata) {
             CpiMetadataEntity(
@@ -339,7 +340,7 @@ internal class VirtualNodeEntityRepositoryTest {
         }
         val holdingIdentityEntity = with(holdingIdentity) {
             HoldingIdentityEntity(
-                shortHash, fullHash, x500Name, groupId, null, null,
+                shortHash, fullHash, x500Name.toString(), groupId, null, null,
                 null, null, null
             )
         }
@@ -366,7 +367,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val signerSummaryHash = "TEST:121212121212"
         val cpiId = CpiIdentifier("Test CPI 3", "1.0", SecureHash.create(signerSummaryHash))
         val cpiMetadata = CpiMetadataLite(cpiId, hexFileChecksum, "Test Group ID", "Test Group Policy")
-        val holdingIdentity = HoldingIdentity("X500 Name 5", "Group ID")
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-5, O=Bob Corp, L=LDN, C=GB"), "Group ID")
 
         val cpiMetadataEntity = with(cpiMetadata) {
             CpiMetadataEntity(
@@ -383,7 +384,7 @@ internal class VirtualNodeEntityRepositoryTest {
         }
         val holdingIdentityEntity = with(holdingIdentity) {
             HoldingIdentityEntity(
-                shortHash, fullHash, x500Name, groupId, null, null,
+                shortHash, fullHash, x500Name.toString(), groupId, null, null,
                 null, null, null
             )
         }

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
@@ -17,9 +17,8 @@ import net.corda.libs.virtualnode.datamodel.VirtualNodeEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntityKey
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.write.db.impl.writer.CpiMetadataLite
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbConnections
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeEntityRepository
@@ -165,7 +164,7 @@ internal class VirtualNodeEntityRepositoryTest {
 
     @Test
     fun `can read holding identity`() {
-        val expectedHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), "Group ID")
+        val expectedHoldingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "Group ID")
 
         val holdingIdentityEntity = with(expectedHoldingIdentity) {
             HoldingIdentityEntity(
@@ -191,7 +190,7 @@ internal class VirtualNodeEntityRepositoryTest {
     fun `can save holding identity`() {
         val entityManager = entityManagerFactory.createEntityManager()
 
-        val expectedHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-2, O=Bob Corp, L=LDN, C=GB"), "Group ID")
+        val expectedHoldingIdentity = createTestHoldingIdentity("CN=Bob-2, O=Bob Corp, L=LDN, C=GB", "Group ID")
 
         // Save holding identity and DB connections
 
@@ -241,7 +240,7 @@ internal class VirtualNodeEntityRepositoryTest {
 
     @Test
     fun `can update holding identity`() {
-        val expectedHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-3, O=Bob Corp, L=LDN, C=GB"), "Group ID")
+        val expectedHoldingIdentity = createTestHoldingIdentity("CN=Bob-3, O=Bob Corp, L=LDN, C=GB", "Group ID")
 
         // Save holding identity and DB connections
 
@@ -323,7 +322,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val signerSummaryHash = "TEST:121212121212"
         val cpiId = CpiIdentifier("Test CPI 2", "1.0", SecureHash.create(signerSummaryHash))
         val cpiMetadata = CpiMetadataLite(cpiId, hexFileChecksum, "Test Group ID", "Test Group Policy")
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-4, O=Bob Corp, L=LDN, C=GB"), "Group ID")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob-4, O=Bob Corp, L=LDN, C=GB", "Group ID")
 
         val cpiMetadataEntity = with(cpiMetadata) {
             CpiMetadataEntity(
@@ -367,7 +366,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val signerSummaryHash = "TEST:121212121212"
         val cpiId = CpiIdentifier("Test CPI 3", "1.0", SecureHash.create(signerSummaryHash))
         val cpiMetadata = CpiMetadataLite(cpiId, hexFileChecksum, "Test Group ID", "Test Group Policy")
-        val holdingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob-5, O=Bob Corp, L=LDN, C=GB"), "Group ID")
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob-5, O=Bob Corp, L=LDN, C=GB", "Group ID")
 
         val cpiMetadataEntity = with(cpiMetadata) {
             CpiMetadataEntity(

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
@@ -9,6 +9,7 @@ import net.corda.libs.virtualnode.datamodel.findVirtualNode
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
@@ -93,7 +94,7 @@ internal class VirtualNodeEntityRepository(private val entityManagerFactory: Ent
             .transaction { entityManager ->
                 val hidEntity = entityManager.find(HoldingIdentityEntity::class.java, holdingIdentityShortHash)
                     ?: return null
-                HoldingIdentity(hidEntity.x500Name, hidEntity.mgmGroupId)
+                HoldingIdentity(MemberX500Name.parse(hidEntity.x500Name), hidEntity.mgmGroupId)
             }
     }
 
@@ -118,7 +119,7 @@ internal class VirtualNodeEntityRepository(private val entityManagerFactory: Ent
         } ?: HoldingIdentityEntity(
             holdingIdentity.shortHash,
             holdingIdentity.fullHash,
-            holdingIdentity.x500Name,
+            holdingIdentity.x500Name.toString(),
             holdingIdentity.groupId,
             connections.vaultDdlConnectionId,
             connections.vaultDmlConnectionId,
@@ -188,7 +189,7 @@ internal class VirtualNodeEntityRepository(private val entityManagerFactory: Ent
     fun HoldingIdentity.toEntity(connections: VirtualNodeDbConnections?) = HoldingIdentityEntity(
         this.shortHash,
         this.fullHash,
-        this.x500Name,
+        this.x500Name.toString(),
         this.groupId,
         connections?.vaultDdlConnectionId,
         connections?.vaultDmlConnectionId,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -102,7 +102,7 @@ internal class VirtualNodeWriterProcessor(
             val groupId = cpiMetadata.mgmGroupId.let {
                 if (it == MGM_DEFAULT_GROUP_ID) UUID.randomUUID().toString() else it
             }
-            val holdingId = HoldingIdentity(create.getX500CanonicalName(), groupId)
+            val holdingId = HoldingIdentity(MemberX500Name.parse(create.getX500CanonicalName()), groupId)
             if (virtualNodeEntityRepository.virtualNodeExists(holdingId, cpiMetadata.id)) {
                 handleException(
                     respFuture,
@@ -164,7 +164,7 @@ internal class VirtualNodeWriterProcessor(
                     this.cpiVersion
                 ) ?: throw CpiNotFoundException(this.holdingIdentity.holdingIdentityShortHash)
                 val holdingIdentity = HoldingIdentity(
-                    this.holdingIdentity.x500Name,
+                    MemberX500Name.parse(this.holdingIdentity.x500Name),
                     this.holdingIdentity.mgmGroupId
                 )
                 val cpiIdentifier = CpiIdentifier(
@@ -421,7 +421,7 @@ internal class VirtualNodeWriterProcessor(
             logger.info("No MGM information found in group policy. MGM member info not published.")
             return
         }
-        val mgmHoldingIdentity = HoldingIdentity(mgmInfo.name.toString(), mgmInfo.groupId)
+        val mgmHoldingIdentity = HoldingIdentity(mgmInfo.name, mgmInfo.groupId)
         val mgmRecord = Record(
             MEMBER_LIST_TOPIC,
             "${holdingIdentity.shortHash}-${mgmHoldingIdentity.shortHash}",
@@ -450,7 +450,7 @@ internal class VirtualNodeWriterProcessor(
         val response = VirtualNodeManagementResponse(
             instant,
             VirtualNodeCreateResponse(
-                holdingIdentity.x500Name, cpiMetadata.id.toAvro(), cpiMetadata.fileChecksum,
+                holdingIdentity.x500Name.toString(), cpiMetadata.id.toAvro(), cpiMetadata.fileChecksum,
                 holdingIdentity.groupId, holdingIdentity.toAvro(), holdingIdentity.shortHash,
                 dbConnections.vaultDdlConnectionId?.toString(),
                 dbConnections.vaultDmlConnectionId.toString(),

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -79,9 +79,9 @@ class VirtualNodeWriterProcessorTests {
 
     private val groupId = "f3676687-ab69-4ca1-a17b-ab20b7bc6d03"
     private val x500Name = "OU=LLC, O=Bob, L=Dublin, C=IE"
-    private val holdingIdentity = HoldingIdentity(x500Name, groupId)
+    private val holdingIdentity = HoldingIdentity(MemberX500Name.parse(x500Name), groupId)
     private val mgmName = MemberX500Name.parse("CN=Corda Network MGM, OU=MGM, O=Corda Network, L=London, C=GB")
-    private val mgmHoldingIdentity = HoldingIdentity(mgmName.toString(), groupId)
+    private val mgmHoldingIdentity = HoldingIdentity(mgmName, groupId)
 
     private val secureHash = SecureHash(
         "SHA-256",
@@ -380,7 +380,7 @@ class VirtualNodeWriterProcessorTests {
         assertSoftly {
             val publishedVirtualNode = publishedVirtualNodeList.first()
             with ((publishedVirtualNode.value as VirtualNodeInfo).holdingIdentity.toCorda()) {
-                it.assertThat(x500Name).isEqualTo(mgmName.toString())
+                it.assertThat(x500Name).isEqualTo(mgmName)
                 it.assertThat(groupId).isNotEqualTo(MGM_DEFAULT_GROUP_ID)
             }
         }
@@ -485,7 +485,7 @@ class VirtualNodeWriterProcessorTests {
         )
 
         val collisionHoldingIdentity = mock<HoldingIdentity>() {
-            on { x500Name }.thenReturn("OU=LLC, O=Alice, L=Dublin, C=IE")
+            on { x500Name }.thenReturn(MemberX500Name.parse("OU=LLC, O=Alice, L=Dublin, C=IE"))
             on { groupId }.thenReturn("group_id")
             on { shortHash }.thenReturn(holdingIdentity.shortHash)
         }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -26,6 +26,7 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import net.corda.schema.Schemas.VirtualNode.Companion.VIRTUAL_NODE_INFO_TOPIC
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MGMContext
@@ -79,7 +80,7 @@ class VirtualNodeWriterProcessorTests {
 
     private val groupId = "f3676687-ab69-4ca1-a17b-ab20b7bc6d03"
     private val x500Name = "OU=LLC, O=Bob, L=Dublin, C=IE"
-    private val holdingIdentity = HoldingIdentity(MemberX500Name.parse(x500Name), groupId)
+    private val holdingIdentity = createTestHoldingIdentity(x500Name, groupId)
     private val mgmName = MemberX500Name.parse("CN=Corda Network MGM, OU=MGM, O=Corda Network, L=London, C=GB")
     private val mgmHoldingIdentity = HoldingIdentity(mgmName, groupId)
 

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -107,7 +107,7 @@ class MemberInfoExtension {
         /** Member holding identity. */
         @JvmStatic
         val MemberInfo.holdingIdentity: HoldingIdentity
-            get() = HoldingIdentity(groupId = groupId, x500Name = name.toString())
+            get() = HoldingIdentity(groupId = groupId, x500Name = name)
 
         /** Member ID. */
         @JvmStatic

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImplTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImplTest.kt
@@ -70,7 +70,7 @@ class GroupPolicyParserImplTest {
     private val persistedProperties = buildPersistedProperties(layeredPropertyMapFactory)
 
     private val holdingIdentity = HoldingIdentity(
-        MemberX500Name.parse("O=Alice, L=London, C=GB").toString(),
+        MemberX500Name.parse("O=Alice, L=London, C=GB"),
         "13822f7f-0d2c-450b-8f6f-93c3b8ce9602"
     )
 

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/MGMGroupPolicyImplTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/MGMGroupPolicyImplTest.kt
@@ -40,7 +40,7 @@ class MGMGroupPolicyImplTest {
         const val WHITESPACE_STRING = "   "
 
         private val name = MemberX500Name.parse("O=MGM, L=London, C=GB")
-        val holdingIdentity = HoldingIdentity(name.toString(), TEST_GROUP_ID)
+        val holdingIdentity = HoldingIdentity(name, TEST_GROUP_ID)
     }
     private val layeredPropertyMapFactory = LayeredPropertyMapMocks.createFactory()
     private val emptyProperties = buildEmptyProperties(layeredPropertyMapFactory)

--- a/libs/virtual-node/virtual-node-info/build.gradle
+++ b/libs/virtual-node/virtual-node-info/build.gradle
@@ -16,4 +16,5 @@ dependencies {
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation project(':testing:test-utilities')
 }

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/HoldingIdentity.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/HoldingIdentity.kt
@@ -1,10 +1,11 @@
 package net.corda.virtualnode
 
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import java.security.MessageDigest
 
-data class HoldingIdentity(val x500Name: String, val groupId: String) {
+data class HoldingIdentity(val x500Name: MemberX500Name, val groupId: String) {
     /**
      * Returns the holding identity as the first 12 characters of a SHA-256 hash of the x500 name and group id.
      *
@@ -18,7 +19,7 @@ data class HoldingIdentity(val x500Name: String, val groupId: String) {
      * Returns the holding identity full hash (SHA-256 hash of the x500 name and group ID)
      */
     val fullHash: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        val s = (x500Name + groupId)
+        val s = (x500Name.toString() + groupId)
         val digest: MessageDigest = MessageDigest.getInstance(DigestAlgorithmName.SHA2_256.name)
         val hash: ByteArray = digest.digest(s.toByteArray())
         SecureHash(DigestAlgorithmName.SHA2_256.name, hash)
@@ -27,7 +28,7 @@ data class HoldingIdentity(val x500Name: String, val groupId: String) {
 }
 
 fun HoldingIdentity.toAvro(): net.corda.data.identity.HoldingIdentity =
-    net.corda.data.identity.HoldingIdentity(x500Name, groupId)
+    net.corda.data.identity.HoldingIdentity(x500Name.toString(), groupId)
 
 fun net.corda.data.identity.HoldingIdentity.toCorda(): HoldingIdentity =
-    HoldingIdentity(x500Name, groupId)
+    HoldingIdentity(MemberX500Name.parse(x500Name), groupId)

--- a/libs/virtual-node/virtual-node-info/src/test/kotlin/net/corda/virtualnode/HoldingIdentityTest.kt
+++ b/libs/virtual-node/virtual-node-info/src/test/kotlin/net/corda/virtualnode/HoldingIdentityTest.kt
@@ -1,6 +1,6 @@
 package net.corda.virtualnode
 
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -9,9 +9,9 @@ internal class HoldingIdentityTest {
 
     @Test
     fun getId() {
-        val holdingIdentityA = HoldingIdentity(MemberX500Name.parse("C=GB,L=London,O=PartyA"), "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
-        val holdingIdentityB = HoldingIdentity(MemberX500Name.parse("C=GB,L=London,O=PartyB"), "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
-        val holdingIdentityC = HoldingIdentity(MemberX500Name.parse("C=GB,L=London,O=PartyB"), "b8baa6fc-4c77-11ec-8b1e-bb51725ace53")
+        val holdingIdentityA = createTestHoldingIdentity("C=GB,L=London,O=PartyA", "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
+        val holdingIdentityB = createTestHoldingIdentity("C=GB,L=London,O=PartyB", "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
+        val holdingIdentityC = createTestHoldingIdentity("C=GB,L=London,O=PartyB", "b8baa6fc-4c77-11ec-8b1e-bb51725ace53")
 
         assertNotNull(holdingIdentityA.shortHash)
         assertNotNull(holdingIdentityB.shortHash)

--- a/libs/virtual-node/virtual-node-info/src/test/kotlin/net/corda/virtualnode/HoldingIdentityTest.kt
+++ b/libs/virtual-node/virtual-node-info/src/test/kotlin/net/corda/virtualnode/HoldingIdentityTest.kt
@@ -1,5 +1,6 @@
 package net.corda.virtualnode
 
+import net.corda.v5.base.types.MemberX500Name
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -8,9 +9,9 @@ internal class HoldingIdentityTest {
 
     @Test
     fun getId() {
-        val holdingIdentityA = HoldingIdentity("C=GB,L=London,O=PartyA", "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
-        val holdingIdentityB = HoldingIdentity("C=GB,L=London,O=PartyB", "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
-        val holdingIdentityC = HoldingIdentity("C=GB,L=London,O=PartyB", "b8baa6fc-4c77-11ec-8b1e-bb51725ace53")
+        val holdingIdentityA = HoldingIdentity(MemberX500Name.parse("C=GB,L=London,O=PartyA"), "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
+        val holdingIdentityB = HoldingIdentity(MemberX500Name.parse("C=GB,L=London,O=PartyB"), "b8baa6fc-4c77-11ec-8b1e-bb51725ace52")
+        val holdingIdentityC = HoldingIdentity(MemberX500Name.parse("C=GB,L=London,O=PartyB"), "b8baa6fc-4c77-11ec-8b1e-bb51725ace53")
 
         assertNotNull(holdingIdentityA.shortHash)
         assertNotNull(holdingIdentityB.shortHash)

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -50,7 +50,7 @@ import net.corda.schema.Schemas.Crypto.Companion.FLOW_OPS_MESSAGE_TOPIC
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.test.util.eventually
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.cipher.suite.SignatureVerificationService
@@ -59,7 +59,6 @@ import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.X25519_CODE_NAME
 import net.corda.v5.crypto.publicKeyId
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.bouncycastle.jcajce.provider.util.DigestFactory
@@ -145,10 +144,7 @@ class CryptoProcessorTests {
 
         private lateinit var transformer: CryptoFlowOpsTransformer
 
-        private val vnodeIdentity = HoldingIdentity(
-            MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"),
-            UUID.randomUUID().toString()
-        )
+        private val vnodeIdentity = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", UUID.randomUUID().toString())
 
         private val vnodeId: String = vnodeIdentity.shortHash
 

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -50,6 +50,7 @@ import net.corda.schema.Schemas.Crypto.Companion.FLOW_OPS_MESSAGE_TOPIC
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.test.util.eventually
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.cipher.suite.SignatureVerificationService
@@ -145,7 +146,7 @@ class CryptoProcessorTests {
         private lateinit var transformer: CryptoFlowOpsTransformer
 
         private val vnodeIdentity = HoldingIdentity(
-            "CN=Alice, O=Alice Corp, L=LDN, C=GB",
+            MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"),
             UUID.randomUUID().toString()
         )
 

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -84,4 +84,5 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation project(':testing:test-utilities')
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeInfoDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeInfoDbReconcilerReader.kt
@@ -4,6 +4,7 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntity
 import net.corda.libs.virtualnode.datamodel.findAllVirtualNodes
 import net.corda.reconciliation.VersionedRecord
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -23,7 +24,7 @@ fun virtualNodeEntitiesToVersionedRecords(virtualNodes: Stream<VirtualNodeEntity
     virtualNodes.map { entity ->
         val x500Name = entity.holdingIdentity.x500Name
         val groupId = entity.holdingIdentity.mgmGroupId
-        val holdingIdentity = HoldingIdentity(x500Name, groupId)
+        val holdingIdentity = HoldingIdentity(MemberX500Name.parse(x500Name), groupId)
 
         object : VersionedRecord<HoldingIdentity, VirtualNodeInfo> {
             override val version = entity.entityVersion

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
@@ -3,9 +3,8 @@ package net.corda.processors.db.internal.reconcile.db
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.datamodel.HoldingIdentityEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntity
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -62,7 +61,7 @@ class VirtualNodeDbReconcilerReaderTest {
         val versionedRecords = virtualNodeEntitiesToVersionedRecords(entities.stream())
         val record = versionedRecords.toList().single()
 
-        val expectedKey = HoldingIdentity(MemberX500Name.parse(x500name), groupId)
+        val expectedKey = createTestHoldingIdentity(x500name, groupId)
 
         Assertions.assertThat(record.key).isEqualTo(expectedKey)
 

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
@@ -3,6 +3,7 @@ package net.corda.processors.db.internal.reconcile.db
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.datamodel.HoldingIdentityEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntity
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -61,7 +62,7 @@ class VirtualNodeDbReconcilerReaderTest {
         val versionedRecords = virtualNodeEntitiesToVersionedRecords(entities.stream())
         val record = versionedRecords.toList().single()
 
-        val expectedKey = HoldingIdentity(x500name, groupId)
+        val expectedKey = HoldingIdentity(MemberX500Name.parse(x500name), groupId)
 
         Assertions.assertThat(record.key).isEqualTo(expectedKey)
 

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
@@ -55,10 +55,9 @@ import net.corda.processors.crypto.CryptoProcessor
 import net.corda.processors.member.MemberProcessor
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
 import net.corda.test.util.eventually
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.seconds
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -124,13 +123,13 @@ class MemberProcessorIntegrationTest {
 
         lateinit var publisher: Publisher
 
-        private val invalidHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), groupId)
+        private val invalidHoldingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
 
-        private val aliceVNodeId = HoldingIdentity(MemberX500Name.parse(aliceName), groupId).shortHash
+        private val aliceVNodeId = createTestHoldingIdentity(aliceName, groupId).shortHash
 
-        private val bobVNodeId = HoldingIdentity(MemberX500Name.parse(bobName), groupId).shortHash
+        private val bobVNodeId = createTestHoldingIdentity(bobName, groupId).shortHash
 
-        private val charlieVNodeId = HoldingIdentity(MemberX500Name.parse(charlieName), groupId).shortHash
+        private val charlieVNodeId = createTestHoldingIdentity(charlieName, groupId).shortHash
 
         private lateinit var testDependencies: TestDependenciesTracker
 

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
@@ -124,13 +124,13 @@ class MemberProcessorIntegrationTest {
 
         lateinit var publisher: Publisher
 
-        private val invalidHoldingIdentity = HoldingIdentity("", groupId)
+        private val invalidHoldingIdentity = HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), groupId)
 
-        private val aliceVNodeId = HoldingIdentity(MemberX500Name.parse(aliceName).toString(), groupId).shortHash
+        private val aliceVNodeId = HoldingIdentity(MemberX500Name.parse(aliceName), groupId).shortHash
 
-        private val bobVNodeId = HoldingIdentity(MemberX500Name.parse(bobName).toString(), groupId).shortHash
+        private val bobVNodeId = HoldingIdentity(MemberX500Name.parse(bobName), groupId).shortHash
 
-        private val charlieVNodeId = HoldingIdentity(MemberX500Name.parse(charlieName).toString(), groupId).shortHash
+        private val charlieVNodeId = HoldingIdentity(MemberX500Name.parse(charlieName), groupId).shortHash
 
         private lateinit var testDependencies: TestDependenciesTracker
 

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -111,8 +111,8 @@ class MemberProcessorTestUtils {
         val bobX500Name = MemberX500Name.parse(bobName)
         val charlieX500Name = MemberX500Name.parse(charlieName)
         const val groupId = "7c5d6948-e17b-44e7-9d1c-fa4a3f667cad"
-        val aliceHoldingIdentity = HoldingIdentity(aliceX500Name.toString(), groupId)
-        val bobHoldingIdentity = HoldingIdentity(bobX500Name.toString(), groupId)
+        val aliceHoldingIdentity = HoldingIdentity(aliceX500Name, groupId)
+        val bobHoldingIdentity = HoldingIdentity(bobX500Name, groupId)
 
         fun Publisher.publishRawGroupPolicyData(
             virtualNodeInfoReader: VirtualNodeInfoReadService,

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -35,7 +35,7 @@ class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
 
     private class MembershipGroupReaderImpl(holdingIdentity: HoldingIdentity) : MembershipGroupReader {
         override val groupId: String = holdingIdentity.groupId
-        override val owningMember: MemberX500Name = MemberX500Name.parse(holdingIdentity.x500Name)
+        override val owningMember: MemberX500Name = holdingIdentity.x500Name
 
         override val groupParameters: GroupParameters
             get() = TODO("groupParameters: Not yet implemented")

--- a/testing/test-utilities/build.gradle
+++ b/testing/test-utilities/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api project(":libs:utilities")
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "org.mockito:mockito-core:$mockitoVersion"
+    implementation project(":libs:virtual-node:virtual-node-info")
 }
 
 description 'Test Utilities'

--- a/testing/test-utilities/src/main/java/net/corda/test/util/identity/package-info.java
+++ b/testing/test-utilities/src/main/java/net/corda/test/util/identity/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.test.util.identity;
+
+import org.osgi.annotation.bundle.Export;

--- a/testing/test-utilities/src/main/kotlin/net/corda/test/util/identity/IdentityUtils.kt
+++ b/testing/test-utilities/src/main/kotlin/net/corda/test/util/identity/IdentityUtils.kt
@@ -1,0 +1,12 @@
+package net.corda.test.util.identity
+
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.virtualnode.HoldingIdentity
+
+/**
+ * Helper method to create holding identities with X500 name represented as string.
+ * In regular code, the default constructor should be used as the `MemberX500Name` is encouraged, instead of the string type.
+ */
+fun createTestHoldingIdentity(x500Name: String, groupId: String): HoldingIdentity {
+    return HoldingIdentity(MemberX500Name.parse(x500Name), groupId)
+}

--- a/testing/virtual-node-info-read-service-fake/build.gradle
+++ b/testing/virtual-node-info-read-service-fake/build.gradle
@@ -22,4 +22,5 @@ dependencies {
 
     testImplementation project(":libs:lifecycle:lifecycle-impl")
     testImplementation project(":libs:lifecycle:registry")
+    testImplementation project(':testing:test-utilities')
 }

--- a/testing/virtual-node-info-read-service-fake/src/main/kotlin/net/corda/virtualnode/read/fake/VirtualNodeInfoReadServiceFakeParser.kt
+++ b/testing/virtual-node-info-read-service-fake/src/main/kotlin/net/corda/virtualnode/read/fake/VirtualNodeInfoReadServiceFakeParser.kt
@@ -1,10 +1,15 @@
 package net.corda.virtualnode.read.fake
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.VirtualNodeInfo
 import java.io.File
 import java.io.Reader
@@ -22,11 +27,18 @@ internal object VirtualNodeInfoReadServiceFakeParser {
      * Loads the virtual nodes info from the [reader]. Data must be in yaml format.
      */
     fun loadFrom(reader: Reader) : List<VirtualNodeInfo> {
+        val memberX500NameModule = SimpleModule()
+        memberX500NameModule.addDeserializer(MemberX500Name::class.java, object: JsonDeserializer<MemberX500Name>() {
+            override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): MemberX500Name {
+                return MemberX500Name.parse(p!!.valueAsString)
+            }
+        })
+
         val mapper = ObjectMapper(YAMLFactory())
         mapper.registerModule(KotlinModule.Builder().withReflectionCacheSize(512)
             .configure(KotlinFeature.NullToEmptyCollection, false).configure(KotlinFeature.NullToEmptyMap, false)
             .configure(KotlinFeature.NullIsSameAsDefault, false).configure(KotlinFeature.StrictNullChecks, false)
-            .build()).registerModule(JavaTimeModule())
+            .build()).registerModule(JavaTimeModule()).registerModule(memberX500NameModule)
 
         val listWrapperWorkaround = object : Any() {
             var virtualNodeInfos: List<VirtualNodeInfo> = emptyList()

--- a/testing/virtual-node-info-read-service-fake/src/test/kotlin/net/corda/virtualnode/read/fake/TestCatalogue.kt
+++ b/testing/virtual-node-info-read-service-fake/src/test/kotlin/net/corda/virtualnode/read/fake/TestCatalogue.kt
@@ -1,6 +1,7 @@
 package net.corda.virtualnode.read.fake
 
 import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import java.time.Instant
@@ -10,15 +11,15 @@ object TestCatalogue {
 
     object Identity {
         fun alice(groupId: String): HoldingIdentity {
-            return HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", groupId)
+            return HoldingIdentity(MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), groupId)
         }
 
         fun bob(groupId: String): HoldingIdentity {
-            return HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
+            return HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), groupId)
         }
 
         fun carol(groupId: String): HoldingIdentity {
-            return HoldingIdentity("CN=Carol, O=Carol Corp, L=LDN, C=GB", groupId)
+            return HoldingIdentity(MemberX500Name.parse("CN=Carol, O=Carol Corp, L=LDN, C=GB"), groupId)
         }
     }
 

--- a/testing/virtual-node-info-read-service-fake/src/test/kotlin/net/corda/virtualnode/read/fake/TestCatalogue.kt
+++ b/testing/virtual-node-info-read-service-fake/src/test/kotlin/net/corda/virtualnode/read/fake/TestCatalogue.kt
@@ -1,7 +1,7 @@
 package net.corda.virtualnode.read.fake
 
 import net.corda.libs.packaging.core.CpiIdentifier
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import java.time.Instant
@@ -11,15 +11,15 @@ object TestCatalogue {
 
     object Identity {
         fun alice(groupId: String): HoldingIdentity {
-            return HoldingIdentity(MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"), groupId)
+            return createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", groupId)
         }
 
         fun bob(groupId: String): HoldingIdentity {
-            return HoldingIdentity(MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB"), groupId)
+            return createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
         }
 
         fun carol(groupId: String): HoldingIdentity {
-            return HoldingIdentity(MemberX500Name.parse("CN=Carol, O=Carol Corp, L=LDN, C=GB"), groupId)
+            return createTestHoldingIdentity("CN=Carol, O=Carol Corp, L=LDN, C=GB", groupId)
         }
     }
 


### PR DESCRIPTION
Switch `HoldingIdentity` to use `MemberX500Name` type, instead of string.

The main change is in `HoldingIdentity.kt`. The rest is just applying the refactoring to the rest of the codebase that was using its constructor or the `x500Name` field. 