### PR TITLE
NOTICK: set snakeyaml dependecy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ detektPluginVersion=1.21.+
 internalPublishVersion=1.+
 internalDockerVersion=1.+
 dependencyCheckVersion=0.42.+
-snakeyamlVersion=1.31
+snakeyamlVersion=1.30
 
 # Implementation dependency versions
 activationVersion = 1.2.0


### PR DESCRIPTION
previous upgrade from 1.29-> 1.31 introduces copyleft license we can not have this in our shipped code , rolling back to 1.30 resolves this as this version of software uses apache 2.0 