### PR TITLE
NOTICK: Increase duration to action vNode state transition

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
+import java.time.temporal.ChronoUnit
 
 // The CPB we're using in this test
 const val TEST_CPB = "/META-INF/flow-worker-dev.cpb"
@@ -251,6 +252,7 @@ class VirtualNodeRpcTest {
             updateVirtualNodeState(vnode.first, newState)
 
             assertWithRetry {
+                timeout(Duration.of(10, ChronoUnit.SECONDS))
                 command { vNodeList() }
                 condition {
                     it.code == 200 &&
@@ -263,6 +265,7 @@ class VirtualNodeRpcTest {
             updateVirtualNodeState(vnode.first, oldState)
 
             assertWithRetry {
+                timeout(Duration.of(10, ChronoUnit.SECONDS))
                 command { vNodeList() }
                 condition {
                     it.code == 200 &&


### PR DESCRIPTION
Default timeout is just 2 seconds, which might be too short for K8s to fully facilitate this transition.