### PR TITLE
CORE-4869 - Reject messages where source and destination group IDs do not match

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/OutboundMessageProcessor.kt
@@ -14,6 +14,7 @@ import net.corda.p2p.linkmanager.sessions.recordsForSessionEstablished
 import net.corda.p2p.markers.TtlExpiredMarker
 import net.corda.p2p.markers.AppMessageMarker
 import net.corda.p2p.markers.Component
+import net.corda.p2p.markers.LinkManagerDiscardedMarker
 import net.corda.p2p.markers.LinkManagerProcessedMarker
 import net.corda.p2p.markers.LinkManagerReceivedMarker
 import net.corda.p2p.markers.LinkManagerSentMarker
@@ -104,6 +105,13 @@ internal class OutboundMessageProcessor(
 
     private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
         logger.debug { "Processing outbound ${message.javaClass} to ${message.header.destination}." }
+
+        if (message.header.source.groupId != message.header.destination.groupId) {
+            logger.warn("Dropping outbound unauthenticated message from ${message.header.source.toCorda()} " +
+                    "to ${message.header.destination.toCorda()} as their group IDs do not match.")
+            return emptyList()
+        }
+
         val destMemberInfo = members.getMemberInfo(message.header.source.toCorda(), message.header.destination.toCorda())
         if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
             return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))
@@ -142,6 +150,14 @@ internal class OutboundMessageProcessor(
             "Processing outbound ${messageAndKey.message.javaClass} with ID ${messageAndKey.message.header.messageId} " +
                 "to ${messageAndKey.message.header.destination}."
         }
