### PR TITLE
CORE-6116: send slack notifications for combined worker failures

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -147,7 +147,7 @@ pipeline {
             sh 'rm -f forward.txt workerLogs.txt podLogs.txt'
         }
         failure {
-            sendSlackNotifications("danger", "BUILD FAILURE", true, "#corda-corda5-build-notifications")
+            sendSlackNotifications("danger", "BUILD FAILURE - Combined Worker E2E Tests", true, "#corda-corda5-build-notifications")
         }
     }
 }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -146,6 +146,9 @@ pipeline {
             archiveArtifacts artifacts: 'forward.txt, workerLogs.txt, podLogs.txt', allowEmptyArchive: true
             sh 'rm -f forward.txt workerLogs.txt podLogs.txt'
         }
+        failure {
+            sendSlackNotifications("danger", "BUILD FAILURE", true, "#corda-corda5-build-notifications")
+        }
     }
 }
 


### PR DESCRIPTION
- if combined worker fails send slack notifications 
- this will only happen for the release branch. Logic in sendSlackNotifications filters this
- see [here ](https://github.com/corda/corda-shared-build-pipeline-steps/blob/ronanb/CORE-4377/snyk-scanning_/vars/sendSlackNotifications.groovy) for helper implementation logic 

Note will hold off merging until combined worker is stable to avoid spamming channel see this PR https://github.com/corda/corda-runtime-os/pull/1849

 