### PR TITLE
CORE-6523: Improve Jenkins to Splunk hyperlink

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -187,7 +187,7 @@ pipeline {
             findBuildScans()
             splunkLogGenerator()
             script{
-                createSummary("yellow.png").appendText("<a href='https://r3ll3.splunkcloud.com/en-US/app/r3_kubernetes_app/kubernetes_overview?form.period.earliest=0&form.period.latest=&form.span=5m&form.cluster=eks-e2e&form.namespace=${NAMESPACE}&form.pod=*'>Splunk K8s E2E Dashboard</a>", false)
+                createSummary("yellow.png").appendText("<a href='https://r3ll3.splunkcloud.com/en-US/app/r3_kubernetes_app/namespace_details?form.namespace=${NAMESPACE}&form.cluster_name=eks-e2e&form.period.earliest=0&form.period.latest=&form.span=5m&form.pod=*&form.event_message=*'>Splunk K8s E2E Dashboard</a>", false)
                 writeFile file: "e2eTestDataForSplunk.log", text: "${env.BUILD_URL}\n${NAMESPACE}"
                 archiveArtifacts artifacts: "e2eTestDataForSplunk.log", fingerprint: true
             }


### PR DESCRIPTION
At the moment, there is loading issue when loading the namespace details from the Splunk hyperlink feature in Splunk.
* Improve Splunk Kubernetes dashboard loading time and added new features for namespace logging events.
* Redirect hyperlink to namespace_details instead of namespace_overview page.