### PR TITLE
CORE-5444: test and implement new list-based persistence Avro API

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -387,9 +387,9 @@ class FlowServiceTestContext @Activate constructor(
     override fun entityResponseSuccessReceived(
         flowId: String,
         requestId: String,
-        byteBuffer: ByteBuffer?
+        byteBuffers: List<ByteBuffer>
     ): FlowIoRequestSetup {
-        return addEntityResponseToTestRun(requestId, EntityResponseSuccess(byteBuffer), flowId)
+        return addEntityResponseToTestRun(requestId, EntityResponseSuccess(byteBuffers), flowId)
     }
 
     override fun entityResponseErrorReceived(

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/StepSetup.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/StepSetup.kt
@@ -88,7 +88,7 @@ interface StepSetup {
     fun entityResponseSuccessReceived(
         flowId: String,
         requestId: String,
-        byteBuffer: ByteBuffer?,
+        byteBuffers: List<ByteBuffer>,
     ): FlowIoRequestSetup
 
     fun entityResponseErrorReceived(

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/DeleteEntityAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/DeleteEntityAcceptanceTest.kt
@@ -1,7 +1,7 @@
 package net.corda.flow.testing.tests.persistence
 
+import net.corda.data.persistence.DeleteEntities
 import java.nio.ByteBuffer
-import net.corda.data.persistence.DeleteEntity
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.flow.testing.tests.ALICE_HOLDING_IDENTITY
@@ -50,7 +50,7 @@ class DeleteEntityAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                entityRequestSent(DeleteEntity(byteBuffer))
+                entityRequestSent(DeleteEntities(listOf(byteBuffer)))
             }
         }
     }
@@ -67,7 +67,7 @@ class DeleteEntityAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, null)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, emptyList())
         }
 
         then {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/EntityRequestErrorHandlingAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/EntityRequestErrorHandlingAcceptanceTest.kt
@@ -57,7 +57,7 @@ class EntityRequestErrorHandlingAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, "invalidId", byteBuffer)
+            entityResponseSuccessReceived(FLOW_ID1, "invalidId", listOf(byteBuffer))
         }
 
         then {
@@ -83,7 +83,7 @@ class EntityRequestErrorHandlingAcceptanceTest : FlowServiceTestBase() {
         `when` {
             entityResponseErrorReceived(FLOW_ID1, requestId, Error.VIRTUAL_NODE, ExceptionEnvelope("", ""))
             entityResponseErrorReceived(FLOW_ID1, requestId, Error.VIRTUAL_NODE, ExceptionEnvelope("", ""))
-            entityResponseSuccessReceived(FLOW_ID1, requestId, byteBuffer)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf(byteBuffer))
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
@@ -153,7 +153,7 @@ class EntityRequestErrorHandlingAcceptanceTest : FlowServiceTestBase() {
             wakeupEventReceived(FLOW_ID1)
             wakeupEventReceived(FLOW_ID1)
             wakeupEventReceived(FLOW_ID1)
-            entityResponseSuccessReceived(FLOW_ID1, requestId, byteBuffer)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf(byteBuffer))
                 .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
@@ -197,7 +197,7 @@ class EntityRequestErrorHandlingAcceptanceTest : FlowServiceTestBase() {
         `when` {
             entityResponseErrorReceived(FLOW_ID1, requestId, Error.NOT_READY, ExceptionEnvelope("", ""))
             entityResponseErrorReceived(FLOW_ID1, requestId, Error.NOT_READY, ExceptionEnvelope("", ""))
-            entityResponseSuccessReceived(FLOW_ID1, requestId, byteBuffer)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf(byteBuffer))
         }
 
         then {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/FindAllAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/FindAllAcceptanceTest.kt
@@ -60,12 +60,12 @@ class FindAllAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, null)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf())
         }
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(null)
+                flowResumedWith(emptyList<ByteBuffer>())
             }
         }
     }
@@ -78,12 +78,12 @@ class FindAllAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, byteBuffer)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf(byteBuffer))
         }
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(byteBuffer)
+                flowResumedWith(listOf(byteBuffer))
             }
         }
     }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/FindEntityAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/FindEntityAcceptanceTest.kt
