### PR TITLE
CORE-5831: Example app using MemberX500Name serializer

### DIFF
--- a/simulator/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
+++ b/simulator/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
@@ -53,7 +53,7 @@ class RollCallTest {
             RequestData.create(
                 "r1",
                 RollCallFlow::class.java,
-                RollCallInitiationRequest(truantingAuth.toString())
+                RollCallInitiationRequest(truantingAuth)
         ))
 
         // Then we should get the response back

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/AbsenceSubFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/AbsenceSubFlow.kt
@@ -8,7 +8,7 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 
 @InitiatingFlow("absence-call")
-class AbsenceSubFlow(val counterparty: MemberX500Name) : SubFlow<String> {
+class AbsenceSubFlow(private val counterparty: MemberX500Name) : SubFlow<String> {
 
     @CordaInject
     lateinit var flowMessaging: FlowMessaging
@@ -16,7 +16,7 @@ class AbsenceSubFlow(val counterparty: MemberX500Name) : SubFlow<String> {
     @Suspendable
     override fun call(): String {
         val session = flowMessaging.initiateFlow(counterparty)
-        session.send(RollCallRequest(counterparty.toString()))
+        session.send(RollCallRequest(counterparty))
         return session.receive(RollCallResponse::class.java).unwrap {it}.response
     }
 }

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/RollCallFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/RollCallFlow.kt
@@ -58,10 +58,10 @@ class RollCallFlow: RPCStartableFlow {
 
         val students = findStudents(memberLookup)
 
-        val truancyOffice = MemberX500Name.parse(requestBody.getRequestBodyAs(
+        val truancyOffice = requestBody.getRequestBodyAs(
             jsonMarshallingService,
             RollCallInitiationRequest::class.java
-        ).truancyOfficeX500)
+        ).truancyOfficeX500
 
         val sessionsAndRecipients = students.map {
             SessionAndRecipient(flowMessaging.initiateFlow(it.name), it.name)
@@ -95,7 +95,7 @@ class RollCallFlow: RPCStartableFlow {
     @Suspendable
     private fun sendTruancyRecord(truancyOffice : MemberX500Name, truants: List<MemberX500Name>) {
         if (truants.isNotEmpty()) {
-            val unsignedTruants = jsonMarshallingService.format(truants.map { it.toString() })
+            val unsignedTruants = jsonMarshallingService.format(truants)
             val signedTruants = signingService.sign(
                 unsignedTruants.toByteArray(),
                 memberLookup.myInfo().ledgerKeys[0],
@@ -113,7 +113,7 @@ class RollCallFlow: RPCStartableFlow {
                 sessionAndRecipient.flowSession,
                 sessionAndRecipient.flowSession.sendAndReceive(
                     RollCallResponse::class.java,
-                    RollCallRequest(sessionAndRecipient.receipient.toString())
+                    RollCallRequest(sessionAndRecipient.receipient)
                 ).unwrap { r -> r }.response
             )
         )
@@ -147,10 +147,10 @@ class RollCallFlow: RPCStartableFlow {
     }
 }
 @CordaSerializable
-data class RollCallInitiationRequest(val truancyOfficeX500: String)
+data class RollCallInitiationRequest(val truancyOfficeX500: MemberX500Name)
 
 @CordaSerializable
-data class RollCallRequest(val recipientX500: String)
+data class RollCallRequest(val recipientX500: MemberX500Name)
 @CordaSerializable
 data class RollCallResponse(val response: String)
 

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/TruancyResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/TruancyResponderFlow.kt
@@ -39,7 +39,7 @@ class TruancyResponderFlow : ResponderFlow {
         val record = session.receive(TruancyRecord::class.java).unwrap {it}
 
         verificationService.verify(record.signature.by, SignatureSpec.ECDSA_SHA256, record.signature.bytes,
-            jsonMarshallingService.format(record.absentees.map{it.toString()}).toByteArray())
+            jsonMarshallingService.format(record.absentees).toByteArray())
 
         persistenceService.persist(record.absentees.map { TruancyEntity(name = it.toString()) })
 


### PR DESCRIPTION
Now that MemberX500 names have a JSON serializer, we no longer need to parse them to strings in requests / responses.