### PR TITLE
NOTICK - Adjust the logging pattern for the p2p-layer-deployment tool to match against MDC

### DIFF
--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/Gateway.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/Gateway.kt
@@ -38,7 +38,7 @@ class Gateway(
     }
     override val imageName = "p2p-gateway"
 
-    override val readyLog = ".*Gateway-1 - Starting child.*".toRegex()
+    override val readyLog = ".*Gateway-1.* - Starting child.*".toRegex()
 
     override val otherPorts = when (details.lbType) {
         // In K8S load balancer the load balancer service will listen to the Gateway port, so no need to create a service.

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/LinkManager.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/pods/LinkManager.kt
@@ -13,5 +13,5 @@ class LinkManager(
 
     override val imageName = "p2p-link-manager"
 
-    override val readyLog = ".*LinkManager-1 - Starting child.*".toRegex()
+    override val readyLog = ".*LinkManager-1.* - Starting child.*".toRegex()
 }


### PR DESCRIPTION
## Changes
Recently, some changes were merged that add MDC to our logging. This means that the regex patterns the `p2p-layer-deployment` tool was using were not catching the necessary logs. For instance, the new form of the logs is the following:
```
15:21:36.745 [lifecycle-coordinator-3] INFO  Gateway-1 {} - Starting child InboundMessageHandler-1
```

Adjusting the pattern to catch them.

## Testing
Tested by performing a full deployment and e2e test run with the tool.