@@ -53,14 +53,14 @@ class FindEntityAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
-    fun `Receiving a null response from a Find request resumes the flow`() {
+    fun `Receiving an empty response from a Find request resumes the flow`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(FlowIORequest.Find(requestId, className, bytes))
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, null)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf())
         }
 
         then {
@@ -78,7 +78,7 @@ class FindEntityAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, byteBuffer)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf(byteBuffer))
         }
 
         then {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/MergeEntityAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/MergeEntityAcceptanceTest.kt
@@ -1,7 +1,7 @@
 package net.corda.flow.testing.tests.persistence
 
 import java.nio.ByteBuffer
-import net.corda.data.persistence.MergeEntity
+import net.corda.data.persistence.MergeEntities
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.flow.testing.tests.ALICE_HOLDING_IDENTITY
@@ -50,7 +50,7 @@ class MergeEntityAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                entityRequestSent(MergeEntity(byteBuffer))
+                entityRequestSent(MergeEntities(listOf(byteBuffer)))
             }
         }
     }
@@ -66,7 +66,7 @@ class MergeEntityAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, null)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf())
         }
 
         then {
@@ -87,7 +87,7 @@ class MergeEntityAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, byteBuffer)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf(byteBuffer))
         }
 
         then {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/PersistEntityAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/persistence/PersistEntityAcceptanceTest.kt
@@ -1,7 +1,7 @@
 package net.corda.flow.testing.tests.persistence
 
+import net.corda.data.persistence.PersistEntities
 import java.nio.ByteBuffer
-import net.corda.data.persistence.PersistEntity
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.flow.testing.tests.ALICE_HOLDING_IDENTITY
@@ -50,7 +50,7 @@ class PersistEntityAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                entityRequestSent(PersistEntity(byteBuffer))
+                entityRequestSent(PersistEntities(listOf(byteBuffer)))
             }
         }
     }
