### PR TITLE
CORE-6432: ensure we release module externally

### DIFF
--- a/cordapp-test-utils/api/build.gradle
+++ b/cordapp-test-utils/api/build.gradle
@@ -2,6 +2,11 @@
 plugins {
     id 'org.jetbrains.kotlin.plugin.jpa'
     id 'org.jetbrains.kotlin.plugin.allopen'
+    id 'corda.common-publishing'
+}
+
+ext {
+    releasable = true
 }
 
 group = "net.corda"


### PR DESCRIPTION
- add publishing plugin which was missing
- add property which controls DP2 release artifacts `releasable`