### PR TITLE
CORE-6651 Remove `FlowException`

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
@@ -4,7 +4,7 @@ import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.flow.testing.context.flowResumedWithError
 import net.corda.flow.testing.context.initiateFlowMessage
-import net.corda.v5.application.flows.exceptions.FlowException
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -90,7 +90,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWithError<FlowException>()
+                flowResumedWithError<CordaRuntimeException>()
                 noPendingUserException()
             }
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandler.kt
@@ -20,7 +20,11 @@ class WakeupWaitingForHandler : FlowWaitingForHandler<Wakeup> {
         log.info("Waking up [${context.checkpoint.flowId}]")
         val pendingPlatformError = context.checkpoint.pendingPlatformError
         return if (pendingPlatformError != null) {
-            FlowContinuation.Error(CordaRuntimeException("Type='${pendingPlatformError.errorType}' Message='${pendingPlatformError.errorMessage}'"))
+            FlowContinuation.Error(
+                CordaRuntimeException(
+                    "Type='${pendingPlatformError.errorType}' Message='${pendingPlatformError.errorMessage}'"
+                )
+            )
         } else {
             FlowContinuation.Run(Unit)
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandler.kt
@@ -3,7 +3,7 @@ package net.corda.flow.pipeline.handlers.waiting
 import net.corda.data.flow.state.waiting.Wakeup
 import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.pipeline.FlowEventContext
-import net.corda.v5.application.flows.exceptions.FlowException
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Component
 
@@ -20,7 +20,7 @@ class WakeupWaitingForHandler : FlowWaitingForHandler<Wakeup> {
         log.info("Waking up [${context.checkpoint.flowId}]")
         val pendingPlatformError = context.checkpoint.pendingPlatformError
         return if (pendingPlatformError != null) {
-            FlowContinuation.Error(FlowException("Type='${pendingPlatformError.errorType}' Message='${pendingPlatformError.errorMessage}'"))
+            FlowContinuation.Error(CordaRuntimeException("Type='${pendingPlatformError.errorType}' Message='${pendingPlatformError.errorMessage}'"))
         } else {
             FlowContinuation.Run(Unit)
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/WakeupWaitingForHandlerTest.kt
@@ -5,7 +5,7 @@ import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.state.waiting.Wakeup
 import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.test.utils.buildFlowEventContext
-import net.corda.v5.application.flows.exceptions.FlowException
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ class WakeupWaitingForHandlerTest {
 
         val continuation = WakeupWaitingForHandler().runOrContinue(inputContext, Wakeup()) as FlowContinuation.Error
 
-        assertThat(continuation.exception).isInstanceOf(FlowException::class.java)
+        assertThat(continuation.exception).isInstanceOf(CordaRuntimeException::class.java)
         assertThat(continuation.exception.message).isEqualTo("Type='a' Message='b'")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.179-beta+
+cordaApiVersion=5.0.0.180-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -1,5 +1,21 @@
 package net.corda.internal.serialization.amqp
 
+import java.io.IOException
+import java.io.InputStream
+import java.io.NotSerializableException
+import java.math.BigDecimal
+import java.time.DayOfWeek
+import java.time.Month
+import java.util.Currency
+import java.util.Date
+import java.util.EnumMap
+import java.util.NavigableMap
+import java.util.Objects
+import java.util.Random
+import java.util.SortedSet
+import java.util.TreeMap
+import java.util.TreeSet
+import java.util.UUID
 import net.corda.internal.serialization.CordaSerializationEncoding
 import net.corda.internal.serialization.SnappyEncodingAllowList
 import net.corda.internal.serialization.amqp.custom.BigDecimalSerializer
@@ -15,7 +31,6 @@ import net.corda.internal.serialization.encodingNotPermittedFormat
 import net.corda.internal.serialization.registerCustomSerializers
 import net.corda.serialization.EncodingAllowList
 import net.corda.serialization.SerializationContext
-import net.corda.v5.application.flows.exceptions.FlowException
 import net.corda.v5.base.annotations.ConstructorForDeserialization
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
@@ -45,22 +60,6 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
-import java.io.IOException
-import java.io.InputStream
-import java.io.NotSerializableException
-import java.math.BigDecimal
-import java.time.DayOfWeek
-import java.time.Month
-import java.util.Currency
-import java.util.Date
-import java.util.EnumMap
-import java.util.NavigableMap
-import java.util.Objects
-import java.util.Random
-import java.util.SortedSet
-import java.util.TreeMap
-import java.util.TreeSet
-import java.util.UUID
 
 object AckWrapper {
     @CordaSerializable
@@ -614,7 +613,7 @@ class SerializationOutputTests {
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory2)
 
-        val obj = FlowException("message").fillInStackTrace()
+        val obj = CordaRuntimeException("message").fillInStackTrace()
         serdes(obj, factory, factory2)
     }
 


### PR DESCRIPTION
`FlowException` is not being used anymore, since we are not encouraging the sending of exceptions between sessions to communicate errors. Instead they should pass around POJOs that signify an error.

`FlowException`s specified an exception as needing to be seen as it was on a peer flow. This behaviour is no longer required.