### PR TITLE
CORE-6146 - Add configuration for websocket idle timeout

### DIFF
--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
@@ -8,7 +8,6 @@ import net.corda.data.flow.FlowKey
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.rpcops.FlowStatusCacheService
-import net.corda.flow.rpcops.flowstatus.FlowStatusListenerValidationException
 import net.corda.flow.rpcops.flowstatus.FlowStatusUpdateListener
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
@@ -45,7 +45,6 @@ class FlowStatusCacheServiceImpl @Activate constructor(
 
     private companion object {
         val log = contextLogger()
-        const val MAX_WEBSOCKET_CONNECTIONS_PER_FLOW_KEY = 10
     }
 
     private var flowStatusSubscription: CompactedSubscription<FlowKey, FlowStatus>? = null
@@ -134,8 +133,6 @@ class FlowStatusCacheServiceImpl @Activate constructor(
     ): AutoCloseable {
         val flowKey = FlowKey(clientRequestId, holdingIdentity)
 
-        validateMaxConnectionsPerFlowKey(flowKey)
-
         lock.writeLock().withLock {
             statusListenersPerFlowKey.put(flowKey, listener)
         }
@@ -164,19 +161,6 @@ class FlowStatusCacheServiceImpl @Activate constructor(
                 "Unregistered flow status listener: ${listener.id} for clientId: $clientRequestId." +
                         " Total number of open listeners: ${statusListenersPerFlowKey.size()}."
             )
-        }
-    }
-
-    private fun validateMaxConnectionsPerFlowKey(flowKey: FlowKey) {
-        val existingHandlers = lock.readLock().withLock { statusListenersPerFlowKey[flowKey] }
-        val handlersForRequestAndHoldingIdAlreadyExist = existingHandlers != null && existingHandlers.isNotEmpty()
-        if (handlersForRequestAndHoldingIdAlreadyExist) {
-            if (existingHandlers.size >= MAX_WEBSOCKET_CONNECTIONS_PER_FLOW_KEY) {
-                throw FlowStatusListenerValidationException(
-                    "Max WebSocket connections ($MAX_WEBSOCKET_CONNECTIONS_PER_FLOW_KEY) reached for req: ${flowKey.id}, " +
-                            "identity ${flowKey.identity.toCorda().shortHash}."
-                )
-            }
         }
     }
 

--- a/components/http-rpc-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/HttpRpcGatewayEventHandler.kt
+++ b/components/http-rpc-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/HttpRpcGatewayEventHandler.kt
@@ -36,6 +36,7 @@ import net.corda.schema.configuration.ConfigKeys.RPC_CONFIG
 import net.corda.schema.configuration.ConfigKeys.RPC_CONTEXT_DESCRIPTION
 import net.corda.schema.configuration.ConfigKeys.RPC_CONTEXT_TITLE
 import net.corda.schema.configuration.ConfigKeys.RPC_MAX_CONTENT_LENGTH
+import net.corda.schema.configuration.ConfigKeys.RPC_WEBSOCKET_CONNECTION_IDLE_TIMEOUT_MS
 import net.corda.utilities.NetworkHostAndPort
 import net.corda.utilities.PathProvider
 import net.corda.utilities.TempPathProvider
@@ -203,7 +204,8 @@ internal class HttpRpcGatewayEventHandler(
             ),
             ssl = HttpRpcSSLSettings(keyStoreInfo.path, keyStoreInfo.password),
             sso = config.retrieveSsoOptions(),
-            maxContentLength = config.retrieveMaxContentLength()
+            maxContentLength = config.retrieveMaxContentLength(),
+            webSocketIdleTimeoutMs = config.getInt(RPC_WEBSOCKET_CONNECTION_IDLE_TIMEOUT_MS).toLong()
         )
 
         val multiPartDir = tempPathProvider.getOrCreate(config, MULTI_PART_DIR)

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/java/net/corda/httprpc/client/HttpRpcJavaClientIntegrationTest.java
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/java/net/corda/httprpc/client/HttpRpcJavaClientIntegrationTest.java
@@ -28,7 +28,8 @@ public class HttpRpcJavaClientIntegrationTest extends HttpRpcIntegrationTestBase
             HttpRpcIntegrationTestBase.Companion.getContext(),
             null,
             null,
