### PR TITLE
CORE-6140: FakeCorda creates fake virtual nodes

### DIFF
--- a/cordapp-test-utils/README.md
+++ b/cordapp-test-utils/README.md
@@ -16,9 +16,9 @@ the `CPI_HASH`).
 ```kotlin
     val corda = FakeCorda()
     val member = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")
-    corda.upload(member, HelloFlow::class.java)
+    val node = corda.createVirtualNode(member, HelloFlow::class.java)
 
-    val response = corda.invoke(member,
+    val response = node.callFlow(
         RPCRequestDataMock("r1", HelloFlow::class.java.name, "{ \"name\" : \"CordaDev\" }")
     )
 ```
@@ -67,7 +67,7 @@ val requestBody = RPCRequestDataMock.fromData("r1",
 
 ## Instance vs Class upload
 
-The FakeCorda has two methods of uploading responder flows:
+The FakeCorda has two methods of creating nodes with responder flows:
 - via a class, which will be constructed when a response flow is initialized.
 - via an instance, which must be uploaded against a protocol.
 
@@ -81,7 +81,7 @@ independently in conjunction with the FakeCorda's instance-upload capability.
 
 ```kotlin
 responder.whenever(CountRequest(7), listOf(CountResponse(1, 2, 3, 4, 5, 6, 7)))
-cordaMock.upload(member, "count-protocol", responder)
+cordaMock.createVirtualNode(member, "count-protocol", responder)
 ```
 
 ## Standalone tools and services
@@ -101,4 +101,5 @@ Note these will eventually move to being `cordaProvided` from a factory.
 - Handle errors for unmatched sends / receives
 - Implement FlowMessaging send / receive methods
 - Make FlowSession and FlowEngine mocks for InitiatingFlow tests
+- Timeouts
 - SigningService, MemberLookup

--- a/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
+++ b/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
@@ -1,6 +1,7 @@
 package net.cordacon.example
 
 import net.corda.testutils.FakeCorda
+import net.corda.testutils.HoldingIdentity
 import net.corda.testutils.tools.RPCRequestDataMock
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
@@ -13,25 +14,28 @@ class RollCallTest {
     fun `should get roll call from multiple recipients`() {
         // Given a RollCallFlow that's been uploaded to Corda for a teacher
         val corda = FakeCorda()
-        val teacher = MemberX500Name.parse("CN=Ben Stein, OU=Economics, O=Glenbrook North High School, L=Chicago, C=US")
-        corda.upload(teacher, RollCallFlow::class.java)
+        val teacher = MemberX500Name.parse(
+            "CN=Ben Stein, OU=Economics, O=Glenbrook North High School, L=Chicago, C=US")
+        val teacherId = HoldingIdentity(teacher)
+        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // and recipients with the responder flow
+        //
+        // and a flow to invoke when someone is absent (they return an empty string)
+        // Note: We don't actually need to do the upload, because it's a subflow so constructed inside the main flow -
+        // initialization, checking etc. will happen when it's passed to the engine.
+        //
+        // and a response (which we do need, but it's exactly the same; Ferris Bueller continues to take a day off)
         val students = listOf("Albers", "Anderson", "Anheiser", "Busch", "Bueller"). map {
             "CN=$it, OU=Economics, O=Glenbrook North High School, L=Chicago, C=US"
         }
-        students.forEach { corda.upload(MemberX500Name.parse(it), RollCallResponderFlow::class.java) }
-
-        // and a flow to invoke when someone is absent (they return an empty string)
-        // Note: We don't actually need to do the upload, because it's constructed inside the main flow -
-        // initialization, checking etc. will have to happen when it's passed to the engine.
-        // corda.upload(teacher, AbsenceSubFlow::class.java)
-
-        // and a response (which we do need, but it's exactly the same; Ferris Bueller continues to take a day off)
-        students.forEach { corda.upload(MemberX500Name.parse(it), AbsenceCallResponderFlow::class.java) }
+        students.forEach { corda.createVirtualNode(
+            HoldingIdentity(MemberX500Name.parse(it)),
+            RollCallResponderFlow::class.java,
+            AbsenceCallResponderFlow::class.java) }
 
         // When we invoke it in Corda
-        val response = corda.invoke(teacher, RPCRequestDataMock.fromData(
+        val response = corda.invoke(teacherId, RPCRequestDataMock.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)
@@ -54,7 +58,7 @@ class RollCallTest {
         """.trimIndent().replace("\n", System.lineSeparator())))
 
         // And Ferris Bueller's absence should have been persisted
-        val persistence = corda.getPersistenceServiceFor(teacher)
+        val persistence = corda.getPersistenceServiceFor(teacherId)
         val absenceResponses = persistence.findAll(AbsenceRecordEntity::class.java)
         assertThat(absenceResponses.execute().map { it.name }, `is`(listOf("Bueller")))
     }
@@ -63,18 +67,22 @@ class RollCallTest {
     fun `should default to using the org name if a student has no common name`() {
         // Given a RollCallFlow that's been uploaded to Corda
         val corda = FakeCorda()
-        val teacher = MemberX500Name.parse("O=BEN STEIN, L=Chicago, C=US")
-        corda.upload(teacher, RollCallFlow::class.java)
+        val teacherId = HoldingIdentity(MemberX500Name.parse("O=BEN STEIN, L=Chicago, C=US"))
+        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // and recipients with the responder and absence flow
         val students = listOf("Albers", "Anderson", "Anheiser", "Busch", "Bueller"). map {
             "O=$it, L=Chicago, C=US"
         }
-        students.forEach { corda.upload(MemberX500Name.parse(it), RollCallResponderFlow::class.java) }
-        students.forEach { corda.upload(MemberX500Name.parse(it), AbsenceCallResponderFlow::class.java) }
+
+        students.forEach { corda.createVirtualNode(
+            HoldingIdentity(MemberX500Name.parse(it)),
+            RollCallResponderFlow::class.java,
+            AbsenceCallResponderFlow::class.java)
+        }
 
         // When we invoke it in Corda
-        val response = corda.invoke(teacher, RPCRequestDataMock.fromData(
+        val response = corda.invoke(teacherId, RPCRequestDataMock.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)

--- a/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
+++ b/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
@@ -17,7 +17,7 @@ class RollCallTest {
         val teacher = MemberX500Name.parse(
             "CN=Ben Stein, OU=Economics, O=Glenbrook North High School, L=Chicago, C=US")
         val teacherId = HoldingIdentity(teacher)
-        val teacherVNodeInfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNode = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // and recipients with the responder flow
         //
@@ -35,7 +35,7 @@ class RollCallTest {
             AbsenceCallResponderFlow::class.java) }
 
         // When we invoke it in Corda
-        val response = corda.callFlow(teacherVNodeInfo, RPCRequestDataWrapper.fromData(
+        val response = teacherVNode.callFlow(RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)
@@ -58,7 +58,7 @@ class RollCallTest {
         """.trimIndent().replace("\n", System.lineSeparator())))
 
         // And Ferris Bueller's absence should have been persisted
-        val persistence = corda.getPersistenceServiceFor(teacherVNodeInfo)
+        val persistence = teacherVNode.getPersistenceService()
         val absenceResponses = persistence.findAll(AbsenceRecordEntity::class.java)
         assertThat(absenceResponses.execute().map { it.name }, `is`(listOf("Bueller")))
 
@@ -70,7 +70,7 @@ class RollCallTest {
         // Given a RollCallFlow that's been uploaded to Corda
         val corda = FakeCorda()
         val teacherId = HoldingIdentity(MemberX500Name.parse("O=BEN STEIN, L=Chicago, C=US"))
-        val teacherVNodeinfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNode = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // and recipients with the responder and absence flow
         val students = listOf("Albers", "Anderson", "Anheiser", "Busch", "Bueller"). map {
@@ -84,7 +84,7 @@ class RollCallTest {
         }
 
         // When we invoke it in Corda
-        val response = corda.callFlow(teacherVNodeinfo, RPCRequestDataWrapper.fromData(
+        val response = teacherVNode.callFlow(RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)

--- a/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
+++ b/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
@@ -2,7 +2,7 @@ package net.cordacon.example
 
 import net.corda.testutils.FakeCorda
 import net.corda.testutils.HoldingIdentity
-import net.corda.testutils.tools.RPCRequestDataMock
+import net.corda.testutils.tools.RPCRequestDataWrapper
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
@@ -35,7 +35,7 @@ class RollCallTest {
             AbsenceCallResponderFlow::class.java) }
 
         // When we invoke it in Corda
-        val response = corda.invoke(teacherId, RPCRequestDataMock.fromData(
+        val response = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)
@@ -82,7 +82,7 @@ class RollCallTest {
         }
 
         // When we invoke it in Corda
-        val response = corda.invoke(teacherId, RPCRequestDataMock.fromData(
+        val response = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)

--- a/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
+++ b/cordapp-test-utils/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
@@ -17,7 +17,7 @@ class RollCallTest {
         val teacher = MemberX500Name.parse(
             "CN=Ben Stein, OU=Economics, O=Glenbrook North High School, L=Chicago, C=US")
         val teacherId = HoldingIdentity(teacher)
-        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNodeInfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // and recipients with the responder flow
         //
@@ -35,7 +35,7 @@ class RollCallTest {
             AbsenceCallResponderFlow::class.java) }
 
         // When we invoke it in Corda
-        val response = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
+        val response = corda.callFlow(teacherVNodeInfo, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)
@@ -58,9 +58,11 @@ class RollCallTest {
         """.trimIndent().replace("\n", System.lineSeparator())))
 
         // And Ferris Bueller's absence should have been persisted
-        val persistence = corda.getPersistenceServiceFor(teacherId)
+        val persistence = corda.getPersistenceServiceFor(teacherVNodeInfo)
         val absenceResponses = persistence.findAll(AbsenceRecordEntity::class.java)
         assertThat(absenceResponses.execute().map { it.name }, `is`(listOf("Bueller")))
+
+        corda.close()
     }
 
     @Test
@@ -68,7 +70,7 @@ class RollCallTest {
         // Given a RollCallFlow that's been uploaded to Corda
         val corda = FakeCorda()
         val teacherId = HoldingIdentity(MemberX500Name.parse("O=BEN STEIN, L=Chicago, C=US"))
-        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNodeinfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // and recipients with the responder and absence flow
         val students = listOf("Albers", "Anderson", "Anheiser", "Busch", "Bueller"). map {
@@ -82,7 +84,7 @@ class RollCallTest {
         }
 
         // When we invoke it in Corda
-        val response = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
+        val response = corda.callFlow(teacherVNodeinfo, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students)
@@ -103,5 +105,7 @@ class RollCallTest {
             BEN STEIN: Bueller?
             
         """.trimIndent().replace("\n", System.lineSeparator())))
+
+        corda.close()
     }
 }

--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/ResponderFlowDelegate.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/ResponderFlowDelegate.kt
@@ -2,6 +2,7 @@ package net.cordacon.example
 
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.util.contextLogger
 
 class ResponderFlowDelegate {
@@ -10,6 +11,7 @@ class ResponderFlowDelegate {
         val log = contextLogger()
     }
 
+    @Suspendable
     fun callDelegate(session: FlowSession, flowEngine: FlowEngine) {
         log.info("Responder ${flowEngine.virtualNodeName} called")
         session.receive(RollCallRequest::class.java)

--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/RollCallFlow.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/RollCallFlow.kt
@@ -97,6 +97,7 @@ class RollCallFlow: RPCStartableFlow {
         }
     }
 
+    @Suspendable
     private fun retryRollCall(
         r: Pair<FlowSession, String>
     ) : List<AbsenceResponse> {

--- a/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
+++ b/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
@@ -24,7 +24,7 @@ class RollCallFlowTest {
         // Given a teacher with an initiating flow
         val teacherId = HoldingIdentity.create("Teach")
         val corda = FakeCorda()
-        val teacherVNodeinfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNode = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // And a list of students who will respond predictably
         val students = listOf("Alpha", "Beta", "Gamma").map {
@@ -45,7 +45,7 @@ class RollCallFlowTest {
         }
 
         // When we contact the students
-        val result = corda.callFlow(teacherVNodeinfo, RPCRequestDataWrapper.fromData(
+        val result = teacherVNode.callFlow(RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students.values.toList())))
@@ -67,7 +67,7 @@ class RollCallFlowTest {
         // Given a teacher with an initiating flow
         val teacherId = HoldingIdentity.create("Teach")
         val corda = FakeCorda()
-        val teacherVNodeinfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNode = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // And a student who will respond with empty string repeatedly
         val studentId = "CN=Zammo, OU=VIth Form, O=Grange Hill, L=London, C=GB"
@@ -79,7 +79,7 @@ class RollCallFlowTest {
         corda.createVirtualNode(HoldingIdentity(MemberX500Name.parse(studentId)), "absence-call", responder)
 
         // When we contact the student
-        val result = corda.callFlow(teacherVNodeinfo, RPCRequestDataWrapper.fromData(
+        val result = teacherVNode.callFlow(RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(listOf(studentId))))

--- a/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
+++ b/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
@@ -24,7 +24,7 @@ class RollCallFlowTest {
         // Given a teacher with an initiating flow
         val teacherId = HoldingIdentity.create("Teach")
         val corda = FakeCorda()
-        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNodeinfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // And a list of students who will respond predictably
         val students = listOf("Alpha", "Beta", "Gamma").map {
@@ -45,7 +45,7 @@ class RollCallFlowTest {
         }
 
         // When we contact the students
-        val result = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
+        val result = corda.callFlow(teacherVNodeinfo, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students.values.toList())))
@@ -67,7 +67,7 @@ class RollCallFlowTest {
         // Given a teacher with an initiating flow
         val teacherId = HoldingIdentity.create("Teach")
         val corda = FakeCorda()
-        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
+        val teacherVNodeinfo = corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // And a student who will respond with empty string repeatedly
         val studentId = "CN=Zammo, OU=VIth Form, O=Grange Hill, L=London, C=GB"
@@ -79,7 +79,7 @@ class RollCallFlowTest {
         corda.createVirtualNode(HoldingIdentity(MemberX500Name.parse(studentId)), "absence-call", responder)
 
         // When we contact the student
-        val result = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
+        val result = corda.callFlow(teacherVNodeinfo, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(listOf(studentId))))

--- a/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
+++ b/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
@@ -1,6 +1,7 @@
 package net.cordacon.example
 
 import net.corda.testutils.FakeCorda
+import net.corda.testutils.HoldingIdentity
 import net.corda.testutils.services.SimpleJsonMarshallingService
 import net.corda.testutils.tools.RPCRequestDataMock
 import net.corda.testutils.tools.ResponderMock
@@ -21,9 +22,9 @@ class RollCallFlowTest {
     @Test
     fun `should request each student to respond to roll call`() {
         // Given a teacher with an initiating flow
-        val teacher = MemberX500Name.parse("CN=Teach, OU=Economics, O=Grange Hill, L=London, C=GB")
+        val teacherId = HoldingIdentity.create("Teach")
         val corda = FakeCorda()
-        corda.upload(teacher, RollCallFlow::class.java)
+        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // And a list of students who will respond predictably
         val students = listOf("Alpha", "Beta", "Gamma").map {
@@ -40,11 +41,11 @@ class RollCallFlowTest {
         responses.forEach {
             val student = students[it.key]!!
             responder.whenever(RollCallRequest(student), listOf(RollCallResponse(it.value)))
-            corda.upload(MemberX500Name.parse(student), "roll-call", responder)
+            corda.createVirtualNode(HoldingIdentity(MemberX500Name.parse(student)), "roll-call", responder)
         }
 
         // When we contact the students
-        val result = corda.invoke(teacher, RPCRequestDataMock.fromData(
+        val result = corda.invoke(teacherId, RPCRequestDataMock.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students.values.toList())))
@@ -64,24 +65,24 @@ class RollCallFlowTest {
     @Test
     fun `should retry twice if any student fails to respond`() {
         // Given a teacher with an initiating flow
-        val teacher = MemberX500Name.parse("CN=Teach, OU=Economics, O=Grange Hill, L=London, C=GB")
+        val teacherId = HoldingIdentity.create("Teach")
         val corda = FakeCorda()
-        corda.upload(teacher, RollCallFlow::class.java)
+        corda.createVirtualNode(teacherId, RollCallFlow::class.java)
 
         // And a student who will respond with empty string repeatedly
-        val student = "CN=Zammo, OU=VIth Form, O=Grange Hill, L=London, C=GB"
+        val studentId = "CN=Zammo, OU=VIth Form, O=Grange Hill, L=London, C=GB"
         val responder = ResponderMock<RollCallRequest, RollCallResponse>()
-        responder.whenever(RollCallRequest(student), listOf(RollCallResponse("")))
+        responder.whenever(RollCallRequest(studentId), listOf(RollCallResponse("")))
 
         // ...for both kinds of flow
-        corda.upload(MemberX500Name.parse(student), "roll-call", responder)
-        corda.upload(MemberX500Name.parse(student), "absence-call", responder)
+        corda.createVirtualNode(HoldingIdentity(MemberX500Name.parse(studentId)), "roll-call", responder)
+        corda.createVirtualNode(HoldingIdentity(MemberX500Name.parse(studentId)), "absence-call", responder)
 
         // When we contact the student
-        val result = corda.invoke(teacher, RPCRequestDataMock.fromData(
+        val result = corda.invoke(teacherId, RPCRequestDataMock.fromData(
             "r1",
             RollCallFlow::class.java,
-            RollCallInitiationRequest(listOf(student))))
+            RollCallInitiationRequest(listOf(studentId))))
 
         // Then it should just be the teacher calling into empty air
         assertThat(result, `is`("""
@@ -95,21 +96,21 @@ class RollCallFlowTest {
     @Test
     fun `should use the AbsenceFlow to do the retry`() {
         // Given a teacher with an initiating flow
-        val teacher = MemberX500Name.parse("CN=Teach, OU=Economics, O=Grange Hill, L=London, C=GB")
+        val teacherId = HoldingIdentity.create("Teach")
         val flow = RollCallFlow()
         flow.flowMessaging = mock()
         flow.flowEngine = mock()
         flow.persistenceService = mock()
         flow.jsonMarshallingService = SimpleJsonMarshallingService()
 
-        whenever(flow.flowEngine.virtualNodeName).thenReturn(teacher)
+        whenever(flow.flowEngine.virtualNodeName).thenReturn(teacherId.member)
 
         // And a student who we'll mimic being absent
-        val student = "CN=Zammo, OU=VIth Form, O=Grange Hill, L=London, C=GB"
+        val studentId = HoldingIdentity.create("Zammo")
 
         val flowSession = mock<FlowSession>()
-        whenever(flowSession.counterparty).thenReturn(MemberX500Name.parse(student))
-        whenever(flow.flowMessaging.initiateFlow(MemberX500Name.parse(student))).thenReturn(flowSession)
+        whenever(flowSession.counterparty).thenReturn(studentId.member)
+        whenever(flow.flowMessaging.initiateFlow(studentId.member)).thenReturn(flowSession)
         whenever(flowSession.sendAndReceive<RollCallResponse>(any(), any()))
             .thenReturn(UntrustworthyData(RollCallResponse("")))
 
@@ -120,7 +121,7 @@ class RollCallFlowTest {
         flow.call(RPCRequestDataMock.fromData(
             "r1",
             RollCallFlow::class.java,
-            RollCallInitiationRequest(listOf(student))).toRPCRequestData())
+            RollCallInitiationRequest(listOf(studentId.member.toString()))).toRPCRequestData())
 
         // Then the subflow should have been called twice
         verify(flow.flowEngine, times(2)).subFlow(any<AbsenceSubFlow>())

--- a/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
+++ b/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/RollCallFlowTest.kt
@@ -3,7 +3,7 @@ package net.cordacon.example
 import net.corda.testutils.FakeCorda
 import net.corda.testutils.HoldingIdentity
 import net.corda.testutils.services.SimpleJsonMarshallingService
-import net.corda.testutils.tools.RPCRequestDataMock
+import net.corda.testutils.tools.RPCRequestDataWrapper
 import net.corda.testutils.tools.ResponderMock
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.messaging.UntrustworthyData
@@ -45,7 +45,7 @@ class RollCallFlowTest {
         }
 
         // When we contact the students
-        val result = corda.invoke(teacherId, RPCRequestDataMock.fromData(
+        val result = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(students.values.toList())))
@@ -79,7 +79,7 @@ class RollCallFlowTest {
         corda.createVirtualNode(HoldingIdentity(MemberX500Name.parse(studentId)), "absence-call", responder)
 
         // When we contact the student
-        val result = corda.invoke(teacherId, RPCRequestDataMock.fromData(
+        val result = corda.invoke(teacherId, RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(listOf(studentId))))
@@ -118,7 +118,7 @@ class RollCallFlowTest {
         whenever(flow.flowEngine.subFlow(any<AbsenceSubFlow>())).thenReturn("")
 
         // When we call the flow for a student who is absent
-        flow.call(RPCRequestDataMock.fromData(
+        flow.call(RPCRequestDataWrapper.fromData(
             "r1",
             RollCallFlow::class.java,
             RollCallInitiationRequest(listOf(studentId.member.toString()))).toRPCRequestData())

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/FakeCorda.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/FakeCorda.kt
@@ -9,7 +9,7 @@ import net.corda.testutils.internal.FlowServicesInjector
 import net.corda.testutils.internal.cast
 import net.corda.testutils.tools.CordaFlowChecker
 import net.corda.testutils.tools.FlowChecker
-import net.corda.testutils.tools.RPCRequestDataMock
+import net.corda.testutils.tools.RPCRequestDataWrapper
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.ResponderFlow
@@ -83,7 +83,7 @@ class FakeCorda(
      *
      * @return the response from the flow
      */
-    fun invoke(initiator: HoldingIdentity, input: RPCRequestDataMock): String {
+    fun invoke(initiator: HoldingIdentity, input: RPCRequestDataWrapper): String {
         val flowClassName = input.flowClassName
         val flow = flowFactory.createInitiatingFlow(initiator.member, flowClassName)
         injector.injectServices(flow, initiator.member, fakeFiber, flowFactory)

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/FakeVirtualNode.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/FakeVirtualNode.kt
@@ -1,0 +1,25 @@
+package net.corda.testutils
+
+import net.corda.testutils.tools.RPCRequestDataWrapper
+import net.corda.v5.application.persistence.PersistenceService
+import net.corda.v5.base.types.MemberX500Name
+
+interface FakeVirtualNode {
+    val holdingIdentity: HoldingIdentity
+    val member : MemberX500Name
+
+    /**
+     * Calls the flow with the given request. Note that this call happens on the calling thread, which will wait until
+     * the flow has completed before returning the response.
+     *
+     * @input the data to input to the flow
+     *
+     * @return the response from the flow
+     */
+    fun callFlow(input: RPCRequestDataWrapper): String
+
+    /**
+     * Retrieves the persistence service associated with this node's member
+     */
+    fun getPersistenceService(): PersistenceService
+}

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/HoldingIdentity.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/HoldingIdentity.kt
@@ -1,0 +1,12 @@
+package net.corda.testutils
+
+import net.corda.v5.base.types.MemberX500Name
+
+data class HoldingIdentity(val member: MemberX500Name) {
+    companion object {
+        fun create(commonName: String): HoldingIdentity {
+            return HoldingIdentity(MemberX500Name.parse(
+                "CN=$commonName, OU=ExampleUnit, O=ExampleOrg, L=London, C=GB"))
+        }
+    }
+}

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/VirtualNodeInfo.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/VirtualNodeInfo.kt
@@ -1,0 +1,8 @@
+package net.corda.testutils
+
+import net.corda.v5.base.types.MemberX500Name
+
+data class VirtualNodeInfo(val holdingIdentity: HoldingIdentity) {
+
+    val member : MemberX500Name = holdingIdentity.member
+}

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/VirtualNodeInfo.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/VirtualNodeInfo.kt
@@ -1,8 +1,0 @@
-package net.corda.testutils
-
-import net.corda.v5.base.types.MemberX500Name
-
-data class VirtualNodeInfo(val holdingIdentity: HoldingIdentity) {
-
-    val member : MemberX500Name = holdingIdentity.member
-}

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/internal/FakeVirtualNodeBase.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/internal/FakeVirtualNodeBase.kt
@@ -1,0 +1,36 @@
+package net.corda.testutils.internal
+
+import net.corda.testutils.FakeVirtualNode
+import net.corda.testutils.HoldingIdentity
+import net.corda.testutils.tools.RPCRequestDataWrapper
+import net.corda.v5.application.persistence.PersistenceService
+import net.corda.v5.base.types.MemberX500Name
+
+class FakeVirtualNodeBase(
+    override val holdingIdentity: HoldingIdentity,
+    private val fakeFiber: FakeFiber,
+    private val injector: FlowServicesInjector,
+    private val flowFactory: FlowFactory
+) : FakeVirtualNode {
+
+    override val member : MemberX500Name = holdingIdentity.member
+
+
+    /**
+     * Calls the flow with the given request. Note that this call happens on the calling thread, which will wait until
+     * the flow has completed before returning the response.
+     *
+     * @input the data to input to the flow
+     *
+     * @return the response from the flow
+     */
+    override fun callFlow(input: RPCRequestDataWrapper): String {
+        val flowClassName = input.flowClassName
+        val flow = flowFactory.createInitiatingFlow(member, flowClassName)
+        injector.injectServices(flow, member, fakeFiber, flowFactory)
+        return flow.call(input.toRPCRequestData())
+    }
+
+    override fun getPersistenceService(): PersistenceService =
+        fakeFiber.getOrCreatePersistenceService(member)
+}

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/internal/HttpStartFlow.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/internal/HttpStartFlow.kt
@@ -1,5 +1,5 @@
 package net.corda.testutils.internal
 
-import net.corda.testutils.tools.RPCRequestDataMock
+import net.corda.testutils.tools.RPCRequestDataWrapper
 
-data class HttpStartFlow(val httpStartFlow: RPCRequestDataMock)
+data class HttpStartFlow(val httpStartFlow: RPCRequestDataWrapper)

--- a/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/tools/RPCRequestDataWrapper.kt
+++ b/cordapp-test-utils/test-utils/src/main/kotlin/net/corda/testutils/tools/RPCRequestDataWrapper.kt
@@ -14,7 +14,7 @@ import net.corda.v5.application.marshalling.MarshallingService
  * @flowClassName the name of the flow class to run
  * @requestData the data for the request
  */
-data class RPCRequestDataMock(val clientRequestId : String, val flowClassName: String, val requestData : String) {
+data class RPCRequestDataWrapper(val clientRequestId : String, val flowClassName: String, val requestData : String) {
 
     companion object {
         private val jms = SimpleJsonMarshallingService()
@@ -32,8 +32,8 @@ data class RPCRequestDataMock(val clientRequestId : String, val flowClassName: S
          * @requestData the data for the request; this will be converted to a string before being converted back again
          * on consumption.
          */
-        fun <T : Any> fromData(clientRequestId: String, flowClass: Class<out RPCStartableFlow>, requestData: T): RPCRequestDataMock =
-            RPCRequestDataMock(clientRequestId, flowClass.name, jms.format(requestData))
+        fun <T : Any> fromData(clientRequestId: String, flowClass: Class<out RPCStartableFlow>, requestData: T): RPCRequestDataWrapper =
+            RPCRequestDataWrapper(clientRequestId, flowClass.name, jms.format(requestData))
     }
 
     /**

--- a/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
+++ b/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
@@ -9,7 +9,6 @@ import net.corda.testutils.tools.FlowChecker
 import net.corda.testutils.tools.RPCRequestDataMock
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
-import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
@@ -22,7 +21,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class FakeCordaTest {
-    private val member = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")
+    private val holdingId = HoldingIdentity.create("IRunCordapps")
 
     @Test
     fun `should pass on any errors from the flow checker`() {
@@ -35,7 +34,7 @@ class FakeCordaTest {
 
         // When we upload the flow
         // Then it should error
-        assertThrows<NoDefaultConstructorException> { corda.upload(member, HelloFlow::class.java) }
+        assertThrows<NoDefaultConstructorException> { corda.createVirtualNode(holdingId, HelloFlow::class.java) }
     }
 
     @Test
@@ -44,11 +43,11 @@ class FakeCordaTest {
         val corda = FakeCorda()
 
         // When I upload two flows
-        corda.upload(member, HelloFlow::class.java)
-        corda.upload(member, ValidStartingFlow::class.java)
+        corda.createVirtualNode(holdingId, HelloFlow::class.java)
+        corda.createVirtualNode(holdingId, ValidStartingFlow::class.java)
 
         // And I invoke the first one (let's use the constructor for RPC requests for fun)
-        val response = corda.invoke(member,
+        val response = corda.invoke(holdingId,
             RPCRequestDataMock("r1", HelloFlow::class.java.name, "{ \"name\" : \"CordaDev\" }")
         )
 
@@ -69,11 +68,11 @@ class FakeCordaTest {
         }
 
         // When I upload the relevant flow and concrete responder
-        corda.upload(member, PingAckFlow::class.java)
-        corda.upload(member, "ping-ack", responder)
+        corda.createVirtualNode(holdingId, PingAckFlow::class.java)
+        corda.createVirtualNode(holdingId, "ping-ack", responder)
 
         // Then it should have registered the responder with the fiber
-        verify(fiber, times(1)).registerResponderInstance(member,"ping-ack", responder)
+        verify(fiber, times(1)).registerResponderInstance(holdingId.member,"ping-ack", responder)
     }
 
     @Test

--- a/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
+++ b/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
@@ -6,7 +6,7 @@ import net.corda.testutils.flows.PingAckFlow
 import net.corda.testutils.flows.ValidStartingFlow
 import net.corda.testutils.internal.FakeFiber
 import net.corda.testutils.tools.FlowChecker
-import net.corda.testutils.tools.RPCRequestDataMock
+import net.corda.testutils.tools.RPCRequestDataWrapper
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
 import org.hamcrest.MatcherAssert.assertThat
@@ -48,7 +48,7 @@ class FakeCordaTest {
 
         // And I invoke the first one (let's use the constructor for RPC requests for fun)
         val response = corda.invoke(holdingId,
-            RPCRequestDataMock("r1", HelloFlow::class.java.name, "{ \"name\" : \"CordaDev\" }")
+            RPCRequestDataWrapper("r1", HelloFlow::class.java.name, "{ \"name\" : \"CordaDev\" }")
         )
 
         // Then it should appear to properly invoke the flow

--- a/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
+++ b/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
@@ -43,11 +43,10 @@ class FakeCordaTest {
         val corda = FakeCorda()
 
         // When I upload two flows
-        corda.createVirtualNode(holdingId, HelloFlow::class.java)
-        corda.createVirtualNode(holdingId, ValidStartingFlow::class.java)
+        val helloVNInfo = corda.createVirtualNode(holdingId, HelloFlow::class.java, ValidStartingFlow::class.java)
 
         // And I invoke the first one (let's use the constructor for RPC requests for fun)
-        val response = corda.invoke(holdingId,
+        val response = corda.callFlow(helloVNInfo,
             RPCRequestDataWrapper("r1", HelloFlow::class.java.name, "{ \"name\" : \"CordaDev\" }")
         )
 

--- a/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
+++ b/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/FakeCordaTest.kt
@@ -43,10 +43,10 @@ class FakeCordaTest {
         val corda = FakeCorda()
 
         // When I upload two flows
-        val helloVNInfo = corda.createVirtualNode(holdingId, HelloFlow::class.java, ValidStartingFlow::class.java)
+        val helloVirtualNode = corda.createVirtualNode(holdingId, HelloFlow::class.java, ValidStartingFlow::class.java)
 
         // And I invoke the first one (let's use the constructor for RPC requests for fun)
-        val response = corda.callFlow(helloVNInfo,
+        val response = helloVirtualNode.callFlow(
             RPCRequestDataWrapper("r1", HelloFlow::class.java.name, "{ \"name\" : \"CordaDev\" }")
         )
 

--- a/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/internal/FakeVirtualNodeBaseTest.kt
+++ b/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/internal/FakeVirtualNodeBaseTest.kt
@@ -1,0 +1,74 @@
+package net.corda.testutils.internal
+
+import net.corda.testutils.HoldingIdentity
+import net.corda.testutils.tools.RPCRequestDataWrapper
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.persistence.PersistenceService
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class FakeVirtualNodeBaseTest {
+
+    @Test
+    fun `should instantiate flow, inject services and call flow`() {
+        // Given a virtual node with dependencies
+        val fakeFiber = mock<FakeFiber>()
+        val flowFactory = mock<FlowFactory>()
+        val injector = mock<FlowServicesInjector>()
+        val flow = mock<RPCStartableFlow>()
+
+        whenever(flowFactory.createInitiatingFlow(any(), any())).thenReturn(flow)
+
+        val holdingId = HoldingIdentity.create("IRunCordapps")
+        val virtualNode = FakeVirtualNodeBase(
+            holdingId,
+            fakeFiber,
+            injector,
+            flowFactory
+        )
+
+        // When a flow class is run on that node
+        // (NB: it doesn't actually matter if the flow class was created in that node or not)
+        val input = RPCRequestDataWrapper("r1", "aClass", "someData")
+        virtualNode.callFlow(input)
+
+        // Then it should have instantiated the node and injected the services into it
+        verify(injector, times(1)).injectServices(flow, holdingId.member, fakeFiber, flowFactory)
+
+        // And the flow should have been called
+        verify(flow, times(1)).call(argThat {request -> request.getRequestBody() == "someData" })
+    }
+
+    @Test
+    fun `should return any persistence service registered for that member on the FakeFiber`() {
+        // Given a virtual node with dependencies
+        val fakeFiber = mock<FakeFiber>()
+        val flowFactory = mock<FlowFactory>()
+        val injector = mock<FlowServicesInjector>()
+
+        val holdingId = HoldingIdentity.create("IRunCordapps")
+        val virtualNode = FakeVirtualNodeBase(
+            holdingId,
+            fakeFiber,
+            injector,
+            flowFactory
+        )
+
+        // And a persistence service registered on the fiber
+        val persistenceService = mock<PersistenceService>()
+        whenever(fakeFiber.getOrCreatePersistenceService(holdingId.member)).thenReturn(persistenceService)
+
+        // When we get the persistence service
+        val result = virtualNode.getPersistenceService()
+
+        // Then it should be the one that was registered
+        assertThat(result, `is`(persistenceService))
+    }
+}

--- a/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/services/DbPersistenceServiceTest.kt
+++ b/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/services/DbPersistenceServiceTest.kt
@@ -31,6 +31,8 @@ class DBPersistenceServiceTest {
         // Then we should be able to retrieve them again
         val greetings = persistence.findAll(GreetingEntity::class.java).execute()
         assertThat(greetings.map{ it.greeting }.toSet(), `is`(setOf("Hello!", "Bonjour!")))
+
+        persistence.close()
     }
 
     @Test
@@ -47,6 +49,9 @@ class DBPersistenceServiceTest {
         // Then it should not show up in the other one
         val greetings = persistence2.findAll(GreetingEntity::class.java).execute()
         assertThat("Greetings should be empty", greetings.isEmpty())
+
+        persistence1.close()
+        persistence2.close()
     }
 
     @Test
@@ -74,6 +79,9 @@ class DBPersistenceServiceTest {
         // Then it should show up in the other one
         val greetings = persistence2.findAll(GreetingEntity::class.java).execute()
         assertThat(greetings, `is`(listOf(hello)))
+
+        persistence1.close()
+        persistence2.close()
     }
 
     @Test
@@ -94,6 +102,8 @@ class DBPersistenceServiceTest {
         // Then it should be the merged version
         assertThat(retrievedHello, `is`(bonjour))
         assertThat(merged, `is`(bonjour))
+
+        persistence.close()
     }
 
     @Test
@@ -116,6 +126,8 @@ class DBPersistenceServiceTest {
         // Then they should be the merged versions
         assertThat(retrievedHellos.toSet(), `is`(setOf(goodEve, gutenAbend)))
         assertThat(merged.toSet(), `is`(setOf(goodEve, gutenAbend)))
+
+        persistence.close()
     }
 
     @Test
@@ -136,6 +148,8 @@ class DBPersistenceServiceTest {
 
         // Then they should be removed successfully
         assertThat(persistence.findAll(GreetingEntity::class.java).execute(), `is`(listOf(greetings[3])))
+
+        persistence.close()
     }
 
     @Test
@@ -146,6 +160,8 @@ class DBPersistenceServiceTest {
         assertThrows<CordaPersistenceException> { persistence.find(BadEntity::class.java, UUID.randomUUID()) }
         assertThrows<CordaPersistenceException> { persistence.merge(BadEntity()) }
         assertThrows<CordaPersistenceException> { persistence.remove(listOf(BadEntity())) }
+
+        persistence.close()
     }
 }
 

--- a/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/tools/RPCRequestDataWrapperTest.kt
+++ b/cordapp-test-utils/test-utils/src/test/kotlin/net/corda/testutils/tools/RPCRequestDataWrapperTest.kt
@@ -7,7 +7,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
 
-class RPCRequestDataMockTest {
+class RPCRequestDataWrapperTest {
 
     private val record = InputMessage(6, 7)
 
@@ -22,13 +22,13 @@ class RPCRequestDataMockTest {
           }
         }
         """.trimIndent()
-        val requestBody = RPCRequestDataMock.fromJSonString(input)
+        val requestBody = RPCRequestDataWrapper.fromJSonString(input)
         assertThat(requestBody.toRPCRequestData().getRequestBody(), `is`("{ \"a\" : 6, \"b\" : 7 }"))
     }
 
     @Test
     fun `should create a valid RPC request from individual values`() {
-        val requestBody = RPCRequestDataMock("r1",
+        val requestBody = RPCRequestDataWrapper("r1",
             "${HelloFlow::class.java.name}",
             "{ \"a\" : 6, \"b\" : 7 }")
         assertThat(
@@ -40,7 +40,7 @@ class RPCRequestDataMockTest {
 
     @Test
     fun `should create a valid RPC request from a input object`() {
-        val requestBody = RPCRequestDataMock.fromData("r1", ValidStartingFlow::class.java, InputMessage(6, 7))
+        val requestBody = RPCRequestDataWrapper.fromData("r1", ValidStartingFlow::class.java, InputMessage(6, 7))
         assertThat(
             requestBody.toRPCRequestData().getRequestBodyAs(
                 SimpleJsonMarshallingService(),


### PR DESCRIPTION
Virtual nodes are associated with more than just a member. FakeCorda now works with a HoldingIdentity class and explicitly creates "virtual nodes" rather than just `upload`. Also takes multiple vararg flows on upload.