### PR TITLE
CORE-6558: Example app refactored with better tests

### DIFF
--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/AbsenceCallResponderFlow.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/AbsenceCallResponderFlow.kt
@@ -1,0 +1,20 @@
+package net.cordacon.example
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.Suspendable
+
+@InitiatedBy("absence-call")
+class AbsenceCallResponderFlow: ResponderFlow {
+
+    @CordaInject
+    lateinit var flowEngine: FlowEngine
+
+    @Suspendable
+    override fun call(session: FlowSession) {
+        ResponderFlowDelegate().callDelegate(session, flowEngine)
+    }
+}

--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/AbsenceSubFlow.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/AbsenceSubFlow.kt
@@ -1,0 +1,22 @@
+package net.cordacon.example
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.InitiatingFlow
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.types.MemberX500Name
+
+@InitiatingFlow("absence-call")
+class AbsenceSubFlow(val counterparty: MemberX500Name) : SubFlow<String> {
+
+    @CordaInject
+    lateinit var flowMessaging: FlowMessaging
+
+    @Suspendable
+    override fun call(): String {
+        val session = flowMessaging.initiateFlow(counterparty)
+        session.send(RollCallRequest(counterparty.toString()))
+        return session.receive(RollCallResponse::class.java).unwrap {it}.response
+    }
+}

