### PR TITLE
CORE-6687: Simulator handles exceptions and timeouts in flows

### DIFF
--- a/simulator/README.md
+++ b/simulator/README.md
@@ -8,6 +8,20 @@ flows or handle more than one version of any Flow.  It is intended only for low-
 quick feedback and documenting examples of how things work) or demoing CorDapps. For full testing, use a real or
 production-like implementation of Corda.
 
+## Setting up dependencies
+
+You will need to set up the following dependencies in your build file, assuming you are using this for testing:
+
+```
+      testImplementation "net.corda:simulator-api:$simulatorVersion"
+      testRuntimeOnly "net.corda:simulator-runtime:$simulatorVersion"
+```
+
+Do not use the runtime libraries as an implementation dependency, as your code may fail to compile or run
+when Simulator is updated. The API is much more stable.
+
+## How to run Simulator
+
 The main class for starting your CorDapps is `net.corda.simulator.Simulator`. "Uploading" your flow for a given party 
 will create a simulated "virtual node" which can then be invoked using the initiating flow class (in a real Corda
 network this would be done using the `CPI_HASH`).
@@ -26,6 +40,26 @@ network this would be done using the `CPI_HASH`).
 Simulator will wire up your flow with lightweight versions of the same injected services that you'd get with
 the real Corda, enabling your flows to communicate with each other, persist data (currently to an in-memory database)
 and "sign" data (see below).
+
+## Configuration
+
+Simulator configuration can be set using the `SimulatorConfigurationBuilder`. You can configure:
+- the clock (defaults to system default clock)
+- timeouts for flows (defaults to 1 minute)
+- polling interval (defaults to 100 ms)
+
+The default timeout should be suitable for most tests. For demos, showcasing proofs of concept etc. you may want
+to make it longer.
+
+The polling interval is used to check for any exceptions thrown by responder flows.
+
+```kotlin
+val simulator = Simulator(SimulatorConfigurationBuilder.create()
+    .withTimeout(Duration.ofMinutes(2))
+    .withPollInterval(Duration.ofMillis(50))
+    .build()
+)
+```
 
 ## RequestData
 

--- a/simulator/api/src/main/kotlin/net/corda/simulator/Simulator.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/Simulator.kt
@@ -1,6 +1,8 @@
 package net.corda.simulator
 
 import net.corda.simulator.exceptions.ServiceConfigurationException
+import net.corda.simulator.factories.SimulatorConfigurationBuilder
+import net.corda.simulator.factories.SimulatorDelegateFactory
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.ResponderFlow
 import java.util.ServiceLoader
@@ -22,10 +24,12 @@ import java.util.ServiceLoader
  * @fiber The simulated "fiber" with which responder flows will be registered by protocol
  * @injector An injector to initialize services annotated with @CordaInject in flows and subflows
  */
