### PR TITLE
CORE-6050 - Reuse connection pool in membership components

### DIFF
--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/VirtualNodeDbType.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/VirtualNodeDbType.kt
@@ -1,4 +1,4 @@
-package net.corda.virtualnode.write.db.impl.writer
+package net.corda.db.connection.manager
 
 import net.corda.db.core.DbPrivilege
 import net.corda.db.core.DbPrivilege.DDL

--- a/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/CertificatesProcessorTest.kt
+++ b/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/CertificatesProcessorTest.kt
@@ -8,6 +8,7 @@ import net.corda.data.certificates.rpc.response.CertificateImportedRpcResponse
 import net.corda.data.certificates.rpc.response.CertificateRetrievalRpcResponse
 import net.corda.data.certificates.rpc.response.CertificateRpcResponse
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.membership.certificates.datamodel.Certificate
 import net.corda.membership.certificates.datamodel.ClusterCertificate
@@ -21,10 +22,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
@@ -44,19 +45,16 @@ class CertificatesProcessorTest {
     private val nodeFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn nodeEntityManager
     }
-    private val connectionId = UUID(0, 0)
     private val registry = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn registry
     }
+    private val nodeTenantId = "ID1"
     private val dbConnectionManager = mock<DbConnectionManager> {
         on { getClusterEntityManagerFactory() } doReturn clusterFactory
-        on { createEntityManagerFactory(connectionId, registry) } doReturn nodeFactory
+        on { getOrCreateEntityManagerFactory(eq("vnode_vault_id1"), eq(DbPrivilege.DML), eq(registry)) } doReturn nodeFactory
     }
