### PR TITLE
CORE-6105 Remove avro dependency on net.corda.flow.rpcops

### DIFF
--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/factory/MessageFactoryImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/factory/MessageFactoryImpl.kt
@@ -11,7 +11,7 @@ import net.corda.data.virtualnode.VirtualNodeInfo
 import net.corda.flow.rpcops.factory.MessageFactory
 import net.corda.flow.rpcops.v1.types.response.FlowStateErrorResponse
 import net.corda.flow.rpcops.v1.types.response.FlowStatusResponse
-import net.corda.flow.utils.KeyValueStore
+import net.corda.flow.utils.keyValuePairListOf
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Component
 import java.time.Instant
@@ -24,7 +24,7 @@ class MessageFactoryImpl : MessageFactory {
         virtualNode: VirtualNodeInfo,
         flowClassName: String,
         flowStartArgs: String,
-        flowContextPlatformProperties: KeyValueStore
+        flowContextPlatformProperties: Map<String, String>
     ): FlowMapperEvent {
         val context = FlowStartContext(
             FlowKey(clientRequestId, virtualNode.holdingIdentity),
@@ -35,7 +35,7 @@ class MessageFactoryImpl : MessageFactory {
             virtualNode.holdingIdentity,
             flowClassName,
             flowStartArgs,
-            flowContextPlatformProperties.avro,
+            keyValuePairListOf(flowContextPlatformProperties),
             Instant.now()
         )
 

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -80,7 +80,7 @@ class FlowRPCOpsImpl @Activate constructor(
         val flowClassName = startFlow.flowClassName
         // TODO Platform properties to be populated correctly, for now a fixed 'account zero' is the only property
         // This is a placeholder which indicates access to everything, see CORE-6076
-        val flowContextPlatformProperties = keyValueStoreOf("net.corda.account" to "account-zero")
+        val flowContextPlatformProperties = mapOf("net.corda.account" to "account-zero")
         val startEvent =
             messageFactory.createStartFlowEvent(
                 clientRequestId,

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -10,7 +10,6 @@ import net.corda.flow.rpcops.v1.FlowRpcOps
 import net.corda.flow.rpcops.v1.types.request.StartFlowParameters
 import net.corda.flow.rpcops.v1.types.response.FlowStatusResponse
 import net.corda.flow.rpcops.v1.types.response.FlowStatusResponses
-import net.corda.flow.utils.keyValueStoreOf
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.httprpc.exception.ResourceNotFoundException

--- a/components/flow/flow-rpcops-service/build.gradle
+++ b/components/flow/flow-rpcops-service/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(':libs:configuration:configuration-core')
     implementation project(':libs:lifecycle:lifecycle')
-    implementation project(':libs:flows:utils')
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'

--- a/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/factory/MessageFactory.kt
+++ b/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/factory/MessageFactory.kt
@@ -4,7 +4,6 @@ import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.virtualnode.VirtualNodeInfo
 import net.corda.flow.rpcops.v1.types.response.FlowStatusResponse
-import net.corda.flow.utils.KeyValueStore
 
 interface MessageFactory {
 
@@ -13,7 +12,7 @@ interface MessageFactory {
         virtualNode: VirtualNodeInfo,
         flowClassName: String,
         flowStartArgs: String,
-        flowContextPlatformProperties: KeyValueStore
+        flowContextPlatformProperties: Map<String, String>
     ): FlowMapperEvent
 
     fun createFlowStatusResponse(flowStatus: FlowStatus): FlowStatusResponse

--- a/libs/flows/utils/build.gradle
+++ b/libs/flows/utils/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "net.corda:corda-base"
-    implementation "net.corda:corda-avro-schema"
+    api "net.corda:corda-avro-schema"
 }
 
 description 'Flow related utilities'

--- a/libs/flows/utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
+++ b/libs/flows/utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
@@ -6,12 +6,22 @@ import net.corda.data.KeyValuePairList
 fun mutableKeyValuePairList() = KeyValuePairList(mutableListOf())
 fun emptyKeyValuePairList() = KeyValuePairList(emptyList())
 
+/**
+ * Creates a [KeyValueStore] from a variable number of pairs of strings.
+ * @param pairs Pairs of strings, the first is considered the key, the second the value.
+ * @return A [KeyValueStore] containing the keys and values from the pairs.
+ */
 fun keyValueStoreOf(vararg pairs: Pair<String, String>) = KeyValueStore().apply {
     pairs.forEach {
         put(it.first, it.second)
     }
 }
 
+/**
+ * Creates an avro generated [KeyValuePairList] from a Kotlin Map
+ * @param map The Kotlin map
+ * @return An avro [KeyValuePairList]
+ */
 fun keyValuePairListOf(map: Map<String, String>) = mutableKeyValuePairList().apply {
     map.entries.forEach {
         items.add(KeyValuePair(it.key, it.value))

--- a/libs/flows/utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
+++ b/libs/flows/utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
@@ -12,6 +12,12 @@ fun keyValueStoreOf(vararg pairs: Pair<String, String>) = KeyValueStore().apply 
     }
 }
 
+fun keyValuePairListOf(map: Map<String, String>) = mutableKeyValuePairList().apply {
+    map.entries.forEach {
+        items.add(KeyValuePair(it.key, it.value))
+    }
+}
+
 /**
  * A KeyValueStore which operates much like a map from the user perspective. Internally it is backed by an Avro array
  * which means serialization and deserialization are guaranteed to produce the same object, which is not the case with

--- a/libs/flows/utils/src/test/kotlin/net/corda/flow/utils/KeyValueStoreTest.kt
+++ b/libs/flows/utils/src/test/kotlin/net/corda/flow/utils/KeyValueStoreTest.kt
@@ -74,4 +74,17 @@ class KeyValueStoreTest {
 
         assertThat(store.avro.items.size).isEqualTo(2)
     }
+
+    @Test
+    fun `keyValuePairListOf creates list from map`() {
+        val map = mapOf("key1" to "value1", "key2" to "value2")
+        val keyValuePairList = keyValuePairListOf(map)
+
+        // Back the list by a store facade for convenience of testing the values in it
+        val store = KeyValueStore(keyValuePairList)
+        assertThat(store["key1"]).isEqualTo("value1")
+        assertThat(store["key2"]).isEqualTo("value2")
+
+        assertThat(keyValuePairList.items.size).isEqualTo(2)
+    }
 }


### PR DESCRIPTION
- For reasons unknown at the moment, the avro base class org.apache.avro.specific.SpecificRecordBase cannot be located by the classloader in the combined worker when this dependency is added.
- Whilst this is a workaround, it's probably not such a bad idea not to expose avro so far up the public api of modules anyway.