### PR TITLE
CORE-5274: Add framework properties required by Quasar to TestOSGi tasks.

### DIFF
--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -84,6 +84,13 @@ def testOSGi = tasks.register('testOSGi', TestOSGi) {
     resultsDirectory = file("$testResultsDir/integrationTest")
     bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
     bndrun = resolve.flatMap { it.outputBndrun }
+
+    // These properties are for Quasar's framework extension, should it be present.
+    properties.put '-runproperties.quasarExcludePackages', 'co.paralleluniverse.quasar.excludePackages="aQute.**,kotlin**,org.osgi.**,org.apache.felix.**,org.slf4j**,org.junit.**,org.assertj.**,org.opentest4j**"'
+    properties.put '-runproperties.quasarSuspendableAnnotation', 'co.paralleluniverse.quasar.suspendableAnnotation=net.corda.v5.base.annotations.Suspendable'
+
+    // Ensure we still get Gradle's project properties too.
+    properties.put 'project', '__convention__'
 }
 
 tasks.named('check') {

--- a/components/flow/flow-service/test.bndrun
+++ b/components/flow/flow-service/test.bndrun
@@ -19,10 +19,7 @@
     sun.security.x509
 
 -runproperties: \
-    co.paralleluniverse.quasar.suspendableAnnotation=net.corda.v5.base.annotations.Suspendable,\
-    co.paralleluniverse.quasar.excludePackages='aQute.**,kotlin**,org.osgi.**,org.apache.felix.**,org.slf4j**,org.junit.**,org.assertj.**,org.opentest4j**',\
-    co.paralleluniverse.quasar.verbose=false,\
-    org.osgi.framework.bundle.parent=framework
+    co.paralleluniverse.quasar.verbose=false
 
 -runrequires: \
     bnd.identity;id='flow-service-tests',\

--- a/libs/serialization/serialization-kryo/test.bndrun
+++ b/libs/serialization/serialization-kryo/test.bndrun
@@ -17,11 +17,6 @@
     javax.xml.stream.events;version=1.0.0,\
     javax.xml.stream.util;version=1.0.0
 
--runproperties: \
-    co.paralleluniverse.quasar.suspendableAnnotation=net.corda.v5.base.annotations.Suspendable,\
-    co.paralleluniverse.quasar.excludePackages='aQute.**,kotlin**,org.osgi.**,org.apache.felix.**,org.slf4j**,org.junit.**,org.assertj.**,org.opentest4j**',\
-    org.osgi.framework.bundle.parent=framework
-
 -runrequires: \
     bnd.identity;id='serialization-kryo-tests',\
     bnd.identity;id='net.corda.serialization-kryo',\


### PR DESCRIPTION
Configure Quasar's framework extension for executing JUnit tests. These extra `-runproperties.*` values will be merged with any `-runproperties` value in the `test.bndrun` file. With any luck, Quasar should now "just work" for people's `TestOSGi` tasks in the vast majority of cases .