-    private val nodeInfo = mock< VirtualNodeInfo> {
-        on { vaultDmlConnectionId } doReturn connectionId
-    }
-    private val nodeTenantId = "ID1"
+    private val nodeInfo = mock<VirtualNodeInfo>()
     private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
         on { getByHoldingIdentityShortHash(nodeTenantId) } doReturn nodeInfo
     }

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -238,7 +238,7 @@ class MembershipPersistenceTest {
         private val groupId = randomUUID().toString()
         private val x500Name = MemberX500Name.parse("O=Alice, C=GB, L=London")
         private val viewOwningHoldingIdentity = HoldingIdentity(x500Name, groupId)
-        private val holdingIdentityShortHash: String = viewOwningHoldingIdentity.shortHash
+        private val holdingIdentityShortHash: String = viewOwningHoldingIdentity.shortHash.lowercase()
 
         private val registeringX500Name = MemberX500Name.parse("O=Bob, C=GB, L=London")
         private val registeringHoldingIdentity = HoldingIdentity(registeringX500Name, groupId)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -3,6 +3,8 @@ package net.corda.membership.impl.persistence.service.handler
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
@@ -45,9 +47,10 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
     }
 
     private fun getEntityManagerFactory(info: VirtualNodeInfo): EntityManagerFactory {
-        return dbConnectionManager.createEntityManagerFactory(
-            info.vaultDmlConnectionId,
-            jpaEntitiesRegistry.get(CordaDb.Vault.persistenceUnitName)
+        return dbConnectionManager.getOrCreateEntityManagerFactory(
+            name = VirtualNodeDbType.VAULT.getConnectionName(info.holdingIdentity.shortHash),
+            privilege = DbPrivilege.DML,
+            entitiesSet = jpaEntitiesRegistry.get(CordaDb.Vault.persistenceUnitName)
                 ?: throw java.lang.IllegalStateException(
                     "persistenceUnitName ${CordaDb.Vault.persistenceUnitName} is not registered."
                 )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
@@ -6,6 +6,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.query.QueryGroupPolicy
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.schema.CordaDb
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.datamodel.GroupPolicyEntity
@@ -39,9 +40,6 @@ class QueryGroupPolicyHandlerTest {
     private val groupId = UUID.randomUUID().toString()
     private val holdingIdentity = createTestHoldingIdentity(x500Name, groupId)
 
-    private val vaultDmlConnectionId = UUID.randomUUID()
-    private val cryptoDmlConnectionId = UUID.randomUUID()
-
     private val clock = TestClock(Instant.ofEpochSecond(0))
 
     private val entityTransaction: EntityTransaction = mock()
@@ -53,7 +51,11 @@ class QueryGroupPolicyHandlerTest {
     }
 
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(eq(vaultDmlConnectionId), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(
+            eq(VirtualNodeDbType.VAULT.getConnectionName(holdingIdentity.shortHash)),
+            any(),
+            any()
+        ) } doReturn entityManagerFactory
     }
 
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
@@ -76,8 +78,8 @@ class QueryGroupPolicyHandlerTest {
     private val virtualNodeInfo = VirtualNodeInfo(
         holdingIdentity,
         CpiIdentifier("TEST_CPI", "1.0", null),
-        vaultDmlConnectionId = vaultDmlConnectionId,
-        cryptoDmlConnectionId = cryptoDmlConnectionId,
+        vaultDmlConnectionId = UUID(0, 0),
+        cryptoDmlConnectionId = UUID(0, 0),
         timestamp = clock.instant()
     )
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
@@ -7,6 +7,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.query.QueryMemberInfo
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.schema.CordaDb
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.datamodel.MemberInfoEntity
@@ -54,13 +55,11 @@ class QueryMemberInfoHandlerTest {
     private val ourRegistrationId = UUID.randomUUID().toString()
     private val clock = TestClock(Instant.ofEpochSecond(0))
 
-    private val vaultDmlConnectionId = UUID.randomUUID()
-    private val cryptoDmlConnectionId = UUID.randomUUID()
     private val virtualNodeInfo = VirtualNodeInfo(
         ourHoldingIdentity,
         CpiIdentifier("TEST_CPI", "1.0", null),
-        vaultDmlConnectionId = vaultDmlConnectionId,
-        cryptoDmlConnectionId = cryptoDmlConnectionId,
+        vaultDmlConnectionId = UUID(0, 0),
+        cryptoDmlConnectionId = UUID(0, 0),
         timestamp = clock.instant()
     )
 
@@ -79,7 +78,13 @@ class QueryMemberInfoHandlerTest {
     }
 
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(eq(vaultDmlConnectionId), any()) } doReturn entityManagerFactory
+        on {
+            getOrCreateEntityManagerFactory(
+                eq(VirtualNodeDbType.VAULT.getConnectionName(ourHoldingIdentity.shortHash)),
+                any(),
+                any(),
+            )
+        } doReturn entityManagerFactory
     }
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
         on { get(eq(CordaDb.Vault.persistenceUnitName)) } doReturn mock()
@@ -169,7 +174,7 @@ class QueryMemberInfoHandlerTest {
             verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
             assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
         }
-        verify(dbConnectionManager).createEntityManagerFactory(any(), any())
+        verify(dbConnectionManager).getOrCreateEntityManagerFactory(any(), any(), any())
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
         verify(entityTransaction).begin()
@@ -197,7 +202,7 @@ class QueryMemberInfoHandlerTest {
             verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
             assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
         }
-        verify(dbConnectionManager).createEntityManagerFactory(any(), any())
+        verify(dbConnectionManager).getOrCreateEntityManagerFactory(any(), any(), any())
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
         verify(entityTransaction).begin()
@@ -241,7 +246,7 @@ class QueryMemberInfoHandlerTest {
             verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
             assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
         }
-        verify(dbConnectionManager).createEntityManagerFactory(any(), any())
+        verify(dbConnectionManager).getOrCreateEntityManagerFactory(any(), any(), any())
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
         verify(entityTransaction).begin()
@@ -273,7 +278,7 @@ class QueryMemberInfoHandlerTest {
             verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
             assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
         }
-        verify(dbConnectionManager).createEntityManagerFactory(any(), any())
+        verify(dbConnectionManager).getOrCreateEntityManagerFactory(any(), any(), any())
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
         verify(entityTransaction).begin()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -10,6 +10,8 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.query.QueryMemberSignature
 import net.corda.data.membership.db.response.query.MemberSignature
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
@@ -53,9 +55,8 @@ class QueryMemberSignatureHandlerTest {
             )
         } doReturn keyValuePairListDeserializer
     }
-    private val connectionId = UUID(0, 0)
     private val virtualNodeInfo = VirtualNodeInfo(
-        vaultDmlConnectionId = connectionId,
+        vaultDmlConnectionId = UUID(0, 0),
         cpiIdentifier = CpiIdentifier(
             "", "", null
         ),
@@ -74,8 +75,9 @@ class QueryMemberSignatureHandlerTest {
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
-                connectionId,
+            getOrCreateEntityManagerFactory(
+                VirtualNodeDbType.VAULT.getConnectionName(virtualNodeInfo.holdingIdentity.shortHash),
+                DbPrivilege.DML,
                 jpaEntitiesSet
             )
         } doReturn factory

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -11,6 +11,8 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.RegistrationStatus
 import net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToApproved
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.datamodel.MemberInfoEntity
@@ -65,9 +67,8 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
             createAvroSerializer<KeyValuePairList>(any())
         } doReturn keyValuePairListSerializer
     }
