### PR TITLE
NOTICK: Try using a local 1.4.0-SNAPSHOT of Aries SPI-Fly.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ snakeyamlVersion=1.33
 dokkaVersion=1.7.+
 # Implementation dependency versions
 activationVersion=1.2.0
-ariesDynamicFrameworkExtensionVersion=1.3.6
+ariesDynamicFrameworkExtensionVersion=1.4.0-SNAPSHOT
 antlrVersion=2.7.7
 asmVersion=9.4
 avroVersion=1.11.1


### PR DESCRIPTION
Local attempt to resolve "Common Superclass" issue between Liquibase and JAXB.