### PR TITLE
CORE-6572 Error persisting CPI and CPK to database

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
@@ -75,7 +75,8 @@ class DatabaseCpiPersistence(private val entityManagerFactory: EntityManagerFact
                 CpiCpkEntity(
                     CpiCpkKey(
                         cpi.metadata.cpiId.name, cpi.metadata.cpiId.version, cpi.metadata.cpiId.signerSummaryHash?.toString() ?: "",
-                        cpk.metadata.cpkId.name, cpk.metadata.cpkId.version, cpk.metadata.cpkId.signerSummaryHash.toString()
+                        // TODO Fallback to empty string can be removed after package verification is enabled (CORE-5405)
+                        cpk.metadata.cpkId.name, cpk.metadata.cpkId.version, cpk.metadata.cpkId.signerSummaryHash?.toString().orEmpty()
                     ),
                     cpk.originalFileName!!,
                     cpk.metadata.fileChecksum.toString(),

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2.kt
@@ -65,7 +65,7 @@ class CpkLoaderV2(private val clock: Clock = UTCClock()) : CpkLoader {
 
     private fun readCpkMetadata(cpkBytes: ByteArray): CpkMetadata {
 
-        val (manifest, cpkEntries) = JarInputStream(cpkBytes.inputStream(), false).use {
+        val (manifest, cpkEntries) = JarInputStream(cpkBytes.inputStream(), true).use {
             val manifest = it.manifest
             val jarEntries = readJar(it).toList()
             Pair(manifest, jarEntries)


### PR DESCRIPTION
- Enabled JarInputStream verification in CpkLoaderV2 so that code signers are initialized and CPK's signerSummaryHash can be calculated