-    private val connectionId = UUID(0, 0)
     private val virtualNodeInfo = VirtualNodeInfo(
-        vaultDmlConnectionId = connectionId,
+        vaultDmlConnectionId = UUID(0, 0),
         cpiIdentifier = CpiIdentifier(
             "", "", null
         ),
@@ -86,8 +87,9 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
-                connectionId,
+            getOrCreateEntityManagerFactory(
+                VirtualNodeDbType.VAULT.getConnectionName(virtualNodeInfo.holdingIdentity.shortHash),
+                DbPrivilege.DML,
                 jpaEntitiesSet
             )
         } doReturn factory

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToDeclinedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToDeclinedHandlerTest.kt
@@ -11,6 +11,8 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.RegistrationStatus
 import net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToDeclined
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.datamodel.MemberInfoEntity
@@ -63,9 +65,8 @@ class UpdateMemberAndRegistrationRequestToDeclinedHandlerTest {
             createAvroSerializer<KeyValuePairList>(any())
         } doReturn keyValuePairListSerializer
     }
-    private val connectionId = UUID(0, 0)
     private val virtualNodeInfo = VirtualNodeInfo(
-        vaultDmlConnectionId = connectionId,
+        vaultDmlConnectionId = UUID(0, 0),
         cpiIdentifier = CpiIdentifier(
             "", "", null
         ),
@@ -84,8 +85,9 @@ class UpdateMemberAndRegistrationRequestToDeclinedHandlerTest {
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
-                connectionId,
+            getOrCreateEntityManagerFactory(
+                VirtualNodeDbType.VAULT.getConnectionName(virtualNodeInfo.holdingIdentity.shortHash),
+                DbPrivilege.DML,
                 jpaEntitiesSet
             )
         } doReturn factory

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -37,8 +37,6 @@ import javax.persistence.EntityTransaction
 
 class UpdateRegistrationRequestStatusHandlerTest {
     private val clock = TestClock(Instant.ofEpochSecond(0))
-    private val vaultDmlConnectionId = UUID.randomUUID()
-    private val cryptoDmlConnectionId = UUID.randomUUID()
 
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = "cbdc24f5-35b0-4ef3-be9e-f428d273d7b1"
@@ -50,8 +48,8 @@ class UpdateRegistrationRequestStatusHandlerTest {
     private val virtualNodeInfo = VirtualNodeInfo(
         ourHoldingIdentity,
         CpiIdentifier("TEST_CPI", "1.0", null),
-        vaultDmlConnectionId = vaultDmlConnectionId,
-        cryptoDmlConnectionId = cryptoDmlConnectionId,
+        vaultDmlConnectionId = UUID(0, 0),
+        cryptoDmlConnectionId = UUID(0, 0),
         timestamp = clock.instant()
     )
 
@@ -64,7 +62,13 @@ class UpdateRegistrationRequestStatusHandlerTest {
     }
 
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(eq(vaultDmlConnectionId), any()) } doReturn entityManagerFactory
+        on {
+            getOrCreateEntityManagerFactory(
+                eq("vnode_vault_${ourHoldingIdentity.shortHash.lowercase()}"),
+                any(),
+                any()
+            )
+        } doReturn entityManagerFactory
     }
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
         on { get(eq(CordaDb.Vault.persistenceUnitName)) } doReturn mock()

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -7,6 +7,7 @@ import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.connection.manager.DBConfigurationException
 import net.corda.db.connection.manager.DbAdmin
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.core.DbPrivilege
 import net.corda.db.core.DbPrivilege.DDL
 import net.corda.db.core.DbPrivilege.DML

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactory.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactory.kt
@@ -5,13 +5,14 @@ import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.db.admin.LiquibaseSchemaMigrator
 import net.corda.db.connection.manager.DbAdmin
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.connection.manager.VirtualNodeDbType.CRYPTO
+import net.corda.db.connection.manager.VirtualNodeDbType.VAULT
 import net.corda.db.connection.manager.createDbConfig
 import net.corda.db.core.DbPrivilege
 import net.corda.db.core.DbPrivilege.DDL
 import net.corda.db.core.DbPrivilege.DML
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbType.CRYPTO
-import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbType.VAULT
 import java.security.SecureRandom
 
 /**

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -10,6 +10,9 @@ import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.data.virtualnode.VirtualNodeStateChangeRequest
 import net.corda.data.virtualnode.VirtualNodeStateChangeResponse
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.connection.manager.VirtualNodeDbType.CRYPTO
+import net.corda.db.connection.manager.VirtualNodeDbType.VAULT
 import net.corda.db.core.DbPrivilege
 import net.corda.db.core.DbPrivilege.DDL
 import net.corda.db.core.DbPrivilege.DML
@@ -19,7 +22,6 @@ import net.corda.libs.cpi.datamodel.findDbChangeLogForCpi
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
-import net.corda.membership.lib.MemberInfoExtension.Companion.id
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.Root.MGM_DEFAULT_GROUP_ID
 import net.corda.messaging.api.processor.RPCResponderProcessor
 import net.corda.messaging.api.publisher.Publisher
@@ -37,8 +39,6 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.VirtualNodeState
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
-import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbType.CRYPTO
-import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbType.VAULT
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.CompletableFuture

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -13,6 +13,7 @@ import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.core.CloseableDataSource
 import net.corda.db.core.DbPrivilege
 import net.corda.libs.configuration.SmartConfig
@@ -41,7 +42,6 @@ import net.corda.virtualnode.write.db.impl.writer.DbConnection
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDb
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbFactory
-import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbType
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeEntityRepository
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeWriterProcessor
 import org.assertj.core.api.SoftAssertions.assertSoftly


### PR DESCRIPTION
Change usage from `createEntityManagerFactory` to `getOrCreateEntityManagerFactory` to force the usage of the connection pool cache (`DbConnectionOpsCachedImpl`).

The issue was that every time we accessed the database we created a new Hikary pool with ten new connections and didn't close it. This cause PostgreSQL to use all the connections after a few calls. The exception is ` ERROR com.zaxxer.hikari.pool.HikariPool {} - HikariPool-79 - Exception during pool initialization.
org.postgresql.util.PSQLException: FATAL: remaining connection slots are reserved for non-replication superuser connections`

Testing the change shows that it removes the exception and allows reusing the pool multiple times.