### PR TITLE
CORE-5778 Refactor API for setting up locally-hosted identity

### DIFF
--- a/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/CertificatesClientImpl.kt
+++ b/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/CertificatesClientImpl.kt
@@ -86,13 +86,14 @@ class CertificatesClientImpl @Activate constructor(
 
     override fun setupLocallyHostedIdentity(
         holdingIdentityShortHash: String,
-        certificateChainAlias: String,
-        tlsTenantId: String?,
+        p2pTlsCertificateChainAlias: String,
+        p2pTlsTenantId: String?,
+        sessionKeyTenantId: String?,
         sessionKeyId: String?,
     ) {
 
         val record = hostedIdentityEntryFactory.createIdentityRecord(
-            holdingIdentityShortHash, certificateChainAlias, tlsTenantId, sessionKeyId
+            holdingIdentityShortHash, p2pTlsCertificateChainAlias, p2pTlsTenantId, sessionKeyTenantId, sessionKeyId
         )
 
         val futures = publisher?.publish(

--- a/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/CertificatesClientImplTest.kt
+++ b/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/CertificatesClientImplTest.kt
@@ -141,10 +141,22 @@ class CertificatesClientImplTest {
             )
             handler.firstValue.processEvent(event, coordinator)
 
-            client.setupLocallyHostedIdentity("holdingIdentityShortHash", "Alias", "tlsTenantId", "sessionAlias")
+            client.setupLocallyHostedIdentity(
+                "holdingIdentityShortHash",
+                "Alias",
+                "tlsTenantId",
+                "sessionKeyTenantId",
+                "sessionAlias"
+            )
 
-            verify(mockHostedIdentityEntryFactory.constructed().first()).createIdentityRecord(
-                "holdingIdentityShortHash", "Alias", "tlsTenantId", "sessionAlias"
+            verify(
+                mockHostedIdentityEntryFactory.constructed().first()
+            ).createIdentityRecord(
+                "holdingIdentityShortHash",
+                "Alias",
+                "tlsTenantId",
+                "sessionKeyTenantId",
+                "sessionAlias"
             )
         }
 
@@ -177,6 +189,7 @@ class CertificatesClientImplTest {
                     "holdingIdentityShortHash",
                     "Alias",
                     "tlsTenantId",
+                    "sessionKeyTenantId",
                     "sessionAlias"
                 )
             }
@@ -196,6 +209,7 @@ class CertificatesClientImplTest {
                     "holdingIdentityShortHash",
                     "Alias",
                     "tlsTenantId",
+                    "sessionKeyTenantId",
                     "sessionAlias"
                 )
             }
@@ -204,7 +218,10 @@ class CertificatesClientImplTest {
         @Test
         fun `publishToLocallyHostedIdentities publish the correct record`() {
             val record = mock<Record<String, HostedIdentityEntry>>()
-            whenever(mockHostedIdentityEntryFactory.constructed().first().createIdentityRecord(any(), any(), any(), any())).doReturn(record)
+            whenever(
+                mockHostedIdentityEntryFactory.constructed().first()
+                    .createIdentityRecord(any(), any(), any(), any(), any())
+            ).doReturn(record)
             val event = ConfigChangedEvent(
                 emptySet(),
                 mapOf(ConfigKeys.MESSAGING_CONFIG to mock())
@@ -215,6 +232,7 @@ class CertificatesClientImplTest {
                 "holdingIdentityShortHash",
                 "Alias",
                 "tlsTenantId",
+                "sessionKeyTenantId",
                 "sessionAlias"
             )
 

--- a/components/membership/certificates-client/src/main/kotlin/net/corda/membership/certificate/client/CertificatesClient.kt
+++ b/components/membership/certificates-client/src/main/kotlin/net/corda/membership/certificate/client/CertificatesClient.kt
@@ -3,7 +3,7 @@ package net.corda.membership.certificate.client
 import net.corda.lifecycle.Lifecycle
 
 /**
- * A client that handle certificates requests
+ * A client that handles certificates requests.
  */
 interface CertificatesClient : Lifecycle {
 
@@ -18,19 +18,21 @@ interface CertificatesClient : Lifecycle {
     fun importCertificates(tenantId: String, alias: String, certificates: String)
 
     /**
-     * Setup locally hosted identity.
+     * Set up locally hosted identity.
      *
      *
      * @param holdingIdentityShortHash ID of the holding identity to be published.
-     * @param certificateChainAlias The certificates chain alias.
-     * @param tlsTenantId The TLS tenant ID (either p2p ot the holdingIdentityShortHash, default to the holdingIdentityShortHash).
+     * @param p2pTlsCertificateChainAlias The certificates chain alias.
+     * @param p2pTlsTenantId The TLS tenant ID (either p2p or the holdingIdentityShortHash, defaults to [holdingIdentityShortHash]).
+     * @param sessionKeyTenantId The tenant ID under which the session initiation key is stored (defaults to [holdingIdentityShortHash]).
      * @param sessionKeyId The session key ID (will use the first one if null).
-     * @throws CertificatesResourceNotFoundException if a resource was not found
+     * @throws CertificatesResourceNotFoundException if a resource was not found.
      */
     fun setupLocallyHostedIdentity(
         holdingIdentityShortHash: String,
-        certificateChainAlias: String,
-        tlsTenantId: String?,
+        p2pTlsCertificateChainAlias: String,
+        p2pTlsTenantId: String?,
+        sessionKeyTenantId: String?,
         sessionKeyId: String?
     )
 }

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImpl.kt
@@ -36,8 +36,9 @@ class NetworkRpcOpsImpl @Activate constructor(
         try {
             certificatesClient.setupLocallyHostedIdentity(
                 holdingIdentityShortHash,
-                request.certificateChainAlias,
-                request.tlsTenantId,
+                request.p2pTlsCertificateChainAlias,
+                request.p2pTlsTenantId,
+                request.sessionKeyTenantId,
                 request.sessionKeyId,
             )
         } catch (e: CertificatesResourceNotFoundException) {

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImplTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImplTest.kt
@@ -81,6 +81,7 @@ class NetworkRpcOpsImplTest {
                 HostedIdentitySetupRequest(
                     "alias",
                     "tls",
+                    "session-tenant",
                     "session"
                 )
             )
@@ -89,6 +90,7 @@ class NetworkRpcOpsImplTest {
                 "id",
                 "alias",
                 "tls",
+                "session-tenant",
                 "session",
             )
         }
@@ -96,6 +98,7 @@ class NetworkRpcOpsImplTest {
         fun `it catches resource not found exception`() {
             whenever(
                 certificatesClient.setupLocallyHostedIdentity(
+                    any(),
                     any(),
                     any(),
                     any(),
@@ -109,6 +112,7 @@ class NetworkRpcOpsImplTest {
                     HostedIdentitySetupRequest(
                         "alias",
                         "tls",
+                        "session-tenant",
                         "session"
                     )
                 )
@@ -122,6 +126,7 @@ class NetworkRpcOpsImplTest {
                     any(),
                     any(),
                     any(),
+                    any(),
                 )
             ).doThrow(RuntimeException("Nop"))
 
@@ -131,6 +136,7 @@ class NetworkRpcOpsImplTest {
                     HostedIdentitySetupRequest(
                         "alias",
                         "tls",
+                        "session-tenant",
                         "session"
                     )
                 )

--- a/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/types/request/HostedIdentitySetupRequest.kt
+++ b/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/types/request/HostedIdentitySetupRequest.kt
@@ -3,12 +3,14 @@ package net.corda.membership.httprpc.v1.types.request
 /**
  * Request for setting up a hosted identity for a particular vNode.
  *
- * @param certificateChainAlias The certificates chain alias.
- * @param tlsTenantId The TLS tenant ID (either 'p2p' or the holdingIdentityShortHash, default to the holdingIdentityShortHash).
+ * @param p2pTlsCertificateChainAlias The certificates chain alias.
+ * @param p2pTlsTenantId The TLS tenant ID (either 'p2p' or the holdingIdentityShortHash, defaults to the holdingIdentityShortHash).
+ * @param sessionKeyTenantId The tenant ID under which the session initiation key is stored (defaults to holdingIdentityShortHash).
  * @param sessionKeyId The session key identifier (will use the first one if null).
  */
 data class HostedIdentitySetupRequest(
-    val certificateChainAlias: String,
-    val tlsTenantId: String?,
+    val p2pTlsCertificateChainAlias: String,
+    val p2pTlsTenantId: String?,
+    val sessionKeyTenantId: String?,
     val sessionKeyId: String?
 )

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -2923,10 +2923,10 @@
         }
       },
       "HostedIdentitySetupRequest" : {
-        "required" : [ "certificateChainAlias" ],
+        "required" : [ "p2pTlsCertificateChainAlias" ],
         "type" : "object",
         "properties" : {
-          "certificateChainAlias" : {
+          "p2pTlsCertificateChainAlias" : {
             "type" : "string",
             "nullable" : false,
             "example" : "string"
@@ -2936,7 +2936,12 @@
             "nullable" : true,
             "example" : "string"
           },
-          "tlsTenantId" : {
+          "p2pTlsTenantId" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
+          "sessionKeyTenantId" : {
             "type" : "string",
             "nullable" : true,
             "example" : "string"


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-5778
Changes:
1. Add `sessionKeyTenantId` optional field which defaults to `holdingIdentityShortHash`
2. Rename `certificateChainAlias` to `p2pTlsCertificateChainAlias`
3. Rename `tlsTenantId` to `p2pTlsTenantId`