### PR TITLE
CORE-6044: allocate port dynamically for health monitor tests

### DIFF
--- a/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
+++ b/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
@@ -151,6 +151,7 @@ class ConfigTests {
     private class DummyHealthMonitor : HealthMonitor {
         override fun listen(port: Int) = Unit
         override fun stop() = throw NotImplementedError()
+        override val port = 7000
     }
 
     private class DummyValidatorFactory : ConfigurationValidatorFactory {

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/HealthMonitor.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/HealthMonitor.kt
@@ -15,4 +15,7 @@ interface HealthMonitor {
 
     /** Stops serving worker health and readiness. */
     fun stop()
+
+    /** The port the health monitor listens on, once it has successfully managed to listen on a socket */
+    val port: Int?
 }

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/HealthMonitorImpl.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/HealthMonitorImpl.kt
@@ -46,6 +46,8 @@ internal class HealthMonitorImpl @Activate constructor(
             }
     }
 
+    override val port get() = server?.port()
+
     override fun stop() {
         server?.stop()
     }


### PR DESCRIPTION
Previously we just listened on port 7000, hoping it was free. On my work MacOs Monterey
machine Control centre, which is a standard part of MacOS, is already using port 7000
so the tests fail. Even if that were not the case, assuming one specific TCP port
is available introduces a race condition if s multiple test cases are running in parallel.
So, we let the OS pick the port, for test purposes.