### PR TITLE
NOTICK Return early in `CordaRPCSenderImpl` on serialization error

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -234,9 +234,9 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
         val correlationId = UUID.randomUUID().toString()
         val future = CompletableFuture<RESPONSE>()
         val partitions = partitionListener.getPartitions()
-        var reqBytes: ByteArray? = null
-        try {
-            reqBytes = serializer.serialize(req)
+
+        val reqBytes = try {
+            serializer.serialize(req)
         } catch (ex: Exception) {
             future.completeExceptionally(
                 CordaRPCAPISenderException(
@@ -249,6 +249,7 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
                         "Verify that the fields of the request are populated correctly. " +
                         "Request was: $req", ex
             )
+            return future
         }
 
         if (partitions.isEmpty()) {


### PR DESCRIPTION
`CordaRPCSenderImpl.sendRequest` was causing a null pointer error if the
request failed to serialize. This was due to the method continuing on
even though the future had been completed exceptionally. The error was
masking the underlying error causing the serialization failure.

Returning early when there is a serialization error resolves this.