### PR TITLE
CORE-6366 Adjustments to membership mapping between key scheme to default signature scheme

### DIFF
--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImpl.kt
@@ -64,8 +64,8 @@ class CertificatesRpcOpsImpl @Activate constructor(
         private val logger = contextLogger()
 
         private val defaultCodeNameToSpec = mapOf(
-            ECDSA_SECP256K1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
-            ECDSA_SECP256R1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
+            ECDSA_SECP256K1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
+            ECDSA_SECP256R1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
             EDDSA_ED25519_TEMPLATE to SignatureSpec.EDDSA_ED25519,
             GOST3410_GOST3411_TEMPLATE to SignatureSpec.GOST3410_GOST3411,
             RSA_CODE_NAME to SignatureSpec.RSA_SHA512,

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImplTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImplTest.kt
@@ -16,6 +16,7 @@ import net.corda.v5.cipher.suite.KeyEncodingService
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.crypto.SignatureSpec.Companion.ECDSA_SHA256
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.asn1.DEROctetString
 import org.bouncycastle.asn1.x500.X500Name
@@ -126,7 +127,7 @@ class CertificatesRpcOpsImplTest {
                 cryptoOpsClient.sign(
                     eq(holdingIdentityShortHash),
                     eq(publicKey),
-                    argThat<SignatureSpec> { this.signatureName == "SHA512withECDSA" },
+                    argThat<SignatureSpec> { this.signatureName == ECDSA_SHA256.signatureName },
                     any(),
                     eq(emptyMap())
                 )
@@ -170,7 +171,7 @@ class CertificatesRpcOpsImplTest {
             verify(cryptoOpsClient).sign(
                 eq(holdingIdentityShortHash),
                 eq(publicKey),
-                argThat<SignatureSpec> { this.signatureName == "SHA512withECDSA" },
+                argThat<SignatureSpec> { this.signatureName == ECDSA_SHA256.signatureName },
                 any(),
                 eq(emptyMap())
             )

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/helpers/Signer.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/helpers/Signer.kt
@@ -20,8 +20,8 @@ internal class Signer(
 ) {
     private companion object {
         val defaultCodeNameToSpec = mapOf(
-            ECDSA_SECP256K1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
-            ECDSA_SECP256R1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
+            ECDSA_SECP256K1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
+            ECDSA_SECP256R1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
             EDDSA_ED25519_TEMPLATE to SignatureSpec.EDDSA_ED25519,
             GOST3410_GOST3411_TEMPLATE to SignatureSpec.GOST3410_GOST3411,
             RSA_CODE_NAME to SignatureSpec.RSA_SHA512,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -110,8 +110,8 @@ class DynamicMemberRegistrationService @Activate constructor(
         const val SERIAL_CONST = "1"
 
         val defaultCodeNameToSpec = mapOf(
-            ECDSA_SECP256K1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
-            ECDSA_SECP256R1_CODE_NAME to SignatureSpec("SHA512withECDSA"),
+            ECDSA_SECP256K1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
+            ECDSA_SECP256R1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
             EDDSA_ED25519_TEMPLATE to SignatureSpec.EDDSA_ED25519,
             GOST3410_GOST3411_TEMPLATE to SignatureSpec.GOST3410_GOST3411,
             RSA_CODE_NAME to SignatureSpec.RSA_SHA512,


### PR DESCRIPTION
There are a couple of places where we are using `SHA-512` for `SECP256R1` and `SECP256K1`. It has been advised that we should be using `SHA-256` instead.