### PR TITLE
CORE-6138 AccessControlException in ForkJoinPool

### DIFF
--- a/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityManagerServiceImpl.kt
+++ b/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityManagerServiceImpl.kt
@@ -38,6 +38,10 @@ class SecurityManagerServiceImpl @Activate constructor(
     private var cordaSecurityManager: CordaSecurityManager? = null
 
     init {
+        // TODO Might need to be moved somewhere else and set when osgi security property is set
+        System.setProperty(
+            "java.util.concurrent.ForkJoinPool.common.threadFactory",
+            "net.corda.osgi.framework.SecManagerForkJoinWorkerThreadFactory")
         enablePackageAccessPermission("net.corda.")
         startRestrictiveMode()
         val url = bundleContext.bundle.getResource(DEFAULT_SECURITY_POLICY)

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -5,7 +5,6 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.base.util.loggerFor
-import java.util.concurrent.ForkJoinPool
 
 internal class SandboxGroupContextCacheImpl(override val cacheSize: Long): SandboxGroupContextCache {
     private companion object {
@@ -13,12 +12,6 @@ internal class SandboxGroupContextCacheImpl(override val cacheSize: Long): Sandb
     }
     private val contexts: Cache<VirtualNodeContext, CloseableSandboxGroupContext> = Caffeine.newBuilder()
         .maximumSize(cacheSize)
-        .executor(ForkJoinPool(
-            Runtime.getRuntime().availableProcessors(),
-            SandboxForkJoinWorkerThreadFactory(),
-            null,
-            false
-        ))
         .removalListener<VirtualNodeContext, CloseableSandboxGroupContext> { key, value, cause ->
             logger.info("Evicting ${key!!.sandboxGroupType} sandbox for: ${key.holdingIdentity.x500Name} [${cause.name}]")
             value?.close()

--- a/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/SecManagerForkJoinWorkerThreadFactory.kt
+++ b/osgi-framework-bootstrap/src/main/kotlin/net/corda/osgi/framework/SecManagerForkJoinWorkerThreadFactory.kt
@@ -1,4 +1,4 @@
-package net.corda.sandboxgroupcontext.service.impl
+package net.corda.osgi.framework
 
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory
@@ -9,11 +9,11 @@ import java.util.concurrent.ForkJoinWorkerThread
  * ([ForkJoinPool]'s common pool uses a factory supplying threads that have no Permissions enabled if a
  * [SecurityManager] is present.)
  */
-class SandboxForkJoinWorkerThreadFactory : ForkJoinWorkerThreadFactory {
+class SecManagerForkJoinWorkerThreadFactory : ForkJoinWorkerThreadFactory {
 
     override fun newThread(pool: ForkJoinPool?): ForkJoinWorkerThread {
-        return SandboxFForkJoinWorkerThread(pool)
+        return SecManagerForkJoinWorkerThread(pool)
     }
 
-    private class SandboxFForkJoinWorkerThread(pool: ForkJoinPool?) : ForkJoinWorkerThread(pool)
+    private class SecManagerForkJoinWorkerThread(pool: ForkJoinPool?) : ForkJoinWorkerThread(pool)
 }


### PR DESCRIPTION
- Setting `ForkJoinWorkerThreadFactory` for default pool when `SecurityManager` is used so that permissions of supplied threads are not changed