### PR TITLE
CORE-6679 make SerializationServiceImpl a system service to allow CPIs to access it 

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceImpl.kt
@@ -18,7 +18,8 @@ import org.osgi.service.component.annotations.ServiceScope
         SerializationServiceInternal::class,
         SingletonSerializeAsToken::class
     ],
-    scope = ServiceScope.PROTOTYPE
+    scope = ServiceScope.PROTOTYPE,
+    property = [ "corda.system=true" ]
 )
 class SerializationServiceImpl @Activate constructor(
     @Reference(service = FlowFiberService::class)


### PR DESCRIPTION
Without this filter the service does not pass the security policy file check as the api package name is:
net.corda.flow.application.serialization. SerializationServiceInternal

instead of

 net.corda.v5.*