### PR TITLE
CORE-6548: Change signature of `withPermissionManager` method

### DIFF
--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionManagementHandler.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionManagementHandler.kt
@@ -17,11 +17,11 @@ import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import org.slf4j.Logger
 
 @Suppress("ComplexMethod", "ThrowsCount")
-fun <T : Any> withPermissionManager(
+fun <T : Any?> withPermissionManager(
     permissionManager: PermissionManager,
     logger: Logger,
-    block: PermissionManager.() -> T?
-): T? {
+    block: PermissionManager.() -> T
+): T {
     return try {
         block.invoke(permissionManager)
 

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
@@ -52,7 +52,7 @@ class PermissionEndpointImpl @Activate constructor(
             createPermission(createPermissionType.convertToDto(principal))
         }
 
-        return ResponseEntity.created(createPermissionResult!!.convertToEndpointType())
+        return ResponseEntity.created(createPermissionResult.convertToEndpointType())
     }
 
     override fun getPermission(id: String): PermissionResponseType {

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
@@ -47,7 +47,7 @@ class RoleEndpointImpl @Activate constructor(
     override fun getRoles(): Set<RoleResponseType> {
         val allRoles = withPermissionManager(permissionManagementService.permissionManager, logger) {
             getRoles()
-        }!!
+        }
         return allRoles.map { it.convertToEndpointType() }.toSet()
     }
 
@@ -59,7 +59,7 @@ class RoleEndpointImpl @Activate constructor(
             createRole(createRoleType.convertToDto(principal))
         }
 
-        return ResponseEntity.created(createRoleResult!!.convertToEndpointType())
+        return ResponseEntity.created(createRoleResult.convertToEndpointType())
     }
 
     override fun getRole(id: String): RoleResponseType {
@@ -81,7 +81,7 @@ class RoleEndpointImpl @Activate constructor(
             addPermissionToRole(roleId, permissionId, principal)
         }
 
-        return ResponseEntity.updated(updatedRoleResult!!.convertToEndpointType())
+        return ResponseEntity.updated(updatedRoleResult.convertToEndpointType())
     }
 
     override fun removePermission(roleId: String, permissionId: String): ResponseEntity<RoleResponseType> {
@@ -92,7 +92,7 @@ class RoleEndpointImpl @Activate constructor(
             removePermissionFromRole(roleId, permissionId, principal)
         }
 
-        return ResponseEntity.deleted(updatedRoleResult!!.convertToEndpointType())
+        return ResponseEntity.deleted(updatedRoleResult.convertToEndpointType())
     }
 
     override val isRunning: Boolean

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
@@ -55,7 +55,7 @@ class UserEndpointImpl @Activate constructor(
             createUser(createUserType.convertToDto(principal))
         }
 
-        return ResponseEntity.created(createUserResult!!.convertToEndpointType())
+        return ResponseEntity.created(createUserResult.convertToEndpointType())
     }
 
     override fun getUser(loginName: String): UserResponseType {
@@ -74,7 +74,7 @@ class UserEndpointImpl @Activate constructor(
         val result = withPermissionManager(permissionManagementService.permissionManager, logger) {
             addRoleToUser(AddRoleToUserRequestDto(principal, loginName.lowercase(), roleId))
         }
-        return ResponseEntity.ok(result!!.convertToEndpointType())
+        return ResponseEntity.ok(result.convertToEndpointType())
     }
 
     override fun removeRole(loginName: String, roleId: String): ResponseEntity<UserResponseType> {
@@ -83,7 +83,7 @@ class UserEndpointImpl @Activate constructor(
         val result = withPermissionManager(permissionManagementService.permissionManager, logger) {
             removeRoleFromUser(RemoveRoleFromUserRequestDto(principal, loginName.lowercase(), roleId))
         }
-        return ResponseEntity.deleted(result!!.convertToEndpointType())
+        return ResponseEntity.deleted(result.convertToEndpointType())
     }
 
     override fun getPermissionSummary(loginName: String): UserPermissionSummaryResponseType {


### PR DESCRIPTION
Such that we can remove unnecessary nullable checks for entities creation methods.