### PR TITLE
CORE-6062 Component "virtual.node.creation.request-RPC_SENDER-virtual.node.management" down after startup

### DIFF
--- a/libs/messaging/db-message-bus-impl/src/integrationTest/kotlin/net/corda/messagebus/db/persistence/DBAccessIntegrationTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/integrationTest/kotlin/net/corda/messagebus/db/persistence/DBAccessIntegrationTest.kt
@@ -393,6 +393,8 @@ class DBAccessIntegrationTest {
         val topic = randomId()
         val expectedResult = setOf(
             CordaTopicPartition(topic, 0),
+            CordaTopicPartition(topic, 1),
+            CordaTopicPartition(topic, 2),
         )
 
         assertThat(dbAccess.getTopicPartitionMapFor(topic)).isEqualTo(expectedResult)

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
@@ -27,8 +27,9 @@ import javax.persistence.PersistenceException
 class DBAccess(
     private val entityManagerFactory: EntityManagerFactory,
 ) {
-
-    private val defaultNumPartitions = 1
+    // At the moment it's not easy to create partitions, so default value increased to 3 until tooling is available
+    // (There are multiple consumers using the same group for some topics and some stay idle if there is only 1 partition)
+    private val defaultNumPartitions = 3
     private val autoCreate = true
 
     companion object {


### PR DESCRIPTION
- Increased the number of default partition for DB message bus to 3