### PR TITLE
NOTICK: Close subscription correctly

### DIFF
--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceProcessorImpl.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceProcessorImpl.kt
@@ -6,7 +6,9 @@ import net.corda.messaging.api.subscription.Subscription
 import org.osgi.service.component.annotations.Component
 
 /**
- * Entity processor.  Starts the subscription, which in turn passes the messages to the [EntityMessageProcessor].
+ * Entity processor.
+ * Starts the subscription, which in turn passes the messages to the
+ * [net.corda.entityprocessor.impl.internal.EntityMessageProcessor].
  */
 @Component(service = [FlowPersistenceProcessor::class])
 class FlowPersistenceProcessorImpl(
@@ -18,5 +20,8 @@ class FlowPersistenceProcessorImpl(
 
     override fun start() = subscription.start()
 
-    override fun stop() = subscription.stop()
+    // It is important to call `subscription.close()` rather than `subscription.stop()` as the latter does not remove
+    // Lifecycle coordinator from the registry, causing it to appear there in `DOWN` state. This will in turn fail
+    // overall Health check's `status` check.
+    override fun stop() = subscription.close()
 }


### PR DESCRIPTION
It is important to call `subscription.close()` rather than `subscription.stop()` as the latter does not remove Lifecycle coordinator from the registry, causing it to appear there in `DOWN` state. This will in turn fail overall Health check's `status` check from DB Worker.

Evidence:
```
	"db.entity.processor-DURABLE-virtual.node.entity.processor-DURABLE-virtual.node.entity.processor-db.entity.processor-12": {
		"name": {
			"componentName": "db.entity.processor-DURABLE-virtual.node.entity.processor",
			"instanceId": "DURABLE-virtual.node.entity.processor-db.entity.processor-12"
		},
		"status": "DOWN",
		"reason": "Component has been stopped"
	},
...
	"db.entity.processor-DURABLE-virtual.node.entity.processor-DURABLE-virtual.node.entity.processor-db.entity.processor-20": {
		"name": {
			"componentName": "db.entity.processor-DURABLE-virtual.node.entity.processor",
			"instanceId": "DURABLE-virtual.node.entity.processor-db.entity.processor-20"
		},
		"status": "UP",
		"reason": "Status has changed to UP"
	},
```