### PR TITLE
CORE-6014 embeddable json in request bodies

### DIFF
--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -76,7 +76,7 @@ class FlowRPCOpsImpl @Activate constructor(
         }
 
         val flowClassName = startFlow.flowClassName
-        val startEvent = messageFactory.createStartFlowEvent(clientRequestId, vNode, flowClassName, startFlow.requestData)
+        val startEvent = messageFactory.createStartFlowEvent(clientRequestId, vNode, flowClassName, startFlow.requestData.toString())
         val status = messageFactory.createStartFlowStatus(clientRequestId, vNode, flowClassName)
 
         val records = listOf(

--- a/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/types/request/StartFlowParameters.kt
+++ b/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/types/request/StartFlowParameters.kt
@@ -1,14 +1,16 @@
 package net.corda.flow.rpcops.v1.types.request
 
+import net.corda.httprpc.JsonObject
+
 /**
  * Request sent to start a flow
  *
  * @param clientRequestId Client provided flow identifier
  * @param flowClassName Fully qualified class name of the flow to start.
- * @param requestData Optional start arguments string passed to the flow. Defaults to empty string.
+ * @param requestData Optional start arguments string passed to the flow. Defaults to empty object.
  */
 data class StartFlowParameters(
     val clientRequestId: String,
     val flowClassName: String,
-    val requestData: String
+    val requestData: JsonObject
 )

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/JsonObject.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/JsonObject.kt
@@ -1,0 +1,3 @@
+package net.corda.httprpc
+
+interface JsonObject


### PR DESCRIPTION
without the need for escaping a string. The json within the parameter will be unmarshalled as an ObjectNode. It also supports escaped JSON as before, the escaped string will be unmarshalled as a TextNode.

Needs the latest rebase to pick up recent changes in this area.