-class Simulator : SimulatedCordaNetwork {
+class Simulator(
+    configuration: SimulatorConfiguration = SimulatorConfigurationBuilder.create().build()
+) : SimulatedCordaNetwork {
 
     private val delegate : SimulatedCordaNetwork =
-        ServiceLoader.load(SimulatedCordaNetwork::class.java).firstOrNull() ?:
+        ServiceLoader.load(SimulatorDelegateFactory::class.java).firstOrNull()?.create(configuration) ?:
         throw ServiceConfigurationException(SimulatedCordaNetwork::class.java)
 
     /**

--- a/simulator/api/src/main/kotlin/net/corda/simulator/SimulatorConfiguration.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/SimulatorConfiguration.kt
@@ -1,0 +1,12 @@
+package net.corda.simulator
+
+import java.time.Clock
+import java.time.Duration
+
+interface SimulatorConfiguration {
+
+    val pollInterval: Duration
+    val timeout: Duration
+    val clock : Clock
+
+}

--- a/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/NoInitiatingFlowAnnotationException.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/NoInitiatingFlowAnnotationException.kt
@@ -1,7 +1,0 @@
-package net.corda.simulator.exceptions
-
-import net.corda.v5.base.exceptions.CordaRuntimeException
-
-class NoInitiatingFlowAnnotationException(flowClass: Class<*>) : CordaRuntimeException(
-    "No @InitiatingFlow annotation found on flow class ${flowClass.simpleName}"
-)

--- a/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/NoProtocolAnnotationException.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/NoProtocolAnnotationException.kt
@@ -1,0 +1,7 @@
+package net.corda.simulator.exceptions
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class NoProtocolAnnotationException(flowClass: Class<*>) : CordaRuntimeException(
+    "No @InitiatingFlow or @InitiatedBy annotation found on flow class ${flowClass.simpleName}"
+)

--- a/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/ResponderFlowException.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/ResponderFlowException.kt
@@ -1,0 +1,11 @@
+package net.corda.simulator.exceptions
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class ResponderFlowException(cause: Throwable) : CordaRuntimeException(
+    "An error was encountered in the responding flow. Note that exceptions should not be used for " +
+            "normal inter-flow communication; use a structure that can return an error result instead." +
+            "Also note that real Corda will not pass on the cause exception " +
+            "to avoid serializing secure information to peers.",
+    cause
+)

--- a/simulator/api/src/main/kotlin/net/corda/simulator/factories/SimulatorConfigurationBuilder.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/factories/SimulatorConfigurationBuilder.kt
@@ -1,0 +1,27 @@
+package net.corda.simulator.factories
+
+import net.corda.simulator.SimulatorConfiguration
+import java.time.Clock
+import java.time.Duration
+import java.util.ServiceLoader
+
+/**
+ * Builds a configuration with which to call a flow, providing sensible defaults for any value which is
+ * not explicitly overridden.
+ */
+interface SimulatorConfigurationBuilder {
+
+    fun withClock(clock: Clock): SimulatorConfigurationBuilder
+
+    fun withPollInterval(pollInterval: Duration): SimulatorConfigurationBuilder
+
+    fun withTimeout(timeout: Duration): SimulatorConfigurationBuilder
+
+    fun build(): SimulatorConfiguration
+
+    companion object {
+        fun create(): SimulatorConfigurationBuilder {
+            return ServiceLoader.load(SimulatorConfigurationBuilder::class.java).first()
+        }
+    }
+}

--- a/simulator/api/src/main/kotlin/net/corda/simulator/factories/SimulatorDelegateFactory.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/factories/SimulatorDelegateFactory.kt
@@ -1,0 +1,8 @@
+package net.corda.simulator.factories
+
+import net.corda.simulator.SimulatedCordaNetwork
+import net.corda.simulator.SimulatorConfiguration
+
+interface SimulatorDelegateFactory {
+    fun create(configuration: SimulatorConfiguration): SimulatedCordaNetwork
+}

--- a/simulator/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
+++ b/simulator/example-app/src/integrationTest/kotlin/net/cordacon/example/RollCallTest.kt
@@ -4,17 +4,26 @@ import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.RequestData
 import net.corda.simulator.Simulator
 import net.corda.simulator.crypto.HsmCategory
+import net.corda.simulator.factories.SimulatorConfigurationBuilder
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 
+@Timeout(value=5, unit=TimeUnit.MINUTES)
 class RollCallTest {
 
     @Test
     fun `should get roll call from multiple recipients`() {
         // Given a RollCallFlow that's been uploaded to Corda for a teacher
-        val corda = Simulator()
+        val corda = Simulator(SimulatorConfigurationBuilder.create()
+            .withTimeout(Duration.ofMinutes(2))
+            .withPollInterval(Duration.ofMillis(50))
+            .build()
+        )
         val teacher = MemberX500Name.parse(
             "CN=Ben Stein, OU=Economics, O=Glenbrook North High School, L=Chicago, C=US"
         )

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/DefaultConfigurationBuilder.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/DefaultConfigurationBuilder.kt
@@ -1,0 +1,40 @@
+package net.corda.simulator.runtime
+
+import net.corda.simulator.SimulatorConfiguration
+import net.corda.simulator.factories.SimulatorConfigurationBuilder
+import java.time.Clock
+import java.time.Duration
+
+class DefaultConfigurationBuilder : SimulatorConfigurationBuilder {
+
+    companion object {
+        private data class SimulatorConfigurationBase (
+            override val clock: Clock = Clock.systemDefaultZone(),
+            override val timeout: Duration = Duration.ofMinutes(1),
+            override val pollInterval: Duration = Duration.ofMillis(100)
+        ) : SimulatorConfiguration
+    }
+
+    private var config = SimulatorConfigurationBase()
+
+    override fun withClock(clock: Clock): SimulatorConfigurationBuilder {
+        config = config.copy(clock = clock)
+        return this
+    }
+
+    override fun withPollInterval(pollInterval: Duration): SimulatorConfigurationBuilder {
+        config = config.copy(pollInterval = pollInterval)
+        return this
+    }
+
+    override fun withTimeout(timeout: Duration): SimulatorConfigurationBuilder {
+        config = config.copy(timeout = timeout)
+        return this
+    }
+
+    override fun build(): SimulatorConfiguration {
+        return config
+    }
+
+
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
@@ -3,6 +3,7 @@ package net.corda.simulator.runtime
 import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.SimulatedCordaNetwork
 import net.corda.simulator.SimulatedVirtualNode
+import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.runtime.flows.BaseFlowFactory
 import net.corda.simulator.runtime.flows.DefaultServicesInjector
 import net.corda.simulator.runtime.flows.FlowFactory
@@ -18,10 +19,11 @@ import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.base.types.MemberX500Name
 
 
-class SimulatedCordaNetworkBase  (
+class SimulatorDelegateBase  (
+    private val configuration: SimulatorConfiguration,
     private val flowChecker: FlowChecker = CordaFlowChecker(),
     private val fiber: SimFiber = SimFiberBase(),
-    private val injector: FlowServicesInjector = DefaultServicesInjector()
+    private val injector: FlowServicesInjector = DefaultServicesInjector(configuration)
 ) : SimulatedCordaNetwork {
 
     private val flowFactory: FlowFactory = BaseFlowFactory()

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateFactoryBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateFactoryBase.kt
@@ -1,0 +1,11 @@
+package net.corda.simulator.runtime
+
+import net.corda.simulator.SimulatedCordaNetwork
+import net.corda.simulator.SimulatorConfiguration
+import net.corda.simulator.factories.SimulatorDelegateFactory
+
+class SimulatorDelegateFactoryBase : SimulatorDelegateFactory {
+    override fun create(configuration: SimulatorConfiguration): SimulatedCordaNetwork {
+        return SimulatorDelegateBase(configuration)
+    }
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.flows
 
+import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.runtime.messaging.SimFiber
 import net.corda.simulator.runtime.tools.CordaFlowChecker
 import net.corda.simulator.tools.FlowChecker
@@ -23,9 +24,10 @@ import java.util.UUID
  * @return the value returned by the subflow when called
  */
 class InjectingFlowEngine(
+    private val configuration: SimulatorConfiguration,
     override val virtualNodeName: MemberX500Name,
     private val fiber: SimFiber,
-    private val injector: FlowServicesInjector = DefaultServicesInjector(),
+    private val injector: FlowServicesInjector = DefaultServicesInjector(configuration),
     private val flowChecker: FlowChecker = CordaFlowChecker()
 ) : FlowEngine {
     override val flowId: UUID

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
@@ -1,16 +1,21 @@
 package net.corda.simulator.runtime.messaging
 
+import net.corda.simulator.exceptions.ResponderFlowException
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import java.util.concurrent.BlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 class BlockingQueueFlowSession(
-    override val counterparty: MemberX500Name,
+    private val flowDetails: FlowContext,
     private val from: BlockingQueue<Any>,
     private val to: BlockingQueue<Any>
 ) : FlowSession {
 
+    private val configuration = flowDetails.configuration
+    private var caughtResponderError: Throwable? = null
     override fun close() {
         TODO("Not yet implemented")
     }
@@ -20,13 +25,27 @@ class BlockingQueueFlowSession(
             TODO("Not yet implemented")
         }
 
+    override val counterparty: MemberX500Name
+        get() = flowDetails.member
+
     override fun <R : Any> receive(receiveType: Class<R>): R {
-        try {
-            @Suppress("UNCHECKED_CAST")
-            return to.take() as R
-        } catch (e: ClassCastException) {
-            throw IllegalStateException("Message on queue was not a ${receiveType.simpleName}")
+        val start = configuration.clock.instant()
+        while (configuration.clock.instant().minus(configuration.timeout) < start) {
+            val immutableResponderError = caughtResponderError
+            if (immutableResponderError != null) {
+                throw ResponderFlowException(immutableResponderError)
+            }
+            val received = to.poll(configuration.pollInterval.toMillis(), TimeUnit.MILLISECONDS)
+            if (received != null) {
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    return received as R
+                } catch (e: ClassCastException) {
+                    throw IllegalStateException("Message on queue was not a ${receiveType.simpleName}")
+                }
+            }
         }
+        throw TimeoutException("Session belonging to \"$counterparty\" timed out after ${configuration.timeout}")
     }
 
     override fun send(payload: Any) {
@@ -36,5 +55,9 @@ class BlockingQueueFlowSession(
     override fun <R : Any> sendAndReceive(receiveType: Class<R>, payload: Any): R {
         send(payload)
         return receive(receiveType)
+    }
+
+    fun responderErrorCaught(t: Throwable) {
+        caughtResponderError = t
     }
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
@@ -1,11 +1,8 @@
 package net.corda.simulator.runtime.messaging
 
-import net.corda.simulator.exceptions.NoInitiatingFlowAnnotationException
 import net.corda.simulator.exceptions.NoRegisteredResponderException
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowServicesInjector
-import net.corda.v5.application.flows.Flow
-import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.messaging.FlowContextPropertiesBuilder
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
@@ -24,24 +21,20 @@ import kotlin.concurrent.thread
  * Note that the "fiber" must be the same instance for all nodes; it acts as the equivalent of the message bus,
  * allowing nodes to communicate with each other.
  *
- * @initiator The initiating flow
- * @flowClass The class of the initiating flow; used for looking up the protocol
- * @protocolLookUp The "fiber" in which Simulator registered responder flow classes or instances and persistence
+ * @flowContext The context of the flow in which the messaging is taking place
+ * @fiber The "fiber" in which Simulator registered responder flow classes or instances and persistence
  * @injector The injector for @CordaInject flow services
  * @flowFactory The factory which will initialize and inject services into the responder flow.
  */
 class ConcurrentFlowMessaging(
-    private val initiator: MemberX500Name,
-    private val flowClass: Class<out Flow>,
+    private val flowContext: FlowContext,
     private val fiber: SimFiber,
     private val injector: FlowServicesInjector,
     private val flowFactory: FlowFactory
 ) : FlowMessaging {
 
     override fun initiateFlow(x500Name: MemberX500Name): FlowSession {
-        val protocol = flowClass.getAnnotation(InitiatingFlow::class.java)?.protocol
-            ?: throw NoInitiatingFlowAnnotationException(flowClass)
-
+        val protocol = flowContext.protocol
         val responderClass = fiber.lookUpResponderClass(x500Name, protocol)
         val responderFlow = if (responderClass == null) {
             fiber.lookUpResponderInstance(x500Name, protocol)
@@ -55,17 +48,23 @@ class ConcurrentFlowMessaging(
         val fromInitiatorToResponder = LinkedBlockingQueue<Any>()
         val fromResponderToInitiator = LinkedBlockingQueue<Any>()
         val initiatorSession = BlockingQueueFlowSession(
-            x500Name,
+            flowContext.copy(member = x500Name),
             fromInitiatorToResponder,
             fromResponderToInitiator
         )
         val recipientSession = BlockingQueueFlowSession(
-            initiator,
+            flowContext,
             fromResponderToInitiator,
-            fromInitiatorToResponder
+            fromInitiatorToResponder,
         )
 
-        thread { responderFlow.call(recipientSession) }
+        thread {
+            try {
+                responderFlow.call(recipientSession)
+            } catch (t: Throwable) {
+                initiatorSession.responderErrorCaught(t)
+            }
+        }
         return initiatorSession
     }
 

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/FlowContext.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/FlowContext.kt
@@ -1,0 +1,10 @@
+package net.corda.simulator.runtime.messaging
+
+import net.corda.simulator.SimulatorConfiguration
+import net.corda.v5.base.types.MemberX500Name
+
+data class FlowContext(
+    val configuration: SimulatorConfiguration,
+    val member: MemberX500Name,
+    val protocol: String,
+)

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/utils/Utilities.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/utils/Utilities.kt
@@ -6,10 +6,10 @@ import net.corda.v5.base.types.MemberX500Name
 
 fun <T> Flow.injectIfRequired(
     field: Class<T>,
-    value: T
+    valueCreator: () -> T
 ) = this.javaClass.declaredFields.firstOrNull {
     it.type.equals(field) && it.canAccess(this) && it.isAnnotationPresent(CordaInject::class.java)
-}?.set(this, value)
+}?.set(this, valueCreator())
 
 val MemberX500Name.sandboxName: Any
     get() {

--- a/simulator/runtime/src/main/resources/META-INF/services/net.corda.simulator.SimulatedCordaNetwork
+++ b/simulator/runtime/src/main/resources/META-INF/services/net.corda.simulator.SimulatedCordaNetwork
@@ -1,1 +1,1 @@
-net.corda.simulator.runtime.SimulatedCordaNetworkBase
+net.corda.simulator.runtime.SimulatorDelegateBase

--- a/simulator/runtime/src/main/resources/META-INF/services/net.corda.simulator.factories.SimulatorConfigurationBuilder
+++ b/simulator/runtime/src/main/resources/META-INF/services/net.corda.simulator.factories.SimulatorConfigurationBuilder
@@ -1,0 +1,1 @@
+net.corda.simulator.runtime.DefaultConfigurationBuilder

--- a/simulator/runtime/src/main/resources/META-INF/services/net.corda.simulator.factories.SimulatorDelegateFactory
+++ b/simulator/runtime/src/main/resources/META-INF/services/net.corda.simulator.factories.SimulatorDelegateFactory
@@ -1,0 +1,1 @@
+net.corda.simulator.runtime.SimulatorDelegateFactoryBase

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/DefaultConfigurationBuilderTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/DefaultConfigurationBuilderTest.kt
@@ -1,0 +1,34 @@
+package net.corda.simulator.runtime
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.notNullValue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+
+class DefaultConfigurationBuilderTest {
+
+    @Test
+    fun `should allow configuration to be built using a fluent interface`() {
+        val clock = Clock.systemUTC()
+        val config = DefaultConfigurationBuilder()
+            .withClock(clock)
+            .withTimeout(Duration.ofDays(1))
+            .withPollInterval(Duration.ofMillis(1000))
+            .build()
+
+        assertThat(config.clock, `is`(clock))
+        assertThat(config.timeout, `is`(Duration.ofDays(1)))
+        assertThat(config.pollInterval, `is`(Duration.ofMillis(1000)))
+    }
+
+    @Test
+    fun `should provide sensible defaults`() {
+        val config = DefaultConfigurationBuilder().build()
+
+        assertThat(config.clock, notNullValue())
+        assertThat(config.timeout, `is`(Duration.ofMinutes(1)))
+        assertThat(config.pollInterval, `is`(Duration.ofMillis(100)))
+    }
+}

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedCordaNetworkBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedCordaNetworkBaseTest.kt
@@ -27,7 +27,7 @@ class SimulatedCordaNetworkBaseTest {
     fun `should pass on any errors from the flow checker`() {
         // Given a mock flow checker in our simulated Corda network
         val flowChecker = mock<FlowChecker>()
-        val corda = SimulatedCordaNetworkBase(flowChecker)
+        val corda = SimulatorDelegateBase(mock(), flowChecker)
 
         // That is set to provide an error
         whenever(flowChecker.check(any())).doThrow(NoDefaultConstructorException(HelloFlow::class.java))
@@ -40,7 +40,7 @@ class SimulatedCordaNetworkBaseTest {
     @Test
     fun `should be able to choose between multiple flows for a given party`() {
         // Given a simulated Corda network
-        val corda = SimulatedCordaNetworkBase()
+        val corda = SimulatorDelegateBase(mock())
 
         // When I upload two flows
         val helloVirtualNode = corda.createVirtualNode(holdingId, HelloFlow::class.java, ValidStartingFlow::class.java)
@@ -58,7 +58,7 @@ class SimulatedCordaNetworkBaseTest {
     fun `should be able to upload a concrete instance of a responder for a member and protocol`() {
         // Given a simulated Corda network with a simulated fiber we control
         val fiber = mock<SimFiber>()
-        val corda = SimulatedCordaNetworkBase(fiber = fiber)
+        val corda = SimulatorDelegateBase(mock(), fiber = fiber)
 
         // And a concrete responder
         val responder = object : ResponderFlow {
@@ -77,7 +77,7 @@ class SimulatedCordaNetworkBaseTest {
     fun `should register initiating members with the fiber`() {
         // Given a simulated Corda network with a simulated fiber we control
         val fiber = mock<SimFiber>()
-        val corda = SimulatedCordaNetworkBase(fiber = fiber)
+        val corda = SimulatorDelegateBase(mock(), fiber = fiber)
 
         // When I upload an initiating flow
         corda.createVirtualNode(holdingId, PingAckFlow::class.java)
@@ -90,7 +90,7 @@ class SimulatedCordaNetworkBaseTest {
     fun `should close the fiber when it is closed`() {
         // Given a simulated Corda network with a fiber we control
         val fiber = mock<SimFiber>()
-        val corda = SimulatedCordaNetworkBase(fiber = fiber)
+        val corda = SimulatorDelegateBase(mock(), fiber = fiber)
 
         // When we close Corda
         corda.close()
@@ -101,7 +101,7 @@ class SimulatedCordaNetworkBaseTest {
 
     @Test
     fun `should error if no flows are provided`() {
-        val corda = SimulatedCordaNetworkBase()
+        val corda = SimulatorDelegateBase(mock())
         assertThrows<java.lang.IllegalArgumentException> { corda.createVirtualNode(holdingId) }
     }
 }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjectorTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjectorTest.kt
@@ -5,6 +5,7 @@ import net.corda.simulator.runtime.testflows.HelloFlow
 import net.corda.v5.base.types.MemberX500Name
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
 
 class DefaultServicesInjectorTest {
 
@@ -18,7 +19,7 @@ class DefaultServicesInjectorTest {
         val fiber = SimFiberBase()
 
         // When we inject services into it
-        DefaultServicesInjector().injectServices(flow, member, fiber)
+        DefaultServicesInjector(mock()).injectServices(flow, member, fiber)
 
         // Then it should have constructed useful things for us
         assertNotNull(flow.flowEngine)

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngineTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngineTest.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.flows
 
+import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.runtime.messaging.SimFiber
 import net.corda.simulator.runtime.tools.CordaFlowChecker
 import net.corda.simulator.tools.FlowChecker
@@ -27,7 +28,7 @@ class InjectingFlowEngineTest {
         val injector = mock<FlowServicesInjector>()
 
         // And a flow engine which uses them
-        val engine = InjectingFlowEngine(member, fiber, injector, CordaFlowChecker())
+        val engine = InjectingFlowEngine(mock(), member, fiber, injector, CordaFlowChecker())
 
         // When we pass a subflow to the flow engine
         val flow = mock<SubFlow<String>>()
@@ -48,10 +49,11 @@ class InjectingFlowEngineTest {
         val fiber = mock<SimFiber>()
         val injector = mock<FlowServicesInjector>()
         val flowChecker = mock<FlowChecker>()
+        val configuration = mock<SimulatorConfiguration>()
         whenever(flowChecker.check(any())).thenThrow(IllegalArgumentException())
 
         // And a flow engine which uses them
-        val engine = InjectingFlowEngine(member, fiber, injector, flowChecker)
+        val engine = InjectingFlowEngine(configuration, member, fiber, injector, flowChecker)
 
         // When we pass a subflow to the flow engine
         val flow = mock<SubFlow<String>>()

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSessionTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSessionTest.kt
@@ -1,17 +1,41 @@
 package net.corda.simulator.runtime.messaging
 
+import net.corda.simulator.SimulatorConfiguration
+import net.corda.simulator.exceptions.ResponderFlowException
 import net.corda.simulator.runtime.testflows.PingAckMessage
 import net.corda.v5.application.messaging.receive
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.lang.Thread.sleep
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.concurrent.thread
 
+
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 class BlockingQueueFlowSessionTest {
 
     private val sender = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")
     private val receiver = MemberX500Name.parse("CN=IRunCorDappsToo, OU=Application, O=R3, L=London, C=GB")
+
+    private val flowCallConfiguration = mock<SimulatorConfiguration>()
+
+    init {
+        whenever(flowCallConfiguration.pollInterval).doReturn(Duration.ofMillis(100))
+        whenever(flowCallConfiguration.timeout).doReturn(Duration.ofMinutes(1))
+        whenever(flowCallConfiguration.clock).doReturn(Clock.systemDefaultZone())
+    }
 
     @Test
     fun `should retrieve a response from the common queue and pass it back to the sender`() {
@@ -20,13 +44,13 @@ class BlockingQueueFlowSessionTest {
         val fromResponderToInitiator = LinkedBlockingQueue<Any>()
 
         val sendingSession = BlockingQueueFlowSession(
-            receiver,
+            FlowContext(flowCallConfiguration, sender, "ping-ack"),
             fromInitiatorToResponder,
             fromResponderToInitiator
         )
 
         val receivingSession = BlockingQueueFlowSession(
-            sender,
+            FlowContext(flowCallConfiguration, receiver, "ping-ack"),
             fromResponderToInitiator,
             fromInitiatorToResponder
         )
@@ -37,5 +61,61 @@ class BlockingQueueFlowSessionTest {
 
         // Then we should be able to return the response that appears in the queue
         assertThat(receivingSession.receive<PingAckMessage>().message, `is`("Ping"))
+    }
+
+    @Test
+    fun `should throw an exception if receivedException is set`() {
+        // Given a session constructed only on the sending side
+        val fromInitiatorToResponder = LinkedBlockingQueue<Any>()
+        val fromResponderToInitiator = LinkedBlockingQueue<Any>()
+
+        val sendingSession = BlockingQueueFlowSession(
+            FlowContext(flowCallConfiguration, sender, "ping-ack"),
+            fromInitiatorToResponder,
+            fromResponderToInitiator
+        )
+
+        // When we send a message and then set a received exception
+        thread {
+            sleep(100)
+            sendingSession.responderErrorCaught(IllegalArgumentException("Just because"))
+        }
+
+        assertThrows<ResponderFlowException> {
+            sendingSession.receive<Any>()
+        }
+    }
+
+    @Test
+    fun `should time out if flow does not complete`() {
+        // Given a session constructed only on the sending side
+        val fromInitiatorToResponder = LinkedBlockingQueue<Any>()
+        val fromResponderToInitiator = LinkedBlockingQueue<Any>()
+        val fakeClockConfiguration = mock<SimulatorConfiguration>()
+
+        val sendingSession = BlockingQueueFlowSession(
+            FlowContext(fakeClockConfiguration, sender, "ping-ack"),
+            fromInitiatorToResponder,
+            fromResponderToInitiator
+        )
+
+        // With a timeout of 5 minutes (for a demo)
+        val clock = mock<Clock>()
+        whenever(fakeClockConfiguration.timeout).doReturn(Duration.ofMinutes(5))
+        whenever(fakeClockConfiguration.pollInterval).doReturn(Duration.ofMillis(100))
+        whenever(fakeClockConfiguration.clock).doReturn(clock)
+
+        whenever(clock.instant()).thenReturn(Instant.now())
+
+        // When we advance the clock past 5 minutes
+        thread {
+            sleep(100)
+            whenever(clock.instant()).thenReturn(Instant.now().plusSeconds(60*6))
+        }
+
+        // Then the session should time out
+        assertThrows<TimeoutException> {
+            sendingSession.receive<Any>()
+        }
     }
 }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
@@ -1,27 +1,44 @@
 package net.corda.simulator.runtime.messaging
 
+import net.corda.simulator.SimulatorConfiguration
+import net.corda.simulator.exceptions.ResponderFlowException
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowServicesInjector
-import net.corda.simulator.runtime.testflows.PingAckFlow
 import net.corda.simulator.runtime.testflows.PingAckMessage
+import net.corda.simulator.runtime.testflows.PingAckResponderFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Clock
+import java.time.Duration
 import kotlin.concurrent.thread
 
+@Timeout(5000)
 class ConcurrentFlowMessagingTest {
 
     private val senderX500 = MemberX500Name.parse("CN=ISendMessages, OU=Application, O=R3, L=London, C=GB")
     private val receiverX500 = MemberX500Name.parse("CN=IReceiveMessages, OU=Application, O=R3, L=London, C=GB")
+    private val configuration = mock<SimulatorConfiguration>()
+
+    @BeforeEach
+    fun `initialize configuration`() {
+        whenever(configuration.clock).doReturn(Clock.systemDefaultZone())
+        whenever(configuration.timeout).doReturn(Duration.ofMinutes(1))
+        whenever(configuration.pollInterval).doReturn(Duration.ofMillis(100))
+    }
 
     @Test
     fun `can initiate a flow, inject services, send a message and receive a message`() {
@@ -30,8 +47,8 @@ class ConcurrentFlowMessagingTest {
 
         // And a factory that will build our responder
         val flowFactory = mock<FlowFactory>()
-        val responderFlow = IckResponderFlow()
-        whenever(flowFactory.createResponderFlow(receiverX500, IckResponderFlow::class.java))
+        val responderFlow = PingAckResponderFlow()
+        whenever(flowFactory.createResponderFlow(receiverX500, PingAckResponderFlow::class.java))
             .thenReturn(responderFlow)
 
         // And flow messaging that can open sessions to the other side,
@@ -40,14 +57,22 @@ class ConcurrentFlowMessagingTest {
 
         // And a sender and receiver that will be returned by the fiber
         whenever(fiber.lookUpResponderClass(receiverX500, "ping-ack"))
-            .thenReturn(IckResponderFlow::class.java)
+            .thenReturn(PingAckResponderFlow::class.java)
 
         // And an injector that will inject services
         val injector = mock<FlowServicesInjector>()
 
         // When we initiate the flow
-        val flowMessaging = ConcurrentFlowMessaging(senderX500, PingAckFlow::class.java, fiber, injector, flowFactory)
+        val flowMessaging = ConcurrentFlowMessaging(
+            FlowContext(configuration, senderX500, "ping-ack"),
+            fiber,
+            injector,
+            flowFactory
+        )
         val sendingSession = flowMessaging.initiateFlow(receiverX500)
+
+        // Then the counterparty should be correctly set
+        assertThat(sendingSession.counterparty, `is`(receiverX500))
 
         // Then it should have injected the services into the responder
         verify(injector, times(1)).injectServices(
@@ -62,8 +87,9 @@ class ConcurrentFlowMessagingTest {
         thread { sendingSession.send(message) }
         val received = sendingSession.receive(PingAckMessage::class.java)
 
-        // Then it should come through OK
-        assertThat(received, `is`(PingAckMessage("Ick")))
+        // Then it should come through OK with the right counterparty on the session
+        // (as put into the message)
+        assertThat(received, `is`(PingAckMessage("Ack to $senderX500")))
     }
 
     @Test
@@ -88,8 +114,7 @@ class ConcurrentFlowMessagingTest {
 
         // When we initiate the flow
         val flowMessaging = ConcurrentFlowMessaging(
-            senderX500,
-            PingAckFlow::class.java,
+            FlowContext(configuration, senderX500, "ping-ack"),
             flowAndServiceLookUp,
             injector,
             flowFactory
@@ -113,11 +138,48 @@ class ConcurrentFlowMessagingTest {
         assertThat(received, `is`(PingAckMessage("Ick")))
     }
 
+    @Test
+    fun `should set the error on an initiating flow session when a responder flow throws it`() {
+        // And a factory and injector that will not be used, with a responder that's already been created
+        // where the responder will throw an error
+        val flowFactory = mock<FlowFactory>()
+        val injector = mock<FlowServicesInjector>()
+
+        val responderFlow = YuckResponderFlow()
+
+        // And flow messaging that can open sessions to the other side,
+        // looking them up in the fiber
+        val flowAndServiceLookUp = mock<SimFiber>()
+
+        // And a sender and receiver that will be returned by the fiber
+        whenever(flowAndServiceLookUp.lookUpResponderInstance(receiverX500, "ping-ack"))
+            .thenReturn(responderFlow)
+
+        val flowMessaging = ConcurrentFlowMessaging(
+            FlowContext(configuration, senderX500, "ping-ack"),
+            flowAndServiceLookUp,
+            injector,
+            flowFactory
+        )
+        val sendingSession = flowMessaging.initiateFlow(receiverX500)
+
+        // When we receive on the sending flow
+        // Then it should rethrow the error (note Real Corda will not contain the original error)
+        assertThrows<ResponderFlowException> {
+            sendingSession.sendAndReceive(Any::class.java, PingAckMessage("Ping"))
+        }
+    }
+
     class IckResponderFlow : ResponderFlow {
         override fun call(session: FlowSession) {
             session.send(PingAckMessage("Ick"))
         }
+    }
 
+    class YuckResponderFlow : ResponderFlow {
+        override fun call(session: FlowSession) {
+            error("This error should be propagated to the initiator thread")
+        }
     }
 
 }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/HelloFlow.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/HelloFlow.kt
@@ -4,6 +4,7 @@ import net.corda.v5.application.crypto.DigitalSignatureVerificationService
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RPCRequestData
 import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.SubFlow
@@ -14,6 +15,7 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.annotations.Suspendable
 
+@InitiatingFlow("hello")
 class HelloFlow : RPCStartableFlow {
 
     @CordaInject

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/PingAckFlow.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/PingAckFlow.kt
@@ -26,7 +26,7 @@ class PingAckFlow : RPCStartableFlow {
     override fun call(requestBody: RPCRequestData): String {
         val whoToPing = jsonMarshallingService.parse<MemberX500Name>(requestBody.getRequestBody())
         val session = flowMessaging.initiateFlow(whoToPing)
-        session.send(jsonMarshallingService.format(PingAckMessage("Ping")))
+        session.send(jsonMarshallingService.format(PingAckMessage("Ping to ${session.counterparty}")))
         return session.receive(PingAckMessage::class.java).message
     }
 }
@@ -35,7 +35,7 @@ class PingAckFlow : RPCStartableFlow {
 class PingAckResponderFlow : ResponderFlow {
     @Suspendable
     override fun call(session: FlowSession) {
-        session.send(PingAckMessage("Ack"))
+        session.send(PingAckMessage("Ack to ${session.counterparty}"))
     }
 }
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/ValidStartingFlow.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/ValidStartingFlow.kt
@@ -1,9 +1,11 @@
 package net.corda.simulator.runtime.testflows
 
+import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RPCRequestData
 import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.base.annotations.Suspendable
 
+@InitiatingFlow("valid")
 class ValidStartingFlow : RPCStartableFlow {
     @Suspendable
     override fun call(requestBody: RPCRequestData): String {

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/tools/UtilitiesTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/tools/UtilitiesTest.kt
@@ -25,8 +25,8 @@ class UtilitiesTest {
         val b = B()
 
         // When we inject into both of them
-        b.injectIfRequired(String::class.java, "Hello!")
-        b.injectIfRequired(Any::class.java, Object())
+        b.injectIfRequired(String::class.java) { "Hello!" }
+        b.injectIfRequired(Any::class.java) { Object() }
 
         // Then the declared field should be set, but not the inherited one
         assertNotNull(b.declaredField)

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/utils/UtilitiesTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/utils/UtilitiesTest.kt
@@ -14,7 +14,7 @@ class UtilitiesTest {
     fun `should provide injector into flows`() {
         val flowEngine = mock<FlowEngine>()
         val flow = HelloFlow()
-        flow.injectIfRequired(FlowEngine::class.java, flowEngine)
+        flow.injectIfRequired(FlowEngine::class.java) { flowEngine }
         assertThat(flow.flowEngine, `is`(flowEngine))
     }
 


### PR DESCRIPTION
Configuration has been added for a clock, flow timeout and poll interval for exception handling.
Defaults are set to default clock, 1 minute and 100 ms respectively.
FlowMessaging picks up error from Responder and gives it to Initiator, which wraps and rethrows.
A warning is included in error message that real Corda will not provide the cause.

Simulator now builds its delegate using a factory (in order to pass in configuration).
Detekt was complaining about too many parameters, so there is a `FlowContext` containing stuff that makes sense there
And a check to make sure the sessions are initialized correctly.

Services are also now lazily constructed when required.