### PR TITLE
CORE-6116: add logging for Gradle Ent and Splunk for combined worker 

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -99,7 +99,7 @@ pipeline {
         }
         stage('Build  Jar') {
             steps {
-                gradlew (' :applications:workers:release:combined-worker:assemble') // builds the jar build/bin/*/*.jar
+                gradlew (':applications:workers:release:combined-worker:assemble') // builds the jar build/bin/*/*.jar
             }
         } 			
         stage('Start jar / run tests') {
@@ -143,6 +143,7 @@ pipeline {
             
             junit allowEmptyResults: true, testResults: '**/test-results/**/TEST-*.xml'
             archiveArtifacts artifacts: 'forward.txt, workerLogs.txt, podLogs.txt', allowEmptyArchive: true
+            sh 'rm -f forward.txt workerLogs.txt podLogs.txt'
         }
     }
 }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -54,7 +54,7 @@ pipeline {
         CORDA_GRADLE_SCAN_KEY = credentials('gradle-build-scans-key')
         GRADLE_USER_HOME = "/host_tmp/gradle"
         CORDA_REVISION = "${env.GIT_COMMIT}"
-        GRADLE_PERFORMANCE_TUNING = "--parallel -Dscan.tag.combined-worker --build-cache"
+        GRADLE_PERFORMANCE_TUNING = "--parallel -Dscan.tag.combined-worker --build-cache -Si"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
@@ -99,10 +99,9 @@ pipeline {
         }
         stage('Build  Jar') {
             steps {
-                sh './gradlew :applications:workers:release:combined-worker:assemble -Si' // builds the jar build/bin/*/*.jar
+                gradlew (' :applications:workers:release:combined-worker:assemble') // builds the jar build/bin/*/*.jar
             }
-        }
- 			
+        } 			
         stage('Start jar / run tests') {
             
             environment {
@@ -120,9 +119,7 @@ pipeline {
                 '''
 
                 checkConnection()    
-
-                sh './gradlew smoketest -PisCombinedWorker=true'
-    
+                gradlew('smoketest -PisCombinedWorker=true')   
             }            
         }
     }
@@ -148,4 +145,14 @@ pipeline {
             archiveArtifacts artifacts: 'forward.txt, workerLogs.txt, podLogs.txt', allowEmptyArchive: true
         }
     }
+}
+
+
+def gradleCmd() {
+    return isUnix() ? './gradlew' : './gradlew.bat'
+}
+
+def gradlew(String... args) {
+    def allArgs = args.join(' ')
+    sh "${gradleCmd()} ${allArgs} ${GRADLE_PERFORMANCE_TUNING}"
 }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -54,7 +54,7 @@ pipeline {
         CORDA_GRADLE_SCAN_KEY = credentials('gradle-build-scans-key')
         GRADLE_USER_HOME = "/host_tmp/gradle"
         CORDA_REVISION = "${env.GIT_COMMIT}"
-        GRADLE_PERFORMANCE_TUNING = "--parallel -Dscan.tag.E2E -Dscan.tag.${env.NAMESPACE} --build-cache"
+        GRADLE_PERFORMANCE_TUNING = "--parallel -Dscan.tag.combined-worker -Dscan.tag.${env.NAMESPACE} --build-cache"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -54,7 +54,7 @@ pipeline {
         CORDA_GRADLE_SCAN_KEY = credentials('gradle-build-scans-key')
         GRADLE_USER_HOME = "/host_tmp/gradle"
         CORDA_REVISION = "${env.GIT_COMMIT}"
-        GRADLE_PERFORMANCE_TUNING = "--parallel -Dscan.tag.combined-worker -Dscan.tag.${env.NAMESPACE} --build-cache"
+        GRADLE_PERFORMANCE_TUNING = "--parallel -Dscan.tag.combined-worker --build-cache"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -130,7 +130,8 @@ pipeline {
         always {
             
             script {      
-
+                    findBuildScans()
+                    splunkLogGenerator()
                     sh '''
                         for pod in $(kubectl -n postgres get pods -o name); do kubectl -n postgres logs --all-containers --prefix $pod 2>&1 >> podLogs.txt; done
                     '''     


### PR DESCRIPTION
- send build data to splunk and gralde ent
- ensure logs do not override one another