### PR TITLE
NOTICK - add retry to get cpi checksum which is flaky on combined worker

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -21,6 +21,7 @@ import net.corda.applications.workers.smoketest.virtualnode.helpers.assertWithRe
 import net.corda.applications.workers.smoketest.virtualnode.helpers.cluster
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -398,10 +399,14 @@ class VirtualNodeRpcTest {
         return Instant.parse(this.asText())
     }
 
-    fun ClusterBuilder.getCpiChecksum(cpiName: String): String {
-        val cpis = cpiList().toJson()["cpis"]
-        val cpiJson = cpis.toList().first { it["id"]["cpiName"].textValue() == cpiName }
-        return truncateLongHash(cpiJson["cpiFileChecksum"].textValue())
+    private fun ClusterBuilder.getCpiChecksum(cpiName: String): String {
+        val cpiFileChecksum = eventually {
+            val cpis = cpiList().toJson()["cpis"]
+            val cpiJson = cpis.toList().find { it["id"]["cpiName"].textValue() == cpiName }
+            assertNotNull(cpiJson, "Cpi with name $cpiName not yet found in cpi list.")
+            truncateLongHash(cpiJson!!["cpiFileChecksum"].textValue())
+        }
+        return cpiFileChecksum
     }
 
     private fun String.toJson(): JsonNode = ObjectMapper().readTree(this)


### PR DESCRIPTION
Failed buld: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os-combined-worker-e2e-tests/detail/release%2Fos%2F5.0/148/tests/

Failed test: `can upload CPI`

I believe this is flaky because CpiInfoReadService isn't updated quick enough after CPI is uploaded:
- cpi `flow-worker-dev` is uploaded
- test asserts the cpiStatus of the requestId which reads from `UploadStatusProcessor` which tracks status of requests using `cpi.upload.status` topic.
- later the test calls list CPIs ("api/v1/cpi" GET) and looks for the uploaded CPI
- this reads CPI info from `cpiInfoReadService` using `cpi.info` topic

