### PR TITLE
CORE-6554 clean up validation error messages

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessor.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessor.kt
@@ -46,7 +46,8 @@ class ChunkWriteToDbProcessor(
             publisher.complete(request.requestId, checksum)
         } catch (e: Exception) {
             when (e) {
-                is DuplicateCpiUploadException -> log.warn("Unable to accept CPI chunk since CPI already uploaded ${e.message} for request ID ${e.requestId}")
+                is DuplicateCpiUploadException ->
+                    log.warn("Unable to accept CPI chunk since CPI already uploaded ${e.message} for request ID ${request.requestId}")
                 is ValidationException -> log.warn("${e.message} for request id ${e.requestId}")
                 else -> log.error("Unable to accept CPI chunk due to chunk $request causing exception", e)
             }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessor.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessor.kt
@@ -6,6 +6,7 @@ import net.corda.chunking.db.impl.persistence.StatusPublisher
 import net.corda.chunking.db.impl.validation.CpiValidator
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.chunking.Chunk
+import net.corda.libs.cpiupload.DuplicateCpiUploadException
 import net.corda.libs.cpiupload.ValidationException
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
@@ -34,7 +35,7 @@ class ChunkWriteToDbProcessor(
             if (allChunksReceived == AllChunksReceived.NO) return
 
             if (!persistence.checksumIsValid(request.requestId)) {
-                throw ValidationException("Checksum of CPI for ${request.requestId} does not match")
+                throw ValidationException("Checksum of CPI does not match", request.requestId)
             }
 
             // We validate the CPI, persist it to the database, and publish CPI info.
@@ -44,7 +45,11 @@ class ChunkWriteToDbProcessor(
 
             publisher.complete(request.requestId, checksum)
         } catch (e: Exception) {
-            log.error("Could not persist chunk $request", e)
+            when (e) {
+                is DuplicateCpiUploadException -> log.warn("Unable to accept CPI chunk since CPI already uploaded ${e.message} for request ID ${e.requestId}")
+                is ValidationException -> log.warn("${e.message} for request id ${e.requestId}")
+                else -> log.error("Unable to accept CPI chunk due to chunk $request causing exception", e)
+            }
             publisher.error(request.requestId, ExceptionEnvelope(e::class.java.name, e.message), e.message ?: "Error")
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
@@ -85,5 +85,11 @@ interface CpiPersistence {
      *
      * true: If nothing is in the db we can clearly insert `(any, any)`
      */
-    fun canUpsertCpi(cpiName: String, groupId: String, forceUpload: Boolean = false, cpiVersion: String? = null): Boolean
+    fun canUpsertCpi(
+        cpiName: String,
+        groupId: String,
+        forceUpload: Boolean = false,
+        cpiVersion: String? = null,
+        requestId: String = ""
+    ): Boolean
 }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -6,6 +6,7 @@ import net.corda.chunking.db.impl.persistence.ChunkPersistence
 import net.corda.chunking.db.impl.persistence.CpiPersistence
 import net.corda.chunking.db.impl.persistence.StatusPublisher
 import net.corda.cpiinfo.write.CpiInfoWriteService
+import net.corda.libs.cpiupload.ValidationException
 import net.corda.libs.cpiupload.ReUsedGroupIdException
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiMetadata
@@ -47,7 +48,8 @@ class CpiValidatorImpl constructor(
         val fileInfo = assembleFileFromChunks(cpiCacheDir, chunkPersistence, requestId, ChunkReaderFactoryImpl)
 
         publisher.update(requestId, "Checking signatures")
-        fileInfo.checkSignature()
+        if (!fileInfo.checkSignature())
+            throw ValidationException("Signature invalid: ${fileInfo.name}", requestId)
 
         // The following bit in only just adds the verifyCpi call site to compile. Having said that:
         // - The following (cordadevcodesignpublic.pem) is the certificate of "cordadevcodesign.p12" (default)
@@ -65,10 +67,10 @@ class CpiValidatorImpl constructor(
         }
 
         publisher.update(requestId, "Validating CPI")
-        val cpi: Cpi = fileInfo.validateAndGetCpi(cpiPartsDir)
+        val cpi: Cpi = fileInfo.validateAndGetCpi(cpiPartsDir, requestId)
 
         publisher.update(requestId, "Checking group id in CPI")
-        val groupId = cpi.validateAndGetGroupId(GroupPolicyParser::groupIdFromJson)
+        val groupId = cpi.validateAndGetGroupId(requestId, GroupPolicyParser::groupIdFromJson)
 
         if (!fileInfo.forceUpload) {
             publisher.update(requestId, "Validating group id against DB")
@@ -78,7 +80,7 @@ class CpiValidatorImpl constructor(
         publisher.update(
             requestId, "Checking we can upsert a cpi with name=${cpi.metadata.cpiId.name} and groupId=$groupId"
         )
-        canUpsertCpi(cpi, groupId, fileInfo.forceUpload)
+        canUpsertCpi(cpi, groupId, fileInfo.forceUpload, requestId)
 
         publisher.update(requestId, "Extracting Liquibase files from CPKs in CPI")
         val cpkDbChangeLogEntities = cpi.extractLiquibaseScripts()
@@ -106,17 +108,19 @@ class CpiValidatorImpl constructor(
      *  with a different name *and* different group id.  This is enforcing the policy
      *  of one CPI per mgm group id.
      */
-    private fun canUpsertCpi(cpi: Cpi, groupId: String, forceUpload: Boolean) {
+    private fun canUpsertCpi(cpi: Cpi, groupId: String, forceUpload: Boolean, requestId: String) {
         if (!cpiPersistence.canUpsertCpi(
                 cpi.metadata.cpiId.name,
                 groupId,
                 forceUpload,
-                cpi.metadata.cpiId.version
+                cpi.metadata.cpiId.version,
+                requestId
             )
         ) {
             throw ReUsedGroupIdException(
                 "Group id ($groupId) in use with another CPI.  " +
-                    "Cannot upload ${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version}"
+                        "Cannot upload ${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version}",
+                requestId
             )
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -13,6 +13,8 @@ import net.corda.libs.cpiupload.ValidationException
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.CpiReader
 import net.corda.libs.packaging.core.exception.PackagingException
+import net.corda.membership.lib.grouppolicy.GroupPolicyIdNotFoundException
+import net.corda.membership.lib.grouppolicy.GroupPolicyParseException
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
 import org.slf4j.Logger
@@ -55,7 +57,7 @@ fun assembleFileFromChunks(
 
     return with(fileName) {
         if (this == null) {
-            throw ValidationException("Did not combine all chunks to produce file for $requestId")
+            throw ValidationException("Did not combine all chunks to produce file", requestId)
         }
 
         FileInfo(this, tempPath, checksum, localProperties)
@@ -67,18 +69,18 @@ fun assembleFileFromChunks(
  *
  * @throws ValidationException
  */
-fun FileInfo.validateAndGetCpi(cpiPartsDir: Path): Cpi {
+fun FileInfo.validateAndGetCpi(cpiPartsDir: Path, requestId: String): Cpi {
     val cpi: Cpi =
         try {
             Files.newInputStream(this.path).use { CpiReader.readCpi(it, cpiPartsDir) }
         } catch (ex: Exception) {
             when (ex) {
                 is PackagingException -> {
-                    throw ValidationException("Invalid CPI.  ${ex.message}", ex)
+                    throw ValidationException("Invalid CPI.  ${ex.message}", requestId, ex)
                 }
 
                 else -> {
-                    throw ValidationException("Unexpected exception when unpacking CPI.  ${ex.message}", ex)
+                    throw ValidationException("Unexpected exception when unpacking CPI.  ${ex.message}", requestId, ex)
                 }
             }
         }
@@ -133,15 +135,16 @@ fun CpiPersistence.persistCpiToDatabase(
         } else {
             throw ValidationException(
                 "CPI has already been inserted with cpks for " +
-                    "${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version} with groupId=$groupId"
+                    "${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version} with groupId=$groupId",
+                requestId
             )
         }
     } catch (ex: Exception) {
         when (ex) {
             is ValidationException -> throw ex
-            is PersistenceException -> throw ValidationException("Could not persist CPI and CPK to database", ex)
-            is CordaRuntimeException -> throw ValidationException("Could not persist CPI and CPK to database", ex)
-            else -> throw ValidationException("Unexpected error when trying to persist CPI and CPK to database", ex)
+            is PersistenceException -> throw ValidationException("Could not persist CPI and CPK to database", requestId, ex)
+            is CordaRuntimeException -> throw ValidationException("Could not persist CPI and CPK to database", requestId, ex)
+            else -> throw ValidationException("Unexpected error when trying to persist CPI and CPK to database", requestId, ex)
         }
     }
 }
@@ -156,25 +159,27 @@ fun CpiPersistence.persistCpiToDatabase(
  * @return `groupId`
  */
 @Suppress("ThrowsCount")
-fun Cpi.validateAndGetGroupId(getGroupIdFromJson: (String) -> String): String {
-    if (this.metadata.groupPolicy.isNullOrEmpty()) throw ValidationException("CPI is missing a group policy file")
+fun Cpi.validateAndGetGroupId(requestId: String, getGroupIdFromJson: (String) -> String): String {
+    if (this.metadata.groupPolicy.isNullOrEmpty()) throw ValidationException("CPI is missing a group policy file", requestId)
     val groupId = try {
         getGroupIdFromJson(this.metadata.groupPolicy!!)
-    } catch (e: CordaRuntimeException) {
-        throw ValidationException("CPI group policy file needs a groupId", e)
+        // catch specific exceptions, and wrap them up so as to capture the request ID
+        // This exception will end up going over Kafka and being picked up by the RPC worker,
+        // which then matches by class name,  so we cannot use subtypes of ValidationException without
+        // introducing knowledge of specific failure modes into the RPC worker
+    } catch (e: GroupPolicyIdNotFoundException) {
+        throw ValidationException("Unable to upload CPI due to group ID not found", requestId)
+    } catch (e: GroupPolicyParseException) {
+        throw ValidationException("Unable to upload CPI due to group policy parse error ${e.message}", requestId, e)
     }
-    if (groupId.isBlank()) throw ValidationException("CPI group policy file needs a groupId")
+    if (groupId.isBlank()) throw ValidationException("Unable to upload CPI due to group ID being blank", requestId)
     return groupId
 }
 
 /**
- * @throws ValidationException if the signature is incorrect
+ * Return a boolean indicating whether the signature is
  */
-fun FileInfo.checkSignature() {
-    if (!Files.newInputStream(this.path).use { isSigned(it) }) {
-        throw ValidationException("Signature invalid: ${this.name}")
-    }
-}
+fun FileInfo.checkSignature() = Files.newInputStream(this.path).use { isSigned(it) }
 
 /**
  * STUB - this needs to be implemented

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ValidateGroupIdTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ValidateGroupIdTest.kt
@@ -16,7 +16,7 @@ class ValidateGroupIdTest {
         val mockMetadata = mock<CpiMetadata> { on { groupPolicy }.doReturn(null) }
         val cpi = mock<Cpi> { on { metadata }.doReturn(mockMetadata) }
 
-        assertThrows<ValidationException> { cpi.validateAndGetGroupId { s -> s } }
+        assertThrows<ValidationException> { cpi.validateAndGetGroupId("") { s -> s } }
     }
 
     @Test
@@ -24,8 +24,8 @@ class ValidateGroupIdTest {
         val mockMetadata = mock<CpiMetadata> { on { groupPolicy }.doReturn(null) }
         val cpi = mock<Cpi> { on { metadata }.doReturn(mockMetadata) }
 
-        assertThrows<ValidationException> { cpi.validateAndGetGroupId { "" } }
-        assertThrows<ValidationException> { cpi.validateAndGetGroupId { "   " } }
+        assertThrows<ValidationException> { cpi.validateAndGetGroupId("") { "" } }
+        assertThrows<ValidationException> { cpi.validateAndGetGroupId("") { "   " } }
     }
 
     @Test
@@ -34,7 +34,7 @@ class ValidateGroupIdTest {
         val json = """{ "groupId": "$expectedGroupId" }"""
         val mockMetadata = mock<CpiMetadata> { on { groupPolicy }.doReturn(json ) }
         val cpi = mock<Cpi> { on { metadata }.doReturn(mockMetadata) }
-        assertThat(cpi.validateAndGetGroupId(GroupPolicyParser::groupIdFromJson)).isEqualTo(expectedGroupId)
+        assertThat(cpi.validateAndGetGroupId("", GroupPolicyParser::groupIdFromJson)).isEqualTo(expectedGroupId)
     }
 
     @Test
@@ -42,7 +42,7 @@ class ValidateGroupIdTest {
         val emptyJson = """{ }"""
         val mockMetadata = mock<CpiMetadata> { on { groupPolicy }.doReturn(emptyJson ) }
         val cpi = mock<Cpi> { on { metadata }.doReturn(mockMetadata) }
-        assertThrows<ValidationException> {cpi.validateAndGetGroupId(GroupPolicyParser::groupIdFromJson)}
+        assertThrows<ValidationException> {cpi.validateAndGetGroupId("", GroupPolicyParser::groupIdFromJson)}
     }
 
     @Test
@@ -50,6 +50,6 @@ class ValidateGroupIdTest {
         val emptyJson = """{ "groupId": "" }"""
         val mockMetadata = mock<CpiMetadata> { on { groupPolicy }.doReturn(emptyJson ) }
         val cpi = mock<Cpi> { on { metadata }.doReturn(mockMetadata) }
-        assertThrows<ValidationException> {cpi.validateAndGetGroupId(GroupPolicyParser::groupIdFromJson)}
+        assertThrows<ValidationException> {cpi.validateAndGetGroupId("", GroupPolicyParser::groupIdFromJson)}
     }
 }

--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
@@ -58,6 +58,7 @@ class CpiUploadRPCOpsImpl @Activate constructor(
         logger.info("Uploading CPI: ${upload.fileName}")
         requireRunning()
         val cpiUploadRequestId = cpiUploadManager.uploadCpi(upload.fileName, upload.content)
+        logger.info("Request ID for uploading CPI ${upload.fileName} is ${cpiUploadRequestId}")
         return CpiUploadRPCOps.CpiUploadResponse(cpiUploadRequestId.requestId)
     }
 

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicyIdNotFoundException.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicyIdNotFoundException.kt
@@ -1,0 +1,5 @@
+package net.corda.membership.lib.grouppolicy
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class GroupPolicyIdNotFoundException: CordaRuntimeException("group policy ID not found")

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicyParseException.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicyParseException.kt
@@ -1,0 +1,5 @@
+package net.corda.membership.lib.grouppolicy
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class GroupPolicyParseException(_message: String, _cause: Throwable): CordaRuntimeException(_message, _cause)

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicyParser.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicyParser.kt
@@ -22,10 +22,9 @@ interface GroupPolicyParser {
         fun groupIdFromJson(groupPolicyJson: String): String {
             try {
                 return ObjectMapper().readTree(groupPolicyJson).get(GROUP_ID)?.asText()
-                    ?: throw CordaRuntimeException("Failed to parse group policy file. " +
-                            "Could not find `$GROUP_ID` in the JSON")
+                    ?: throw GroupPolicyIdNotFoundException()
             } catch (e: JsonParseException) {
-                throw CordaRuntimeException("Failed to parse group policy file", e)
+                throw GroupPolicyParseException(e.originalMessage, e)
             }
         }
     }

--- a/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ReUsedGroupIdException.kt
+++ b/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ReUsedGroupIdException.kt
@@ -9,5 +9,6 @@ package net.corda.libs.cpiupload
  *
  * @param resourceName Must be the 'resource name' rather than the message so we
  * can pass it back to [net.corda.httprpc.exception.ResourceAlreadyExistsException]
+ * @param requestId The ID of the request that tried to reuse a group ID.
  */
-class ReUsedGroupIdException(resourceName: String) : Exception(resourceName)
+class ReUsedGroupIdException(resourceName: String, val requestId: String) : Exception(resourceName)

--- a/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ValidationException.kt
+++ b/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ValidationException.kt
@@ -6,7 +6,4 @@ package net.corda.libs.cpiupload
  * This exception is passed via a kafka envelope message and then
  * "checked" in the rpc ops layer when received.
  */
-class ValidationException : Exception {
-    constructor(message: String) : super(message)
-    constructor(message: String, ex: Exception) : super(message, ex)
-}
+class ValidationException(message: String,  val requestId: String?, ex:Exception?=null) : Exception(message, ex)


### PR DESCRIPTION
CORE-6554: clean up error messages for CPI validation

Pull out request ID into its own exception field rather than inconsitently embed in certain error strings.
