### PR TITLE
NOTICK : Automatic Setup Scripts

### DIFF
--- a/hack/minikube.sh
+++ b/hack/minikube.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$(dirname "$0")
+set -o errexit -o pipefail
+
+# Colors
+NO_COLOR='\033[0m'
+INFO_COLOR='\033[1;32m'
+WARN_COLOR='\033[0;31m'
+
+# Install namespace, 'corda' by default
+CORDA_NAMESPACE=${CORDA_NAMESPACE:-"corda"}
+
+# Kubernetes Version, 'latest' by default
+CLUSTER_VERSION=${CLUSTER_VERSION:-"latest"}
+
+function info() {
+  echo -e "${INFO_COLOR}"["$(date '+%F %T')"]: "${1}${NO_COLOR}"
+}
+
+function warn() {
+  echo -e "${WARN_COLOR}"["$(date '+%F %T')"]: "${1}${NO_COLOR}"
+}
+
+function check_script_pre_requisites() {
+  command -v helm >/dev/null 2>&1 || { warn "helm must be installed"; exit 1; }
+  command -v kubectl >/dev/null 2>&1 || { warn "kubectl must be installed"; exit 1; }
+  command -v minikube >/dev/null 2>&1 || { warn "minikube must be installed"; exit 1; }
+}
+
+function setUp() {
+  info "Creating MiniKube Cluster With Version ${CLUSTER_VERSION}..."
+  minikube start --cpus=6 --memory=8G --kubernetes-version="${CLUSTER_VERSION}"
+  kubectl cluster-info --context minikube
+  eval "$(minikube docker-env)"
+
+  info "Deploying Pre-Requisites..."
+  kubectl create namespace "${CORDA_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+  pushd "${SCRIPT_DIR}/../../corda-dev-helm" >>/dev/null
+    helm repo add bitnami https://charts.bitnami.com/bitnami
+    helm dependency build charts/corda-dev
+    helm upgrade --install prereqs --namespace "${CORDA_NAMESPACE}" charts/corda-dev --render-subchart-notes --timeout 10m --wait
+  popd >>/dev/null
+
+  info "Pushing Corda Docker Images..."
+  pushd "${SCRIPT_DIR}/../../corda-runtime-os" >>/dev/null
+    ./gradlew publishOSGiImage --parallel
+  popd >>/dev/null
+
+  info "Deploying Corda..."
+  pushd "${SCRIPT_DIR}/../../corda-runtime-os" >>/dev/null
+    helm install corda --namespace "${CORDA_NAMESPACE}" charts/corda --values values.yaml --wait
+  popd >>/dev/null
+
+  info "Setting Up Port Forwarding..."
+  set +o errexit
+  PID=$(pgrep kubectl port-forward deployment/port-forward corda-rpc-worker)
+  [[ -n "${PID}" ]] && kill -9 "${PID}" >>/dev/null
+  rm -Rf portforward-*.log >>/dev/null
+  set -o errexit
+  kubectl port-forward --namespace "${CORDA_NAMESPACE}" deployment/corda-rpc-worker 8888 > ./portforward-rpc-worker.log 2>&1 &
+
+  info "Retrieving Default Corda Credentials..."
+  CORDA_USERNAME=$(kubectl --namespace "${CORDA_NAMESPACE}" get secret corda-initial-admin-user -o go-template='{{ .data.username | base64decode }}')
+  CORDA_PASSWORD=$(kubectl --namespace "${CORDA_NAMESPACE}" get secret corda-initial-admin-user -o go-template='{{ .data.password | base64decode }}')
+
+  info "Done!. Default Credentials: ${CORDA_USERNAME}, ${CORDA_PASSWORD}. Swagger Endpoint: https://localhost:8888/api/v1/swagger"
+}
+
+function tearDown() {
+  info "Deleting Minikube Cluster..."
+  minikube delete
+}
+
+check_script_pre_requisites
+
+case "${1}" in
+  create)
+    setUp
+    ;;
+  delete)
+    tearDown
+    ;;
+  *)
+    echo "Usage: ${0##*/} [create|delete]"
+    ;;
+esac

--- a/hack/workstation-setup-macos.sh
+++ b/hack/workstation-setup-macos.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -o errexit -o pipefail -o nounset
+command -v brew >/dev/null 2>&1 || { warn "Homebrew must be installed -> https://brew.sh/"; exit 1; }
+
+export HOMEBREW_NO_ANALYTICS=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+
+# Install, or upgrade if already installed
+brew_up() {
+    if brew ls --versions "${1}" >/dev/null; then
+        brew upgrade "${1}"
+    else
+        brew install "${1}"
+    fi
+}
+
+echo "Caching Password..."
+sudo -K
+sudo true
+
+echo "Updating Homebrew..."
+brew update
+
+# Kubernetes Tools
+brew_up helm
+brew_up kubectl
+brew_up minikube
+brew_up derailed/k9s/k9s
+
+# Manage Multiple JDKs
+brew_up jenv
+
+# Docker Desktop for Mac
+brew install --cask docker
+
+echo
+echo "Recommended zsh setup for auto-complete and aliases:"
+echo "  1. Install OhMyZSH (https://ohmyz.sh/)"
+echo "  2. Enable plugins git, helm, docker, kubectl (https://github.com/ohmyzsh/ohmyzsh/wiki/Plugins)"


### PR DESCRIPTION
Make it easier for developers to install the required dev tools and set
up a local Kubernetes cluster with Corda installed.

- Add "hack" directory to host helper scripts.
- Create automatic script to install required dev tools for macOS.
- Create script to start local minikube cluster, install prerequisites
  and deploy Corda from scratch.