### PR TITLE
CORE-5786: Be lenient about `SQLTransientException` in DB Bus

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
@@ -85,7 +85,7 @@ internal object ContextUtils {
             MDC.put("http.method", ctx.method())
             MDC.put("http.path", ctx.path())
             MDC.put("http.user", rpcContext()?.principal ?: "<anonymous>")
-            log.info("Servicing ${ctx.method()} request to '${ctx.path()}")
+            log.info("Servicing ${ctx.method()} request to '${ctx.path()}'")
             log.debug { "Invoke method \"${this.method.method.name}\" for route info." }
             log.trace { "Get parameter values." }
             try {


### PR DESCRIPTION
`SQLTransientException` may occur when a connection cannot be retrieved from a Hikari pool.
In particular this scenario may happen when people sit on a breakpoint for long enough, therefore exceeding default time (of 30 seconds) to retrieve a connection from a connection pool.

If we do nothing, this exception will propagate causing Bus consumer/producers to fail. This wil in turn fail all the dependant services via Lifecycle coordinator chain, making Combined Worker unusable after execution resumed.

I have tested this change locally by stopping on breakpoint for over 5 minutes and once resumed Combined worker was still usable and `status` page shown no `DOWN` components.