### PR TITLE
NOTICK: Ignore wronte status update instead of raising an exception

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
@@ -18,11 +18,15 @@ internal class UpdateRegistrationRequestStatusHandler(
             ) ?: throw MembershipPersistenceException("Could not find registration request: ${request.registrationId}")
             val currentStatus = RegistrationStatus.valueOf(registrationRequest.status)
             if (currentStatus.ordinal > request.registrationStatus.ordinal) {
-                throw MembershipPersistenceException("Could not update status from $currentStatus to ${request.registrationStatus}")
+                logger.info(
+                    "Could not update status of registration ${request.registrationId} from $currentStatus to " +
+                        "${request.registrationStatus}, will ignore the update"
+                )
+            } else {
+                registrationRequest.status = request.registrationStatus.name
+                registrationRequest.lastModified = clock.instant()
+                em.merge(registrationRequest)
             }
-            registrationRequest.status = request.registrationStatus.name
-            registrationRequest.lastModified = clock.instant()
-            em.merge(registrationRequest)
         }
     }
 }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -129,7 +130,7 @@ class UpdateRegistrationRequestStatusHandlerTest {
     }
 
     @Test
-    fun `invoke updates fails to downgrade status`() {
+    fun `invoke updates ignores to downgrade status`() {
         val registrationId = "regId"
         val registrationRequestEntity = mock<RegistrationRequestEntity> {
             on { status } doReturn "APPROVED"
@@ -139,8 +140,8 @@ class UpdateRegistrationRequestStatusHandlerTest {
         val statusUpdate = UpdateRegistrationRequestStatus(registrationId, RegistrationStatus.PENDING_AUTO_APPROVAL)
         clock.setTime(Instant.ofEpochMilli(500))
 
-        assertThrows<MembershipPersistenceException> {
-            updateRegistrationRequestStatusHandler.invoke(context, statusUpdate)
-        }
+        updateRegistrationRequestStatusHandler.invoke(context, statusUpdate)
+
+        verify(entityManager, never()).merge(registrationRequestEntity)
     }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -81,7 +81,7 @@ class StartRegistrationHandler(
             }
 
             val mgmMemberInfo = getMGMMemberInfo(mgmHoldingId)
-            logger.info("Registering with MGM for holding identity: $mgmHoldingId")
+            logger.info("Registering $pendingMemberHoldingId with MGM for holding identity: $mgmHoldingId")
             val pendingMemberInfo = buildPendingMemberInfo(registrationRequest)
             // Parse the registration request and verify contents
             // The MemberX500Name matches the source MemberX500Name from the P2P messaging


### PR DESCRIPTION
Replacing the exception with log info and adding the holding Identity ID to the registration request logs.