### PR TITLE
CORE-6191: testing combined worker mandatory PR gate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
+@Library('corda-shared-build-pipeline-steps@ronanb/CORE-6191/combied-worker-smoke-tests-pr-gate') _
 
 cordaPipeline(
     nexusAppId: 'flow-worker-5.0',
@@ -9,5 +9,6 @@ cordaPipeline(
     publishPreTestImage: true,
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
-    runE2eTests: true
+    runE2eTests: true,
+    combinedWorkere2eTests: true
     )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@ronanb/CORE-6191/combied-worker-smoke-tests-pr-gate') _
+@Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaPipeline(
     nexusAppId: 'flow-worker-5.0',


### PR DESCRIPTION
Add config to ensure combined worker smoke tests are ran as part of PR gate.
Not to be merged before https://github.com/corda/corda-shared-build-pipeline-steps/pull/284 