+
+        if (messageAndKey.message.header.source.groupId != messageAndKey.message.header.destination.groupId) {
+            logger.warn("Dropping outbound authenticated message ${messageAndKey.message.header.messageId} " +
+                    "from ${messageAndKey.message.header.source.toCorda()} to ${messageAndKey.message.header.destination.toCorda()} " +
+                    "as their group IDs do not match.")
+            return listOf(recordForLMDiscardedMarker(messageAndKey, "Destination and source groups not matching."))
+        }
+
         if (ttlExpired(messageAndKey.message.header.ttl)) {
             val expiryMarker = recordForTTLExpiredMarker(messageAndKey.message.header.messageId)
             return if (isReplay) {
@@ -256,4 +272,11 @@ internal class OutboundMessageProcessor(
         val marker = AppMessageMarker(LinkManagerSentMarker(), clock.instant().toEpochMilli())
         return Record(Schemas.P2P.P2P_OUT_MARKERS, messageId, marker)
     }
+
+    private fun recordForLMDiscardedMarker(message: AuthenticatedMessageAndKey,
+                                           reason: String): Record<String, AppMessageMarker> {
+        val marker = AppMessageMarker(LinkManagerDiscardedMarker(message, reason), clock.instant().toEpochMilli())
+        return Record(Schemas.P2P.P2P_OUT_MARKERS, message.message.header.messageId, marker)
+    }
+
 }

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -94,6 +94,7 @@ class P2PLayerEndToEndTest {
         private const val SUBSYSTEM = "e2e.test.app"
         private val logger = contextLogger()
         private const val GROUP_ID = "group-1"
+        private const val TLS_KEY_TENANT_ID = "p2p"
 
         fun Key.toPem(): String {
             return StringWriter().use { str ->
@@ -112,8 +113,8 @@ class P2PLayerEndToEndTest {
     @Timeout(60)
     fun `two hosts can exchange data messages over p2p using RSA keys`() {
         val numberOfMessages = 10
-        val aliceId = Identity("O=Alice, L=London, C=GB", "sslkeystore_alice")
-        val chipId = Identity("O=Chip, L=London, C=GB", "sslkeystore_chip")
+        val aliceId = Identity("O=Alice, L=London, C=GB", GROUP_ID, "sslkeystore_alice")
+        val chipId = Identity("O=Chip, L=London, C=GB", GROUP_ID, "sslkeystore_chip")
         Host(
             listOf(aliceId),
             "www.alice.net",
@@ -163,8 +164,8 @@ class P2PLayerEndToEndTest {
     @Timeout(60)
     fun `two hosts can exchange data messages over p2p with ECDSA keys`() {
         val numberOfMessages = 10
-        val receiverId = Identity("O=Alice, L=London, C=GB", "receiver")
-        val senderId = Identity("O=Chip, L=London, C=GB", "sender")
+        val receiverId = Identity("O=Alice, L=London, C=GB", GROUP_ID, "receiver")
+        val senderId = Identity("O=Chip, L=London, C=GB", GROUP_ID, "sender")
         Host(
             listOf(receiverId),
             "www.receiver.net",
@@ -214,8 +215,8 @@ class P2PLayerEndToEndTest {
     @Timeout(60)
     fun `messages can be looped back between locally hosted identities`() {
         val numberOfMessages = 10
-        val receiverId = Identity("O=Alice, L=London, C=GB", "receiver")
-        val senderId = Identity("O=Chip, L=London, C=GB", "sender")
+        val receiverId = Identity("O=Alice, L=London, C=GB", GROUP_ID, "receiver")
+        val senderId = Identity("O=Chip, L=London, C=GB", GROUP_ID, "sender")
         Host(
             listOf(receiverId, senderId),
             "www.alice.net",
@@ -248,8 +249,8 @@ class P2PLayerEndToEndTest {
     @Timeout(60)
     fun `messages with expired ttl have processed marker and ttl expired marker and no received marker`() {
         val numberOfMessages = 10
-        val aliceId = Identity("O=Alice, L=London, C=GB", "sslkeystore_alice")
-        val chipId = Identity("O=Chip, L=London, C=GB", "sslkeystore_chip")
+        val aliceId = Identity("O=Alice, L=London, C=GB", GROUP_ID, "sslkeystore_alice")
+        val chipId = Identity("O=Chip, L=London, C=GB", GROUP_ID, "sslkeystore_chip")
         Host(
             listOf(aliceId),
             "www.alice.net",
@@ -346,6 +347,7 @@ class P2PLayerEndToEndTest {
 
     internal data class Identity(
         val x500Name: String,
+        val groupId: String,
         val keyStoreFileName: String,
     )
 
@@ -380,7 +382,7 @@ class P2PLayerEndToEndTest {
         private val configPublisher = publisherFactory.createPublisher(PublisherConfig("config-writer", false), bootstrapConfig)
         private val gatewayConfig = createGatewayConfig(p2pPort, p2pAddress, sslConfig)
         private val tlsTenantId by lazy {
-            GROUP_ID
+            TLS_KEY_TENANT_ID
         }
         private val linkManagerConfig by lazy {
             ConfigFactory.empty()
@@ -482,7 +484,7 @@ class P2PLayerEndToEndTest {
         }
         private val groupPolicyEntry = ourIdentities.map {
             GroupPolicyEntry(
-                HoldingIdentity(it.x500Name, GROUP_ID),
+                HoldingIdentity(it.x500Name, it.groupId),
                 NetworkType.CORDA_5,
                 listOf(
                     ProtocolMode.AUTHENTICATION_ONLY,
@@ -496,7 +498,7 @@ class P2PLayerEndToEndTest {
 
         private val memberInfoEntry = ourIdentities.mapIndexed { i, identity ->
             MemberInfoEntry(
-                HoldingIdentity(identity.x500Name, GROUP_ID),
+                HoldingIdentity(identity.x500Name, identity.groupId),
                 keyPairs[i].public.toPem(),
                 "http://$p2pAddress:$p2pPort",
             )
@@ -505,18 +507,18 @@ class P2PLayerEndToEndTest {
         private fun publishNetworkMapAndIdentityKeys(otherHost: Host? = null) {
             val publisherForHost = publisherFactory.createPublisher(PublisherConfig("test-runner-publisher", false), bootstrapConfig)
             val memberInfoRecords = ourIdentities.mapIndexed { i, identity ->
-                Record(MEMBER_INFO_TOPIC, "${identity.x500Name}-$GROUP_ID", memberInfoEntry[i])
+                Record(MEMBER_INFO_TOPIC, "${identity.x500Name}-${identity.groupId}", memberInfoEntry[i])
             }
             val otherHostMemberInfoRecords = otherHost?.ourIdentities?.mapIndexed { i, identity ->
-                Record(MEMBER_INFO_TOPIC, "${identity.x500Name}-$GROUP_ID", otherHost.memberInfoEntry[i])
+                Record(MEMBER_INFO_TOPIC, "${identity.x500Name}-${identity.groupId}", otherHost.memberInfoEntry[i])
             }?.toList() ?: emptyList()
 
             val hostingMapRecords = ourIdentities.mapIndexed { i, identity ->
                 Record(
                     P2P_HOSTED_IDENTITIES_TOPIC, "hosting-1",
                     HostedIdentityEntry(
-                        HoldingIdentity(identity.x500Name, GROUP_ID),
-                        GROUP_ID,
+                        HoldingIdentity(identity.x500Name, identity.groupId),
+                        TLS_KEY_TENANT_ID,
                         identity.x500Name,
                         tlsCertificatesPem[i],
                         keyPairs[i].public.toPem(),
@@ -629,8 +631,8 @@ class P2PLayerEndToEndTest {
             val initialMessages = (1..messagesToSend).map { index ->
                 val incrementalId = index.toString()
                 val messageHeader = AuthenticatedMessageHeader(
-                    HoldingIdentity(peer.x500Name, GROUP_ID),
-                    HoldingIdentity(ourIdentity.x500Name, GROUP_ID),
+                    HoldingIdentity(peer.x500Name, peer.groupId),
+                    HoldingIdentity(ourIdentity.x500Name, ourIdentity.groupId),
                     ttl,
                     incrementalId,
                     incrementalId,

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.186-DevPreview-2-beta+
+cordaApiVersion=5.0.0.188-DevPreview-2-alpha-
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.188-DevPreview-2-alpha-1663142736746
+cordaApiVersion=5.0.0.188-DevPreview-2-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsTextVersion = 1.9
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.188-DevPreview-2-alpha-
+cordaApiVersion=5.0.0.188-DevPreview-2-alpha-1663142736746
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24


### PR DESCRIPTION
## Changes
This change introduces logic that rejects messages where source and destination group IDs do not match. This will be adjusted in the future, if/when we get to implement cross-group communication. I also adjusted the `P2PLayerEndToEndTest`, so that it's easy to temporarily adjust it to test communication across groups.

This makes use of a new marker introduced in: https://github.com/corda/corda-api/pull/569

## Testing
Apart from the added unit tests, I temporarily adjusted the `P2PLayerEndToEndTest` to run the test with the locally hosted identities across groups. Before the change, it was passing. After the change, it started failing as expected. I reverted the change and didn't introduce a new test there as I think capturing that only at the unit level is reasonable.