### PR TITLE
NOTICK: Capture detailed explanations for sandbox bundle resolution problems.

### DIFF
--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
+import org.osgi.framework.BundleException
 import org.osgi.test.common.annotation.InjectBundleContext
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
@@ -52,5 +53,8 @@ class SandboxIrresolvableBundleTest {
         assertThat(e)
             .hasMessageStartingWith("Failed to resolve bundles: ")
             .hasMessageContaining("com.example.sandbox.sandbox-irresolvable-cpk")
+        assertThat(e.suppressed)
+            .allMatch { it is BundleException }
+            .hasSize(1)
     }
 }


### PR DESCRIPTION
We need to resolve all bundles within a sandbox group before trying to start any of them, but we also need to understand _why_ any bundles fail to resolve. Unfortunately, `FrameworkWiring.resolveBundles()` swallows all `BundleException` instances and just returns `false` :facepalm:.

Compensate for this by identifying all bundles which have failed to resolve, and then try to start them! This will try - and fail - to resolve them again, but this time we can catch the `BundleException` ourselves and add it to our `SandbxException` as a "suppressed" exception.