@@ -66,7 +66,7 @@ class PersistEntityAcceptanceTest : FlowServiceTestBase() {
         }
 
         `when` {
-            entityResponseSuccessReceived(FLOW_ID1, requestId, null)
+            entityResponseSuccessReceived(FLOW_ID1, requestId, listOf())
         }
 
         then {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowIORequest.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowIORequest.kt
@@ -106,7 +106,7 @@ interface FlowIORequest<out R> {
     data class Find(val requestId: String, val className: String, val primaryKey: ByteArray) :
         FlowIORequest<ByteBuffer?>
 
-    data class FindAll(val requestId: String, val className: String) : FlowIORequest<ByteBuffer?>
+    data class FindAll(val requestId: String, val className: String) : FlowIORequest<List<ByteBuffer>>
 
     data class Merge(val requestId: String, val obj: ByteArray) : FlowIORequest<ByteBuffer?>
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/DeleteRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/DeleteRequestHandler.kt
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import net.corda.data.flow.state.waiting.EntityResponse
 import net.corda.data.flow.state.waiting.WaitingFor
-import net.corda.data.persistence.DeleteEntity
+import net.corda.data.persistence.DeleteEntities
 import net.corda.data.persistence.EntityRequest
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.persistence.manager.PersistenceManager
@@ -28,7 +28,7 @@ class DeleteRequestHandler @Activate constructor(
     }
 
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.Delete): FlowEventContext<Any> {
-        val deleteRequest = DeleteEntity(ByteBuffer.wrap(request.obj))
+        val deleteRequest = DeleteEntities(listOf(ByteBuffer.wrap(request.obj)))
         val checkpoint = context.checkpoint
         val entityRequest = EntityRequest(Instant.now(), checkpoint.flowId, checkpoint.holdingIdentity.toAvro(), deleteRequest)
         context.checkpoint.persistenceState  = persistenceManager.processMessageToSend(request.requestId, entityRequest)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/MergeRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/MergeRequestHandler.kt
@@ -5,7 +5,7 @@ import java.time.Instant
 import net.corda.data.flow.state.waiting.EntityResponse
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.data.persistence.EntityRequest
-import net.corda.data.persistence.MergeEntity
+import net.corda.data.persistence.MergeEntities
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.persistence.manager.PersistenceManager
 import net.corda.flow.pipeline.FlowEventContext
@@ -28,7 +28,7 @@ class MergeRequestHandler @Activate constructor(
     }
 
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.Merge): FlowEventContext<Any> {
-        val persistRequest = MergeEntity(ByteBuffer.wrap(request.obj))
+        val persistRequest = MergeEntities( listOf( ByteBuffer.wrap(request.obj)))
         val checkpoint = context.checkpoint
         val entityRequest = EntityRequest(Instant.now(), checkpoint.flowId, checkpoint.holdingIdentity.toAvro(), persistRequest)
         return context.apply { checkpoint.persistenceState = persistenceManager.processMessageToSend(request.requestId, entityRequest) }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/PersistRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/persistence/PersistRequestHandler.kt
@@ -5,7 +5,7 @@ import java.time.Instant
 import net.corda.data.flow.state.waiting.EntityResponse
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.data.persistence.EntityRequest
-import net.corda.data.persistence.PersistEntity
+import net.corda.data.persistence.PersistEntities
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.persistence.manager.PersistenceManager
 import net.corda.flow.pipeline.FlowEventContext
@@ -28,7 +28,7 @@ class PersistRequestHandler @Activate constructor(
     }
 
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.Persist): FlowEventContext<Any> {
-        val persistRequest = PersistEntity(ByteBuffer.wrap(request.obj))
+        val persistRequest = PersistEntities(listOf(ByteBuffer.wrap(request.obj) ))
         val checkpoint = context.checkpoint
         val entityRequest = EntityRequest(Instant.now(), checkpoint.flowId, checkpoint.holdingIdentity.toAvro(), persistRequest)
         return context.apply { checkpoint.persistenceState = persistenceManager.processMessageToSend(request.requestId, entityRequest) }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/persistence/EntityResponseWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/persistence/EntityResponseWaitingForHandler.kt
@@ -4,15 +4,15 @@ package net.corda.flow.pipeline.handlers.waiting.persistence
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.state.persistence.PersistenceState
 import net.corda.data.flow.state.waiting.EntityResponse
-import net.corda.data.persistence.DeleteEntity
+import net.corda.data.persistence.DeleteEntities
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.EntityResponseFailure
 import net.corda.data.persistence.EntityResponseSuccess
 import net.corda.data.persistence.Error
 import net.corda.data.persistence.FindAll
 import net.corda.data.persistence.FindEntity
-import net.corda.data.persistence.MergeEntity
-import net.corda.data.persistence.PersistEntity
+import net.corda.data.persistence.MergeEntities
+import net.corda.data.persistence.PersistEntities
 import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowFatalException
@@ -136,10 +136,13 @@ class EntityResponseWaitingForHandler : FlowWaitingForHandler<EntityResponse> {
 
     private fun getPayloadFromResponse(request: EntityRequest, response: EntityResponseSuccess): FlowContinuation {
         return when (request.request) {
-            is FindEntity, is MergeEntity, is FindAll -> {
-                FlowContinuation.Run(response.result)
+            is FindEntity, is MergeEntities -> {
+                FlowContinuation.Run(response.results.firstOrNull())
             }
-            is DeleteEntity, is PersistEntity -> {
+            is FindAll -> {
+                FlowContinuation.Run(response.results)
+            }
+            is DeleteEntities, is PersistEntities -> {
                 FlowContinuation.Run(Unit)
             }
             else -> {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/EntityResponseHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/EntityResponseHandlerTest.kt
@@ -17,7 +17,7 @@ class EntityResponseHandlerTest {
     @Test
     fun `PersistenceState was null`() {
         val instant = Instant.now()
-        val response = EntityResponse(instant, "request1", EntityResponseSuccess())
+        val response = EntityResponse(instant, "request1", EntityResponseSuccess(emptyList()))
         val (mockPersistenceManager, mockContext) = mockPersistenceManagerAndStubContext(response)
 
         val entityResponseHandler = EntityResponseHandler(mockPersistenceManager)
@@ -30,7 +30,7 @@ class EntityResponseHandlerTest {
     fun `Process entity response`() {
         val instant = Instant.now()
         val persistenceState = PersistenceState("request1", instant, EntityRequest(), 0, null)
-        val response = EntityResponse(instant, "request1", EntityResponseSuccess())
+        val response = EntityResponse(instant, "request1", EntityResponseSuccess(emptyList()))
         val (mockDbManager, stubContext) = mockPersistenceManagerAndStubContext(response, persistenceState)
 
         stubContext.inputEventPayload = response

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/persistence/EntityResponseWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/persistence/EntityResponseWaitingForHandlerTest.kt
@@ -14,7 +14,7 @@ import net.corda.data.persistence.EntityResponseFailure
 import net.corda.data.persistence.EntityResponseSuccess
 import net.corda.data.persistence.Error
 import net.corda.data.persistence.FindEntity
-import net.corda.data.persistence.PersistEntity
+import net.corda.data.persistence.PersistEntities
 import net.corda.flow.BOB_X500_HOLDING_IDENTITY
 import net.corda.flow.FLOW_ID_1
 import net.corda.flow.fiber.FlowContinuation
@@ -61,7 +61,7 @@ class EntityResponseWaitingForHandlerTest {
     @BeforeEach
     fun setup() {
         persistRequest = EntityRequest.newBuilder()
-            .setRequest(PersistEntity(bytes))
+            .setRequest(PersistEntities(listOf(bytes)))
             .setTimestamp(Instant.ofEpochMilli(persistTimeStampMilli))
             .setFlowId(flowId)
             .setHoldingIdentity(HoldingIdentity("Alice", "Group1"))
@@ -84,13 +84,13 @@ class EntityResponseWaitingForHandlerTest {
         successResponseBytes = EntityResponse.newBuilder()
             .setRequestId(requestId)
             .setTimestamp(Instant.now())
-            .setResponseType(EntityResponseSuccess(bytes))
+            .setResponseType(EntityResponseSuccess(listOf(bytes)))
             .build()
 
         successResponseNull = EntityResponse.newBuilder()
             .setRequestId(requestId)
             .setTimestamp(Instant.now())
-            .setResponseType(EntityResponseSuccess(null))
+            .setResponseType(EntityResponseSuccess(emptyList()))
             .build()
 
         errorResponseFatal = EntityResponse.newBuilder()

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -11,7 +11,7 @@ import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.EntityResponse
 import net.corda.data.persistence.EntityResponseFailure
 import net.corda.data.persistence.Error
-import net.corda.data.persistence.PersistEntity
+import net.corda.data.persistence.PersistEntities
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.entityprocessor.impl.internal.EntityMessageProcessor
 import net.corda.entityprocessor.impl.internal.EntitySandboxServiceImpl
@@ -228,7 +228,7 @@ class PersistenceExceptionTests {
         val serialisedDog = sandboxOne.getSerializer().serialize(dog).bytes
 
         // create persist request for the sandbox that isn't dog-aware
-        val request = EntityRequest(Instant.now(), UUID.randomUUID().toString(), virtualNodeInfoOne.holdingIdentity.toAvro(), PersistEntity(ByteBuffer.wrap(serialisedDog)))
+        val request = EntityRequest(Instant.now(), UUID.randomUUID().toString(), virtualNodeInfoOne.holdingIdentity.toAvro(), PersistEntities(listOf(ByteBuffer.wrap(serialisedDog))))
         return Pair(dbConnectionManager, request)
     }
 }

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -2,8 +2,8 @@ package net.corda.entityprocessor.impl.tests
 
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.flow.event.FlowEvent
-import net.corda.data.persistence.DeleteEntity
-import net.corda.data.persistence.DeleteEntityById
+import net.corda.data.persistence.DeleteEntities
+import net.corda.data.persistence.DeleteEntitiesById
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.EntityResponse
 import net.corda.data.persistence.EntityResponseFailure
@@ -11,8 +11,8 @@ import net.corda.data.persistence.EntityResponseSuccess
 import net.corda.data.persistence.Error
 import net.corda.data.persistence.FindAll
 import net.corda.data.persistence.FindEntity
-import net.corda.data.persistence.MergeEntity
-import net.corda.data.persistence.PersistEntity
+import net.corda.data.persistence.MergeEntities
+import net.corda.data.persistence.PersistEntities
 import net.corda.data.persistence.FindWithNamedQuery
 import net.corda.db.admin.LiquibaseSchemaMigrator
 import net.corda.db.admin.impl.ClassloaderChangeLog
@@ -169,7 +169,7 @@ class PersistenceServiceInternalTests {
         val persistenceService =
             PersistenceServiceInternal(entitySandboxService::getClass, requestId, UTCClock(), this::noOpPayloadCheck)
         val dog = sandbox.createDogInstance(dogId, "Rover", Instant.now(), "me")
-        val payload = PersistEntity(sandbox.serialize(dog))
+        val payload = PersistEntities(listOf(sandbox.serialize(dog)))
 
         val entityManager = BasicMocks.entityManager()
 
@@ -193,7 +193,7 @@ class PersistenceServiceInternalTests {
         val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity)
 
         val dog = sandbox.createDogInstance(UUID.randomUUID(), "Walter", Instant.now(), "me")
-        val request = createRequest(virtualNodeInfo.holdingIdentity, PersistEntity(sandbox.serialize(dog)))
+        val request = createRequest(virtualNodeInfo.holdingIdentity, PersistEntities(listOf(sandbox.serialize(dog))))
         val processor = EntityMessageProcessor(entitySandboxService, UTCClock(), this::noOpPayloadCheck)
 
         val requestId = UUID.randomUUID().toString() // just needs to be something unique.
@@ -246,7 +246,7 @@ class PersistenceServiceInternalTests {
         val dog = sandboxOne.createDogInstance(UUID.randomUUID(), "Stray", Instant.now(), "Not Known")
 
         // create persist request for the sandbox that isn't dog-aware
-        val request = EntityRequest(Instant.now(), UUID.randomUUID().toString(), virtualNodeInfoTwo.holdingIdentity.toAvro(), PersistEntity(sandboxOne.serialize(dog)))
+        val request = EntityRequest(Instant.now(), UUID.randomUUID().toString(), virtualNodeInfoTwo.holdingIdentity.toAvro(), PersistEntities(listOf(sandboxOne.serialize(dog))))
         val processor = EntityMessageProcessor(entitySandboxService, UTCClock(), this::noOpPayloadCheck)
         val requestId = UUID.randomUUID().toString() // just needs to be something unique.
         val records = listOf(Record(TOPIC, requestId, request))
@@ -286,7 +286,7 @@ class PersistenceServiceInternalTests {
             Instant.now().truncatedTo(ChronoUnit.MILLIS),
             "me"
         )
-        val dogRequest = createRequest(ctx.virtualNodeInfo.holdingIdentity, PersistEntity(ctx.serialize(dog)))
+        val dogRequest = createRequest(ctx.virtualNodeInfo.holdingIdentity, PersistEntities(listOf(ctx.serialize(dog))))
 
         // Now create a cat instance in the same way.
         val catId = UUID.randomUUID()
@@ -304,7 +304,7 @@ class PersistenceServiceInternalTests {
             dogRequest.timestamp,
             dogRequest.flowId,
             dogRequest.holdingIdentity,
-            PersistEntity(ctx.serialize(cat))
+            PersistEntities(listOf(ctx.serialize(cat)))
         )
 
         // Now send the two messages (both 'persist') to the message processor.  This is the point where we would
@@ -332,7 +332,7 @@ class PersistenceServiceInternalTests {
         val bytes = assertFindEntity(CAT_CLASS_NAME, ctx.serialize(catKey))
 
         // It's the cat we persisted.
-        assertThat(ctx.deserialize(bytes!!)).isEqualTo(cat)
+        assertThat(ctx.deserialize(bytes.first())).isEqualTo(cat)
     }
 
     @Test
@@ -354,7 +354,7 @@ class PersistenceServiceInternalTests {
         val bytes = assertFindEntity(DOG_CLASS_NAME, ctx.serialize(basilId))
 
         // assert it's the dog
-        val result = ctx.deserialize(bytes!!)
+        val result = ctx.deserialize(bytes.first())
         assertThat(result).isEqualTo(basilTheDog)
     }
 
@@ -386,8 +386,8 @@ class PersistenceServiceInternalTests {
         val entityResponse = flowEvent.payload as EntityResponse
         assertThat(entityResponse.responseType as EntityResponseSuccess).isInstanceOf(EntityResponseSuccess::class.java)
         val entityResponseSuccess = entityResponse.responseType as EntityResponseSuccess
-        val bytes = entityResponseSuccess.result as ByteBuffer
-        val responseEntity = ctx.deserialize(bytes)
+        val bytes = entityResponseSuccess.results as List<ByteBuffer>
+        val responseEntity = ctx.deserialize(bytes.first())
         assertThat(responseEntity).isEqualTo(bellaTheDog)
 
         // and can be found in the DB
@@ -430,7 +430,7 @@ class PersistenceServiceInternalTests {
         ctx.persist(dog)
 
         // use API to remove it
-        val responses = assertDeleteEntityById(DOG_CLASS_NAME, ctx.serialize(dogId))
+        val responses = assertDeleteEntityById(DOG_CLASS_NAME, listOf(ctx.serialize(dogId)))
 
         // assert the change - one response message (which contains success)
         assertThat(responses.size).isEqualTo(1)
@@ -440,13 +440,42 @@ class PersistenceServiceInternalTests {
         assertThat(actual).isNull()
     }
 
+
+    @Test
+    fun `delete with mulitple ids`() {
+        val dogIds = arrayOf("Athos", "Porthos", "Aramis").map {
+            // save a dog
+            val dogId = UUID.randomUUID()
+            val dog = ctx.sandbox.createDogInstance(
+                dogId,
+                it,
+                LocalDate.of(2015, 1, 11).atStartOfDay().toInstant(ZoneOffset.UTC),
+                "Musketeer"
+            )
+            ctx.persist(dog)
+            dogId
+        }
+        // use API to remove it
+        val responses = assertDeleteEntityById(DOG_CLASS_NAME, listOf(ctx.serialize(dogIds[0]), ctx.serialize(dogIds[1])))
+
+        // assert the change - one response message (which contains success)
+        assertThat(responses.size).isEqualTo(1)
+
+        // Check there's nothing.
+        val actual = ctx.findDog(dogIds[0])
+        assertThat(actual).isNull()
+
+        val actual2 = ctx.findDog(dogIds[2])
+        assertThat(actual2).isNotNull()
+    }
+
     @Test
     fun `delete by id is still successful if id not found`() {
         val dogId = UUID.randomUUID()
         ctx.persist(ctx.sandbox.createDogInstance(dogId, "K9", Instant.now(), "Doctor Who"))
 
         val differentDogId = UUID.randomUUID()
-        val responses = assertDeleteEntityById(DOG_CLASS_NAME, ctx.serialize(differentDogId))
+        val responses = assertDeleteEntityById(DOG_CLASS_NAME, listOf(ctx.serialize(differentDogId)))
 
         // we should not have deleted anything, and also not thrown either, i.e. the response contains a
         // 'success' message.
@@ -581,7 +610,7 @@ class PersistenceServiceInternalTests {
             if (it.array().size > 4) throw KafkaMessageSizeException("Too large")
             it
         }
-        val request = createRequest(ctx.virtualNodeInfo.holdingIdentity, MergeEntity(ctx.serialize(modifiedDog)))
+        val request = createRequest(ctx.virtualNodeInfo.holdingIdentity, MergeEntities(listOf(ctx.serialize(modifiedDog))))
 
         val responses = assertFailureResponses(processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), request))))
 
@@ -626,14 +655,14 @@ class PersistenceServiceInternalTests {
         assertPersistEntity(ctx.serialize(cat))
 
         val bytes = assertFindEntity(CAT_CLASS_NAME, ctx.serialize(catKey))
-        val actualCat = ctx.deserialize(bytes!!)
+        val actualCat = ctx.deserialize(bytes.first())
 
         assertThat(cat).isEqualTo(actualCat)
 
         assertDeleteEntity(ctx.serialize(cat))
 
-        val newBytes = assertFindEntity(CAT_CLASS_NAME, ctx.serialize(catKey))
-        assertThat(newBytes).isNull()
+        val newBytesList = assertFindEntity(CAT_CLASS_NAME, ctx.serialize(catKey))
+        assertThat(newBytesList.size).isEqualTo(0)
     }
 
     @Test
@@ -735,7 +764,8 @@ class PersistenceServiceInternalTests {
 
     @Test
     fun `find with named query result which hits Kafka message size limit`() {
-        assertQuery(QuerySetup.NamedQuery(mapOf(), "Dog.all"), expectFailure="Too large", sizeLimit = 10)
+        persistDogs(ctx, 1)
+        assertQuery(QuerySetup.NamedQuery(mapOf() , query="Dog.all"), expectFailure="Too large", sizeLimit = 10)
     }
 
 
@@ -818,17 +848,6 @@ class PersistenceServiceInternalTests {
         return records
     }
 
-    private fun assertThatResponseIsAList(entityResponse: EntityResponse): List<*> {
-        val entityResponseSuccess = entityResponse.responseType as EntityResponseSuccess
-        val bytes = entityResponseSuccess.result as ByteBuffer
-        val results = ctx.deserialize(bytes)
-
-        // We have a list
-        assertThat(results as List<*>).isInstanceOf(List::class.java)
-
-        return results
-    }
-
     private fun createRequest(holdingId: net.corda.virtualnode.HoldingIdentity, entity: Any): EntityRequest {
         logger.info("Entity Request - entity: ${entity.javaClass.simpleName} $entity")
         return EntityRequest(Instant.now(), UUID.randomUUID().toString(), holdingId.toAvro(), entity)
@@ -841,7 +860,7 @@ class PersistenceServiceInternalTests {
     ): List<*> {
         val rec = when(querySetup) {
             is QuerySetup.NamedQuery -> {
-                val paramsSerialized = querySetup.params.mapValues { ctx.serialize(it.value) }
+                val paramsSerialized = querySetup.params.mapValues { v -> ctx.serialize(v.value) }
                 FindWithNamedQuery(querySetup.query, paramsSerialized, offset, limit)
             }
             is QuerySetup.All -> {
@@ -849,7 +868,9 @@ class PersistenceServiceInternalTests {
             }
         }
         val processor = EntityMessageProcessor(ctx.entitySandboxService, UTCClock()) {
-            if (sizeLimit != Int.MAX_VALUE && it.array().size > sizeLimit) throw KafkaMessageSizeException("Too large")
+            val size = it.array().size
+            logger.info("payload check size $size c/w limit $sizeLimit")
+            if (size > sizeLimit) throw KafkaMessageSizeException("Too large; size $size exceeds limit $sizeLimit")
             it
         }
         val request = createRequest(ctx.virtualNodeInfo.holdingIdentity, rec)
@@ -857,8 +878,8 @@ class PersistenceServiceInternalTests {
         assertThat(records.size).withFailMessage("can only use this helper method with 1 result").isEqualTo(1)
         val record = records.first()
         val flowEvent = record.value as FlowEvent
+        val response = flowEvent.payload as EntityResponse
         if (expectFailure != null) {
-            val response = flowEvent.payload as EntityResponse
             if (response.responseType is EntityResponseFailure) {
                 logger.error("$response.responseType (expected failure)")
                 assertThat(response.responseType).isInstanceOf(EntityResponseFailure::class.java)
@@ -867,8 +888,7 @@ class PersistenceServiceInternalTests {
             assertThat(response.responseType.toString()).contains(expectFailure)
             return listOf<String>()
         } else {
-            val entityResponse = flowEvent.payload as EntityResponse
-            return assertThatResponseIsAList(entityResponse)
+            return (response.responseType as EntityResponseSuccess).results.map { ctx.deserialize(it as ByteBuffer) }
         }
     }
     /** Delete entity and assert
@@ -883,7 +903,7 @@ class PersistenceServiceInternalTests {
                     Record(
                         TOPIC,
                         UUID.randomUUID().toString(),
-                        createRequest(ctx.virtualNodeInfo.holdingIdentity, DeleteEntity(bytes))
+                        createRequest(ctx.virtualNodeInfo.holdingIdentity, DeleteEntities(listOf(bytes)))
                     )
                 )
             )
@@ -893,8 +913,8 @@ class PersistenceServiceInternalTests {
     /** Delete entity by primary key and do some asserting
      * @return the list of successful responses
      * */
-    private fun assertDeleteEntityById(className: String, bytes: ByteBuffer): List<Record<*, *>> {
-        val deleteByPrimaryKey = DeleteEntityById(className, bytes)
+    private fun assertDeleteEntityById(className: String, bytes: List<ByteBuffer>): List<Record<*, *>> {
+        val deleteByPrimaryKey = DeleteEntitiesById(className, bytes)
         val processor = EntityMessageProcessor(ctx.entitySandboxService, UTCClock(), this::noOpPayloadCheck)
         val records = listOf(
             Record(
@@ -909,7 +929,7 @@ class PersistenceServiceInternalTests {
     /** Find an entity and do some asserting
      * @return the list of successful responses
      * */
-    private fun assertFindEntity(className: String, bytes: ByteBuffer): ByteBuffer? {
+    private fun assertFindEntity(className: String, bytes: ByteBuffer): List<ByteBuffer> {
         val processor = EntityMessageProcessor(ctx.entitySandboxService, UTCClock(), this::noOpPayloadCheck)
 
         val responses = assertSuccessResponses(
@@ -931,7 +951,7 @@ class PersistenceServiceInternalTests {
         val response = flowEvent.payload as EntityResponse
         val success = response.responseType as EntityResponseSuccess
 
-        return success.result
+        return success.results
     }
 
     /** Persist an entity and do some asserting
@@ -946,7 +966,7 @@ class PersistenceServiceInternalTests {
                     Record(
                         TOPIC,
                         UUID.randomUUID().toString(),
-                        createRequest(ctx.virtualNodeInfo.holdingIdentity, PersistEntity(bytes))
+                        createRequest(ctx.virtualNodeInfo.holdingIdentity, PersistEntities(listOf(bytes)))
                     )
                 )
             )
@@ -964,7 +984,7 @@ class PersistenceServiceInternalTests {
                     Record(
                         TOPIC,
                         UUID.randomUUID().toString(),
-                        createRequest(ctx.virtualNodeInfo.holdingIdentity, MergeEntity(bytes))
+                        createRequest(ctx.virtualNodeInfo.holdingIdentity, MergeEntities(listOf(bytes)))
                     )
                 )
             )

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/BasicMocks.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/BasicMocks.kt
@@ -2,9 +2,13 @@ package net.corda.entityprocessor.impl.tests.helpers
 
 import net.corda.db.connection.manager.DbConnectionManager
 import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 import org.osgi.service.component.ComponentContext
+import javax.persistence.Entity
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
+import javax.persistence.EntityTransaction
 
 /** Most **basic** mocks possible. */
 object BasicMocks {
@@ -23,5 +27,10 @@ object BasicMocks {
 
     fun componentContext() = Mockito.mock(ComponentContext::class.java)!!
 
-    fun entityManager() = Mockito.mock(EntityManager::class.java)!!
+    fun entityManager():EntityManager {
+        val em = Mockito.mock(EntityManager::class.java)!!
+        val t = Mockito.mock(EntityTransaction::class.java)
+        whenever(em.transaction).thenReturn(t)
+        return em
+    }
 }

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
@@ -4,8 +4,8 @@ import java.nio.ByteBuffer
 import javax.persistence.EntityManagerFactory
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.event.FlowEvent
-import net.corda.data.persistence.DeleteEntity
-import net.corda.data.persistence.DeleteEntityById
+import net.corda.data.persistence.DeleteEntities
+import net.corda.data.persistence.DeleteEntitiesById
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.EntityResponse
 import net.corda.data.persistence.EntityResponseFailure
@@ -13,8 +13,8 @@ import net.corda.data.persistence.Error
 import net.corda.data.persistence.FindAll
 import net.corda.data.persistence.FindEntity
 import net.corda.data.persistence.FindWithNamedQuery
-import net.corda.data.persistence.MergeEntity
-import net.corda.data.persistence.PersistEntity
+import net.corda.data.persistence.MergeEntities
+import net.corda.data.persistence.PersistEntities
 import net.corda.entityprocessor.impl.internal.exceptions.KafkaMessageSizeException
 import net.corda.entityprocessor.impl.internal.exceptions.NotReadyException
 import net.corda.entityprocessor.impl.internal.exceptions.NullParameterException
@@ -43,6 +43,8 @@ fun EntitySandboxService.getClass(holdingIdentity: HoldingIdentity, fullyQualifi
  *
  * The [EntityResponse] contains the response or an exception-like payload whose presence indicates
  * an error has occurred.
+ *
+ * [payloadCheck] is called against each AMQP payload in the result (not the entire Avro array of results)
  */
 class EntityMessageProcessor(
     private val entitySandboxService: EntitySandboxService,
@@ -129,26 +131,26 @@ class EntityMessageProcessor(
         val response = try {
             entityManagerFactory.createEntityManager().transaction {
                 when (request.request) {
-                    is PersistEntity -> persistenceServiceInternal.persist(
+                    is PersistEntities -> persistenceServiceInternal.persist(
                         serializationService,
                         it,
-                        request.request as PersistEntity
+                        request.request as PersistEntities
                     )
-                    is DeleteEntity -> persistenceServiceInternal.remove(
+                    is DeleteEntities -> persistenceServiceInternal.deleteEntities(
                         serializationService,
                         it,
-                        request.request as DeleteEntity
+                        request.request as DeleteEntities
                     )
-                    is DeleteEntityById -> persistenceServiceInternal.removeById(
+                    is DeleteEntitiesById -> persistenceServiceInternal.deleteEntitiesByIds(
                         serializationService,
                         it,
-                        request.request as DeleteEntityById,
+                        request.request as DeleteEntitiesById,
                         holdingIdentity
                     )
-                    is MergeEntity -> persistenceServiceInternal.merge(
+                    is MergeEntities -> persistenceServiceInternal.merge(
                         serializationService,
                         it,
-                        request.request as MergeEntity
+                        request.request as MergeEntities
                     )
                     is FindEntity -> persistenceServiceInternal.find(
                         serializationService,

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.XXX-SNAPSHOT
-cordaApiVersion=5.0.0.158-beta+
+cordaApiVersion=5.0.0.159-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/flows/persistence-manager/src/test/kotlin/net/corda/flow/persistence/manager/PersistenceManagerImplTest.kt
+++ b/libs/flows/persistence-manager/src/test/kotlin/net/corda/flow/persistence/manager/PersistenceManagerImplTest.kt
@@ -8,7 +8,7 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.EntityResponse
 import net.corda.data.persistence.EntityResponseSuccess
-import net.corda.data.persistence.PersistEntity
+import net.corda.data.persistence.PersistEntities
 import net.corda.flow.persistence.manager.impl.PersistenceManagerImpl
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigImpl
@@ -26,7 +26,7 @@ class PersistenceManagerImplTest {
             .withValue(FlowConfig.PERSISTENCE_MESSAGE_RESEND_WINDOW, ConfigValueFactory.fromAnyRef(resendWindow))
 
         val persistRequest: EntityRequest = EntityRequest.newBuilder()
-            .setRequest(PersistEntity(ByteBuffer.wrap("bytes".toByteArray())))
+            .setRequest(PersistEntities(listOf(ByteBuffer.wrap("bytes".toByteArray()))))
             .setTimestamp(Instant.ofEpochMilli(persistTimeStampMilli))
             .setFlowId("flowId")
             .setHoldingIdentity(HoldingIdentity("Alice", "Group1"))


### PR DESCRIPTION
Previous merge, persist and delete Avro messages did one operation at a time.
Update these records to take lists of actions, so that they can be used for bulk operations,
provided the records still fit in Kafka messages.