### PR TITLE
NOTICK: Remove SLF4J implementation bundle from member-worker.

### DIFF
--- a/applications/workers/release/member-worker/build.gradle
+++ b/applications/workers/release/member-worker/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-    runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
     runtimeOnly project(":libs:messaging:kafka-message-bus-impl")
 


### PR DESCRIPTION
An application's SLF4J implementation is provided by our OSGi bootstrapper.