### PR TITLE
CORE-5665: Fixup error messages and response code

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -153,6 +153,21 @@ class VirtualNodeRpcTest {
     }
 
     @Test
+    @Order(31)
+    fun `cannot upload same CPI with different groupId`() {
+        cluster {
+            endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+            val requestId = cpiUpload(TEST_CPB, "SOMETHING ELSE").let { it.toJson()["id"].textValue() }
+            assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
+
+            assertWithRetry {
+                command { cpiStatus(requestId) }
+                condition { it.code == 409 }
+            }
+        }
+    }
+
+    @Test
     @Order(33)
     fun `list cpis`() {
         cluster {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -157,7 +157,7 @@ class VirtualNodeRpcTest {
     fun `cannot upload same CPI with different groupId`() {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
-            val requestId = cpiUpload(TEST_CPB, "SOMETHING ELSE").let { it.toJson()["id"].textValue() }
+            val requestId = cpiUpload(TEST_CPB, "differentGroupId").let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
             assertWithRetry {

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -6,6 +6,7 @@ import net.corda.chunking.db.impl.persistence.ChunkPersistence
 import net.corda.chunking.db.impl.persistence.CpiPersistence
 import net.corda.chunking.db.impl.persistence.StatusPublisher
 import net.corda.cpiinfo.write.CpiInfoWriteService
+import net.corda.libs.cpiupload.ReUsedGroupIdException
 import net.corda.libs.cpiupload.ValidationException
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiMetadata
@@ -114,9 +115,9 @@ class CpiValidatorImpl constructor(
                 cpi.metadata.cpiId.version
             )
         ) {
-            throw ValidationException(
+            throw ReUsedGroupIdException(
                 "Group id ($groupId) in use with another CPI.  " +
-                        "Cannot upload ${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version}"
+                    "Cannot upload ${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version}"
             )
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -7,7 +7,6 @@ import net.corda.chunking.db.impl.persistence.CpiPersistence
 import net.corda.chunking.db.impl.persistence.StatusPublisher
 import net.corda.cpiinfo.write.CpiInfoWriteService
 import net.corda.libs.cpiupload.ReUsedGroupIdException
-import net.corda.libs.cpiupload.ValidationException
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.verify.verifyCpi

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -133,7 +133,7 @@ fun CpiPersistence.persistCpiToDatabase(
         } else {
             throw ValidationException(
                 "CPI has already been inserted with cpks for " +
-                        "${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version} with groupId=$groupId"
+                    "${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version} with groupId=$groupId"
             )
         }
     } catch (ex: Exception) {
@@ -201,7 +201,8 @@ fun CpiPersistence.verifyGroupIdIsUniqueForCpi(cpi: Cpi) {
         // Carefully constructed message because the "409/conflict" exception:
         // ResourceAlreadyExistsException
         // just wants "the resource".
-        val resource = "${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version} (groupId=$groupIdInDatabase)"
+        val resource = "CPI ${cpi.metadata.cpiId.name} ${cpi.metadata.cpiId.version} " +
+            "already uploaded with groupId(groupId=$groupIdInDatabase)"
         throw DuplicateCpiUploadException(resource)
     }
 }

--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRPCOpsImpl.kt
@@ -22,6 +22,7 @@ import net.corda.httprpc.exception.BadRequestException
 import net.corda.httprpc.exception.InvalidInputDataException
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.libs.cpiupload.DuplicateCpiUploadException
+import net.corda.libs.cpiupload.ReUsedGroupIdException
 import net.corda.libs.cpiupload.ValidationException
 
 @Component(service = [PluggableRPCOps::class])
@@ -91,6 +92,7 @@ class CpiUploadRPCOpsImpl @Activate constructor(
         when (ex.errorType) {
             ValidationException::class.java.name -> throw BadRequestException(ex.errorMessage, details)
             DuplicateCpiUploadException::class.java.name -> throw ResourceAlreadyExistsException(ex.errorMessage)
+            ReUsedGroupIdException::class.java.name -> throw ResourceAlreadyExistsException(ex.errorMessage)
             else -> throw InternalServerException(ex.toString(), details)
         }
     }

--- a/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ReUsedGroupIdException.kt
+++ b/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ReUsedGroupIdException.kt
@@ -1,0 +1,13 @@
+package net.corda.libs.cpiupload
+
+/**
+ * Exception type that is thrown if there is an attempt to upload a
+ * duplicate CPI .
+ *
+ * This exception is passed via a kafka envelope message and then
+ * "checked" in the rpc ops layer when received.
+ *
+ * @param resourceName Must be the 'resource name' rather than the message so we
+ * can pass it back to [net.corda.httprpc.exception.ResourceAlreadyExistsException]
+ */
+class ReUsedGroupIdException(resourceName: String) : Exception(resourceName)

--- a/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ReUsedGroupIdException.kt
+++ b/libs/virtual-node/cpi-upload-manager/src/main/kotlin/net/corda/libs/cpiupload/ReUsedGroupIdException.kt
@@ -2,7 +2,7 @@ package net.corda.libs.cpiupload
 
 /**
  * Exception type that is thrown if there is an attempt to upload a
- * duplicate CPI .
+ * CPI with a groupID that's already in use.
  *
  * This exception is passed via a kafka envelope message and then
  * "checked" in the rpc ops layer when received.


### PR DESCRIPTION
Changes the error received when re-using a groupId from a 400, to a 409. Also expands the error received when a CPI and Version are found with a different group ID

Also add E2E Test to help validate