### PR TITLE
CORE-6627: Use Java-compatible Corda serialization API.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.178-beta+
+cordaApiVersion=5.0.0.179-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/RemoteSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/RemoteSerializerFactory.kt
@@ -95,8 +95,8 @@ class DefaultRemoteSerializerFactory(
 
             // Return the specific serializer the caller asked for.
             serializers[typeDescriptor] ?: throw MissingSerializerException(
-                message = "Could not find type matching descriptor $typeDescriptor.",
-                typeDescriptor = typeDescriptor
+                "Could not find type matching descriptor $typeDescriptor.",
+                typeDescriptor
             )
         }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformTypes.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformTypes.kt
@@ -28,7 +28,7 @@ enum class TransformTypes(val build: (Annotation) -> Transform) : DescribedType 
         override fun getDescriptor(): Any = DESCRIPTOR
         override fun getDescribed(): Any = ordinal
     },
-    EnumDefault({ a -> EnumDefaultSchemaTransform((a as CordaSerializationTransformEnumDefault).old, a.new) }) {
+    EnumDefault({ a -> EnumDefaultSchemaTransform((a as CordaSerializationTransformEnumDefault).oldName, a.newName) }) {
         override fun getDescriptor(): Any = DESCRIPTOR
         override fun getDescribed(): Any = ordinal
     },

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformsSchema.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformsSchema.kt
@@ -133,7 +133,7 @@ class EnumDefaultSchemaTransform(val old: String, val new: String) : Transform()
     }
 
     @Suppress("UNUSED")
