### PR TITLE
CORE-6106 Add logging.level to Corda chart

### DIFF
--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -6,7 +6,8 @@ bootstrap:
     password: "admin"
 
 logging:
-  format: text
+  format: "text"
+  level: "info"
 
 kafka:
   bootstrapServers: prereqs-kafka:9092

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -187,6 +187,8 @@ Worker environment variables
     {{- end }}
 - name: LOG4J_CONFIG_FILE
   value: "log4j2-console{{ if eq .Values.logging.format "json" }}-json{{ end }}.xml"
+- name: CONSOLE_LOG_LEVEL
+  value: {{ ( get .Values.workers .worker ).logging.level | default .Values.logging.level }}
 {{- end }}
 
 {{/*

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -32,6 +32,8 @@ resources:
 logging:
   # -- log format; "json" or "text"
   format: "json"
+  # -- log level; one of "all", "trace", "debug", "info", "warn" (the default), "error", "fatal", or "off"
+  level: "warn"
 
 # Open Telemetry configuration
 openTelemetry:
@@ -174,6 +176,10 @@ workers:
       enabled: false
       # -- if debug is enabled, suspend the crypto worker until the debugger is attached
       suspend: false
+    # logging configuration
+    logging:
+      # -- log level: one of "all", "trace", "debug", "info", "warn", "error", "fatal", or "off"; defaults to logging.level if not specified
+      level: ""
     profiling:
       # -- run crypto worker with profiling enabled
       enabled: false
@@ -202,6 +208,10 @@ workers:
       enabled: false
       # -- if debug is enabled, suspend the DB worker until the debugger is attached
       suspend: false
+    # logging configuration
+    logging:
+      # -- log level: one of "all", "trace", "debug", "info", "warn", "error", "fatal", or "off"; defaults to logging.level if not specified
+      level: ""
     profiling:
       # -- run DB worker with profiling enabled
       enabled: false
@@ -234,6 +244,10 @@ workers:
       enabled: false
       # -- if debug is enabled, suspend the flow worker until the debugger is attached
       suspend: false
+    # logging configuration
+    logging:
+      # -- log level: one of "all", "trace", "debug", "info", "warn", "error", "fatal", or "off"; defaults to logging.level if not specified
+      level: ""
     profiling:
       # -- run flow worker with profiling enabled
       enabled: false
@@ -264,6 +278,10 @@ workers:
       enabled: false
       # -- if debug is enabled, suspend the membership worker until the debugger is attached
       suspend: false
+    # logging configuration
+    logging:
+      # -- log level: one of "all", "trace", "debug", "info", "warn", "error", "fatal", or "off"; defaults to logging.level if not specified
+      level: ""
     profiling:
       # -- run membership worker with profiling enabled
       enabled: false
@@ -292,6 +310,10 @@ workers:
       enabled: false
       # -- if debug is enabled, suspend the RPC worker until the debugger is attached
       suspend: false
+    # logging configuration
+    logging:
+      # -- log level: one of "all", "trace", "debug", "info", "warn", "error", "fatal", or "off"; defaults to logging.level if not specified
+      level: ""
     profiling:
       # -- run RPC worker with profiling enabled
       enabled: false
@@ -332,6 +354,10 @@ workers:
       enabled: false
       # -- if debug is enabled, suspend the p2p-link-manager worker until the debugger is attached
       suspend: false
+    # logging configuration
+    logging:
+      # -- log level: one of "all", "trace", "debug", "info", "warn", "error", "fatal", or "off"; defaults to logging.level if not specified
+      level: ""
     profiling:
       # -- run p2p-link-manager worker with profiling enabled
       enabled: false
@@ -362,6 +388,10 @@ workers:
       enabled: false
       # -- if debug is enabled, suspend the p2p-gateway worker until the debugger is attached
       suspend: false
+    # logging configuration
+    logging:
+      # -- log level: one of "all", "trace", "debug", "info", "warn", "error", "fatal", or "off"; defaults to logging.level if not specified
+      level: ""
     profiling:
       # -- run p2p-gateway worker with profiling enabled
       enabled: false

--- a/debug.yaml
+++ b/debug.yaml
@@ -16,24 +16,34 @@ workers:
 #    debug:
 #      enabled: true
 #      suspend: true
+#    logging:
+#      level: "debug"
   db:
     replicaCount: 1
 #    debug:
 #      enabled: true
 #      suspend: true
+#    logging:
+#      level: "debug"
   flow:
     replicaCount: 1
 #    debug:
 #      enabled: true
 #      suspend: true
+#    logging:
+#      level: "debug"
     verifyInstrumentation: true
   membership:
     replicaCount: 1
 #    debug:
 #      enabled: true
 #      suspend: true
+#    logging:
+#      level: "debug"
   rpc:
     replicaCount: 1
 #    debug:
 #      enabled: true
 #      suspend: true
+#    logging:
+#      level: "debug"

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,8 @@ image:
   tag: latest-local
 
 logging:
-  format: text
+  format: "text"
+  level: "info"
 
 bootstrap:
   initialAdminUser:


### PR DESCRIPTION
Adds the ability to set the logging level globally for all workers via `logging.level` or per worker via `workers.xxx.logging.level` (where `xxx` is `rpc`, `crypto`, etc..). The default is a global logging level of `warn` (likely more appropriate for production environments). The default is overridden back to `info` for E2E tests and local developer usage (`values.yaml`). The `debug.yaml` is also updated to demonstrate setting the level per worker.