### PR TITLE
CORE-6014 - Allow real JSON to be supplied as FlowStartParams via JsonObject request type

### DIFF
--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -89,7 +89,7 @@ class FlowRPCOpsImpl @Activate constructor(
                 clientRequestId,
                 vNode,
                 flowClassName,
-                startFlow.requestData,
+                startFlow.requestData.toString(),
                 flowContextPlatformProperties
             )
         val status = messageFactory.createStartFlowStatus(clientRequestId, vNode, flowClassName)

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -89,7 +89,7 @@ class FlowRPCOpsImpl @Activate constructor(
                 clientRequestId,
                 vNode,
                 flowClassName,
-                startFlow.requestData.toString(),
+                startFlow.requestData.escapedJson,
                 flowContextPlatformProperties
             )
         val status = messageFactory.createStartFlowStatus(clientRequestId, vNode, flowClassName)

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -8,6 +8,7 @@ import net.corda.flow.rpcops.FlowRPCOpsServiceException
 import net.corda.flow.rpcops.FlowStatusCacheService
 import net.corda.flow.rpcops.factory.MessageFactory
 import net.corda.flow.rpcops.v1.types.request.StartFlowParameters
+import net.corda.httprpc.JsonObject
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.libs.packaging.core.CpiIdentifier
@@ -104,12 +105,14 @@ class FlowRPCOpsImplTest {
         verify(messageFactory, times(2)).createFlowStatusResponse(any())
     }
 