--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/ResponderFlowDelegate.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/ResponderFlowDelegate.kt
@@ -4,6 +4,7 @@ import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.util.contextLogger
+import net.cordacon.example.utils.rollCallName
 
 class ResponderFlowDelegate {
 

--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/RollCallFlow.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/RollCallFlow.kt
@@ -2,12 +2,9 @@ package net.cordacon.example
 
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
-import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RPCRequestData
 import net.corda.v5.application.flows.RPCStartableFlow
-import net.corda.v5.application.flows.ResponderFlow
-import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
@@ -17,29 +14,23 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
+import net.cordacon.example.utils.createScript
+import net.cordacon.example.utils.findStudents
+import net.cordacon.example.utils.rollCallName
 import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
 
 
-val MemberX500Name.rollCallName: String
-    get() {
-        return this.commonName ?: this.organisation
-    }
-
-private val MemberX500Name.regOrderer: String
-    get() {
-        // Put Busch before Bueller when sorted alphabetically
-        return this.rollCallName.replace("Busch", "Bua")
-    }
-
 @InitiatingFlow("roll-call")
 class RollCallFlow: RPCStartableFlow {
 
+    private data class SessionAndRecipient(val flowSession: FlowSession, val receipient : MemberX500Name)
+    private data class SessionAndResponse(val flowSession: FlowSession, val response : String)
+
     private companion object {
         private const val RETRIES: Int = 2
-        private val nl = System.lineSeparator()
         val log = contextLogger()
     }
 
@@ -63,97 +54,64 @@ class RollCallFlow: RPCStartableFlow {
         log.info("Flow invoked")
         log.info("Initiating roll call")
 
-        val students = memberLookup.lookup().minus(memberLookup.myInfo()).sortedBy { it.name.regOrderer }
+        val students = findStudents(memberLookup)
 
         val sessionsAndRecipients = students.map {
-            Pair(flowMessaging.initiateFlow(it.name), it.name)
+            SessionAndRecipient(flowMessaging.initiateFlow(it.name), it.name)
         }
 
         log.info("Roll call initiated; waiting for responses")
-        val teacherPrompt = flowEngine.virtualNodeName.rollCallName.uppercase()
         val responses = sessionsAndRecipients.map {
-            val firstResponses = listOf(Pair(
-                it.first, it.first.sendAndReceive(
-                    RollCallResponse::class.java,
-                    RollCallRequest(it.second.toString())
-                ).unwrap { r -> r }.response
-            ))
-            val rechecks = firstResponses.filter { r -> r.second.isEmpty() }
-                .map { r ->
-                    val absenceResponses = retryRollCall(r)
-                    if (absenceResponses.none{ar -> ar.response.isNotEmpty()}) {
-                        persistenceService.persist(AbsenceRecordEntity(name = r.first.counterparty.rollCallName))
-                        absenceResponses.map { _ -> Pair(r.first, "") }
-                    } else {
-                        listOf(
-                            Pair(r.first, absenceResponses.first { ar -> ar.response.isNotEmpty() }.response))
-                    }
-                }.flatten()
+            val firstResponses = sendRollCall(it)
+            val absenteeSessions = firstResponses.filter { r -> r.response.isEmpty() }
+                .map { (flowSession) -> flowSession }
+            val rechecks = sendRetries(absenteeSessions)
             firstResponses + rechecks
         }.flatten()
 
-        return responses.joinToString("") {
-            val student = it.first.counterparty.rollCallName
-            val teacherAsking = "$teacherPrompt: $student?$nl"
-            val studentResponding =
-                if (it.second.isNotEmpty()) {
-                    student.uppercase() + ": " + it.second + nl
-                } else {
-                    ""
-                }
-            teacherAsking + studentResponding
-        }
+        val studentsAndResponses = responses
+            .map { Pair(it.flowSession.counterparty, it.response) }
+        return createScript(studentsAndResponses, flowEngine.virtualNodeName)
     }
 
     @Suspendable
-    private fun retryRollCall(
-        r: Pair<FlowSession, String>
-    ): List<AbsenceResponse> {
+    private fun sendRollCall(sessionAndRecipient: SessionAndRecipient) =
+        listOf(
+            SessionAndResponse(
+                sessionAndRecipient.flowSession,
+                sessionAndRecipient.flowSession.sendAndReceive(
+                    RollCallResponse::class.java,
+                    RollCallRequest(sessionAndRecipient.receipient.toString())
+                ).unwrap { r -> r }.response
+            )
+        )
+
+    @Suspendable
+    private fun sendRetries(absenteeSessions: List<FlowSession>) =
+        absenteeSessions.map { session ->
+                val absenceResponses = retryRollCall(session)
+                if (absenceResponses.none { (response) -> response.isNotEmpty() }) {
+                    persistenceService.persist(AbsenceRecordEntity(name = session.counterparty.rollCallName))
+                    absenceResponses.map { SessionAndResponse(session, "") }
+                } else {
+                    listOf(
+                        SessionAndResponse(
+                            session, absenceResponses.first { (response) -> response.isNotEmpty() }.response
+                        )
+                    )
+                }
+            }.flatten()
+
+
+    @Suspendable
+    private fun retryRollCall(session: FlowSession): List<AbsenceResponse> {
         var retries = 0
         val responses = mutableListOf<AbsenceResponse>()
         while(retries < RETRIES && responses.none { it.response.isNotEmpty() }) {
-            responses.add(AbsenceResponse(flowEngine.subFlow(AbsenceSubFlow(r.first.counterparty))))
+            responses.add(AbsenceResponse(flowEngine.subFlow(AbsenceSubFlow(session.counterparty))))
             retries++
         }
         return responses
-    }
-}
-
-@InitiatingFlow("absence-call")
-class AbsenceSubFlow(val counterparty: MemberX500Name) : SubFlow<String> {
-
-    @CordaInject
-    lateinit var flowMessaging: FlowMessaging
-
-    @Suspendable
-    override fun call(): String {
-        val session = flowMessaging.initiateFlow(counterparty)
-        session.send(RollCallRequest(counterparty.toString()))
-        return session.receive(RollCallResponse::class.java).unwrap {it}.response
-    }
-}
-
-@InitiatedBy("roll-call")
-class RollCallResponderFlow: ResponderFlow {
-
-    @CordaInject
-    lateinit var flowEngine: FlowEngine
-
-    @Suspendable
-    override fun call(session: FlowSession) {
-        ResponderFlowDelegate().callDelegate(session, flowEngine)
-    }
-}
-
-@InitiatedBy("absence-call")
-class AbsenceCallResponderFlow: ResponderFlow {
-
-    @CordaInject
-    lateinit var flowEngine: FlowEngine
-
-    @Suspendable
-    override fun call(session: FlowSession) {
-        ResponderFlowDelegate().callDelegate(session, flowEngine)
     }
 }
 

--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/RollCallResponderFlow.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/RollCallResponderFlow.kt
@@ -1,0 +1,20 @@
+package net.cordacon.example
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.Suspendable
+
+@InitiatedBy("roll-call")
+class RollCallResponderFlow: ResponderFlow {
+
+    @CordaInject
+    lateinit var flowEngine: FlowEngine
+
+    @Suspendable
+    override fun call(session: FlowSession) {
+        ResponderFlowDelegate().callDelegate(session, flowEngine)
+    }
+}

--- a/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/utils/RollCallUtils.kt
+++ b/cordapp-test-utils/example-app/src/main/kotlin/net/cordacon/example/utils/RollCallUtils.kt
@@ -1,0 +1,36 @@
+package net.cordacon.example.utils
+
+import net.corda.v5.application.membership.MemberLookup
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.MemberInfo
+
+@Suspendable
+fun findStudents(memberLookup: MemberLookup): List<MemberInfo> = memberLookup.lookup().minus(memberLookup.myInfo())
+
+fun createScript(
+    studentResponses: List<Pair<MemberX500Name, String>>,
+    teacher: MemberX500Name
+) = studentResponses.sortedBy { it.first.rollCallOrder }.joinToString("") {
+    val student = it.first.rollCallName
+    val teacherPrompt = teacher.rollCallName.uppercase()
+    val teacherAsking = "$teacherPrompt: $student?${System.lineSeparator()}"
+    val studentResponding =
+        if (it.second.isNotEmpty()) {
+            student.uppercase() + ": " + it.second + System.lineSeparator()
+        } else {
+            ""
+        }
+    teacherAsking + studentResponding
+}
+
+val MemberX500Name.rollCallName: String
+    get() {
+        return this.commonName ?: this.organisation
+    }
+
+val MemberX500Name.rollCallOrder: String
+    get() {
+        // Put Busch before Bueller when sorted alphabetically
+        return if(this.rollCallName =="Busch") "Bua" else this.rollCallName
+}

--- a/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/utils/RollCallUtilsTest.kt
+++ b/cordapp-test-utils/example-app/src/test/kotlin/net/cordacon/example/utils/RollCallUtilsTest.kt
@@ -1,0 +1,91 @@
+package net.cordacon.example.utils
+
+import net.corda.v5.application.membership.MemberLookup
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.MemberInfo
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RollCallUtilsTest {
+
+    private fun MemberX500Name.toMemberInfoMock(): MemberInfo {
+        val memberInfo = mock<MemberInfo>()
+        whenever(memberInfo.name).thenReturn(this)
+        return memberInfo
+    }
+
+    @Test
+    fun `find students should use the member lookup minus teacher (self)`() {
+
+        // Given a member lookup that knows about all the registrants including the teacher
+        val teacher = MemberX500Name.parse("CN=Teach, O=Org, L=London, C=GB")
+        val students = listOf("Alice", "Bob", "Charlie")
+            .map {MemberX500Name.parse("CN=it, O=Org, L=London, C=GB") }
+        val studentInfos = students.map { it.toMemberInfoMock() }
+        val teacherInfo = teacher.toMemberInfoMock()
+        val allInfo = listOf(studentInfos[0], studentInfos[2], teacherInfo, studentInfos[1])
+
+        val memberLookup = mock<MemberLookup>()
+        whenever(memberLookup.myInfo()).thenReturn(teacherInfo)
+        whenever(memberLookup.lookup()).thenReturn(allInfo)
+
+        // When we look up the students then the teacher should be removed
+        assertThat(findStudents(memberLookup).map {it.name}.sorted(), `is`(students))
+    }
+
+    @Test
+    fun `create script should use teacher then students while missing out empty responses`() {
+        // Given some students and their responses
+        val rollCallResult = listOf(
+            "Alice" to "Here",
+            "Bob" to "Yes",
+            "Charlie" to "",
+            "Charlie" to "",
+            "Charlie" to "Oh! Me?"
+        ).map { Pair(MemberX500Name.parse("CN=${it.first}, O=School, L=London, C=GB"), it.second) }
+
+        // When we create a script with them plus a teacher
+        val script = createScript(rollCallResult, MemberX500Name.parse("CN=Fred, O=School, L=London, C=GB"))
+
+        // Then it should read like a film script
+        assertThat(script, `is`("""
+            FRED: Alice?
+            ALICE: Here
+            FRED: Bob?
+            BOB: Yes
+            FRED: Charlie?
+            FRED: Charlie?
+            FRED: Charlie?
+            CHARLIE: Oh! Me?
+            
+        """.trimIndent().replace("\n", System.lineSeparator())))
+    }
+
+    @Test
+    fun `script for Ferris Bueller actually has Busch before Bueller`() {
+        // Given Bueller and Busch and responses
+        // Given some students and their responses
+        val rollCallResult = listOf(
+            "Anheiser" to "Here",
+            "Bueller" to "Here",
+            "Busch" to "Yes"
+        ).map { Pair(MemberX500Name.parse("CN=${it.first}, O=School, L=London, C=GB"), it.second) }
+
+        // When we create a script with them plus a teacher
+        val script = createScript(rollCallResult, MemberX500Name.parse("CN=Fred, O=School, L=London, C=GB"))
+
+        // Then Busch should come after Anheiser but before Bueller
+        assertThat(script, `is`("""
+            FRED: Anheiser?
+            ANHEISER: Here
+            FRED: Busch?
+            BUSCH: Yes
+            FRED: Bueller?
+            BUELLER: Here
+            
+        """.trimIndent().replace("\n", System.lineSeparator())))
+    }
+}


### PR DESCRIPTION
The example app was looking hugely procedural and becoming unwieldy to maintain, so this PR refactors out some utility methods with their own tests, and restructures the remaining code to be easier to read and understand.

- All flows are now in their own files.
- Initial roll call, and absentee retries, are in separate methods.
- The method to find students from MemberLookup is refactored out and tested
- The method to write the resulting script from the student responses is refactored out and tested
- The small hack to deal with two students not appearing in alphabetical order is also explained (note this never mattered until we started looking them up dynamically through MemberLookup).
