### PR TITLE
CORE-6035 Ensure MGM session key hash is available to members

### DIFF
--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -44,7 +44,7 @@ class MembershipGroupReaderImplTest {
     private val mockSessionKeyHash = PublicKeyHash.parse(mockSessionKeyAsByteArray.sha256Bytes())
     private val mockedSuspendedMemberProvidedContext = mock<MemberContext> {
         on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
-        on { parse(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
+        on { parseOrNull(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
     }
     private val mockedSuspendedMgmProvidedContext = mock<MGMContext> {
         on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_SUSPENDED
@@ -60,7 +60,7 @@ class MembershipGroupReaderImplTest {
 
     private val mockedActiveMemberProvidedContext = mock<MemberContext> {
         on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
-        on { parse(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
+        on { parseOrNull(eq(SESSION_KEY_HASH), eq(PublicKeyHash::class.java)) } doReturn mockSessionKeyHash
         on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_ACTIVE
     }
     private val mockedActiveMgmProvidedContext = mock<MGMContext> {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -194,24 +194,23 @@ class MGMRegistrationService @Activate constructor(
                 val sessionKey = getKeyFromId(context[SESSION_KEY_ID]!!, member.shortHash)
                 val ecdhKey = getKeyFromId(context[ECDH_KEY_ID]!!, member.shortHash)
                 val now = clock.instant().toString()
+                val memberContext = context.filterKeys {
+                    !keyIdList.contains(it)
+                }.filterKeys {
+                    !it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
+                } + mapOf(
+                    GROUP_ID to member.groupId,
+                    PARTY_NAME to member.x500Name.toString(),
+                    PARTY_SESSION_KEY to sessionKey.toPem(),
+                    SESSION_KEY_HASH to sessionKey.calculateHash().value,
+                    ECDH_KEY to ecdhKey.toPem(),
+                    // temporarily hardcoded
+                    PLATFORM_VERSION to PLATFORM_VERSION_CONST,
+                    SOFTWARE_VERSION to SOFTWARE_VERSION_CONST,
+                    SERIAL to SERIAL_CONST,
+                )
                 val mgmInfo = memberInfoFactory.create(
-                    memberContext = (
-                            context.filterKeys {
-                                !keyIdList.contains(it)
-                            }.filterKeys {
-                                !it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
-                            } + mapOf(
-                                GROUP_ID to member.groupId,
-                                PARTY_NAME to member.x500Name.toString(),
-                                PARTY_SESSION_KEY to sessionKey.toPem(),
-                                SESSION_KEY_HASH to sessionKey.calculateHash().value,
-                                ECDH_KEY to ecdhKey.toPem(),
-                                // temporarily hardcoded
-                                PLATFORM_VERSION to PLATFORM_VERSION_CONST,
-                                SOFTWARE_VERSION to SOFTWARE_VERSION_CONST,
-                                SERIAL to SERIAL_CONST,
-                            )
-                            ).toSortedMap(),
+                    memberContext = memberContext.toSortedMap(),
                     mgmContext = sortedMapOf(
                         CREATED_TIME to now,
                         MODIFIED_TIME to now,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -16,7 +16,6 @@ import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
-import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
@@ -28,9 +27,11 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoExtension.Companion.URL_KEY
+import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
@@ -47,12 +48,14 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.crypto.calculateHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import java.security.PublicKey
 import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
@@ -117,8 +120,10 @@ class MGMRegistrationService @Activate constructor(
             )
         }
     }
+
     // for watching the config changes
     private var configHandle: AutoCloseable? = null
+
     // for checking the components' health
     private var componentHandle: RegistrationHandle? = null
 
@@ -186,27 +191,27 @@ class MGMRegistrationService @Activate constructor(
         ): MembershipRequestRegistrationResult {
             try {
                 validateContext(context)
-                val sessionKey = getPemKeyFromId(context[SESSION_KEY_ID]!!, member.shortHash)
-                val ecdhKey = getPemKeyFromId(context[ECDH_KEY_ID]!!, member.shortHash)
+                val sessionKey = getKeyFromId(context[SESSION_KEY_ID]!!, member.shortHash)
+                val ecdhKey = getKeyFromId(context[ECDH_KEY_ID]!!, member.shortHash)
                 val now = clock.instant().toString()
                 val mgmInfo = memberInfoFactory.create(
                     memberContext = (
-                        context.filterKeys {
-                            !keyIdList.contains(it)
-                        }.filterKeys {
-                            !it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
-                        } +
-                            mapOf(
+                            context.filterKeys {
+                                !keyIdList.contains(it)
+                            }.filterKeys {
+                                !it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
+                            } + mapOf(
                                 GROUP_ID to member.groupId,
                                 PARTY_NAME to member.x500Name.toString(),
-                                PARTY_SESSION_KEY to sessionKey,
-                                ECDH_KEY to ecdhKey,
+                                PARTY_SESSION_KEY to sessionKey.toPem(),
+                                SESSION_KEY_HASH to sessionKey.calculateHash().value,
+                                ECDH_KEY to ecdhKey.toPem(),
                                 // temporarily hardcoded
                                 PLATFORM_VERSION to PLATFORM_VERSION_CONST,
                                 SOFTWARE_VERSION to SOFTWARE_VERSION_CONST,
                                 SERIAL to SERIAL_CONST,
                             )
-                        ).toSortedMap(),
+                            ).toSortedMap(),
                     mgmContext = sortedMapOf(
                         CREATED_TIME to now,
                         MODIFIED_TIME to now,
@@ -305,14 +310,15 @@ class MGMRegistrationService @Activate constructor(
                     true
                 }
 
-        private fun getPemKeyFromId(keyId: String, tenantId: String): String {
+        private fun getKeyFromId(keyId: String, tenantId: String): PublicKey {
             return with(cryptoOpsClient) {
                 lookup(tenantId, listOf(keyId)).firstOrNull()?.let {
-                    val key = keyEncodingService.decodePublicKey(it.publicKey.array())
-                    keyEncodingService.encodeAsString(key)
+                    keyEncodingService.decodePublicKey(it.publicKey.array())
                 } ?: throw IllegalArgumentException("No key found for tenant: $tenantId under ID: $keyId.")
             }
         }
+
+        private fun PublicKey.toPem(): String = keyEncodingService.encodeAsString(this)
     }
 
     private fun handleEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -255,9 +255,9 @@ class MGMRegistrationServiceTest {
             val expectedRecordKey = "$mgmId-$mgmId"
             it.assertThat(publishedMgmInfo.key).isEqualTo(expectedRecordKey)
 
-            val persistentMemberPublished = publishedMgmInfo.value as PersistentMemberInfo
+            val persistedMgm = publishedMgmInfo.value as PersistentMemberInfo
 
-            it.assertThat(persistentMemberPublished.memberContext.items.map { item -> item.key })
+            it.assertThat(persistedMgm.memberContext.items.map { item -> item.key })
                 .containsExactlyInAnyOrderElementsOf(
                     listOf(
                         GROUP_ID,
@@ -272,7 +272,7 @@ class MGMRegistrationServiceTest {
                         String.format(PROTOCOL_VERSION, 0),
                     )
                 )
-            it.assertThat(persistentMemberPublished.mgmContext.items.map { item -> item.key })
+            it.assertThat(persistedMgm.mgmContext.items.map { item -> item.key })
                 .containsExactlyInAnyOrderElementsOf(
                     listOf(
                         CREATED_TIME,
@@ -283,10 +283,10 @@ class MGMRegistrationServiceTest {
                 )
 
             fun getProperty(prop: String): String {
-                return persistentMemberPublished
+                return persistedMgm
                     .memberContext.items.firstOrNull { item ->
                         item.key == prop
-                    }?.value ?: persistentMemberPublished.mgmContext.items.firstOrNull { item ->
+                    }?.value ?: persistedMgm.mgmContext.items.firstOrNull { item ->
                     item.key == prop
                 }?.value ?: fail("Could not find property within published member for test")
             }
@@ -341,8 +341,8 @@ class MGMRegistrationServiceTest {
             eq(mgm),
             argThat {
                 this.size == 1 &&
-                        this.first().isMgm &&
-                        this.first().name == mgmName
+                    this.first().isMgm &&
+                    this.first().name == mgmName
             }
         )
     }
@@ -396,7 +396,7 @@ class MGMRegistrationServiceTest {
         val testProperties =
             properties + mapOf(
                 "corda.group.truststore.tls.100" to
-                        "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----"
+                    "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----"
             )
         registrationService.start()
         val result = registrationService.register(mgm, testProperties)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -4,6 +4,8 @@ import com.typesafe.config.ConfigFactory
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
+import net.corda.crypto.impl.converter.PublicKeyConverter
+import net.corda.crypto.impl.converter.PublicKeyHashConverter
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.layeredpropertymap.LayeredPropertyMapFactory
@@ -18,12 +20,25 @@ import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
-import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
+import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
+import net.corda.membership.lib.MemberInfoExtension.Companion.URL_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
+import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.impl.MemberInfoFactoryImpl
 import net.corda.membership.lib.impl.converter.EndpointInfoConverter
-import net.corda.crypto.impl.converter.PublicKeyConverter
-import net.corda.crypto.impl.converter.PublicKeyHashConverter
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.membership.registration.MembershipRequestRegistrationOutcome
@@ -40,6 +55,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.cipher.suite.KeyEncodingService
 import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.KArgumentCaptor
@@ -61,27 +77,28 @@ import java.util.concurrent.CompletableFuture
 
 class MGMRegistrationServiceTest {
     companion object {
-        private const val SESSION_KEY = "1234"
+        private const val SESSION_KEY_STRING = "1234"
         private const val SESSION_KEY_ID = "1"
-        private const val ECDH_KEY = "5678"
+        private const val ECDH_KEY_STRING = "5678"
         private const val ECDH_KEY_ID = "2"
         private const val PUBLISHER_CLIENT_ID = "mgm-registration-service"
     }
 
+    private val groupId = "43b5b6e6-4f2d-498f-8b41-5e2f8f97e7e8"
     private val mgmName = MemberX500Name("Corda MGM", "London", "GB")
-    private val mgm = HoldingIdentity(mgmName, "dummy_group")
+    private val mgm = HoldingIdentity(mgmName, groupId)
     private val mgmId = mgm.shortHash
     private val sessionKey: PublicKey = mock {
-        on { encoded } doReturn SESSION_KEY.toByteArray()
+        on { encoded } doReturn SESSION_KEY_STRING.toByteArray()
     }
     private val sessionCryptoSigningKey: CryptoSigningKey = mock {
-        on { publicKey } doReturn ByteBuffer.wrap(SESSION_KEY.toByteArray())
+        on { publicKey } doReturn ByteBuffer.wrap(SESSION_KEY_STRING.toByteArray())
     }
     private val ecdhKey: PublicKey = mock {
-        on { encoded } doReturn ECDH_KEY.toByteArray()
+        on { encoded } doReturn ECDH_KEY_STRING.toByteArray()
     }
     private val ecdhCryptoSigningKey: CryptoSigningKey = mock {
-        on { publicKey } doReturn ByteBuffer.wrap(ECDH_KEY.toByteArray())
+        on { publicKey } doReturn ByteBuffer.wrap(ECDH_KEY_STRING.toByteArray())
     }
     private val mockPublisher = mock<Publisher>().apply {
         whenever(publish(any())).thenReturn(listOf(CompletableFuture.completedFuture(Unit)))
@@ -91,11 +108,11 @@ class MGMRegistrationServiceTest {
         on { createPublisher(any(), any()) } doReturn mockPublisher
     }
     private val keyEncodingService: KeyEncodingService = mock {
-        on { decodePublicKey(SESSION_KEY.toByteArray()) } doReturn sessionKey
-        on { decodePublicKey(ECDH_KEY.toByteArray()) } doReturn ecdhKey
+        on { decodePublicKey(SESSION_KEY_STRING.toByteArray()) } doReturn sessionKey
+        on { decodePublicKey(ECDH_KEY_STRING.toByteArray()) } doReturn ecdhKey
 
-        on { encodeAsString(any()) } doReturn SESSION_KEY
-        on { encodeAsString(ecdhKey) } doReturn ECDH_KEY
+        on { encodeAsString(any()) } doReturn SESSION_KEY_STRING
+        on { encodeAsString(ecdhKey) } doReturn ECDH_KEY_STRING
     }
     private val cryptoOpsClient: CryptoOpsClient = mock {
         on { lookup(mgmId, listOf(SESSION_KEY_ID)) } doReturn listOf(sessionCryptoSigningKey)
@@ -230,14 +247,54 @@ class MGMRegistrationServiceTest {
         val publishedMgmInfoList = capturedPublishedList.firstValue
         assertSoftly {
             it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
-            it.assertThat(publishedMgmInfoList.size).isEqualTo(1)
+            it.assertThat(publishedMgmInfoList).hasSize(1)
+
             val publishedMgmInfo = publishedMgmInfoList.first()
             it.assertThat(publishedMgmInfo.topic).isEqualTo(Schemas.Membership.MEMBER_LIST_TOPIC)
+
             val expectedRecordKey = "$mgmId-$mgmId"
             it.assertThat(publishedMgmInfo.key).isEqualTo(expectedRecordKey)
+
             val persistentMemberPublished = publishedMgmInfo.value as PersistentMemberInfo
-            val mgmPublished = memberInfoFactory.create(persistentMemberPublished)
-            it.assertThat(mgmPublished.name.toString()).isEqualTo(mgmName.toString())
+
+            it.assertThat(persistentMemberPublished.memberContext.items.map { item -> item.key })
+                .containsExactlyInAnyOrderElementsOf(
+                    listOf(
+                        GROUP_ID,
+                        PARTY_NAME,
+                        PARTY_SESSION_KEY,
+                        SESSION_KEY_HASH,
+                        ECDH_KEY,
+                        PLATFORM_VERSION,
+                        SOFTWARE_VERSION,
+                        SERIAL,
+                        String.format(URL_KEY, 0),
+                        String.format(PROTOCOL_VERSION, 0),
+                    )
+                )
+            it.assertThat(persistentMemberPublished.mgmContext.items.map { item -> item.key })
+                .containsExactlyInAnyOrderElementsOf(
+                    listOf(
+                        CREATED_TIME,
+                        MODIFIED_TIME,
+                        STATUS,
+                        IS_MGM
+                    )
+                )
+
+            fun getProperty(prop: String): String {
+                return persistentMemberPublished
+                    .memberContext.items.firstOrNull { item ->
+                        item.key == prop
+                    }?.value ?: persistentMemberPublished.mgmContext.items.firstOrNull { item ->
+                    item.key == prop
+                }?.value ?: fail("Could not find property within published member for test")
+            }
+
+            it.assertThat(getProperty(PARTY_NAME)).isEqualTo(mgmName.toString())
+            it.assertThat(getProperty(GROUP_ID)).isEqualTo(groupId)
+            it.assertThat(getProperty(STATUS)).isEqualTo(MEMBER_STATUS_ACTIVE)
+            it.assertThat(getProperty(IS_MGM)).isEqualTo("true")
         }
         registrationService.stop()
     }
@@ -284,8 +341,8 @@ class MGMRegistrationServiceTest {
             eq(mgm),
             argThat {
                 this.size == 1 &&
-                    this.first().isMgm &&
-                    this.first().name == mgmName
+                        this.first().isMgm &&
+                        this.first().name == mgmName
             }
         )
     }
@@ -339,13 +396,14 @@ class MGMRegistrationServiceTest {
         val testProperties =
             properties + mapOf(
                 "corda.group.truststore.tls.100" to
-                    "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----"
+                        "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----"
             )
         registrationService.start()
         val result = registrationService.register(mgm, testProperties)
         assertSoftly {
             it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-            it.assertThat(result.message).isEqualTo("Registration failed. Reason: Provided TLS trust stores are incorrectly numbered.")
+            it.assertThat(result.message)
+                .isEqualTo("Registration failed. Reason: Provided TLS trust stores are incorrectly numbered.")
         }
         registrationService.stop()
     }

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -1,11 +1,13 @@
 package net.corda.membership.lib
 
 import net.corda.v5.base.util.NetworkHostAndPort
+import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.parse
 import net.corda.v5.base.util.parseList
 import net.corda.v5.base.util.parseOrNull
 import net.corda.v5.base.util.parseSet
 import net.corda.v5.crypto.PublicKeyHash
+import net.corda.v5.crypto.calculateHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -14,6 +16,8 @@ import java.time.Instant
 
 class MemberInfoExtension {
     companion object {
+        val logger = contextLogger()
+
         /** Key name for ledger keys property. */
         const val LEDGER_KEYS = "corda.ledger.keys"
         const val LEDGER_KEYS_KEY = "corda.ledger.keys.%s"
@@ -155,10 +159,17 @@ class MemberInfoExtension {
         val MemberInfo.ledgerKeyHashes: Collection<PublicKeyHash>
             get() = memberProvidedContext.parseSet(LEDGER_KEY_HASHES)
 
-        /** Collection of ledger key hashes for member's node. */
+        /**
+         * [PublicKeyHash] for the session initiation key.
+         * The hash value should be stored in the member context, but as a fallback it is calculated if not available.
+         * It is preferable to always store this in the member context to avoid the repeated calculation.
+         */
         @JvmStatic
         val MemberInfo.sessionKeyHash: PublicKeyHash
-            get() = memberProvidedContext.parse(SESSION_KEY_HASH)
+            get() = memberProvidedContext.parseOrNull(SESSION_KEY_HASH) ?: sessionInitiationKey.calculateHash().also {
+                logger.warn("Calculating the session key hash for $name in group $groupId. " +
+                        "It is preferable to store this hash in the member context to avoid calculating on each access.")
+            }
 
         /** Denotes whether this [MemberInfo] represents an MGM node. */
         @JvmStatic


### PR DESCRIPTION
Members receiving messages from the MGM needs to lookup the member info by session key hash. Currently we are not setting that on the mgm info loaded from the group policy file so lookup fails and message sending fails. Added session key hash set up to MGM onboarding. Also added back up hash calculation if hash is not set. This will log a warning also so that we can see when it occurs. It is better to store the hash rather than calculate so that lookups can be performed faster.