### PR TITLE
CORE-6688 cleanup, a fix and new tests for DatabaseCpiPersistence

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
@@ -42,6 +42,7 @@ import java.nio.file.Path
 import java.time.Instant
 import java.util.Random
 import java.util.UUID
+import javax.persistence.PersistenceException
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UpsertCpiTests {
@@ -165,9 +166,7 @@ class UpsertCpiTests {
         val id = CpiIdentifier(name, version, newRandomSecureHash())
         val cpi = mockCpiWithId(cpks, id)
 
-        cpiPersistence.persistMetadataAndCpks(
-            cpi, "test.cpi", newRandomSecureHash(), UUID.randomUUID().toString(), groupId, emptyList()
-        )
+        cpiPersistence.store(cpi, groupId = groupId, allowCpiUpdate = true)
         return cpi
     }
 
@@ -194,8 +193,8 @@ class UpsertCpiTests {
         val entity = findCpiMetadataEntity(cpi)
 
         assertThat(entity).isNotNull
-        assertThat(entity!!.name).isEqualTo(cpi.metadata.cpiId.name)
-        assertThat(entity.version).isEqualTo(cpi.metadata.cpiId.version)
+        assertThat(entity!!.id.name).isEqualTo(cpi.metadata.cpiId.name)
+        assertThat(entity.id.version).isEqualTo(cpi.metadata.cpiId.version)
         assertThat(entity.groupId).isEqualTo(groupId)
     }
 
@@ -251,7 +250,7 @@ class UpsertCpiTests {
         val groupId = "nonExistent"
         val name = "neverBefore"
         val version = "1.0.0"
-        val ex = assertThrows<ValidationException> {
+        val ex = assertThrows<PersistenceException> {
             cpiPersistence.canUpsertCpi(name, groupId, true, version)
         }
 
@@ -263,7 +262,7 @@ class UpsertCpiTests {
         val name = "newTest"
         val version = "1.0.0"
         persistCpi(name, version, groupId)
-        val ex = assertThrows<ValidationException> {
+        val ex = assertThrows<PersistenceException> {
             cpiPersistence.canUpsertCpi(name, groupId, true, "1.0.1")
         }
 

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
@@ -27,7 +27,7 @@ interface CpiPersistence {
      */
     fun cpiExists(cpiName: String, cpiVersion: String, signerSummaryHash: String): Boolean
 
-    /** Persist the CPI metadata and the CPKs
+    /** Store CPI metadata and the CPKs in the database
      *
      * @param cpi a [Cpi] object
      * @param cpiFileName the original CPI file name
@@ -35,36 +35,19 @@ interface CpiPersistence {
      * @param requestId the request id for the CPI that is being uploaded
      * @param groupId the group id from the group policy file
      * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
+     * @param allowCpiUpdate if the CPI is already in the database, replace it if this is true otherwise throw a ValidationException
      */
     @Suppress("LongParameterList")
-    fun persistMetadataAndCpks(
+    fun store(
         cpi: Cpi,
         cpiFileName: String = "test.cpi",
         checksum: SecureHash = newRandomSecureHash(),
         requestId: RequestId = UUID.randomUUID().toString(),
         groupId: String = "group-a",
-        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity> = emptyList()
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity> = emptyList(),
+        allowCpiUpdate: Boolean = false,
     ): CpiMetadataEntity
-
-    /**
-     * When CPI has previously been saved, delete all the stale data and update in place.
-     *
-     * @param cpi a [Cpi] object
-     * @param cpiFileName the original CPI file name
-     * @param checksum the checksum of the CPI file
-     * @param requestId the request id for the CPI that is being uploaded
-     * @param groupId the group id from the group policy file
-     * @param cpkDbChangeLogEntities the list of entities containing Liquibase scripts for all cpks of the given cpi
-     */
-    @Suppress("LongParameterList")
-    fun updateMetadataAndCpks(
-        cpi: Cpi,
-        cpiFileName: String = "test.cpi",
-        checksum: SecureHash = newRandomSecureHash(),
-        requestId: RequestId = UUID.randomUUID().toString(),
-        groupId: String = "group-a",
-        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity> = emptyList()
-    ): CpiMetadataEntity
+    
 
     /**
      *  Get the group id for a given CPI

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/CpiPersistence.kt
@@ -4,7 +4,14 @@ import net.corda.chunking.RequestId
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.packaging.Cpi
+import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
+import java.util.*
+
+val random = Random(0)
+fun newRandomSecureHash(): SecureHash {
+    return SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32).also(random::nextBytes))
+}
 
 interface CpiPersistence {
     /**
@@ -32,11 +39,11 @@ interface CpiPersistence {
     @Suppress("LongParameterList")
     fun persistMetadataAndCpks(
         cpi: Cpi,
-        cpiFileName: String,
-        checksum: SecureHash,
-        requestId: RequestId,
-        groupId: String,
-        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
+        cpiFileName: String = "test.cpi",
+        checksum: SecureHash = newRandomSecureHash(),
+        requestId: RequestId = UUID.randomUUID().toString(),
+        groupId: String = "group-a",
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity> = emptyList()
     ): CpiMetadataEntity
 
     /**
@@ -52,11 +59,11 @@ interface CpiPersistence {
     @Suppress("LongParameterList")
     fun updateMetadataAndCpks(
         cpi: Cpi,
-        cpiFileName: String,
-        checksum: SecureHash,
-        requestId: RequestId,
-        groupId: String,
-        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity>
+        cpiFileName: String = "test.cpi",
+        checksum: SecureHash = newRandomSecureHash(),
+        requestId: RequestId = UUID.randomUUID().toString(),
+        groupId: String = "group-a",
+        cpkDbChangeLogEntities: List<CpkDbChangeLogEntity> = emptyList()
     ): CpiMetadataEntity
 
     /**

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
@@ -107,7 +107,7 @@ class DatabaseCpiPersistence(private val entityManagerFactory: EntityManagerFact
     ) {
         cpkDbChangeLogEntities.forEach {
             val inDb = em.find(CpkDbChangeLogEntity::class.java, it.id)
-            if (inDb!=null) it.entityVersion = inDb.entityVersion
+            if (inDb != null) it.entityVersion = inDb.entityVersion
             em.merge(it)
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -73,7 +73,7 @@ class CpiValidatorImpl constructor(
 
         publisher.update(requestId, "Persisting CPI")
         val cpiMetadataEntity =
-            cpiPersistence.persistCpiToDatabase(cpi, groupId, fileInfo, requestId, cpkDbChangeLogEntities, log)
+            cpiPersistence.persistCpiToDatabase(cpi, groupId, fileInfo, requestId, cpkDbChangeLogEntities)
 
         publisher.update(requestId, "Notifying flow workers")
         val cpiMetadata = CpiMetadata(

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -142,7 +142,7 @@ fun CpiPersistence.persistCpiToDatabase(
         when (ex) {
             is ValidationException -> throw ex
             is PersistenceException -> throw ValidationException("Could not persist CPI and CPK to database", requestId, ex)
-            is CordaRuntimeException -> throw ValidationException("Could not persist CPI and CPK to database", requestId, ex)
+            is CordaRuntimeException -> throw ValidationException("Runtime exception persisting CPI and CPK to database", requestId, ex)
             else -> throw ValidationException("Unexpected error when trying to persist CPI and CPK to database", requestId, ex)
         }
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
@@ -10,6 +10,7 @@ import net.corda.libs.configuration.datamodel.ConfigurationEntities
 import net.corda.libs.configuration.datamodel.DbConnectionConfig
 import net.corda.libs.cpi.datamodel.CpiEntities
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpiMetadataEntityKey
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.datamodel.HoldingIdentityEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntities
@@ -83,9 +84,7 @@ internal class VirtualNodeEntityRepositoryTest {
 
         val cpiMetadataEntity = with(expectedCpiMetadata) {
             CpiMetadataEntity(
-                id.name,
-                id.version,
-                signerSummaryHash,
+                CpiMetadataEntityKey(id.name, id.version, signerSummaryHash),
                 "TestFile",
                 fileChecksum,
                 "Test Group Policy",
@@ -142,9 +141,7 @@ internal class VirtualNodeEntityRepositoryTest {
 
         val cpiMetadataEntity = with(expectedCpiMetadata) {
             CpiMetadataEntity(
-                id.name,
-                id.version,
-                signerSummaryHash,
+                CpiMetadataEntityKey(id.name, id.version, signerSummaryHash),
                 "TestFile",
                 fileChecksum,
                 groupPolicy,
@@ -375,9 +372,7 @@ internal class VirtualNodeEntityRepositoryTest {
 
         val cpiMetadataEntity = with(cpiMetadata) {
             CpiMetadataEntity(
-                id.name,
-                id.version,
-                signerSummaryHash,
+                CpiMetadataEntityKey(id.name, id.version, signerSummaryHash),
                 "TestFile",
                 fileChecksum,
                 "Test Group Policy",
@@ -428,9 +423,7 @@ internal class VirtualNodeEntityRepositoryTest {
 
         val cpiMetadataEntity = with(cpiMetadata) {
             CpiMetadataEntity(
-                id.name,
-                id.version,
-                signerSummaryHash,
+                CpiMetadataEntityKey(id.name, id.version, signerSummaryHash),
                 "TestFile",
                 fileChecksum,
                 "Test Group Policy",

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
@@ -53,10 +53,10 @@ internal class VirtualNodeEntityRepository(private val entityManagerFactory: Ent
             if (foundCpi.isNotEmpty()) foundCpi[0] else null
         } ?: return null
 
-        val signerSummaryHash = cpiMetadataEntity.signerSummaryHash.let {
+        val signerSummaryHash = cpiMetadataEntity.id.signerSummaryHash.let {
             if (it == "") null else SecureHash.parse(it)
         }
-        val cpiId = CpiIdentifier(cpiMetadataEntity.name, cpiMetadataEntity.version, signerSummaryHash)
+        val cpiId = CpiIdentifier(cpiMetadataEntity.id.name, cpiMetadataEntity.id.version, signerSummaryHash)
         val fileChecksum = SecureHash.parse(cpiMetadataEntity.fileChecksum).toHexString()
         return CpiMetadataLite(cpiId, fileChecksum, cpiMetadataEntity.groupId, cpiMetadataEntity.groupPolicy)
     }
@@ -67,8 +67,8 @@ internal class VirtualNodeEntityRepository(private val entityManagerFactory: Ent
             it.transaction {
                 it.createQuery(
                     "SELECT cpi FROM CpiMetadataEntity cpi " +
-                            "WHERE cpi.name = :cpiName "+
-                            "AND cpi.version = :cpiVersion ",
+                            "WHERE cpi.id.name = :cpiName " +
+                            "AND cpi.id.version = :cpiVersion ",
                     CpiMetadataEntity::class.java
                 )
                     .setParameter("cpiName", name)
@@ -77,10 +77,10 @@ internal class VirtualNodeEntityRepository(private val entityManagerFactory: Ent
             }
         }
 
-        val signerSummaryHash = cpiMetadataEntity.signerSummaryHash.let {
+        val signerSummaryHash = cpiMetadataEntity.id.signerSummaryHash.let {
             if (it.isBlank()) null else SecureHash.parse(it)
         }
-        val cpiId = CpiIdentifier(cpiMetadataEntity.name, cpiMetadataEntity.version, signerSummaryHash)
+        val cpiId = CpiIdentifier(cpiMetadataEntity.id.name, cpiMetadataEntity.id.version, signerSummaryHash)
         val fileChecksum = SecureHash.parse(cpiMetadataEntity.fileChecksum).toHexString()
         return CpiMetadataLite(cpiId, fileChecksum, cpiMetadataEntity.groupId, cpiMetadataEntity.groupPolicy)
     }

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
@@ -88,10 +88,11 @@ class CpiEntitiesIntegrationTest {
         ).use {
             val loadedCpiEntity = it.find(
                 CpiMetadataEntity::class.java,
-                CpiMetadataEntityKey(cpi.name, cpi.version, cpi.signerSummaryHash)
+                CpiMetadataEntityKey(cpi.id.name, cpi.id.version, cpi.id.signerSummaryHash)
             )
-
-            assertThat(loadedCpiEntity.cpks).isEqualTo(cpi.cpks)
+            // the db version will differ on insertTimestamp so null that out before comparing
+            assertThat(loadedCpiEntity.cpks.map { it.copy(insertTimestamp = null) }
+                .toTypedArray()).isEqualTo(cpi.cpks.toTypedArray())
         }
 
     }
@@ -146,16 +147,16 @@ class CpiEntitiesIntegrationTest {
         ).use { em ->
             val  loadedCpiEntity = em.find(
                 CpiMetadataEntity::class.java,
-                CpiMetadataEntityKey(cpi.name, cpi.version, cpi.signerSummaryHash)
+                CpiMetadataEntityKey(cpi.id.name, cpi.id.version, cpi.id.signerSummaryHash)
             )
 
             val updated = loadedCpiEntity.copy(
                 cpks = loadedCpiEntity.cpks.plus(
                     CpiCpkEntity(
                         CpiCpkKey(
-                            cpi.name,
-                            cpi.version,
-                            cpi.signerSummaryHash,
+                            cpi.id.name,
+                            cpi.id.version,
+                            cpi.id.signerSummaryHash,
                             cpkMetadataEntity2.id.cpkName,
                             cpkMetadataEntity2.id.cpkVersion,
                             cpkMetadataEntity2.id.cpkSignerSummaryHash
@@ -181,7 +182,7 @@ class CpiEntitiesIntegrationTest {
         ).use {
             it.find(
                 CpiMetadataEntity::class.java,
-                CpiMetadataEntityKey(cpi.name, cpi.version, cpi.signerSummaryHash)
+                CpiMetadataEntityKey(cpi.id.name, cpi.id.version, cpi.id.signerSummaryHash)
             )
         }
 
@@ -257,7 +258,7 @@ class CpiEntitiesIntegrationTest {
         ).use {
             it.find(
                 CpiMetadataEntity::class.java,
-                CpiMetadataEntityKey(cpi2.name, cpi2.version, cpi2.signerSummaryHash)
+                CpiMetadataEntityKey(cpi2.id.name, cpi2.id.version, cpi2.id.signerSummaryHash)
             )
         }
 

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
@@ -181,7 +181,7 @@ class CpkDbChangeLogEntityTest {
             flush()
             val changeLogs = findDbChangeLogForCpi(
                 this,
-                CpiIdentifier(cpi1.name, cpi1.version, SecureHash.parse(cpi1.signerSummaryHash))
+                CpiIdentifier(cpi1.id.name, cpi1.id.version, SecureHash.parse(cpi1.id.signerSummaryHash))
             )
             assertThat(changeLogs.size).isEqualTo(3)
             assertThat(changeLogs.map { it.id }).containsAll(listOf(changeLog1.id, changeLog1b.id, changeLog2.id))
@@ -199,7 +199,11 @@ class CpkDbChangeLogEntityTest {
             flush()
             val changeLogs = findDbChangeLogForCpi(
                 this,
-                CpiIdentifier(cpi1.name, cpi1.version, SecureHash("SHA1", cpi1.signerSummaryHash.toByteArray()))
+                CpiIdentifier(
+                    cpi1.id.name,
+                    cpi1.id.version,
+                    SecureHash("SHA1", cpi1.id.signerSummaryHash.toByteArray())
+                )
             )
             assertThat(changeLogs).isEmpty()
         }

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/TestObject.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/TestObject.kt
@@ -1,11 +1,7 @@
 package net.corda.libs.cpi.datamodel.tests
 
-import net.corda.libs.cpi.datamodel.CpiMetadataEntity
-import net.corda.libs.cpi.datamodel.CpkKey
-import net.corda.libs.cpi.datamodel.CpkMetadataEntity
+import net.corda.libs.cpi.datamodel.*
 import java.util.UUID
-import net.corda.libs.cpi.datamodel.CpiCpkEntity
-import net.corda.libs.cpi.datamodel.CpiCpkKey
 import net.corda.v5.crypto.SecureHash
 import java.nio.ByteBuffer
 
@@ -17,8 +13,8 @@ object TestObject {
     }
 
     fun createCpi(id: String, cpiName: String, cpiVersion: String, cpiSSH: String, cpks: Set<CpiCpkEntity>) =
-        CpiMetadataEntity.create(
-            cpiName, cpiVersion, cpiSSH,
+        CpiMetadataEntity(
+            CpiMetadataEntityKey(cpiName, cpiVersion, cpiSSH),
             "test-cpi-$id.cpi",
             "test-cpi.cpi-$id-hash",
             "{group-policy-json}",
@@ -28,10 +24,8 @@ object TestObject {
         )
 
     fun createCpi(cpiId: UUID, cpks: Set<CpiCpkEntity>) =
-        CpiMetadataEntity.create(
-            "test-cpi-$cpiId",
-            "1.0",
-            "test-cpi-hash",
+        CpiMetadataEntity(
+            CpiMetadataEntityKey("test-cpi-$cpiId", "1.0", "test-cpi-hash"),
             "test-cpi-$cpiId.cpi",
             "test-cpi.cpi-$cpiId-hash",
             "{group-policy-json}",

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiCpkEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiCpkEntity.kt
@@ -23,11 +23,11 @@ import javax.persistence.Version
 @Table(name = "cpi_cpk", schema = DbSchema.CONFIG)
 data class CpiCpkEntity(
     @EmbeddedId
-    private val id: CpiCpkKey,
+    val id: CpiCpkKey,
     @Column(name = "cpk_file_name", nullable = false)
-    var cpkFileName: String,
+    val cpkFileName: String = "",
     @Column(name = "cpk_file_checksum", nullable = false)
-    var cpkFileChecksum: String,
+    val cpkFileChecksum: String = "",
     @OneToOne(cascade = [CascadeType.MERGE, CascadeType.PERSIST])
     @JoinColumns(
         JoinColumn(name = "cpk_name", referencedColumnName = "cpk_name", insertable = false, updatable = false),
@@ -39,17 +39,16 @@ data class CpiCpkEntity(
             updatable = false
         ),
     )
-    var metadata: CpkMetadataEntity,
-) {
+    val metadata: CpkMetadataEntity,
     @Version
     @Column(name = "entity_version", nullable = false)
-    var entityVersion: Int = 0
+    val entityVersion: Int = 0,
     // Initial population of this TS is managed on the DB itself
     @Column(name = "insert_ts", insertable = false, updatable = true)
-    var insertTimestamp: Instant? = null
+    var insertTimestamp: Instant? = null, // changed on update
     @Column(name = "is_deleted", nullable = false)
-    var isDeleted: Boolean = false
-
+    val isDeleted: Boolean = false
+) {
     @PreUpdate
     fun onUpdate() {
         insertTimestamp = Instant.now()

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogEntity.kt
@@ -53,7 +53,7 @@ data class CpkDbChangeLogKey(
     @Column(name = "cpk_signer_summary_hash", nullable = false)
     var cpkSignerSummaryHash: String,
     @Column(name = "file_path", nullable = false)
-    val filePath: String,
+    val filePath: String
 ) : Serializable
 
 

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkFileEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkFileEntity.kt
@@ -11,6 +11,7 @@ import javax.persistence.EntityManager
 import javax.persistence.NamedQuery
 import javax.persistence.Version
 
+// Now only used for testing- move to test code?
 const val QUERY_NAME_UPDATE_CPK_FILE_DATA = "CpkFileEntity.updateFileData"
 const val QUERY_PARAM_FILE_CHECKSUM = "fileChecksum"
 const val QUERY_PARAM_DATA = "data"
@@ -31,6 +32,7 @@ const val QUERY_PARAM_ID = "id"
 @Entity
 @Table(name = "cpk_file", schema = DbSchema.CONFIG)
 @NamedQuery(
+    // Now only used for testing- move to test code?
     name = QUERY_NAME_UPDATE_CPK_FILE_DATA,
     query = "UPDATE CpkFileEntity f" +
             " SET f.fileChecksum = :$QUERY_PARAM_FILE_CHECKSUM," +
@@ -44,20 +46,19 @@ data class CpkFileEntity(
     @EmbeddedId
     val id: CpkKey,
     @Column(name = "file_checksum", nullable = false, unique = true)
-    var fileChecksum: String,
+    val fileChecksum: String,
     @Lob
     @Column(name = "data", nullable = false)
-    var data: ByteArray,
+    val data: ByteArray,
     @Column(name = "is_deleted", nullable = false)
-    var isDeleted: Boolean = false
-) {
+    val isDeleted: Boolean = false,
     @Version
     @Column(name = "entity_version", nullable = false)
-    var entityVersion: Int = 0
-
+    val entityVersion: Int = 0,
     // this TS is managed on the DB itself
     @Column(name = "insert_ts", insertable = false, updatable = false)
-    var insertTimestamp: Instant? = null
+    val insertTimestamp: Instant? = null // changed on update
+) {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkMetadataEntity.kt
@@ -18,18 +18,18 @@ data class CpkMetadataEntity(
     @EmbeddedId
     val id: CpkKey,
     @Column(name = "file_checksum", nullable = false, unique = true)
-    var cpkFileChecksum: String,
+    val cpkFileChecksum: String,
     @Column(name = "format_version", nullable = false)
-    var formatVersion: String,
+    val formatVersion: String,
     @Column(name = "metadata", nullable = false)
-    var serializedMetadata: String,
+    val serializedMetadata: String,
     @Column(name = "is_deleted", nullable = false)
-    var isDeleted: Boolean = false
-) : Serializable {
+    val isDeleted: Boolean = false,
     @Version
     @Column(name = "entity_version", nullable = false)
-    var entityVersion: Int = 0
-}
+    val entityVersion: Int = 0
+) : Serializable
+
 
 /**
  * Composite primary key for a Cpk.
@@ -37,9 +37,9 @@ data class CpkMetadataEntity(
 @Embeddable
 data class CpkKey(
     @Column(name = "cpk_name")
-    var cpkName: String,
+    val cpkName: String,
     @Column(name = "cpk_version")
-    var cpkVersion: String,
+    val cpkVersion: String,
     @Column(name = "cpk_signer_summary_hash")
-    var cpkSignerSummaryHash: String,
+    val cpkSignerSummaryHash: String,
 ) : Serializable

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -7,6 +7,7 @@ import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
 import net.corda.libs.cpi.datamodel.CpiEntities
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpiMetadataEntityKey
 import net.corda.libs.virtualnode.datamodel.HoldingIdentityEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntities
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntity
@@ -223,9 +224,7 @@ class VirtualNodeEntitiesIntegrationTest {
         version: String,
         hash: String
     ) = CpiMetadataEntity(
-        name = name,
-        version = version,
-        signerSummaryHash = hash,
+        CpiMetadataEntityKey(name, version, hash),
         fileName = "file",
         fileChecksum = Generator.randomHoldingIdentityShortHash(),
         groupPolicy = "group policy",

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReader.kt
@@ -16,10 +16,10 @@ import net.corda.v5.crypto.SecureHash
 val getAllCpiInfoDBVersionedRecords: (EntityManager) -> Stream<VersionedRecord<CpiIdentifier, CpiMetadata>> = { em ->
     em.findAllCpiMetadata().map { cpiMetadataEntity ->
         val cpiId = CpiIdentifier(
-            cpiMetadataEntity.name,
-            cpiMetadataEntity.version,
-            if (cpiMetadataEntity.signerSummaryHash != "")
-                SecureHash.parse(cpiMetadataEntity.signerSummaryHash)
+            cpiMetadataEntity.id.name,
+            cpiMetadataEntity.id.version,
+            if (cpiMetadataEntity.id.signerSummaryHash != "")
+                SecureHash.parse(cpiMetadataEntity.id.signerSummaryHash)
             else
                 null
         )


### PR DESCRIPTION
CORE-6688: rework DatabaseCpiPersistence to handle entityVersion consistently, add tests

In some places we did not retrieve entity version and so could get optimistic concurrency exceptions from JPA. This required changing the expected entity version level assertions in the tests.

Refactor to combine CPI persist and update paths. The code for persist and update had a lot of similarities which caused significant duplication and made it hard to read.

Make a number of entity fields val (i.e. readonly), since that is easier to reason about and maintain.

Have CpiMetadataEntity comply with the pattern that synthetic primary keys are embedded, to make the code more uniform and shorter.

Use the standard timestamp mechanism for dCpkDbChnageLogEntity

Note that insertTimestamp changes on update since that might be surprising.

Refactor test cases to reduce the duplication, and starting adding test cases around changelogs which have low integration test coverage.