### PR TITLE
CORE-6553 - fix issue caused by println

### DIFF
--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicy.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicy.kt
@@ -279,6 +279,8 @@ class ConsoleGroupPolicyOutput : GroupPolicyOutput {
      * Receives the content of the file and prints it to the console output. It makes the testing easier.
      */
     override fun generateOutput(content: String) {
-        println(content)
+        content.lines().forEach {
+            println(it)
+        }
     }
 }


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-6553

Seems like println has a limit for large strings an adds additional new lines. Fix was to print everything out line by line.