### PR TITLE
CORE-6224 Use go-template base64decode

### DIFF
--- a/charts/corda/templates/NOTES.txt
+++ b/charts/corda/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Extract the credentials for the initial admin user:
-kubectl get secret {{ include "corda.initialAdminUserSecretName" . }} -o jsonpath='{ .data.{{ include "corda.initialAdminUserSecretUsernameKey" . }} }' | base64 --decode
-kubectl get secret {{ include "corda.initialAdminUserSecretName" . }} -o jsonpath='{ .data.{{ include "corda.initialAdminUserSecretPasswordKey" . }} }' | base64 --decode
+kubectl get secret {{ include "corda.initialAdminUserSecretName" . }} -o go-template='{{ `{{` }} .data.{{ include "corda.initialAdminUserSecretUsernameKey" . }} | base64decode {{ `}}` }}'
+kubectl get secret {{ include "corda.initialAdminUserSecretName" . }} -o go-template='{{ `{{` }} .data.{{ include "corda.initialAdminUserSecretPasswordKey" . }} | base64decode {{ `}}` }}'
 
 2. Expose the APC endpoint on localhost by running this command:
 kubectl port-forward --namespace {{ .Release.Namespace }} deployment/{{ include "corda.fullname" . }}-rpc-worker 8888 &


### PR DESCRIPTION
Switch to using `go-template` and `base64decode` to remove the dependency on `base64` (where different versions have slight variations in behavior.

Note: ``{{ `{{` }}`` is the ugliness required to escape the use of `{{` within a Helm template.