### PR TITLE
INFRA-1843 update tagging for arm64 arch

### DIFF
--- a/.ci/nightly/JenkinsfileNightlyARM64
+++ b/.ci/nightly/JenkinsfileNightlyARM64
@@ -7,7 +7,7 @@ cordaNightlyPipeline(
     publishRepoPrefix: '', // change this to 'corda-ent-maven', when JARs don't overwrite AMD64 ones
     createPostgresDb: true,
     publishOSGiImage: false, // change this to true when images don't overwrite AMD64 ones
-    publishPreTestImage: false, // change this to true when images don't overwrite AMD64 ones
+    publishPreTestImage: true, // change this to true when images don't overwrite AMD64 ones
     publishHelmChart: false, // change this to true when images don't overwrite AMD64 ones
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: false, // change this to true when E2E infrastructure is in place

--- a/.ci/nightly/JenkinsfileNightlyARM64
+++ b/.ci/nightly/JenkinsfileNightlyARM64
@@ -12,4 +12,5 @@ cordaNightlyPipeline(
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: false, // change this to true when E2E infrastructure is in place
     linuxArch: 'arm64',
+    gradleAdditionalArgs: '-PcliBasebaseTag=arm64-latest'
     )

--- a/.ci/nightly/JenkinsfileNightlyARM64
+++ b/.ci/nightly/JenkinsfileNightlyARM64
@@ -12,5 +12,5 @@ cordaNightlyPipeline(
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: false, // change this to true when E2E infrastructure is in place
     linuxArch: 'arm64',
-    gradleAdditionalArgs: '-PcliBasebaseTag=arm64-latest'
+    gradleAdditionalArgs: '-PcliBasebaseTag=arm64-nightly'
     )

--- a/.ci/nightly/JenkinsfileNightlyARM64
+++ b/.ci/nightly/JenkinsfileNightlyARM64
@@ -7,7 +7,7 @@ cordaNightlyPipeline(
     publishRepoPrefix: '', // change this to 'corda-ent-maven', when JARs don't overwrite AMD64 ones
     createPostgresDb: true,
     publishOSGiImage: false, // change this to true when images don't overwrite AMD64 ones
-    publishPreTestImage: true, // change this to true when images don't overwrite AMD64 ones
+    publishPreTestImage: true,
     publishHelmChart: false, // change this to true when images don't overwrite AMD64 ones
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: false, // change this to true when E2E infrastructure is in place

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -236,8 +236,8 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
         if (preTest.get()) {
             targetRepo = "corda-os-docker-pre-test.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "${tagPrefix}preTest-"+version)
-            tagContainer(builder, "${tagPrefix}preTest-"+gitRevision)
+            tagContainer(builder, "preTest-${tagPrefix}"+version)
+            tagContainer(builder, "preTest-${tagPrefix}"+gitRevision)
         } else if (releaseType == 'RC' || releaseType == 'GA') {
             targetRepo = "corda-os-docker-stable.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "${tagPrefix}latest")

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -152,7 +152,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
     def updateImage() {
         def buildBaseDir = temporaryDir.toPath()
         def containerizationDir = Paths.get("$buildBaseDir/containerization/")
-
+        String tagPrefix = ""
         String gitRevision = gitTask.flatMap { it.revision }.get()
         def jiraTicket = hasJiraTicket()
         def timeStamp =  new SimpleDateFormat("ddMMyy").format(new Date())
@@ -222,43 +222,46 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
+        
+
         if (System.properties['os.arch'] == "aarch64") {
             logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")
             Set<Platform> platformSet = new HashSet<Platform>()
             platformSet.add(new Platform("arm64", "linux"))
             builder.setPlatforms(platformSet)
+            tagPrefix = "arm64-"
         }
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()
 
         if (preTest.get()) {
             targetRepo = "corda-os-docker-pre-test.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "preTest-"+version)
-            tagContainer(builder, "preTest-"+gitRevision)
+            tagContainer(builder, "${tagPrefix}preTest-"+version)
+            tagContainer(builder, "${tagPrefix}preTest-"+gitRevision)
         } else if (releaseType == 'RC' || releaseType == 'GA') {
             targetRepo = "corda-os-docker-stable.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "latest")
-            tagContainer(builder, version)
+            tagContainer(builder, "${tagPrefix}latest")
+            tagContainer(builder, "${tagPrefix}${version}")
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "unstable")
-            gitAndVersionTag(builder, gitRevision)
+            tagContainer(builder, "${tagPrefix}unstable")
+            gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"
-            gitAndVersionTag(builder, gitRevision)
+            gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
         } else if (releaseType == 'BETA' && nightlyBuild.get()){
             targetRepo = "corda-os-docker-nightly.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "nightly")
-            tagContainer(builder, "nightly" + "-" + timeStamp)
+            tagContainer(builder, "${tagPrefix}nightly")
+            tagContainer(builder, "${tagPrefix}nightly" + "-" + timeStamp)
         } else if (releaseType == 'ALPHA' && nightlyBuild.get()) {
             targetRepo = "corda-os-docker-nightly.software.r3.com/corda-os-${containerName}"
             if (!jiraTicket.isEmpty()) {
-                tagContainer(builder, "nightly-" + jiraTicket)
-                tagContainer(builder, "nightly" + "-" + jiraTicket + "-" + timeStamp)
-                tagContainer(builder, "nightly" + "-" + jiraTicket + "-" + gitRevision)
+                tagContainer(builder, "${tagPrefix}nightly-" + jiraTicket)
+                tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + timeStamp)
+                tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + gitRevision)
             }else{
-                gitAndVersionTag(builder, "nightly-" + version)
-                gitAndVersionTag(builder, "nightly-" + gitRevision)
+                gitAndVersionTag(builder, "${tagPrefix}nightly-" + version)
+                gitAndVersionTag(builder, "${tagPrefix}nightly-" + gitRevision)
             }
         } else{
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -222,8 +222,6 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
-        
-
         if (System.properties['os.arch'] == "aarch64") {
             logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")
             Set<Platform> platformSet = new HashSet<Platform>()

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -77,8 +77,8 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
         baseImageName = (cordaCliIncluded) ? "corda-os-docker-dev.software.r3.com/corda-os-cli" : "corda-os-docker.software.r3.com/corda-os-cli"
     }
 
-    if (project.hasProperty('baseTag')) {
-        baseImageTag = baseTag
+    if (project.hasProperty('cliBasebaseTag')) {
+        baseImageTag = cliBasebaseTag
     } else {
         it.baseImageTag = (cordaCliIncluded) ? "latest-local" : "unstable"
     }


### PR DESCRIPTION
Enabler piece for the production of arch64 images, we need to ensure we do not override existing arm images

Example
`Publishing 'corda-os-docker-pre-test.software.r3.com/corda-os-member-worker:preTest-arm64-5.0.0.0-alpha-1660576794525'`

For now no changes for non ARM64 images tagging to ensure exiting compatibility with deployments environment. 
