### PR TITLE
CORE-5324 Correct Cpi/ Cpb v1 format in `packaging-verify` library

### DIFF
--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1Verifier.kt
@@ -5,12 +5,9 @@ import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants.CPB_FORMAT_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPB_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPB_VERSION_ATTRIBUTE
-import net.corda.libs.packaging.PackagingConstants.CPI_GROUP_POLICY_ENTRY
 import net.corda.libs.packaging.PackagingConstants.CPK_FILE_EXTENSION
 import net.corda.libs.packaging.core.exception.PackagingException
-import net.corda.libs.packaging.verify.internal.cpi.GroupPolicy
 import net.corda.libs.packaging.verify.internal.cpk.CpkV1Verifier
-import net.corda.libs.packaging.verify.internal.firstOrThrow
 import net.corda.libs.packaging.verify.internal.requireAttribute
 import net.corda.libs.packaging.verify.internal.requireAttributeValueIn
 import java.util.TreeMap
@@ -23,7 +20,6 @@ class CpbV1Verifier internal constructor(private val packageType: String, jarRea
     private val name = jarReader.jarName
     private val manifest: Manifest = jarReader.manifest
     private val cpkVerifiers: List<CpkV1Verifier>
-    private val groupPolicy: GroupPolicy
 
     constructor (jarReader: JarReader): this("CPB", jarReader)
 
@@ -31,8 +27,6 @@ class CpbV1Verifier internal constructor(private val packageType: String, jarRea
         cpkVerifiers = jarReader.entries.filter(::isCpk).map {
             CpkV1Verifier(JarReader("$name/${it.name}", it.createInputStream(), jarReader.trustedCerts))
         }
-        groupPolicy = jarReader.entries.filter(::isGroupPolicy).map { GroupPolicy() }
-            .firstOrThrow(PackagingException("Group policy not found in $packageType \"$name\""))
     }
 
     private fun isCpk(entry: JarReader.Entry): Boolean {
@@ -41,9 +35,6 @@ class CpbV1Verifier internal constructor(private val packageType: String, jarRea
             it.endsWith(CPK_FILE_EXTENSION, ignoreCase = true)
         }
     }
-
-    private fun isGroupPolicy(entry: JarReader.Entry): Boolean =
-        entry.name.endsWith(CPI_GROUP_POLICY_ENTRY, ignoreCase = true)
 
     private fun verifyManifest() {
         with (manifest) {
@@ -67,6 +58,5 @@ class CpbV1Verifier internal constructor(private val packageType: String, jarRea
     override fun verify() {
         verifyManifest()
         verifyCpks()
-        groupPolicy.verify()
     }
 }

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1Verifier.kt
@@ -1,16 +1,29 @@
 package net.corda.libs.packaging.verify.internal.cpi
 
+import net.corda.libs.packaging.PackagingConstants
+import net.corda.libs.packaging.core.exception.PackagingException
 import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.verify.internal.cpb.CpbV1Verifier
+import net.corda.libs.packaging.verify.internal.firstOrThrow
 
 /**
  * Verifies CPI format 1.0
  */
 class CpiV1Verifier(jarReader: JarReader): CpiVerifier {
-    // CPB and CPI format 1 are same
+    private val name = jarReader.jarName
     private val verifier = CpbV1Verifier("CPI", jarReader)
+    private val groupPolicy: GroupPolicy
+
+    init {
+        groupPolicy = jarReader.entries.filter(::isGroupPolicy).map { GroupPolicy() }
+            .firstOrThrow(PackagingException("Group policy not found in CPI \"$name\""))
+    }
+
+    private fun isGroupPolicy(entry: JarReader.Entry): Boolean =
+        entry.name.equals("META-INF/${PackagingConstants.CPI_GROUP_POLICY_ENTRY}", ignoreCase = true)
 
     override fun verify() {
         verifier.verify()
+        groupPolicy.verify()
     }
 }

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV1VerifierTest.kt
@@ -10,7 +10,6 @@ import net.corda.libs.packaging.testutils.TestUtils.BOB
 import net.corda.libs.packaging.testutils.TestUtils.ROOT_CA
 import net.corda.libs.packaging.testutils.TestUtils.signedBy
 import net.corda.libs.packaging.testutils.cpb.TestCpbV1Builder
-import net.corda.libs.packaging.testutils.cpb.TestCpbV1Builder.Companion.POLICY_FILE
 import net.corda.libs.packaging.testutils.cpk.TestCpkV1Builder
 import net.corda.test.util.InMemoryZipFile
 import net.corda.v5.crypto.SecureHash
@@ -48,7 +47,7 @@ class CpbV1VerifierTest {
         val exception = assertThrows<InvalidSignatureException> {
             verify(cpb)
         }
-        assertEquals("File $POLICY_FILE is not signed in package \"test.cpb\"", exception.message)
+        assertEquals("File testCpk1-1.0.0.0.cpk is not signed in package \"test.cpb\"", exception.message)
     }
 
     @Test

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpi/CpiV1VerifierTest.kt
@@ -11,7 +11,6 @@ import net.corda.libs.packaging.testutils.TestUtils.BOB
 import net.corda.libs.packaging.testutils.TestUtils.ROOT_CA
 import net.corda.libs.packaging.testutils.TestUtils.signedBy
 import net.corda.libs.packaging.testutils.cpb.TestCpbV1Builder
-import net.corda.libs.packaging.testutils.cpb.TestCpbV1Builder.Companion.POLICY_FILE
 import net.corda.libs.packaging.testutils.cpk.TestCpkV1Builder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -21,6 +20,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.io.BufferedReader
+import net.corda.libs.packaging.testutils.cpi.TestCpiV1Builder
+import net.corda.libs.packaging.testutils.cpi.TestCpiV1Builder.Companion.POLICY_FILE
 
 class CpiV1VerifierTest {
     private fun verify(cpi: InMemoryZipFile) {
@@ -31,7 +32,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `successfully verifies valid CPI`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -42,7 +43,13 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if CPI not signed`() {
-        val cpi = TestCpbV1Builder().build()
+        val cpi =
+            TestCpiV1Builder()
+                .cpb(
+                    TestCpbV1Builder()
+                        .signers(ALICE)
+                )
+                .build()
 
         val exception = assertThrows<InvalidSignatureException> {
             verify(cpi)
@@ -52,7 +59,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if CPI has no manifest`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -66,7 +73,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if entry deleted from Manifest`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -83,7 +90,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if entry deleted from signature file`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -105,7 +112,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if entry deleted from one of multiple signature files`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE, BOB)
             .build()
 
@@ -127,7 +134,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if file modified in CPI`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -141,7 +148,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if unsigned file added to CPI`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -155,7 +162,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if signed file added to CPI`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -170,7 +177,7 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if file deleted in CPI`() {
-        val cpi = TestCpbV1Builder()
+        val cpi = TestCpiV1Builder()
             .signers(ALICE)
             .build()
 
@@ -184,8 +191,11 @@ class CpiV1VerifierTest {
 
     @Test
     fun `throws if CPK dependencies not satisfied`() {
-        val cpi = TestCpbV1Builder()
-            .cpks(TestCpkV1Builder().dependencies(TestUtils.Dependency("notExisting.cpk", "1.0.0.0")))
+        val cpi = TestCpiV1Builder()
+            .cpb(
+                TestCpbV1Builder()
+                    .cpks(TestCpkV1Builder().dependencies(TestUtils.Dependency("notExisting.cpk", "1.0.0.0")))
+            )
             .signers(ALICE)
             .build()
 

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpb/TestCpbV1Builder.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpb/TestCpbV1Builder.kt
@@ -9,16 +9,11 @@ import java.io.ByteArrayInputStream
 import java.util.jar.Manifest
 
 class TestCpbV1Builder {
-    companion object {
-        val POLICY_FILE = "META-INF/GroupPolicy.json"
-    }
     var name = "testCpbV1.cpb"
         private set
     var version = "1.0.0.0"
         private set
     var manifest: Manifest? = null
-        private set
-    var policy = "{\"groupId\":\"test\"}"
         private set
     var cpks = arrayOf<TestCpkV1Builder>(
             TestCpkV1Builder().name("testCpk1-1.0.0.0.cpk").bundleName("test.cpk1").bundleVersion("1.0.0.0"),
@@ -32,13 +27,11 @@ class TestCpbV1Builder {
     fun name(name: String) = apply { this.name = name }
     fun version(version: String) = apply { this.version = version }
     fun manifest(manifest: Manifest) = apply { this.manifest = manifest }
-    fun policy(policy: String) = apply { this.policy = policy }
     fun cpks(vararg cpks: TestCpkV1Builder) = apply { this.cpks = arrayOf(*cpks) }
     fun signers(vararg signers: TestUtils.Signer) = apply { this.signers = arrayOf(*signers) }
     fun build() =
         InMemoryZipFile().apply {
             setManifest(manifest ?: cpbV1Manifest())
-            addFile(POLICY_FILE, policy)
             cpks.forEach {
                 if (it.signers.isEmpty()) it.signers(signers = signers)
                 it.build().use { cpk ->

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpb/TestCpbV2Builder.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpb/TestCpbV2Builder.kt
@@ -15,8 +15,6 @@ class TestCpbV2Builder {
         private set
     var manifest: Manifest? = null
         private set
-    var policy = "{\"groupId\":\"test\"}"
-        private set
     var cpks = arrayOf<TestCpkV2Builder>(
             TestCpkV2Builder().name("testCpk1-1.0.0.0.jar").bundleName("test.cpk1").bundleVersion("1.0.0.0"),
             TestCpkV2Builder().name("testCpk2-2.0.0.0.jar").bundleName("test.cpk2").bundleVersion("2.0.0.0")

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpi/TestCpiV1Builder.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpi/TestCpiV1Builder.kt
@@ -1,0 +1,30 @@
+package net.corda.libs.packaging.testutils.cpi
+
+import net.corda.libs.packaging.testutils.TestUtils
+import net.corda.libs.packaging.testutils.TestUtils.addFile
+import net.corda.libs.packaging.testutils.TestUtils.signedBy
+import net.corda.libs.packaging.testutils.cpb.TestCpbV1Builder
+import net.corda.test.util.InMemoryZipFile
+
+class TestCpiV1Builder {
+    companion object {
+        val POLICY_FILE = "META-INF/GroupPolicy.json"
+    }
+    var policy = "{\"groupId\":\"test\"}"
+        private set
+    var cpb = TestCpbV1Builder()
+        private set
+    var signers: Array<out TestUtils.Signer> = emptyArray()
+        private set
+
+    fun policy(policy: String) = apply { this.policy = policy }
+    fun cpb(cpb: TestCpbV1Builder) = apply { this.cpb = cpb }
+    fun signers(vararg signers: TestUtils.Signer) = apply { this.signers = signers }
+
+    fun build(): InMemoryZipFile {
+        if (cpb.signers.isEmpty()) cpb.signers(signers = signers)
+        return cpb.build().apply {
+            addFile(POLICY_FILE, policy)
+        }.signedBy(signers = signers)
+    }
+}

--- a/testing/packaging-test-utilities/src/test/kotlin/net/corda/libs/packaging/testutils/cpi/TestCpiV1BuilderTest.kt
+++ b/testing/packaging-test-utilities/src/test/kotlin/net/corda/libs/packaging/testutils/cpi/TestCpiV1BuilderTest.kt
@@ -1,0 +1,123 @@
+package net.corda.libs.packaging.testutils.cpi
+
+import java.util.jar.JarInputStream
+import java.util.jar.Manifest
+import net.corda.libs.packaging.testutils.TestUtils
+import net.corda.libs.packaging.testutils.TestUtils.ALICE
+import net.corda.libs.packaging.testutils.TestUtils.BOB
+import net.corda.libs.packaging.testutils.cpb.TestCpbV1Builder
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TestCpiV1BuilderTest {
+
+    companion object {
+        const val CPB_SIGNER_NAME = "CPB_SIG"
+        const val CPI_SIGNER_NAME = "CPI_SIG"
+        val CPB_SIGNER = TestUtils.Signer(CPB_SIGNER_NAME, ALICE.privateKeyEntry)
+        val CPI_SIGNER = TestUtils.Signer(CPI_SIGNER_NAME, BOB.privateKeyEntry)
+    }
+
+    @Test
+    fun `TestCpiV1Builder produces expected cpi v1 format`() {
+        val cpiV1 =
+            TestCpiV1Builder()
+                .cpb(
+                    TestCpbV1Builder()
+                        .signers(CPB_SIGNER)
+                )
+                .signers(CPI_SIGNER)
+                .build()
+                .inputStream()
+
+        JarInputStream(cpiV1).use { cpiInStream ->
+            val manifest = cpiInStream.manifest
+            assertCpiV1Manifest(manifest)
+            assertCpiV1JarEntries(cpiInStream)
+        }
+    }
+}
+
+@Suppress("NestedBlockDepth", "ComplexMethod")
+private fun assertCpiV1Manifest(cpiV1Manifest: Manifest) {
+    // main attributes
+    var containsCpbFormat = false
+    var containsCpbName = false
+    var containsCpbVersion = false
+
+    // signing related entries
+    var containsGroupPolicySig = false
+    var containsTestCpk1Sig = false
+    var containsTestCpk2Sig = false
+
+    run breaking@{
+        cpiV1Manifest.mainAttributes.forEach {
+            when (it.key.toString()) {
+                "Corda-CPB-Format" -> {
+                    if (it.value != "1.0")
+                        return@breaking
+                    containsCpbFormat = true
+                }
+                "Corda-CPB-Name" -> {
+                    if (it.value != "testCpbV1.cpb")
+                        return@breaking
+                    containsCpbName = true
+                }
+                "Corda-CPB-Version" -> {
+                    if (it.value != "1.0.0.0")
+                        return@breaking
+                    containsCpbVersion = true
+                }
+            }
+        }
+    }
+
+    cpiV1Manifest.entries.forEach {
+        when (it.key) {
+            "META-INF/GroupPolicy.json" -> containsGroupPolicySig = true
+            "testCpk1-1.0.0.0.cpk" -> containsTestCpk1Sig = true
+            "testCpk2-2.0.0.0.cpk" -> containsTestCpk2Sig = true
+        }
+    }
+
+    assertTrue(containsCpbFormat)
+    assertTrue(containsCpbName)
+    assertTrue(containsCpbVersion)
+    assertTrue(containsGroupPolicySig)
+    assertTrue(containsTestCpk1Sig)
+    assertTrue(containsTestCpk2Sig)
+    assertTrue(containsCpbFormat)
+}
+
+@Suppress("ComplexMethod")
+private fun assertCpiV1JarEntries(cpiInStream: JarInputStream) {
+    var testCpk1Exists = false
+    var testCpk2Exists = false
+    var cpbSigFileExists = false
+    var cpbSigBlockFileExists = false
+    var cpiSigFileExists = false
+    var cpiSigBlockFileExists = false
+    var groupPolicyExists = false
+
+    while (true) {
+        val nextEntry = cpiInStream.nextEntry ?: break
+
+        when (nextEntry.name) {
+            "testCpk1-1.0.0.0.cpk" -> testCpk1Exists = true
+            "testCpk2-2.0.0.0.cpk" -> testCpk2Exists = true
+            "META-INF/${TestCpiV1BuilderTest.CPB_SIGNER_NAME}.SF" -> cpbSigFileExists = true
+            "META-INF/${TestCpiV1BuilderTest.CPB_SIGNER_NAME}.EC" -> cpbSigBlockFileExists = true
+            "META-INF/${TestCpiV1BuilderTest.CPI_SIGNER_NAME}.SF" -> cpiSigFileExists = true
+            "META-INF/${TestCpiV1BuilderTest.CPI_SIGNER_NAME}.EC" -> cpiSigBlockFileExists = true
+            "META-INF/GroupPolicy.json" -> groupPolicyExists = true
+        }
+    }
+
+    assertTrue(testCpk1Exists)
+    assertTrue(testCpk2Exists)
+    assertTrue(cpbSigFileExists)
+    assertTrue(cpbSigBlockFileExists)
+    assertTrue(cpiSigFileExists)
+    assertTrue(cpiSigBlockFileExists)
+    assertTrue(groupPolicyExists)
+}


### PR DESCRIPTION
Currently `CpbV1Verifier` expects a Cpb v1 to contain a group policy file. Even though in v1 we amend the Cpb file by adding the group policy file to become the Cpi, the check for group policy file should not be happening at  `CpbV1Verifier` level but rather at `CpiV1Verifier` level.

- moves group policy file check from `CpbV1Verifier` to `CpiV1Verifier`.
- removes from `TestCpbV1Builder` adding of group policy file.
- adds `TestCpiV1Builder` which creates a Cpb and then it amends it to include group policy file.

    