### PR TITLE
CORE-5944: Support FileHash dependencies

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -136,7 +136,8 @@ internal class DatabaseCpiPersistenceTest {
         val cpkId = CpkIdentifier(
             name = name,
             version = "cpk-version",
-            signerSummaryHash = cpkSignerSummaryHash
+            signerSummaryHash = cpkSignerSummaryHash,
+            fileHash = null
         )
 
         val cpkManifest = CpkManifest(CpkFormatVersion(1, 0))

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
@@ -116,7 +116,7 @@ class UpsertCpiTests {
         fileChecksum: SecureHash = newRandomSecureHash(),
         cpkSignerSummaryHash: SecureHash? = newRandomSecureHash()
     ) = mock<Cpk>().also { cpk ->
-        val cpkId = CpkIdentifier(name, "cpk-version", cpkSignerSummaryHash)
+        val cpkId = CpkIdentifier(name, "cpk-version", cpkSignerSummaryHash, null)
 
         val cordappManifest = CordappManifest(
             "", "", -1, -1,

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
@@ -75,7 +75,7 @@ internal class LiquibaseExtractorHelpersTest {
     }
 
     private fun mockCpk(name: String, version: String, signerHash: SecureHash, fileChecksum: SecureHash): Cpk {
-        val cpkId = CpkIdentifier(name, version, signerHash)
+        val cpkId = CpkIdentifier(name, version, signerHash, null)
         val mockMetadata = mock<CpkMetadata>().also {
             whenever(it.cpkId).thenReturn(cpkId)
             whenever(it.fileChecksum).thenReturn(fileChecksum)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -473,7 +473,8 @@ class FlowServiceTestContext @Activate constructor(
         return CpkIdentifier(
             cpkId,
             "0.0",
-            getSecureHash()
+            getSecureHash(),
+            null
         )
     }
 

--- a/components/virtual-node/cpi-upload-rpcops-service/src/test/kotlin/net/corda/cpi/upload/endpoints/v1/EndpointTypeConvertersTest.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/test/kotlin/net/corda/cpi/upload/endpoints/v1/EndpointTypeConvertersTest.kt
@@ -14,7 +14,7 @@ import java.time.Instant
 internal class EndpointTypeConvertersTest {
 
     fun cpk() : CpkMetadata {
-        val id = CpkIdentifier("cpk", "1.0", SecureHash.parse("DONT_CARE:1234"))
+        val id = CpkIdentifier("cpk", "1.0", SecureHash.parse("DONT_CARE:1234"), null)
         return CpkMetadata(
             cpkId = id,
             manifest = mock(),

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/Helpers.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/Helpers.kt
@@ -35,7 +35,7 @@ object Helpers {
         val cordappManifest = CordappManifest(name, version, 1, 1,
             CordappType.WORKFLOW, "", "", 0, "", mock())
         return CpkMetadata(
-            CpkIdentifier(mainBundle, version, SecureHash.parse("SHA-256:0000000000000000")),
+            CpkIdentifier(mainBundle, version, SecureHash.parse("SHA-256:0000000000000000"), null),
             CpkManifest(CpkFormatVersion(1, 0)),
             mainBundle,
             emptyList(),

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpiIdentifier.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpiIdentifier.kt
@@ -26,6 +26,8 @@ data class CpiIdentifier(
         )
     }
 
+    override val fileHash: SecureHash? = null
+
     override fun compareTo(other: CpiIdentifier) = identifierComparator.compare(this, other)
 
     fun toAvro(): CpiIdentifierAvro {

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkIdentifier.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkIdentifier.kt
@@ -17,14 +17,16 @@ import net.corda.data.packaging.CpkIdentifier as CpkIdentifierAvro
 data class CpkIdentifier(
     override val name: String,
     override val version: String,
-    override val signerSummaryHash: SecureHash?
+    override val signerSummaryHash: SecureHash?,
+    override val fileHash: SecureHash?
 ) : Identifier, Comparable<CpkIdentifier> {
     companion object {
         fun fromAvro(other: CpkIdentifierAvro): CpkIdentifier {
             return CpkIdentifier(
                 other.name,
                 other.version,
-                other.signerSummaryHash?.let { SecureHash(it.algorithm, it.serverHash.array()) }
+                other.signerSummaryHash?.let { SecureHash(it.algorithm, it.serverHash.array()) },
+                other.fileHash?.let { SecureHash(it.algorithm, it.serverHash.array()) }
             )
         }
     }
@@ -35,12 +37,13 @@ data class CpkIdentifier(
         return CpkIdentifierAvro(
             name,
             version,
-            signerSummaryHash?.let { hash ->
-                net.corda.data.crypto.SecureHash(
-                    hash.algorithm,
-                    ByteBuffer.wrap(hash.bytes)
-                )
-            }
+            signerSummaryHash?.let((::secureHash)),
+            fileHash?.let((::secureHash))
         )
     }
+
+    private fun secureHash(hash: SecureHash) = net.corda.data.crypto.SecureHash(
+        hash.algorithm,
+        ByteBuffer.wrap(hash.bytes)
+    )
 }

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/Identifier.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/Identifier.kt
@@ -6,4 +6,5 @@ interface Identifier {
     val name: String
     val version: String
     val signerSummaryHash: SecureHash?
+    val fileHash: SecureHash?
 }

--- a/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/ConvertersTest.kt
+++ b/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/ConvertersTest.kt
@@ -58,7 +58,7 @@ class ConvertersTest {
 
     @Test
     fun `CPK․Identifier without signerSummaryHash round trip`() {
-        val original = CpkIdentifier("SomeName", "1.0", null)
+        val original = CpkIdentifier("SomeName", "1.0", null, null)
         val avroObject = original.toAvro()
         val cordaObject = CpkIdentifier.fromAvro(avroObject)
         Assertions.assertEquals(original, cordaObject)

--- a/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/CpkMetaTestData.kt
+++ b/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/CpkMetaTestData.kt
@@ -19,11 +19,15 @@ object CpkMetaTestData {
     )
     val cpkId = CpkIdentifier(
         "SomeName",
-        "1.0", SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
+        "1.0",
+        SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes)),
+        null
     )
     val cpkDependencyId = CpkIdentifier(
         "SomeName 2",
-        "1.0", SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
+        "1.0",
+        SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes)),
+        null
     )
     val cpkType = CpkType.CORDA_API
     val cpkFormatVersion = CpkFormatVersion(2, 3)

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkDependencies.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkDependencies.kt
@@ -24,7 +24,7 @@ class CpkDependencies(private val jarName: String, inputStream: InputStream, cpk
         val cpkSummaryHash = certificates.asSequence().signerSummaryHash()
         dependencies = dependencies.mapTo(TreeSet()) { cpk ->
             if (cpk.signerSummaryHash === CpkDocumentReader.SAME_SIGNER_PLACEHOLDER) {
-                CpkIdentifier(cpk.name, cpk.version, cpkSummaryHash)
+                CpkIdentifier(cpk.name, cpk.version, cpkSummaryHash, cpk.fileHash)
             } else {
                 cpk
             }

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1Verifier.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/cpk/CpkV1Verifier.kt
@@ -1,14 +1,14 @@
 package net.corda.libs.packaging.verify.internal.cpk
 
-import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.PackagingConstants
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_NAME_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_BUNDLE_VERSION_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_FORMAT_ATTRIBUTE
 import net.corda.libs.packaging.PackagingConstants.CPK_LIB_FOLDER
-import net.corda.libs.packaging.signerSummaryHash
 import net.corda.libs.packaging.core.CpkIdentifier
 import net.corda.libs.packaging.core.exception.PackagingException
+import net.corda.libs.packaging.signerSummaryHash
+import net.corda.libs.packaging.verify.JarReader
 import net.corda.libs.packaging.verify.internal.requireAttributeValueIn
 import net.corda.libs.packaging.verify.internal.singleOrThrow
 import java.util.jar.JarEntry
@@ -27,7 +27,12 @@ class CpkV1Verifier(jarReader: JarReader): CpkVerifier {
             val certificates = codeSigners.map { it.signerCertPath.certificates.first() }.toSet()
             val cpkSummaryHash = certificates.asSequence().signerSummaryHash()
             with (mainBundle.manifest.mainAttributes) {
-                return CpkIdentifier(getValue(CPK_BUNDLE_NAME_ATTRIBUTE), getValue(CPK_BUNDLE_VERSION_ATTRIBUTE), cpkSummaryHash)
+                return CpkIdentifier(
+                    getValue(CPK_BUNDLE_NAME_ATTRIBUTE),
+                    getValue(CPK_BUNDLE_VERSION_ATTRIBUTE),
+                    cpkSummaryHash,
+                    null
+                )
             }
         }
     val dependencies: CpkDependencies

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDependencyResolver.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDependencyResolver.kt
@@ -23,10 +23,13 @@ object CpkDependencyResolver {
             val dependencyAlreadyResolved = resolvedSet.tailSet(cpkIdentifier).any { it.name == cpkIdentifier.name }
             if (!dependencyAlreadyResolved) {
                 //All CPKs with the required symbolic name and version greater or equal are valid candidates
-                val needle = CpkIdentifier(cpkIdentifier.name, cpkIdentifier.version, null)
+                val needle = CpkIdentifier(cpkIdentifier.name, cpkIdentifier.version, null, null)
                 val cpkCandidates = availableIds.tailMap(needle).asSequence()
-                    .filter { it.key.name == needle.name
-                            && (!useSignatures || cpkIdentifier.signerSummaryHash == it.key.signerSummaryHash) }
+                    .filter {
+                        it.key.name == needle.name
+                            && (!useSignatures
+                                || ((cpkIdentifier.signerSummaryHash != null && cpkIdentifier.signerSummaryHash == it.key.signerSummaryHash)
+                                || (cpkIdentifier.fileHash != null && cpkIdentifier.fileHash == it.key.fileHash))) }
                     .toList()
                 when {
                     cpkCandidates.isNotEmpty() -> {

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDocumentReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDocumentReader.kt
@@ -119,7 +119,8 @@ class CpkDocumentReader {
                 CpkIdentifier(
                     dependencyNameElements.item(0).textContent,
                     dependencyVersionElements.item(0).textContent,
-                    publicKeySummaryHash
+                    publicKeySummaryHash,
+                    null
                 ).takeIf {
                     when (dependencyTypeElements.length) {
                         0 -> true

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v1/CpkLoaderV1.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v1/CpkLoaderV1.kt
@@ -105,16 +105,18 @@ internal object CpkLoaderV1 : CpkLoader {
         }
 
         fun buildMetadata(): CpkMetadata {
+            val fileChecksum = SecureHash(DigestAlgorithmName.SHA2_256.name, cpkDigest.digest())
             return CpkMetadata(
                 cpkId = CpkIdentifier(
                     cordappManifest!!.bundleSymbolicName,
                     cordappManifest!!.bundleVersion,
-                    cordappCertificates!!.asSequence().signerSummaryHash()
+                    cordappCertificates!!.asSequence().signerSummaryHash(),
+                    fileChecksum
                 ),
                 type = cpkType,
                 manifest = cpkManifest!!,
                 mainBundle = cordappFileName!!,
-                fileChecksum = SecureHash(DigestAlgorithmName.SHA2_256.name, cpkDigest.digest()),
+                fileChecksum = fileChecksum,
                 cordappManifest = cordappManifest!!,
                 cordappCertificates = cordappCertificates!!,
                 libraries = Collections.unmodifiableList(ArrayList(libraryMap.keys)),
@@ -201,7 +203,7 @@ internal object CpkLoaderV1 : CpkLoader {
         val cpkSummaryHash = certificates.asSequence().signerSummaryHash()
         ctx.cpkDependencies = ctx.cpkDependencies.mapTo(TreeSet()) { cpk ->
             if (cpk.signerSummaryHash === SAME_SIGNER_PLACEHOLDER) {
-                CpkIdentifier(cpk.name, cpk.version, cpkSummaryHash)
+                CpkIdentifier(cpk.name, cpk.version, cpkSummaryHash, null)
             } else {
                 cpk
             }

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkDependencyResolverTest.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkDependencyResolverTest.kt
@@ -23,7 +23,10 @@ private fun id(name: String,
             .map(String::toByteArray)
             .forEach(md::update)
     }
-    return CpkIdentifier(name, version, signersSummaryHash, null)
+    val fileHash = hash { md ->
+        md.update(("$name $signers $signersSummaryHash").toByteArray())
+    }
+    return CpkIdentifier(name, version, signersSummaryHash, fileHash)
 }
 
 private fun ids(vararg ids : CpkIdentifier) = ids.toCollection(TreeSet())

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkDependencyResolverTest.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkDependencyResolverTest.kt
@@ -23,7 +23,7 @@ private fun id(name: String,
             .map(String::toByteArray)
             .forEach(md::update)
     }
-    return CpkIdentifier(name, version, signersSummaryHash)
+    return CpkIdentifier(name, version, signersSummaryHash, null)
 }
 
 private fun ids(vararg ids : CpkIdentifier) = ids.toCollection(TreeSet())

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkImplTest.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.internal
 
 import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.libs.packaging.hash
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import org.junit.jupiter.api.Assertions
@@ -13,9 +14,9 @@ class CpkImplTest {
     @Test
     fun `CPK identifiers without a signerSummaryHash compares correctly`() {
         val signerSummaryHash = SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32))
-        val id1 = CpkIdentifier("a", "1.0", null, null)
-        val id2 = CpkIdentifier("a", "1.0", signerSummaryHash, null)
-        val id3 = CpkIdentifier("a", "2.0", signerSummaryHash, null)
+        val id1 = CpkIdentifier("a", "1.0", null, hash { it.update("a1.0".toByteArray()) })
+        val id2 = CpkIdentifier("a", "1.0", signerSummaryHash, hash { it.update("a1.0".toByteArray()) })
+        val id3 = CpkIdentifier("a", "2.0", signerSummaryHash, hash { it.update("a2.0".toByteArray()) })
         var ids : NavigableSet<CpkIdentifier> = Collections.emptyNavigableSet()
         Assertions.assertDoesNotThrow {
              ids = TreeSet<CpkIdentifier>().apply {

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkImplTest.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/CpkImplTest.kt
@@ -12,9 +12,10 @@ import java.util.TreeSet
 class CpkImplTest {
     @Test
     fun `CPK identifiers without a signerSummaryHash compares correctly`() {
-        val id1 = CpkIdentifier("a", "1.0", null)
-        val id2 = CpkIdentifier("a", "1.0", SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32)))
-        val id3 = CpkIdentifier("a", "2.0", SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32)))
+        val signerSummaryHash = SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32))
+        val id1 = CpkIdentifier("a", "1.0", null, null)
+        val id2 = CpkIdentifier("a", "1.0", signerSummaryHash, null)
+        val id3 = CpkIdentifier("a", "2.0", signerSummaryHash, null)
         var ids : NavigableSet<CpkIdentifier> = Collections.emptyNavigableSet()
         Assertions.assertDoesNotThrow {
              ids = TreeSet<CpkIdentifier>().apply {

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -561,8 +561,12 @@ private data class CpkAndContents(
                 }
             }
         }
+        val fileChecksum = cpkChecksum ?: SecureHash(
+            HASH_ALGORITHM,
+            MessageDigest.getInstance(HASH_ALGORITHM).digest(cpkBytes.toByteArray())
+        )
         override val metadata = CpkMetadata(
-            cpkId = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash(), null),
+            cpkId = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash(), fileChecksum),
             manifest = CpkManifest(CpkFormatVersion(0, 0)),
             mainBundle = mainBundle,
             libraries = libraries,
@@ -572,8 +576,7 @@ private data class CpkAndContents(
                 whenever(bundleVersion).thenAnswer { "${random.nextInt()}" }
             },
             type = CpkType.UNKNOWN,
-            fileChecksum = cpkChecksum ?:
-                SecureHash(HASH_ALGORITHM, MessageDigest.getInstance(HASH_ALGORITHM).digest(cpkBytes.toByteArray())),
+            fileChecksum = fileChecksum,
             cordappCertificates = emptySet(),
             timestamp = Instant.now())
         override fun getInputStream() = ByteArrayInputStream(cpkBytes.toByteArray())

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -562,7 +562,7 @@ private data class CpkAndContents(
             }
         }
         override val metadata = CpkMetadata(
-            cpkId = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash()),
+            cpkId = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash(), null),
             manifest = CpkManifest(CpkFormatVersion(0, 0)),
             mainBundle = mainBundle,
             libraries = libraries,

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
@@ -38,7 +38,7 @@ fun mockBundle(
 
 /** Generates a mock CpkMetadata. */
 fun mockCpkMeta(): CpkMetadata {
-    val id = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash())
+    val id = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash(), null)
     val hash = randomSecureHash()
     return mock<CpkMetadata>().apply {
         whenever(this.cpkId).thenReturn(id)

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
@@ -38,8 +38,8 @@ fun mockBundle(
 
 /** Generates a mock CpkMetadata. */
 fun mockCpkMeta(): CpkMetadata {
-    val id = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash(), null)
     val hash = randomSecureHash()
+    val id = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash(), hash)
     return mock<CpkMetadata>().apply {
         whenever(this.cpkId).thenReturn(id)
         whenever(this.fileChecksum).thenReturn(hash)

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
@@ -35,7 +35,9 @@ class CpiInfoDbReconcilerReaderTest {
     private val dummyCpkMetadata = CpkMetadata(
         CpkIdentifier(
             "SomeName",
-            "1.0", SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
+            "1.0",
+            SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes)),
+            null
         ),
         CpkManifest(CpkFormatVersion(2, 3)),
         "mainBundle.jar",
@@ -44,7 +46,8 @@ class CpiInfoDbReconcilerReaderTest {
             CpkIdentifier(
                 "SomeName 2",
                 "1.0",
-                SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
+                SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes)),
+                null
             )
         ),
         CordappManifest(

--- a/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/TestCatalogue.kt
+++ b/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/TestCatalogue.kt
@@ -21,7 +21,12 @@ object TestCatalogue {
                 SecureHash("ALG", byteArrayOf(0, 0, 0, 0)),
                 listOf(
                     CpkMetadata(
-                        CpkIdentifier(cpkName, "0.0", SecureHash("ALG", byteArrayOf(0, 0, 0, 0)), null),
+                        CpkIdentifier(
+                            cpkName,
+                            "0.0",
+                            SecureHash("ALG", byteArrayOf(0, 0, 0, 0)),
+                            SecureHash("ALG", byteArrayOf(0, 0, 0, 0))
+                        ),
                         CpkManifest(CpkFormatVersion(0, 0)),
                         "",
                         listOf(),

--- a/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/TestCatalogue.kt
+++ b/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/TestCatalogue.kt
@@ -21,7 +21,7 @@ object TestCatalogue {
                 SecureHash("ALG", byteArrayOf(0, 0, 0, 0)),
                 listOf(
                     CpkMetadata(
-                        CpkIdentifier(cpkName, "0.0", SecureHash("ALG", byteArrayOf(0, 0, 0, 0))),
+                        CpkIdentifier(cpkName, "0.0", SecureHash("ALG", byteArrayOf(0, 0, 0, 0)), null),
                         CpkManifest(CpkFormatVersion(0, 0)),
                         "",
                         listOf(),


### PR DESCRIPTION
- Read verifyFileHash from CPKDependencies.json and store inside CpkIdentifier
- Set to a sensible value in all usages that will benefit from it being set
- Set to null in all other usages
- Set to file hash when building the CPK ID so we can match dependencies to loaded CPKs
- Update CpkDependencyResolver to match file hashes if not null