### PR TITLE
CORE-6055: Use X500 name as key in trust store map

### DIFF
--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
@@ -12,6 +12,7 @@ import net.corda.p2p.GatewayTruststore
 import net.corda.p2p.gateway.TestBase
 import net.corda.schema.Schemas
 import net.corda.test.util.eventually
+import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.junit.jupiter.api.Test
@@ -57,7 +58,7 @@ class TrustStoresMapIntegrationTests : TestBase() {
             assertThat(map.isRunning).isTrue
 
             val store = assertDoesNotThrow {
-                map.getTrustStore(ALICE_NAME, GROUP_ID)
+                map.getTrustStore(MemberX500Name.parse(ALICE_NAME), GROUP_ID)
             }
 
             val certificate = store.aliases().toList().map {

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
@@ -21,6 +21,7 @@ import java.io.StringWriter
 class TrustStoresMapIntegrationTests : TestBase() {
     companion object {
         private const val GROUP_ID = "Group-A"
+        private const val ALICE_NAME = "O=Alice, L=LDN, C=GB"
     }
     private val topicService = TopicServiceImpl()
     private val rpcTopicService = RPCTopicServiceImpl()
@@ -41,8 +42,8 @@ class TrustStoresMapIntegrationTests : TestBase() {
                 listOf(
                     Record(
                         Schemas.P2P.GATEWAY_TLS_TRUSTSTORES,
-                        "alice-$GROUP_ID",
-                        GatewayTruststore(HoldingIdentity("alice", GROUP_ID), listOf(expectedCertificatePem))
+                        "$ALICE_NAME-$GROUP_ID",
+                        GatewayTruststore(HoldingIdentity(ALICE_NAME, GROUP_ID), listOf(expectedCertificatePem))
                     )
                 )
             ).forEach {
@@ -56,7 +57,7 @@ class TrustStoresMapIntegrationTests : TestBase() {
             assertThat(map.isRunning).isTrue
 
             val store = assertDoesNotThrow {
-                map.getTrustStore("alice", GROUP_ID)
+                map.getTrustStore(ALICE_NAME, GROUP_ID)
             }
 
             val certificate = store.aliases().toList().map {

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -49,8 +49,8 @@ internal class TrustStoresMap(
         emptyList()
     )
 
-    fun getTrustStore(sourceX500Name: String, destinationGroupId: String) =
-        trustRootsPerHoldingIdentity[createKey(sourceX500Name, destinationGroupId)]
+    fun getTrustStore(sourceX500Name: MemberX500Name, destinationGroupId: String) =
+        trustRootsPerHoldingIdentity[TruststoreKey(sourceX500Name, destinationGroupId)]
             ?.trustStore
             ?: throw IllegalArgumentException("Unknown trust store for source X500 name ($sourceX500Name) " +
                     "and group ID ($destinationGroupId)")

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -17,6 +17,7 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTruststore
 import net.corda.schema.Schemas
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 
 internal class TrustStoresMap(
@@ -49,7 +50,7 @@ internal class TrustStoresMap(
     )
 
     fun getTrustStore(sourceX500Name: String, destinationGroupId: String) =
-        trustRootsPerHoldingIdentity[TruststoreKey(sourceX500Name, destinationGroupId)]
+        trustRootsPerHoldingIdentity[createKey(sourceX500Name, destinationGroupId)]
             ?.trustStore
             ?: throw IllegalArgumentException("Unknown trust store for source X500 name ($sourceX500Name) " +
                     "and group ID ($destinationGroupId)")
@@ -92,12 +93,12 @@ internal class TrustStoresMap(
         override fun onSnapshot(currentData: Map<String, GatewayTruststore>) {
             // Using source group ID here, since source and identity are expected to be in the same group.
             val newEntriesPerKey = currentData.mapValues {
-                TruststoreKey(it.value.sourceIdentity.x500Name, it.value.sourceIdentity.groupId)
+                createKey(it.value.sourceIdentity.x500Name, it.value.sourceIdentity.groupId)
             }
             entriesPerKey.putAll(newEntriesPerKey)
 
             val newTrustRoots = currentData.map {
-                val truststoreKey = TruststoreKey(it.value.sourceIdentity.x500Name, it.value.sourceIdentity.groupId)
+                val truststoreKey = createKey(it.value.sourceIdentity.x500Name, it.value.sourceIdentity.groupId)
                 truststoreKey to TrustedCertificates(it.value.trustedCertificates, certificateFactory)
             }.toMap()
             trustRootsPerHoldingIdentity.putAll(newTrustRoots)
@@ -114,7 +115,7 @@ internal class TrustStoresMap(
             val value = newRecord.value
 
             if (value != null) {
-                val truststoreKey = TruststoreKey(value.sourceIdentity.x500Name, value.sourceIdentity.groupId)
+                val truststoreKey = createKey(value.sourceIdentity.x500Name, value.sourceIdentity.groupId)
                 entriesPerKey[newRecord.key] = truststoreKey
                 val trustedCertificates = TrustedCertificates(value.trustedCertificates, certificateFactory)
                 trustRootsPerHoldingIdentity[truststoreKey] = trustedCertificates
@@ -131,5 +132,12 @@ internal class TrustStoresMap(
         }
     }
 
-    private data class TruststoreKey(val sourceX500Name: String, val destinationGroupId: String)
+    private fun createKey(sourceX500Name: String, destinationGroupId: String) : TruststoreKey {
+        return TruststoreKey(
+            MemberX500Name.parse(sourceX500Name),
+            destinationGroupId,
+        )
+    }
+
+    private data class TruststoreKey(val sourceX500Name: MemberX500Name, val destinationGroupId: String)
 }

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
@@ -26,6 +26,7 @@ import net.corda.p2p.gateway.messaging.http.HttpResponse
 import net.corda.p2p.gateway.messaging.http.SniCalculator
 import net.corda.p2p.gateway.messaging.http.TrustStoresMap
 import net.corda.schema.Schemas.P2P.Companion.LINK_OUT_TOPIC
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.debug
 import org.bouncycastle.asn1.x500.X500Name
 import org.slf4j.LoggerFactory
@@ -92,8 +93,10 @@ internal class OutboundMessageHandler(
             val peerMessage = event.value
             return@withLifecycleLock if (peerMessage != null) {
                 try {
-                    val trustStore = trustStoresMap.getTrustStore(peerMessage.header.sourceIdentity.x500Name,
-                                                                  peerMessage.header.destinationIdentity.groupId)
+                    val trustStore = trustStoresMap.getTrustStore(
+                        MemberX500Name.parse(peerMessage.header.sourceIdentity.x500Name),
+                        peerMessage.header.destinationIdentity.groupId
+                    )
 
                     val sni = SniCalculator.calculateSni(
                         peerMessage.header.destinationIdentity.x500Name,

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
@@ -14,6 +14,7 @@ import net.corda.messaging.api.subscription.CompactedSubscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.GatewayTruststore
 import net.corda.schema.Schemas
+import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -103,7 +104,7 @@ class TrustStoresMapTest {
             emptyMap()
         )
 
-        assertThat(testObject.getTrustStore(sourceX500Name, groupId)).isEqualTo(keyStore)
+        assertThat(testObject.getTrustStore(MemberX500Name.parse(sourceX500Name), groupId)).isEqualTo(keyStore)
     }
 
     @Test
@@ -115,7 +116,8 @@ class TrustStoresMapTest {
         processor.firstValue.onNext(
             Record(
                 Schemas.P2P.GATEWAY_TLS_TRUSTSTORES,
-                "key", GatewayTruststore(
+                "key",
+                GatewayTruststore(
                     HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", groupId),
                     listOf("one")
                 )
@@ -124,7 +126,13 @@ class TrustStoresMapTest {
             emptyMap()
         )
 
-        assertThat(testObject.getTrustStore("C=GB,   CN=Alice, O=Alice Corp, L=LDN", groupId)).isEqualTo(keyStore)
+        assertThat(
+            testObject.getTrustStore(
+                MemberX500Name.parse("C=GB,   CN=Alice, O=Alice Corp, L=LDN"),
+                groupId
+            )
+        )
+            .isEqualTo(keyStore)
     }
 
     @Test
@@ -146,7 +154,7 @@ class TrustStoresMapTest {
         )
 
         assertThrows<IllegalArgumentException> {
-            testObject.getTrustStore(sourceX500Name, groupId)
+            testObject.getTrustStore(MemberX500Name.parse(sourceX500Name), groupId)
         }
     }
 
@@ -160,7 +168,7 @@ class TrustStoresMapTest {
             )
         )
 
-        assertThat(testObject.getTrustStore(sourceX500Name, groupId)).isEqualTo(keyStore)
+        assertThat(testObject.getTrustStore(MemberX500Name.parse(sourceX500Name), groupId)).isEqualTo(keyStore)
     }
 
     @Test
@@ -174,7 +182,7 @@ class TrustStoresMapTest {
             )
         )
 
-        testObject.getTrustStore(sourceX500Name, groupId)
+        testObject.getTrustStore(MemberX500Name.parse(sourceX500Name), groupId)
 
         verify(keyStore).setCertificateEntry("gateway-0", certificate)
         verify(keyStore).setCertificateEntry("gateway-1", certificate)
@@ -191,7 +199,7 @@ class TrustStoresMapTest {
             )
         )
 
-        testObject.getTrustStore(sourceX500Name, groupId)
+        testObject.getTrustStore(MemberX500Name.parse(sourceX500Name), groupId)
 
         verify(keyStore).load(null, null)
     }
@@ -209,7 +217,7 @@ class TrustStoresMapTest {
             )
         )
 
-        testObject.getTrustStore(sourceX500Name, groupId)
+        testObject.getTrustStore(MemberX500Name.parse(sourceX500Name), groupId)
 
         assertThat(data.firstValue.reader().readText()).isEqualTo("one")
         assertThat(data.secondValue.reader().readText()).isEqualTo("two")

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
@@ -100,10 +100,31 @@ class TrustStoresMapTest {
         processor.firstValue.onNext(
             Record(Schemas.P2P.GATEWAY_TLS_TRUSTSTORES, "key", GatewayTruststore(HoldingIdentity(sourceX500Name, groupId), listOf("one"))),
             null,
-            emptyMap(),
+            emptyMap()
         )
 
         assertThat(testObject.getTrustStore(sourceX500Name, groupId)).isEqualTo(keyStore)
+    }
+
+    @Test
+    fun `getTrustStore will use normalized X500 name`() {
+        creteResources.get()?.invoke(mock())
+        processor.firstValue.onSnapshot(emptyMap())
+
+        val groupId = "group id 1"
+        processor.firstValue.onNext(
+            Record(
+                Schemas.P2P.GATEWAY_TLS_TRUSTSTORES,
+                "key", GatewayTruststore(
+                    HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", groupId),
+                    listOf("one")
+                )
+            ),
+            null,
+            emptyMap()
+        )
+
+        assertThat(testObject.getTrustStore("C=GB,   CN=Alice, O=Alice Corp, L=LDN", groupId)).isEqualTo(keyStore)
     }
 
     @Test
@@ -121,7 +142,7 @@ class TrustStoresMapTest {
         processor.firstValue.onNext(
             Record(Schemas.P2P.GATEWAY_TLS_TRUSTSTORES, "key", null),
             null,
-            emptyMap(),
+            emptyMap()
         )
 
         assertThrows<IllegalArgumentException> {
@@ -149,7 +170,7 @@ class TrustStoresMapTest {
         creteResources.get()?.invoke(mock())
         processor.firstValue.onSnapshot(
             mapOf(
-                "key" to GatewayTruststore(HoldingIdentity(sourceX500Name, groupId), listOf("one", "two")),
+                "key" to GatewayTruststore(HoldingIdentity(sourceX500Name, groupId), listOf("one", "two"))
             )
         )
 
@@ -166,7 +187,7 @@ class TrustStoresMapTest {
         creteResources.get()?.invoke(mock())
         processor.firstValue.onSnapshot(
             mapOf(
-                "key" to GatewayTruststore(HoldingIdentity(sourceX500Name, groupId), listOf("one", "two")),
+                "key" to GatewayTruststore(HoldingIdentity(sourceX500Name, groupId), listOf("one", "two"))
             )
         )
 
@@ -184,7 +205,7 @@ class TrustStoresMapTest {
         creteResources.get()?.invoke(mock())
         processor.firstValue.onSnapshot(
             mapOf(
-                "key" to GatewayTruststore(HoldingIdentity(sourceX500Name, groupId), listOf("one", "two")),
+                "key" to GatewayTruststore(HoldingIdentity(sourceX500Name, groupId), listOf("one", "two"))
             )
         )
 

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandlerTest.kt
@@ -29,13 +29,13 @@ import net.corda.p2p.gateway.messaging.http.HttpClient
 import net.corda.p2p.gateway.messaging.http.HttpResponse
 import net.corda.p2p.gateway.messaging.http.TrustStoresMap
 import net.corda.test.util.MockTimeFacilitiesProvider
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.millis
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.asn1.x500.X500Name
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mockConstruction
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -57,6 +57,7 @@ import java.util.concurrent.ScheduledExecutorService
 class OutboundMessageHandlerTest {
     companion object {
         private const val GROUP_ID = "My group ID"
+        private const val VALID_X500_NAME = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
     }
 
     private val mockTimeFacilitiesProvider = MockTimeFacilitiesProvider()
@@ -92,7 +93,7 @@ class OutboundMessageHandlerTest {
     }
     private val truststore = mock<KeyStore>()
     private val trustStores = mockConstruction(TrustStoresMap::class.java) { mock, _ ->
-        whenever(mock.getTrustStore(anyString(), eq(GROUP_ID))).doReturn(truststore)
+        whenever(mock.getTrustStore(any(), eq(GROUP_ID))).doReturn(truststore)
         val mockDominoTile = mock<ComplexDominoTile> {
             whenever(it.coordinatorName).doReturn(LifecycleCoordinatorName("", ""))
         }
@@ -173,7 +174,7 @@ class OutboundMessageHandlerTest {
         }.build()
         val headers = LinkOutHeader(
             HoldingIdentity("b", GROUP_ID),
-            HoldingIdentity("a", GROUP_ID),
+            HoldingIdentity(VALID_X500_NAME, GROUP_ID),
             NetworkType.CORDA_5,
             "https://r3.com/",
         )
@@ -231,7 +232,7 @@ class OutboundMessageHandlerTest {
         }.build()
         val headers = LinkOutHeader(
             HoldingIdentity("b", GROUP_ID),
-            HoldingIdentity("a", GROUP_ID),
+            HoldingIdentity(VALID_X500_NAME, GROUP_ID),
             NetworkType.CORDA_5,
             "https://r3.com/",
         )
@@ -329,7 +330,7 @@ class OutboundMessageHandlerTest {
         }.build()
         val headers = LinkOutHeader(
             HoldingIdentity("bbb", GROUP_ID),
-            HoldingIdentity("aaa", GROUP_ID),
+            HoldingIdentity(VALID_X500_NAME, GROUP_ID),
             NetworkType.CORDA_4,
             "https://r3.com/",
         )
@@ -341,7 +342,8 @@ class OutboundMessageHandlerTest {
 
         handler.onNext(Record("", "", message))
 
-        verify(trustStores.constructed().first()).getTrustStore("aaa", GROUP_ID)
+        verify(trustStores.constructed().first())
+            .getTrustStore(MemberX500Name.parse(VALID_X500_NAME), GROUP_ID)
     }
 
     @Test
@@ -365,7 +367,7 @@ class OutboundMessageHandlerTest {
         }.build()
         val headers = LinkOutHeader(
             HoldingIdentity("b", GROUP_ID),
-            HoldingIdentity("a", GROUP_ID),
+            HoldingIdentity(VALID_X500_NAME, GROUP_ID),
             NetworkType.CORDA_5,
             "https://r3.com/",
         )
@@ -405,7 +407,7 @@ class OutboundMessageHandlerTest {
         }.build()
         val headers = LinkOutHeader(
             HoldingIdentity("b", GROUP_ID),
-            HoldingIdentity("a", GROUP_ID),
+            HoldingIdentity(VALID_X500_NAME, GROUP_ID),
             NetworkType.CORDA_5,
             "https://r3.com/",
         )
@@ -450,7 +452,7 @@ class OutboundMessageHandlerTest {
         }.build()
         val headers = LinkOutHeader(
             HoldingIdentity("b", GROUP_ID),
-            HoldingIdentity("a", GROUP_ID),
+            HoldingIdentity(VALID_X500_NAME, GROUP_ID),
             NetworkType.CORDA_5,
             "https://r3.com/",
         )
@@ -493,7 +495,7 @@ class OutboundMessageHandlerTest {
         }.build()
         val headers = LinkOutHeader(
             HoldingIdentity("b", GROUP_ID),
-            HoldingIdentity("a", GROUP_ID),
+            HoldingIdentity(VALID_X500_NAME, GROUP_ID),
             NetworkType.CORDA_5,
             "https://r3.com/",
         )


### PR DESCRIPTION
Change the key of the Trust store map to be `MemberX500Name`.