-    constructor (annotation: CordaSerializationTransformEnumDefault) : this(annotation.old, annotation.new)
+    constructor (annotation: CordaSerializationTransformEnumDefault) : this(annotation.oldName, annotation.newName)
 
     override fun getDescribed(): Any = listOf(name, old, new)
     override fun params() = "old=${old.esc()} new=${new.esc()}"

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
@@ -96,7 +96,7 @@ class CorDappCustomSerializer(
                              context: SerializationContext, debugIndent: Int
     ) {
         @Suppress("unchecked_cast")
-        val proxy = (serializer as SerializationCustomSerializer<Any, Any?>).toProxy(obj)
+        val proxy = (serializer as SerializationCustomSerializer<Any, Any>).toProxy(obj)
 
         data.withDescribed(descriptor) {
             data.withList {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ObjectSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ObjectSerializer.kt
@@ -42,8 +42,8 @@ interface ObjectSerializer : AMQPSerializer<Any> {
             if (typeInformation is LocalTypeInformation.NonComposable) {
                 val typeNames = typeInformation.nonComposableTypes.map { it.observedType.typeName }
                 throw MissingSerializerException(
-                    message = nonComposableExceptionMessage(typeInformation, factory),
-                    typeNames = typeNames
+                    nonComposableExceptionMessage(typeInformation, factory),
+                    typeNames
                 )
             }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
@@ -22,8 +22,8 @@ import net.corda.internal.serialization.model.LocalTypeInformation.Top
 import net.corda.internal.serialization.model.LocalTypeInformation.Unknown
 import net.corda.kotlin.reflect.kotlinClass
 import net.corda.utilities.reflection.kotlinObjectInstance
-import net.corda.v5.serialization.annotations.ConstructorForDeserialization
-import net.corda.v5.serialization.annotations.DeprecatedConstructorForDeserialization
+import net.corda.v5.base.annotations.ConstructorForDeserialization
+import net.corda.v5.base.annotations.DeprecatedConstructorForDeserialization
 import java.io.NotSerializableException
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -32,6 +32,7 @@ import java.lang.reflect.Type
 import java.util.Locale
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.internal.KotlinReflectionInternalError
 import kotlin.reflect.jvm.isAccessible
@@ -511,7 +512,9 @@ private fun constructorForDeserialization(type: Type): KFunction<Any>? {
 
     val kotlinCtors = clazz.kotlin.constructors
 
-    val annotatedCtors = kotlinCtors.filter { it.findAnnotation<ConstructorForDeserialization>() != null }
+    val annotatedCtors = kotlinCtors.filter { ctor ->
+        ctor.hasAnnotation<ConstructorForDeserialization>()
+    }
     if (annotatedCtors.size > 1) return null
     if (annotatedCtors.size == 1) return annotatedCtors.first().apply { isAccessible = true }
 

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaCustomSerializerListProxyTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaCustomSerializerListProxyTests.java
@@ -2,6 +2,7 @@ package net.corda.internal.serialization.amqp;
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
 import net.corda.v5.serialization.SerializationCustomSerializer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -17,11 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class JavaCustomSerializerListProxyTests {
     public static class ExampleSerializer implements SerializationCustomSerializer<ClassThatNeedsCustomSerializer, List<Integer>> {
 
-        public List<Integer> toProxy(ClassThatNeedsCustomSerializer obj) {
+        @NotNull
+        public List<Integer> toProxy(@NotNull ClassThatNeedsCustomSerializer obj) {
             return asList(obj.getA(), obj.getB());
         }
 
-        public ClassThatNeedsCustomSerializer fromProxy(List<Integer> proxy) {
+        @NotNull
+        public ClassThatNeedsCustomSerializer fromProxy(@NotNull List<Integer> proxy) {
             List<Integer> constructorInput = new ArrayList<>(2);
             constructorInput.add(proxy.get(0));
             constructorInput.add(proxy.get(1));

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaCustomSerializerMapProxyTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaCustomSerializerMapProxyTests.java
@@ -2,6 +2,7 @@ package net.corda.internal.serialization.amqp;
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
 import net.corda.v5.serialization.SerializationCustomSerializer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -18,14 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class JavaCustomSerializerMapProxyTests {
     public static class ExampleSerializer implements SerializationCustomSerializer<ClassThatNeedsCustomSerializer, Map<String, Integer>> {
 
-        public Map<String, Integer> toProxy(ClassThatNeedsCustomSerializer obj) {
+        @NotNull
+        public Map<String, Integer> toProxy(@NotNull ClassThatNeedsCustomSerializer obj) {
             Map<String, Integer> map = new LinkedHashMap<>();
             map.put("a", obj.getA());
             map.put("b", obj.getB());
             return map;
         }
 
-        public ClassThatNeedsCustomSerializer fromProxy(Map<String, Integer> proxy) {
+        @NotNull
+        public ClassThatNeedsCustomSerializer fromProxy(@NotNull Map<String, Integer> proxy) {
             List<Integer> constructorInput = new ArrayList<>(2);
             constructorInput.add(proxy.get("a"));
             constructorInput.add(proxy.get("b"));

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaCustomSerializerTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaCustomSerializerTests.java
@@ -2,6 +2,7 @@ package net.corda.internal.serialization.amqp;
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
 import net.corda.v5.serialization.SerializationCustomSerializer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -53,7 +54,8 @@ public class JavaCustomSerializerTests {
          *
          *  Essentially convert ClassThatNeedsCustomSerializer -> ExampleProxy
          */
-        public ExampleProxy toProxy(ClassThatNeedsCustomSerializer obj) {
+        @NotNull
+        public ExampleProxy toProxy(@NotNull ClassThatNeedsCustomSerializer obj) {
             return new ExampleProxy(obj.getA(), obj.getB());
         }
 
@@ -64,7 +66,8 @@ public class JavaCustomSerializerTests {
          *  Essentially convert ExampleProxy -> Example
          *
          */
-        public ClassThatNeedsCustomSerializer fromProxy(ExampleProxy proxy) {
+        @NotNull
+        public ClassThatNeedsCustomSerializer fromProxy(@NotNull ExampleProxy proxy) {
             List<Integer> l = new ArrayList<>(2);
             l.add(proxy.getProxiedA());
             l.add(proxy.getProxiedB());

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaSerializationOutputTests.java
@@ -1,9 +1,9 @@
 package net.corda.internal.serialization.amqp;
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
+import net.corda.v5.base.annotations.ConstructorForDeserialization;
 import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.serialization.SerializedBytes;
-import net.corda.v5.serialization.annotations.ConstructorForDeserialization;
 import org.apache.qpid.proton.codec.DecoderImpl;
 import org.apache.qpid.proton.codec.EncoderImpl;
 import org.junit.jupiter.api.Assertions;

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/SerializationAPIJavaApiTest.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/SerializationAPIJavaApiTest.java
@@ -296,12 +296,14 @@ public class SerializationAPIJavaApiTest {
     class BaseProxyTestClass implements SerializationCustomSerializer<BaseTestClass<?>, ProxyTestClass> {
 
         @Override
-        public ProxyTestClass toProxy(BaseTestClass<?> baseTestClass) {
+        @NotNull
+        public ProxyTestClass toProxy(@NotNull BaseTestClass<?> baseTestClass) {
             return proxy;
         }
 
         @Override
-        public BaseTestClass<?> fromProxy(ProxyTestClass proxyTestClass) {
+        @NotNull
+        public BaseTestClass<?> fromProxy(@NotNull ProxyTestClass proxyTestClass) {
             return obj;
         }
     }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumEvolvabilityTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumEvolvabilityTests.kt
@@ -45,22 +45,22 @@ class EnumEvolvabilityTests {
         A, B, C, D
     }
 
-    @CordaSerializationTransformEnumDefault("D", "A")
+    @CordaSerializationTransformEnumDefault(newName = "D", oldName = "A")
     @CordaSerializable
     enum class AnnotatedEnumOnce {
         A, B, C, D
     }
 
     @CordaSerializationTransformEnumDefaults(
-        CordaSerializationTransformEnumDefault("E", "D"),
-        CordaSerializationTransformEnumDefault("D", "A")
+        CordaSerializationTransformEnumDefault(newName = "E", oldName = "D"),
+        CordaSerializationTransformEnumDefault(newName = "D", oldName = "A")
     )
     @CordaSerializable
     enum class AnnotatedEnumTwice {
         A, B, C, D, E
     }
 
-    @CordaSerializationTransformRename("E", "D")
+    @CordaSerializationTransformRename(to = "E", from = "D")
     @CordaSerializable
     enum class RenameEnumOnce {
         A, B, C, E
@@ -250,8 +250,8 @@ class EnumEvolvabilityTests {
     }
 
     @CordaSerializationTransformRenames(
-        CordaSerializationTransformRename("E", "C"),
-        CordaSerializationTransformRename("F", "D")
+        CordaSerializationTransformRename(to = "E", from = "C"),
+        CordaSerializationTransformRename(to = "F", from = "D")
     )
     @CordaSerializable
     enum class RenameEnumTwice {
@@ -301,7 +301,7 @@ class EnumEvolvabilityTests {
     }
 
     @CordaSerializationTransformRename(from = "A", to = "X")
-    @CordaSerializationTransformEnumDefault(old = "X", new = "E")
+    @CordaSerializationTransformEnumDefault(oldName = "X", newName = "E")
     @CordaSerializable
     enum class RenameAndExtendEnum {
         X, B, C, D, E
@@ -339,8 +339,8 @@ class EnumEvolvabilityTests {
     }
 
     @CordaSerializationTransformEnumDefaults(
-        CordaSerializationTransformEnumDefault("D", "A"),
-        CordaSerializationTransformEnumDefault("D", "A")
+        CordaSerializationTransformEnumDefault(newName = "D", oldName = "A"),
+        CordaSerializationTransformEnumDefault(newName = "D", oldName = "A")
     )
     enum class RepeatedAnnotation {
         A, B, C, D, E
@@ -357,22 +357,22 @@ class EnumEvolvabilityTests {
         }.isInstanceOf(NotSerializableException::class.java)
     }
 
-    @CordaSerializationTransformEnumDefault("D", "A")
+    @CordaSerializationTransformEnumDefault(newName = "D", oldName = "A")
     @CordaSerializable
     enum class E1 {
         A, B, C, D
     }
 
     @CordaSerializationTransformEnumDefaults(
-        CordaSerializationTransformEnumDefault("D", "A"),
-        CordaSerializationTransformEnumDefault("E", "A")
+        CordaSerializationTransformEnumDefault(newName = "D", oldName = "A"),
+        CordaSerializationTransformEnumDefault(newName = "E", oldName = "A")
     )
     @CordaSerializable
     enum class E2 {
         A, B, C, D, E
     }
 
-    @CordaSerializationTransformEnumDefaults(CordaSerializationTransformEnumDefault("D", "A"))
+    @CordaSerializationTransformEnumDefaults(CordaSerializationTransformEnumDefault(newName = "D", oldName = "A"))
     @CordaSerializable
     enum class E3 {
         A, B, C, D
@@ -546,8 +546,8 @@ class EnumEvolvabilityTests {
     // And we're not at 3. However, we ban this rename
     //
     @CordaSerializationTransformRenames(
-        CordaSerializationTransformRename("D", "C"),
-        CordaSerializationTransformRename("C", "D")
+        CordaSerializationTransformRename(to = "D", from = "C"),
+        CordaSerializationTransformRename(to = "C", from = "D")
     )
     enum class RejectCyclicRename { A, B, C }
 
@@ -562,11 +562,11 @@ class EnumEvolvabilityTests {
     }
 
     @CordaSerializationTransformRenames(
-        CordaSerializationTransformRename("G", "C"),
-        CordaSerializationTransformRename("F", "G"),
-        CordaSerializationTransformRename("E", "F"),
-        CordaSerializationTransformRename("D", "E"),
-        CordaSerializationTransformRename("C", "D")
+        CordaSerializationTransformRename(to = "G", from = "C"),
+        CordaSerializationTransformRename(to = "F", from = "G"),
+        CordaSerializationTransformRename(to = "E", from = "F"),
+        CordaSerializationTransformRename(to = "D", from = "E"),
+        CordaSerializationTransformRename(to = "C", from = "D")
     )
     enum class RejectCyclicRenameRedux { A, B, C }
 
@@ -580,7 +580,7 @@ class EnumEvolvabilityTests {
         }.isInstanceOf(NotSerializableException::class.java)
     }
 
-    @CordaSerializationTransformEnumDefault(new = "D", old = "X")
+    @CordaSerializationTransformEnumDefault(newName = "D", oldName = "X")
     enum class RejectBadDefault { A, B, C, D }
 
     @Test
@@ -593,7 +593,7 @@ class EnumEvolvabilityTests {
         }.isInstanceOf(NotSerializableException::class.java)
     }
 
-    @CordaSerializationTransformEnumDefault(new = "D", old = "D")
+    @CordaSerializationTransformEnumDefault(newName = "D", oldName = "D")
     enum class RejectBadDefaultToSelf { A, B, C, D }
 
     @Test

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumEvolveTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumEvolveTests.kt
@@ -401,7 +401,7 @@ class EnumEvolveTests {
         load(stage5Resources).forEach { assertEquals(it.second, it.first.e) }
     }
 
-    @CordaSerializationTransformEnumDefault(old = "A", new = "F")
+    @CordaSerializationTransformEnumDefault(oldName = "A", newName = "F")
     enum class BadNewValue { A, B, C, D }
 
     @Test
@@ -416,8 +416,8 @@ class EnumEvolveTests {
     }
 
     @CordaSerializationTransformEnumDefaults(
-        CordaSerializationTransformEnumDefault(new = "D", old = "E"),
-        CordaSerializationTransformEnumDefault(new = "E", old = "A")
+        CordaSerializationTransformEnumDefault(newName = "D", oldName = "E"),
+        CordaSerializationTransformEnumDefault(newName = "E", oldName = "A")
     )
     enum class OutOfOrder { A, B, C, D, E }
 
@@ -437,7 +437,7 @@ class EnumEvolveTests {
     // enum class ChangedOrdinality { A, B, C }
     //
     // class as it exists for the tests
-    @CordaSerializationTransformEnumDefault("D", "A")
+    @CordaSerializationTransformEnumDefault(newName = "D", oldName = "A")
     enum class ChangedOrdinality { A, B, D, C }
 
     @Test
@@ -466,8 +466,8 @@ class EnumEvolveTests {
     //
     // Version of the class as it's used in the test
     @CordaSerializationTransformEnumDefaults(
-        CordaSerializationTransformEnumDefault("E", "C"),
-        CordaSerializationTransformEnumDefault("D", "C")
+        CordaSerializationTransformEnumDefault(newName = "E", oldName = "C"),
+        CordaSerializationTransformEnumDefault(newName = "D", oldName = "C")
     )
     @CordaSerializable
     enum class ExtendedEnum { A, B, C, D, E }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTransformationTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTransformationTests.kt
@@ -16,8 +16,8 @@ import kotlin.test.assertFailsWith
 class EnumTransformationTests {
 
     @CordaSerializationTransformEnumDefaults(
-            CordaSerializationTransformEnumDefault(old = "C", new = "D"),
-            CordaSerializationTransformEnumDefault(old = "D", new = "E")
+            CordaSerializationTransformEnumDefault(oldName = "C", newName = "D"),
+            CordaSerializationTransformEnumDefault(oldName = "D", newName = "E")
     )
     @CordaSerializationTransformRenames(
         CordaSerializationTransformRename(to = "BOB", from = "FRED"),

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionObjectBuilderRenamedPropertyTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionObjectBuilderRenamedPropertyTests.kt
@@ -5,8 +5,8 @@ import net.corda.internal.serialization.amqp.testutils.serialize
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.internal.serialization.amqp.testutils.writeTestResource
 import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.base.annotations.DeprecatedConstructorForDeserialization
 import net.corda.v5.serialization.SerializedBytes
-import net.corda.v5.serialization.annotations.DeprecatedConstructorForDeserialization
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolvabilityTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolvabilityTests.kt
@@ -7,10 +7,10 @@ import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.serializeAndReturnSchema
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.internal.serialization.amqp.testutils.testName
+import net.corda.v5.base.annotations.ConstructorForDeserialization
 import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.base.annotations.DeprecatedConstructorForDeserialization
 import net.corda.v5.serialization.SerializedBytes
-import net.corda.v5.serialization.annotations.ConstructorForDeserialization
-import net.corda.v5.serialization.annotations.DeprecatedConstructorForDeserialization
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivatePropertyTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivatePropertyTests.kt
@@ -1,6 +1,5 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.v5.serialization.annotations.ConstructorForDeserialization
 import net.corda.internal.serialization.amqp.testutils.TestDescriptorBasedSerializerRegistry
 import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.serialize
@@ -9,6 +8,7 @@ import net.corda.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolu
 import net.corda.internal.serialization.model.ConfigurableLocalTypeModel
 import net.corda.internal.serialization.model.LocalPropertyInformation
 import net.corda.internal.serialization.model.LocalTypeInformation
+import net.corda.v5.base.annotations.ConstructorForDeserialization
 import net.corda.v5.base.annotations.CordaSerializable
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Java6Assertions.assertThat

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/RoundTripTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/RoundTripTests.kt
@@ -1,9 +1,9 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.v5.serialization.annotations.ConstructorForDeserialization
 import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.serialize
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
+import net.corda.v5.base.annotations.ConstructorForDeserialization
 import net.corda.v5.base.annotations.CordaSerializable
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -16,10 +16,10 @@ import net.corda.internal.serialization.registerCustomSerializers
 import net.corda.serialization.EncodingAllowList
 import net.corda.serialization.SerializationContext
 import net.corda.v5.application.flows.exceptions.FlowException
+import net.corda.v5.base.annotations.ConstructorForDeserialization
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.OpaqueBytes
-import net.corda.v5.serialization.annotations.ConstructorForDeserialization
 import org.apache.qpid.proton.amqp.Decimal128
 import org.apache.qpid.proton.amqp.Decimal32
 import org.apache.qpid.proton.amqp.Decimal64

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationPropertyOrdering.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationPropertyOrdering.kt
@@ -1,11 +1,11 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.v5.serialization.annotations.ConstructorForDeserialization
 import net.corda.internal.serialization.amqp.testutils.TestDescriptorBasedSerializerRegistry
 import net.corda.internal.serialization.amqp.testutils.TestSerializationOutput
 import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.serializeAndReturnSchema
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
+import net.corda.v5.base.annotations.ConstructorForDeserialization
 import net.corda.v5.base.annotations.CordaSerializable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout


### PR DESCRIPTION
Some of the serialization annotations have been moved into the `base` module, and those remaining annotations have been rewritten as Java. This _forces_ them to have Java-compatible names, and also allows them to become `@Repeatable` annotations.

As Java annotations, we must set their parameters by name, which isn't a Bad Thing either :grin:.