### PR TITLE
CORE-5954: Early exit from poll when topic partitions haven't been allocated yet

### DIFF
--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -232,6 +232,10 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
     internal fun getNextTopicPartition(): CordaTopicPartition? {
         updateTopicPartitions()
 
+        if (topicPartitions.isEmpty()) {
+            return null
+        }
+
         @Synchronized
         fun nextPartition(): CordaTopicPartition {
             return if (!currentTopicPartition.hasNext()) {

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
@@ -302,6 +302,14 @@ internal class DBCordaConsumerImplTest {
     }
 
     @Test
+    fun `consumer returns empty list when no partitions are given`() {
+        whenever(consumerGroup.getTopicPartitionsFor(any())).thenAnswer { emptySet<CordaTopicPartition>() }
+
+        val consumer = makeConsumer()
+        assertThat(consumer.poll(Duration.ZERO)).isEmpty()
+    }
+
+    @Test
     fun `consumer returns correct position when not available based on auto_offset_reset`() {
         fun createAutoResetConsumer(strategy: CordaOffsetResetStrategy): CordaConsumer<String, String> {
             val keyDeserializer = mock<CordaAvroDeserializer<String>>()

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
@@ -303,6 +303,21 @@ internal class DBCordaConsumerImplTest {
 
     @Test
     fun `consumer returns empty list when no partitions are given`() {
+        // Something to return.  But we don't expect to actually see it.
+        val pollResult = listOf(
+            TopicRecordEntry(
+                topic,
+                0,
+                0,
+                serializedKey,
+                serializedValue,
+                TransactionRecordEntry("id", TransactionState.COMMITTED),
+                Instant.parse("2022-01-01T00:00:00.00Z")
+            )
+        )
+
+        whenever(dbAccess.getMaxCommittedPositions(any(), any())).thenAnswer { mapOf(partition0 to 0L) }
+        whenever(dbAccess.readRecords(any(), any(), any())).thenAnswer { pollResult }
         whenever(consumerGroup.getTopicPartitionsFor(any())).thenAnswer { emptySet<CordaTopicPartition>() }
 
         val consumer = makeConsumer()


### PR DESCRIPTION
This way we avoid the empty iterator.  And hopefully we'll be allocation a topic partition on the next poll