### PR TITLE
CORE-5655 Duplicate cpi upload returns http/409

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -145,20 +145,7 @@ class VirtualNodeRpcTest {
 
             assertWithRetry {
                 command { cpiStatus(requestId) }
-                condition {
-                    try {
-                        if(it.code == 400) {
-                            val json = it.toJson()["details"]
-                            json["errorMessage"].textValue().startsWith(EXPECTED_ERROR_ALREADY_UPLOADED)
-                        } else {
-                            false
-                        }
-                    }
-                    catch (e: Exception) {
-                        println("Failed, repsonse: $it")
-                        false
-                    }
-                }
+                condition { it.code == 409 }
             }
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -8,6 +8,7 @@ import net.corda.chunking.db.impl.persistence.CpiPersistence
 import net.corda.chunking.db.impl.persistence.PersistenceUtils.signerSummaryHashForDbQuery
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpiupload.DuplicateCpiUploadException
 import net.corda.libs.cpiupload.ValidationException
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.CpiReader
@@ -197,7 +198,11 @@ fun CpiPersistence.verifyGroupIdIsUniqueForCpi(cpi: Cpi) {
     )
 
     if (groupIdInDatabase != null) {
-        throw ValidationException("CPI already uploaded with groupId = $groupIdInDatabase")
+        // Carefully constructed message because the "409/conflict" exception:
+        // ResourceAlreadyExistsException
+        // just wants "the resource".
+        val resource = "${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version} (groupId=$groupIdInDatabase)"
+        throw DuplicateCpiUploadException(resource)
     }
 }
 

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ValidateUniqueCpiAndGroupIdTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ValidateUniqueCpiAndGroupIdTest.kt
@@ -1,7 +1,7 @@
 package net.corda.chunking.db.impl.validation
 
 import net.corda.chunking.db.impl.persistence.CpiPersistence
-import net.corda.libs.cpiupload.ValidationException
+import net.corda.libs.cpiupload.DuplicateCpiUploadException
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
-class UniqueGroupIdTest {
+class ValidateUniqueCpiAndGroupIdTest {
     @Test
     fun `succeeds with unique groupId`() {
         val requiredName = "aaa"
@@ -54,7 +54,7 @@ class UniqueGroupIdTest {
             on { getGroupId(requiredName, requiredVersion, hash.toString()) }.doReturn(groupId)
         }
 
-        assertThrows<ValidationException> { cpiExists.verifyGroupIdIsUniqueForCpi(cpi) }
+        assertThrows<DuplicateCpiUploadException> { cpiExists.verifyGroupIdIsUniqueForCpi(cpi) }
     }
 
 }

--- a/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/DuplicateCpiUploadException.kt
+++ b/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/DuplicateCpiUploadException.kt
@@ -1,0 +1,13 @@
+package net.corda.libs.cpiupload
+
+/**
+ * Exception type that is thrown if there is an attempt to upload a
+ * duplicate CPI .
+ *
+ * This exception is passed via a kafka envelope message and then
+ * "checked" in the rpc ops layer when received.
+ *
+ * @param resourceName Must be the 'resource name' rather than the message so we
+ * can pass it back to [net.corda.httprpc.exception.ResourceAlreadyExistsException]
+ */
+class DuplicateCpiUploadException(resourceName: String) : Exception(resourceName)


### PR DESCRIPTION
If we upload a duplicate CPI (and not 'force reloading' it), we return
a custom exception, passed over kafka, then translated to the correct
http status code (409).