### PR TITLE
CORE-6343 Specifying custom vault DB connection expects default schema name

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -79,10 +79,14 @@ class VirtualNodeDb(
                 ClassloaderChangeLog.ChangeLogResourceFiles(klass.packageName, dbChangeFiles, klass.classLoader)
             }
             val dbChange = ClassloaderChangeLog(changeLogResourceFiles)
-            val dbSchema = dbType.getSchemaName(holdingIdentityShortHash)
 
             dataSource.connection.use { connection ->
-                schemaMigrator.updateDb(connection, dbChange, dbSchema)
+                if (isClusterDb) {
+                    val dbSchema = dbType.getSchemaName(holdingIdentityShortHash)
+                    schemaMigrator.updateDb(connection, dbChange, dbSchema)
+                } else {
+                    schemaMigrator.updateDb(connection, dbChange)
+                }
             }
         }
     }


### PR DESCRIPTION
- Fixed bug that caused specifying custom virtual node DB connection expecting default schema name