-            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
         );
         HttpRpcIntegrationTestBase.Companion.setServer(
                 new HttpRpcServerImpl(

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientAadIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientAadIntegrationTest.kt
@@ -27,7 +27,8 @@ class HttpRpcClientAadIntegrationTest : HttpRpcIntegrationTestBase() {
             context,
             null,
             SsoSettings(AzureAdSettings(AzureAdMock.clientId, null, AzureAdMock.tenantId, trustedIssuers = listOf(AzureAdMock.issuer))),
-            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
         )
         server = HttpRpcServerImpl(
             listOf(TestHealthCheckAPIImpl()),

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
@@ -54,7 +54,8 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
                 context,
                 null,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcSSLClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcSSLClientIntegrationTest.kt
@@ -40,7 +40,8 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
                 context,
                 sslConfig,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(TestHealthCheckAPIImpl(), CustomSerializationAPIImpl()),

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerAzureAdTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerAzureAdTest.kt
@@ -32,10 +32,16 @@ class HttpRpcServerAzureAdTest {
     @BeforeEach
     fun setUp() {
         securityManager = FakeSecurityManager()
-        httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost", findFreePort()),
-                HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description"),
-                null,
-                SsoSettings(AzureAdSettings(AzureAdMock.clientId, null, AzureAdMock.tenantId, trustedIssuers = listOf(AzureAdMock.issuer))), HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE)
+        httpRpcSettings = HttpRpcSettings(
+            NetworkHostAndPort("localhost", findFreePort()),
+            HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description"),
+            null,
+            SsoSettings(
+                AzureAdSettings(AzureAdMock.clientId, null, AzureAdMock.tenantId, trustedIssuers = listOf(AzureAdMock.issuer))
+            ),
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
+        )
         httpRpcServer = HttpRpcServerImpl(
             listOf(TestHealthCheckAPIImpl()),
             ::securityManager,

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveLoginTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveLoginTest.kt
@@ -24,7 +24,8 @@ class HttpRpcServerCaseSensitiveLoginTest: HttpRpcServerTestBase() {
                 context,
                 null,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(TestHealthCheckAPIImpl()),

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveUrlTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveUrlTest.kt
@@ -22,7 +22,7 @@ class HttpRpcServerCaseSensitiveUrlTest: HttpRpcServerTestBase() {
         @JvmStatic
         @Suppress("Unused")
         fun setUpBeforeClass() {
-            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost", findFreePort()), context, null, null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE)
+            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost", findFreePort()), context, null, null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE, 20000L)
             server = HttpRpcServerImpl(
                 listOf(TestHealthCheckAPIImpl()),
                 ::securityManager,

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerDurableStreamsRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerDurableStreamsRequestsTest.kt
@@ -25,7 +25,7 @@ class HttpRpcServerDurableStreamsRequestsTest {
         @BeforeAll
         @JvmStatic
         fun setUpBeforeClass() {
-            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost",  findFreePort()), HttpRpcServerTestBase.context, null, null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE)
+            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost",  findFreePort()), HttpRpcServerTestBase.context, null, null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE, 20000L)
             HttpRpcServerTestBase.server = HttpRpcServerImpl(
                 listOf(NumberSequencesRPCOpsImpl(), CalendarRPCOpsImpl(), TestHealthCheckAPIImpl(), CustomSerializationAPIImpl()),
                 { FakeSecurityManager() } ,

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
@@ -25,7 +25,8 @@ class HttpRpcServerJsonObjectTest : HttpRpcServerTestBase() {
                 context,
                 null,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerLifecycleTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerLifecycleTest.kt
@@ -28,7 +28,8 @@ class HttpRpcServerLifecycleTest : HttpRpcServerTestBase() {
                 context,
                 null,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(lifecycleRPCOpsImpl),

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerMaxContentLengthTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerMaxContentLengthTest.kt
@@ -23,7 +23,7 @@ class HttpRpcServerMaxContentLengthTest : HttpRpcServerTestBase() {
         @BeforeAll
         @JvmStatic
         fun setUpBeforeClass() {
-            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost",  findFreePort()), context, null, null, MAX_CONTENT_LENGTH)
+            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost",  findFreePort()), context, null, null, MAX_CONTENT_LENGTH, 20000L)
             server = HttpRpcServerImpl(
                 listOf(TestHealthCheckAPIImpl()),
                 ::securityManager,

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
@@ -45,7 +45,8 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
             context,
             null,
             null,
-            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
         )
 
         @BeforeAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
@@ -41,7 +41,8 @@ class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
                 context,
                 null,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerResponseEntityTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerResponseEntityTest.kt
@@ -29,7 +29,8 @@ class HttpRpcServerResponseEntityTest : HttpRpcServerTestBase() {
                 context,
                 null,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerWebsocketTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerWebsocketTest.kt
@@ -21,7 +21,8 @@ class HttpRpcServerWebsocketTest : AbstractWebsocketTest() {
             context,
             null,
             null,
-            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
         )
 
         @BeforeAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpsRpcServerWebsocketTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpsRpcServerWebsocketTest.kt
@@ -39,7 +39,8 @@ class HttpsRpcServerWebsocketTest : AbstractWebsocketTest() {
                 context,
                 sslConfig,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
 
             server = HttpRpcServerImpl(

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/InvalidRequestTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/InvalidRequestTest.kt
@@ -36,7 +36,8 @@ class InvalidRequestTest : HttpRpcServerTestBase() {
                 context,
                 null,
                 null,
-                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+                HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+                20000L
             )
             server = HttpRpcServerImpl(
                 listOf(TestHealthCheckAPIImpl(), TestJavaPrimitivesRPCopsImpl()),

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/RouteProvider.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/RouteProvider.kt
@@ -156,12 +156,15 @@ internal class RouteInfo(
         securityManager: HttpRpcSecurityManager,
         credentialResolver: DefaultCredentialResolver,
         webSocketCloserService: WebSocketCloserService,
-        adaptors: MutableList<AutoCloseable>
+        adaptors: MutableList<AutoCloseable>,
+        webSocketIdleTimeoutMs: Long
     ): (WsConfig) -> Unit {
         return { wsConfig ->
             log.info("Setting-up WS call for '$fullPath'")
             try {
-                val adaptor = WebSocketRouteAdaptor(this, securityManager, credentialResolver, webSocketCloserService)
+                val adaptor = WebSocketRouteAdaptor(
+                    this, securityManager, credentialResolver, webSocketCloserService, webSocketIdleTimeoutMs
+                )
                 wsConfig.onMessage(adaptor)
                 wsConfig.onClose(adaptor)
                 wsConfig.onConnect(adaptor)

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
@@ -375,7 +375,13 @@ internal class HttpRpcServerInternal(
 
             ws(
                 routeInfo.fullPath,
-                routeInfo.setupWsCall(securityManager, credentialResolver, webSocketCloserService, webSocketRouteAdaptors)
+                routeInfo.setupWsCall(
+                    securityManager,
+                    credentialResolver,
+                    webSocketCloserService,
+                    webSocketRouteAdaptors,
+                    configurationsProvider.getWebSocketIdleTimeoutMs()
+                )
             )
 
             log.debug { "Add WS handler for \"${routeInfo.fullPath}\" completed." }

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebSocketRouteAdaptor.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebSocketRouteAdaptor.kt
@@ -36,12 +36,12 @@ internal class WebSocketRouteAdaptor(
     private val routeInfo: RouteInfo,
     private val securityManager: HttpRpcSecurityManager,
     private val credentialResolver: DefaultCredentialResolver,
-    private val webSocketCloserService: WebSocketCloserService
+    private val webSocketCloserService: WebSocketCloserService,
+    private val webSocketIdleTimeoutMs: Long
 ) : WsMessageHandler, WsCloseHandler, WsConnectHandler, WsErrorHandler, AutoCloseable {
 
     private companion object {
         val log = contextLogger()
-        const val WEBSOCKET_IDLE_TIMEOUT = 20000L
     }
 
     private val channelsBySessionId = ConcurrentHashMap<SessionId, DuplexChannel>()
@@ -59,7 +59,7 @@ internal class WebSocketRouteAdaptor(
             ServerDuplexChannel(ctx, webSocketCloserService, ctx.sessionId).let { newChannel ->
                 channelsBySessionId[ctx.sessionId] = newChannel
 
-                ctx.session.idleTimeout = WEBSOCKET_IDLE_TIMEOUT
+                ctx.session.idleTimeout = webSocketIdleTimeoutMs
                 val clientWsRequestContext = ClientWsRequestContext(ctx)
 
                 try {

--- a/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/config/models/HttpRpcSettingsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/test/kotlin/net/corda/httprpc/server/impl/config/models/HttpRpcSettingsTest.kt
@@ -31,7 +31,9 @@ class HttpRpcSettingsTest {
                     tenantId,
                     trustedIssuers = listOf(issuer)
                 )
-            ), HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            ),
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
         )
             .toString()
 

--- a/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/config/HttpRpcSettingsProvider.kt
+++ b/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/config/HttpRpcSettingsProvider.kt
@@ -58,4 +58,9 @@ interface HttpRpcSettingsProvider {
     fun getSsoSettings(): SsoSettingsProvider?
 
     fun maxContentLength(): Int
+
+    /**
+     * @return The time (in milliseconds) after which an idle websocket connection will be timed out and closed
+     */
+    fun getWebSocketIdleTimeoutMs(): Long
 }

--- a/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/config/impl/HttpRpcObjectSettingsProvider.kt
+++ b/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/config/impl/HttpRpcObjectSettingsProvider.kt
@@ -47,4 +47,6 @@ class HttpRpcObjectSettingsProvider(
     override fun getSsoSettings(): SsoSettingsProvider? = ssoSettingsProvider
 
     override fun maxContentLength(): Int = httpRpcSettings.maxContentLength
+
+    override fun getWebSocketIdleTimeoutMs(): Long = httpRpcSettings.webSocketIdleTimeoutMs
 }

--- a/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/config/models/HttpRpcSettings.kt
+++ b/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/config/models/HttpRpcSettings.kt
@@ -10,7 +10,11 @@ data class HttpRpcSettings(
     /**
      * The maximum content length in bytes accepted for POST requests
      */
-    val maxContentLength: Int
+    val maxContentLength: Int,
+    /**
+     * The time (in milliseconds) after which an idle websocket connection will be timed out and closed
+     */
+    val webSocketIdleTimeoutMs: Long
 ) {
     companion object {
         const val MAX_CONTENT_LENGTH_DEFAULT_VALUE = 1024 * 1024

--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
@@ -111,7 +111,8 @@ class OpenApiCompatibilityTest {
             context,
             null,
             null,
-            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE
+            HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
         )
 
         val server = httpServerFactory.createHttpRpcServer(


### PR DESCRIPTION
https://github.com/corda/corda-api/pull/547
- remove validation on flow key as this is redundant.
- update corda-api revision to use alpha build with websocket default and configuration

I tested locally using combined worker. 
- Default config is 30 seconds idle timeout
- Confirmed it took 30 seconds for websocket connection to close via timeout.
- `PUT /config` request with below payload to change timeout to 10 seconds
- Confirmed it took 10 seconds for websocket connection to close via timeout

```
{
    "section": "corda.rpc",
    "version": 0,
    "config": "{\"websocket\": {\"idleTimeoutMs\": 10000}}",
    "schemaVersion": {
        "major": 1,
        "minor": 0
    }
}
```