### PR TITLE
CORE-6142 - bugfix allow multiple duplex channels in websocket adaptor

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -2,6 +2,7 @@ package net.corda.applications.workers.smoketest.websocket
 
 import java.time.Duration
 import java.util.LinkedList
+import java.util.Queue
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
 import net.corda.applications.workers.smoketest.GROUP_ID
@@ -17,7 +18,6 @@ import net.corda.applications.workers.smoketest.websocket.client.SmokeTestWebsoc
 import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.MethodOrderer
@@ -39,7 +39,7 @@ class FlowStatusFeedSmokeTest {
     @Order(10)
     @Test
     fun `websocket connection can be opened to listen for updates for flow clientRequestid`() {
-        val flowStatusFeedPath = "/flow/$bobHoldingId/${UUID.randomUUID()}"
+        val flowStatusFeedPath = "/flow/$bobHoldingId/${generateRequestId("test10")}"
 
         val wsHandler = MessageQueueWebsocketHandler(LinkedList())
 
@@ -59,7 +59,7 @@ class FlowStatusFeedSmokeTest {
     @Order(20)
     @Test
     fun `flow status update feed receives updates for the basic lifecycle of a flow`() {
-        val clientRequestId = UUID.randomUUID().toString()
+        val clientRequestId = generateRequestId("test20")
         val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
 
         useWebsocketConnection(flowStatusFeedPath) { wsHandler ->
@@ -77,7 +77,7 @@ class FlowStatusFeedSmokeTest {
     @Order(30)
     @Test
     fun `multiple websocket connections can be open for one flow from one holding identity and request id`() {
-        val clientRequestId = UUID.randomUUID().toString()
+        val clientRequestId = generateRequestId("test30")
         val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
 
         useWebsocketConnection(flowStatusFeedPath) { wsHandler1 ->
@@ -98,10 +98,44 @@ class FlowStatusFeedSmokeTest {
         }
     }
 
+    private fun generateRequestId(identifyingTest: String): String {
+        return "$identifyingTest-${UUID.randomUUID()}"
+    }
+
+    @Order(31)
+    @Test
+    fun `multiple websocket connections can be open for two flows and receive the correct statuses`() {
+        val clientRequestId1 = generateRequestId("test31-req1")
+        val clientRequestId2 = generateRequestId("test31-req2")
+        val flowStatusFeedPath1 = "/flow/$bobHoldingId/$clientRequestId1"
+        val flowStatusFeedPath2 = "/flow/$bobHoldingId/$clientRequestId2"
+
+        fun assertNormalFlowStatusesForRequest(messageQueue: Queue<String>, clientRequestId1: String) {
+            assertThat(messageQueue).hasSize(3)
+            val flowStatus1 = messageQueue.poll()
+            assertThat(flowStatus1).contains(FlowStates.START_REQUESTED.name)
+            assertThat(flowStatus1).contains(clientRequestId1)
+            assertThat(messageQueue.poll()).contains(FlowStates.RUNNING.name)
+            assertThat(messageQueue.poll()).contains(FlowStates.COMPLETED.name)
+        }
+
+        useWebsocketConnection(flowStatusFeedPath1) { wsHandler1 ->
+            useWebsocketConnection(flowStatusFeedPath2) { wsHandler2 ->
+                startFlow(clientRequestId1)
+                startFlow(clientRequestId2)
+
+                eventually(Duration.ofSeconds(300)) {
+                    assertNormalFlowStatusesForRequest(wsHandler1.messageQueue, clientRequestId1)
+                    assertNormalFlowStatusesForRequest(wsHandler2.messageQueue, clientRequestId2)
+                }
+            }
+        }
+    }
+
     @Order(40)
     @Test
     fun `registering for flow status feed when flow is already finished sends the finished status and terminates connection`() {
-        val clientRequestId = UUID.randomUUID().toString()
+        val clientRequestId = generateRequestId("test40")
         val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
 
         startFlow(clientRequestId)
@@ -133,7 +167,7 @@ class FlowStatusFeedSmokeTest {
     @Order(41)
     @Test
     fun `two test clients can function after first reports completed flow during registration`() {
-        val clientRequestId = UUID.randomUUID().toString()
+        val clientRequestId = generateRequestId("test41")
         val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
 
         startFlow(clientRequestId)
@@ -183,7 +217,7 @@ class FlowStatusFeedSmokeTest {
     @Order(50)
     @Test
     fun `websocket connection terminated when client sends server a message`() {
-        val clientRequestId = UUID.randomUUID().toString()
+        val clientRequestId = generateRequestId("test50")
         val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
 
         useWebsocketConnection(flowStatusFeedPath) { wsHandler ->
@@ -194,10 +228,42 @@ class FlowStatusFeedSmokeTest {
         }
     }
 
+    @Order(51)
+    @Test
+    fun `two websocket connections correct one terminated when it sends server a message`() {
+        val clientRequestId1 = generateRequestId("test51-req1")
+        val clientRequestId2 = generateRequestId("test51-req2")
+        val flowStatusFeedPath1 = "/flow/$bobHoldingId/$clientRequestId1"
+        val flowStatusFeedPath2 = "/flow/$bobHoldingId/$clientRequestId2"
+
+        val messageQueue1 = ConcurrentLinkedQueue<String>()
+        val wsHandler1 = MessageQueueWebsocketHandler(messageQueue1)
+        val client1 = SmokeTestWebsocketClient()
+        client1.start()
+        val session1 = client1.connect(flowStatusFeedPath1, wsHandler1)
+
+        val messageQueue2 = ConcurrentLinkedQueue<String>()
+        val wsHandler2 = MessageQueueWebsocketHandler(messageQueue2)
+        val client2 = SmokeTestWebsocketClient()
+        client2.start()
+        val session2 = client2.connect(flowStatusFeedPath2, wsHandler2)
+
+        wsHandler1.send("malicious message for client 1 ($clientRequestId1)")
+
+        eventually {
+            assertFalse(wsHandler1.isConnected)
+        }
+
+        session1.close()
+        session2.close()
+        client1.close()
+        client2.close()
+    }
+
     @Order(60)
     @Test
     fun `websocket connection terminated when client registers for holding identity with invalid holding identity hex string`() {
-        val clientRequestId = UUID.randomUUID().toString()
+        val clientRequestId = generateRequestId("test60")
         val flowStatusFeedPath = "/flow/THIS_HOLDING_ID_IS_NOT_HEX/$clientRequestId"
 
         val wsHandler = MessageQueueWebsocketHandler(ConcurrentLinkedQueue())
@@ -212,7 +278,7 @@ class FlowStatusFeedSmokeTest {
     @Order(61)
     @Test
     fun `websocket connection terminated when client registers for non existing holding identity`() {
-        val clientRequestId = UUID.randomUUID().toString()
+        val clientRequestId = generateRequestId("test61")
         val flowStatusFeedPath = "/flow/544849535f484f4c44494e475f49445f49535f4e4f545f484558/$clientRequestId"
 
         val wsHandler = MessageQueueWebsocketHandler(ConcurrentLinkedQueue())

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/InternalWebsocketHandler.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/InternalWebsocketHandler.kt
@@ -1,9 +1,7 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
-import java.util.Queue
-
 interface InternalWebsocketHandler {
-    val messageQueue: Queue<String>
+    val messageQueue: MutableList<String>
     fun isConnected(): Boolean
     fun send(message: String)
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebsocketHandler.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebsocketHandler.kt
@@ -1,13 +1,13 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
 import java.io.IOException
-import java.util.Queue
+import java.util.LinkedList
 import net.corda.applications.workers.smoketest.contextLogger
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.client.NoOpEndpoint
 
 class MessageQueueWebsocketHandler(
-    override val messageQueue: Queue<String>,
+    override val messageQueue: MutableList<String> = LinkedList(),
 ) : NoOpEndpoint(), InternalWebsocketHandler {
 
     private companion object {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
@@ -3,8 +3,6 @@ package net.corda.applications.workers.smoketest.websocket.client
 import java.net.URI
 import java.time.Duration
 import java.util.LinkedList
-import java.util.Queue
-import java.util.concurrent.ConcurrentLinkedQueue
 import net.corda.applications.workers.smoketest.contextLogger
 import net.corda.applications.workers.smoketest.getOrThrow
 import net.corda.test.util.eventually
@@ -21,7 +19,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 
 fun useWebsocketConnection(
     path: String,
-    messageQueue: Queue<String> = ConcurrentLinkedQueue(),
+    messageQueue: MutableList<String> = LinkedList(),
     block: (wsHandler: InternalWebsocketHandler) -> Unit
 ) {
     val wsHandler = MessageQueueWebsocketHandler(messageQueue)

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/flowstatus/websocket/DuplexChannelHookRegistration.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/flowstatus/websocket/DuplexChannelHookRegistration.kt
@@ -1,7 +1,6 @@
 package net.corda.flow.rpcops.impl.flowstatus.websocket
 
 import java.time.Instant
-import java.util.UUID
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.identity.HoldingIdentity as AvroHoldingIdentity
@@ -24,9 +23,8 @@ fun DuplexChannel.registerFlowStatusFeedHooks(
     log: Logger,
 ) {
     val holdingIdentityShortHash = holdingIdentity.toCorda().shortHash
-    val id = UUID.randomUUID()
     val listener: FlowStatusUpdateListener = WebSocketFlowStatusUpdateListener(
-        id,
+        this.id,
         clientRequestId,
         holdingIdentity,
         onCloseCallback(),
@@ -34,14 +32,14 @@ fun DuplexChannel.registerFlowStatusFeedHooks(
     )
     onClose = { statusCode, reason ->
         log.info(
-            "Close hook called for id ${listener.id} with status $statusCode, reason: $reason " +
+            "Close hook called for duplex channel ${listener.id} with status $statusCode, reason: $reason " +
                     "(clientRequestId=$clientRequestId, holdingId=$holdingIdentityShortHash)"
         )
         flowStatusCacheService.unregisterFlowStatusListener(clientRequestId, holdingIdentity, listener)
     }
     onError = { e ->
         log.warn(
-            "Error hook called for id ${listener.id}. " +
+            "Error hook called for duplex channel ${listener.id}. " +
                     "(clientRequestId=$clientRequestId, holdingId=$holdingIdentityShortHash)",
             e
         )
@@ -67,6 +65,7 @@ fun DuplexChannel.registerFlowStatusFeedHooks(
 private fun DuplexChannel.onStatusUpdate(log: Logger, holdingIdentity: AvroHoldingIdentity, clientRequestId: String) =
     { avroStatus: FlowStatus ->
         try {
+            log.info("Sending flow status update (${avroStatus.flowStatus.name}) to session ${this.id}.")
             val future = send(avroStatus.createFlowStatusResponse())
             if (avroStatus.flowStatus.isFlowFinished()) {
                 try {

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/flowstatus/websocket/WebSocketFlowStatusUpdateListener.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/flowstatus/websocket/WebSocketFlowStatusUpdateListener.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.rpcops.impl.flowstatus.websocket
 
-import java.util.UUID
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.rpcops.flowstatus.FlowStatusUpdateListener
@@ -11,7 +10,7 @@ import net.corda.virtualnode.toCorda
  * Flow status update handler that uses websockets to communicate updates to the counterpart connection.
  */
 class WebSocketFlowStatusUpdateListener(
-    override val id: UUID,
+    override val id: String,
     private val clientRequestId: String,
     private val holdingIdentity: HoldingIdentity,
     private val onCloseCallback: (String) -> Unit,
@@ -26,7 +25,7 @@ class WebSocketFlowStatusUpdateListener(
     @Synchronized
     override fun updateReceived(status: FlowStatus) {
         logger.info(
-            "Flow status update: ${status.flowStatus.name} for listener $id (clientRequestId: $clientRequestId, " +
+            "Listener $id received flow status update: ${status.flowStatus.name} (clientRequestId: $clientRequestId, " +
                     "holdingId: ${holdingIdentity.toCorda().shortHash})."
         )
 

--- a/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/flowstatus/FlowStatusUpdateListener.kt
+++ b/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/flowstatus/FlowStatusUpdateListener.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.rpcops.flowstatus
 
-import java.util.UUID
 import net.corda.data.flow.output.FlowStatus
 
 /**
@@ -11,7 +10,7 @@ interface FlowStatusUpdateListener : AutoCloseable {
     /**
      * Identifier for this listener.
      */
-    val id: UUID
+    val id: String
 
     /**
      * Update received for flow status.

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/ServerDuplexChannel.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/ServerDuplexChannel.kt
@@ -9,7 +9,8 @@ import java.util.concurrent.Future
 
 internal class ServerDuplexChannel(
     private val ctx: WsConnectContext,
-    private val webSocketCloserService: WebSocketCloserService
+    private val webSocketCloserService: WebSocketCloserService,
+    override val id: String
 ) : DuplexChannel {
 
     private var errorHook: ((Throwable?) -> Unit)? = null

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebsocketRouteAdaptor.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebsocketRouteAdaptor.kt
@@ -109,8 +109,7 @@ internal class WebsocketRouteAdaptor(
     // The handler is called when a WebSocket client closes the connection.
     override fun handleClose(ctx: WsCloseContext) {
         try {
-            requireNotNull(channels[ctx.sessionId]).onClose?.invoke(ctx.status(), ctx.reason())
-            channels.remove(ctx.sessionId)
+            channels.remove(ctx.sessionId)?.onClose?.invoke(ctx.status(), ctx.reason())
         } catch (th: Throwable) {
             log.error("Unexpected exception in handleClose", th)
         }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebsocketRouteAdaptor.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebsocketRouteAdaptor.kt
@@ -9,6 +9,7 @@ import io.javalin.websocket.WsErrorContext
 import io.javalin.websocket.WsErrorHandler
 import io.javalin.websocket.WsMessageContext
 import io.javalin.websocket.WsMessageHandler
+import java.util.concurrent.ConcurrentHashMap
 import net.corda.httprpc.server.impl.apigen.processing.RouteInfo
 import net.corda.httprpc.server.impl.context.ClientWsRequestContext
 import net.corda.httprpc.server.impl.context.ContextUtils.authenticate
@@ -21,6 +22,15 @@ import net.corda.v5.base.util.contextLogger
 import org.eclipse.jetty.websocket.api.CloseStatus
 import org.eclipse.jetty.websocket.api.StatusCode.POLICY_VIOLATION
 
+typealias SessionId = String
+
+/**
+ * This adapter class handles connect, message, close and error events for all websocket connections for an endpoint i.e. if clientA
+ * and clientB are both connected to the server, clientA sends a message, clientB sends a message, both messages will be handled by this
+ * handleMessage function.
+ *
+ * WsContext contains a SessionId which is unique per connection and used as an identifier for a duplex channel and key in [channels] map.
+ */
 internal class WebsocketRouteAdaptor(
     private val routeInfo: RouteInfo,
     private val securityManager: HttpRpcSecurityManager,
@@ -34,17 +44,20 @@ internal class WebsocketRouteAdaptor(
         const val WEBSOCKET_IDLE_TIMEOUT = 20000L
     }
 
-    @Volatile
-    private var channel: DuplexChannel? = null
+    private val channels = ConcurrentHashMap<SessionId, DuplexChannel>()
 
     // The handler is called when a WebSocket client connects.
     @Suppress("NestedBlockDepth")
     override fun handleConnect(ctx: WsConnectContext) {
         try {
+            channels[ctx.sessionId]?.let {
+                log.info("Session with id ${ctx.sessionId} already exists, overwriting and closing the old session.")
+                it.close("New session overwriting old session with id ${ctx.sessionId}")
+            }
             log.info("Connected to remote: ${ctx.session.remoteAddress}")
 
-            ServerDuplexChannel(ctx, webSocketCloserService).let { newChannel ->
-                channel = newChannel
+            ServerDuplexChannel(ctx, webSocketCloserService, ctx.sessionId).let { newChannel ->
+                channels[ctx.sessionId] = newChannel
 
                 ctx.session.idleTimeout = WEBSOCKET_IDLE_TIMEOUT
                 val clientWsRequestContext = ClientWsRequestContext(ctx)
@@ -58,7 +71,7 @@ internal class WebsocketRouteAdaptor(
 
                     @Suppress("SpreadOperator")
                     routeInfo.invokeDelegatedMethod(*fullListOfParams.toTypedArray())
-                    newChannel.onConnect?.let { it() }
+                    newChannel.onConnect?.invoke()
                 } catch (ex: UnauthorizedResponse) {
                     "Websocket operation not permitted".let {
                         log.warn("$it - ${ex.message}")
@@ -77,7 +90,7 @@ internal class WebsocketRouteAdaptor(
             // incoming messages could be malicious. We won't do anything with the message unless an onTextMessage
             // hook has been defined. The hook will be responsible for ensuring the messages respect the protocol
             // and terminate connections when malicious messages arrive.
-            requireNotNull(channel).onTextMessage?.invoke(ctx.message())
+            requireNotNull(channels[ctx.sessionId]).onTextMessage?.invoke(ctx.message())
                 ?: log.info("Inbound messages are not supported.")
         } catch (th: Throwable) {
             log.error("Unexpected exception in handleMessage", th)
@@ -87,7 +100,7 @@ internal class WebsocketRouteAdaptor(
     // The handler is called when an error is detected.
     override fun handleError(ctx: WsErrorContext) {
         try {
-            requireNotNull(channel).onError?.let { it(ctx.error()) }
+            requireNotNull(channels[ctx.sessionId]).onError?.invoke(ctx.error())
         } catch (th: Throwable) {
             log.error("Unexpected exception in handleError", th)
         }
@@ -96,7 +109,8 @@ internal class WebsocketRouteAdaptor(
     // The handler is called when a WebSocket client closes the connection.
     override fun handleClose(ctx: WsCloseContext) {
         try {
-            requireNotNull(channel).onClose?.let { it(ctx.status(), ctx.reason()) }
+            requireNotNull(channels[ctx.sessionId]).onClose?.invoke(ctx.status(), ctx.reason())
+            channels.remove(ctx.sessionId)
         } catch (th: Throwable) {
             log.error("Unexpected exception in handleClose", th)
         }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/deferred/DeferredWebSocketCloserService.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/deferred/DeferredWebSocketCloserService.kt
@@ -23,9 +23,10 @@ class DeferredWebSocketCloserService : WebSocketCloserService {
     override fun close(webSocketContext: WsContext, closeStatus: CloseStatus) {
         deferredWebsocketClosePool.schedule({
             if (webSocketContext.session.isOpen) {
-                log.info("Closing open session with status ${closeStatus.code}, reason: ${closeStatus.phrase}")
+                log.info("Closing open session ${webSocketContext.sessionId}: status ${closeStatus.code}, reason: ${closeStatus.phrase}")
             } else {
-                log.info("Closing session that's already closed with status ${closeStatus.code}, reason: ${closeStatus.phrase}")
+                log.info("Closing session ${webSocketContext.sessionId} that's already reported closed: " +
+                        "status ${closeStatus.code}, reason: ${closeStatus.phrase}")
             }
             webSocketContext.closeSession(closeStatus)
         }, 1, TimeUnit.SECONDS)

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ws/DuplexChannel.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ws/DuplexChannel.kt
@@ -11,6 +11,11 @@ import java.util.concurrent.Future
 interface DuplexChannel : AutoCloseable {
 
     /**
+     * Identifier for a duplex channel connection.
+     */
+    val id: String
+
+    /**
      * Allows to asynchronously send a message to the remote side
      */
     fun send(message: String): Future<Void>


### PR DESCRIPTION
Asserted this fixes the issue mentioned in the jira, connect 10 websocket connections for a flow, wait for them each to time out, notice that the correct session is disconnected and correct listeners removed. After they disconnect we can connect again to the flow (prior to the fix, we got error "max 10 connections...").