### PR TITLE
CORE-5987: Add Field Injection Test

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
@@ -20,7 +20,7 @@ const val CPI_NAME = "flow-worker-dev"
 
 const val USERNAME = "admin"
 const val PASSWORD = "admin"
-const val GROUP_ID = "placeholder"
+const val GROUP_ID = "group-id-placeholder"
 
 val CLUSTER_URI = URI(System.getProperty("rpcHost"))
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sandbox/SandboxDependencyInjectorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sandbox/SandboxDependencyInjectorImplTest.kt
@@ -2,15 +2,19 @@ package net.corda.flow.pipeline.sandbox
 
 import net.corda.flow.pipeline.sandbox.impl.SandboxDependencyInjectorImpl
 import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.serialization.SingletonSerializeAsToken
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 
 class SandboxDependencyInjectorImplTest {
     private val s1 = Service1Impl()
     private val s2 = Service2Impl()
+    private val s3 = SharedServiceImpl()
 
     private val serviceTypes1 = arrayOf(
         Service1::class.java.name,
@@ -20,12 +24,17 @@ class SandboxDependencyInjectorImplTest {
         Service2::class.java.name,
         SingletonSerializeAsToken::class.java.name
     )
-    private val flowDependencyInjector = SandboxDependencyInjectorImpl(mapOf(s1 to serviceTypes1, s2 to serviceTypes2), mock())
+    private val serviceTypes3 = arrayOf(
+        SharedService::class.java.name,
+        SingletonSerializeAsToken::class.java.name
+    )
+    private val flowDependencyInjector =
+        SandboxDependencyInjectorImpl(mapOf(s1 to serviceTypes1, s2 to serviceTypes2, s3 to serviceTypes3), mock())
 
     @Test
     fun `get singletons returns all singletons`() {
         val results = flowDependencyInjector.getRegisteredSingletons()
-        Assertions.assertThat(results).containsExactly(s1, s2)
+        assertThat(results).containsExactly(s1, s2, s3)
     }
 
     @Test
@@ -36,21 +45,21 @@ class SandboxDependencyInjectorImplTest {
         val service1 = flow.service1
         val service2 = flow.service2
 
-        Assertions.assertThat(service1).isNotNull
-        Assertions.assertThat(service2).isNotNull
+        assertThat(service1).isNotNull
+        assertThat(service2).isNotNull
     }
 
     @Test
     fun `an exception is thrown if the flow request a type that is unregistered`() {
         val flow = ExampleInvalidFlow()
-        Assertions.assertThatIllegalArgumentException()
+        assertThatIllegalArgumentException()
             .isThrownBy { flowDependencyInjector.injectServices(flow) }
             .withMessage("No registered types could be found for the following field(s) 'service'")
     }
 
     @Test
     fun `an exception is thrown if the same interface is implemented by more than once service`() {
-        Assertions.assertThatIllegalArgumentException()
+        assertThatIllegalArgumentException()
             .isThrownBy {
                 SandboxDependencyInjectorImpl(
                     mapOf(
@@ -64,6 +73,28 @@ class SandboxDependencyInjectorImplTest {
                         "registered by '${Service2Impl::class.qualifiedName}' it can't be registered again " +
                         "by '${DuplicateService2Impl::class.qualifiedName}'."
             )
+    }
+
+    @Test
+    fun `allows the injection of fields and usage of common logic inherited from parent flows`() {
+        val flow = ChildFlow()
+        flowDependencyInjector.injectServices(flow)
+
+        assertThat(flow.service1).isNotNull
+        assertThat(flow.service2).isNotNull
+        assertThat(flow.sharedService).isNotNull
+        assertThat(flow.call()).isEqualTo(SharedService.from(ChildFlow::class.java.simpleName))
+    }
+
+    @Test
+    fun `allows the injection of fields and usage of common logic inherited from abstract flows and interfaces`() {
+        val flow = ConcreteChildFlow()
+        flowDependencyInjector.injectServices(flow)
+
+        assertThat(flow.service1).isNotNull
+        assertThat(flow.service2).isNotNull
+        assertThat(flow.sharedService).isNotNull
+        assertThat(flow.call(mock())).isEqualTo(SharedService.from(ConcreteChildFlow::class.java.simpleName))
     }
 }
 
@@ -94,5 +125,114 @@ class ExampleInvalidFlow : SubFlow<String> {
 
     override fun call(): String {
         return ""
+    }
+}
+
+// Dummy service shared between flows
+interface SharedService {
+    companion object {
+        const val START_TOKEN = "["
+        const val FINISH_TOKEN = "]"
+        fun from(str: String): String = StringBuilder().append(START_TOKEN).append(str).append(FINISH_TOKEN).toString()
+    }
+
+    fun start()
+
+    fun process(str: String)
+
+    fun finish()
+
+    fun get(): String
+}
+
+class SharedServiceImpl : SharedService, SingletonSerializeAsToken {
+    private val builder = StringBuilder()
+
+    override fun start() {
+        builder.append(SharedService.START_TOKEN)
+    }
+
+    override fun process(str: String) {
+        builder.append(str)
+    }
+
+    override fun finish() {
+        builder.append(SharedService.FINISH_TOKEN)
+    }
+
+    override fun get(): String {
+        return builder.toString()
+    }
+}
+
+// Test scenarios on which users have common logic inherited between concrete flows.
+open class ConcreteParentFlow : SubFlow<String> {
+    @CordaInject
+    lateinit var service1: Service1
+
+    @CordaInject
+    internal lateinit var service2: Service2
+
+    @CordaInject
+    lateinit var sharedService: SharedService
+
+    private fun beginProcessing() {
+        sharedService.start()
+    }
+
+    open fun process() {
+    }
+
+    private fun doneProcessing() {
+        sharedService.finish()
+    }
+
+    open fun templateMethod(): String {
+        beginProcessing()
+        process()
+        doneProcessing()
+
+        return sharedService.get()
+    }
+
+    override fun call(): String {
+        return templateMethod()
+    }
+}
+
+class ChildFlow : ConcreteParentFlow() {
+    override fun process() {
+        sharedService.process(this::class.java.simpleName)
+    }
+}
+
+// Test scenarios on which users have common logic inherited from abstract flows.
+
+interface CustomFlowInterface {
+    fun method(): String
+}
+
+abstract class AbstractParentFlow : RPCStartableFlow, CustomFlowInterface {
+    @CordaInject
+    lateinit var service1: Service1
+
+    @CordaInject
+    internal lateinit var service2: Service2
+
+    @CordaInject
+    lateinit var sharedService: SharedService
+}
+
+class ConcreteChildFlow : AbstractParentFlow() {
+    override fun method(): String {
+        sharedService.start()
+        sharedService.process(this::class.java.simpleName)
+        sharedService.finish()
+
+        return sharedService.get()
+    }
+
+    override fun call(requestBody: RPCRequestData): String {
+        return method()
     }
 }

--- a/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/smoketests/flow/InheritanceTestFlow.kt
+++ b/testing/cpbs/flow-worker-dev/src/main/kotlin/net/cordapp/flowworker/development/smoketests/flow/InheritanceTestFlow.kt
@@ -1,0 +1,60 @@
+package net.cordapp.flowworker.development.smoketests.flow
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.getRequestBodyAs
+import net.corda.v5.application.marshalling.JsonMarshallingService
+import net.corda.v5.application.membership.MemberLookup
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.membership.MemberInfo
+
+interface MemberResolver {
+    fun findMember(memberX500Name: String): MemberInfo?
+}
+
+@Suppress("unused")
+abstract class AbstractFlow : RPCStartableFlow, MemberResolver {
+    private companion object {
+        val log = contextLogger()
+    }
+
+    abstract fun buildOutput(memberInfo: MemberInfo?): String
+
+    @CordaInject
+    lateinit var memberLookupService: MemberLookup
+
+    @CordaInject
+    lateinit var jsonMarshallingService: JsonMarshallingService
+
+    @Suspendable
+    override fun call(requestBody: RPCRequestData): String {
+        log.info("Executing Flow...")
+
+        try {
+            val request = requestBody.getRequestBodyAs<Map<String, String>>(jsonMarshallingService)
+            val memberInfoRequest = checkNotNull(request["id"]) { "Failed to find key 'id' in the RPC input args" }
+
+            return buildOutput(findMember(memberInfoRequest))
+        } catch (e: Exception) {
+            log.error("Unexpected error while processing the flow", e)
+            throw e
+        }
+    }
+}
+
+/**
+ * Used to verify that dependency injection works while using inheritance, interfaces and Corda native services.
+ */
+@Suppress("unused")
+class DependencyInjectionTestFlow : AbstractFlow() {
+    override fun buildOutput(memberInfo: MemberInfo?): String {
+        return memberInfo?.name?.toString() ?: "Failed to find MemberInfo"
+    }
+
+    override fun findMember(memberX500Name: String): MemberInfo? {
+        return memberLookupService.lookup(MemberX500Name.parse(memberX500Name))
+    }
+}


### PR DESCRIPTION
Add unit and smoke tests to verify that fields annotated with
@CordaInject are automatically injected and that common logic can be
shared when there is flow inheritance involved.

- Fix groupId placeholder used by FlowTestUtils.
- Rename and improve FlowTestUtils helper method to prevent failures
  when executing smoke tests multiple times sequentially against the
  same environment.
