### PR TITLE
CORE-5964 - Switch p2p to use Corda's domain model HoldingIdentity

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProvider.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProvider.kt
@@ -1,7 +1,6 @@
 package net.corda.p2p.linkmanager
 
 import net.corda.cpiinfo.read.CpiInfoReadService
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -12,9 +11,8 @@ import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.p2p.NetworkType
 import net.corda.p2p.crypto.ProtocolMode
+import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
-import net.corda.virtualnode.toAvro
-import net.corda.virtualnode.toCorda
 
 internal class ForwardingGroupPolicyProvider(coordinatorFactory: LifecycleCoordinatorFactory,
                                              private val groupPolicyProvider: GroupPolicyProvider,
@@ -45,12 +43,12 @@ internal class ForwardingGroupPolicyProvider(coordinatorFactory: LifecycleCoordi
     )
 
     override fun getGroupInfo(holdingIdentity: HoldingIdentity): GroupPolicyListener.GroupInfo? {
-       return groupPolicyProvider.getGroupPolicy(holdingIdentity.toCorda())?.let { toGroupInfo(holdingIdentity, it) }
+       return groupPolicyProvider.getGroupPolicy(holdingIdentity)?.let { toGroupInfo(holdingIdentity, it) }
     }
 
     override fun registerListener(groupPolicyListener: GroupPolicyListener) {
         groupPolicyProvider.registerListener { holdingIdentity, groupPolicy ->
-            val groupInfo = toGroupInfo(holdingIdentity.toAvro(), groupPolicy)
+            val groupInfo = toGroupInfo(holdingIdentity, groupPolicy)
             groupPolicyListener.groupAdded(groupInfo)
         }
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/GroupPolicyListener.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/GroupPolicyListener.kt
@@ -1,8 +1,8 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.p2p.NetworkType
 import net.corda.p2p.crypto.ProtocolMode
+import net.corda.virtualnode.HoldingIdentity
 
 interface GroupPolicyListener {
     data class GroupInfo(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/HostingMapListener.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/HostingMapListener.kt
@@ -1,6 +1,6 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
+import net.corda.virtualnode.HoldingIdentity
 import java.security.PublicKey
 
 interface HostingMapListener {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessor.kt
@@ -30,6 +30,7 @@ import net.corda.p2p.markers.LinkManagerReceivedMarker
 import net.corda.schema.Schemas
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.debug
+import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
 
 internal class InboundMessageProcessor(
@@ -163,7 +164,7 @@ internal class InboundMessageProcessor(
         val sessionDestination = counterparties.ourId
         val messageDestination = innerMessage.message.header.destination
         val messageSource = innerMessage.message.header.source
-        if (sessionSource == messageSource && sessionDestination == messageDestination) {
+        if (sessionSource == messageSource.toCorda() && sessionDestination == messageDestination.toCorda()) {
             logger.debug {
                 "Processing message ${innerMessage.message.header.messageId} " +
                     "of type ${innerMessage.message.javaClass} from session ${session.sessionId}"
@@ -171,7 +172,7 @@ internal class InboundMessageProcessor(
             messages.add(Record(Schemas.P2P.P2P_IN_TOPIC, innerMessage.key, AppMessage(innerMessage.message)))
             makeAckMessageForFlowMessage(innerMessage.message, session)?.let { ack -> messages.add(ack) }
             sessionManager.inboundSessionEstablished(session.sessionId)
-        } else if (sessionSource != messageSource) {
+        } else if (sessionSource != messageSource.toCorda()) {
             logger.warn(
                 "The identity in the message's source header ($messageSource)" +
                     " does not match the session's source identity ($sessionSource)," +
@@ -239,8 +240,8 @@ internal class InboundMessageProcessor(
         session: Session
     ): Record<String, LinkOutMessage>? {
         // We route the ACK back to the original source
-        val ackDest = message.header.source
-        val ackSource = message.header.destination
+        val ackDest = message.header.source.toCorda()
+        val ackSource = message.header.destination.toCorda()
         val ack = MessageConverter.linkOutMessageFromAck(
             MessageAck(AuthenticatedMessageAck(message.header.messageId)),
             ackSource,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerGroupPolicyProvider.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerGroupPolicyProvider.kt
@@ -1,7 +1,7 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
+import net.corda.virtualnode.HoldingIdentity
 
 interface LinkManagerGroupPolicyProvider : LifecycleWithDominoTile {
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerHostingMap.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerHostingMap.kt
@@ -1,7 +1,7 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
+import net.corda.virtualnode.HoldingIdentity
 
 /**
  * This interface represents a component that has knowledge about the identities that are hosted locally.

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerHostingMapImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerHostingMapImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.BlockingDominoTile
@@ -12,6 +11,8 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.HostedIdentityEntry
 import net.corda.schema.Schemas.P2P.Companion.P2P_HOSTED_IDENTITIES_TOPIC
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toCorda
 import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -98,7 +99,7 @@ internal class LinkManagerHostingMapImpl(
         ) {
             if (oldValue != null) {
                 publicHashToIdentityInfo.remove(oldValue.toGroupIdWithPublicKeyHash())
-                locallyHostedIdentityToIdentityInfo.remove(oldValue.holdingIdentity)
+                locallyHostedIdentityToIdentityInfo.remove(oldValue.holdingIdentity.toCorda())
             }
             val newIdentity = newRecord.value
             if (newIdentity != null) {
@@ -117,13 +118,13 @@ internal class LinkManagerHostingMapImpl(
 
     private fun addEntry(entry: HostedIdentityEntry) {
         val info = HostingMapListener.IdentityInfo(
-            holdingIdentity = entry.holdingIdentity,
+            holdingIdentity = entry.holdingIdentity.toCorda(),
             tlsCertificates = entry.tlsCertificates,
             tlsTenantId = entry.tlsTenantId,
             sessionKeyTenantId = entry.sessionKeyTenantId,
             sessionPublicKey = publicKeyReader.loadPublicKey(entry.sessionPublicKey)
         )
-        locallyHostedIdentityToIdentityInfo[entry.holdingIdentity] = info
+        locallyHostedIdentityToIdentityInfo[entry.holdingIdentity.toCorda()] = info
         publicHashToIdentityInfo[entry.toGroupIdWithPublicKeyHash()] = info
         listeners.forEach {
             it.identityAdded(info)

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerMembershipGroupReader.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManagerMembershipGroupReader.kt
@@ -1,8 +1,8 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.p2p.crypto.protocol.api.KeyAlgorithm
+import net.corda.virtualnode.HoldingIdentity
 import java.security.PublicKey
 
 interface LinkManagerMembershipGroupReader : LifecycleWithDominoTile {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessor.kt
@@ -21,6 +21,7 @@ import net.corda.schema.Schemas
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import net.corda.virtualnode.toCorda
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -103,7 +104,7 @@ internal class OutboundMessageProcessor(
 
     private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
         logger.debug { "Processing outbound ${message.javaClass} to ${message.header.destination}." }
-        return if (linkManagerHostingMap.isHostedLocally(message.header.destination)) {
+        return if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
             listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))
         } else {
             val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(message, groups, members)
@@ -141,7 +142,7 @@ internal class OutboundMessageProcessor(
             }
         }
 
-        if (linkManagerHostingMap.isHostedLocally(messageAndKey.message.header.destination)) {
+        if (linkManagerHostingMap.isHostedLocally(messageAndKey.message.header.destination.toCorda())) {
             return if (isReplay) {
                 /* This code block was added to fix a race which happens if the OutboundMessageProcessor runs quicker than the
                  * DeliveryTracker. Under normal circumstances a message to locally hosted holding identity will be added and then removed

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/StubGroupPolicyProvider.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/StubGroupPolicyProvider.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.BlockingDominoTile
@@ -12,6 +11,8 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.test.GroupPolicyEntry
 import net.corda.schema.Schemas.P2P.Companion.GROUP_POLICIES_TOPIC
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toCorda
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
@@ -23,7 +24,7 @@ internal class StubGroupPolicyProvider(
     companion object {
         fun GroupPolicyEntry.toGroupInfo(): GroupPolicyListener.GroupInfo {
             return GroupPolicyListener.GroupInfo(
-                this.holdingIdentity,
+                this.holdingIdentity.toCorda(),
                 this.networkType,
                 this.protocolModes.toSet(),
                 this.trustedCertificates
@@ -57,7 +58,7 @@ internal class StubGroupPolicyProvider(
         ) {
             val newValue = newRecord.value
             if (newValue == null) {
-                groups.remove(oldValue?.holdingIdentity)
+                groups.remove(oldValue?.holdingIdentity?.toCorda())
             } else {
                 addGroup(newValue)
             }
@@ -65,7 +66,7 @@ internal class StubGroupPolicyProvider(
 
         private fun addGroup(group: GroupPolicyEntry) {
             val info = group.toGroupInfo()
-            groups[group.holdingIdentity] = info
+            groups[group.holdingIdentity.toCorda()] = info
             listeners.forEach {
                 it.groupAdded(info)
             }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/StubMembershipGroupReader.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/StubMembershipGroupReader.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.BlockingDominoTile
@@ -13,6 +12,8 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.linkmanager.PublicKeyReader.Companion.toKeyAlgorithm
 import net.corda.p2p.test.MemberInfoEntry
 import net.corda.schema.Schemas.P2P.Companion.MEMBER_INFO_TOPIC
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toCorda
 import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -56,7 +57,7 @@ internal class StubMembershipGroupReader(
             val newValue = newRecord.value
             if (oldValue != null) {
                 publicHashToMemberInformation.remove(oldValue.toGroupIdWithPublicKeyHash())
-                membersInformation.remove(oldValue.holdingIdentity)
+                membersInformation.remove(oldValue.holdingIdentity.toCorda())
             }
             if (newValue != null) {
                 addMember(newValue)
@@ -64,7 +65,7 @@ internal class StubMembershipGroupReader(
         }
 
         private fun addMember(member: MemberInfoEntry) {
-            membersInformation[member.holdingIdentity] = member.toMemberInfo()
+            membersInformation[member.holdingIdentity.toCorda()] = member.toMemberInfo()
             publicHashToMemberInformation[member.toGroupIdWithPublicKeyHash()] = member.toMemberInfo()
         }
     }
@@ -98,7 +99,7 @@ internal class StubMembershipGroupReader(
     private fun MemberInfoEntry.toMemberInfo(): LinkManagerMembershipGroupReader.MemberInfo {
         val publicKey = publicKeyReader.loadPublicKey(this.sessionPublicKey)
         return LinkManagerMembershipGroupReader.MemberInfo(
-            HoldingIdentity(this.holdingIdentity.x500Name, this.holdingIdentity.groupId),
+            this.holdingIdentity.toCorda(),
             publicKey,
             publicKey.toKeyAlgorithm(),
             this.address,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TlsCertificatesPublisher.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.BlockingDominoTile
@@ -16,6 +15,7 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTlsCertificates
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_CERTIFICATES
+import net.corda.virtualnode.HoldingIdentity
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisher.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -20,6 +19,8 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTruststore
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_TRUSTSTORES
 import net.corda.v5.base.util.contextLogger
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
 
 @Suppress("LongParameterList")
 internal class TrustStoresPublisher(
@@ -127,7 +128,7 @@ internal class TrustStoresPublisher(
             val certificatesSet = certificates.toSet()
             if (certificatesSet != publishedCertificates) {
                 val record = Record(GATEWAY_TLS_TRUSTSTORES, holdingIdentity.toKafkaKey(),
-                    GatewayTruststore(HoldingIdentity(holdingIdentity.x500Name, holdingIdentity.groupId), certificates))
+                    GatewayTruststore(holdingIdentity.toAvro(), certificates))
                 publisher.publish(
                     listOf(record)
                 ).forEach {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -30,6 +30,7 @@ import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_MARKERS
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
@@ -195,8 +196,8 @@ internal class DeliveryTracker(
             private fun sessionCounterpartiesFromState(state: AuthenticatedMessageDeliveryState): SessionManager.SessionCounterparties {
                 val header = state.message.message.header
                 return SessionManager.SessionCounterparties(
-                    header.source,
-                    header.destination
+                    header.source.toCorda(),
+                    header.destination.toCorda()
                 )
             }
         }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
@@ -1,7 +1,6 @@
 package net.corda.p2p.linkmanager.delivery
 
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -18,6 +17,7 @@ import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.schema.Schemas.P2P.Companion.LINK_OUT_TOPIC
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.debug
+import net.corda.virtualnode.HoldingIdentity
 import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverter.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverter.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager.messaging
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.p2p.AuthenticatedMessageAndKey
 import net.corda.p2p.DataMessagePayload
 import net.corda.p2p.HeartbeatMessage
@@ -21,6 +20,9 @@ import net.corda.p2p.linkmanager.LinkManagerGroupPolicyProvider
 import net.corda.p2p.linkmanager.LinkManagerMembershipGroupReader
 import net.corda.p2p.linkmanager.messaging.AvroSealedClasses.DataMessage
 import net.corda.p2p.linkmanager.messaging.AvroSealedClasses.SessionAndMessage
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
+import net.corda.virtualnode.toCorda
 import org.apache.avro.AvroRuntimeException
 import org.slf4j.LoggerFactory
 import java.io.IOException
@@ -52,8 +54,8 @@ class MessageConverter {
             networkType: NetworkType
         ): LinkOutHeader {
             return LinkOutHeader(
-                peer.holdingIdentity,
-                source,
+                peer.holdingIdentity.toAvro(),
+                source.toAvro(),
                 networkType,
                 peer.endPoint,
             )
@@ -110,8 +112,8 @@ class MessageConverter {
             }
             return createLinkOutMessageFromPayload(
                 serializedMessage,
-                message.message.header.source,
-                message.message.header.destination,
+                message.message.header.source.toCorda(),
+                message.message.header.destination.toCorda(),
                 session,
                 groups,
                 members,
@@ -148,23 +150,24 @@ class MessageConverter {
             groups: LinkManagerGroupPolicyProvider,
             members: LinkManagerMembershipGroupReader,
         ): LinkOutMessage? {
-            val destination = message.header.destination
-            val destMemberInfo = members.getMemberInfo(message.header.source, destination)
+            val destination = message.header.destination.toCorda()
+            val source = message.header.source.toCorda()
+            val destMemberInfo = members.getMemberInfo(source, destination)
             if (destMemberInfo == null) {
                 logger.warn("Attempted to send message to peer $destination which is not in the network map. The message was discarded.")
                 return null
             }
 
-            val groupInfo = groups.getGroupInfo(message.header.source)
+            val groupInfo = groups.getGroupInfo(source)
             if (groupInfo == null) {
                 logger.warn(
                     "Could not find the group information in the" +
-                        " GroupPolicyProvider for ${message.header.source}. The message was discarded."
+                        " GroupPolicyProvider for $source. The message was discarded."
                 )
                 return null
             }
 
-            return createLinkOutMessage(message, message.header.source, destMemberInfo, groupInfo.networkType)
+            return createLinkOutMessage(message, source, destMemberInfo, groupInfo.networkType)
         }
 
         @Suppress("LongParameterList")

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager.sessions
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.messaging.api.records.Record
 import net.corda.p2p.AuthenticatedMessageAndKey
@@ -12,6 +11,7 @@ import net.corda.p2p.linkmanager.LinkManagerGroupPolicyProvider
 import net.corda.p2p.linkmanager.LinkManagerMembershipGroupReader
 import net.corda.p2p.linkmanager.messaging.MessageConverter
 import net.corda.schema.Schemas
+import net.corda.virtualnode.HoldingIdentity
 
 internal interface SessionManager : LifecycleWithDominoTile {
     fun processOutboundMessage(message: AuthenticatedMessageAndKey): SessionState

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerWarnings.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerWarnings.kt
@@ -1,6 +1,6 @@
 package net.corda.p2p.linkmanager.sessions
 
-import net.corda.data.identity.HoldingIdentity
+import net.corda.virtualnode.HoldingIdentity
 import org.slf4j.Logger
 
 internal object SessionManagerWarnings {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
@@ -1,7 +1,6 @@
 package net.corda.p2p.linkmanager
 
 import net.corda.cpiinfo.read.CpiInfoReadService
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.NamedLifecycle
@@ -11,6 +10,7 @@ import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.p2p.NetworkType
 import net.corda.p2p.crypto.ProtocolMode
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
@@ -24,7 +24,7 @@ import org.mockito.kotlin.whenever
 
 class ForwardingGroupPolicyProviderTest {
 
-    private val alice = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group-1")
+    private val alice = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group-1")
     private val groupInfo =
         GroupPolicyListener.GroupInfo(
             alice,
@@ -99,7 +99,7 @@ class ForwardingGroupPolicyProviderTest {
     fun `get group info delegates to the real policy provider properly`() {
         val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
 
-        whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(groupPolicy)
+        whenever(realGroupPolicyProvider.getGroupPolicy(alice)).thenReturn(groupPolicy)
         assertThat(forwardingGroupPolicyProvider.getGroupInfo(alice)).isEqualTo(groupInfo)
     }
 
@@ -108,7 +108,7 @@ class ForwardingGroupPolicyProviderTest {
         val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
         whenever(groupPolicy.p2pParameters.tlsPki).thenReturn(P2PParameters.TlsPkiMode.CORDA_4)
 
-        whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(groupPolicy)
+        whenever(realGroupPolicyProvider.getGroupPolicy(alice)).thenReturn(groupPolicy)
         assertThat(forwardingGroupPolicyProvider.getGroupInfo(alice)).isEqualTo(groupInfo.copy(networkType = NetworkType.CORDA_4))
     }
 
@@ -117,7 +117,7 @@ class ForwardingGroupPolicyProviderTest {
         val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
         whenever(groupPolicy.p2pParameters.protocolMode).thenReturn(P2PParameters.ProtocolMode.AUTH)
 
-        whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(groupPolicy)
+        whenever(realGroupPolicyProvider.getGroupPolicy(alice)).thenReturn(groupPolicy)
         assertThat(forwardingGroupPolicyProvider.getGroupInfo(alice))
             .isEqualTo(groupInfo.copy(protocolModes = setOf(ProtocolMode.AUTHENTICATION_ONLY)))
     }
@@ -127,7 +127,7 @@ class ForwardingGroupPolicyProviderTest {
         val forwardingGroupPolicyProvider = createForwardingGroupPolicyProvider()
         whenever(groupPolicy.p2pParameters.protocolMode).thenReturn(P2PParameters.ProtocolMode.AUTH)
 
-        whenever(realGroupPolicyProvider.getGroupPolicy(alice.toCorda())).thenReturn(null)
+        whenever(realGroupPolicyProvider.getGroupPolicy(alice)).thenReturn(null)
         assertThat(forwardingGroupPolicyProvider.getGroupInfo(alice)).isNull()
     }
 
@@ -140,7 +140,7 @@ class ForwardingGroupPolicyProviderTest {
         val capturedListener = argumentCaptor<(net.corda.virtualnode.HoldingIdentity, GroupPolicy) -> Unit>()
         verify(realGroupPolicyProvider).registerListener(capturedListener.capture())
 
-        capturedListener.firstValue.invoke(alice.toCorda(), groupPolicy)
+        capturedListener.firstValue.invoke(alice, groupPolicy)
         verify(listener).groupAdded(groupInfo)
     }
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
@@ -12,7 +12,6 @@ import net.corda.p2p.NetworkType
 import net.corda.p2p.crypto.ProtocolMode
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
-import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingMembershipGroupReaderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingMembershipGroupReaderTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.NamedLifecycle
@@ -8,6 +7,7 @@ import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.p2p.crypto.protocol.api.KeyAlgorithm
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.parse
 import net.corda.v5.base.util.parseList
@@ -30,9 +30,9 @@ class ForwardingMembershipGroupReaderTest {
     companion object {
         private const val GROUP_ID = "Group-Id"
         private val ALICE_X500_NAME = MemberX500Name.parse("O=Alice,C=GB,L=London")
-        private val ALICE = HoldingIdentity(ALICE_X500_NAME.toString(), GROUP_ID)
+        private val ALICE = createTestHoldingIdentity(ALICE_X500_NAME.toString(), GROUP_ID)
         private val BOB_X500_NAME = MemberX500Name.parse("O=Bob,C=GB,L=London")
-        private val BOB = HoldingIdentity(BOB_X500_NAME.toString(), GROUP_ID)
+        private val BOB = createTestHoldingIdentity(BOB_X500_NAME.toString(), GROUP_ID)
         private const val KEY_ALGORITHM = "EC"
         private const val BOB_ENDPOINT = "0.0.0.0"
         private val PUBLIC_KEY_HASH = "---- 32 Byte Public Key Hash----".toByteArray()
@@ -60,13 +60,13 @@ class ForwardingMembershipGroupReaderTest {
     }
 
     private val bobMemberInfo = mock<MemberInfo> {
-        on { name } doReturn MemberX500Name.parse(BOB.x500Name)
+        on { name } doReturn BOB.x500Name
         on { sessionInitiationKey } doReturn bobSessionKey
         on { memberProvidedContext } doReturn bobMemberContext
     }
     private val aliceGroupReader = mock<MembershipGroupReader>()
     private val mockMembershipGroupReaderProvider = mock<MembershipGroupReaderProvider> {
-        on { getGroupReader(ALICE.toCorda()) } doReturn aliceGroupReader
+        on { getGroupReader(ALICE) } doReturn aliceGroupReader
     }
     private val forwardingMembershipGroupReader = ForwardingMembershipGroupReader(mockMembershipGroupReaderProvider, mock())
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingMembershipGroupReaderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingMembershipGroupReaderTest.kt
@@ -15,7 +15,6 @@ import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
-import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/InboundMessageProcessorTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.p2p.AuthenticatedMessageAck
 import net.corda.p2p.AuthenticatedMessageAndKey
@@ -39,7 +38,9 @@ import net.corda.schema.Schemas.P2P.Companion.P2P_IN_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_MARKERS
 import net.corda.schema.Schemas.P2P.Companion.SESSION_OUT_PARTITIONS
 import net.corda.test.util.MockTimeFacilitiesProvider
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.util.seconds
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
@@ -59,8 +60,8 @@ class InboundMessageProcessorTest {
         private const val MESSAGE_ID = "MessageId"
     }
     private val sessionManager = mock<SessionManager>()
-    private val myIdentity = HoldingIdentity("PartyA", "Group")
-    private val remoteIdentity = HoldingIdentity("PartyC", "Group")
+    private val myIdentity = createTestHoldingIdentity("CN=PartyA, O=Corp, L=LDN, C=GB", "Group")
+    private val remoteIdentity = createTestHoldingIdentity("CN=PartyC, O=Corp, L=LDN, C=GB", "Group")
     private val membersAndGroups = mockMembersAndGroups(
         myIdentity, remoteIdentity
     )
@@ -126,8 +127,8 @@ class InboundMessageProcessorTest {
         fun `AuthenticatedDataMessage with Inbound session will produce a message on the P2P_IN_TOPIC and LINK_OUT_TOPIC topics`() {
             val authenticatedMsg = AuthenticatedMessage(
                 AuthenticatedMessageHeader(
-                    remoteIdentity,
-                    myIdentity,
+                    remoteIdentity.toAvro(),
+                    myIdentity.toAvro(),
                     null, MESSAGE_ID, "trace-id", "system-1"
                 ),
                 ByteBuffer.wrap("payload".toByteArray())
@@ -323,8 +324,8 @@ class InboundMessageProcessorTest {
         fun `AuthenticatedDataMessage with no session  will not produce records`() {
             val authenticatedMsg = AuthenticatedMessage(
                 AuthenticatedMessageHeader(
-                    remoteIdentity,
-                    myIdentity,
+                    remoteIdentity.toAvro(),
+                    myIdentity.toAvro(),
                     null, MESSAGE_ID, "trace-id", "system-1"
                 ),
                 ByteBuffer.wrap("payload".toByteArray())
@@ -361,8 +362,8 @@ class InboundMessageProcessorTest {
         fun `receiving data message with Inbound session will produce a message on the P2P_IN_TOPIC and LINK_OUT_TOPIC topics`() {
             val authenticatedMsg = AuthenticatedMessage(
                 AuthenticatedMessageHeader(
-                    remoteIdentity,
-                    myIdentity,
+                    remoteIdentity.toAvro(),
+                    myIdentity.toAvro(),
                     null, MESSAGE_ID, "trace-id", "system-1"
                 ),
                 ByteBuffer.wrap("payload".toByteArray())
@@ -430,8 +431,8 @@ class InboundMessageProcessorTest {
         fun `when the message's source identity does not match the one of the session the message is discarded`() {
             val authenticatedMsg = AuthenticatedMessage(
                 AuthenticatedMessageHeader(
-                    remoteIdentity,
-                    myIdentity,
+                    remoteIdentity.toAvro(),
+                    myIdentity.toAvro(),
                     null, MESSAGE_ID, "trace-id", "system-1"
                 ),
                 ByteBuffer.wrap("payload".toByteArray())
@@ -490,8 +491,8 @@ class InboundMessageProcessorTest {
         fun `when the message's dest identity does not match the one of the session the message is discarded`() {
             val authenticatedMsg = AuthenticatedMessage(
                 AuthenticatedMessageHeader(
-                    remoteIdentity,
-                    myIdentity,
+                    remoteIdentity.toAvro(),
+                    myIdentity.toAvro(),
                     null, MESSAGE_ID, "trace-id", "system-1"
                 ),
                 ByteBuffer.wrap("payload".toByteArray())

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessorTest.kt
@@ -22,7 +22,9 @@ import net.corda.p2p.markers.LinkManagerProcessedMarker
 import net.corda.p2p.markers.TtlExpiredMarker
 import net.corda.schema.Schemas
 import net.corda.test.util.MockTimeFacilitiesProvider
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.util.seconds
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
@@ -37,9 +39,9 @@ import java.nio.ByteBuffer
 import java.time.Instant
 
 class OutboundMessageProcessorTest {
-    private val myIdentity = HoldingIdentity("PartyA", "Group")
-    private val localIdentity = HoldingIdentity("PartyB", "Group")
-    private val remoteIdentity = HoldingIdentity("PartyC", "Group")
+    private val myIdentity = createTestHoldingIdentity("CN=PartyA, O=Corp, L=LDN, C=GB", "Group")
+    private val localIdentity = createTestHoldingIdentity("CN=PartyB, O=Corp, L=LDN, C=GB", "Group")
+    private val remoteIdentity = createTestHoldingIdentity("CN=PartyC, O=Corp, L=LDN, C=GB", "Group")
     private val membersAndGroups = mockMembersAndGroups(
         myIdentity, localIdentity, remoteIdentity
     )
@@ -75,8 +77,8 @@ class OutboundMessageProcessorTest {
         val payload = "test"
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                myIdentity,
-                localIdentity,
+                myIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "message-id", "trace-id", "system-1"
             ),
             ByteBuffer.wrap(payload.toByteArray())
@@ -123,8 +125,8 @@ class OutboundMessageProcessorTest {
         val payload = "test"
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                myIdentity,
-                localIdentity,
+                myIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "message-id", "trace-id", "system-1"
             ),
             ByteBuffer.wrap(payload.toByteArray())
@@ -143,8 +145,8 @@ class OutboundMessageProcessorTest {
         val payload = "test"
         val unauthenticatedMsg = UnauthenticatedMessage(
             UnauthenticatedMessageHeader(
-                myIdentity,
-                localIdentity,
+                myIdentity.toAvro(),
+                localIdentity.toAvro(),
                 "subsystem"
             ),
             ByteBuffer.wrap(payload.toByteArray())
@@ -172,8 +174,8 @@ class OutboundMessageProcessorTest {
         val payload = "test"
         val unauthenticatedMsg = UnauthenticatedMessage(
             UnauthenticatedMessageHeader(
-                remoteIdentity,
-                myIdentity,
+                remoteIdentity.toAvro(),
+                myIdentity.toAvro(),
                 "subsystem"
             ),
             ByteBuffer.wrap(payload.toByteArray()),
@@ -205,8 +207,8 @@ class OutboundMessageProcessorTest {
         val numberOfMessages = 3
         val messages = (1..numberOfMessages).map { i ->
             val header = AuthenticatedMessageHeader(
-                remoteIdentity,
-                myIdentity,
+                remoteIdentity.toAvro(),
+                myIdentity.toAvro(),
                 null,
                 "MessageId$i",
                 "trace-$i",
@@ -239,8 +241,8 @@ class OutboundMessageProcessorTest {
         val numberOfMessages = 3
         val messages = (1..numberOfMessages).map { i ->
             val header = AuthenticatedMessageHeader(
-                remoteIdentity,
-                myIdentity,
+                remoteIdentity.toAvro(),
+                myIdentity.toAvro(),
                 null,
                 "MessageId$i",
                 "trace-$i",
@@ -269,8 +271,8 @@ class OutboundMessageProcessorTest {
         whenever(sessionManager.processOutboundMessage(any())).thenReturn(SessionManager.SessionState.SessionAlreadyPending)
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                remoteIdentity,
-                localIdentity,
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "message-id", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("payload".toByteArray())
@@ -301,8 +303,8 @@ class OutboundMessageProcessorTest {
         whenever(assignedListener.getCurrentlyAssignedPartitions()).doReturn(inboundSubscribedTopics)
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                remoteIdentity,
-                localIdentity,
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "message-id", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("payload".toByteArray())
@@ -356,8 +358,8 @@ class OutboundMessageProcessorTest {
         whenever(assignedListener.getCurrentlyAssignedPartitions()).doReturn(inboundSubscribedTopics)
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                remoteIdentity,
-                localIdentity,
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "message-id", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("payload".toByteArray())
@@ -393,8 +395,8 @@ class OutboundMessageProcessorTest {
         whenever(assignedListener.getCurrentlyAssignedPartitions()).doReturn(inboundSubscribedTopics)
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                remoteIdentity,
-                localIdentity,
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "message-id", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("payload".toByteArray())
@@ -420,8 +422,8 @@ class OutboundMessageProcessorTest {
                 AppMessage(
                     AuthenticatedMessage(
                         AuthenticatedMessageHeader(
-                            remoteIdentity,
-                            myIdentity,
+                            remoteIdentity.toAvro(),
+                            myIdentity.toAvro(),
                             null, id, "trace-id", "system-1"
                         ),
                         ByteBuffer.wrap(id.toByteArray())
@@ -459,8 +461,8 @@ class OutboundMessageProcessorTest {
         whenever(sessionManager.processOutboundMessage(any())).thenReturn(state)
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                remoteIdentity,
-                localIdentity,
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "message-id", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("0".toByteArray())
@@ -498,8 +500,8 @@ class OutboundMessageProcessorTest {
                 AppMessage(
                     AuthenticatedMessage(
                         AuthenticatedMessageHeader(
-                            remoteIdentity,
-                            localIdentity,
+                            remoteIdentity.toAvro(),
+                            localIdentity.toAvro(),
                             null, "message-id", "trace-id", "system-1"
                         ),
                         ByteBuffer.wrap("payload".toByteArray())
@@ -527,8 +529,8 @@ class OutboundMessageProcessorTest {
             AuthenticatedMessageAndKey(
                 AuthenticatedMessage(
                     AuthenticatedMessageHeader(
-                        remoteIdentity,
-                        localIdentity,
+                        remoteIdentity.toAvro(),
+                        localIdentity.toAvro(),
                         null, "message-id", "trace-id", "system-1"
                     ),
                     ByteBuffer.wrap("payload".toByteArray())
@@ -548,8 +550,8 @@ class OutboundMessageProcessorTest {
         val appMessage = AppMessage(
             AuthenticatedMessage(
                 AuthenticatedMessageHeader(
-                    HoldingIdentity("PartyE", "Group"),
-                    localIdentity,
+                    HoldingIdentity("CN=PartyE, O=Corp, L=LDN, C=GB", "Group"),
+                    localIdentity.toAvro(),
                     null, "message-id", "trace-id", "system-1"
                 ),
                 ByteBuffer.wrap("payload".toByteArray())
@@ -581,8 +583,8 @@ class OutboundMessageProcessorTest {
         whenever(sessionManager.processOutboundMessage(any())).thenReturn(SessionManager.SessionState.SessionAlreadyPending)
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                remoteIdentity,
-                localIdentity,
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
                 null, "MessageId", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("payload".toByteArray())
@@ -613,8 +615,8 @@ class OutboundMessageProcessorTest {
     fun `OutboundMessageProcessor produces TtlExpiredMarker and LinkManagerProcessedMarker if TTL expiry is true and replay is false`() {
         val authenticatedMsg = AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                remoteIdentity,
-                localIdentity,
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
                 Instant.ofEpochMilli(0), "MessageId", "trace-id", "system-1"
             ),
             ByteBuffer.wrap("payload".toByteArray())

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/PendingSessionMessageQueuesImplTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/PendingSessionMessageQueuesImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.domino.logic.DominoTile
 import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
 import net.corda.messaging.api.records.Record
@@ -15,6 +14,8 @@ import net.corda.p2p.crypto.protocol.api.AuthenticatedSession
 import net.corda.p2p.crypto.protocol.api.AuthenticationResult
 import net.corda.p2p.crypto.protocol.api.KeyAlgorithm
 import net.corda.p2p.linkmanager.sessions.SessionManager
+import net.corda.test.util.identity.createTestHoldingIdentity
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -50,8 +51,8 @@ class PendingSessionMessageQueuesImplTest {
         whenever(mock.publish(publishedRecords.capture())).doReturn(emptyList())
     }
     private val sessionCounterparties = SessionManager.SessionCounterparties(
-        HoldingIdentity("carol", "group-1"),
-        HoldingIdentity("david", "group-2")
+        createTestHoldingIdentity("CN=Carol, O=Corp, L=LDN, C=GB", "group-1"),
+        createTestHoldingIdentity("CN=David, O=Corp, L=LDN, C=GB", "group-2")
     )
     private val members = mock<LinkManagerMembershipGroupReader> {
         on { getMemberInfo(sessionCounterparties.ourId, sessionCounterparties.counterpartyId) } doReturn
@@ -77,8 +78,8 @@ class PendingSessionMessageQueuesImplTest {
     fun `sessionNegotiatedCallback publish messages`() {
         val messages = (1..5).map {
             val header = AuthenticatedMessageHeader(
-                sessionCounterparties.counterpartyId,
-                sessionCounterparties.ourId,
+                sessionCounterparties.counterpartyId.toAvro(),
+                sessionCounterparties.ourId.toAvro(),
                 null,
                 "msg-$it",
                 "",
@@ -108,8 +109,8 @@ class PendingSessionMessageQueuesImplTest {
         val count = 3
         (1..count).map {
             val header = AuthenticatedMessageHeader(
-                sessionCounterparties.counterpartyId,
-                sessionCounterparties.ourId,
+                sessionCounterparties.counterpartyId.toAvro(),
+                sessionCounterparties.ourId.toAvro(),
                 null,
                 "msg-$it",
                 "",
@@ -130,8 +131,8 @@ class PendingSessionMessageQueuesImplTest {
     fun `sessionNegotiatedCallback will not publish messages for another counter parties`() {
         (1..5).map {
             val header = AuthenticatedMessageHeader(
-                sessionCounterparties.counterpartyId,
-                sessionCounterparties.ourId,
+                sessionCounterparties.counterpartyId.toAvro(),
+                sessionCounterparties.ourId.toAvro(),
                 null,
                 "msg-$it",
                 "",
@@ -144,8 +145,8 @@ class PendingSessionMessageQueuesImplTest {
         }
 
         val anotherSessionCounterparties = SessionManager.SessionCounterparties(
-            HoldingIdentity("carol", "group-2"),
-            HoldingIdentity("david", "group-1")
+            createTestHoldingIdentity("CN=Carol, O=Corp, L=LDN, C=GB", "group-2"),
+            createTestHoldingIdentity("CN=David, O=Corp, L=LDN, C=GB", "group-1")
         )
         queue.sessionNegotiatedCallback(sessionManager, anotherSessionCounterparties, session, groups, members)
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/StubGroupPolicyProviderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/StubGroupPolicyProviderTest.kt
@@ -14,6 +14,7 @@ import net.corda.p2p.crypto.ProtocolMode
 import net.corda.p2p.linkmanager.StubGroupPolicyProvider.Companion.toGroupInfo
 import net.corda.p2p.test.GroupPolicyEntry
 import net.corda.schema.Schemas.P2P.Companion.GROUP_POLICIES_TOPIC
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.AfterEach
@@ -95,13 +96,13 @@ class StubGroupPolicyProviderTest {
         processor.firstValue.onSnapshot(groupsToPublish)
 
         assertSoftly {
-            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity)).isEqualTo(
+            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity.toCorda())).isEqualTo(
                 groupOne.toGroupInfo()
             )
-            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity)).isEqualTo(
+            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity.toCorda())).isEqualTo(
                 groupTwo.toGroupInfo()
             )
-            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity)).isNull()
+            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity.toCorda())).isNull()
         }
     }
 
@@ -120,11 +121,11 @@ class StubGroupPolicyProviderTest {
         )
 
         assertSoftly {
-            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity)).isNull()
-            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity)).isEqualTo(
+            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity.toCorda())).isNull()
+            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity.toCorda())).isEqualTo(
                 groupTwo.toGroupInfo()
             )
-            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity)).isNull()
+            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity.toCorda())).isNull()
         }
     }
 
@@ -147,11 +148,11 @@ class StubGroupPolicyProviderTest {
         )
 
         assertSoftly {
-            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity)).isNull()
-            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity)).isEqualTo(
+            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity.toCorda())).isNull()
+            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity.toCorda())).isEqualTo(
                 groupTwo.toGroupInfo()
             )
-            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity)).isNull()
+            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity.toCorda())).isNull()
         }
     }
 
@@ -174,13 +175,13 @@ class StubGroupPolicyProviderTest {
         )
 
         assertSoftly {
-            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity)).isEqualTo(
+            it.assertThat(groups.getGroupInfo(groupOne.holdingIdentity.toCorda())).isEqualTo(
                 groupOne.toGroupInfo()
             )
-            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity)).isEqualTo(
+            it.assertThat(groups.getGroupInfo(groupTwo.holdingIdentity.toCorda())).isEqualTo(
                 groupTwo.toGroupInfo()
             )
-            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity)).isEqualTo(
+            it.assertThat(groups.getGroupInfo(groupThree.holdingIdentity.toCorda())).isEqualTo(
                 groupThree.toGroupInfo()
             )
         }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/StubMembershipGroupReaderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/StubMembershipGroupReaderTest.kt
@@ -12,6 +12,7 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.crypto.protocol.api.KeyAlgorithm
 import net.corda.p2p.test.MemberInfoEntry
 import net.corda.schema.Schemas.P2P.Companion.MEMBER_INFO_TOPIC
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.AfterEach
@@ -42,28 +43,28 @@ class StubMembershipGroupReaderTest {
         whenever(mock.isRunning).doReturn(true)
     }
     private val subscriptionDominoTile = mockConstruction(SubscriptionDominoTile::class.java)
-    private val aliceObserver = HoldingIdentity("Observer", "GROUP-1")
+    private val aliceObserver = HoldingIdentity("CN=Observer, O=Corp, L=LDN, C=GB", "GROUP-1")
     private val alice = MemberInfoEntry(
         HoldingIdentity(
-            "Alice",
+            "CN=Alice, O=Corp, L=LDN, C=GB",
             "GROUP-1"
         ),
         "alice_pem",
         "alice.com",
     )
-    private val bobObserver = HoldingIdentity("Observer", "GROUP-2")
+    private val bobObserver = HoldingIdentity("CN=Observer, O=Corp, L=LDN, C=GB", "GROUP-2")
     private val bob = MemberInfoEntry(
         HoldingIdentity(
-            "Bob",
+            "CN=Bob, O=Corp, L=LDN, C=GB",
             "GROUP-2"
         ),
         "bob_pem",
         "bob.net"
     )
-    private val carolObserver = HoldingIdentity("Observer", "GROUP-3")
+    private val carolObserver = HoldingIdentity("CN=Observer, O=Corp, L=LDN, C=GB", "GROUP-3")
     private val carol = MemberInfoEntry(
         HoldingIdentity(
-            "Carol",
+            "CN=Carol, O=Corp, L=LDN, C=GB",
             "GROUP-3"
         ),
         "carol_pem",
@@ -129,40 +130,40 @@ class StubMembershipGroupReaderTest {
         processor.firstValue.onSnapshot(membersToPublish)
 
         assertSoftly {
-            it.assertThat(members.getMemberInfo(aliceObserver, alice.holdingIdentity)).isEqualTo(
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), alice.holdingIdentity.toCorda())).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    alice.holdingIdentity,
+                    alice.holdingIdentity.toCorda(),
                     alicePublicKey,
                     KeyAlgorithm.ECDSA,
                     alice.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(bobObserver, bob.holdingIdentity)).isEqualTo(
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bob.holdingIdentity.toCorda())).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carol.holdingIdentity)).isNull()
-            it.assertThat(members.getMemberInfo(aliceObserver, aliceHash)).isEqualTo(
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carol.holdingIdentity.toCorda())).isNull()
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), aliceHash)).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    alice.holdingIdentity,
+                    alice.holdingIdentity.toCorda(),
                     alicePublicKey,
                     KeyAlgorithm.ECDSA,
                     alice.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(bobObserver, bobHash)).isEqualTo(
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bobHash)).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carolHash)).isNull()
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carolHash)).isNull()
         }
     }
 
@@ -181,26 +182,26 @@ class StubMembershipGroupReaderTest {
         )
 
         assertSoftly {
-            it.assertThat(members.getMemberInfo(aliceObserver, alice.holdingIdentity)).isNull()
-            it.assertThat(members.getMemberInfo(bobObserver, bob.holdingIdentity)).isEqualTo(
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), alice.holdingIdentity.toCorda())).isNull()
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bob.holdingIdentity.toCorda())).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carol.holdingIdentity)).isNull()
-            it.assertThat(members.getMemberInfo(aliceObserver, aliceHash)).isNull()
-            it.assertThat(members.getMemberInfo(bobObserver, bobHash)).isEqualTo(
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carol.holdingIdentity.toCorda())).isNull()
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), aliceHash)).isNull()
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bobHash)).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carolHash)).isNull()
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carolHash)).isNull()
         }
     }
 
@@ -223,26 +224,26 @@ class StubMembershipGroupReaderTest {
         )
 
         assertSoftly {
-            it.assertThat(members.getMemberInfo(aliceObserver, alice.holdingIdentity)).isNull()
-            it.assertThat(members.getMemberInfo(bobObserver, bob.holdingIdentity)).isEqualTo(
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), alice.holdingIdentity.toCorda())).isNull()
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bob.holdingIdentity.toCorda())).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carol.holdingIdentity)).isNull()
-            it.assertThat(members.getMemberInfo(aliceObserver, aliceHash)).isNull()
-            it.assertThat(members.getMemberInfo(bobObserver, bobHash)).isEqualTo(
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carol.holdingIdentity.toCorda())).isNull()
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), aliceHash)).isNull()
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bobHash)).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carolHash)).isNull()
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carolHash)).isNull()
         }
     }
     @Test
@@ -264,49 +265,49 @@ class StubMembershipGroupReaderTest {
         )
 
         assertSoftly {
-            it.assertThat(members.getMemberInfo(aliceObserver, alice.holdingIdentity)).isEqualTo(
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), alice.holdingIdentity.toCorda())).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    alice.holdingIdentity,
+                    alice.holdingIdentity.toCorda(),
                     alicePublicKey,
                     KeyAlgorithm.ECDSA,
                     alice.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(bobObserver, bob.holdingIdentity)).isEqualTo(
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bob.holdingIdentity.toCorda())).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carol.holdingIdentity)).isEqualTo(
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carol.holdingIdentity.toCorda())).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    carol.holdingIdentity,
+                    carol.holdingIdentity.toCorda(),
                     carolPublicKey,
                     KeyAlgorithm.RSA,
                     carol.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(aliceObserver, aliceHash)).isEqualTo(
+            it.assertThat(members.getMemberInfo(aliceObserver.toCorda(), aliceHash)).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    alice.holdingIdentity,
+                    alice.holdingIdentity.toCorda(),
                     alicePublicKey,
                     KeyAlgorithm.ECDSA,
                     alice.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(bobObserver, bobHash)).isEqualTo(
+            it.assertThat(members.getMemberInfo(bobObserver.toCorda(), bobHash)).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    bob.holdingIdentity,
+                    bob.holdingIdentity.toCorda(),
                     bobPublicKey,
                     KeyAlgorithm.RSA,
                     bob.address,
                 )
             )
-            it.assertThat(members.getMemberInfo(carolObserver, carolHash)).isEqualTo(
+            it.assertThat(members.getMemberInfo(carolObserver.toCorda(), carolHash)).isEqualTo(
                 LinkManagerMembershipGroupReader.MemberInfo(
-                    carol.holdingIdentity,
+                    carol.holdingIdentity.toCorda(),
                     carolPublicKey,
                     KeyAlgorithm.RSA,
                     carol.address,

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisherTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/TrustStoresPublisherTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -17,6 +16,8 @@ import net.corda.p2p.GatewayTruststore
 import net.corda.p2p.NetworkType
 import net.corda.p2p.crypto.ProtocolMode
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_TRUSTSTORES
+import net.corda.test.util.identity.createTestHoldingIdentity
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
@@ -69,7 +70,7 @@ class TrustStoresPublisherTest {
 
     private val certificates = listOf("one", "two")
     private val groupInfo = GroupPolicyListener.GroupInfo(
-        HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "groupOne"),
+        createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "groupOne"),
         NetworkType.CORDA_5,
         setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
         certificates,
@@ -103,7 +104,7 @@ class TrustStoresPublisherTest {
             assertThat(publishedRecords.allValues).containsExactly(
                 listOf(Record(GATEWAY_TLS_TRUSTSTORES,
                     "${groupInfo.holdingIdentity.x500Name}-${groupInfo.holdingIdentity.groupId}",
-                    GatewayTruststore(HoldingIdentity(groupInfo.holdingIdentity.x500Name, groupInfo.holdingIdentity.groupId), certificates)
+                    GatewayTruststore(groupInfo.holdingIdentity.toAvro(), certificates)
                 ))
             )
         }
@@ -151,13 +152,12 @@ class TrustStoresPublisherTest {
                 listOf(
                     Record(GATEWAY_TLS_TRUSTSTORES,
                     "${groupInfo.holdingIdentity.x500Name}-${groupInfo.holdingIdentity.groupId}",
-                    GatewayTruststore(HoldingIdentity(groupInfo.holdingIdentity.x500Name, groupInfo.holdingIdentity.groupId), certificates))
+                    GatewayTruststore(groupInfo.holdingIdentity.toAvro(), certificates))
                 ),
                 listOf(
                     Record(GATEWAY_TLS_TRUSTSTORES,
                     "${groupInfo.holdingIdentity.x500Name}-${groupInfo.holdingIdentity.groupId}",
-                    GatewayTruststore(HoldingIdentity(groupInfo.holdingIdentity.x500Name, groupInfo.holdingIdentity.groupId),
-                        certificatesTwo))
+                    GatewayTruststore(groupInfo.holdingIdentity.toAvro(), certificatesTwo))
                 ),
             )
         }
@@ -231,7 +231,7 @@ class TrustStoresPublisherTest {
             processor.firstValue.onSnapshot(
                 mapOf(
                     "${groupInfo.holdingIdentity.x500Name}-${groupInfo.holdingIdentity.groupId}" to
-                    GatewayTruststore(HoldingIdentity(groupInfo.holdingIdentity.x500Name, groupInfo.holdingIdentity.groupId), certificates)
+                    GatewayTruststore(groupInfo.holdingIdentity.toAvro(), certificates)
                 )
             )
 
@@ -246,7 +246,7 @@ class TrustStoresPublisherTest {
             processor.firstValue.onSnapshot(
                 mapOf(
                     "${groupInfo.holdingIdentity.x500Name}-${groupInfo.holdingIdentity.groupId}" to
-                    GatewayTruststore(HoldingIdentity(groupInfo.holdingIdentity.x500Name, groupInfo.holdingIdentity.groupId), certificates)
+                    GatewayTruststore(groupInfo.holdingIdentity.toAvro(), certificates)
                 )
             )
 
@@ -270,7 +270,7 @@ class TrustStoresPublisherTest {
             processor.firstValue.onNext(
                 Record(
                     "", "${groupInfo.holdingIdentity.x500Name}-${groupInfo.holdingIdentity.groupId}",
-                    GatewayTruststore(HoldingIdentity(groupInfo.holdingIdentity.x500Name, groupInfo.holdingIdentity.groupId), certificates)
+                    GatewayTruststore(groupInfo.holdingIdentity.toAvro(), certificates)
                 ),
                 null, emptyMap()
             )

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTrackerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTrackerTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager.delivery
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.NamedLifecycle
@@ -21,6 +20,8 @@ import net.corda.p2p.linkmanager.utilities.LoggingInterceptor
 import net.corda.p2p.markers.AppMessageMarker
 import net.corda.p2p.markers.LinkManagerReceivedMarker
 import net.corda.p2p.markers.LinkManagerProcessedMarker
+import net.corda.test.util.identity.createTestHoldingIdentity
+import net.corda.virtualnode.toAvro
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -91,11 +92,11 @@ class DeliveryTrackerTest {
         whenever(mock.dominoTile).doReturn(mockDominoTile)
     }
 
-    private val source = HoldingIdentity("Source", groupId)
-    private val dest = HoldingIdentity("Dest", groupId)
+    private val source = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
+    private val dest = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", groupId)
     private val header = mock<AuthenticatedMessageHeader> {
-        on { source } doReturn source
-        on { destination } doReturn dest
+        on { source } doReturn source.toAvro()
+        on { destination } doReturn dest.toAvro()
     }
     private val message = mock<AuthenticatedMessage> {
         on { header } doReturn header

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager.delivery
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.DominoTile
@@ -19,6 +18,7 @@ import net.corda.p2p.linkmanager.utilities.LoggingInterceptor
 import net.corda.p2p.linkmanager.utilities.mockMembersAndGroups
 import net.corda.schema.Schemas.P2P.Companion.LINK_OUT_TOPIC
 import net.corda.test.util.MockTimeFacilitiesProvider
+import net.corda.test.util.identity.createTestHoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.AfterEach
@@ -42,8 +42,8 @@ class InMemorySessionReplayerTest {
 
     companion object {
         private const val GROUP_ID = "myGroup"
-        private val US = HoldingIdentity("Us",GROUP_ID)
-        private val COUNTER_PARTY = HoldingIdentity("CounterParty", GROUP_ID)
+        private val US = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB",GROUP_ID)
+        private val COUNTER_PARTY = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", GROUP_ID)
         private val SESSION_COUNTERPARTIES = SessionManager.SessionCounterparties(US, COUNTER_PARTY)
         private const val MAX_MESSAGE_SIZE = 100000
         lateinit var loggingInterceptor: LoggingInterceptor

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/ReplaySchedulerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/ReplaySchedulerTest.kt
@@ -3,7 +3,6 @@ package net.corda.p2p.linkmanager.delivery
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
@@ -11,6 +10,7 @@ import net.corda.lifecycle.domino.logic.util.ResourcesHolder
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.p2p.linkmanager.utilities.LoggingInterceptor
 import net.corda.test.util.MockTimeFacilitiesProvider
+import net.corda.test.util.identity.createTestHoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
@@ -31,8 +31,8 @@ class ReplaySchedulerTest {
         private const val MAX_REPLAYING_MESSAGES = 100
         private val replayPeriod = Duration.ofMillis(2)
         private val sessionCounterparties = SessionManager.SessionCounterparties(
-            HoldingIdentity("Source", DeliveryTrackerTest.groupId),
-            HoldingIdentity("Dest", DeliveryTrackerTest.groupId)
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", DeliveryTrackerTest.groupId),
+            createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", DeliveryTrackerTest.groupId)
         )
         lateinit var loggingInterceptor: LoggingInterceptor
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverterTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverterTest.kt
@@ -110,7 +110,11 @@ class MessageConverterTest {
         val groupId = "group-1"
         val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
         val members = mockMembers(emptyList())
-        val flowMessage = authenticatedMessageAndKey(createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId), peer, ByteBuffer.wrap("DATA".toByteArray()))
+        val flowMessage = authenticatedMessageAndKey(
+            createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId),
+            peer,
+            ByteBuffer.wrap("DATA".toByteArray())
+        )
         assertThat(MessageConverter.linkOutMessageFromAuthenticatedMessageAndKey(flowMessage, session, mock(), members)).isNull()
         loggingInterceptor.assertSingleWarning(
             "Attempted to send message to peer $peer which is not in the network map." +

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverterTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverterTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager.messaging
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.p2p.AuthenticatedMessageAndKey
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.p2p.app.AuthenticatedMessageHeader
@@ -18,6 +17,9 @@ import net.corda.p2p.linkmanager.messaging.AvroSealedClasses.SessionAndMessage
 import net.corda.p2p.linkmanager.utilities.LoggingInterceptor
 import net.corda.p2p.linkmanager.utilities.mockGroups
 import net.corda.p2p.linkmanager.utilities.mockMembers
+import net.corda.test.util.identity.createTestHoldingIdentity
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
@@ -105,9 +107,10 @@ class MessageConverterTest {
         val session = mock<AuthenticatedSession> {
             on { createMac(any()) } doReturn mac
         }
-        val peer = HoldingIdentity("Imposter", "")
+        val groupId = "group-1"
+        val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
         val members = mockMembers(emptyList())
-        val flowMessage = authenticatedMessageAndKey(HoldingIdentity("", ""), peer, ByteBuffer.wrap("DATA".toByteArray()))
+        val flowMessage = authenticatedMessageAndKey(createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId), peer, ByteBuffer.wrap("DATA".toByteArray()))
         assertThat(MessageConverter.linkOutMessageFromAuthenticatedMessageAndKey(flowMessage, session, mock(), members)).isNull()
         loggingInterceptor.assertSingleWarning(
             "Attempted to send message to peer $peer which is not in the network map." +
@@ -124,8 +127,9 @@ class MessageConverterTest {
         val session = mock<AuthenticatedSession> {
             on { createMac(any()) } doReturn mac
         }
-        val peer = HoldingIdentity("Imposter", "")
-        val us = HoldingIdentity("", "")
+        val groupId = "group-1"
+        val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
+        val us = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
         val members = mockMembers(listOf(us, peer))
         val groups = mockGroups(emptyList())
         val flowMessage = authenticatedMessageAndKey(us, peer, ByteBuffer.wrap("DATA".toByteArray()))
@@ -139,10 +143,11 @@ class MessageConverterTest {
     @Test
     fun `linkOutFromUnauthenticatedMessage returns null (with appropriate logging) if if the destination is not in the network map`() {
         val payload = "test"
-        val us = HoldingIdentity("Alice", "test-group-id")
-        val peer = HoldingIdentity("Imposter", "")
+        val groupId = "group-1"
+        val us = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
+        val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
         val unauthenticatedMsg = UnauthenticatedMessage(
-            UnauthenticatedMessageHeader(peer, us, "subsystem"),
+            UnauthenticatedMessageHeader(peer.toAvro(), us.toAvro(), "subsystem"),
             ByteBuffer.wrap(payload.toByteArray())
         )
 
@@ -158,10 +163,11 @@ class MessageConverterTest {
     @Test
     fun `linkOutFromUnauthenticatedMessage returns null (with appropriate logging) if if their network type is not in the network map`() {
         val payload = "test"
-        val us = HoldingIdentity("Alice", "test-group-id")
-        val peer = HoldingIdentity("Imposter", "")
+        val groupId = "group-1"
+        val us = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
+        val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
         val unauthenticatedMsg = UnauthenticatedMessage(
-            UnauthenticatedMessageHeader(peer, us, "subsystem"),
+            UnauthenticatedMessageHeader(peer.toAvro(), us.toAvro(), "subsystem"),
             ByteBuffer.wrap(payload.toByteArray())
         )
 
@@ -180,7 +186,7 @@ class MessageConverterTest {
         data: ByteBuffer,
         messageId: String = ""
     ): AuthenticatedMessageAndKey {
-        val header = AuthenticatedMessageHeader(dest, source, null, messageId, "", "system-1")
+        val header = AuthenticatedMessageHeader(dest.toAvro(), source.toAvro(), null, messageId, "", "system-1")
         return AuthenticatedMessageAndKey(AuthenticatedMessage(header, data), "key")
     }
 }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager.sessions
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.DominoTile
@@ -53,9 +52,12 @@ import net.corda.p2p.test.stub.crypto.processor.UnsupportedAlgorithm
 import net.corda.schema.Schemas.P2P.Companion.LINK_OUT_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.SESSION_OUT_PARTITIONS
 import net.corda.test.util.MockTimeFacilitiesProvider
+import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.base.util.millis
 import net.corda.v5.base.util.toBase64
 import net.corda.v5.crypto.SignatureSpec
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.AfterEach
@@ -106,12 +108,12 @@ class SessionManagerTest {
         private val keyGenerator = KeyPairGenerator.getInstance("EC", BouncyCastleProvider())
         private val messageDigest = MessageDigest.getInstance(ProtocolConstants.HASH_ALGO, BouncyCastleProvider())
 
-        private val OUR_PARTY = HoldingIdentity("Alice", GROUP_ID)
+        private val OUR_PARTY = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", GROUP_ID)
         private val OUR_KEY = keyGenerator.genKeyPair()
         private val OUR_MEMBER_INFO =
             LinkManagerMembershipGroupReader.MemberInfo(OUR_PARTY, OUR_KEY.public, KeyAlgorithm.ECDSA,
                 "http://alice.com")
-        private val PEER_PARTY = HoldingIdentity("Bob", GROUP_ID)
+        private val PEER_PARTY = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", GROUP_ID)
         private val PEER_KEY = keyGenerator.genKeyPair()
         private val PEER_MEMBER_INFO =
             LinkManagerMembershipGroupReader.MemberInfo(PEER_PARTY, PEER_KEY.public, KeyAlgorithm.ECDSA,
@@ -282,8 +284,8 @@ class SessionManagerTest {
     private val message = AuthenticatedMessageAndKey(
         AuthenticatedMessage(
             AuthenticatedMessageHeader(
-                PEER_PARTY,
-                OUR_PARTY,
+                PEER_PARTY.toAvro(),
+                OUR_PARTY.toAvro(),
                 null,
                 "messageId",
                 "", "system-1"

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/utilities/MockMembersAndGroups.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/utilities/MockMembersAndGroups.kt
@@ -1,6 +1,5 @@
 package net.corda.p2p.linkmanager.utilities
 
-import net.corda.data.identity.HoldingIdentity
 import net.corda.lifecycle.domino.logic.DominoTile
 import net.corda.p2p.NetworkType
 import net.corda.p2p.crypto.ProtocolMode
@@ -9,6 +8,7 @@ import net.corda.p2p.crypto.protocol.api.KeyAlgorithm
 import net.corda.p2p.linkmanager.GroupPolicyListener
 import net.corda.p2p.linkmanager.LinkManagerGroupPolicyProvider
 import net.corda.p2p.linkmanager.LinkManagerMembershipGroupReader
+import net.corda.virtualnode.HoldingIdentity
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.mockito.kotlin.mock
 import java.security.KeyPairGenerator


### PR DESCRIPTION
## Changes
Currently, p2p code was predominantly using the Avro-type `net.corda.data.identity.HoldingIdentity` in internal logic. This change switches the code to use the `net.corda.virtualnode.HoldingIdentity` type, instead. The latter models the x500 name as a strong type (`MemberX500Name`), instead of a string. This ensures any comparisons will be order-insensitive and reliable and any hashing will be stable.

This was introducing a bug in the p2p side, where if a message was sent to an identity where the x500 name had a slightly difference to the one registered in the members map (e.g. the attributes in the string were in different order), then p2p would classify those as different identities and would not send the message.

## Testing
In order to confirm the bug is resolved, I slightly adjusted the `P2PLayerEndToEndTest` to send a message with a slightly modified x500 name and saw the test failing originally and then passing after these changes were added. I didn't add that as an extra test case as I thought it is probably an overkill for that suite (but maybe something we can add if we end up having a more extended regression suite).
