### PR TITLE
CORE-6118 increase combined worker e2e test timeouts

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -73,6 +73,7 @@ fun awaitRpcFlowFinished(holdingId: String, requestId: String): FlowStatus {
         ObjectMapper().readValue(
             assertWithRetry {
                 command { flowStatus(holdingId, requestId) }
+                //CORE-6118 - tmp increase this timeout to a large number to allow tests to pass while slow flow sessions are investigated
                 timeout(Duration.ofMinutes(6))
                 condition {
                     it.code == 200 &&

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -73,7 +73,7 @@ fun awaitRpcFlowFinished(holdingId: String, requestId: String): FlowStatus {
         ObjectMapper().readValue(
             assertWithRetry {
                 command { flowStatus(holdingId, requestId) }
-                timeout(Duration.ofSeconds(90))
+                timeout(Duration.ofMinutes(6))
                 condition {
                     it.code == 200 &&
                             (it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||


### PR DESCRIPTION
Combined worker e2e tests are failing due to some very slow flow sessions. However flows complete successfully eventually after about 3 or 4 minutes. tmp push up timeout to allow for this to be a pr gate