### PR TITLE
CORE-6223: Rename x500name to x500Name in the APIs

### DIFF
--- a/applications/tools/flow-worker-setup/README.md
+++ b/applications/tools/flow-worker-setup/README.md
@@ -79,7 +79,7 @@ To publish the configuration required by the `LinkManager` which is used by the 
   ],
   "membersToAdd": [
     {
-        "x500Name": "CN=Alice, O=Alice Corp, L=LDN, C=GB",
+      "x500Name": "CN=Alice, O=Alice Corp, L=LDN, C=GB",
       "groupId": "flow-worker-dev",
       "data": {
         "address": "http://alice.com:8085",

--- a/applications/tools/flow-worker-setup/README.md
+++ b/applications/tools/flow-worker-setup/README.md
@@ -79,7 +79,7 @@ To publish the configuration required by the `LinkManager` which is used by the 
   ],
   "membersToAdd": [
     {
-      "x500name": "CN=Alice, O=Alice Corp, L=LDN, C=GB",
+        "x500Name": "CN=Alice, O=Alice Corp, L=LDN, C=GB",
       "groupId": "flow-worker-dev",
       "data": {
         "address": "http://alice.com:8085",
@@ -87,7 +87,7 @@ To publish the configuration required by the `LinkManager` which is used by the 
       }
     },
     {
-      "x500name": "CN=Bob, O=Bob Corp, L=LDN, C=GB",
+      "x500Name": "CN=Bob, O=Bob Corp, L=LDN, C=GB",
       "groupId": "flow-worker-dev",
       "data": {
         "address": "http://alice.com:8085",
@@ -97,7 +97,7 @@ To publish the configuration required by the `LinkManager` which is used by the 
   ],
   "identitiesToAdd": [
     {
-      "x500name": "CN=Alice, O=Alice Corp, L=LDN, C=GB",
+      "x500Name": "CN=Alice, O=Alice Corp, L=LDN, C=GB",
       "groupId": "flow-worker-dev",
       "data": {
         "tlsTenantId": "cluster",
@@ -107,7 +107,7 @@ To publish the configuration required by the `LinkManager` which is used by the 
       }
     },
     {
-      "x500name": "CN=Bob, O=Bob Corp, L=LDN, C=GB",
+      "x500Name": "CN=Bob, O=Bob Corp, L=LDN, C=GB",
       "groupId": "flow-worker-dev",
       "data": {
         "tlsTenantId": "cluster",

--- a/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/ConfigureAll.kt
+++ b/applications/tools/p2p-test/p2p-layer-deployment/src/main/kotlin/net/corda/p2p/deployment/commands/ConfigureAll.kt
@@ -82,7 +82,7 @@ class ConfigureAll : Runnable {
     private val host by lazy {
         annotations["host"] as? String ?: throw DeploymentException("Missing host for $namespaceName")
     }
-    private val x500name by lazy {
+    private val x500Name by lazy {
         annotations["x500-name"] as? String ?: throw DeploymentException("Missing x500 name for $namespaceName")
     }
     private val groupId by lazy {
@@ -128,7 +128,7 @@ class ConfigureAll : Runnable {
     }
 
     private val tenantId by lazy {
-        "$groupId|$x500name"
+        "$groupId|$x500Name"
     }
 
     private fun tlsCertificates(host: String): File {
@@ -181,7 +181,7 @@ class ConfigureAll : Runnable {
         }
         val entry =
             mapOf(
-                "x500name" to x500name,
+                "x500Name" to x500Name,
                 "groupId" to groupId,
                 "data" to mapOf(
                     "publicSessionKey" to publicKeyFile(host).readText(),
@@ -213,7 +213,7 @@ class ConfigureAll : Runnable {
         }
         val entriesToAdd = mapOf(
             "groupId" to annotations["group-id"],
-            "x500name" to x500name,
+            "x500Name" to x500Name,
             "data" to mapOf(
                 "networkType" to "CORDA_5",
                 "protocolModes" to listOf("AUTHENTICATED_ENCRYPTION"),
@@ -234,7 +234,7 @@ class ConfigureAll : Runnable {
         }
         val entry =
             mapOf(
-                "x500name" to x500name,
+                "x500Name" to x500Name,
                 "groupId" to groupId,
                 "data" to mapOf(
                     "tlsTenantId" to tenantId,
@@ -263,7 +263,7 @@ class ConfigureAll : Runnable {
             .map { annotations ->
                 val host = annotations["host"] as String
                 mapOf(
-                    "x500name" to annotations["x500-name"],
+                    "x500Name" to annotations["x500-name"],
                     "groupId" to annotations["group-id"],
                     "data" to mapOf(
                         "publicSessionKey" to publicKeyFile(host).readText(),
@@ -290,7 +290,7 @@ class ConfigureAll : Runnable {
                 mapOf(
                     "keys" to privateKeyFile(host).readText(),
                     "tenantId" to tenantId,
-                    "publishAlias" to "$x500name.$groupId.ec",
+                    "publishAlias" to "$x500Name.$groupId.ec",
                 )
             )
         }
@@ -301,7 +301,7 @@ class ConfigureAll : Runnable {
                 mapOf(
                     "keys" to sslPrivateKeyFile.readText(),
                     "tenantId" to tenantId,
-                    "publishAlias" to "$host.$x500name.rsa"
+                    "publishAlias" to "$host.$x500Name.rsa"
                 )
             )
         }

--- a/applications/tools/p2p-test/p2p-setup/README.md
+++ b/applications/tools/p2p-test/p2p-setup/README.md
@@ -48,7 +48,7 @@ First:
 2. Prepare a configuration file with the identity data. For example:
 ```json
 {
-  "x500name": "O=Alice, L=London, C=GB",
+  "x500Name": "O=Alice, L=London, C=GB",
   "groupId": "group-1",
   "data": {
     "tlsTenantId": "cluster",
@@ -90,7 +90,7 @@ First:
 ```json
 {
   "groupId": "group-1",
-  "x500name": "O=Alice, L=London, C=GB",
+  "x500Name": "O=Alice, L=London, C=GB",
   "data": {
     "networkType": "CORDA_5",
     "protocolModes": ["AUTHENTICATION_ONLY", "AUTHENTICATED_ENCRYPTION"],
@@ -99,7 +99,7 @@ First:
 }
 ```
 where:
-* `x500name` is the x500 name of the identity the group policy corresponds to.
+* `x500Name` is the x500 name of the identity the group policy corresponds to.
 * `networkType` is either `CORDA_5`, `CORDA_4`.
 * `protocolModes` are either: `AUTHENTICATED_ENCRYPTION` or `AUTHENTICATION_ONLY`.
 * `trustRootCertificates` is the content of the root certificates in PEM format (use either this or `trustRootCertificatesFiles`).
@@ -127,7 +127,7 @@ First:
 2. Prepare a configuration file with the member data. For example:
 ```json
 {
-  "x500name": "O=Alice, L=London, C=GB",
+  "x500Name": "O=Alice, L=London, C=GB",
   "groupId": "group-1",
   "data": {
        "publicSessionKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w...xwIDAQAB\n-----END PUBLIC KEY-----",
@@ -251,7 +251,7 @@ The file should look like the following:
   ],
   "membersToAdd": [
     {
-      "x500name": "O=Alice, L=London, C=GB",
+      "x500Name": "O=Alice, L=London, C=GB",
       "groupId": "group-1",
       "data": {
         "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w...xwIDAQAB\n-----END PUBLIC KEY-----",
@@ -261,7 +261,7 @@ The file should look like the following:
   ],
   "identitiesToAdd": [
     {
-      "x500name": "O=Alice, L=London, C=GB",
+      "x500Name": "O=Alice, L=London, C=GB",
       "groupId": "group-2",
       "data": {
         "tlsTenantId": "cluster",
@@ -281,13 +281,13 @@ The file should look like the following:
   "groupsToRemove": ["group-3", "group-5"],
   "membersToRemove": [
     {
-      "x500name": "O=Alice, L=London, C=GB",
+      "x500Name": "O=Alice, L=London, C=GB",
       "groupId": "group-3"
     }
   ],
   "identitiesToRemove": [
     {
-      "x500name": "O=Alice, L=London, C=GB",
+      "x500Name": "O=Alice, L=London, C=GB",
       "groupId": "group-3"
     }
   ]

--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/AddGroup.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/AddGroup.kt
@@ -27,7 +27,7 @@ class AddGroup : Callable<Collection<Record<String, GroupPolicyEntry>>> {
     companion object {
         internal fun Config.toGroupRecord(topic: String = GROUP_POLICIES_TOPIC): Record<String, GroupPolicyEntry> {
             val groupId = this.getString("groupId")
-            val x500Name = this.getString("x500name")
+            val x500Name = this.getString("x500Name")
             val dataConfig = this.getConfig("data")
             val networkType = dataConfig.getEnum(NetworkType::class.java, "networkType")
             val trustRootCertificates = try {

--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/AddIdentity.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/AddIdentity.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.Callable
 class AddIdentity : Callable<Collection<Record<String, HostedIdentityEntry>>> {
     companion object {
         fun Config.toIdentityRecord(topic: String = P2P_HOSTED_IDENTITIES_TOPIC): Record<String, HostedIdentityEntry> {
-            val x500Name = this.getString("x500name")
+            val x500Name = this.getString("x500Name")
             val groupId = this.getString("groupId")
             val dataConfig = this.getConfig("data")
             val tlsTenantId = dataConfig.getString("tlsTenantId")

--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/AddMember.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/AddMember.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.Callable
 class AddMember : Callable<Collection<Record<String, MemberInfoEntry>>> {
     companion object {
         fun Config.toMemberRecord(topic: String = MEMBER_INFO_TOPIC): Record<String, MemberInfoEntry> {
-            val x500Name = this.getString("x500name")
+            val x500Name = this.getString("x500Name")
             val groupId = this.getString("groupId")
             val dataConfig = this.getConfig("data")
             val address = dataConfig.getString("address")

--- a/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Apply.kt
+++ b/applications/tools/p2p-test/p2p-setup/src/main/kotlin/net/corda/p2p/setup/Apply.kt
@@ -112,7 +112,7 @@ class Apply : Callable<Collection<Record<String, *>>> {
             "membersToRemove"
         ) {
             val groupId = it.getString("groupId")
-            val x500Name = it.getString("x500name")
+            val x500Name = it.getString("x500Name")
             Record(
                 MEMBER_INFO_TOPIC,
                 "$x500Name-$groupId",
@@ -124,7 +124,7 @@ class Apply : Callable<Collection<Record<String, *>>> {
             "identitiesToRemove"
         ) {
             val groupId = it.getString("groupId")
-            val x500Name = it.getString("x500name")
+            val x500Name = it.getString("x500Name")
             Record(
                 P2P_HOSTED_IDENTITIES_TOPIC,
                 "$x500Name-$groupId",

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImpl.kt
@@ -89,7 +89,7 @@ class CertificatesRpcOpsImpl @Activate constructor(
     override fun generateCsr(
         tenantId: String,
         keyId: String,
-        x500name: String,
+        x500Name: String,
         certificateRole: String,
         subjectAlternativeNames: List<String>?,
         contextMap: Map<String, String?>?,
@@ -116,7 +116,7 @@ class CertificatesRpcOpsImpl @Activate constructor(
         val signer = CsrContentSigner(spec, publicKey, tenantId)
 
         val p10Builder = JcaPKCS10CertificationRequestBuilder(
-            X500Principal(x500name), publicKey
+            X500Principal(x500Name), publicKey
         )
 
         p10Builder

--- a/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/CertificatesRpcOps.kt
+++ b/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/CertificatesRpcOps.kt
@@ -50,7 +50,7 @@ interface CertificatesRpcOps : RpcOps {
      *
      * @param tenantId The tenant ID.
      * @param keyId The Key ID.
-     * @param x500name A valid X500 name.
+     * @param x500Name A valid X500 name.
      * @param certificateRole - The certificate role
      * @param subjectAlternativeNames - list of subject alternative DNS names
      * @param contextMap - Any additional attributes to add to the CSR.
@@ -71,7 +71,7 @@ interface CertificatesRpcOps : RpcOps {
             description = "The X500 name",
             required = true,
         )
-        x500name: String,
+        x500Name: String,
         @HttpRpcRequestBodyParameter(
             description = "Certificate role. For example: TLS, SESSION_INIT, ...",
             required = true,

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -2838,7 +2838,7 @@
         }
       },
       "GenerateCsrWrapperRequest" : {
-        "required" : [ "certificateRole", "x500name" ],
+        "required" : [ "certificateRole", "x500Name" ],
         "properties" : {
           "certificateRole" : {
             "type" : "string",
@@ -2865,7 +2865,7 @@
               "example" : "string"
             }
           },
-          "x500name" : {
+          "x500Name" : {
             "type" : "string",
             "description" : "The X500 name",
             "nullable" : false,


### PR DESCRIPTION
Changing the argument name in the P2P tool and API to be consistent. We need to change the wiki after this is merged.