+    data class TestJsonObject(val value: String = "") : JsonObject
+
     @Test
     fun `start flow event triggers successfully`() {
         val flowRPCOps =
             FlowRPCOpsImpl(virtualNodeInfoReadService, flowStatusCacheService, publisherFactory, messageFactory)
         flowRPCOps.initialise(SmartConfigImpl.empty())
-        flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", ""))
+        flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", TestJsonObject()))
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -126,7 +129,7 @@ class FlowRPCOpsImplTest {
             FlowRPCOpsImpl(virtualNodeInfoReadService, flowStatusCacheService, publisherFactory, messageFactory)
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", ""))
+            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(0)).getByHoldingIdentityShortHash(any())
@@ -145,7 +148,7 @@ class FlowRPCOpsImplTest {
 
         whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(mock())
         assertThrows<ResourceAlreadyExistsException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", ""))
+            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -164,7 +167,7 @@ class FlowRPCOpsImplTest {
 
         doThrow(CordaMessageAPIFatalException("")).whenever(publisher).publish(any())
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", ""))
+            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -105,7 +105,7 @@ class FlowRPCOpsImplTest {
         verify(messageFactory, times(2)).createFlowStatusResponse(any())
     }
 
-    data class TestJsonObject(val value: String = "") : JsonObject
+    data class TestJsonObject(override val escapedJson: String = "") : JsonObject
 
     @Test
     fun `start flow event triggers successfully`() {

--- a/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/types/request/StartFlowParameters.kt
+++ b/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/types/request/StartFlowParameters.kt
@@ -1,5 +1,7 @@
 package net.corda.flow.rpcops.v1.types.request
 
+import net.corda.httprpc.JsonObject
+
 /**
  * Request sent to start a flow
  *
@@ -10,5 +12,5 @@ package net.corda.flow.rpcops.v1.types.request
 data class StartFlowParameters(
     val clientRequestId: String,
     val flowClassName: String,
-    val requestData: String
+    val requestData: JsonObject
 )

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
@@ -31,7 +31,7 @@ class HttpRpcServerJsonObjectTest : HttpRpcServerTestBase() {
                 listOf(
                     ObjectsInJsonEndpointImpl()
                 ),
-                securityManager,
+                ::securityManager,
                 httpRpcSettings,
                 multipartDir,
                 true

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
@@ -1,0 +1,290 @@
+package net.corda.httprpc.server.impl
+
+import net.corda.httprpc.server.config.models.HttpRpcSettings
+import net.corda.httprpc.test.*
+import net.corda.httprpc.tools.HttpVerb.POST
+import net.corda.v5.base.util.NetworkHostAndPort
+import org.apache.http.HttpStatus
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
+import net.corda.httprpc.test.utils.WebRequest
+import net.corda.httprpc.test.utils.findFreePort
+import net.corda.httprpc.test.utils.multipartDir
+
+class HttpRpcServerJsonObjectTest : HttpRpcServerTestBase() {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setUpBeforeClass() {
+            val httpRpcSettings = HttpRpcSettings(
+                NetworkHostAndPort("localhost", findFreePort()),
+                context,
+                null,
+                null,
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            )
+            server = HttpRpcServerImpl(
+                listOf(
+                    ObjectsInJsonEndpointImpl()
+                ),
+                securityManager,
+                httpRpcSettings,
+                multipartDir,
+                true
+            ).apply { start() }
+            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun cleanUpAfterClass() {
+            if (isServerInitialized()) {
+                server.stop()
+            }
+        }
+    }
+
+    @AfterEach
+    fun reset() {
+        CustomUnsafeString.flag = false
+        CustomNonSerializableString.flag = false
+        securityManager.forgetChecks()
+    }
+
+    private val stringEscapedObjectPayload = """
+        {
+            "id": "aaa123",
+            "obj": "{\"message\":\"Hey Mars\",\"planetaryOnly\":\"true\",\"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"}"
+        }
+    """.trimIndent()
+
+    private val realJsonObjectPayload = """
+        {
+            "id": "aaa123",
+            "obj": {"message":"Hey Mars","planetaryOnly":"true","target":"C=GB, L=FOURTH, O=MARS, OU=PLANET"}
+        }
+    """.trimIndent()
+
+    private val expectedObjectResponse = """
+        {"id":"aaa123","obj":"{\"message\":\"Hey Mars\",\"planetaryOnly\":\"true\",\"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"}"}
+    """.trimIndent()
+
+    private val stringEscapedMapPayload = """
+        {
+            "id": "aaa123",
+            "obj": "{\"1\":{\"message\":\"Hey Mars\",\"planetaryOnly\":\"true\",\"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"},\"2\":{\"message\":\"Hey Pluto\",\"planetaryOnly\":\"false\",\"target\":\"C=GB, L=FOURTH, O=PLUTO, OU=NON_PLANET\"}}"
+        }
+    """.trimIndent()
+
+    private val realJsonMap = """
+        {
+            "id": "aaa123",
+            "obj": {
+                "1": {
+                    "message":"Hey Mars",
+                    "planetaryOnly":"true",
+                    "target":"C=GB, L=FOURTH, O=MARS, OU=PLANET"
+                },
+                "2": {
+                    "message":"Hey Pluto",
+                    "planetaryOnly":"false",
+                    "target":"C=GB, L=FOURTH, O=PLUTO, OU=NON_PLANET"
+                }
+            }
+        }
+    """.trimIndent()
+
+    private val expectedMapResponse = """
+        {"id":"aaa123","obj":"{\"1\":{\"message\":\"Hey Mars\",\"planetaryOnly\":\"true\",\"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"},\"2\":{\"message\":\"Hey Pluto\",\"planetaryOnly\":\"false\",\"target\":\"C=GB, L=FOURTH, O=PLUTO, OU=NON_PLANET\"}}"}
+    """.trimIndent()
+
+    private val stringEscapedArrayPayload = """
+        {
+            "id": "aaa123",
+            "obj": "[{\"message\":\"Hey Mars\",\"planetaryOnly\":\"true\",\"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"},{\"message\":\"Hey Pluto\",\"planetaryOnly\":\"false\",\"target\":\"C=GB, L=FOURTH, O=PLUTO, OU=NON_PLANET\"}]"
+        }
+    """.trimIndent()
+
+    private val realJsonArrayPayload = """
+        {
+          "id": "aaa123",
+          "obj": [
+            {
+              "message": "Hey Mars",
+              "planetaryOnly": "true",
+              "target": "C=GB, L=FOURTH, O=MARS, OU=PLANET"
+            },
+            {
+              "message": "Hey Pluto",
+              "planetaryOnly": "false",
+              "target": "C=GB, L=FOURTH, O=PLUTO, OU=NON_PLANET"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private val expectedArrayResponse = """
+        {"id":"aaa123","obj":"[{\"message\":\"Hey Mars\",\"planetaryOnly\":\"true\",\"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"},{\"message\":\"Hey Pluto\",\"planetaryOnly\":\"false\",\"target\":\"C=GB, L=FOURTH, O=PLUTO, OU=NON_PLANET\"}]"}
+    """.trimIndent()
+
+    @Test
+    fun `test escaped string serialization with api taking object`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-one-object",
+                stringEscapedObjectPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedObjectResponse, response.body)
+    }
+
+    @Test
+    fun `test real json object serialization with api taking object`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-one-object",
+                realJsonObjectPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedObjectResponse, response.body)
+    }
+
+    @Test
+    fun `test escaped string serialization with api taking individual parameters`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-individual-params",
+                stringEscapedObjectPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedObjectResponse, response.body)
+    }
+
+    @Test
+    fun `test real json object serialization with api taking individual parameters`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-individual-params",
+                realJsonObjectPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedObjectResponse, response.body)
+    }
+
+    @Test
+    fun `test real json map serialization with api taking object`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-one-object",
+                realJsonMap
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedMapResponse, response.body)
+    }
+
+    @Test
+    fun `test real json map serialization with api taking single parameters`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-individual-params",
+                realJsonMap
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedMapResponse, response.body)
+    }
+
+    @Test
+    fun `test string escaped map serialization with api taking object`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-one-object",
+                stringEscapedMapPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedMapResponse, response.body)
+    }
+
+    @Test
+    fun `test string escaped map serialization with api taking single parameters`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-individual-params",
+                stringEscapedMapPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedMapResponse, response.body)
+    }
+
+    @Test
+    fun `test string escaped array serialization with api taking object`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-one-object",
+                stringEscapedArrayPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedArrayResponse, response.body)
+    }
+
+    @Test
+    fun `test string escaped array serialization with api taking single parameters`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-individual-params",
+                stringEscapedArrayPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedArrayResponse, response.body)
+    }
+
+    @Test
+    fun `test real json array serialization with api taking object`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-one-object",
+                realJsonArrayPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedArrayResponse, response.body)
+    }
+
+    @Test
+    fun `test real json array serialization with api taking single parameters`() {
+        val response = client.call(
+            POST, WebRequest<Any>(
+                "objects-in-json-endpoint/create-with-individual-params",
+                realJsonArrayPayload
+            ),
+            userName, password
+        )
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals(expectedArrayResponse, response.body)
+    }
+
+}

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
@@ -3,7 +3,13 @@ package net.corda.httprpc.server.impl
 import io.swagger.v3.core.util.Json
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.BooleanSchema
 import io.swagger.v3.oas.models.media.ComposedSchema
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.NumberSchema
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.server.impl.internal.OptionalDependency
 import net.corda.httprpc.server.impl.utils.compact
@@ -25,6 +31,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import net.corda.httprpc.test.NullabilityRPCOpsImpl
+import net.corda.httprpc.test.ObjectsInJsonEndpointImpl
 import net.corda.httprpc.test.TestFileUploadImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
@@ -33,12 +40,26 @@ import net.corda.httprpc.test.utils.multipartDir
 
 class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
     companion object {
-        private val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost", findFreePort()), context, null, null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE)
+        private val httpRpcSettings = HttpRpcSettings(
+            NetworkHostAndPort("localhost", findFreePort()),
+            context,
+            null,
+            null,
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+        )
+
         @BeforeAll
         @JvmStatic
         fun setUpBeforeClass() {
             server = HttpRpcServerImpl(
-                listOf(CalendarRPCOpsImpl(), TestHealthCheckAPIImpl(), TestEntityRpcOpsImpl(), TestFileUploadImpl(), NullabilityRPCOpsImpl()),
+                listOf(
+                    CalendarRPCOpsImpl(),
+                    TestHealthCheckAPIImpl(),
+                    TestEntityRpcOpsImpl(),
+                    TestFileUploadImpl(),
+                    NullabilityRPCOpsImpl(),
+                    ObjectsInJsonEndpointImpl()
+                ),
                 ::securityManager,
                 httpRpcSettings,
                 multipartDir,
@@ -82,7 +103,10 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
         val responseOk = path.post.responses["200"]
         assertNotNull(responseOk)
         //need to assert that FiniteDurableReturnResult is generated as a referenced schema rather than inline content
-        assertEquals("#/components/schemas/FiniteDurableReturnResult_of_CalendarDay", responseOk.content["application/json"]!!.schema.`$ref`)
+        assertEquals(
+            "#/components/schemas/FiniteDurableReturnResult_of_CalendarDay",
+            responseOk.content["application/json"]!!.schema.`$ref`
+        )
 
         val compactBody = body.compact()
 
@@ -380,6 +404,84 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             assertEquals("binary", file.format)
             assertFalse(file.nullable)
             assertEquals("differentDesc", file.description, "File upload should have a description.")
+        }
+    }
+
+    @Test
+    fun `OpenApi spec json should include correctly formatted json objects including nullability`() {
+
+        val apiSpec = client.call(GET, WebRequest<Any>("swagger.json"))
+        val body = apiSpec.body!!.compact()
+
+        val openAPI = Json.mapper().readValue(body, OpenAPI::class.java)
+
+        fun assertJsonObject(jsonObject: Schema<*>?, nullable: Boolean? = false) {
+            assertNotNull(jsonObject)
+            assertNull(jsonObject.type)
+            assertNull(jsonObject.format)
+            assertEquals("Can be any value - string, number, boolean, array or object.", jsonObject.description)
+            assertEquals("{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}", jsonObject.example)
+            assertEquals(nullable, jsonObject.nullable)
+            val composedSchema = jsonObject as ComposedSchema
+            assertTrue(composedSchema.anyOf.containsAll(setOf(StringSchema(), NumberSchema(), IntegerSchema(), BooleanSchema(),
+                ArraySchema(), ObjectSchema()))
+            )
+        }
+
+        with(openAPI.paths["/objects-in-json-endpoint/create-with-one-object"]) {
+            assertNotNull(this)
+            val requestSchema = post.requestBody.content["application/json"]!!.schema
+            assertEquals("#/components/schemas/RequestWithJsonObject", requestSchema.`$ref`)
+        }
+
+        with(openAPI.components.schemas["RequestWithJsonObject"]) {
+            assertNotNull(this)
+            assertEquals(listOf("id", "obj"), this.required)
+            assertEquals(2, this.properties.size)
+            assertNotNull(this.properties["id"])
+            val jsonObject = this.properties["obj"]
+            assertJsonObject(jsonObject)
+        }
+
+        with(openAPI.paths["/objects-in-json-endpoint/create-with-individual-params"]) {
+            assertNotNull(this)
+            val requestSchema = post.requestBody.content["application/json"]!!.schema
+            assertEquals("#/components/schemas/CreateWithIndividualParamsWrapperRequest", requestSchema.`$ref`)
+        }
+
+        with(openAPI.components.schemas["CreateWithIndividualParamsWrapperRequest"]) {
+            assertNotNull(this)
+            assertEquals(listOf("id", "obj"), this.required)
+            assertEquals(2, this.properties.size)
+            assertNotNull(this.properties["id"])
+            val jsonObject = this.properties["obj"]
+            assertJsonObject(jsonObject)
+        }
+
+        with(openAPI.paths["/objects-in-json-endpoint/nullable-json-object-in-request"]) {
+            assertNotNull(this)
+            val requestSchema = post.requestBody.content["application/json"]!!.schema
+            assertEquals("#/components/schemas/NullableJsonObjectInRequestWrapperRequest", requestSchema.`$ref`)
+            val responseSchema = post.responses["200"]!!.content["application/json"]!!.schema
+            assertEquals("#/components/schemas/ResponseWithJsonObjectNullable", responseSchema.`$ref`)
+        }
+
+        with(openAPI.components.schemas["NullableJsonObjectInRequestWrapperRequest"]) {
+            assertNotNull(this)
+            assertEquals(listOf("id"), this.required)
+            assertEquals(2, this.properties.size)
+            assertNotNull(this.properties["id"])
+            val jsonObject = this.properties["obj"]
+            assertJsonObject(jsonObject, true)
+        }
+
+        with(openAPI.components.schemas["ResponseWithJsonObjectNullable"]) {
+            assertNotNull(this)
+            assertEquals(listOf("id"), this.required)
+            assertEquals(2, this.properties.size)
+            assertNotNull(this.properties["id"])
+            val jsonObject = this.properties["obj"]
+            assertJsonObject(jsonObject, true)
         }
     }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelProvider.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelProvider.kt
@@ -1,6 +1,7 @@
 package net.corda.httprpc.server.impl.apigen.processing.openapi.schema
 
 import net.corda.httprpc.server.impl.apigen.models.EndpointParameter
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.JsonSchemaBuilder
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.SchemaBigDecimalBuilder
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.SchemaBigIntegerBuilder
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.SchemaBooleanBuilder
@@ -83,7 +84,8 @@ internal class DefaultSchemaModelProvider(private val schemaModelContextHolder: 
         StringSchemaModelBuilder(),
         SchemaPairBuilder(this),
         SchemaDurableReturnResultBuilder(this),
-        SchemaPositionedValueBuilder(this)
+        SchemaPositionedValueBuilder(this),
+        JsonSchemaBuilder()
     )
 
     override fun toSchemaModel(properties: List<EndpointParameter>, schemaModelName: String): SchemaModel {

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelToOpenApiSchemaConverter.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelToOpenApiSchemaConverter.kt
@@ -1,7 +1,14 @@
 package net.corda.httprpc.server.impl.apigen.processing.openapi.schema
 
 import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.BooleanSchema
+import io.swagger.v3.oas.models.media.ComposedSchema
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.NumberSchema
+import io.swagger.v3.oas.models.media.ObjectSchema
 import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.JsonSchemaModel
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaCollectionModel
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaDurableReturnResultModel
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaEnumModel
@@ -56,6 +63,20 @@ object SchemaModelToOpenApiSchemaConverter {
             // extraordinary case, where the object's ref is expected to be found in the overall structure
             is SchemaRefObjectModel -> Schema<Any>().apply {
                 `$ref`(schemaModel.ref)
+            }
+            is JsonSchemaModel -> ComposedSchema().apply {
+                description = "Can be any value - string, number, boolean, array or object."
+                example = "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
+                anyOf(
+                    listOf(
+                        StringSchema(),
+                        NumberSchema(),
+                        IntegerSchema(),
+                        BooleanSchema(),
+                        ArraySchema(),
+                        ObjectSchema(),
+                    )
+                )
             }
             else -> convertBaseSchemaModel(schemaModel)
 

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/JsonSchemaBuilder.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/JsonSchemaBuilder.kt
@@ -1,0 +1,14 @@
+package net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders
+
+import net.corda.httprpc.JsonObject
+import net.corda.httprpc.server.impl.apigen.models.GenericParameterizedType
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.JsonSchemaModel
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaModel
+
+internal class JsonSchemaBuilder : SchemaBuilder {
+    override val keys = listOf(JsonObject::class.java)
+
+    override fun build(clazz: Class<*>, parameterizedClassList: List<GenericParameterizedType>): SchemaModel{
+        return JsonSchemaModel()
+    }
+}

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/model/SchemaModel.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/model/SchemaModel.kt
@@ -62,5 +62,13 @@ open class SchemaMultiRefObjectModel(
     override fun getRequiredFields() = this.properties.filter { it.value.isRequiredField() }.keys.toList().sorted()
 }
 
+/**
+ * JsonSchemaModel is a special type that allows all JSON types and null format.
+ */
+open class JsonSchemaModel : SchemaModel(
+    type = null,
+    format = null,
+)
+
 private fun SchemaModel.isRequiredField() = required && notNullableOrNull()
 private fun SchemaModel.notNullableOrNull() = (nullable == null || nullable == false)

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRPCServerSerialization.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRPCServerSerialization.kt
@@ -1,10 +1,18 @@
 package net.corda.httprpc.server.impl.internal
 
 import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.TreeNode
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.ValueNode
 import net.corda.common.json.serialization.jacksonObjectMapper
+import net.corda.httprpc.JsonObject
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 
@@ -12,6 +20,8 @@ internal val serverJacksonObjectMapper = jacksonObjectMapper().apply {
     val module = SimpleModule()
     module.addSerializer(SecureHash::class.java, SecureHashSerializer)
     module.addSerializer(MemberX500Name::class.java, MemberX500NameSerializer)
+    module.addSerializer(JsonObject::class.java, JsonObjectSerializer)
+    module.addDeserializer(JsonObject::class.java, JsonObjectDeserializer)
     registerModule(module)
 }
 
@@ -24,5 +34,27 @@ internal object SecureHashSerializer : JsonSerializer<SecureHash>() {
 internal object MemberX500NameSerializer : JsonSerializer<MemberX500Name>() {
     override fun serialize(obj: MemberX500Name, generator: JsonGenerator, provider: SerializerProvider) {
         generator.writeString(obj.toString())
+    }
+}
+
+internal object JsonObjectSerializer : JsonSerializer<JsonObject>() {
+    override fun serialize(obj: JsonObject, generator: JsonGenerator, provider: SerializerProvider) {
+        generator.writeString(obj.toString())
+    }
+}
+
+internal object JsonObjectDeserializer : JsonDeserializer<JsonObject>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): JsonObject {
+        val treeNode = p.readValueAsTree<TreeNode>()
+        val str = if (treeNode.isObject) {
+            (treeNode as ObjectNode).toString()
+        } else if (treeNode.isValueNode) {
+            (treeNode as ValueNode).textValue()
+        } else if (treeNode.isArray) {
+            (treeNode as ArrayNode).toString()
+        } else {
+            treeNode.toString()
+        }
+        return JsonObjectAsString(str)
     }
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRPCServerSerialization.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRPCServerSerialization.kt
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.ValueNode
 import net.corda.common.json.serialization.jacksonObjectMapper
 import net.corda.httprpc.JsonObject
@@ -45,16 +43,10 @@ internal object JsonObjectSerializer : JsonSerializer<JsonObject>() {
 
 internal object JsonObjectDeserializer : JsonDeserializer<JsonObject>() {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): JsonObject {
-        val treeNode = p.readValueAsTree<TreeNode>()
-        val str = if (treeNode.isObject) {
-            (treeNode as ObjectNode).toString()
-        } else if (treeNode.isValueNode) {
-            (treeNode as ValueNode).textValue()
-        } else if (treeNode.isArray) {
-            (treeNode as ArrayNode).toString()
-        } else {
-            treeNode.toString()
+        val jsonValue = p.readValueAsTree<TreeNode>().let {
+            if (it.isValueNode) (it as ValueNode).textValue()
+            else it.toString()
         }
-        return JsonObjectAsString(str)
+        return JsonObjectAsString(jsonValue)
     }
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/JsonObjectAsString.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/JsonObjectAsString.kt
@@ -3,10 +3,10 @@ package net.corda.httprpc.server.impl.internal
 import net.corda.httprpc.JsonObject
 
 /**
- * Implementation of [JsonObject] that provides the String [value] of a Json object for marshalling purposes.
+ * Implementation of [JsonObject] that provides the [escapedJson] of a Json object for marshalling purposes.
  */
-data class JsonObjectAsString(val value: String) : JsonObject {
+data class JsonObjectAsString(override val escapedJson: String) : JsonObject {
     override fun toString(): String {
-        return value
+        return escapedJson
     }
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/JsonObjectAsString.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/JsonObjectAsString.kt
@@ -1,0 +1,12 @@
+package net.corda.httprpc.server.impl.internal
+
+import net.corda.httprpc.JsonObject
+
+/**
+ * Implementation of [JsonObject] that provides the String [value] of a Json object for marshalling purposes.
+ */
+data class JsonObjectAsString(val value: String) : JsonObject {
+    override fun toString(): String {
+        return value
+    }
+}

--- a/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/apigen/processing/ResourceToOpenApiSpecMapperTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/apigen/processing/ResourceToOpenApiSpecMapperTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.reflect.jvm.javaMethod
+import net.corda.httprpc.JsonObject
 import net.corda.httprpc.test.TestFileUploadAPI
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -414,5 +415,29 @@ class ResourceToOpenApiSpecMapperTest {
         assertEquals("binary", file.format)
         assertEquals("The file input stream.", file.description)
         assertFalse(file.nullable)
+    }
+
+    @Test
+    fun `Can convert JsonObject parameter to OpenApiParameter`() {
+        val schemaModelProvider = DefaultSchemaModelProvider(SchemaModelContextHolder())
+        val queryParameter = EndpointParameter(
+            id = "id",
+            name = "name",
+            description = "description",
+            required = true,
+            default = "default",
+            classType = JsonObject::class.java,
+            type = ParameterType.BODY
+        )
+        val openApiQueryParameter = queryParameter.toOpenApiParameter(schemaModelProvider)
+        assertEquals("name", openApiQueryParameter.name)
+        assertEquals("description", openApiQueryParameter.description)
+        assertEquals(true, openApiQueryParameter.required)
+        assertEquals("body", openApiQueryParameter.`in`)
+        assertEquals(null, openApiQueryParameter.schema.type)
+        assertEquals(null, openApiQueryParameter.schema.format)
+        assertEquals("Can be any value - string, number, boolean, array or object.", openApiQueryParameter.schema.description)
+        assertEquals("{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            openApiQueryParameter.schema.example)
     }
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelToOpenApiSchemaConverterTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelToOpenApiSchemaConverterTest.kt
@@ -3,6 +3,7 @@ package net.corda.httprpc.server.impl.apigen.processing.openapi.schema
 import io.swagger.v3.oas.models.media.ArraySchema
 import io.swagger.v3.oas.models.media.Schema
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.DataType
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.JsonSchemaModel
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaCollectionModel
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaEnumModel
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaMapModel
@@ -82,5 +83,15 @@ internal class SchemaModelToOpenApiSchemaConverterTest {
         val result = SchemaModelToOpenApiSchemaConverter.convert(model)
 
         assertNull(result.enum)
+    }
+
+    @Test
+    fun `convert JsonObject succeeds`() {
+        val model = JsonSchemaModel()
+
+        val result = SchemaModelToOpenApiSchemaConverter.convert(model)
+
+        assertEquals("{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}", result.example)
+        assertEquals("Can be any value - string, number, boolean, array or object.", result.description)
     }
 }

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpoint.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpoint.kt
@@ -1,0 +1,27 @@
+package net.corda.httprpc.test
+
+import net.corda.httprpc.JsonObject
+import net.corda.httprpc.RpcOps
+import net.corda.httprpc.annotations.HttpRpcPOST
+import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
+import net.corda.httprpc.annotations.HttpRpcResource
+
+@HttpRpcResource(
+    name = "ObjectsInJsonEndpoint",
+    description = "RESTful operations with json objects in payloads",
+    path = "objects-in-json-endpoint"
+)
+interface ObjectsInJsonEndpoint : RpcOps {
+
+    data class RequestWithJsonObject(val id: String, val obj: JsonObject)
+    data class ResponseWithJsonObject(val id: String, val obj: JsonObject)
+
+    @HttpRpcPOST(path = "create-with-one-object")
+    fun createWithOneObject(@HttpRpcRequestBodyParameter creationObject: RequestWithJsonObject): ResponseWithJsonObject
+
+    @HttpRpcPOST(path = "create-with-individual-params")
+    fun createWithIndividualParams(
+        @HttpRpcRequestBodyParameter id: String,
+        @HttpRpcRequestBodyParameter obj: JsonObject
+    ): ResponseWithJsonObject
+}

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpoint.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpoint.kt
@@ -15,6 +15,7 @@ interface ObjectsInJsonEndpoint : RpcOps {
 
     data class RequestWithJsonObject(val id: String, val obj: JsonObject)
     data class ResponseWithJsonObject(val id: String, val obj: JsonObject)
+    data class ResponseWithJsonObjectNullable(val id: String, val obj: JsonObject?)
 
     @HttpRpcPOST(path = "create-with-one-object")
     fun createWithOneObject(@HttpRpcRequestBodyParameter creationObject: RequestWithJsonObject): ResponseWithJsonObject
@@ -24,4 +25,10 @@ interface ObjectsInJsonEndpoint : RpcOps {
         @HttpRpcRequestBodyParameter id: String,
         @HttpRpcRequestBodyParameter obj: JsonObject
     ): ResponseWithJsonObject
+
+    @HttpRpcPOST(path = "nullable-json-object-in-request")
+    fun nullableJsonObjectInRequest(
+        @HttpRpcRequestBodyParameter id: String,
+        @HttpRpcRequestBodyParameter obj: JsonObject?
+    ): ResponseWithJsonObjectNullable
 }

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpointImpl.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpointImpl.kt
@@ -23,4 +23,9 @@ class ObjectsInJsonEndpointImpl : ObjectsInJsonEndpoint, PluggableRPCOps<Objects
         log.info("Create with individual params: id: $id object: $obj")
         return ObjectsInJsonEndpoint.ResponseWithJsonObject(id, obj)
     }
+
+    override fun nullableJsonObjectInRequest(id: String, obj: JsonObject?): ObjectsInJsonEndpoint.ResponseWithJsonObjectNullable {
+        log.info("Create with individual params: id: $id object: $obj")
+        return ObjectsInJsonEndpoint.ResponseWithJsonObjectNullable(id, obj)
+    }
 }

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpointImpl.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpointImpl.kt
@@ -1,0 +1,26 @@
+package net.corda.httprpc.test
+
+import net.corda.httprpc.JsonObject
+import net.corda.httprpc.PluggableRPCOps
+import net.corda.v5.base.util.contextLogger
+
+class ObjectsInJsonEndpointImpl : ObjectsInJsonEndpoint, PluggableRPCOps<ObjectsInJsonEndpoint> {
+
+    companion object {
+        val log = contextLogger()
+    }
+
+    override val protocolVersion: Int = 1
+    override val targetInterface = ObjectsInJsonEndpoint::class.java
+
+    override fun createWithOneObject(creationObject: ObjectsInJsonEndpoint.RequestWithJsonObject):
+            ObjectsInJsonEndpoint.ResponseWithJsonObject {
+        log.info("Create with one object: $creationObject")
+        return ObjectsInJsonEndpoint.ResponseWithJsonObject(creationObject.id, creationObject.obj)
+    }
+
+    override fun createWithIndividualParams(id: String, obj: JsonObject): ObjectsInJsonEndpoint.ResponseWithJsonObject {
+        log.info("Create with individual params: id: $id object: $obj")
+        return ObjectsInJsonEndpoint.ResponseWithJsonObject(id, obj)
+    }
+}

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/JsonObject.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/JsonObject.kt
@@ -1,8 +1,10 @@
 package net.corda.httprpc
 
 /**
- * Marker interface which can be used in HTTP request / response objects to indicate a field is a JSON object. As a result, such fields
- * accept the object as a JSON object or a string version of the JSON with escaped quotation marks.
+ * Interface which can be used in HTTP request / response objects to indicate a field is a JSON value, object or array. Request payloads
+ * will unmarshall to an escaped string which can be obtained through [escapedJson].
+ *
+ * This allows real JSON to be supplied in requests rather than escaping JSON and supplying it as a string value field.
  *
  * For example, if the request object is defined as follows:
  *
@@ -10,7 +12,7 @@ package net.corda.httprpc
  * data class RequestWithJsonObject(val id: String, val obj: JsonObject)
  * ```
  *
- * Then the following payloads will be acceptable:
+ * Then both the following payloads will be acceptable:
  *
  * A - "obj" is a JSON object.
  * ```
@@ -26,7 +28,7 @@ package net.corda.httprpc
  *   "obj": "{\"message\":\"Hey Mars\", \"planetaryOnly\":\"true\", \"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"}"
  * }
  * ```
- *
- * Internally, implementations of [RpcOps] endpoints should use `toString()` on the [JsonObject] to get access to the object's JSON.
  */
-interface JsonObject
+interface JsonObject {
+    val escapedJson: String
+}

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/JsonObject.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/JsonObject.kt
@@ -1,0 +1,32 @@
+package net.corda.httprpc
+
+/**
+ * Marker interface which can be used in HTTP request / response objects to indicate a field is a JSON object. As a result, such fields
+ * accept the object as a JSON object or a string version of the JSON with escaped quotation marks.
+ *
+ * For example, if the request object is defined as follows:
+ *
+ * ```
+ * data class RequestWithJsonObject(val id: String, val obj: JsonObject)
+ * ```
+ *
+ * Then the following payloads will be acceptable:
+ *
+ * A - "obj" is a JSON object.
+ * ```
+ * {
+ *   "id": "real-object",
+ *   "obj": {"message": "Hey Mars", "planetaryOnly":"true", "target":"C=GB, L=FOURTH, O=MARS, OU=PLANET"}
+ * }
+ * ```
+ * B - "obj" is a String containing JSON with escaped quotation marks.
+ * ```
+ * {
+ *   "id": "string-escaped",
+ *   "obj": "{\"message\":\"Hey Mars\", \"planetaryOnly\":\"true\", \"target\":\"C=GB, L=FOURTH, O=MARS, OU=PLANET\"}"
+ * }
+ * ```
+ *
+ * Internally, implementations of [RpcOps] endpoints should use `toString()` on the [JsonObject] to get access to the object's JSON.
+ */
+interface JsonObject

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -3072,6 +3072,10 @@
           }
         }
       },
+      "JsonObject" : {
+        "type" : "object",
+        "properties" : { }
+      },
       "KeyMetaData" : {
         "required" : [ "alias", "created", "hsmCategory", "keyId", "scheme" ],
         "type" : "object",
@@ -3425,9 +3429,7 @@
             "example" : "string"
           },
           "requestData" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
+            "$ref" : "#/components/schemas/JsonObject"
           }
         },
         "description" : "Information required to start a flow for this holdingId"

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -3072,10 +3072,6 @@
           }
         }
       },
