### PR TITLE
NOTICK - Set the provider in the e2e protocol library code back to BouncyCastle

### DIFF
--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
@@ -77,7 +77,7 @@ abstract class AuthenticationProtocol {
     private val hkdfGenerator = HKDFBytesGenerator(messageDigest.convertToBCDigest())
 
     fun getSignature(signatureSpec: SignatureSpec): Signature {
-        return Signature.getInstance(signatureSpec.signatureName)
+        return Signature.getInstance(signatureSpec.signatureName, provider)
     }
 
     fun generateHandshakeSecrets(inputKeyMaterial: ByteArray, initiatorHelloToResponderHello: ByteArray): SharedHandshakeSecrets {

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticationProtocolTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/AuthenticationProtocolTest.kt
@@ -35,6 +35,16 @@ class AuthenticationProtocolTest {
     }
 
     @Test
+    fun `authentication protocol works successfully with ECDSA key algorithm`() {
+        val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+        val keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", provider)
+        val partyASessionKey = keyPairGenerator.generateKeyPair()
+        val partyBSessionKey = keyPairGenerator.generateKeyPair()
+
+        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpec.ECDSA_SHA256)
+    }
+
+    @Test
     fun `authentication protocol works successfully with RSA signatures`() {
         val signature = Signature.getInstance(SignatureSpec.RSA_SHA256.signatureName, provider)
         val keyPairGenerator = KeyPairGenerator.getInstance("RSA", provider)


### PR DESCRIPTION
All the other instances in the e2e session protocol library were using the BouncyCastle provider except the signature. This was not causing issues so far, because the stubs and the tooling used were using the algorithm name `EC`. With the integration with crypto & membership components, this started being a problem, because they use the algorithm name `ECDSA` and the Java library is unable to deal with that gracefully. So, signature verification was failing with the following:
```
08:12:25.401 [durable processing thread inbound_message_processor_group-link.in] ERROR EVENT_LOG-inbound_message_processor_group-link.in-6 {} - Failed to read and process records from topic link.in, group inbound_message_processor_group, producerClientId EVENT_LOG-inbound_message_processor_group-link.in-6. Attempts: 1. Closing subscription.
net.corda.messaging.api.exception.CordaMessageAPIFatalException: Failed to process records from topic link.in, group inbound_message_processor_group, producerClientId EVENT_LOG-inbound_message_processor_group-link.in-6. Unexpected error occurred in this transaction. Closing producer.
	at net.corda.messaging.subscription.EventLogSubscriptionImpl.processDurableRecords(EventLogSubscriptionImpl.kt:288) ~[?:?]
	at net.corda.messaging.subscription.EventLogSubscriptionImpl.pollAndProcessRecords(EventLogSubscriptionImpl.kt:203) ~[?:?]
	at net.corda.messaging.subscription.EventLogSubscriptionImpl.runConsumeLoop(EventLogSubscriptionImpl.kt:165) ~[?:?]
	at net.corda.messaging.subscription.EventLogSubscriptionImpl$start$2$1.invoke(EventLogSubscriptionImpl.kt:101) ~[?:?]
	at net.corda.messaging.subscription.EventLogSubscriptionImpl$start$2$1.invoke(EventLogSubscriptionImpl.kt:101) ~[?:?]
	at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30) ~[p2p-link-manager.jar:?]
Caused by: java.security.InvalidKeyException: Not an EC key: ECDSA
	at sun.security.ec.ECKeyFactory.checkKey(ECKeyFactory.java:121) ~[jdk.crypto.ec:?]
	at sun.security.ec.ECKeyFactory.toECKey(ECKeyFactory.java:90) ~[jdk.crypto.ec:?]
	at sun.security.ec.ECDSASignature.engineInitVerify(ECDSASignature.java:285) ~[jdk.crypto.ec:?]
	at java.security.Signature$Delegate.tryOperation(Signature.java:1302) ~[?:?]
	at java.security.Signature$Delegate.chooseProvider(Signature.java:1257) ~[?:?]
	at java.security.Signature$Delegate.engineInitVerify(Signature.java:1330) ~[?:?]
	at java.security.Signature.initVerify(Signature.java:506) ~[?:?]
	at net.corda.p2p.crypto.util.CryptoUtilsKt.verify(CryptoUtils.kt:49) ~[?:?]
	at net.corda.p2p.crypto.protocol.api.AuthenticationProtocolResponder$validatePeerHandshakeMessage$2.invoke(AuthenticationProtocolResponder.kt:167) ~[?:?]
	at net.corda.p2p.crypto.protocol.api.AuthenticationProtocolResponder$validatePeerHandshakeMessage$2.invoke(AuthenticationProtocolResponder.kt:138) ~[?:?]
	at net.corda.p2p.crypto.protocol.api.AuthenticationProtocolResponder.transition(AuthenticationProtocolResponder.kt:280) ~[?:?]
	at net.corda.p2p.crypto.protocol.api.AuthenticationProtocolResponder.validatePeerHandshakeMessage(AuthenticationProtocolResponder.kt:138) ~[?:?]
	at net.corda.p2p.linkmanager.sessions.SessionManagerImpl.processInitiatorHandshake(SessionManagerImpl.kt:622) ~[?:?]
	at net.corda.p2p.linkmanager.sessions.SessionManagerImpl.access$processInitiatorHandshake(SessionManagerImpl.kt:77) ~[?:?]
	at net.corda.p2p.linkmanager.sessions.SessionManagerImpl$processSessionMessage$1.invoke(SessionManagerImpl.kt:250) ~[?:?]
	at net.corda.p2p.linkmanager.sessions.SessionManagerImpl$processSessionMessage$1.invoke(SessionManagerImpl.kt:245) ~[?:?]
	at net.corda.lifecycle.domino.logic.ComplexDominoTile.withLifecycleLock(ComplexDominoTile.kt:91) ~[?:?]
	at net.corda.p2p.linkmanager.sessions.SessionManagerImpl.processSessionMessage(SessionManagerImpl.kt:245) ~[?:?]
	at net.corda.p2p.linkmanager.InboundMessageProcessor.processSessionMessage(InboundMessageProcessor.kt:80) ~[?:?]
	at net.corda.p2p.linkmanager.InboundMessageProcessor.onNext(InboundMessageProcessor.kt:65) ~[?:?]
	at net.corda.messaging.subscription.EventLogSubscriptionImpl.processDurableRecords(EventLogSubscriptionImpl.kt:269) ~[?:?]
	... 5 more
```
This change switches the provider of the signature to be BouncyCastle too.