### PR TITLE
CORE-6058: Fix `PermissionManagementCacheService` coordinator registration closure

### DIFF
--- a/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
+++ b/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
@@ -182,6 +182,10 @@ class PermissionManagementCacheService @Activate constructor(
     }
 
     private fun createAndStartSubscriptionsAndCache(config: SmartConfig) {
+        // It is important to close `topicsRegistration` ahead of closing `userSubscription`,
+        // `groupSubscription`, etc. Failure to do so will cause `coordinator` to go into
+        // error state as followed dependency will be closed whilst registration is still active.
+        topicsRegistration?.close()
 
         userSubscription?.close()
         userSubscription = createUserSubscription(userData, config)
@@ -207,7 +211,6 @@ class PermissionManagementCacheService @Activate constructor(
                 it.start()
             }
 
-        topicsRegistration?.close()
         topicsRegistration = coordinator.followStatusChangesByName(
             setOf(
                 userSubscription!!.subscriptionName, groupSubscription!!.subscriptionName,


### PR DESCRIPTION
Error observed in the logs without this change:
```
{"instant":{"epochSecond":1659625609,"nanoOfSecond":145000000},"thread":"lifecycle-coordinator-14","level":"ERROR","loggerName":"net.corda.lifecycle.impl.LifecycleProcessor","message":"Registration(registeringCoordinator=net.corda.permissions.management.cache.PermissionManagementCacheService,coordinators=rpc.permissions.user-COMPACTED-PERMISSION_SERVICE-COMPACTED-PERMISSION_SERVICE-rpc.permissions.user-3, rpc.permissions.group-COMPACTED-PERMISSION_SERVICE-COMPACTED-PERMISSION_SERVICE-rpc.permissions.group-6, rpc.permissions.role-COMPACTED-PERMISSION_SERVICE-COMPACTED-PERMISSION_SERVICE-rpc.permissions.role-7, rpc.permissions.permission-COMPACTED-PERMISSION_SERVICE-COMPACTED-PERMISSION_SERVICE-rpc.permissions.permission-8) on rpc.permissions.user-COMPACTED-PERMISSION_SERVICE-COMPACTED-PERMISSION_SERVICE-rpc.permissions.user-3 not closed.","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":46,"threadPriority":5}
```