### PR TITLE
CORE-6218: ensure timeouts fail combined worker job

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -118,22 +118,20 @@ pipeline {
             }            
         }
         stage('connect to worker') {
-            options {
-                timeout(time: 3, unit: 'MINUTES')
-            }  
             steps {
-	       script{
-		    try {
-		       timeout(time: 1, unit: 'SECONDS') {
-				checkConnection()
-			}
-		    } catch(err) {
-			// timeout reached
-			error 'Could not connect to the Combined Worker in a 3 minute window'
-		    }
-		    }
+                script{
+                    try {
+                       timeout(time: 3, unit: 'MINUTES') {
+                       checkConnection()
+                    }
+                    } catch(err) {
+                        // timeout reached fail the build as we want the calling job to result in a failure here
+                        // without this the calling job will result in a aborted status which is unclear
+                        error 'Could not connect to the Combined Worker in a 3 minute window'
+                    }
+                }
             }
-        } 
+        }
         stage('smoketests') {
             options {
                 timeout(time: 15, unit: 'MINUTES')

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -122,7 +122,14 @@ pipeline {
                 timeout(time: 3, unit: 'MINUTES')
             }  
             steps {
-                checkConnection()
+		    try {
+		       timeout(time: 1, unit: 'SECONDS') {
+				checkConnection()
+			}
+		    } catch(err) {
+			// timeout reached
+			error 'Could not connect to the Combined Worker in a 3 minute window'
+		    }
             }
         } 
         stage('smoketests') {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -122,6 +122,7 @@ pipeline {
                 timeout(time: 3, unit: 'MINUTES')
             }  
             steps {
+	       script{
 		    try {
 		       timeout(time: 1, unit: 'SECONDS') {
 				checkConnection()
@@ -129,6 +130,7 @@ pipeline {
 		    } catch(err) {
 			// timeout reached
 			error 'Could not connect to the Combined Worker in a 3 minute window'
+		    }
 		    }
             }
         } 

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -122,11 +122,11 @@ pipeline {
                 script{
                     try {
                        timeout(time: 3, unit: 'MINUTES') {
-                       checkConnection()
-                    }
+                            checkConnection()
+                       }
                     } catch(err) {
-                        // timeout reached fail the build as we want the calling job to result in a failure here
-                        // without this the calling job will result in a aborted status which is unclear
+                        // If a timeout is reached fail the build as we want the calling job to result in a failure also
+                        // without this the calling job will result in a aborted status
                         error 'Could not connect to the Combined Worker in a 3 minute window'
                     }
                 }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -125,7 +125,7 @@ pipeline {
                             checkConnection()
                        }
                     } catch(err) {
-                        // If a timeout is reached fail the build as we want the calling job to result in a failure also
+                        // If a timeout is reached fail the build as we want the calling job to result in a failure
                         // without this the calling job will result in a aborted status
                         error 'Could not connect to the Combined Worker in a 3 minute window'
                     }


### PR DESCRIPTION
If we hit a timeout while attempting to connect to the combined worker we should fail the build not set the status to aborted, which is the default behavior of a timeout. 

A timeout raises a specific type of error which results in Jenkins "aborted" status , We can catch this and throw a explicit failure which will propagate back to the calling build, this results in a clearer error message / failure in this situation 

Tested here with a intentional failure https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-combined-worker-e2e-tests/view/change-requests/job/PR-1903/3/console