### PR TITLE
CORE-4874 Fix CorDapp security policy

### DIFF
--- a/components/db/db-connection-manager-impl/src/integrationTest/kotlin/net/corda/db/connection/manager/impl/tests/DbAdminTest.kt
+++ b/components/db/db-connection-manager-impl/src/integrationTest/kotlin/net/corda/db/connection/manager/impl/tests/DbAdminTest.kt
@@ -20,7 +20,7 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.impl.JpaEntitiesRegistryImpl
-import net.corda.testing.bundles.cats.Cat
+import net.cordapp.testing.bundles.cats.Cat
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions

--- a/components/security-manager/src/main/resources/basic_security.policy
+++ b/components/security-manager/src/main/resources/basic_security.policy
@@ -26,10 +26,6 @@ ALLOW {
 
 (org.osgi.framework.PackagePermission "co.paralleluniverse.fibers.suspend" "import")
 
-# TODO This is required for CalculatorFlow (E2E tests) but will be removed (JIRA CORE-4813)
-(java.lang.RuntimePermission "accessClassInPackage.net.corda.testing.*" "")
-(org.osgi.framework.PackagePermission "net.corda.testing.*" "exportonly,import")
-
 } "Allow public packages and services for FLOW Sandbox"
 
 DENY {
@@ -146,10 +142,6 @@ ALLOW {
 (org.osgi.framework.PackagePermission "net.corda.v5.*" "import")
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=PERSISTENCE/*)" "get")
-
-# TODO This is required for Smoke tests (e.g. net.corda.testing.bundles.dogs) but will be removed (JIRA CORE-4813)
-(java.lang.RuntimePermission "accessClassInPackage.net.corda.testing.*" "")
-(org.osgi.framework.PackagePermission "net.corda.testing.*" "exportonly,import")
 
 } "Allow public packages and services for PERSISTENCE Sandbox"
 

--- a/components/security-manager/src/main/resources/high_security.policy
+++ b/components/security-manager/src/main/resources/high_security.policy
@@ -27,10 +27,6 @@ ALLOW {
 
 (org.osgi.framework.PackagePermission "co.paralleluniverse.fibers.suspend" "import")
 
-# TODO This is required for CalculatorFlow (E2E tests) but will be removed (JIRA CORE-4813)
-(java.lang.RuntimePermission "accessClassInPackage.net.corda.testing.*" "")
-(org.osgi.framework.PackagePermission "net.corda.testing.*" "exportonly,import")
-
 } "Allow public packages and services for FLOW Sandbox"
 
 DENY {
@@ -157,10 +153,6 @@ ALLOW {
 (org.osgi.framework.PackagePermission "net.corda.v5.*" "import")
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=PERSISTENCE/*)" "get")
-
-# TODO This is required for Smoke tests (e.g. net.corda.testing.bundles.dogs) but will be removed (JIRA CORE-4813)
-(java.lang.RuntimePermission "accessClassInPackage.net.corda.testing.*" "")
-(org.osgi.framework.PackagePermission "net.corda.testing.*" "exportonly,import")
 
 } "Allow public packages and services for PERSISTENCE Sandbox"
 

--- a/components/security-manager/src/main/resources/medium_security.policy
+++ b/components/security-manager/src/main/resources/medium_security.policy
@@ -27,10 +27,6 @@ ALLOW {
 
 (org.osgi.framework.PackagePermission "co.paralleluniverse.fibers.suspend" "import")
 
-# TODO This is required for CalculatorFlow (E2E tests) but will be removed (JIRA CORE-4813)
-(java.lang.RuntimePermission "accessClassInPackage.net.corda.testing.*" "")
-(org.osgi.framework.PackagePermission "net.corda.testing.*" "exportonly,import")
-
 } "Allow public packages and services for FLOW Sandbox"
 
 DENY {
@@ -154,10 +150,6 @@ ALLOW {
 (org.osgi.framework.PackagePermission "net.corda.v5.*" "import")
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=PERSISTENCE/*)" "get")
-
-# TODO This is required for Smoke tests (e.g. net.corda.testing.bundles.dogs) but will be removed (JIRA CORE-4813)
-(java.lang.RuntimePermission "accessClassInPackage.net.corda.testing.*" "")
-(org.osgi.framework.PackagePermission "net.corda.testing.*" "exportonly,import")
 
 } "Allow public packages and services for PERSISTENCE Sandbox"
 

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/CpbEntityTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/CpbEntityTests.kt
@@ -58,7 +58,7 @@ class CpbEntityTests {
 
         // does contain packages from cpks
         assertThat(entities).containsAll(
-            listOf("net.corda.testing.bundles.dogs.Dog", "net.corda.testing.bundles.cats.Cat", "net.corda.testing.bundles.cats.Owner")
+            listOf("net.cordapp.testing.bundles.dogs.Dog", "net.cordapp.testing.bundles.cats.Cat", "net.cordapp.testing.bundles.cats.Owner")
         )
     }
 }

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/SandboxHelper.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/helpers/SandboxHelper.kt
@@ -15,9 +15,9 @@ import java.util.*
  * twice, with a separate class loader.
  */
 object SandboxHelper {
-    const val DOG_CLASS_NAME = "net.corda.testing.bundles.dogs.Dog"
-    const val CAT_CLASS_NAME = "net.corda.testing.bundles.cats.Cat"
-    const val CAT_KEY_CLASS_NAME = "net.corda.testing.bundles.cats.CatKey"
+    const val DOG_CLASS_NAME = "net.cordapp.testing.bundles.dogs.Dog"
+    const val CAT_CLASS_NAME = "net.cordapp.testing.bundles.cats.Cat"
+    const val CAT_KEY_CLASS_NAME = "net.cordapp.testing.bundles.cats.CatKey"
 
 
     fun SandboxGroup.getDogClass(): Class<*> {
@@ -33,7 +33,7 @@ object SandboxHelper {
     }
 
     fun SandboxGroup.getOwnerClass(): Class<*> {
-        return this.loadClassFromMainBundles("net.corda.testing.bundles.cats.Owner")
+        return this.loadClassFromMainBundles("net.cordapp.testing.bundles.cats.Owner")
     }
 
     data class Box(val instance: Any, val id: UUID)

--- a/libs/db/osgi-integration-tests/src/integrationTest/kotlin/net/corda/db/test/osgi/EntitiesInBundlesTest.kt
+++ b/libs/db/osgi-integration-tests/src/integrationTest/kotlin/net/corda/db/test/osgi/EntitiesInBundlesTest.kt
@@ -38,10 +38,10 @@ import javax.persistence.EntityManagerFactory
 @ExtendWith(ServiceExtension::class)
 class EntitiesInBundlesTest {
     companion object {
-        private const val DOG_CLASS_NAME = "net.corda.testing.bundles.dogs.Dog"
-        private const val CAT_CLASS_NAME = "net.corda.testing.bundles.cats.Cat"
-        private const val CAT_KEY_CLASS_NAME = "net.corda.testing.bundles.cats.CatKey"
-        private const val OWNER_CLASS_NAME = "net.corda.testing.bundles.cats.Owner"
+        private const val DOG_CLASS_NAME = "net.cordapp.testing.bundles.dogs.Dog"
+        private const val CAT_CLASS_NAME = "net.cordapp.testing.bundles.cats.Cat"
+        private const val CAT_KEY_CLASS_NAME = "net.cordapp.testing.bundles.cats.CatKey"
+        private const val OWNER_CLASS_NAME = "net.cordapp.testing.bundles.cats.Owner"
 
         private val logger: Logger = LoggerFactory.getLogger("TEST")
 

--- a/libs/db/readme.md
+++ b/libs/db/readme.md
@@ -155,7 +155,7 @@ pairs, and we allow that full name to be used in file inclusion tags. E.g.:
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <include file="migration/cats-migration-v1.0.xml"/>
-    <include file="classloader://net.corda.testing.bundles.cats/migration/owner-migration-v1.0.xml"/>
+    <include file="classloader://net.cordapp.testing.bundles.cats/migration/owner-migration-v1.0.xml"/>
 </databaseChangeLog>
 ```
 

--- a/testing/bundles/testing-cats/src/main/java/net/cordapp/testing/bundles/cats/package-info.java
+++ b/testing/bundles/testing-cats/src/main/java/net/cordapp/testing/bundles/cats/package-info.java
@@ -1,4 +1,4 @@
 @Export
-package net.corda.testing.bundles.dogs;
+package net.cordapp.testing.bundles.cats;
 
 import org.osgi.annotation.bundle.Export;

--- a/testing/bundles/testing-cats/src/main/kotlin/net/cordapp/testing/bundles/cats/Cat.kt
+++ b/testing/bundles/testing-cats/src/main/kotlin/net/cordapp/testing/bundles/cats/Cat.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.bundles.cats
+package net.cordapp.testing.bundles.cats
 
 import net.corda.v5.base.annotations.CordaSerializable
 import java.util.UUID

--- a/testing/bundles/testing-cats/src/main/kotlin/net/cordapp/testing/bundles/cats/CatKey.kt
+++ b/testing/bundles/testing-cats/src/main/kotlin/net/cordapp/testing/bundles/cats/CatKey.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.bundles.cats
+package net.cordapp.testing.bundles.cats
 import net.corda.v5.base.annotations.CordaSerializable
 import java.util.UUID
 

--- a/testing/bundles/testing-cats/src/main/kotlin/net/cordapp/testing/bundles/cats/Owner.kt
+++ b/testing/bundles/testing-cats/src/main/kotlin/net/cordapp/testing/bundles/cats/Owner.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.bundles.cats
+package net.cordapp.testing.bundles.cats
 
 import net.corda.v5.base.annotations.CordaSerializable
 import java.util.UUID

--- a/testing/bundles/testing-cats/src/main/resources/migration/db.changelog-master.xml
+++ b/testing/bundles/testing-cats/src/main/resources/migration/db.changelog-master.xml
@@ -8,5 +8,5 @@
         This must match the name passed into the 'ChangeLogResourceFiles' objects when setting up LiquibaseSchemaMigrator
         This is to allow overlapping resource names in different bundles.
     -->
-    <include file="classloader://net.corda.testing.bundles.cats/migration/owner-migration-v1.0.xml"/>
+    <include file="classloader://net.cordapp.testing.bundles.cats/migration/owner-migration-v1.0.xml"/>
 </databaseChangeLog>

--- a/testing/bundles/testing-dogs/src/main/java/net/cordapp/testing/bundles/dogs/package-info.java
+++ b/testing/bundles/testing-dogs/src/main/java/net/cordapp/testing/bundles/dogs/package-info.java
@@ -1,4 +1,4 @@
 @Export
-package net.corda.testing.bundles.cats;
+package net.cordapp.testing.bundles.dogs;
 
 import org.osgi.annotation.bundle.Export;

--- a/testing/bundles/testing-dogs/src/main/kotlin/net/cordapp/testing/bundles/dogs/Dog.kt
+++ b/testing/bundles/testing-dogs/src/main/kotlin/net/cordapp/testing/bundles/dogs/Dog.kt
@@ -1,4 +1,4 @@
-package net.corda.testing.bundles.dogs
+package net.cordapp.testing.bundles.dogs
 
 import net.corda.v5.base.annotations.CordaSerializable
 import java.time.Instant

--- a/testing/cpbs/extendable-cpb/build.gradle
+++ b/testing/cpbs/extendable-cpb/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 description 'Animal CPB'
-group 'net.corda.testing.animals'
+group 'net.cordapp.testing.animals'
 
 cordapp {
     targetPlatformVersion platformVersion as Integer

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/smoketests/flow/RpcSmokeTestFlow.kt
@@ -1,6 +1,6 @@
 package net.cordapp.flowworker.development.smoketests.flow
 
-import net.corda.testing.bundles.dogs.Dog
+import net.cordapp.testing.bundles.dogs.Dog
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.flows.CordaInject

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/testflows/PersistenceFlow.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/testflows/PersistenceFlow.kt
@@ -2,7 +2,7 @@ package net.cordapp.flowworker.development.testflows
 
 import java.time.Instant
 import java.util.UUID
-import net.corda.testing.bundles.dogs.Dog
+import net.cordapp.testing.bundles.dogs.Dog
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RPCRequestData
 import net.corda.v5.application.flows.RPCStartableFlow


### PR DESCRIPTION
- Removed Security Manager permissions for "net.corda.testing*" used by cordapps as "net.corda*" is reserved for platform implementation classes
- Refactored bundles testing-cats and testing-dogs to use package "net.cordapp.testing" instead of "net.corda.testing"