-      "JsonObject" : {
-        "type" : "object",
-        "properties" : { }
-      },
       "KeyMetaData" : {
         "required" : [ "alias", "created", "hsmCategory", "keyId", "scheme" ],
         "type" : "object",
@@ -3429,7 +3425,23 @@
             "example" : "string"
           },
           "requestData" : {
-            "$ref" : "#/components/schemas/JsonObject"
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : false,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
           }
         },
         "description" : "Information required to start a flow for this holdingId"


### PR DESCRIPTION
Real JSON can be supplied in start flow params and JsonObject can be used in any other request type to allow real JSON object to be sent rather than escaping JSON.
- Add support for marshalling and unmarshalling `JsonObject` in configured Javalin Jackson object mapper
- Add JsonObject to StartFlowParameters.kt so escaped JSON or real JSON can be provided as part of payload.
- test arrays, objects, maps, values.
- Also supports escaped JSON as before.
- Response objects that return JsonObject return escaped JSON rather than JSON object.

Working examples:
```
POST https://localhost:8888/api/v1/flow/6D5296318533
{
    "clientRequestId": "launchpad-7",
    "flowClassName": "net.cordapp.flowworker.development.flows.RpcSmokeTestFlow",
    "requestData": "{\"command\":\"echo\", \"data\":{\"echo_value\": \"helloconal\"}}"
}
```
```
POST https://localhost:8888/api/v1/flow/6D5296318533
{
    "clientRequestId": "launchpad-6",
    "flowClassName": "net.cordapp.flowworker.development.flows.RpcSmokeTestFlow",
    "requestData": {
      "command":"echo", 
      "data":{
        "echo_value": "helloconal"
      }
    }
}
```