### PR TITLE
CORE-6502: Look for peer in all the local members view

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -607,15 +607,18 @@ internal class SessionManagerImpl(
         }
 
         val initiatorIdentityData = session.getInitiatorIdentity()
-        val hostedIdentityInSameGroup = linkManagerHostingMap.allLocallyHostedIdentities()
-            .find { it.groupId == initiatorIdentityData.groupId }
-        if (hostedIdentityInSameGroup == null) {
+        val hostedIdentitiesInSameGroup = linkManagerHostingMap.allLocallyHostedIdentities()
+            .filter { it.groupId == initiatorIdentityData.groupId }
+        if (hostedIdentitiesInSameGroup.isEmpty()) {
             logger.warn("There is no locally hosted identity in group ${initiatorIdentityData.groupId}. The initiator handshake message" +
                     " was discarded.")
             return null
         }
 
-        val peer = members.getMemberInfo(hostedIdentityInSameGroup, initiatorIdentityData.initiatorPublicKeyHash.array())
+        val peer = hostedIdentitiesInSameGroup
+            .firstNotNullOfOrNull {
+                members.getMemberInfo(it, initiatorIdentityData.initiatorPublicKeyHash.array())
+            }
         if (peer == null) {
             logger.peerHashNotInMembersMapWarning(
                 message::class.java.simpleName,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -559,16 +559,15 @@ internal class SessionManagerImpl(
         }
 
         val sessionManagerConfig = config.get()
-        val sourceAndPeer = hostedIdentitiesInSameGroup
-            .firstNotNullOfOrNull {
-                val member = members.getMemberInfo(it, message.source.initiatorPublicKeyHash.array())
+        val (hostedIdentityInSameGroup, peer) = hostedIdentitiesInSameGroup
+            .firstNotNullOfOrNull { hostedIdentityInSameGroup ->
+                val member = members.getMemberInfo(hostedIdentityInSameGroup, message.source.initiatorPublicKeyHash.array())
                 if (member == null) {
                     null
                 } else {
-                    it to member
+                    hostedIdentityInSameGroup to member
                 }
-            }
-        if (sourceAndPeer == null) {
+            } ?: let {
             logger.peerHashNotInMembersMapWarning(
                 message::class.java.simpleName,
                 message.header.sessionId,
@@ -577,9 +576,9 @@ internal class SessionManagerImpl(
             return null
         }
 
-        val groupInfo = groups.getGroupInfo(sourceAndPeer.first)
+        val groupInfo = groups.getGroupInfo(hostedIdentityInSameGroup)
         if (groupInfo == null) {
-            logger.couldNotFindGroupInfo(message::class.java.simpleName, message.header.sessionId, sourceAndPeer.first)
+            logger.couldNotFindGroupInfo(message::class.java.simpleName, message.header.sessionId, hostedIdentityInSameGroup)
             return null
         }
 
@@ -594,8 +593,8 @@ internal class SessionManagerImpl(
         }
         val responderHello = session.generateResponderHello()
 
-        logger.info("Remote identity ${sourceAndPeer.second.holdingIdentity} initiated new session ${message.header.sessionId}.")
-        return createLinkOutMessage(responderHello, sourceAndPeer.first, sourceAndPeer.second, groupInfo.networkType)
+        logger.info("Remote identity ${peer.holdingIdentity} initiated new session ${message.header.sessionId}.")
+        return createLinkOutMessage(responderHello, hostedIdentityInSameGroup, peer, groupInfo.networkType)
     }
 
     private fun processInitiatorHandshake(message: InitiatorHandshakeMessage): LinkOutMessage? {
@@ -616,8 +615,8 @@ internal class SessionManagerImpl(
         }
 
         val peer = hostedIdentitiesInSameGroup
-            .firstNotNullOfOrNull {
-                members.getMemberInfo(it, initiatorIdentityData.initiatorPublicKeyHash.array())
+            .firstNotNullOfOrNull { hostedIdentityInSameGroup ->
+                members.getMemberInfo(hostedIdentityInSameGroup, initiatorIdentityData.initiatorPublicKeyHash.array())
             }
         if (peer == null) {
             logger.peerHashNotInMembersMapWarning(

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -69,6 +69,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -508,7 +509,7 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `when an initiator hello is received, we will try all the locally hosted identities`() {
+    fun `when an initiator hello is received, we do a lookup for the public key hash, using all the locally hosted identities`() {
         val sessionId = "some-session-id"
         val responderHello = mock<ResponderHelloMessage>()
         val carol = createTestHoldingIdentity("CN=Carol, O=Alice Corp, L=LDN, C=GB", GROUP_ID)
@@ -758,6 +759,48 @@ class SessionManagerTest {
         assertThat(sessionManager.getSessionById(sessionId)).isInstanceOfSatisfying(SessionManager.SessionDirection.Inbound::class.java) {
             assertThat(it.session).isEqualTo(session)
         }
+    }
+
+    @Test
+    fun `when initiator handshake is received, we do a lookup for the public key hash, using all the locally hosted identities`() {
+        val sessionId = "some-session-id"
+        val initiatorPublicKeyHash = messageDigest.hash(PEER_KEY.public.encoded)
+        val responderPublicKeyHash = messageDigest.hash(OUR_KEY.public.encoded)
+        whenever(protocolResponder.generateResponderHello()).thenReturn(mock())
+        val carol = createTestHoldingIdentity("CN=Carol, O=Alice Corp, L=LDN, C=GB", GROUP_ID)
+        val david = createTestHoldingIdentity("CN=David, O=Alice Corp, L=LDN, C=GB", GROUP_ID)
+        whenever(linkManagerHostingMap.allLocallyHostedIdentities()).thenReturn(
+            listOf(
+                carol,
+                david,
+                OUR_PARTY,
+            )
+        )
+
+        val initiatorHelloHeader = CommonHeader(MessageType.INITIATOR_HELLO, 1, sessionId, 1, Instant.now().toEpochMilli())
+        val initiatorHelloMessage = InitiatorHelloMessage(initiatorHelloHeader, ByteBuffer.wrap(PEER_KEY.public.encoded),
+            PROTOCOL_MODES, InitiatorHandshakeIdentity(ByteBuffer.wrap(messageDigest.hash(PEER_KEY.public.encoded)), GROUP_ID))
+        sessionManager.processSessionMessage(LinkInMessage(initiatorHelloMessage))
+
+        val initiatorHandshakeHeader = CommonHeader(MessageType.INITIATOR_HANDSHAKE, 1, sessionId, 3, Instant.now().toEpochMilli())
+        val initiatorHandshakeMessage = InitiatorHandshakeMessage(initiatorHandshakeHeader, RANDOM_BYTES, RANDOM_BYTES)
+        whenever(protocolResponder.getInitiatorIdentity())
+            .thenReturn(InitiatorHandshakeIdentity(ByteBuffer.wrap(initiatorPublicKeyHash), GROUP_ID))
+        whenever(
+            protocolResponder.validatePeerHandshakeMessage(
+                initiatorHandshakeMessage,
+                PEER_KEY.public,
+                SignatureSpec.ECDSA_SHA256,
+            )
+        ).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
+        val responderHandshakeMsg = mock<ResponderHandshakeMessage>()
+        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), any())).thenReturn(responderHandshakeMsg)
+        val session = mock<Session>()
+        whenever(protocolResponder.getSession()).thenReturn(session)
+        sessionManager.processSessionMessage(LinkInMessage(initiatorHandshakeMessage))
+
+        verify(members, atLeast(1)).getMemberInfo(eq(carol), any<ByteArray>())
+        verify(members, atLeast(1)).getMemberInfo(eq(david), any<ByteArray>())
     }
 
     @Test


### PR DESCRIPTION
This will allow the Link Manager to field a member by public key if some of the locally hosted identities are still not aware of the entity.

During registration, only the MGM knows about the entities that are trying to register, so if we look at the first locally hosted identity, we might find an identity that is not the MGM, and then we won't be able to find the peer, and won't be able to complete the registration.