### PR TITLE
NOTICK - fix concurrency issue with linked list in smoke tests

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -67,7 +67,7 @@ class FlowStatusFeedSmokeTest {
             startFlow(clientRequestId)
 
             eventually(Duration.ofSeconds(300)) {
-                assertThat(wsHandler.messageQueueSnapshot.size).isEqualTo(3)
+                assertThat(wsHandler.messageQueueSnapshot).hasSize(3)
             }
             eventually {
                 val messageQueue = wsHandler.messageQueueSnapshot
@@ -89,8 +89,8 @@ class FlowStatusFeedSmokeTest {
                 startFlow(clientRequestId)
 
                 eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueueSnapshot.size).isEqualTo(3)
-                    assertThat(wsHandler2.messageQueueSnapshot.size).isEqualTo(3)
+                    assertThat(wsHandler1.messageQueueSnapshot).hasSize(3)
+                    assertThat(wsHandler2.messageQueueSnapshot).hasSize(3)
                 }
                 eventually {
                     val messageQueue1 = wsHandler1.messageQueueSnapshot
@@ -129,8 +129,8 @@ class FlowStatusFeedSmokeTest {
                 startFlow(clientRequestId2)
 
                 eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueueSnapshot.size).isEqualTo(3)
-                    assertThat(wsHandler2.messageQueueSnapshot.size).isEqualTo(3)
+                    assertThat(wsHandler1.messageQueueSnapshot).hasSize(3)
+                    assertThat(wsHandler2.messageQueueSnapshot).hasSize(3)
                 }
 
                 eventually {
@@ -159,7 +159,7 @@ class FlowStatusFeedSmokeTest {
 
         client.use {
             eventually {
-                assertThat(wsHandler.messageQueueSnapshot.size).isEqualTo(1)
+                assertThat(wsHandler.messageQueueSnapshot).hasSize(1)
             }
             eventually {
                 assertThat(wsHandler.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -10,7 +10,7 @@ import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.getFlowClasses
 import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.startRpcFlow
-import net.corda.applications.workers.smoketest.websocket.client.MessageQueueWebsocketHandler
+import net.corda.applications.workers.smoketest.websocket.client.MessageQueueWebSocketHandler
 import net.corda.applications.workers.smoketest.websocket.client.SmokeTestWebsocketClient
 import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
 import net.corda.test.util.eventually
@@ -42,7 +42,7 @@ class FlowStatusFeedSmokeTest {
     fun `websocket connection can be opened to listen for updates for flow clientRequestid`() {
         val flowStatusFeedPath = "/flow/$bobHoldingId/${generateRequestId("test10")}"
 
-        val wsHandler = MessageQueueWebsocketHandler()
+        val wsHandler = MessageQueueWebSocketHandler()
 
         val client = SmokeTestWebsocketClient()
         client.start()
@@ -70,9 +70,10 @@ class FlowStatusFeedSmokeTest {
                 assertThat(wsHandler.messageQueue.size).isEqualTo(3)
             }
             eventually {
-                assertThat(wsHandler.messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
-                assertThat(wsHandler.messageQueue[1]).contains(FlowStates.RUNNING.name)
-                assertThat(wsHandler.messageQueue[2]).contains(FlowStates.COMPLETED.name)
+                val messageQueue = wsHandler.messageQueue
+                assertThat(messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
+                assertThat(messageQueue[1]).contains(FlowStates.RUNNING.name)
+                assertThat(messageQueue[2]).contains(FlowStates.COMPLETED.name)
             }
         }
     }
@@ -92,12 +93,14 @@ class FlowStatusFeedSmokeTest {
                     assertThat(wsHandler2.messageQueue.size).isEqualTo(3)
                 }
                 eventually {
-                    assertThat(wsHandler1.messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
-                    assertThat(wsHandler1.messageQueue[1]).contains(FlowStates.RUNNING.name)
-                    assertThat(wsHandler1.messageQueue[2]).contains(FlowStates.COMPLETED.name)
-                    assertThat(wsHandler2.messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
-                    assertThat(wsHandler2.messageQueue[1]).contains(FlowStates.RUNNING.name)
-                    assertThat(wsHandler2.messageQueue[2]).contains(FlowStates.COMPLETED.name)
+                    val messageQueue1 = wsHandler1.messageQueue
+                    val messageQueue2 = wsHandler2.messageQueue
+                    assertThat(messageQueue1[0]).contains(FlowStates.START_REQUESTED.name)
+                    assertThat(messageQueue1[1]).contains(FlowStates.RUNNING.name)
+                    assertThat(messageQueue1[2]).contains(FlowStates.COMPLETED.name)
+                    assertThat(messageQueue2[0]).contains(FlowStates.START_REQUESTED.name)
+                    assertThat(messageQueue2[1]).contains(FlowStates.RUNNING.name)
+                    assertThat(messageQueue2[2]).contains(FlowStates.COMPLETED.name)
                 }
             }
         }
@@ -147,7 +150,7 @@ class FlowStatusFeedSmokeTest {
         startFlow(clientRequestId)
         awaitRpcFlowFinished(bobHoldingId, clientRequestId)
 
-        val wsHandler = MessageQueueWebsocketHandler()
+        val wsHandler = MessageQueueWebSocketHandler()
         val client = SmokeTestWebsocketClient()
 
         client.start()
@@ -161,7 +164,6 @@ class FlowStatusFeedSmokeTest {
             eventually {
                 assertThat(wsHandler.messageQueue[0]).contains(FlowStates.COMPLETED.name)
             }
-
             eventually {
                 assertFalse(wsHandler.isConnected)
             }
@@ -180,7 +182,7 @@ class FlowStatusFeedSmokeTest {
         startFlow(clientRequestId)
         awaitRpcFlowFinished(bobHoldingId, clientRequestId)
 
-        val wsHandler1 = MessageQueueWebsocketHandler()
+        val wsHandler1 = MessageQueueWebSocketHandler()
         val client1 = SmokeTestWebsocketClient()
 
         client1.start()
@@ -202,7 +204,7 @@ class FlowStatusFeedSmokeTest {
         session1.close(1000, "Smoke test closing session 1.")
         client1.close()
 
-        val wsHandler2 = MessageQueueWebsocketHandler()
+        val wsHandler2 = MessageQueueWebSocketHandler()
         val client2 = SmokeTestWebsocketClient()
 
         client2.start()
@@ -247,12 +249,12 @@ class FlowStatusFeedSmokeTest {
         val flowStatusFeedPath1 = "/flow/$bobHoldingId/$clientRequestId1"
         val flowStatusFeedPath2 = "/flow/$bobHoldingId/$clientRequestId2"
 
-        val wsHandler1 = MessageQueueWebsocketHandler()
+        val wsHandler1 = MessageQueueWebSocketHandler()
         val client1 = SmokeTestWebsocketClient()
         client1.start()
         val session1 = client1.connect(flowStatusFeedPath1, wsHandler1)
 
-        val wsHandler2 = MessageQueueWebsocketHandler()
+        val wsHandler2 = MessageQueueWebSocketHandler()
         val client2 = SmokeTestWebsocketClient()
         client2.start()
         val session2 = client2.connect(flowStatusFeedPath2, wsHandler2)
@@ -275,7 +277,7 @@ class FlowStatusFeedSmokeTest {
         val clientRequestId = generateRequestId("test60")
         val flowStatusFeedPath = "/flow/THIS_HOLDING_ID_IS_NOT_HEX/$clientRequestId"
 
-        val wsHandler = MessageQueueWebsocketHandler()
+        val wsHandler = MessageQueueWebSocketHandler()
         val client = SmokeTestWebsocketClient()
         client.start()
         client.connect(flowStatusFeedPath, wsHandler)
@@ -290,7 +292,7 @@ class FlowStatusFeedSmokeTest {
         val clientRequestId = generateRequestId("test61")
         val flowStatusFeedPath = "/flow/544849535f484f4c44494e475f49445f49535f4e4f545f484558/$clientRequestId"
 
-        val wsHandler = MessageQueueWebsocketHandler()
+        val wsHandler = MessageQueueWebSocketHandler()
         val client = SmokeTestWebsocketClient()
         client.start()
         client.connect(flowStatusFeedPath, wsHandler)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -67,10 +67,10 @@ class FlowStatusFeedSmokeTest {
             startFlow(clientRequestId)
 
             eventually(Duration.ofSeconds(300)) {
-                assertThat(wsHandler.messageQueue.size).isEqualTo(3)
+                assertThat(wsHandler.messageQueueSnapshot.size).isEqualTo(3)
             }
             eventually {
-                val messageQueue = wsHandler.messageQueue
+                val messageQueue = wsHandler.messageQueueSnapshot
                 assertThat(messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
                 assertThat(messageQueue[1]).contains(FlowStates.RUNNING.name)
                 assertThat(messageQueue[2]).contains(FlowStates.COMPLETED.name)
@@ -89,12 +89,12 @@ class FlowStatusFeedSmokeTest {
                 startFlow(clientRequestId)
 
                 eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueue.size).isEqualTo(3)
-                    assertThat(wsHandler2.messageQueue.size).isEqualTo(3)
+                    assertThat(wsHandler1.messageQueueSnapshot.size).isEqualTo(3)
+                    assertThat(wsHandler2.messageQueueSnapshot.size).isEqualTo(3)
                 }
                 eventually {
-                    val messageQueue1 = wsHandler1.messageQueue
-                    val messageQueue2 = wsHandler2.messageQueue
+                    val messageQueue1 = wsHandler1.messageQueueSnapshot
+                    val messageQueue2 = wsHandler2.messageQueueSnapshot
                     assertThat(messageQueue1[0]).contains(FlowStates.START_REQUESTED.name)
                     assertThat(messageQueue1[1]).contains(FlowStates.RUNNING.name)
                     assertThat(messageQueue1[2]).contains(FlowStates.COMPLETED.name)
@@ -129,13 +129,13 @@ class FlowStatusFeedSmokeTest {
                 startFlow(clientRequestId2)
 
                 eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueue.size).isEqualTo(3)
-                    assertThat(wsHandler2.messageQueue.size).isEqualTo(3)
+                    assertThat(wsHandler1.messageQueueSnapshot.size).isEqualTo(3)
+                    assertThat(wsHandler2.messageQueueSnapshot.size).isEqualTo(3)
                 }
 
                 eventually {
-                    assertNormalFlowStatusesForRequest(wsHandler1.messageQueue, clientRequestId1)
-                    assertNormalFlowStatusesForRequest(wsHandler2.messageQueue, clientRequestId2)
+                    assertNormalFlowStatusesForRequest(wsHandler1.messageQueueSnapshot, clientRequestId1)
+                    assertNormalFlowStatusesForRequest(wsHandler2.messageQueueSnapshot, clientRequestId2)
                 }
             }
         }
@@ -159,10 +159,10 @@ class FlowStatusFeedSmokeTest {
 
         client.use {
             eventually {
-                assertThat(wsHandler.messageQueue.size).isEqualTo(1)
+                assertThat(wsHandler.messageQueueSnapshot.size).isEqualTo(1)
             }
             eventually {
-                assertThat(wsHandler.messageQueue[0]).contains(FlowStates.COMPLETED.name)
+                assertThat(wsHandler.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
             }
             eventually {
                 assertFalse(wsHandler.isConnected)
@@ -190,11 +190,11 @@ class FlowStatusFeedSmokeTest {
         // The websocket channel is terminated too quickly to use eventually to assert wsHandler.isConnected
 
         eventually {
-            assertThat(wsHandler1.messageQueue).hasSize(1)
+            assertThat(wsHandler1.messageQueueSnapshot).hasSize(1)
         }
 
         eventually {
-            assertThat(wsHandler1.messageQueue[0]).contains(FlowStates.COMPLETED.name)
+            assertThat(wsHandler1.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
         }
 
         eventually {
@@ -212,11 +212,11 @@ class FlowStatusFeedSmokeTest {
         // The websocket channel is terminated too quickly to use eventually to assert wsHandler.isConnected
 
         eventually {
-            assertThat(wsHandler2.messageQueue).hasSize(1)
+            assertThat(wsHandler2.messageQueueSnapshot).hasSize(1)
         }
 
         eventually {
-            assertThat(wsHandler2.messageQueue[0]).contains(FlowStates.COMPLETED.name)
+            assertThat(wsHandler2.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
         }
 
         eventually {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -69,12 +69,10 @@ class FlowStatusFeedSmokeTest {
             eventually(Duration.ofSeconds(300)) {
                 assertThat(wsHandler.messageQueueSnapshot).hasSize(3)
             }
-            eventually {
-                val messageQueue = wsHandler.messageQueueSnapshot
-                assertThat(messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
-                assertThat(messageQueue[1]).contains(FlowStates.RUNNING.name)
-                assertThat(messageQueue[2]).contains(FlowStates.COMPLETED.name)
-            }
+            val messageQueue = wsHandler.messageQueueSnapshot
+            assertThat(messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
+            assertThat(messageQueue[1]).contains(FlowStates.RUNNING.name)
+            assertThat(messageQueue[2]).contains(FlowStates.COMPLETED.name)
         }
     }
 
@@ -92,16 +90,14 @@ class FlowStatusFeedSmokeTest {
                     assertThat(wsHandler1.messageQueueSnapshot).hasSize(3)
                     assertThat(wsHandler2.messageQueueSnapshot).hasSize(3)
                 }
-                eventually {
-                    val messageQueue1 = wsHandler1.messageQueueSnapshot
-                    val messageQueue2 = wsHandler2.messageQueueSnapshot
-                    assertThat(messageQueue1[0]).contains(FlowStates.START_REQUESTED.name)
-                    assertThat(messageQueue1[1]).contains(FlowStates.RUNNING.name)
-                    assertThat(messageQueue1[2]).contains(FlowStates.COMPLETED.name)
-                    assertThat(messageQueue2[0]).contains(FlowStates.START_REQUESTED.name)
-                    assertThat(messageQueue2[1]).contains(FlowStates.RUNNING.name)
-                    assertThat(messageQueue2[2]).contains(FlowStates.COMPLETED.name)
-                }
+                val messageQueue1 = wsHandler1.messageQueueSnapshot
+                val messageQueue2 = wsHandler2.messageQueueSnapshot
+                assertThat(messageQueue1[0]).contains(FlowStates.START_REQUESTED.name)
+                assertThat(messageQueue1[1]).contains(FlowStates.RUNNING.name)
+                assertThat(messageQueue1[2]).contains(FlowStates.COMPLETED.name)
+                assertThat(messageQueue2[0]).contains(FlowStates.START_REQUESTED.name)
+                assertThat(messageQueue2[1]).contains(FlowStates.RUNNING.name)
+                assertThat(messageQueue2[2]).contains(FlowStates.COMPLETED.name)
             }
         }
     }
@@ -133,10 +129,8 @@ class FlowStatusFeedSmokeTest {
                     assertThat(wsHandler2.messageQueueSnapshot).hasSize(3)
                 }
 
-                eventually {
-                    assertNormalFlowStatusesForRequest(wsHandler1.messageQueueSnapshot, clientRequestId1)
-                    assertNormalFlowStatusesForRequest(wsHandler2.messageQueueSnapshot, clientRequestId2)
-                }
+                assertNormalFlowStatusesForRequest(wsHandler1.messageQueueSnapshot, clientRequestId1)
+                assertNormalFlowStatusesForRequest(wsHandler2.messageQueueSnapshot, clientRequestId2)
             }
         }
     }
@@ -161,9 +155,8 @@ class FlowStatusFeedSmokeTest {
             eventually {
                 assertThat(wsHandler.messageQueueSnapshot).hasSize(1)
             }
-            eventually {
-                assertThat(wsHandler.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
-            }
+            assertThat(wsHandler.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
+
             eventually {
                 assertFalse(wsHandler.isConnected)
             }
@@ -192,10 +185,7 @@ class FlowStatusFeedSmokeTest {
         eventually {
             assertThat(wsHandler1.messageQueueSnapshot).hasSize(1)
         }
-
-        eventually {
-            assertThat(wsHandler1.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
-        }
+        assertThat(wsHandler1.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
 
         eventually {
             assertFalse(wsHandler1.isConnected)
@@ -214,10 +204,7 @@ class FlowStatusFeedSmokeTest {
         eventually {
             assertThat(wsHandler2.messageQueueSnapshot).hasSize(1)
         }
-
-        eventually {
-            assertThat(wsHandler2.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
-        }
+        assertThat(wsHandler2.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
 
         eventually {
             assertFalse(wsHandler2.isConnected)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -67,7 +67,9 @@ class FlowStatusFeedSmokeTest {
             startFlow(clientRequestId)
 
             eventually(Duration.ofSeconds(300)) {
-                assertThat(wsHandler.messageQueue).hasSize(3)
+                assertThat(wsHandler.messageQueue.size).isEqualTo(3)
+            }
+            eventually {
                 assertThat(wsHandler.messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
                 assertThat(wsHandler.messageQueue[1]).contains(FlowStates.RUNNING.name)
                 assertThat(wsHandler.messageQueue[2]).contains(FlowStates.COMPLETED.name)
@@ -86,11 +88,13 @@ class FlowStatusFeedSmokeTest {
                 startFlow(clientRequestId)
 
                 eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueue).hasSize(3)
+                    assertThat(wsHandler1.messageQueue.size).isEqualTo(3)
+                    assertThat(wsHandler2.messageQueue.size).isEqualTo(3)
+                }
+                eventually {
                     assertThat(wsHandler1.messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
                     assertThat(wsHandler1.messageQueue[1]).contains(FlowStates.RUNNING.name)
                     assertThat(wsHandler1.messageQueue[2]).contains(FlowStates.COMPLETED.name)
-                    assertThat(wsHandler2.messageQueue).hasSize(3)
                     assertThat(wsHandler2.messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
                     assertThat(wsHandler2.messageQueue[1]).contains(FlowStates.RUNNING.name)
                     assertThat(wsHandler2.messageQueue[2]).contains(FlowStates.COMPLETED.name)
@@ -108,12 +112,12 @@ class FlowStatusFeedSmokeTest {
         val flowStatusFeedPath2 = "/flow/$bobHoldingId/$clientRequestId2"
 
         fun assertNormalFlowStatusesForRequest(messageQueue: List<String>, clientRequestId1: String) {
-            assertThat(messageQueue).hasSize(3)
-            val flowStatus1 = messageQueue[0]
-            assertThat(flowStatus1).contains(FlowStates.START_REQUESTED.name)
-            assertThat(flowStatus1).contains(clientRequestId1)
+            assertThat(messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
+            assertThat(messageQueue[0]).contains(clientRequestId1)
             assertThat(messageQueue[1]).contains(FlowStates.RUNNING.name)
+            assertThat(messageQueue[1]).contains(clientRequestId1)
             assertThat(messageQueue[2]).contains(FlowStates.COMPLETED.name)
+            assertThat(messageQueue[2]).contains(clientRequestId1)
         }
 
         useWebsocketConnection(flowStatusFeedPath1) { wsHandler1 ->
@@ -122,8 +126,8 @@ class FlowStatusFeedSmokeTest {
                 startFlow(clientRequestId2)
 
                 eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueue).hasSize(3)
-                    assertThat(wsHandler2.messageQueue).hasSize(3)
+                    assertThat(wsHandler1.messageQueue.size).isEqualTo(3)
+                    assertThat(wsHandler2.messageQueue.size).isEqualTo(3)
                 }
 
                 eventually {
@@ -152,7 +156,9 @@ class FlowStatusFeedSmokeTest {
 
         client.use {
             eventually {
-                assertThat(wsHandler.messageQueue).hasSize(1)
+                assertThat(wsHandler.messageQueue.size).isEqualTo(1)
+            }
+            eventually {
                 assertThat(wsHandler.messageQueue[0]).contains(FlowStates.COMPLETED.name)
             }
 
@@ -183,6 +189,9 @@ class FlowStatusFeedSmokeTest {
 
         eventually {
             assertThat(wsHandler1.messageQueue).hasSize(1)
+        }
+
+        eventually {
             assertThat(wsHandler1.messageQueue[0]).contains(FlowStates.COMPLETED.name)
         }
 
@@ -202,6 +211,9 @@ class FlowStatusFeedSmokeTest {
 
         eventually {
             assertThat(wsHandler2.messageQueue).hasSize(1)
+        }
+
+        eventually {
             assertThat(wsHandler2.messageQueue[0]).contains(FlowStates.COMPLETED.name)
         }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/InternalWebsocketHandler.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/InternalWebsocketHandler.kt
@@ -1,7 +1,7 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
 interface InternalWebsocketHandler {
-    val messageQueue: MutableList<String>
+    val messageQueue: List<String>
     fun isConnected(): Boolean
     fun send(message: String)
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/InternalWebsocketHandler.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/InternalWebsocketHandler.kt
@@ -1,7 +1,7 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
 interface InternalWebsocketHandler {
-    val messageQueue: List<String>
+    val messageQueueSnapshot: List<String>
     fun isConnected(): Boolean
     fun send(message: String)
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebSocketHandler.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebSocketHandler.kt
@@ -1,16 +1,16 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
 import java.io.IOException
-import java.util.LinkedList
+import java.util.concurrent.CopyOnWriteArrayList
 import net.corda.applications.workers.smoketest.contextLogger
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.client.NoOpEndpoint
 
 class MessageQueueWebSocketHandler : NoOpEndpoint(), InternalWebsocketHandler {
 
-    private val _messageQueue = LinkedList<String>()
+    private val _messageQueue = CopyOnWriteArrayList<String>()
 
-    override val messageQueue: List<String>
+    override val messageQueueSnapshot: List<String>
         get() = ArrayList(_messageQueue)
 
     private companion object {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebSocketHandler.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebSocketHandler.kt
@@ -6,9 +6,12 @@ import net.corda.applications.workers.smoketest.contextLogger
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.client.NoOpEndpoint
 
-class MessageQueueWebsocketHandler(
-    override val messageQueue: MutableList<String> = LinkedList(),
-) : NoOpEndpoint(), InternalWebsocketHandler {
+class MessageQueueWebSocketHandler : NoOpEndpoint(), InternalWebsocketHandler {
+
+    private val _messageQueue = LinkedList<String>()
+
+    override val messageQueue: List<String>
+        get() = ArrayList(_messageQueue)
 
     private companion object {
         val log = contextLogger()
@@ -26,11 +29,11 @@ class MessageQueueWebsocketHandler(
 
     override fun onWebSocketText(message: String) {
         log.info("Received message: $message")
-        messageQueue.add(message)
+        _messageQueue.add(message)
     }
 
     override fun send(message: String) {
-        if(super.isConnected()) {
+        if (super.isConnected()) {
             try {
                 log.info("Attempting to send message from client websocket handler to server. Message: $message")
                 remote.sendString(message)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
@@ -19,10 +19,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 
 fun useWebsocketConnection(
     path: String,
-    messageQueue: MutableList<String> = LinkedList(),
     block: (wsHandler: InternalWebsocketHandler) -> Unit
 ) {
-    val wsHandler = MessageQueueWebsocketHandler(messageQueue)
+    val wsHandler = MessageQueueWebSocketHandler()
     val client = SmokeTestWebsocketClient()
 
     client.use {


### PR DESCRIPTION
This test appears to be flaky with ConcurrentModificationException. The eventually block accesses the linked list while the list is being added to in the websocket handler.

Changed the handler to use a CopyOnWriteArrayList and the API to expose a copy of it in an ArrayList so when new items are added, a new copy of the list is created. This should mean when we get snapshot of the list with `ArrayList(_messageQueue)` we should avoid concurrent modification exception. Afaik ArrayList constructor iterates over the collection its given which could result in the exception too.