### PR TITLE
CORE-6698 Vnode reconciler goes down

### DIFF
--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -63,7 +63,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
             reconcileAndScheduleNext(coordinator)
             coordinator.updateStatus(LifecycleStatus.UP)
         } else {
-            logger.warn(
+            logger.info(
                 "Received a ${RegistrationStatusChangeEvent::class.java.simpleName} with status ${event.status}." +
                         " Switching to ${event.status}"
             )

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReaderEventHandler.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReaderEventHandler.kt
@@ -79,13 +79,20 @@ class VirtualNodeInfoReaderEventHandler(
             config
         )
         subscription?.start()
+        log.info("Switching to UP")
         coordinator.updateStatus(LifecycleStatus.UP)
     }
 
     private fun onRegistrationStatusChangeEvent(event: RegistrationStatusChangeEvent, coordinator: LifecycleCoordinator) {
         if (event.status == LifecycleStatus.UP) {
+            configSubscription?.close()
             configSubscription = configurationReadService.registerComponentForUpdates(coordinator, setOf(ConfigKeys.MESSAGING_CONFIG))
         } else {
+            log.info(
+                "Received a ${RegistrationStatusChangeEvent::class.java.simpleName} with status ${event.status}. " +
+                        "Switching to ${event.status}"
+            )
+            coordinator.updateStatus(event.status)
             configSubscription?.close()
         }
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
@@ -19,6 +19,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.toAvro
@@ -124,11 +125,17 @@ class VirtualNodeInfoWriterComponentImpl @Activate constructor(
 
     private fun onRegistrationStatusChangeEvent(event: RegistrationStatusChangeEvent) {
         if (event.status == LifecycleStatus.UP) {
+            configSubscription?.close()
             configSubscription = configurationReadService.registerComponentForUpdates(
                 coordinator,
                 setOf(ConfigKeys.MESSAGING_CONFIG)
             )
         } else {
+            log.info(
+                "Received a ${RegistrationStatusChangeEvent::class.java.simpleName} with status ${event.status}. " +
+                        "Switching to ${event.status}"
+            )
+            coordinator.updateStatus(event.status)
             configSubscription?.close()
         }
     }
@@ -138,12 +145,13 @@ class VirtualNodeInfoWriterComponentImpl @Activate constructor(
      * require as defined in [onNewConfiguration]
      */
     private fun onConfigChangedEventReceived(coordinator: LifecycleCoordinator, event: ConfigChangedEvent) {
-        coordinator.updateStatus(LifecycleStatus.DOWN)
-        recreatePublisher(event)
+        log.debug { "Creating resources" }
+        createPublisher(event)
+        log.info("Switching to UP")
         coordinator.updateStatus(LifecycleStatus.UP)
     }
 
-    private fun recreatePublisher(event: ConfigChangedEvent) {
+    private fun createPublisher(event: ConfigChangedEvent) {
         publisher?.close()
         publisher = publisherFactory.createPublisher(
             PublisherConfig(CLIENT_ID),

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
@@ -73,9 +73,13 @@ class DbReconcilerReader<K : Any, V : Any>(
     private fun onRegistrationStatusChangeEvent(event: RegistrationStatusChangeEvent, coordinator: LifecycleCoordinator) {
         if (event.status == LifecycleStatus.UP) {
             entityManagerFactory = dbConnectionManager.getClusterEntityManagerFactory()
+            logger.info("Switching to UP")
             coordinator.updateStatus(LifecycleStatus.UP)
         } else {
-            logger.warn("Received a ${RegistrationStatusChangeEvent::class.java.simpleName} with status ${event.status}.")
+            logger.info(
+                "Received a ${RegistrationStatusChangeEvent::class.java.simpleName} with status ${event.status}. " +
+                        "Switching to ${event.status}"
+            )
             coordinator.updateStatus(event.status)
             closeResources()
         }


### PR DESCRIPTION
The problem is, Vnode reconciler goes down.

Vnode reconciler component depends on `VirtualNodeInfoWriterComponentImpl` (`VirtualNodeInfoWriteService` is used as the Kafka writer in Vnode info reconciliation). 

In `VirtualNodeInfoWriterComponentImpl.onConfigChangedEventReceived` we would switch coordinator status to `DOWN` every time we would receive a `ConfigChangedEvent` to mark that component is down during resources re-creation. However, that is propagated to components depending on this one and therefore to Vnode reconciler.

- removes `VirtualNodeInfoWriterComponentImpl` switching to `DOWN` every time we receive a `ConfigChangedEvent`.
- improves logging for Vnode reconciler readers and writer.