### PR TITLE
CORE-6048: Improve Error When Max Retries Reached

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
@@ -144,13 +144,9 @@ class StartFlowTest : FlowServiceTestBase() {
                 flowStatus(
                     state = FlowStates.FAILED,
                     errorType = FlowProcessingExceptionTypes.FLOW_FAILED,
-                    errorMessage = "Max retry attempts '1' has been reached."
+                    errorMessage = "Execution failed with \"Failed to create the sandbox: Failed to find the virtual node info for holder 'HoldingIdentity(x500Name=${BOB_HOLDING_IDENTITY.x500Name}, groupId=${BOB_HOLDING_IDENTITY.groupId})'\" after 1 retry attempts."
                 )
             }
         }
     }
 }
-
-
-
-

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 
-@Suppress("CanBePrimaryConstructorProperty", "Unused")
+@Suppress("Unused")
 @Component(service = [FlowEventExceptionProcessor::class])
 class FlowEventExceptionProcessorImpl @Activate constructor(
     @Reference(service = FlowMessageFactory::class)
@@ -67,7 +67,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             if (flowCheckpoint.currentRetryCount >= maxRetryAttempts) {
                 return@withEscalation process(
                     FlowFatalException(
-                        "Max retry attempts '${maxRetryAttempts}' has been reached.",
+                        "Execution failed with \"${exception.message}\" after $maxRetryAttempts retry attempts.",
                         exception
                     ), context
                 )

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -101,7 +101,8 @@ class FlowEventExceptionProcessorImplTest {
             flowMessageFactory.createFlowFailedStatusMessage(
                 flowCheckpoint,
                 FlowProcessingExceptionTypes.FLOW_FAILED,
-                "Execution failed with \"${error.message}\" after ${flowConfig.getInt(FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS)} retry attempts.",
+                "Execution failed with \"${error.message}\" after " +
+                        "${flowConfig.getInt(FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS)} retry attempts.",
             )
         ).thenReturn(flowStatusUpdate)
         whenever(flowRecordFactory.createFlowStatusRecord(flowStatusUpdate)).thenReturn(flowStatusUpdateRecord)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -32,7 +32,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class FlowEventExceptionProcessorImplTest {
-
     private val flowMessageFactory = mock<FlowMessageFactory>()
     private val flowRecordFactory = mock<FlowRecordFactory>()
     private val flowEventContextConverter = mock<FlowEventContextConverter>()
@@ -94,7 +93,7 @@ class FlowEventExceptionProcessorImplTest {
 
     @Test
     fun `flow transient exception processed as fatal when retry limit reached`() {
-        val error = FlowTransientException("error")
+        val error = FlowTransientException("mock error message")
         val flowStatusUpdate = FlowStatus()
         val flowStatusUpdateRecord = Record("", FlowKey(), flowStatusUpdate)
         whenever(flowCheckpoint.currentRetryCount).thenReturn(2)
@@ -102,7 +101,7 @@ class FlowEventExceptionProcessorImplTest {
             flowMessageFactory.createFlowFailedStatusMessage(
                 flowCheckpoint,
                 FlowProcessingExceptionTypes.FLOW_FAILED,
-                "Max retry attempts '2' has been reached."
+                "Execution failed with \"${error.message}\" after ${flowConfig.getInt(FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS)} retry attempts.",
             )
         ).thenReturn(flowStatusUpdate)
         whenever(flowRecordFactory.createFlowStatusRecord(flowStatusUpdate)).thenReturn(flowStatusUpdateRecord)
@@ -158,7 +157,7 @@ class FlowEventExceptionProcessorImplTest {
     }
 
     @Test
-    fun `flow flow exception outputs the transformed context as normal`() {
+    fun `flow exception outputs the transformed context as normal`() {
         val error = FlowEventException("error")
 
         val result = target.process(error, context)


### PR DESCRIPTION
When a flow failure goes above the maximum configured retries, set the
error status to the last exception message ocurred so users have an
idea of what happened and can troubleshoot the issue.