### PR TITLE
CORE-2395 Remove serialisation of private properties

### DIFF
--- a/libs/ledger/ledger-common-impl/src/main/kotlin/net/corda/ledger/common/impl/transaction/TransactionMetaData.kt
+++ b/libs/ledger/ledger-common-impl/src/main/kotlin/net/corda/ledger/common/impl/transaction/TransactionMetaData.kt
@@ -5,7 +5,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 //TODO(CORE-5940: guarantee its serialization is deterministic)
 @CordaSerializable
 class TransactionMetaData(
-    val properties: Map<String, Any>
+    private val properties: Map<String, Any>
     ) {
 
     operator fun get(key: String): Any? = properties[key]

--- a/libs/ledger/ledger-common-impl/src/main/kotlin/net/corda/ledger/common/impl/transaction/TransactionMetaData.kt
+++ b/libs/ledger/ledger-common-impl/src/main/kotlin/net/corda/ledger/common/impl/transaction/TransactionMetaData.kt
@@ -5,7 +5,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 //TODO(CORE-5940: guarantee its serialization is deterministic)
 @CordaSerializable
 class TransactionMetaData(
-    private val properties: Map<String, Any>
+    val properties: Map<String, Any>
     ) {
 
     operator fun get(key: String): Any? = properties[key]

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
@@ -131,6 +131,8 @@ class ComposableTypePropertySerializer(
     }
 }
 
+// TODO `PropertyReader` needs to be removed as it now always is a `GetterReader`.
+//  Most likely `LocalPropertyInformation` too and perhaps further APIs after `LocalPropertyInformation` is removed.
 /**
  * Obtains the value of a property from an instance of the type to which that property belongs, either by calling a getter method
  * or by reading the value of a private backing field.
@@ -146,7 +148,6 @@ sealed class PropertyReader {
             is LocalPropertyInformation.ConstructorPairedProperty -> GetterReader(propertyInformation.observedGetter)
             is LocalPropertyInformation.ReadOnlyProperty -> GetterReader(propertyInformation.observedGetter)
             is LocalPropertyInformation.CalculatedProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.PrivateConstructorPairedProperty -> FieldReader(propertyInformation.observedField)
         }
     }
 
@@ -160,13 +161,6 @@ sealed class PropertyReader {
      */
     class GetterReader(private val getter: Method) : PropertyReader() {
         override fun read(obj: Any?): Any? = if (obj == null) null else getter.invoke(obj)
-    }
-
-    /**
-     * Reads a property using a backing [Field].
-     */
-    class FieldReader(private val field: Field) : PropertyReader() {
-        override fun read(obj: Any?): Any? = if (obj == null) null else field.get(obj)
     }
 }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
