### PR TITLE
CORE-5894: Publish end-user CLI plugins to Artifactory

### DIFF
--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'org.jetbrains.kotlin.kapt'
     id 'corda.cli-plugin-packager'
+    id 'corda.common-publishing'
 }
 
 group 'net.corda.cli.deployment'

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'org.jetbrains.kotlin.kapt'
     id 'corda.cli-plugin-packager'
+    id 'corda.common-publishing'
 }
 
 group 'net.corda.cli.deployment'


### PR DESCRIPTION
Currently including:
- CLI packaging plugin;
- Virtual Node plugin.

Such that anyone doing testing (QA and DevEx) will be able to download plugins rather than building them locally every time.