### PR TITLE
CORE-6046: Improve Flow Store Creation Errors

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreFactoryImpl.kt
@@ -32,10 +32,11 @@ class FlowProtocolStoreFactoryImpl : FlowProtocolStoreFactory {
                 val protocols = versions.map { FlowProtocol(protocol, it) }
                 initiatorToProtocol[flowName] = protocols
             }
+
             flowClass.isAnnotationPresent(InitiatedBy::class.java) -> {
                 if (!flowClass.interfaces.contains(ResponderFlow::class.java)) {
                     throw FlowFatalException(
-                        "Found a responder flow that does not implement ResponderFlow"
+                        "Flow ${flowClass.canonicalName} must implement ${ResponderFlow::class.simpleName}"
                     )
                 }
                 val protocol = flowClass.getAnnotation(InitiatedBy::class.java).protocol


### PR DESCRIPTION
Include offending class name while reporting errors when the
@InitiatedBy annotation is used on a class that does not implement
the ResponderFlow interface.