### PR TITLE
NOTICK: use correct parameter name

### DIFF
--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -3,5 +3,5 @@
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',
   snykTokenId: 'r3-snyk-corda5',
-  additionalArguments: "--configuration-matching='^runtimeClasspath\$'"
+  snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$'"
 )


### PR DESCRIPTION
Tested here:
https://ci02.dev.r3.com/job/Corda5/job/Snyk-Delta-PR-Scans/job/corda-runtime-os-snyk-delta/job/PR-1854/23/console

Substituted output:
`snyk-linux test --prune-repeated-subdependencies --configuration-matching='^runtimeClasspath$' --sub-project=entity-processor-service-impl --json --severity-threshold=high`