### PR TITLE
CORE-6609: Fix `install.sh` script for CLI

### DIFF
--- a/tools/plugins/installScripts/install.sh
+++ b/tools/plugins/installScripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cliHome="~/.corda/cli/"
+cliHome=~/.corda/cli/
 
 echo "Creating corda-cli dir at cliHome"
 mkdir -p $cliHome
@@ -10,3 +10,4 @@ cp -R . $cliHome
 
 echo "Creating corda-cli Script"
 echo "java -Dpf4j.pluginsDir=$cliHome/plugins -jar corda-cli.jar $@" > $cliHome/corda-cli.sh
+

--- a/tools/plugins/installScripts/install.sh
+++ b/tools/plugins/installScripts/install.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
+zipdir=$(dirname $0)
+
 cliHome=~/.corda/cli/
 
 echo "Creating corda-cli dir at cliHome"
 mkdir -p $cliHome
 
 echo "copying files and plugins"
-cp -R . $cliHome
+cp -R $zipdir/* $cliHome
 
 echo "Creating corda-cli Script"
-echo "java -Dpf4j.pluginsDir=$cliHome/plugins -jar corda-cli.jar $@" > $cliHome/corda-cli.sh
+echo "java -Dpf4j.pluginsDir=$cliHome/plugins -jar $cliHome/corda-cli.jar \"\$@\"" > $cliHome/corda-cli.sh
+
+chmod 755 $cliHome/corda-cli.sh
+
 


### PR DESCRIPTION
Changes to install.sh to copy the files from the correct place, generate the correct corda-cli.sh script and make it executable.