### PR TITLE
CORE-6006, CORE-5819 - Exclude Kryo unused transitive dependencies

### DIFF
--- a/libs/serialization/kryo-serializers/build.gradle
+++ b/libs/serialization/kryo-serializers/build.gradle
@@ -11,8 +11,6 @@ ext {
     kryoCglibVersion = '3.1'
     kryoDexxCollectionVersion = '0.6'
     kryoJodaTimeVersion = '1.6.2'
-    kryoProtobufVersion = '3.6.1'
-    kryoWicketVersion = '1.4.17'
     guavaOsgiVersion = provider {
         parseMavenString(guavaVersion).getOSGiVersion()
     }
@@ -29,8 +27,6 @@ dependencies {
     // This information has been read from kryo-serializers' original POM.
     compileOnly "de.javakaffee:kryo-serializers:$kryoSerializerVersion"
     compileOnly "com.github.andrewoma.dexx:collection:$kryoDexxCollectionVersion"
-    compileOnly "com.google.protobuf:protobuf-java:$kryoProtobufVersion"
-    compileOnly "org.apache.wicket:wicket:$kryoWicketVersion"
     compileOnly "joda-time:joda-time:$kryoJodaTimeVersion"
     compileOnly "cglib:cglib:$kryoCglibVersion"
     api "com.esotericsoftware:kryo:$kryoVersion"

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -62,6 +62,13 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
 }
 
+// excluding these transitive dependencies because we don't need them and
+//  sometimes they raise security issues.
+configurations.implementation {
+    exclude group: 'com.google.protobuf', module: 'protobuf-java'
+    exclude group: 'org.apache.wicket', module: 'wicket'
+}
+
 def integrationTestResources = tasks.named('processIntegrationTestResources', ProcessResources) {
     from configurations.cpbs
 }


### PR DESCRIPTION
Exclude Protobuf and Wicket as transitive dependencies from the kryo serialiser as they are not needed.

```
❯ ./gradlew snyk-test -PsnykSeverity=high -PsnykArguments='--sub-project=kryo-serializers'

> Configure project :
********************** CORDA FLOW WORKER BUILD **********************
SDK version: 11
JAVA HOME /Users/driessamyn/.sdkman/candidates/java/11.0.11.fx-zulu/zulu-11.jdk/Contents/Home
Corda runtime OS release version: 5.0.0.0-SNAPSHOT
Corda API dependency version spec: 5.0.0.155-beta+

> Task :snyk-check-binary
auto update snyk binary: 1.985.0 -> 1.986.0
Download version v1.986.0 of snyk-macos
Downloading: https://github.com/snyk/snyk/releases/download/v1.986.0/snyk-macos
Downloading finished
Using Snyk CLI version: v1.986.0

> Task :snyk-test


Testing /Users/driessamyn/corda5/flow-worker...

Organization:      r3-gradle-plugins
Package manager:   gradle
Target file:       build.gradle
Project name:      flow-worker/kryo-serializers
Open source:       no
Project path:      /Users/driessamyn/corda5/flow-worker
Licenses:          enabled

✔ Tested 93 dependencies for known issues, no vulnerable paths found.
```