### PR TITLE
CORE-6432 add property releasable to control external publishing

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'corda.common-publishing'
     id 'corda.quasar-app'
     id 'corda.docker-app'
+    id 'corda.s3-publish'
 }
 
 ext {

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'corda.docker-app'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Combined Worker'
 
 osgiRun {

--- a/build.gradle
+++ b/build.gradle
@@ -350,6 +350,32 @@ subprojects {
     tasks.register("allDependencyInsight", DependencyInsightReportTask) {}
     tasks.register("allDependencies", DependencyReportTask) {}
 
+    tasks.register('releasable'){
+        description = "Prints a list of all modules which will be released externally"
+        group = "Release"
+        if(project.hasProperty('releasable') && project.releasable){
+            project.publishing.publications.each { publication ->
+                logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
+                publication.artifacts.each { artifact ->
+                    logger.quiet(" * ${artifact.file.name}")
+                }
+            }
+        }
+    }
+
+    tasks.register('unReleasable'){
+        description = "Prints a list of all modules which will not be released externally"
+        group = "Release"
+        if(!project.hasProperty('releasable') || !project.releasable){
+            project.publishing.publications.each { publication ->
+                logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
+                publication.artifacts.each { artifact ->
+                    logger.quiet(" * ${artifact.file.name}")
+                }
+            }
+        }
+    }
+
     configurations {
         all {
             resolutionStrategy {

--- a/build.gradle
+++ b/build.gradle
@@ -350,29 +350,21 @@ subprojects {
     tasks.register("allDependencyInsight", DependencyInsightReportTask) {}
     tasks.register("allDependencies", DependencyReportTask) {}
 
-    tasks.register('releasable'){
+    tasks.register('releasableArtifacts') {
         description = "Prints a list of all modules which will be released externally"
         group = "Release"
-        if(project.hasProperty('releasable') && project.releasable){
-            project.publishing.publications.each { publication ->
-                logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
-                publication.artifacts.each { artifact ->
-                    logger.quiet(" * ${artifact.file.name}")
-                }
-            }
+        if (project.hasProperty('releasable') && project.releasable.toBoolean()) {
+                    println project.releasable.toBoolean()
+
+            logArtifacts(project)
         }
     }
 
-    tasks.register('unReleasable'){
+    tasks.register('unReleasableArtifacts') {
         description = "Prints a list of all modules which will not be released externally"
         group = "Release"
-        if(!project.hasProperty('releasable') || !project.releasable){
-            project.publishing.publications.each { publication ->
-                logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
-                publication.artifacts.each { artifact ->
-                    logger.quiet(" * ${artifact.file.name}")
-                }
-            }
+        if (!project.hasProperty('releasable') || !project.releasable.toBoolean()) {
+            logArtifacts(project)
         }
     }
 
@@ -399,6 +391,16 @@ subprojects {
             "javax.persistence.Embeddable",
             "javax.persistence.MappedSuperclass"
         )
+    }
+}
+
+// helper to log artifacts we will or will not publish during a release process
+def logArtifacts(Project project) {
+    project.publishing.publications.each { publication ->
+        logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
+        publication.artifacts.each { artifact ->
+            logger.quiet(" * ${artifact.file.name}")
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -354,8 +354,6 @@ subprojects {
         description = "Prints a list of all modules which will be released externally"
         group = "Release"
         if (project.hasProperty('releasable') && project.releasable.toBoolean()) {
-                    println project.releasable.toBoolean()
-
             logArtifacts(project)
         }
     }

--- a/buildSrc/src/main/groovy/corda.s3-publish.gradle
+++ b/buildSrc/src/main/groovy/corda.s3-publish.gradle
@@ -1,0 +1,16 @@
+// Allow us to publish to S3 bucket if this plugin is applied to a specific sub module
+// for use in projects which do not use corda.common-publishing plugin
+if (project.hasProperty('maven.repo.s3') && project.hasProperty('releasable')) {
+    publishing {
+        repositories {
+            maven {
+                url = project.findProperty('maven.repo.s3')
+                credentials(AwsCredentials) {
+                    accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
+                    secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
+                    sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
+                }
+            }
+        }
+    }
+}

--- a/cordapp-test-utils/test-utils/build.gradle
+++ b/cordapp-test-utils/test-utils/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 dependencies {
 
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'java'
 }
 
+ext {
+    releasable = true
+}
+
 group 'net.corda.cli.deployment'
 
 configurations {

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'corda.cli-plugin-packager'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'corda.cli-plugin-packager'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {

--- a/tools/plugins/mgm/build.gradle
+++ b/tools/plugins/mgm/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {

--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {

--- a/tools/plugins/secret-config/build.gradle
+++ b/tools/plugins/secret-config/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'corda.cli-plugin-packager'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'corda.cli-plugin-packager'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = false
+}
+
 group 'net.corda.cli.deployment'
 
 dependencies {


### PR DESCRIPTION
add logic to add new property releasable which will control if a particular module will produce artifacts to be consumed outside of R3, this replaces the concept of a whitelist in DP1.

Note we only want the top level plugin published externally currently, to prevent this cascading down to the subprojects we explicitly set these as false 

Also add convince task releasable which can be ran to output the list of modules which will produce releasable artifacts.
Sample output:


```net.corda:corda-application:5.0.0.167-SNAPSHOT [:application]
 * corda-application-5.0.0.167-SNAPSHOT-javadoc.jar
 * application-5.0.0.167-SNAPSHOT-sources.jar
 * corda-application-5.0.0.167-SNAPSHOT.jar

net.corda:corda-base:5.0.0.167-SNAPSHOT [:base]
 * corda-base-5.0.0.167-SNAPSHOT-javadoc.jar
 * base-5.0.0.167-SNAPSHOT-sources.jar
 * corda-base-5.0.0.167-SNAPSHOT.jar

net.corda:corda-cipher-suite:5.0.0.167-SNAPSHOT [:cipher-suite]
 * corda-cipher-suite-5.0.0.167-SNAPSHOT-javadoc.jar
 * cipher-suite-5.0.0.167-SNAPSHOT-sources.jar
 * corda-cipher-suite-5.0.0.167-SNAPSHOT.jar

net.corda:corda-api:5.0.0.167-SNAPSHOT [:corda-api]
A task which outputs the inverse has also been added unReleasable ```

Related logic: https://github.com/corda/corda-internal-gradle-plugins/pull/47