@@ -158,22 +158,14 @@ sealed class PropertyReader {
     /**
      * Reads a property using a getter [Method].
      */
-    class GetterReader(private val getter: Method): PropertyReader() {
-        init {
-            getter.isAccessible = true
-        }
-
+    class GetterReader(private val getter: Method) : PropertyReader() {
         override fun read(obj: Any?): Any? = if (obj == null) null else getter.invoke(obj)
     }
 
     /**
      * Reads a property using a backing [Field].
      */
-    class FieldReader(private val field: Field): PropertyReader() {
-        init {
-            field.isAccessible = true
-        }
-
+    class FieldReader(private val field: Field) : PropertyReader() {
         override fun read(obj: Any?): Any? = if (obj == null) null else field.get(obj)
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
@@ -49,7 +49,7 @@ interface PropertyWriteStrategy {
          * Select the correct strategy for writing properties, based on the property information.
          */
         fun make(name: String, propertyInformation: LocalPropertyInformation, factory: LocalSerializerFactory): PropertyWriteStrategy {
-            val reader = PropertyReader.make(propertyInformation)
+            val reader = GetterReader(propertyInformation.observedGetter)
             val type = propertyInformation.type
             return if (isPrimitive(type.typeIdentifier)) {
                 when (type.typeIdentifier) {
@@ -131,37 +131,14 @@ class ComposableTypePropertySerializer(
     }
 }
 
-// TODO `PropertyReader` needs to be removed as it now always is a `GetterReader`.
-//  Most likely `LocalPropertyInformation` too and perhaps further APIs after `LocalPropertyInformation` is removed.
 /**
- * Obtains the value of a property from an instance of the type to which that property belongs, either by calling a getter method
- * or by reading the value of a private backing field.
+ * Obtains the value of a property from an instance of the type to which that property belongs, by calling a getter [Method].
  */
-sealed class PropertyReader {
-
-    companion object {
-        /**
-         * Make a [PropertyReader] based on the provided [LocalPropertyInformation].
-         */
-        fun make(propertyInformation: LocalPropertyInformation) = when(propertyInformation) {
-            is LocalPropertyInformation.GetterSetterProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.ConstructorPairedProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.ReadOnlyProperty -> GetterReader(propertyInformation.observedGetter)
-            is LocalPropertyInformation.CalculatedProperty -> GetterReader(propertyInformation.observedGetter)
-        }
-    }
-
+class GetterReader(private val getter: Method) {
     /**
      * Get the value of the property from the supplied instance, or null if the instance is itself null.
      */
-    abstract fun read(obj: Any?): Any?
-
-    /**
-     * Reads a property using a getter [Method].
-     */
-    class GetterReader(private val getter: Method) : PropertyReader() {
-        override fun read(obj: Any?): Any? = if (obj == null) null else getter.invoke(obj)
-    }
+    fun read(obj: Any?): Any? = if (obj == null) null else getter.invoke(obj)
 }
 
 private val characterTypes = setOf(
@@ -199,7 +176,7 @@ class DescribedTypeReadStrategy(name: String,
  */
 class DescribedTypeWriteStrategy(private val name: String,
                                  private val propertyInformation: LocalPropertyInformation,
-                                 private val reader: PropertyReader,
+                                 private val reader: GetterReader,
                                  private val serializerProvider: () -> AMQPSerializer<Any>) : PropertyWriteStrategy {
 
     // Lazy to avoid getting into infinite loops when there are cycles.
@@ -226,7 +203,7 @@ object AMQPPropertyReadStrategy : PropertyReadStrategy {
             if (obj is Binary) obj.array else obj
 }
 
-class AMQPPropertyWriteStrategy(private val reader: PropertyReader) : PropertyWriteStrategy {
+class AMQPPropertyWriteStrategy(private val reader: GetterReader) : PropertyWriteStrategy {
     override fun writeClassInfo(output: SerializationOutput, context: SerializationContext) {}
 
     override fun writeProperty(obj: Any?, data: Data, output: SerializationOutput,
@@ -250,7 +227,7 @@ object AMQPCharPropertyReadStrategy : PropertyReadStrategy {
     }
 }
 
-class AMQPCharPropertyWriteStategy(private val reader: PropertyReader) : PropertyWriteStrategy {
+class AMQPCharPropertyWriteStategy(private val reader: GetterReader) : PropertyWriteStrategy {
     override fun writeClassInfo(output: SerializationOutput, context: SerializationContext) {}
 
     override fun writeProperty(obj: Any?, data: Data, output: SerializationOutput,

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
@@ -7,7 +7,6 @@ import net.corda.internal.serialization.model.TypeIdentifier
 import net.corda.serialization.SerializationContext
 import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.codec.Data
-import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Type
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactory.kt
@@ -151,7 +151,6 @@ class DefaultEvolutionSerializerFactory(
 
     private val LocalPropertyInformation.mustBeProvided: Boolean get() = when(this) {
         is LocalPropertyInformation.ConstructorPairedProperty -> isMandatory
-        is LocalPropertyInformation.PrivateConstructorPairedProperty -> isMandatory
         else -> false
     }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ObjectBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ObjectBuilder.kt
@@ -109,8 +109,6 @@ interface ObjectBuilder {
                     when (it) {
                         is LocalPropertyInformation.ConstructorPairedProperty ->
                             it.constructorSlot.constructorInformation == constructor
-                        is LocalPropertyInformation.PrivateConstructorPairedProperty ->
-                            it.constructorSlot.constructorInformation == constructor
                         else -> true
                     }
                 }
@@ -118,7 +116,6 @@ interface ObjectBuilder {
             val constructorIndices = properties.mapValues { (name, property) ->
                 when (property) {
                     is LocalPropertyInformation.ConstructorPairedProperty -> property.constructorSlot.parameterIndex
-                    is LocalPropertyInformation.PrivateConstructorPairedProperty -> property.constructorSlot.parameterIndex
                     is LocalPropertyInformation.CalculatedProperty -> IGNORE_COMPUTED
                     else -> throw NotSerializableException(
                         "Type ${typeIdentifier.prettyPrint(false)} has constructor arguments, " +

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.amqp.custom
 
 import net.corda.internal.serialization.amqp.LocalSerializerFactory
-import net.corda.internal.serialization.amqp.PropertyReader
+import net.corda.internal.serialization.amqp.GetterReader
 import net.corda.internal.serialization.amqp.currentSandboxGroup
 import net.corda.internal.serialization.model.LocalConstructorInformation
 import net.corda.internal.serialization.model.LocalTypeInformation
@@ -53,7 +53,7 @@ class ThrowableSerializer(
                 val typeInformation = factory.getTypeInformation(obj.javaClass)
                 extraProperties.putAll(
                     typeInformation.propertiesOrEmptyMap.mapValues { (_, property) ->
-                        PropertyReader.make(property).read(obj)
+                        GetterReader(property.observedGetter).read(obj)
                     }
                 )
             } catch (e: NotSerializableException) {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalPropertyInformation.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalPropertyInformation.kt
@@ -1,6 +1,5 @@
 package net.corda.internal.serialization.model
 
-import java.lang.reflect.Field
 import java.lang.reflect.Method
 
 /**
@@ -33,16 +32,6 @@ sealed class LocalPropertyInformation(val isCalculated: Boolean) {
      * constructor arguments when creating instances of its owning type.
      */
     data class ConstructorPairedProperty(val observedGetter: Method, val constructorSlot: ConstructorSlot, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
-
-    /**
-     * A property for which we have no getter, but for which there is a backing field a matching slot in an array of
-     * constructor parameters.
-     *
-     * @param observedField The field which can be used to obtain the value of this property from an instance of its owning type.
-     * @param constructorSlot The [ConstructorSlot] to which the property corresponds, used to populate an array of
-     * constructor arguments when creating instances of its owning type.
-     */
-    data class PrivateConstructorPairedProperty(val observedField: Field, val constructorSlot: ConstructorSlot, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
 
     /**
      * A property for which we have both getter and setter methods (usually belonging to a POJO which is initialised

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalPropertyInformation.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalPropertyInformation.kt
@@ -8,6 +8,10 @@ import java.lang.reflect.Method
 sealed class LocalPropertyInformation(val isCalculated: Boolean) {
 
     /**
+     * The method which can be used to obtain the value of this property from an instance of its owning type.
+     */
+    abstract val observedGetter: Method
+    /**
      * [LocalTypeInformation] for the type of the property.
      */
     abstract val type: LocalTypeInformation
@@ -19,33 +23,29 @@ sealed class LocalPropertyInformation(val isCalculated: Boolean) {
 
     /**
      * A property of an interface, for which we have only a getter method.
-     *
-     * @param observedGetter The method which can be used to obtain the value of this property from an instance of its owning type.
      */
-    data class ReadOnlyProperty(val observedGetter: Method, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
+    data class ReadOnlyProperty(override val observedGetter: Method, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
 
     /**
      * A property for which we have both a getter, and a matching slot in an array of constructor parameters.
      *
-     * @param observedGetter The method which can be used to obtain the value of this property from an instance of its owning type.
      * @param constructorSlot The [ConstructorSlot] to which the property corresponds, used to populate an array of
      * constructor arguments when creating instances of its owning type.
      */
-    data class ConstructorPairedProperty(val observedGetter: Method, val constructorSlot: ConstructorSlot, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
+    data class ConstructorPairedProperty(override val observedGetter: Method, val constructorSlot: ConstructorSlot, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
 
     /**
      * A property for which we have both getter and setter methods (usually belonging to a POJO which is initialised
      * with the default no-argument constructor and then configured via setters).
      *
-     * @param observedGetter The method which can be used to obtain the value of this property from an instance of its owning type.
      * @param observedSetter The method which can be used to set the value of this property on an instance of its owning type.
      */
-    data class GetterSetterProperty(val observedGetter: Method, val observedSetter: Method, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
+    data class GetterSetterProperty(override val observedGetter: Method, val observedSetter: Method, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(false)
 
     /**
      * A property for which we have only a getter method, which is annotated with [SerializableCalculatedProperty].
      */
-    data class CalculatedProperty(val observedGetter: Method, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(true)
+    data class CalculatedProperty(override val observedGetter: Method, override val type: LocalTypeInformation, override val isMandatory: Boolean) : LocalPropertyInformation(true)
 }
 
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
@@ -305,7 +305,6 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
         val indicesAddressedByProperties = properties.values.mapNotNullTo(LinkedHashSet()) {
             when (it) {
                 is LocalPropertyInformation.ConstructorPairedProperty -> it.constructorSlot.parameterIndex
-                is LocalPropertyInformation.PrivateConstructorPairedProperty -> it.constructorSlot.parameterIndex
                 else -> null
             }
         }
@@ -324,7 +323,6 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
         val indicesAddressedByProperties = properties.values.mapNotNullTo(LinkedHashSet()) {
             when (it) {
                 is LocalPropertyInformation.ConstructorPairedProperty -> it.constructorSlot.parameterIndex
-                is LocalPropertyInformation.PrivateConstructorPairedProperty -> it.constructorSlot.parameterIndex
                 else -> null
             }
         }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
@@ -421,12 +421,7 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                                               constructorInformation: LocalConstructorInformation): LocalPropertyInformation? {
 
         if (descriptor.getter == null) {
-            if (descriptor.field == null) return null
-
-            throw NotSerializableException(
-                "Property '${descriptor.field.name}' or its getter is non public, " +
-                        "this renders class '${descriptor.field.declaringClass}' unserializable -> ${descriptor.field.declaringClass}"
-            )
+            return null
         }
 
         val paramType = descriptor.getter.genericReturnType

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
@@ -412,24 +412,19 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                     constructorParameterIndices.getValue(normalisedName),
                     descriptor,
                     constructorInformation)
-            if (property == null) null else normalisedName to property
+            normalisedName to property
         }
     }
 
     private fun makeConstructorPairedProperty(constructorIndex: Int,
                                               descriptor: PropertyDescriptor,
-                                              constructorInformation: LocalConstructorInformation): LocalPropertyInformation? {
+                                              constructorInformation: LocalConstructorInformation): LocalPropertyInformation {
 
         if (descriptor.getter == null) {
-            if (descriptor.field == null) return null
-            val paramType = descriptor.field.genericType
-            val paramTypeInformation = resolveAndBuild(paramType)
-
-            return LocalPropertyInformation.PrivateConstructorPairedProperty(
-                    descriptor.field,
-                    ConstructorSlot(constructorIndex, constructorInformation),
-                    paramTypeInformation,
-                    constructorInformation.parameters[constructorIndex].isMandatory)
+            throw NotSerializableException(
+                "Property '${descriptor.field!!.name}' or its getter is non public, " +
+                        "this renders class '${descriptor.field.declaringClass}' unserializable -> ${descriptor.field.declaringClass}"
+            )
         }
 
         val paramType = descriptor.getter.genericReturnType

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/LocalTypeInformationBuilder.kt
@@ -420,24 +420,13 @@ internal data class LocalTypeInformationBuilder(val lookup: LocalTypeLookup,
                                               descriptor: PropertyDescriptor,
                                               constructorInformation: LocalConstructorInformation): LocalPropertyInformation? {
 
-        @Suppress("DEPRECATION")    // JDK11: isAccessible() should be replaced with canAccess() (since 9)
-        if (descriptor.getter == null && descriptor.field != null && !descriptor.field.isAccessible) {
-            throw NotSerializableException(
-                "Property '${descriptor.field.name}' and its getter is non public, " +
-                        "this renders class '${descriptor.field.declaringClass}' unserializable -> ${descriptor.field.declaringClass}"
-            )
-        }
-
         if (descriptor.getter == null) {
             if (descriptor.field == null) return null
-            val paramType = descriptor.field.genericType
-            val paramTypeInformation = resolveAndBuild(paramType)
 
-            return LocalPropertyInformation.PrivateConstructorPairedProperty(
-                    descriptor.field,
-                    ConstructorSlot(constructorIndex, constructorInformation),
-                    paramTypeInformation,
-                    constructorInformation.parameters[constructorIndex].isMandatory)
+            throw NotSerializableException(
+                "Property '${descriptor.field.name}' or its getter is non public, " +
+                        "this renders class '${descriptor.field.declaringClass}' unserializable -> ${descriptor.field.declaringClass}"
+            )
         }
 
         val paramType = descriptor.getter.genericReturnType

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/DummyOptional.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/DummyOptional.java
@@ -13,7 +13,7 @@ public class DummyOptional<T> {
         return item != null;
     }
 
-    public T get() {
+    public T getItem() {
         return item;
     }
 

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
@@ -1,7 +1,6 @@
 package net.corda.internal.serialization.amqp;
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.NotSerializableException;
@@ -9,7 +8,6 @@ import java.io.NotSerializableException;
 import static net.corda.internal.serialization.amqp.testutils.AMQPTestUtilsKt.testDefaultFactory;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@Disabled("Current behaviour allows for the serialization of objects with private members, this will be disallowed at some point in the future")
 public class ErrorMessageTests {
     private String errMsg(String property, String testname) {
         return "Property '"

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
@@ -12,7 +12,7 @@ public class ErrorMessageTests {
     private String errMsg(String property, String testname) {
         return "Property '"
                 + property
-                + "' and its getter is non public, this renders class 'class "
+                + "' or its getter is non public, this renders class 'class "
                 + testname
                 + "$C' unserializable -> class "
                 + testname

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
@@ -12,7 +12,7 @@ public class ErrorMessageTests {
     private String errMsg(String property, String testname) {
         return "Property '"
                 + property
-                + "' or its getter is non public, this renders class 'class "
+                + "' and its getter is non public, this renders class 'class "
                 + testname
                 + "$C' unserializable -> class "
                 + testname

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/ErrorMessageTests.java
@@ -1,6 +1,7 @@
 package net.corda.internal.serialization.amqp;
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
+import net.corda.v5.base.annotations.CordaSerializable;
 import org.junit.jupiter.api.Test;
 
 import java.io.NotSerializableException;
@@ -10,15 +11,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ErrorMessageTests {
     private String errMsg(String property, String testname) {
-        return "Property '"
-                + property
-                + "' or its getter is non public, this renders class 'class "
-                + testname
-                + "$C' unserializable -> class "
-                + testname
-                + "$C";
+        return "Unable to create an object serializer for type class "
+                + testname + "$C:\n" +
+                "Mandatory constructor parameters [" + property + "] are missing from the readable properties []\n\n"
+                + "Either provide getters or readable fields for [" + property + "], or provide a custom serializer for this type\n\n"
+                + "No custom serializers registered.\n";
     }
 
+
+    @CordaSerializable
     static class C {
         public Integer a;
 

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaGenericsTest.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaGenericsTest.java
@@ -33,7 +33,7 @@ public class JavaGenericsTest {
             this.v = v;
         }
 
-        Integer getV() {
+        public Integer getV() {
             return v;
         }
     }

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaNestedInheritenceTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaNestedInheritenceTests.java
@@ -31,12 +31,20 @@ class Wrapper {
     Wrapper(JavaTestContractState cs) {
         this.cs = cs;
     }
+
+    public JavaTestContractState getCs() {
+        return cs;
+    }
 }
 
 @CordaSerializable
 class TemplateWrapper<T> {
     public T obj;
     TemplateWrapper(T obj) { this.obj = obj; }
+
+    public T getObj() {
+        return obj;
+    }
 }
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaPrivatePropertyTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaPrivatePropertyTests.java
@@ -20,6 +20,10 @@ public class JavaPrivatePropertyTests {
         private String a;
 
         C(String a) { this.a = a; }
+
+        public String getA() {
+            return a;
+        }
     }
 
     @CordaSerializable

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
@@ -8,6 +8,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
+import net.corda.v5.base.annotations.CordaSerializable
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class ErrorMessagesTests {
     companion object {
@@ -18,10 +20,6 @@ class ErrorMessagesTests {
         "Property '$property' or its getter is non public, this renders class 'class $testname\$C' unserializable -> class $testname\$C"
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Disabled(
-        "Current behaviour allows for the serialization of objects with private members," +
-            " this will be disallowed at some point in the future"
-    )
     @Test
     fun privateProperty() {
         data class C(private val a: Int)
@@ -36,10 +34,6 @@ class ErrorMessagesTests {
     }
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Disabled(
-        "Current behaviour allows for the serialization of objects with private members," +
-            " this will be disallowed at some point in the future"
-    )
     @Test
     fun privateProperty2() {
         data class C(val a: Int, private val b: Int)
@@ -54,14 +48,11 @@ class ErrorMessagesTests {
     }
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Disabled(
-        "Current behaviour allows for the serialization of objects with private members, " +
-            "this will be disallowed at some point in the future"
-    )
     @Test
     fun privateProperty3() {
         // despite b being private, the getter we've added is public and thus allows for the serialisation
         // of the object
+        @CordaSerializable
         data class C(val a: Int, private val b: Int) {
             @Suppress("unused")
             fun getB() = b
@@ -69,15 +60,14 @@ class ErrorMessagesTests {
 
         val sf = testDefaultFactory()
 
-        val bytes = TestSerializationOutput(VERBOSE, sf).serialize(C(1, 2))
-        DeserializationInput(sf).deserialize(bytes)
+        val input = C(1, 2)
+
+        val bytes = TestSerializationOutput(VERBOSE, sf).serialize(input)
+        val output = DeserializationInput(sf).deserialize(bytes)
+        assertEquals(input, output)
     }
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
-    @Disabled(
-        "Current behaviour allows for the serialization of objects with private members, " +
-            "this will be disallowed at some point in the future"
-    )
     @Test
     fun protectedProperty() {
         open class C(@Suppress("unused") protected val a: Int)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
@@ -5,7 +5,6 @@ import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.internal.serialization.amqp.testutils.testName
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.io.NotSerializableException
 import net.corda.v5.base.annotations.CordaSerializable

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
@@ -16,7 +16,7 @@ class ErrorMessagesTests {
     }
 
     private fun errMsg(property: String, testname: String) =
-        "Property '$property' and its getter is non public, this renders class 'class $testname\$C' unserializable -> class $testname\$C"
+        "Property '$property' or its getter is non public, this renders class 'class $testname\$C' unserializable -> class $testname\$C"
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
     @Test

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
@@ -16,7 +16,7 @@ class ErrorMessagesTests {
     }
 
     private fun errMsg(property: String, testname: String) =
-        "Property '$property' or its getter is non public, this renders class 'class $testname\$C' unserializable -> class $testname\$C"
+        "Property '$property' and its getter is non public, this renders class 'class $testname\$C' unserializable -> class $testname\$C"
 
     // Java allows this to be set at the class level yet Kotlin doesn't for some reason
     @Test

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivatePropertyTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivatePropertyTests.kt
@@ -28,7 +28,9 @@ class PrivatePropertyTests {
     @Test
 	fun testWithOnePrivateProperty() {
         @CordaSerializable
-        data class C(private val b: String)
+        data class C(private val b: String) {
+            fun getB() = b
+        }
 
         val c1 = C("Pants are comfortable sometimes")
         val c2 = DeserializationInput(factory).deserialize(SerializationOutput(factory).serialize(c1))
@@ -38,7 +40,9 @@ class PrivatePropertyTests {
     @Test
 	fun testWithOnePrivatePropertyBoolean() {
         @CordaSerializable
-        data class C(private val b: Boolean)
+        data class C(private val b: Boolean) {
+            fun getB() = b
+        }
 
         C(false).apply {
             assertThat(this).isEqualTo(DeserializationInput(factory).deserialize(SerializationOutput(factory).serialize(this)))
@@ -48,7 +52,9 @@ class PrivatePropertyTests {
     @Test
 	fun testWithOnePrivatePropertyNullableNotNull() {
         @CordaSerializable
-        data class C(private val b: String?)
+        data class C(private val b: String?) {
+            fun getB() = b
+        }
 
         val c1 = C("Pants are comfortable sometimes")
         val c2 = DeserializationInput(factory).deserialize(SerializationOutput(factory).serialize(c1))
@@ -58,7 +64,9 @@ class PrivatePropertyTests {
     @Test
 	fun testWithOnePrivatePropertyNullableNull() {
         @CordaSerializable
-        data class C(private val b: String?)
+        data class C(private val b: String?) {
+            fun getB() = b
+        }
 
         val c1 = C(null)
         val c2 = DeserializationInput(factory).deserialize(SerializationOutput(factory).serialize(c1))
@@ -68,7 +76,9 @@ class PrivatePropertyTests {
     @Test
 	fun testWithOnePublicOnePrivateProperty() {
         @CordaSerializable
-        data class C(val a: Int, private val b: Int)
+        data class C(val a: Int, private val b: Int) {
+            fun getB() = b
+        }
 
         val c1 = C(1, 2)
         val c2 = DeserializationInput(factory).deserialize(SerializationOutput(factory).serialize(c1))
@@ -77,7 +87,8 @@ class PrivatePropertyTests {
 
     @Test
 	fun testWithInheritance() {
-        open class B(val a: String, protected val b: String)
+        open class B(val a: String, @JvmField protected val b: String)
+
         @CordaSerializable
         class D (a: String, b: String) : B (a, b) {
             override fun equals(other: Any?): Boolean = when (other) {
@@ -134,7 +145,9 @@ class PrivatePropertyTests {
     @Test
 	fun testWithOnePublicOnePrivateProperty2() {
         @CordaSerializable
-        data class C(val a: Int, private val b: Int)
+        data class C(val a: Int, private val b: Int) {
+            fun getB() = b
+        }
 
         val c1 = C(1, 2)
         val schemaAndBlob = SerializationOutput(factory).serializeAndReturnSchema(c1)
@@ -146,7 +159,7 @@ class PrivatePropertyTests {
 
         assertThat(typeInformation.properties.size).isEqualTo(2)
         assertThat(typeInformation.properties["a"] is LocalPropertyInformation.ConstructorPairedProperty).isTrue()
-        assertThat(typeInformation.properties["b"] is LocalPropertyInformation.PrivateConstructorPairedProperty).isTrue()
+        assertThat(typeInformation.properties["b"] is LocalPropertyInformation.ConstructorPairedProperty).isTrue()
     }
 
     @Test

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivatePropertyTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/PrivatePropertyTests.kt
@@ -87,7 +87,7 @@ class PrivatePropertyTests {
 
     @Test
 	fun testWithInheritance() {
-        open class B(val a: String, @JvmField protected val b: String)
+        open class B(val a: String, val b: String)
 
         @CordaSerializable
         class D (a: String, b: String) : B (a, b) {
@@ -187,9 +187,13 @@ class PrivatePropertyTests {
     @Test
 	fun testNested() {
         @CordaSerializable
-        data class Inner(private val a: Int)
+        data class Inner(private val a: Int) {
+            fun getA() = a
+        }
         @CordaSerializable
-        data class Outer(private val i: Inner)
+        data class Outer(private val i: Inner) {
+            fun getI() = i
+        }
 
         val c1 = Outer(Inner(1010101))
         val output = SerializationOutput(factory).serializeAndReturnSchema(c1)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/model/LocalTypeModelTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/model/LocalTypeModelTests.kt
@@ -63,7 +63,7 @@ class LocalTypeModelTests {
     @Suppress("unused")
     class Nested(
         val collectionHolder: StringKeyedCollectionHolder<out Int>?,
-        private val intArray: IntArray,
+        val intArray: IntArray,
         @Suppress("UNUSED_PARAMETER") optionalParam: Short?
     )
 


### PR DESCRIPTION
Prevents AMQP serialization of private properties.

- ignores property, during constructor properties information creation, if the property gets initialized through constructor and its getter is missing.
- removes redundant APIs from this change.
- aligns tests.