### PR TITLE
CORE-6380: activate publishing to S3 bucket for corda-runtime-os

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,5 +10,7 @@ cordaPipeline(
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: true,
-    combinedWorkere2eTests: true
+    combinedWorkere2eTests: true,
+    // allow publishing artifacts to S3 bucket
+    publishToMavenS3Repository: true,
     )


### PR DESCRIPTION
* use newly introduced functionality of shared pipeline and set
  `publishToMavenS3Repository`