### PR TITLE
CORE-6692 publish corda-json-serializers module externally for DP2

### DIFF
--- a/libs/serialization/json-serializers/build.gradle
+++ b/libs/serialization/json-serializers/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Corda Common JSON serializers'
 
 


### PR DESCRIPTION
Add property `releasable `and set to `true`.  This logic is evaluated by our r3 publishing plugin which then marks this as to Be published to our maven repo staging area in S3 for DP2 QA testing

this is required as the `net.corda:simulator-runtime:<version>` dependency used in the the hello-corda sample app requires this module to also be published and available as a runtime dependency 