### PR TITLE
CORE-5406: Add L attribute to x500 names in packaging plugin readme

### DIFF
--- a/tools/plugins/package/README.md
+++ b/tools/plugins/package/README.md
@@ -10,8 +10,8 @@ These commands assume you have access to ./corda-cli.sh
 
 ```shell
 # Generate two self-signed signing keys to show how we select one key among multiple
-keytool -genkeypair -alias "signing key 1" -keystore signingkeys.pfx -storepass "keystore password" -dname "cn=CPI Plugin Example - Signing Key 1, o=R3, c=GB" -keyalg RSA -storetype pkcs12 -validity 4000
-keytool -genkeypair -alias "signing key 2" -keystore signingkeys.pfx -storepass "keystore password" -dname "cn=CPI Plugin Example - Signing Key 2, o=R3, c=GB" -keyalg RSA -storetype pkcs12 -validity 4000
+keytool -genkeypair -alias "signing key 1" -keystore signingkeys.pfx -storepass "keystore password" -dname "cn=CPI Plugin Example - Signing Key 1, o=R3, L=London, c=GB" -keyalg RSA -storetype pkcs12 -validity 4000
+keytool -genkeypair -alias "signing key 2" -keystore signingkeys.pfx -storepass "keystore password" -dname "cn=CPI Plugin Example - Signing Key 2, o=R3, L=London, c=GB" -keyalg RSA -storetype pkcs12 -validity 4000
 ```
 
 ### Trust the gradle plugin default signing key

--- a/tools/plugins/package/README.md
+++ b/tools/plugins/package/README.md
@@ -10,8 +10,8 @@ These commands assume you have access to ./corda-cli.sh
 
 ```shell
 # Generate two self-signed signing keys to show how we select one key among multiple
-keytool -genkeypair -alias "signing key 1" -keystore signingkeys.pfx -storepass "keystore password" -dname "cn=CPI Plugin Example - Signing Key 1, o=R3, L=London, c=GB" -keyalg RSA -storetype pkcs12 -validity 4000
-keytool -genkeypair -alias "signing key 2" -keystore signingkeys.pfx -storepass "keystore password" -dname "cn=CPI Plugin Example - Signing Key 2, o=R3, L=London, c=GB" -keyalg RSA -storetype pkcs12 -validity 4000
+keytool -genkeypair -alias "signing key 1" -keystore signingkeys.pfx -storepass "keystore password" -dname "CN=CPI Plugin Example - Signing Key 1, O=R3, L=London, C=GB" -keyalg RSA -storetype pkcs12 -validity 4000
+keytool -genkeypair -alias "signing key 2" -keystore signingkeys.pfx -storepass "keystore password" -dname "CN=CPI Plugin Example - Signing Key 2, O=R3, L=London, C=GB" -keyalg RSA -storetype pkcs12 -validity 4000
 ```
 
 ### Trust the gradle plugin default signing key


### PR DESCRIPTION
We need the L attribute in the x500 name to parse the name correctly.