### PR TITLE
NOTICK: Avoid configuring some gradle tasks on all gradle runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
     id 'com.github.ben-manes.versions' // discover possible dependency version upgrades
 }
 
-wrapper {
+tasks.named("wrapper") {
     gradleVersion = '7.4.2'
     distributionType = Wrapper.DistributionType.BIN
 }
@@ -347,8 +347,8 @@ subprojects {
         detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion"
     }
 
-    task allDependencyInsight(type: DependencyInsightReportTask) {}
-    task allDependencies(type: DependencyReportTask) {}
+    tasks.register("allDependencyInsight", DependencyInsightReportTask) {}
+    tasks.register("allDependencies", DependencyReportTask) {}
 
     configurations {
         all {

--- a/libs/http-rpc/http-rpc-tools/build.gradle
+++ b/libs/http-rpc/http-rpc-tools/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 }
 
-jacocoTestCoverageVerification {
+tasks.named("jacocoTestCoverageVerification", JacocoCoverageVerification) {
     violationRules {
         rule {
             limit {

--- a/testing/cpbs/flow-worker-dev-for-cache-testing/build.gradle
+++ b/testing/cpbs/flow-worker-dev-for-cache-testing/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'net.corda.plugins.cordapp-cpb'
 }
 
-jar {
+tasks.named("jar") {
     baseName 'flow-worker-dev'
 }
 

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -29,7 +29,7 @@ tasks.register('copyCliFiles') {
     }
 }
 
-task cliInstallArchive(type: Zip) {
+tasks.register("cliInstallArchive", Zip) {
     dependsOn tasks.named('copyCliFiles')
     from "$buildDir/cli"
     include '*'


### PR DESCRIPTION
Switch a couple of places in the build to take advantage of Gradle's task configuration avoidance API. This is unlikely to impact build times at all as the tasks in question appear to do relatively little work in the configuration stage, but it is technically correct to do this.

The primary offenders are `allDependencies` and `allDependencyInsight`, which appear to cause ~700 tasks to be created on every Gradle invocation.