### PR TITLE
CORE-6087 Return `400` for invalid short hash in flow apis

### DIFF
--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -12,6 +12,7 @@ import net.corda.flow.rpcops.v1.types.request.StartFlowParameters
 import net.corda.flow.rpcops.v1.types.response.FlowStatusResponse
 import net.corda.flow.rpcops.v1.types.response.FlowStatusResponses
 import net.corda.httprpc.PluggableRPCOps
+import net.corda.httprpc.exception.BadRequestException
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.httprpc.exception.ResourceNotFoundException
 import net.corda.httprpc.response.ResponseEntity
@@ -73,7 +74,7 @@ class FlowRPCOpsImpl @Activate constructor(
             throw FlowRPCOpsServiceException("FlowRPC has not been initialised ")
         }
 
-        val vNode = getVirtualNode(ShortHash.of(holdingIdentityShortHash))
+        val vNode = getVirtualNode(parseShortHash(holdingIdentityShortHash))
         val clientRequestId = startFlow.clientRequestId
         val flowStatus = flowStatusCacheService.getStatus(clientRequestId, vNode.holdingIdentity)
 
@@ -112,7 +113,7 @@ class FlowRPCOpsImpl @Activate constructor(
     }
 
     override fun getFlowStatus(holdingIdentityShortHash: String, clientRequestId: String): FlowStatusResponse {
-        val vNode = getVirtualNode(ShortHash.of(holdingIdentityShortHash))
+        val vNode = getVirtualNode(parseShortHash(holdingIdentityShortHash))
 
         val flowStatus = flowStatusCacheService.getStatus(clientRequestId, vNode.holdingIdentity)
             ?: throw ResourceNotFoundException(
@@ -124,7 +125,7 @@ class FlowRPCOpsImpl @Activate constructor(
     }
 
     override fun getMultipleFlowStatus(holdingIdentityShortHash: String): FlowStatusResponses {
-        val vNode = getVirtualNode(ShortHash.of(holdingIdentityShortHash))
+        val vNode = getVirtualNode(parseShortHash(holdingIdentityShortHash))
         val flowStatuses = flowStatusCacheService.getStatusesPerIdentity(vNode.holdingIdentity)
         return FlowStatusResponses(flowStatusResponses = flowStatuses.map { messageFactory.createFlowStatusResponse(it) })
     }
@@ -136,9 +137,9 @@ class FlowRPCOpsImpl @Activate constructor(
     ) {
         val sessionId = channel.id
         val holdingIdentity = try {
-            getVirtualNode(ShortHash.of(holdingIdentityShortHash)).holdingIdentity
-        } catch (e: ShortHashException) {
-            channel.error(WebSocketValidationException("Invalid holding identifier", e))
+            getVirtualNode(parseShortHash(holdingIdentityShortHash)).holdingIdentity
+        } catch (e: BadRequestException) {
+            channel.error(WebSocketValidationException(e.message, e))
             return
         } catch (e: ResourceNotFoundException) {
             channel.error(WebSocketValidationException(e.message, e))
@@ -171,6 +172,14 @@ class FlowRPCOpsImpl @Activate constructor(
 
     override fun stop() {
         publisher?.close()
+    }
+
+    private fun parseShortHash(holdingIdentityShortHash: String): ShortHash {
+        return try {
+            ShortHash.of(holdingIdentityShortHash)
+        } catch (e: ShortHashException) {
+            throw BadRequestException("Invalid holding identity short hash${e.message?.let { ": $it" }}")
+        }
     }
 
     private fun getVirtualNode(shortId: ShortHash): VirtualNodeInfo {

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/ShortHash.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/ShortHash.kt
@@ -25,10 +25,12 @@ class ShortHash private constructor(val value: String) {
          * @throws [ShortHashException] if the string is not hexadecimal, or short than [LENGTH].
          */
         fun of(hexString : String) : ShortHash {
-            if (hexString.length < LENGTH)
-                throw ShortHashException("Cannot construct Short hash from short hexString (length = ${hexString.length}). " +
-                        "Need a hexstring of at least $LENGTH characters")
-            if (!isHexString(hexString)) throw ShortHashException("Not a hex string: '$hexString'")
+            if (hexString.length < LENGTH) {
+                throw ShortHashException("Hex string has length of ${hexString.length} but should be at least $LENGTH characters")
+            }
+            if (!isHexString(hexString)) {
+                throw ShortHashException("Not a hex string: '$hexString'")
+            }
             return ShortHash(hexString.substring(0, LENGTH).uppercase())
         }
 


### PR DESCRIPTION
If the `holdingIdentityShortHash` fails to parse correctly into a `ShortHash` a `400` response is returned to the client.

`ShortHash.of`'s exception messages were changed so they better translate to a user facing error while still conveying their meaning.