### PR TITLE
CORE-6317 - add ability to control the successful status code of an api call

### DIFF
--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
@@ -47,7 +47,7 @@ class StartFlow(private val context: TaskContext) : Task {
     fun getSmokeTestStartRecord(args: String): Record<*, *> {
         return getStartRPCEventRecord(
             clientId = UUID.randomUUID().toString(),
-            flowName = "net.cordapp.flowworker.development.smoketests.flow",
+            flowName = "net.cordapp.flowworker.development.flows.RpcSmokeTestFlow",
             x500Name = context.startArgs.x500NName,
             groupId = "flow-worker-dev",
             jsonArgs = args

--- a/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
+++ b/applications/tools/flow-worker-setup/src/main/kotlin/net/corda/applications/flowworker/setup/tasks/StartFlow.kt
@@ -47,7 +47,7 @@ class StartFlow(private val context: TaskContext) : Task {
     fun getSmokeTestStartRecord(args: String): Record<*, *> {
         return getStartRPCEventRecord(
             clientId = UUID.randomUUID().toString(),
-            flowName = "net.cordapp.flowworker.development.flows.RpcSmokeTestFlow",
+            flowName = "net.cordapp.flowworker.development.smoketests.flow",
             x500Name = context.startArgs.x500NName,
             groupId = "flow-worker-dev",
             jsonArgs = args

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
@@ -3,7 +3,7 @@ package net.corda.applications.workers.rpc
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.applications.workers.rpc.http.SkipWhenRpcEndpointUnavailable
 import net.corda.httprpc.client.exceptions.MissingRequestedResourceException
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.CreatePermissionType
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionResponseType
@@ -41,7 +41,7 @@ class CreatePermissionE2eTest {
                 }
                 return this
             }
-            fun HttpResponse<PermissionResponseType>.assertCreated(): PermissionResponseType {
+            fun ResponseEntity<PermissionResponseType>.assertCreated(): PermissionResponseType {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
@@ -45,9 +45,9 @@ class CreatePermissionE2eTest {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull
-                    this.responseBody!!.assertResponseType()
+                    this.responseBody.assertResponseType()
                 }
-                return this.responseBody!!
+                return this.responseBody
             }
 
             val permId = proxy.createPermission(createPermType).assertCreated().id

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
@@ -34,29 +34,29 @@ class CreatePermissionE2eTest {
             val setPermString = testToolkit.uniqueName + "-PermissionString"
             val createPermType = CreatePermissionType(PermissionType.ALLOW, setPermString, null, null)
 
-            fun PermissionResponseType.assertAsExpected(): PermissionResponseType {
+            fun PermissionResponseType.assertResponseType(): PermissionResponseType {
                 assertSoftly {
                     it.assertThat(permissionString).isEqualTo(setPermString)
                     it.assertThat(permissionType).isEqualTo(PermissionType.ALLOW)
                 }
                 return this
             }
-            fun HttpResponse<PermissionResponseType>.assertAsExpected(): PermissionResponseType {
+            fun HttpResponse<PermissionResponseType>.assertCreated(): PermissionResponseType {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull
-                    this.responseBody!!.assertAsExpected()
+                    this.responseBody!!.assertResponseType()
                 }
                 return this.responseBody!!
             }
 
-            val permId = proxy.createPermission(createPermType).assertAsExpected().id
+            val permId = proxy.createPermission(createPermType).assertCreated().id
 
             // Check that the permission does exist now. The distribution of entity records may take some time to complete on the
             // message bus, hence use of `eventually` along with `assertDoesNotThrow`.
             eventually {
                 assertDoesNotThrow {
-                    proxy.getPermission(permId).assertAsExpected()
+                    proxy.getPermission(permId).assertResponseType()
                 }
             }
         }

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreatePermissionE2eTest.kt
@@ -3,6 +3,7 @@ package net.corda.applications.workers.rpc
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.applications.workers.rpc.http.SkipWhenRpcEndpointUnavailable
 import net.corda.httprpc.client.exceptions.MissingRequestedResourceException
+import net.corda.httprpc.response.HttpResponse
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.CreatePermissionType
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionResponseType
@@ -39,6 +40,14 @@ class CreatePermissionE2eTest {
                     it.assertThat(permissionType).isEqualTo(PermissionType.ALLOW)
                 }
                 return this
+            }
+            fun HttpResponse<PermissionResponseType>.assertAsExpected(): PermissionResponseType {
+                assertSoftly {
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(201)
+                    it.assertThat(this.responseBody).isNotNull
+                    this.responseBody!!.assertAsExpected()
+                }
+                return this.responseBody!!
             }
 
             val permId = proxy.createPermission(createPermType).assertAsExpected().id

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateRoleE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateRoleE2eTest.kt
@@ -46,12 +46,14 @@ class CreateRoleE2eTest {
 
             val roleId = with(proxy.createRole(createRoleType)) {
                 assertSoftly {
-                    it.assertThat(roleName).isEqualTo(name)
-                    it.assertThat(version).isEqualTo(0L)
-                    it.assertThat(groupVisibility).isNull()
-                    it.assertThat(permissions).isEmpty()
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+                    it.assertThat(this.responseBody).isNotNull
+                    it.assertThat(this.responseBody!!.roleName).isEqualTo(name)
+                    it.assertThat(this.responseBody!!.version).isEqualTo(0L)
+                    it.assertThat(this.responseBody!!.groupVisibility).isNull()
+                    it.assertThat(this.responseBody!!.permissions).isEmpty()
                 }
-                id
+                this.responseBody!!.id
             }
 
             // Check the role does exist now. The distribution of Role record may take some time to complete on the
@@ -100,14 +102,14 @@ class CreateRoleE2eTest {
             // message bus, hence use of `eventually` along with `assertDoesNotThrow`.
             eventually {
                 assertDoesNotThrow {
-                    assertNotNull(proxy.getPermission(perm.id))
+                    assertNotNull(proxy.getPermission(perm.responseBody!!.id))
                 }
             }
             perm
         }
 
-        val permId = permission.id
-        val permTs = permission.updateTimestamp
+        val permId = permission.responseBody!!.id
+        val permTs = permission.responseBody!!.updateTimestamp
 
         // Test adding/removing permission to a role
         testToolkit.httpClientFor(RoleEndpoint::class.java).use { client ->
@@ -118,7 +120,7 @@ class CreateRoleE2eTest {
                 .hasMessageContaining("Permission '$permId' is not associated with Role '$roleId'.")
 
             val roleWithPermission = proxy.addPermission(roleId, permId)
-            assertEquals(permId, roleWithPermission.permissions[0].id)
+            assertEquals(permId, roleWithPermission.responseBody!!.permissions[0].id)
 
             eventually {
                 assertDoesNotThrow {
@@ -138,7 +140,7 @@ class CreateRoleE2eTest {
 
             // Remove permission and test the outcome
             val roleWithPermissionRemoved = proxy.removePermission(roleId, permId)
-            assertTrue(roleWithPermissionRemoved.permissions.isEmpty())
+            assertTrue(roleWithPermissionRemoved.responseBody!!.permissions.isEmpty())
             eventually {
                 assertDoesNotThrow {
                     assertTrue(proxy.getRole(roleId).permissions.isEmpty())

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateRoleE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateRoleE2eTest.kt
@@ -48,12 +48,12 @@ class CreateRoleE2eTest {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull
-                    it.assertThat(this.responseBody!!.roleName).isEqualTo(name)
-                    it.assertThat(this.responseBody!!.version).isEqualTo(0L)
-                    it.assertThat(this.responseBody!!.groupVisibility).isNull()
-                    it.assertThat(this.responseBody!!.permissions).isEmpty()
+                    it.assertThat(this.responseBody.roleName).isEqualTo(name)
+                    it.assertThat(this.responseBody.version).isEqualTo(0L)
+                    it.assertThat(this.responseBody.groupVisibility).isNull()
+                    it.assertThat(this.responseBody.permissions).isEmpty()
                 }
-                this.responseBody!!.id
+                this.responseBody.id
             }
 
             // Check the role does exist now. The distribution of Role record may take some time to complete on the
@@ -102,14 +102,14 @@ class CreateRoleE2eTest {
             // message bus, hence use of `eventually` along with `assertDoesNotThrow`.
             eventually {
                 assertDoesNotThrow {
-                    assertNotNull(proxy.getPermission(perm.responseBody!!.id))
+                    assertNotNull(proxy.getPermission(perm.responseBody.id))
                 }
             }
             perm
         }
 
-        val permId = permission.responseBody!!.id
-        val permTs = permission.responseBody!!.updateTimestamp
+        val permId = permission.responseBody.id
+        val permTs = permission.responseBody.updateTimestamp
 
         // Test adding/removing permission to a role
         testToolkit.httpClientFor(RoleEndpoint::class.java).use { client ->
@@ -120,7 +120,7 @@ class CreateRoleE2eTest {
                 .hasMessageContaining("Permission '$permId' is not associated with Role '$roleId'.")
 
             val roleWithPermission = proxy.addPermission(roleId, permId)
-            assertEquals(permId, roleWithPermission.responseBody!!.permissions[0].id)
+            assertEquals(permId, roleWithPermission.responseBody.permissions[0].id)
 
             eventually {
                 assertDoesNotThrow {
@@ -140,7 +140,7 @@ class CreateRoleE2eTest {
 
             // Remove permission and test the outcome
             val roleWithPermissionRemoved = proxy.removePermission(roleId, permId)
-            assertTrue(roleWithPermissionRemoved.responseBody!!.permissions.isEmpty())
+            assertTrue(roleWithPermissionRemoved.responseBody.permissions.isEmpty())
             eventually {
                 assertDoesNotThrow {
                     assertTrue(proxy.getRole(roleId).permissions.isEmpty())

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateRoleE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateRoleE2eTest.kt
@@ -46,7 +46,7 @@ class CreateRoleE2eTest {
 
             val roleId = with(proxy.createRole(createRoleType)) {
                 assertSoftly {
-                    it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull
                     it.assertThat(this.responseBody!!.roleName).isEqualTo(name)
                     it.assertThat(this.responseBody!!.version).isEqualTo(0L)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateUserE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateUserE2eTest.kt
@@ -36,8 +36,10 @@ class CreateUserE2eTest {
 
             with(proxy.createUser(createUserType)) {
                 assertSoftly {
-                    it.assertThat(loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(passwordExpiry).isEqualTo(passwordExpirySet)
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(201)
+                    it.assertThat(this.responseBody).isNotNull
+                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody!!.passwordExpiry).isEqualTo(passwordExpirySet)
                 }
             }
 

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateUserE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CreateUserE2eTest.kt
@@ -38,8 +38,8 @@ class CreateUserE2eTest {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull
-                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(this.responseBody!!.passwordExpiry).isEqualTo(passwordExpirySet)
+                    it.assertThat(this.responseBody.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody.passwordExpiry).isEqualTo(passwordExpirySet)
                 }
             }
 

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
@@ -31,8 +31,8 @@ class RbacE2eClientRequestHelper(
             SoftAssertions.assertSoftly {
                 it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                 it.assertThat(this.responseBody).isNotNull
-                it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(newUserName)
-                it.assertThat(this.responseBody!!.passwordExpiry).isEqualTo(newUserPasswordExpiry)
+                it.assertThat(this.responseBody.loginName).isEqualToIgnoringCase(newUserName)
+                it.assertThat(this.responseBody.passwordExpiry).isEqualTo(newUserPasswordExpiry)
             }
         }
         verifyUserCreationPersisted(proxy, newUserName, newUserPasswordExpiry)
@@ -60,9 +60,9 @@ class RbacE2eClientRequestHelper(
             SoftAssertions.assertSoftly {
                 it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                 it.assertThat(this.responseBody).isNotNull
-                it.assertThat(this.responseBody!!.roleName).isEqualTo(roleName)
+                it.assertThat(this.responseBody.roleName).isEqualTo(roleName)
             }
-            this.responseBody!!.id
+            this.responseBody.id
         }
         verifyRoleCreationPersisted(proxy, roleId, roleName)
         return roleId
@@ -96,7 +96,7 @@ class RbacE2eClientRequestHelper(
                 SoftAssertions.assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(200)
                     it.assertThat(this.responseBody).isNotNull
-                    it.assertThat(this.responseBody!!.permissions.map { perm -> perm.id }).contains(permissionId)
+                    it.assertThat(this.responseBody.permissions.map { perm -> perm.id }).contains(permissionId)
                 }
             }
         }
@@ -109,7 +109,7 @@ class RbacE2eClientRequestHelper(
             SoftAssertions.assertSoftly {
                 it.assertThat(this.responseCode.statusCode).isEqualTo(200)
                 it.assertThat(this.responseBody).isNotNull
-                it.assertThat(this.responseBody!!.roleAssociations.map { role -> role.roleId }).contains(roleId)
+                it.assertThat(this.responseBody.roleAssociations.map { role -> role.roleId }).contains(roleId)
             }
         }
     }
@@ -121,7 +121,7 @@ class RbacE2eClientRequestHelper(
             SoftAssertions.assertSoftly {
                 it.assertThat(this.responseCode.statusCode).isEqualTo(200)
                 it.assertThat(this.responseBody).isNotNull
-                it.assertThat(this.responseBody!!.roleAssociations.map { role -> role.roleId }).contains(roleId)
+                it.assertThat(this.responseBody.roleAssociations.map { role -> role.roleId }).contains(roleId)
             }
         }
     }
@@ -181,10 +181,10 @@ fun PermissionEndpoint.createPermission(
         SoftAssertions.assertSoftly {
             it.assertThat(this.responseCode.statusCode).isEqualTo(201)
             it.assertThat(this.responseBody).isNotNull
-            it.assertThat(this.responseBody!!.permissionType).isEqualTo(permissionType)
-            it.assertThat(this.responseBody!!.permissionString).isEqualTo(permissionString)
+            it.assertThat(this.responseBody.permissionType).isEqualTo(permissionType)
+            it.assertThat(this.responseBody.permissionString).isEqualTo(permissionString)
         }
-        this.responseBody!!.id
+        this.responseBody.id
     }
     if (verify) {
         verifyPermissionCreationPersisted(this, permissionId, permissionType, permissionString)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
@@ -29,8 +29,10 @@ class RbacE2eClientRequestHelper(
         val createUserType = CreateUserType(newUserName, newUserName, true, newUserPassword, newUserPasswordExpiry, null)
         with(proxy.createUser(createUserType)) {
             SoftAssertions.assertSoftly {
-                it.assertThat(loginName).isEqualToIgnoringCase(newUserName)
-                it.assertThat(this.passwordExpiry).isEqualTo(newUserPasswordExpiry)
+                it.assertThat(this.responseCode.statusCode).isEqualTo(201)
+                it.assertThat(this.responseBody).isNotNull
+                it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(newUserName)
+                it.assertThat(this.responseBody!!.passwordExpiry).isEqualTo(newUserPasswordExpiry)
             }
         }
         verifyUserCreationPersisted(proxy, newUserName, newUserPasswordExpiry)
@@ -56,9 +58,11 @@ class RbacE2eClientRequestHelper(
         val createRoleType = CreateRoleType(roleName, null)
         val roleId = with(proxy.createRole(createRoleType)) {
             SoftAssertions.assertSoftly {
-                it.assertThat(this.roleName).isEqualTo(roleName)
+                it.assertThat(this.responseCode.statusCode).isEqualTo(201)
+                it.assertThat(this.responseBody).isNotNull
+                it.assertThat(this.responseBody!!.roleName).isEqualTo(roleName)
             }
-            this.id
+            this.responseBody!!.id
         }
         verifyRoleCreationPersisted(proxy, roleId, roleName)
         return roleId
@@ -90,7 +94,9 @@ class RbacE2eClientRequestHelper(
         for(permissionId in permissionIds) {
             with(proxy.addPermission(roleId, permissionId)) {
                 SoftAssertions.assertSoftly {
-                    it.assertThat(this.permissions.map { perm -> perm.id }).contains(permissionId)
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+                    it.assertThat(this.responseBody).isNotNull
+                    it.assertThat(this.responseBody!!.permissions.map { perm -> perm.id }).contains(permissionId)
                 }
             }
         }
@@ -101,7 +107,9 @@ class RbacE2eClientRequestHelper(
         val proxy = client.start().proxy
         with(proxy.addRole(userName, roleId)) {
             SoftAssertions.assertSoftly {
-                it.assertThat(this.roleAssociations.map { role -> role.roleId }).contains(roleId)
+                it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+                it.assertThat(this.responseBody).isNotNull
+                it.assertThat(this.responseBody!!.roleAssociations.map { role -> role.roleId }).contains(roleId)
             }
         }
     }
@@ -111,7 +119,9 @@ class RbacE2eClientRequestHelper(
         val proxy = client.start().proxy
         with(proxy.removeRole(userName, roleId)) {
             SoftAssertions.assertSoftly {
-                it.assertThat(this.roleAssociations.map { role -> role.roleId }).contains(roleId)
+                it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+                it.assertThat(this.responseBody).isNotNull
+                it.assertThat(this.responseBody!!.roleAssociations.map { role -> role.roleId }).contains(roleId)
             }
         }
     }
@@ -169,10 +179,12 @@ fun PermissionEndpoint.createPermission(
     val type = CreatePermissionType(permissionType, permissionString, null, null)
     val permissionId = with(createPermission(type)) {
         SoftAssertions.assertSoftly {
-            it.assertThat(this.permissionType).isEqualTo(permissionType)
-            it.assertThat(this.permissionString).isEqualTo(permissionString)
+            it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+            it.assertThat(this.responseBody).isNotNull
+            it.assertThat(this.responseBody!!.permissionType).isEqualTo(permissionType)
+            it.assertThat(this.responseBody!!.permissionString).isEqualTo(permissionString)
         }
-        this.id
+        this.responseBody!!.id
     }
     if (verify) {
         verifyPermissionCreationPersisted(this, permissionId, permissionType, permissionString)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/RbacE2eClientRequestHelper.kt
@@ -179,7 +179,7 @@ fun PermissionEndpoint.createPermission(
     val type = CreatePermissionType(permissionType, permissionString, null, null)
     val permissionId = with(createPermission(type)) {
         SoftAssertions.assertSoftly {
-            it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+            it.assertThat(this.responseCode.statusCode).isEqualTo(201)
             it.assertThat(this.responseBody).isNotNull
             it.assertThat(this.responseBody!!.permissionType).isEqualTo(permissionType)
             it.assertThat(this.responseBody!!.permissionString).isEqualTo(permissionString)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/UserRoleAssociationE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/UserRoleAssociationE2eTest.kt
@@ -34,13 +34,13 @@ class UserRoleAssociationE2eTest {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull
-                    it.assertThat(this.responseBody!!.roleName).isEqualTo(name)
-                    it.assertThat(this.responseBody!!.version).isEqualTo(0L)
-                    it.assertThat(this.responseBody!!.groupVisibility).isNull()
-                    it.assertThat(this.responseBody!!.permissions).isEmpty()
+                    it.assertThat(this.responseBody.roleName).isEqualTo(name)
+                    it.assertThat(this.responseBody.version).isEqualTo(0L)
+                    it.assertThat(this.responseBody.groupVisibility).isNull()
+                    it.assertThat(this.responseBody.permissions).isEmpty()
                 }
 
-                this.responseBody!!.id
+                this.responseBody.id
             }
 
             // Check the role does exist now. The distribution of Role record may take some time to complete on the
@@ -72,8 +72,8 @@ class UserRoleAssociationE2eTest {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(201)
                     it.assertThat(this.responseBody).isNotNull
-                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(this.responseBody!!.passwordExpiry).isEqualTo(passwordExpirySet)
+                    it.assertThat(this.responseBody.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody.passwordExpiry).isEqualTo(passwordExpirySet)
                 }
             }
 
@@ -100,9 +100,9 @@ class UserRoleAssociationE2eTest {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(200)
                     it.assertThat(this.responseBody).isNotNull
-                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(this.responseBody!!.roleAssociations).hasSize(1)
-                    it.assertThat(this.responseBody!!.roleAssociations.first().roleId).isEqualTo(roleId)
+                    it.assertThat(this.responseBody.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody.roleAssociations).hasSize(1)
+                    it.assertThat(this.responseBody.roleAssociations.first().roleId).isEqualTo(roleId)
                 }
             }
 
@@ -116,8 +116,8 @@ class UserRoleAssociationE2eTest {
                 assertSoftly {
                     it.assertThat(this.responseCode.statusCode).isEqualTo(200)
                     it.assertThat(this.responseBody).isNotNull
-                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(this.responseBody!!.roleAssociations).hasSize(0)
+                    it.assertThat(this.responseBody.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody.roleAssociations).hasSize(0)
                 }
             }
 

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/UserRoleAssociationE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/UserRoleAssociationE2eTest.kt
@@ -32,12 +32,15 @@ class UserRoleAssociationE2eTest {
             val createRoleType = CreateRoleType(name, null)
             val roleId = with(proxy.createRole(createRoleType)) {
                 assertSoftly {
-                    it.assertThat(roleName).isEqualTo(name)
-                    it.assertThat(version).isEqualTo(0L)
-                    it.assertThat(groupVisibility).isNull()
-                    it.assertThat(permissions).isEmpty()
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(201)
+                    it.assertThat(this.responseBody).isNotNull
+                    it.assertThat(this.responseBody!!.roleName).isEqualTo(name)
+                    it.assertThat(this.responseBody!!.version).isEqualTo(0L)
+                    it.assertThat(this.responseBody!!.groupVisibility).isNull()
+                    it.assertThat(this.responseBody!!.permissions).isEmpty()
                 }
-                id
+
+                this.responseBody!!.id
             }
 
             // Check the role does exist now. The distribution of Role record may take some time to complete on the
@@ -67,8 +70,10 @@ class UserRoleAssociationE2eTest {
             val createUserType = CreateUserType(userName, userName, true, password, passwordExpirySet, null)
             with(proxy.createUser(createUserType)) {
                 assertSoftly {
-                    it.assertThat(loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(passwordExpiry).isEqualTo(passwordExpirySet)
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(201)
+                    it.assertThat(this.responseBody).isNotNull
+                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody!!.passwordExpiry).isEqualTo(passwordExpirySet)
                 }
             }
 
@@ -93,9 +98,11 @@ class UserRoleAssociationE2eTest {
             // add the role to the user
             with(proxy.addRole(userName, roleId)) {
                 assertSoftly {
-                    it.assertThat(loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(roleAssociations).hasSize(1)
-                    it.assertThat(roleAssociations.first().roleId).isEqualTo(roleId)
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+                    it.assertThat(this.responseBody).isNotNull
+                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody!!.roleAssociations).hasSize(1)
+                    it.assertThat(this.responseBody!!.roleAssociations.first().roleId).isEqualTo(roleId)
                 }
             }
 
@@ -107,8 +114,10 @@ class UserRoleAssociationE2eTest {
             // remove role
             with(proxy.removeRole(userName, roleId)) {
                 assertSoftly {
-                    it.assertThat(loginName).isEqualToIgnoringCase(userName)
-                    it.assertThat(roleAssociations).hasSize(0)
+                    it.assertThat(this.responseCode.statusCode).isEqualTo(200)
+                    it.assertThat(this.responseBody).isNotNull
+                    it.assertThat(this.responseBody!!.loginName).isEqualToIgnoringCase(userName)
+                    it.assertThat(this.responseBody!!.roleAssociations).hasSize(0)
                 }
             }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -21,7 +21,7 @@ fun FlowStatus.getRpcFlowResult(): RpcSmokeTestOutput =
 fun startRpcFlow(
     holdingId: String,
     args: RpcSmokeTestInput,
-    expectedCode: Int = 200,
+    expectedCode: Int = 202,
     requestId: String = UUID.randomUUID().toString()
 ): String {
 
@@ -59,7 +59,7 @@ fun startRpcFlow(holdingId: String, args: Map<String, Any>, flowName: String): S
                     escapeJson(ObjectMapper().writeValueAsString(args))
                 )
             }
-            condition { it.code == 200 }
+            condition { it.code == 202 }
         }
 
         requestId

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -111,7 +111,7 @@ class FlowTests {
             data = mapOf("echo_value" to "hello")
         }
 
-        startRpcFlow(bobHoldingId, requestBody, 200)
+        startRpcFlow(bobHoldingId, requestBody)
         startRpcFlow(bobHoldingId, requestBody, 409)
     }
 

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -14,6 +14,7 @@ import net.corda.flow.rpcops.v1.types.response.FlowStatusResponses
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.response.HttpResponse
 import net.corda.httprpc.ws.DuplexChannel
 import net.corda.httprpc.ws.WebSocketValidationException
 import net.corda.libs.configuration.SmartConfig
@@ -67,7 +68,7 @@ class FlowRPCOpsImpl @Activate constructor(
     override fun startFlow(
         holdingIdentityShortHash: String,
         startFlow: StartFlowParameters
-    ): FlowStatusResponse {
+    ): HttpResponse<FlowStatusResponse> {
         if (publisher == null) {
             throw FlowRPCOpsServiceException("FlowRPC has not been initialised ")
         }
@@ -107,7 +108,7 @@ class FlowRPCOpsImpl @Activate constructor(
             throw FlowRPCOpsServiceException("Failed to publish the Start Flow event.", e)
         }
 
-        return messageFactory.createFlowStatusResponse(status)
+        return HttpResponse.requestAccepted(messageFactory.createFlowStatusResponse(status))
     }
 
     override fun getFlowStatus(holdingIdentityShortHash: String, clientRequestId: String): FlowStatusResponse {

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -14,7 +14,7 @@ import net.corda.flow.rpcops.v1.types.response.FlowStatusResponses
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.httprpc.exception.ResourceNotFoundException
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.ws.DuplexChannel
 import net.corda.httprpc.ws.WebSocketValidationException
 import net.corda.libs.configuration.SmartConfig
@@ -68,7 +68,7 @@ class FlowRPCOpsImpl @Activate constructor(
     override fun startFlow(
         holdingIdentityShortHash: String,
         startFlow: StartFlowParameters
-    ): HttpResponse<FlowStatusResponse> {
+    ): ResponseEntity<FlowStatusResponse> {
         if (publisher == null) {
             throw FlowRPCOpsServiceException("FlowRPC has not been initialised ")
         }
@@ -108,7 +108,7 @@ class FlowRPCOpsImpl @Activate constructor(
             throw FlowRPCOpsServiceException("Failed to publish the Start Flow event.", e)
         }
 
-        return HttpResponse.requestAccepted(messageFactory.createFlowStatusResponse(status))
+        return ResponseEntity.accepted(messageFactory.createFlowStatusResponse(status))
     }
 
     override fun getFlowStatus(holdingIdentityShortHash: String, clientRequestId: String): FlowStatusResponse {

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -112,6 +112,9 @@ class FlowRPCOpsImplTest {
         val flowRPCOps =
             FlowRPCOpsImpl(virtualNodeInfoReadService, flowStatusCacheService, publisherFactory, messageFactory)
         flowRPCOps.initialise(SmartConfigImpl.empty())
+
+        whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
+
         flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", TestJsonObject()))
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -120,7 +123,6 @@ class FlowRPCOpsImplTest {
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).publish(any())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
-        verify(messageFactory, times(1)).createFlowStatusResponse(any())
     }
 
     @Test

--- a/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/FlowRpcOps.kt
+++ b/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/FlowRpcOps.kt
@@ -10,7 +10,7 @@ import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
 import net.corda.httprpc.annotations.HttpRpcWS
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.ws.DuplexChannel
 import net.corda.libs.configuration.SmartConfig
 
@@ -40,7 +40,7 @@ interface FlowRpcOps : RpcOps {
         holdingIdentityShortHash: String,
         @HttpRpcRequestBodyParameter(description = "Information required to start a flow for this holdingId", required = true)
         startFlow: StartFlowParameters
-    ): HttpResponse<FlowStatusResponse>
+    ): ResponseEntity<FlowStatusResponse>
 
     @HttpRpcGET(
         path = "{holdingIdentityShortHash}/{clientRequestId}",

--- a/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/FlowRpcOps.kt
+++ b/components/flow/flow-rpcops-service/src/main/kotlin/net/corda/flow/rpcops/v1/FlowRpcOps.kt
@@ -10,6 +10,7 @@ import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
 import net.corda.httprpc.annotations.HttpRpcWS
+import net.corda.httprpc.response.HttpResponse
 import net.corda.httprpc.ws.DuplexChannel
 import net.corda.libs.configuration.SmartConfig
 
@@ -39,7 +40,7 @@ interface FlowRpcOps : RpcOps {
         holdingIdentityShortHash: String,
         @HttpRpcRequestBodyParameter(description = "Information required to start a flow for this holdingId", required = true)
         startFlow: StartFlowParameters
-    ): FlowStatusResponse
+    ): HttpResponse<FlowStatusResponse>
 
     @HttpRpcGET(
         path = "{holdingIdentityShortHash}/{clientRequestId}",

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
@@ -2,7 +2,7 @@ package net.corda.libs.permissions.endpoints.v1.permission.impl
 
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceNotFoundException
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
 import net.corda.libs.permissions.endpoints.common.withPermissionManager
@@ -44,7 +44,7 @@ class PermissionEndpointImpl @Activate constructor(
         PermissionEndpointEventHandler("PermissionEndpoint")
     )
 
-    override fun createPermission(createPermissionType: CreatePermissionType): HttpResponse<PermissionResponseType> {
+    override fun createPermission(createPermissionType: CreatePermissionType): ResponseEntity<PermissionResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -52,7 +52,7 @@ class PermissionEndpointImpl @Activate constructor(
             createPermission(createPermissionType.convertToDto(principal))
         }
 
-        return HttpResponse.resourceCreated(createPermissionResult!!.convertToEndpointType())
+        return ResponseEntity.created(createPermissionResult!!.convertToEndpointType())
     }
 
     override fun getPermission(id: String): PermissionResponseType {

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
@@ -2,6 +2,7 @@ package net.corda.libs.permissions.endpoints.v1.permission.impl
 
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.response.HttpResponse
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
 import net.corda.libs.permissions.endpoints.common.withPermissionManager
@@ -43,7 +44,7 @@ class PermissionEndpointImpl @Activate constructor(
         PermissionEndpointEventHandler("PermissionEndpoint")
     )
 
-    override fun createPermission(createPermissionType: CreatePermissionType): PermissionResponseType {
+    override fun createPermission(createPermissionType: CreatePermissionType): HttpResponse<PermissionResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -51,7 +52,7 @@ class PermissionEndpointImpl @Activate constructor(
             createPermission(createPermissionType.convertToDto(principal))
         }
 
-        return createPermissionResult!!.convertToEndpointType()
+        return HttpResponse.resourceCreated(createPermissionResult!!.convertToEndpointType())
     }
 
     override fun getPermission(id: String): PermissionResponseType {

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
@@ -2,6 +2,7 @@ package net.corda.libs.permissions.endpoints.v1.role.impl
 
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.response.HttpResponse
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
 import net.corda.libs.permissions.endpoints.common.withPermissionManager
@@ -50,7 +51,7 @@ class RoleEndpointImpl @Activate constructor(
         return allRoles.map { it.convertToEndpointType() }.toSet()
     }
 
-    override fun createRole(createRoleType: CreateRoleType): RoleResponseType {
+    override fun createRole(createRoleType: CreateRoleType): HttpResponse<RoleResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -58,7 +59,7 @@ class RoleEndpointImpl @Activate constructor(
             createRole(createRoleType.convertToDto(principal))
         }
 
-        return createRoleResult!!.convertToEndpointType()
+        return HttpResponse.resourceCreated(createRoleResult!!.convertToEndpointType())
     }
 
     override fun getRole(id: String): RoleResponseType {
@@ -72,7 +73,7 @@ class RoleEndpointImpl @Activate constructor(
         return roleResponseDto?.convertToEndpointType() ?: throw ResourceNotFoundException("Role", id)
     }
 
-    override fun addPermission(roleId: String, permissionId: String): RoleResponseType {
+    override fun addPermission(roleId: String, permissionId: String): HttpResponse<RoleResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -80,10 +81,10 @@ class RoleEndpointImpl @Activate constructor(
             addPermissionToRole(roleId, permissionId, principal)
         }
 
-        return updatedRoleResult!!.convertToEndpointType()
+        return HttpResponse.resourceUpdated(updatedRoleResult!!.convertToEndpointType())
     }
 
-    override fun removePermission(roleId: String, permissionId: String): RoleResponseType {
+    override fun removePermission(roleId: String, permissionId: String): HttpResponse<RoleResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -91,7 +92,7 @@ class RoleEndpointImpl @Activate constructor(
             removePermissionFromRole(roleId, permissionId, principal)
         }
 
-        return updatedRoleResult!!.convertToEndpointType()
+        return HttpResponse.resourceDeleted(updatedRoleResult!!.convertToEndpointType())
     }
 
     override val isRunning: Boolean

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
@@ -2,7 +2,7 @@ package net.corda.libs.permissions.endpoints.v1.role.impl
 
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceNotFoundException
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
 import net.corda.libs.permissions.endpoints.common.withPermissionManager
@@ -51,7 +51,7 @@ class RoleEndpointImpl @Activate constructor(
         return allRoles.map { it.convertToEndpointType() }.toSet()
     }
 
-    override fun createRole(createRoleType: CreateRoleType): HttpResponse<RoleResponseType> {
+    override fun createRole(createRoleType: CreateRoleType): ResponseEntity<RoleResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -59,7 +59,7 @@ class RoleEndpointImpl @Activate constructor(
             createRole(createRoleType.convertToDto(principal))
         }
 
-        return HttpResponse.resourceCreated(createRoleResult!!.convertToEndpointType())
+        return ResponseEntity.created(createRoleResult!!.convertToEndpointType())
     }
 
     override fun getRole(id: String): RoleResponseType {
@@ -73,7 +73,7 @@ class RoleEndpointImpl @Activate constructor(
         return roleResponseDto?.convertToEndpointType() ?: throw ResourceNotFoundException("Role", id)
     }
 
-    override fun addPermission(roleId: String, permissionId: String): HttpResponse<RoleResponseType> {
+    override fun addPermission(roleId: String, permissionId: String): ResponseEntity<RoleResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -81,10 +81,10 @@ class RoleEndpointImpl @Activate constructor(
             addPermissionToRole(roleId, permissionId, principal)
         }
 
-        return HttpResponse.resourceUpdated(updatedRoleResult!!.convertToEndpointType())
+        return ResponseEntity.updated(updatedRoleResult!!.convertToEndpointType())
     }
 
-    override fun removePermission(roleId: String, permissionId: String): HttpResponse<RoleResponseType> {
+    override fun removePermission(roleId: String, permissionId: String): ResponseEntity<RoleResponseType> {
         val rpcContext = CURRENT_RPC_CONTEXT.get()
         val principal = rpcContext.principal
 
@@ -92,7 +92,7 @@ class RoleEndpointImpl @Activate constructor(
             removePermissionFromRole(roleId, permissionId, principal)
         }
 
-        return HttpResponse.resourceDeleted(updatedRoleResult!!.convertToEndpointType())
+        return ResponseEntity.deleted(updatedRoleResult!!.convertToEndpointType())
     }
 
     override val isRunning: Boolean

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
@@ -2,7 +2,7 @@ package net.corda.libs.permissions.endpoints.v1.user.impl
 
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceNotFoundException
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
 import net.corda.libs.permissions.endpoints.v1.converter.convertToDto
 import net.corda.libs.permissions.endpoints.v1.converter.convertToEndpointType
@@ -48,14 +48,14 @@ class UserEndpointImpl @Activate constructor(
         PermissionEndpointEventHandler("UserEndpoint")
     )
 
-    override fun createUser(createUserType: CreateUserType): HttpResponse<UserResponseType> {
+    override fun createUser(createUserType: CreateUserType): ResponseEntity<UserResponseType> {
         val principal = getRpcThreadLocalContext()
 
         val createUserResult = withPermissionManager(permissionManagementService.permissionManager, logger) {
             createUser(createUserType.convertToDto(principal))
         }
 
-        return HttpResponse.resourceCreated(createUserResult!!.convertToEndpointType())
+        return ResponseEntity.created(createUserResult!!.convertToEndpointType())
     }
 
     override fun getUser(loginName: String): UserResponseType {
@@ -68,22 +68,22 @@ class UserEndpointImpl @Activate constructor(
         return userResponseDto?.convertToEndpointType() ?: throw ResourceNotFoundException("User", loginName)
     }
 
-    override fun addRole(loginName: String, roleId: String): HttpResponse<UserResponseType> {
+    override fun addRole(loginName: String, roleId: String): ResponseEntity<UserResponseType> {
         val principal = getRpcThreadLocalContext()
 
         val result = withPermissionManager(permissionManagementService.permissionManager, logger) {
             addRoleToUser(AddRoleToUserRequestDto(principal, loginName.lowercase(), roleId))
         }
-        return HttpResponse.ok(result!!.convertToEndpointType())
+        return ResponseEntity.ok(result!!.convertToEndpointType())
     }
 
-    override fun removeRole(loginName: String, roleId: String): HttpResponse<UserResponseType> {
+    override fun removeRole(loginName: String, roleId: String): ResponseEntity<UserResponseType> {
         val principal = getRpcThreadLocalContext()
 
         val result = withPermissionManager(permissionManagementService.permissionManager, logger) {
             removeRoleFromUser(RemoveRoleFromUserRequestDto(principal, loginName.lowercase(), roleId))
         }
-        return HttpResponse.resourceDeleted(result!!.convertToEndpointType())
+        return ResponseEntity.deleted(result!!.convertToEndpointType())
     }
 
     override fun getPermissionSummary(loginName: String): UserPermissionSummaryResponseType {

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
@@ -2,6 +2,7 @@ package net.corda.libs.permissions.endpoints.v1.user.impl
 
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.response.HttpResponse
 import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
 import net.corda.libs.permissions.endpoints.v1.converter.convertToDto
 import net.corda.libs.permissions.endpoints.v1.converter.convertToEndpointType
@@ -47,14 +48,14 @@ class UserEndpointImpl @Activate constructor(
         PermissionEndpointEventHandler("UserEndpoint")
     )
 
-    override fun createUser(createUserType: CreateUserType): UserResponseType {
+    override fun createUser(createUserType: CreateUserType): HttpResponse<UserResponseType> {
         val principal = getRpcThreadLocalContext()
 
         val createUserResult = withPermissionManager(permissionManagementService.permissionManager, logger) {
             createUser(createUserType.convertToDto(principal))
         }
 
-        return createUserResult!!.convertToEndpointType()
+        return HttpResponse.resourceCreated(createUserResult!!.convertToEndpointType())
     }
 
     override fun getUser(loginName: String): UserResponseType {
@@ -67,22 +68,22 @@ class UserEndpointImpl @Activate constructor(
         return userResponseDto?.convertToEndpointType() ?: throw ResourceNotFoundException("User", loginName)
     }
 
-    override fun addRole(loginName: String, roleId: String): UserResponseType {
+    override fun addRole(loginName: String, roleId: String): HttpResponse<UserResponseType> {
         val principal = getRpcThreadLocalContext()
 
         val result = withPermissionManager(permissionManagementService.permissionManager, logger) {
             addRoleToUser(AddRoleToUserRequestDto(principal, loginName.lowercase(), roleId))
         }
-        return result!!.convertToEndpointType()
+        return HttpResponse.ok(result!!.convertToEndpointType())
     }
 
-    override fun removeRole(loginName: String, roleId: String): UserResponseType {
+    override fun removeRole(loginName: String, roleId: String): HttpResponse<UserResponseType> {
         val principal = getRpcThreadLocalContext()
 
         val result = withPermissionManager(permissionManagementService.permissionManager, logger) {
             removeRoleFromUser(RemoveRoleFromUserRequestDto(principal, loginName.lowercase(), roleId))
         }
-        return result!!.convertToEndpointType()
+        return HttpResponse.resourceDeleted(result!!.convertToEndpointType())
     }
 
     override fun getPermissionSummary(loginName: String): UserPermissionSummaryResponseType {

--- a/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImplTest.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImplTest.kt
@@ -10,7 +10,6 @@ import net.corda.libs.permissions.manager.request.GetRoleRequestDto
 import net.corda.libs.permissions.manager.response.RoleResponseDto
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,6 +21,7 @@ import org.mockito.kotlin.whenever
 import java.time.Instant
 import net.corda.httprpc.ResponseCode
 import net.corda.permissions.management.PermissionManagementService
+import org.junit.jupiter.api.Assertions.assertNotNull
 
 internal class RoleEndpointImplTest {
 
@@ -62,9 +62,12 @@ internal class RoleEndpointImplTest {
         whenever(permissionManager.createRole(createRoleDtoCapture.capture())).thenReturn(roleResponseDto)
 
         endpoint.start()
-        val responseType = endpoint.createRole(createRoleType)
+        val response = endpoint.createRole(createRoleType)
+        val responseType = response.responseBody
 
-        assertEquals("roleId", responseType.id)
+        assertEquals(ResponseCode.CREATED, response.responseCode)
+        assertNotNull(responseType)
+        assertEquals("roleId", responseType!!.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("roleName", responseType.roleName)
@@ -80,7 +83,7 @@ internal class RoleEndpointImplTest {
         endpoint.start()
         val responseType = endpoint.getRole("roleId")
 
-        Assertions.assertNotNull(responseType)
+        assertNotNull(responseType)
         assertEquals("roleId", responseType.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)

--- a/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImplTest.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImplTest.kt
@@ -67,7 +67,7 @@ internal class RoleEndpointImplTest {
 
         assertEquals(ResponseCode.CREATED, response.responseCode)
         assertNotNull(responseType)
-        assertEquals("roleId", responseType!!.id)
+        assertEquals("roleId", responseType.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("roleName", responseType.roleName)

--- a/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImplTest.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImplTest.kt
@@ -90,9 +90,12 @@ internal class UserEndpointImplTest {
         whenever(permissionManager.createUser(createUserDtoCapture.capture())).thenReturn(userResponseDto)
 
         endpoint.start()
-        val responseType = endpoint.createUser(createUserType)
+        val response = endpoint.createUser(createUserType)
+        val responseType = response.responseBody
 
-        assertEquals("uuid", responseType.id)
+        assertEquals(ResponseCode.CREATED, response.responseCode)
+        assertNotNull(responseType)
+        assertEquals("uuid", responseType!!.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("fullName1", responseType.fullName)
@@ -160,7 +163,10 @@ internal class UserEndpointImplTest {
         whenever(permissionManager.addRoleToUser(capture.capture())).thenReturn(userResponseDtoWithRole)
 
         endpoint.start()
-        val responseType = endpoint.addRole("userLogin1", "roleId1")
+        val response = endpoint.addRole("userLogin1", "roleId1")
+        val responseType = response.responseBody
+
+        assertEquals(ResponseCode.OK, response.responseCode)
 
         assertEquals(1, capture.allValues.size)
         assertEquals("anRpcUser", capture.firstValue.requestedBy)
@@ -168,7 +174,7 @@ internal class UserEndpointImplTest {
         assertEquals("roleId1", capture.firstValue.roleId)
 
         assertNotNull(responseType)
-        assertEquals("uuid", responseType.id)
+        assertEquals("uuid", responseType!!.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("fullName1", responseType.fullName)
@@ -202,7 +208,10 @@ internal class UserEndpointImplTest {
         whenever(permissionManager.removeRoleFromUser(capture.capture())).thenReturn(userResponseDto)
 
         endpoint.start()
-        val responseType = endpoint.removeRole("userLogin1", "roleId1")
+        val response = endpoint.removeRole("userLogin1", "roleId1")
+        val responseType = response.responseBody
+
+        assertEquals(ResponseCode.OK, response.responseCode)
 
         assertEquals(1, capture.allValues.size)
         assertEquals("anRpcUser", capture.firstValue.requestedBy)
@@ -210,7 +219,7 @@ internal class UserEndpointImplTest {
         assertEquals("roleId1", capture.firstValue.roleId)
 
         assertNotNull(responseType)
-        assertEquals("uuid", responseType.id)
+        assertEquals("uuid", responseType!!.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("fullName1", responseType.fullName)

--- a/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImplTest.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImplTest.kt
@@ -95,7 +95,7 @@ internal class UserEndpointImplTest {
 
         assertEquals(ResponseCode.CREATED, response.responseCode)
         assertNotNull(responseType)
-        assertEquals("uuid", responseType!!.id)
+        assertEquals("uuid", responseType.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("fullName1", responseType.fullName)
@@ -174,7 +174,7 @@ internal class UserEndpointImplTest {
         assertEquals("roleId1", capture.firstValue.roleId)
 
         assertNotNull(responseType)
-        assertEquals("uuid", responseType!!.id)
+        assertEquals("uuid", responseType.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("fullName1", responseType.fullName)
@@ -219,7 +219,7 @@ internal class UserEndpointImplTest {
         assertEquals("roleId1", capture.firstValue.roleId)
 
         assertNotNull(responseType)
-        assertEquals("uuid", responseType!!.id)
+        assertEquals("uuid", responseType.id)
         assertEquals(0, responseType.version)
         assertEquals(now, responseType.updateTimestamp)
         assertEquals("fullName1", responseType.fullName)

--- a/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/connect/HttpRpcClientProxyHandler.kt
+++ b/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/connect/HttpRpcClientProxyHandler.kt
@@ -23,6 +23,7 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
+import net.corda.httprpc.response.ResponseEntity
 
 /**
  * [HttpRpcClientProxyHandler] is responsible for converting method invocations to web requests that are called against the server,

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
@@ -127,9 +127,9 @@ class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
     }
 
     @Test
-    fun `GET void returns nothing`() {
+    fun `GET void returns NO_CONTENT and no body`() {
         val pingResponse = client.call(GET, WebRequest<Any>("health/void"), userName, password)
-        assertEquals(HttpStatus.SC_OK, pingResponse.responseStatus)
+        assertEquals(HttpStatus.SC_NO_CONTENT, pingResponse.responseStatus)
         assertEquals("", pingResponse.body)
     }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerResponseEntityTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerResponseEntityTest.kt
@@ -1,0 +1,125 @@
+package net.corda.httprpc.server.impl
+
+import kotlin.test.assertEquals
+import net.corda.httprpc.server.config.models.HttpRpcSettings
+import net.corda.httprpc.test.CustomNonSerializableString
+import net.corda.httprpc.test.CustomUnsafeString
+import net.corda.httprpc.test.ResponseEntityRpcOpsImpl
+import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
+import net.corda.httprpc.test.utils.WebRequest
+import net.corda.httprpc.test.utils.findFreePort
+import net.corda.httprpc.test.utils.multipartDir
+import net.corda.httprpc.tools.HttpVerb.DELETE
+import net.corda.httprpc.tools.HttpVerb.POST
+import net.corda.httprpc.tools.HttpVerb.PUT
+import net.corda.v5.base.util.NetworkHostAndPort
+import org.apache.http.HttpStatus
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class HttpRpcServerResponseEntityTest : HttpRpcServerTestBase() {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setUpBeforeClass() {
+            val httpRpcSettings = HttpRpcSettings(
+                NetworkHostAndPort("localhost", findFreePort()),
+                context,
+                null,
+                null,
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            )
+            server = HttpRpcServerImpl(
+                listOf(
+                    ResponseEntityRpcOpsImpl()
+                ),
+                ::securityManager,
+                httpRpcSettings,
+                multipartDir,
+                true
+            ).apply { start() }
+            client =
+                TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun cleanUpAfterClass() {
+            if (isServerInitialized()) {
+                server.stop()
+            }
+        }
+    }
+
+    @AfterEach
+    fun reset() {
+        CustomUnsafeString.flag = false
+        CustomNonSerializableString.flag = false
+        securityManager.forgetChecks()
+    }
+
+    @Test
+    fun `endpoint returns ResponseEntity with null responseBody returns null in json with given status code`() {
+        val response = client.call(PUT, WebRequest<Any>("responseentity/put-returns-nullable-string"), userName, password)
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals("null", response.body)
+    }
+
+    @Test
+    fun `endpoint returns ResponseEntity with responseBody and given status code`() {
+        val response = client.call(PUT, WebRequest<Any>("responseentity/put-returns-ok-string"), userName, password)
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals("some string that isn't json inside response", response.body)
+    }
+
+    @Test
+    fun `endpoint returns string result the same as if using ResponseEntity with OK status`() {
+        val response = client.call(PUT, WebRequest<Any>("responseentity/put-returns-string"), userName, password)
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals("put string", response.body)
+    }
+
+    @Test
+    fun `endpoint returns an object the same as using ResponseEntity with OK status`() {
+        val response = client.call(POST, WebRequest<Any>("responseentity/post-returns-raw-entity"), userName, password)
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals("{\"id\":\"no response entity used\"}", response.body)
+    }
+
+    @Test
+    fun `endpoint with no return type completes with no_content status`() {
+        val response = client.call(DELETE, WebRequest<Any>("responseentity/delete-returns-void"), userName, password)
+        assertEquals(HttpStatus.SC_NO_CONTENT, response.responseStatus)
+        assertEquals("", response.body)
+    }
+
+    @Test
+    fun `post returns void has no_content and empty body`() {
+        val response = client.call(POST, WebRequest<Any>("responseentity/post-returns-void"), userName, password)
+        assertEquals(HttpStatus.SC_NO_CONTENT, response.responseStatus)
+        assertEquals("", response.body)
+    }
+
+    @Test
+    fun `post returns a string and has status OK with the string in the response body`() {
+        val response = client.call(POST, WebRequest<Any>("responseentity/post-returns-ok-string-json"), userName, password)
+        assertEquals(HttpStatus.SC_OK, response.responseStatus)
+        assertEquals("{\"somejson\": \"for confusion\"}", response.body)
+    }
+
+    @Test
+    fun `put returning void has no_content and empty body`() {
+        val response = client.call(PUT, WebRequest<Any>("responseentity/put-returns-void"), userName, password)
+        assertEquals(HttpStatus.SC_NO_CONTENT, response.responseStatus)
+        assertEquals("", response.body)
+    }
+
+    @Test
+    fun `async api returning status code accepted`() {
+        val response = client.call(DELETE, WebRequest<Any>("responseentity/async-delete-returns-accepted"), userName, password)
+        assertEquals(HttpStatus.SC_ACCEPTED, response.responseStatus)
+        assertEquals("\"DELETING\"", response.body)
+    }
+}

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelProvider.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/SchemaModelProvider.kt
@@ -2,6 +2,7 @@ package net.corda.httprpc.server.impl.apigen.processing.openapi.schema
 
 import net.corda.httprpc.server.impl.apigen.models.EndpointParameter
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.JsonSchemaBuilder
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.HttpResponseTypeBuilder
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.SchemaBigDecimalBuilder
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.SchemaBigIntegerBuilder
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders.SchemaBooleanBuilder
@@ -85,7 +86,8 @@ internal class DefaultSchemaModelProvider(private val schemaModelContextHolder: 
         SchemaPairBuilder(this),
         SchemaDurableReturnResultBuilder(this),
         SchemaPositionedValueBuilder(this),
-        JsonSchemaBuilder()
+        JsonSchemaBuilder(),
+        HttpResponseTypeBuilder(this)
     )
 
     override fun toSchemaModel(properties: List<EndpointParameter>, schemaModelName: String): SchemaModel {

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/HttpResponseTypeBuilder.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/HttpResponseTypeBuilder.kt
@@ -1,6 +1,6 @@
 package net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders
 
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.server.impl.apigen.models.GenericParameterizedType
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.ParameterizedClass
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.SchemaModelProvider
@@ -9,7 +9,7 @@ import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.Sche
 internal class HttpResponseTypeBuilder(
     private val schemaModelProvider: SchemaModelProvider
 ) : SchemaBuilder {
-    override val keys = listOf(HttpResponse::class.java)
+    override val keys = listOf(ResponseEntity::class.java)
 
     override fun build(clazz: Class<*>, parameterizedClassList: List<GenericParameterizedType>): SchemaModel {
         // HttpResponse only has one generic type. Get this type and build schema model from it.

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/HttpResponseTypeBuilder.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/HttpResponseTypeBuilder.kt
@@ -1,0 +1,24 @@
+package net.corda.httprpc.server.impl.apigen.processing.openapi.schema.builders
+
+import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.server.impl.apigen.models.GenericParameterizedType
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.ParameterizedClass
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.SchemaModelProvider
+import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaModel
+
+internal class HttpResponseTypeBuilder(
+    private val schemaModelProvider: SchemaModelProvider
+) : SchemaBuilder {
+    override val keys = listOf(HttpResponse::class.java)
+
+    override fun build(clazz: Class<*>, parameterizedClassList: List<GenericParameterizedType>): SchemaModel {
+        // HttpResponse only has one generic type. Get this type and build schema model from it.
+        val realType = parameterizedClassList.first()
+        return schemaModelProvider.toSchemaModel(
+            ParameterizedClass(
+                realType.clazz,
+                realType.nestedParameterizedTypes
+            )
+        )
+    }
+}

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/JsonResultBuilder.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/JsonResultBuilder.kt
@@ -2,12 +2,12 @@ package net.corda.httprpc.server.impl.context
 
 import io.javalin.http.Context
 import net.corda.httprpc.ResponseCode
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 
 fun Context.buildJsonResult(result: Any?, returnType: Class<*>) {
     val ctx = this
     when {
-        result is HttpResponse<*> -> {
+        result is ResponseEntity<*> -> {
             // if the responseBody is null, we return null in json
             ctx.json(result.responseBody ?: "null")
                 .status(result.responseCode.statusCode)

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/JsonResultBuilder.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/JsonResultBuilder.kt
@@ -1,0 +1,32 @@
+package net.corda.httprpc.server.impl.context
+
+import io.javalin.http.Context
+import net.corda.httprpc.ResponseCode
+import net.corda.httprpc.response.HttpResponse
+
+fun Context.buildJsonResult(result: Any?, returnType: Class<*>) {
+    val ctx = this
+    when {
+        result is HttpResponse<*> -> {
+            // if the responseBody is null, we return null in json
+            ctx.json(result.responseBody ?: "null")
+                .status(result.responseCode.statusCode)
+        }
+        (result as? String) != null ->
+            ctx.contentType(ContextUtils.contentTypeApplicationJson).result(result).status(ResponseCode.OK.statusCode)
+        result != null -> {
+            // If the return type does not specify a response code (is not a HttpResponse) we default the status to 200 - OK.
+            ctx.json(result).status(ResponseCode.OK.statusCode)
+        }
+        else -> {
+            val methodHasReturnType = returnType != Void.TYPE
+            if (methodHasReturnType) {
+                // if the method has a return type and returned null we return a status code 200 - OK with null payload
+                ctx.result("null").status(ResponseCode.OK.statusCode)
+            } else {
+                // if the method has no return type we return a status code 204 - No Content.
+                ctx.status(ResponseCode.NO_CONTENT.statusCode)
+            }
+        }
+    }
+}

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ResponseEntityRpcOps.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ResponseEntityRpcOps.kt
@@ -1,0 +1,43 @@
+package net.corda.httprpc.test
+
+import net.corda.httprpc.RpcOps
+import net.corda.httprpc.annotations.HttpRpcDELETE
+import net.corda.httprpc.annotations.HttpRpcPOST
+import net.corda.httprpc.annotations.HttpRpcPUT
+import net.corda.httprpc.annotations.HttpRpcResource
+import net.corda.httprpc.response.ResponseEntity
+
+@HttpRpcResource(path = "responseentity")
+interface ResponseEntityRpcOps : RpcOps {
+
+    data class TestHttpEntity(val id: String)
+    enum class DeleteStatus { DELETING }
+
+    @HttpRpcPOST(path = "post-returns-void")
+    fun postReturnsNoContent()
+
+    @HttpRpcPOST(path = "post-returns-ok-string-json")
+    fun postReturnsOkWithEscapedJson(): ResponseEntity<String>
+
+    @HttpRpcPOST(path = "post-returns-raw-entity")
+    fun postReturnsRawEntity(): TestHttpEntity
+
+    @HttpRpcPUT(path = "put-returns-void")
+    fun putReturnsVoid()
+
+    @HttpRpcPUT(path = "put-returns-ok-string")
+    fun putReturnsOkString(): ResponseEntity<String>
+
+    @HttpRpcPUT(path = "put-returns-string")
+    fun putReturnsString(): String
+
+    @HttpRpcPUT(path = "put-returns-nullable-string")
+    fun putReturnsNullableString(): String?
+
+    @HttpRpcDELETE(path = "delete-returns-void")
+    fun deleteReturnsVoid()
+
+    @HttpRpcDELETE(path = "async-delete-returns-accepted")
+    fun asyncDeleteReturnsAccepted(): ResponseEntity<DeleteStatus>
+
+}

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ResponseEntityRpcOpsImpl.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/ResponseEntityRpcOpsImpl.kt
@@ -1,0 +1,42 @@
+package net.corda.httprpc.test
+
+import net.corda.httprpc.PluggableRPCOps
+import net.corda.httprpc.response.ResponseEntity
+
+class ResponseEntityRpcOpsImpl : ResponseEntityRpcOps, PluggableRPCOps<ResponseEntityRpcOps> {
+    override fun postReturnsNoContent() {}
+
+    override fun postReturnsOkWithEscapedJson(): ResponseEntity<String> {
+        return ResponseEntity.ok("{\"somejson\": \"for confusion\"}")
+    }
+
+    override fun postReturnsRawEntity(): ResponseEntityRpcOps.TestHttpEntity {
+        return ResponseEntityRpcOps.TestHttpEntity("no response entity used")
+    }
+
+    override fun putReturnsOkString(): ResponseEntity<String> {
+        return ResponseEntity.ok("some string that isn't json inside response")
+    }
+
+    override fun putReturnsString(): String {
+        return "put string"
+    }
+
+    override fun putReturnsNullableString(): String? {
+        return null
+    }
+
+    override fun putReturnsVoid() {}
+
+    override fun deleteReturnsVoid() {}
+
+    override fun asyncDeleteReturnsAccepted(): ResponseEntity<ResponseEntityRpcOps.DeleteStatus> {
+        return ResponseEntity.accepted(ResponseEntityRpcOps.DeleteStatus.DELETING)
+    }
+
+    override val protocolVersion: Int
+        get() = 1
+
+    override val targetInterface: Class<ResponseEntityRpcOps>
+        get() = ResponseEntityRpcOps::class.java
+}

--- a/libs/http-rpc/http-rpc/src/main/java/net/corda/httprpc/response/package-info.java
+++ b/libs/http-rpc/http-rpc/src/main/java/net/corda/httprpc/response/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.httprpc.response;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ResponseCode.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ResponseCode.kt
@@ -1,10 +1,7 @@
 package net.corda.httprpc
 
-import net.corda.httprpc.exception.HttpApiException
-
 /**
- * Use this enum when you want to customize the HTTP status code returned in error scenarios in HTTP APIs. Reuse error response codes where
- * appropriate when extending [HttpApiException].
+ * Use this enum when you want to customize the HTTP status code returned in success responses and error scenarios in HTTP APIs.
  *
  * This enum will define all HTTP status codes and their causes. They also include a reason code which will help to identify particular
  * error responses and aid in debugging and support issues.
@@ -13,50 +10,104 @@ import net.corda.httprpc.exception.HttpApiException
  * breaking change. Changing status or reason codes after release is considered a breaking change.
  *
  * Status codes:
- * 4XX - indicate a problem with the request. Requests can be re-submitted, usually with updated arguments and may succeed.
- * 5XX - indicate a problem occurred on the server side while processing the request. An application can't perform any action to correct a
- * 500-level error.
+ * 2XX - indicates a request was successfully received, understood and accepted.
+ * 3XX - indicates further action needs to be taken in order to fulfill a request.
+ * 4XX - indicates a problem with the request. Requests can be re-submitted, usually with updated arguments and may succeed.
+ * 5XX - indicates a problem occurred on the server side that prevented it from fulfilling the request.
  *
  * @param statusCode the http status code for the http response.
  */
 enum class ResponseCode constructor(val statusCode: Int) {
+
+    /**
+     * Request has succeeded.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.200`.
+     */
+    OK(200),
+
+    /**
+     * One or more resources have been successfully created.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.201`.
+     */
+    CREATED(201),
+
+    /**
+     * The request has been accepted for processing but the processing has not been completed.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.202`.
+     */
+    ACCEPTED(202),
+
+    /**
+     * A request has succeeded but there is no content to send to the client.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.204`.
+     */
+    NO_CONTENT(204),
+
+    /**
+     * The requested resource is located at another URI using the GET HTTP method. Use this for response from asynchronous APIs that return
+     * a status URI.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.303`.
+     */
+    SEE_OTHER(303),
+
     /**
      * Signals the exception occurred due to invalid input data in the request or from a resource identified by the request.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.400`.
      */
     BAD_REQUEST(400),
 
     /**
      * Signals the request was syntactically correct but contained data that was invalid to successfully complete the request.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.400`.
      */
     INVALID_INPUT_DATA(400),
 
     /**
      * Signals the user authentication failed.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.401`.
      */
     NOT_AUTHENTICATED(401),
 
     /**
      * Signals the user is not authorized to perform an action.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.403`.
      */
     FORBIDDEN(403),
 
     /**
      * Signals the requested resource was not found.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.404`.
      */
     RESOURCE_NOT_FOUND(404),
 
     /**
-     * Signals the resource is not in the expected state
+     * Signals the resource is not in the expected state.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.409`.
      */
     CONFLICT(409),
 
     /**
-     * An error occurred internally.
+     * An unexpected condition occurred that prevented it from fulfilling the request.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.500`.
      */
     INTERNAL_SERVER_ERROR(500),
 
     /**
      * An unexpected error occurred internally. Caused by programming logic failures such as NPE, most likely requires support intervention.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.500`.
      */
     UNEXPECTED_ERROR(500),
 
@@ -64,8 +115,10 @@ enum class ResponseCode constructor(val statusCode: Int) {
      * Common causes are a server that is down for maintenance or that is overloaded.
      * This response should be used for temporary conditions and the `Retry-After` HTTP header should, if possible,
      * contain the estimated time for the recovery of the service.
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.503`.
      */
-    SERVICE_UNAVAILABLE(503)
+    SERVICE_UNAVAILABLE(503),
     ;
 
     override fun toString(): String {

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ResponseCode.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ResponseCode.kt
@@ -20,6 +20,10 @@ package net.corda.httprpc
 enum class ResponseCode constructor(val statusCode: Int) {
 
     /**
+     * SUCCESSFUL 2xx
+     */
+
+    /**
      * Request has succeeded.
      *
      * See `https://httpwg.org/specs/rfc9110.html#status.200`.
@@ -48,12 +52,37 @@ enum class ResponseCode constructor(val statusCode: Int) {
     NO_CONTENT(204),
 
     /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.205`.
+     */
+    RESET_CONTENT(205),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.206`.
+     */
+    PARTIAL_CONTENT(206),
+
+    /**
+     * REDIRECTION 3xx
+     */
+
+    /**
      * The requested resource is located at another URI using the GET HTTP method. Use this for response from asynchronous APIs that return
      * a status URI.
      *
      * See `https://httpwg.org/specs/rfc9110.html#status.303`.
      */
     SEE_OTHER(303),
+
+    /**
+     *
+     *
+     * See `https://httpwg.org/specs/rfc9110.html#status.306`.
+     */
+    UNUSED(306),
+
+    /**
+     * CLIENT ERRORS 4xx
+     */
 
     /**
      * Signals the exception occurred due to invalid input data in the request or from a resource identified by the request.
@@ -91,11 +120,55 @@ enum class ResponseCode constructor(val statusCode: Int) {
     RESOURCE_NOT_FOUND(404),
 
     /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.405`.
+     */
+    METHOD_NOT_ALLOWED(405),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.406`.
+     */
+    NOT_ACCEPTABLE(406),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.408`.
+     */
+    REQUEST_TIMEOUT(408),
+
+    /**
      * Signals the resource is not in the expected state.
      *
      * See `https://httpwg.org/specs/rfc9110.html#status.409`.
      */
     CONFLICT(409),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.412`.
+     */
+    PRECONDITION_FAILED(412),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.413`.
+     */
+    CONTENT_TOO_LARGE(413),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.415`.
+     */
+    UNSUPPORTED_MEDIA_TYPE(415),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.416`.
+     */
+    RANGE_NOT_SATISFIABLE(416),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.422`.
+     */
+    UNPROCESSABLE_CONTENT(422),
+
+    /**
+     * SERVER ERRORS 5xx
+     */
 
     /**
      * An unexpected condition occurred that prevented it from fulfilling the request.
@@ -119,7 +192,24 @@ enum class ResponseCode constructor(val statusCode: Int) {
      * See `https://httpwg.org/specs/rfc9110.html#status.503`.
      */
     SERVICE_UNAVAILABLE(503),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.504`.
+     */
+    GATEWAY_TIMEOUT(504),
+
+    /**
+     * See `https://httpwg.org/specs/rfc9110.html#status.505`.
+     */
+    HTTP_VERSION_NOT_SUPPORTED(505),
     ;
+
+    companion object {
+        fun fromStatusCode(statusCode: Int): ResponseCode {
+            return values().find { it.statusCode == statusCode }
+                ?: throw RuntimeException("Status code $statusCode not implemented")
+        }
+    }
 
     override fun toString(): String {
         return name

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ResponseCode.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/ResponseCode.kt
@@ -204,13 +204,6 @@ enum class ResponseCode constructor(val statusCode: Int) {
     HTTP_VERSION_NOT_SUPPORTED(505),
     ;
 
-    companion object {
-        fun fromStatusCode(statusCode: Int): ResponseCode {
-            return values().find { it.statusCode == statusCode }
-                ?: throw RuntimeException("Status code $statusCode not implemented")
-        }
-    }
-
     override fun toString(): String {
         return name
     }

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcEndpoint.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcEndpoint.kt
@@ -1,5 +1,9 @@
 package net.corda.httprpc.annotations
 
+import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.ResponseCode
+import net.corda.httprpc.exception.ResourceNotFoundException
+
 /**
  * Annotation that is meant to be applied on annotations to flag the fact that they are meant for exposing
  * an HTTP Endpoint.
@@ -10,6 +14,14 @@ annotation class HttpRpcEndpoint
 /**
  * Marks a function of an @[HttpRpcResource] annotated interface to be exposed as a POST endpoint by the HTTP RPC
  * generated web service.
+ *
+ * - If an endpoint successfully creates a resource, it should return a [HttpResponse] with [ResponseCode.CREATED] (status code 201).
+ * - If an endpoint successfully updates a resource or does some processing without creating a new resource, it should return a
+ * [HttpResponse] with [ResponseCode.OK] (status code 200).
+ * - If an endpoint performs processing asynchronously, it should return a [HttpResponse] with [ResponseCode.ACCEPTED] (status code 202).
+ * The response payload for such an endpoint should contain a representation of the status of the request.
+ * - If an endpoint method does some processing but has no result to return, the method can have no return type and by default
+ * [ResponseCode.NO_CONTENT] (status code 204) is returned, unless an exception is thrown.
  *
  * @property path The relative path of the endpoint within its resource.
  *           Defaults to an empty string, meaning that path of the enclosing [HttpRpcResource] should be used.
@@ -31,6 +43,14 @@ annotation class HttpRpcPOST(
  * Marks a function of an @[HttpRpcResource] annotated interface to be exposed as a PUT endpoint by the HTTP RPC
  * generated web service.
  *
+ * - If an endpoint successfully creates a resource, it should return a [HttpResponse] with [ResponseCode.CREATED] (status code 201).
+ * - If an endpoint successfully updates a resource or does some processing without creating a new resource, it should return a
+ * [HttpResponse] with [ResponseCode.OK] (status code 200).
+ * - If an endpoint performs processing asynchronously, it should return a [HttpResponse] with [ResponseCode.ACCEPTED] (status code 202).
+ * The response payload for such an endpoint should contain a representation of the status of the request.
+ * - If an endpoint method does some processing but has no result to return, the method can have no return type and by default
+ * [ResponseCode.NO_CONTENT] (status code 204) is returned, unless an exception is thrown.
+ *
  * @property path The relative path of the endpoint within its resource.
  *           Defaults to an empty string, meaning that path of the enclosing [HttpRpcResource] should be used.
  * @property title The title of the endpoint, used for documentation. Defaults to the function name.
@@ -51,6 +71,11 @@ annotation class HttpRpcPUT(
  * Marks a function or a property getter of an @[HttpRpcResource] annotated interface to be exposed as a `GET`
  * endpoint by the HTTP RPC generated web service.
  *
+ * - Successful invocation of a GET API should return the representation of the requested resource.
+ * - By default an endpoint does not need to return a [HttpResponse], the return type will be converted to the response payload with
+ * [ResponseCode.OK] (status code 200).
+ * - If a resource cannot be found it should throw a [ResourceNotFoundException].
+ *
  * @property path The relative path of the endpoint within its resource.
  *           Defaults to an empty string, meaning that path of the enclosing [HttpRpcResource] should be used.
  * @property title The title of the endpoint, used for documentation. Defaults to the function name.
@@ -70,6 +95,12 @@ annotation class HttpRpcGET(
 /**
  * Marks a function of an @[HttpRpcResource] annotated interface to be exposed as a `DELETE`
  * endpoint by the HTTP RPC generated web service.
+ *
+ * - If an endpoint successfully deletes a resource, it should return either a [HttpResponse] with [ResponseCode.OK] (status code 200) and
+ * response payload containing a representation of the status, or a [ResponseCode.NO_CONTENT] and no response payload.
+ * - By default if the method has no return type [ResponseCode.NO_CONTENT] (status code 204) is returned, unless an exception is thrown.
+ * - If an endpoint performs processing asynchronously, it should return a [HttpResponse] with [ResponseCode.ACCEPTED] (status code 202).
+ * The response payload for such an endpoint should contain a representation of the status of the request.
  *
  * @property path The relative path of the endpoint within its resource.
  *           Defaults to an empty string, meaning that path of the enclosing [HttpRpcResource] should be used.

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcEndpoint.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/annotations/HttpRpcEndpoint.kt
@@ -1,6 +1,6 @@
 package net.corda.httprpc.annotations
 
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.ResponseCode
 import net.corda.httprpc.exception.ResourceNotFoundException
 
@@ -15,10 +15,10 @@ annotation class HttpRpcEndpoint
  * Marks a function of an @[HttpRpcResource] annotated interface to be exposed as a POST endpoint by the HTTP RPC
  * generated web service.
  *
- * - If an endpoint successfully creates a resource, it should return a [HttpResponse] with [ResponseCode.CREATED] (status code 201).
+ * - If an endpoint successfully creates a resource, it should return a [ResponseEntity] with [ResponseCode.CREATED] (status code 201).
  * - If an endpoint successfully updates a resource or does some processing without creating a new resource, it should return a
- * [HttpResponse] with [ResponseCode.OK] (status code 200).
- * - If an endpoint performs processing asynchronously, it should return a [HttpResponse] with [ResponseCode.ACCEPTED] (status code 202).
+ * [ResponseEntity] with [ResponseCode.OK] (status code 200).
+ * - If an endpoint performs processing asynchronously, it should return a [ResponseEntity] with [ResponseCode.ACCEPTED] (status code 202).
  * The response payload for such an endpoint should contain a representation of the status of the request.
  * - If an endpoint method does some processing but has no result to return, the method can have no return type and by default
  * [ResponseCode.NO_CONTENT] (status code 204) is returned, unless an exception is thrown.
@@ -43,10 +43,10 @@ annotation class HttpRpcPOST(
  * Marks a function of an @[HttpRpcResource] annotated interface to be exposed as a PUT endpoint by the HTTP RPC
  * generated web service.
  *
- * - If an endpoint successfully creates a resource, it should return a [HttpResponse] with [ResponseCode.CREATED] (status code 201).
+ * - If an endpoint successfully creates a resource, it should return a [ResponseEntity] with [ResponseCode.CREATED] (status code 201).
  * - If an endpoint successfully updates a resource or does some processing without creating a new resource, it should return a
- * [HttpResponse] with [ResponseCode.OK] (status code 200).
- * - If an endpoint performs processing asynchronously, it should return a [HttpResponse] with [ResponseCode.ACCEPTED] (status code 202).
+ * [ResponseEntity] with [ResponseCode.OK] (status code 200).
+ * - If an endpoint performs processing asynchronously, it should return a [ResponseEntity] with [ResponseCode.ACCEPTED] (status code 202).
  * The response payload for such an endpoint should contain a representation of the status of the request.
  * - If an endpoint method does some processing but has no result to return, the method can have no return type and by default
  * [ResponseCode.NO_CONTENT] (status code 204) is returned, unless an exception is thrown.
@@ -72,7 +72,7 @@ annotation class HttpRpcPUT(
  * endpoint by the HTTP RPC generated web service.
  *
  * - Successful invocation of a GET API should return the representation of the requested resource.
- * - By default an endpoint does not need to return a [HttpResponse], the return type will be converted to the response payload with
+ * - By default an endpoint does not need to return a [ResponseEntity], the return type will be converted to the response payload with
  * [ResponseCode.OK] (status code 200).
  * - If a resource cannot be found it should throw a [ResourceNotFoundException].
  *
@@ -96,10 +96,10 @@ annotation class HttpRpcGET(
  * Marks a function of an @[HttpRpcResource] annotated interface to be exposed as a `DELETE`
  * endpoint by the HTTP RPC generated web service.
  *
- * - If an endpoint successfully deletes a resource, it should return either a [HttpResponse] with [ResponseCode.OK] (status code 200) and
+ * - If an endpoint successfully deletes a resource, it should return either a [ResponseEntity] with [ResponseCode.OK] (status code 200) and
  * response payload containing a representation of the status, or a [ResponseCode.NO_CONTENT] and no response payload.
  * - By default if the method has no return type [ResponseCode.NO_CONTENT] (status code 204) is returned, unless an exception is thrown.
- * - If an endpoint performs processing asynchronously, it should return a [HttpResponse] with [ResponseCode.ACCEPTED] (status code 202).
+ * - If an endpoint performs processing asynchronously, it should return a [ResponseEntity] with [ResponseCode.ACCEPTED] (status code 202).
  * The response payload for such an endpoint should contain a representation of the status of the request.
  *
  * @property path The relative path of the endpoint within its resource.

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/response/HttpResponse.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/response/HttpResponse.kt
@@ -1,0 +1,49 @@
+package net.corda.httprpc.response
+
+import net.corda.httprpc.ResponseCode
+import net.corda.httprpc.RpcOps
+
+/**
+ * This class can be used as a return type in [RpcOps] endpoints to allow control over the status code returned in the HTTP responses.
+ *
+ * For example, given the http specification (https://httpwg.org/specs/rfc9110.html), a POST that creates a new resource
+ * should return a 201 Created. An asynchronous API that completes the processing of a request occurs at a later time should return a 202
+ * Accepted.
+ *
+ * Use the static helper methods to create the appropriate http response.
+ *
+ * If an [RpcOps] endpoint function doesn't wrap its return type in a [HttpResponse], it will set the response's status code to
+ * [ResponseCode.OK] (200) unless an exception is thrown.
+ *
+ * If an [RpcOps] endpoint has no return type at all, it will return a response with no body and a status code of [ResponseCode.NO_CONTENT]
+ * (204) unless an exception is thrown.
+ *
+ * @param T the type of the response body payload, used in open-api generation.
+ * @param responseCode the status code of the response.
+ * @param responseBody the payload of the response. If null, the response payload will be "null".
+ */
+class HttpResponse<T : Any>(
+    val responseCode: ResponseCode,
+    val responseBody: T?,
+) {
+    companion object {
+        fun <T : Any> ok(responseBody: T): HttpResponse<T> {
+            return HttpResponse(ResponseCode.OK, responseBody)
+        }
+        fun <T : Any> resourceUpdated(responseBody: T): HttpResponse<T> {
+            return HttpResponse(ResponseCode.OK, responseBody)
+        }
+        fun <T : Any> resourceCreated(responseBody: T): HttpResponse<T> {
+            return HttpResponse(ResponseCode.CREATED, responseBody)
+        }
+        fun <T : Any> resourceDeleted(responseBody: T): HttpResponse<T> {
+            return HttpResponse(ResponseCode.OK, responseBody)
+        }
+        fun <T : Any> requestAccepted(responseBody: T): HttpResponse<T> {
+            return HttpResponse(ResponseCode.ACCEPTED, responseBody)
+        }
+        fun <T : Any> seeOther(responseBody: T): HttpResponse<T> {
+            return HttpResponse(ResponseCode.SEE_OTHER, responseBody)
+        }
+    }
+}

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/response/ResponseEntity.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/response/ResponseEntity.kt
@@ -12,7 +12,7 @@ import net.corda.httprpc.RpcOps
  *
  * Use the static helper methods to create the appropriate http response.
  *
- * If an [RpcOps] endpoint function doesn't wrap its return type in a [HttpResponse], it will set the response's status code to
+ * If an [RpcOps] endpoint function doesn't wrap its return type in a [ResponseEntity], it will set the response's status code to
  * [ResponseCode.OK] (200) unless an exception is thrown.
  *
  * If an [RpcOps] endpoint has no return type at all, it will return a response with no body and a status code of [ResponseCode.NO_CONTENT]
@@ -22,28 +22,28 @@ import net.corda.httprpc.RpcOps
  * @param responseCode the status code of the response.
  * @param responseBody the payload of the response. If null, the response payload will be "null".
  */
-class HttpResponse<T : Any>(
+class ResponseEntity<T : Any>(
     val responseCode: ResponseCode,
     val responseBody: T?,
 ) {
     companion object {
-        fun <T : Any> ok(responseBody: T): HttpResponse<T> {
-            return HttpResponse(ResponseCode.OK, responseBody)
+        fun <T : Any> ok(responseBody: T): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.OK, responseBody)
         }
-        fun <T : Any> resourceUpdated(responseBody: T): HttpResponse<T> {
-            return HttpResponse(ResponseCode.OK, responseBody)
+        fun <T : Any> updated(responseBody: T): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.OK, responseBody)
         }
-        fun <T : Any> resourceCreated(responseBody: T): HttpResponse<T> {
-            return HttpResponse(ResponseCode.CREATED, responseBody)
+        fun <T : Any> created(responseBody: T): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.CREATED, responseBody)
         }
-        fun <T : Any> resourceDeleted(responseBody: T): HttpResponse<T> {
-            return HttpResponse(ResponseCode.OK, responseBody)
+        fun <T : Any> deleted(responseBody: T): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.OK, responseBody)
         }
-        fun <T : Any> requestAccepted(responseBody: T): HttpResponse<T> {
-            return HttpResponse(ResponseCode.ACCEPTED, responseBody)
+        fun <T : Any> accepted(responseBody: T): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.ACCEPTED, responseBody)
         }
-        fun <T : Any> seeOther(responseBody: T): HttpResponse<T> {
-            return HttpResponse(ResponseCode.SEE_OTHER, responseBody)
+        fun <T : Any> seeOther(responseBody: T): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.SEE_OTHER, responseBody)
         }
     }
 }

--- a/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/response/ResponseEntity.kt
+++ b/libs/http-rpc/http-rpc/src/main/kotlin/net/corda/httprpc/response/ResponseEntity.kt
@@ -22,27 +22,27 @@ import net.corda.httprpc.RpcOps
  * @param responseCode the status code of the response.
  * @param responseBody the payload of the response. If null, the response payload will be "null".
  */
-class ResponseEntity<T : Any>(
+class ResponseEntity<T : Any?>(
     val responseCode: ResponseCode,
-    val responseBody: T?,
+    val responseBody: T,
 ) {
     companion object {
-        fun <T : Any> ok(responseBody: T): ResponseEntity<T> {
+        fun <T : Any?> ok(responseBody: T): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.OK, responseBody)
         }
-        fun <T : Any> updated(responseBody: T): ResponseEntity<T> {
+        fun <T : Any?> updated(responseBody: T): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.OK, responseBody)
         }
-        fun <T : Any> created(responseBody: T): ResponseEntity<T> {
+        fun <T : Any?> created(responseBody: T): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.CREATED, responseBody)
         }
-        fun <T : Any> deleted(responseBody: T): ResponseEntity<T> {
+        fun <T : Any?> deleted(responseBody: T): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.OK, responseBody)
         }
-        fun <T : Any> accepted(responseBody: T): ResponseEntity<T> {
+        fun <T : Any?> accepted(responseBody: T): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.ACCEPTED, responseBody)
         }
-        fun <T : Any> seeOther(responseBody: T): ResponseEntity<T> {
+        fun <T : Any?> seeOther(responseBody: T): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.SEE_OTHER, responseBody)
         }
     }

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
@@ -6,6 +6,7 @@ import net.corda.httprpc.annotations.HttpRpcPOST
 import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
+import net.corda.httprpc.response.HttpResponse
 import net.corda.libs.permissions.endpoints.v1.permission.types.CreatePermissionType
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionResponseType
 
@@ -26,7 +27,7 @@ interface PermissionEndpoint : RpcOps {
     fun createPermission(
         @HttpRpcRequestBodyParameter(description = "Details of the permission to be created")
         createPermissionType: CreatePermissionType
-    ): PermissionResponseType
+    ): HttpResponse<PermissionResponseType>
 
     /**
      * Get a permission by its identifier in the RBAC permission system.

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
@@ -6,7 +6,7 @@ import net.corda.httprpc.annotations.HttpRpcPOST
 import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.libs.permissions.endpoints.v1.permission.types.CreatePermissionType
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionResponseType
 
@@ -27,7 +27,7 @@ interface PermissionEndpoint : RpcOps {
     fun createPermission(
         @HttpRpcRequestBodyParameter(description = "Details of the permission to be created")
         createPermissionType: CreatePermissionType
-    ): HttpResponse<PermissionResponseType>
+    ): ResponseEntity<PermissionResponseType>
 
     /**
      * Get a permission by its identifier in the RBAC permission system.

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/RoleEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/RoleEndpoint.kt
@@ -8,6 +8,7 @@ import net.corda.httprpc.annotations.HttpRpcPUT
 import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
+import net.corda.httprpc.response.HttpResponse
 import net.corda.libs.permissions.endpoints.v1.role.types.CreateRoleType
 import net.corda.libs.permissions.endpoints.v1.role.types.RoleResponseType
 
@@ -34,7 +35,7 @@ interface RoleEndpoint : RpcOps {
     fun createRole(
         @HttpRpcRequestBodyParameter(description = "Details of the role to be created")
         createRoleType: CreateRoleType
-    ): RoleResponseType
+    ): HttpResponse<RoleResponseType>
 
     /**
      * Get a role by its identifier in the RBAC permission system.
@@ -54,7 +55,7 @@ interface RoleEndpoint : RpcOps {
         roleId: String,
         @HttpRpcPathParameter(description = "Identifier for an existing permission")
         permissionId: String
-    ): RoleResponseType
+    ): HttpResponse<RoleResponseType>
 
     /**
      * Removes Association between a role and a permission
@@ -65,5 +66,5 @@ interface RoleEndpoint : RpcOps {
         roleId: String,
         @HttpRpcPathParameter(description = "Identifier for an existing permission")
         permissionId: String
-    ): RoleResponseType
+    ): HttpResponse<RoleResponseType>
 }

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/RoleEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/RoleEndpoint.kt
@@ -8,7 +8,7 @@ import net.corda.httprpc.annotations.HttpRpcPUT
 import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.libs.permissions.endpoints.v1.role.types.CreateRoleType
 import net.corda.libs.permissions.endpoints.v1.role.types.RoleResponseType
 
@@ -35,7 +35,7 @@ interface RoleEndpoint : RpcOps {
     fun createRole(
         @HttpRpcRequestBodyParameter(description = "Details of the role to be created")
         createRoleType: CreateRoleType
-    ): HttpResponse<RoleResponseType>
+    ): ResponseEntity<RoleResponseType>
 
     /**
      * Get a role by its identifier in the RBAC permission system.
@@ -55,7 +55,7 @@ interface RoleEndpoint : RpcOps {
         roleId: String,
         @HttpRpcPathParameter(description = "Identifier for an existing permission")
         permissionId: String
-    ): HttpResponse<RoleResponseType>
+    ): ResponseEntity<RoleResponseType>
 
     /**
      * Removes Association between a role and a permission
@@ -66,5 +66,5 @@ interface RoleEndpoint : RpcOps {
         roleId: String,
         @HttpRpcPathParameter(description = "Identifier for an existing permission")
         permissionId: String
-    ): HttpResponse<RoleResponseType>
+    ): ResponseEntity<RoleResponseType>
 }

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
@@ -9,7 +9,7 @@ import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcQueryParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
-import net.corda.httprpc.response.HttpResponse
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.libs.permissions.endpoints.v1.user.types.CreateUserType
 import net.corda.libs.permissions.endpoints.v1.user.types.UserPermissionSummaryResponseType
 import net.corda.libs.permissions.endpoints.v1.user.types.UserResponseType
@@ -31,7 +31,7 @@ interface UserEndpoint : RpcOps {
     fun createUser(
         @HttpRpcRequestBodyParameter(description = "Details of the user to be created")
         createUserType: CreateUserType
-    ): HttpResponse<UserResponseType>
+    ): ResponseEntity<UserResponseType>
 
     /**
      * Get a user by loginName in the RBAC permission system.
@@ -51,7 +51,7 @@ interface UserEndpoint : RpcOps {
         loginName: String,
         @HttpRpcPathParameter(description = "Id of the role to associate with this user")
         roleId: String
-    ): HttpResponse<UserResponseType>
+    ): ResponseEntity<UserResponseType>
 
     /**
      * Un-assign a Role from a User in the RBAC permission system.
@@ -62,7 +62,7 @@ interface UserEndpoint : RpcOps {
         loginName: String,
         @HttpRpcPathParameter(description = "Id of the role to un-assign from this user")
         roleId: String
-    ): HttpResponse<UserResponseType>
+    ): ResponseEntity<UserResponseType>
 
     /**
      * Get a summary of a user's permissions.

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
@@ -9,6 +9,7 @@ import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcQueryParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
+import net.corda.httprpc.response.HttpResponse
 import net.corda.libs.permissions.endpoints.v1.user.types.CreateUserType
 import net.corda.libs.permissions.endpoints.v1.user.types.UserPermissionSummaryResponseType
 import net.corda.libs.permissions.endpoints.v1.user.types.UserResponseType
@@ -30,7 +31,7 @@ interface UserEndpoint : RpcOps {
     fun createUser(
         @HttpRpcRequestBodyParameter(description = "Details of the user to be created")
         createUserType: CreateUserType
-    ): UserResponseType
+    ): HttpResponse<UserResponseType>
 
     /**
      * Get a user by loginName in the RBAC permission system.
@@ -50,7 +51,7 @@ interface UserEndpoint : RpcOps {
         loginName: String,
         @HttpRpcPathParameter(description = "Id of the role to associate with this user")
         roleId: String
-    ): UserResponseType
+    ): HttpResponse<UserResponseType>
 
     /**
      * Un-assign a Role from a User in the RBAC permission system.
@@ -61,7 +62,7 @@ interface UserEndpoint : RpcOps {
         loginName: String,
         @HttpRpcPathParameter(description = "Id of the role to un-assign from this user")
         roleId: String
-    ): UserResponseType
+    ): HttpResponse<UserResponseType>
 
     /**
      * Get a summary of a user's permissions.


### PR DESCRIPTION
Added `HttpResponse` as an object that allows endpoints to control the status codes returned.
- Added static helper functions for creating http responses in similar fashion to Spring.
- openApi spec ignores `HttpResponse` and generates schema for the generic type inside
- converted permission, role and user endpoints to use the new HttpResponse as a proof of concept and test that the functionality works
- updated start flow to return accepted status code
- http-rpc client uses reflection to get the generic type argument of the response type