### PR TITLE
CORE-6111 - Adjust link manager to treat cases where destination is not in the network yet gracefully

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverter.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverter.kt
@@ -16,6 +16,7 @@ import net.corda.p2p.crypto.protocol.api.AuthenticatedSession
 import net.corda.p2p.crypto.protocol.api.DecryptionFailedError
 import net.corda.p2p.crypto.protocol.api.InvalidMac
 import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.linkmanager.GroupPolicyListener
 import net.corda.p2p.linkmanager.LinkManagerGroupPolicyProvider
 import net.corda.p2p.linkmanager.LinkManagerMembershipGroupReader
 import net.corda.p2p.linkmanager.messaging.AvroSealedClasses.DataMessage
@@ -147,25 +148,10 @@ class MessageConverter {
 
         fun linkOutFromUnauthenticatedMessage(
             message: UnauthenticatedMessage,
-            groups: LinkManagerGroupPolicyProvider,
-            members: LinkManagerMembershipGroupReader,
-        ): LinkOutMessage? {
-            val destination = message.header.destination.toCorda()
+            destMemberInfo: LinkManagerMembershipGroupReader.MemberInfo,
+            groupInfo: GroupPolicyListener.GroupInfo
+        ): LinkOutMessage {
             val source = message.header.source.toCorda()
-            val destMemberInfo = members.getMemberInfo(source, destination)
-            if (destMemberInfo == null) {
-                logger.warn("Attempted to send message to peer $destination which is not in the network map. The message was discarded.")
-                return null
-            }
-
-            val groupInfo = groups.getGroupInfo(source)
-            if (groupInfo == null) {
-                logger.warn(
-                    "Could not find the group information in the" +
-                        " GroupPolicyProvider for $source. The message was discarded."
-                )
-                return null
-            }
 
             return createLinkOutMessage(message, source, destMemberInfo, groupInfo.networkType)
         }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverterTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/messaging/MessageConverterTest.kt
@@ -3,8 +3,6 @@ package net.corda.p2p.linkmanager.messaging
 import net.corda.p2p.AuthenticatedMessageAndKey
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.p2p.app.AuthenticatedMessageHeader
-import net.corda.p2p.app.UnauthenticatedMessage
-import net.corda.p2p.app.UnauthenticatedMessageHeader
 import net.corda.p2p.crypto.AuthenticatedDataMessage
 import net.corda.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.p2p.crypto.CommonHeader
@@ -140,46 +138,6 @@ class MessageConverterTest {
         assertThat(MessageConverter.linkOutMessageFromAuthenticatedMessageAndKey(flowMessage, session, groups, members)).isNull()
         loggingInterceptor.assertSingleWarning(
             "Could not find the group info in the GroupPolicyProvider for our identity = $us." +
-                " The message was discarded."
-        )
-    }
-
-    @Test
-    fun `linkOutFromUnauthenticatedMessage returns null (with appropriate logging) if if the destination is not in the network map`() {
-        val payload = "test"
-        val groupId = "group-1"
-        val us = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
-        val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
-        val unauthenticatedMsg = UnauthenticatedMessage(
-            UnauthenticatedMessageHeader(peer.toAvro(), us.toAvro(), "subsystem"),
-            ByteBuffer.wrap(payload.toByteArray())
-        )
-
-        val members = mockMembers(emptyList())
-
-        assertThat(MessageConverter.linkOutFromUnauthenticatedMessage(unauthenticatedMsg, mock(), members)).isNull()
-        loggingInterceptor.assertSingleWarning(
-            "Attempted to send message to peer $peer which is not in the network map." +
-                " The message was discarded."
-        )
-    }
-
-    @Test
-    fun `linkOutFromUnauthenticatedMessage returns null (with appropriate logging) if if their network type is not in the network map`() {
-        val payload = "test"
-        val groupId = "group-1"
-        val us = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
-        val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
-        val unauthenticatedMsg = UnauthenticatedMessage(
-            UnauthenticatedMessageHeader(peer.toAvro(), us.toAvro(), "subsystem"),
-            ByteBuffer.wrap(payload.toByteArray())
-        )
-
-        val members = mockMembers(listOf(us, peer))
-        val groups = mockGroups(emptyList())
-        assertThat(MessageConverter.linkOutFromUnauthenticatedMessage(unauthenticatedMsg, groups, members)).isNull()
-        loggingInterceptor.assertSingleWarning(
-            "Could not find the group information in the GroupPolicyProvider for $us." +
                 " The message was discarded."
         )
     }


### PR DESCRIPTION
## Changes
Introducing an extra conditional for cases where the destination identity is not part of the network yet. In case of unauthenticated messages, the message is just dropped with a warning log. In case of authenticated message, the message is kept for replaying. Previously, we were not processing replays for scenarios where the destination identity is locally hosted. This logic is removed now. That should be safe, since the issue we were trying to mitigate is the link manager depositing the message more than once, but that should not be an issue as p2p does not provide exactly-once delivery guarantees. The possibility of that happening has also been reduced signficantly now that we have two type of markers (processed / sent) and the first one (that replays are based on) is only written only once atomically with the consumption of events from `p2p.out`.

## Testing
On top of automated testing, I did some manual testing with a static network where destination identity is created long after message is sent (see ticket for details on how the bug was reproduced). Previously, the message was getting stuck, but with these changes the link manager initially starts emitting the introduced warnings and once the new vnode is created, the message is looped back.