### PR TITLE
CORE-6064: Stop following after the subscription before closing the subscription

### DIFF
--- a/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
+++ b/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
@@ -158,7 +158,7 @@ class SubscriptionDominoTileBaseTest {
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenRegistration, LifecycleStatus.DOWN), coordinator)
         verify(subscription, times(1)).close()
-        handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.DOWN), coordinator)
+        verify(subscriptionRegistration, times(1)).close()
         assertThat(subscriptionTile.isRunning).isFalse
     }
 
@@ -178,7 +178,7 @@ class SubscriptionDominoTileBaseTest {
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenRegistration, LifecycleStatus.ERROR), coordinator)
         verify(subscription, times(1)).close()
-        handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.DOWN), coordinator)
+        verify(subscriptionRegistration, times(1)).close()
         assertThat(subscriptionTile.isRunning).isFalse
     }
 

--- a/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
+++ b/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
@@ -145,12 +145,16 @@ class GroupPolicyProviderImpl @Activate constructor(
                         activate("Received config, started subscriptions and setting status to UP.")
                     }
                 } else {
-                        deactivate("Setting inactive state due to receiving registration status ${event.status}.")
-                        subscription?.close()
-                        subscription = null
+                    deactivate("Setting inactive state due to receiving registration status ${event.status}.")
+                    subRegistration?.close()
+                    subRegistration = null
+                    subscription?.close()
+                    subscription = null
                 }
             }
             is ConfigChangedEvent -> {
+                subRegistration?.close()
+                subRegistration = null
                 val messagingConfig = event.config.getConfig(MESSAGING_CONFIG)
                 subscription?.close()
                 subscription = subscriptionFactory.createDurableSubscription(
@@ -160,7 +164,6 @@ class GroupPolicyProviderImpl @Activate constructor(
                     null
                 ).also {
                     it.start()
-                    subRegistration?.close()
                     subRegistration = coordinator.followStatusChangesByName(setOf(it.subscriptionName))
                 }
             }

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -534,6 +534,7 @@ class GroupPolicyProviderImplTest {
         assertNotNull(lifecycleEventHandler)
 
         postRegistrationStatusChangeEvent(dependencyServiceRegistration, LifecycleStatus.DOWN)
+        postConfigChangedEvent()
         postRegistrationStatusChangeEvent(dependencyServiceRegistration)
         postRegistrationStatusChangeEvent(subRegistration)
 

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PReadServiceImpl.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PReadServiceImpl.kt
@@ -106,11 +106,16 @@ class MembershipP2PReadServiceImpl @Activate constructor(
                 } else {
                     logger.info("Setting deactive state due to receiving registration status ${event.status}")
                     coordinator.updateStatus(LifecycleStatus.DOWN)
+                    subRegistrationHandle?.close()
+                    subRegistrationHandle = null
                     subscription?.close()
+                    subscription = null
                 }
             }
             is ConfigChangedEvent -> {
                 val messagingConfig = event.config.getConfig(MESSAGING_CONFIG)
+                subRegistrationHandle?.close()
+                subRegistrationHandle = null
                 subscription?.close()
                 subscription = subscriptionFactory.createDurableSubscription(
                     SubscriptionConfig(
@@ -122,7 +127,6 @@ class MembershipP2PReadServiceImpl @Activate constructor(
                     null
                 ).also {
                     it.start()
-                    subRegistrationHandle?.close()
                     subRegistrationHandle = coordinator.followStatusChangesByName(setOf(it.subscriptionName))
                 }
             }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
@@ -147,6 +147,8 @@ class MembershipPersistenceServiceImpl @Activate constructor(
 
     private fun handleConfigChangedEvent(event: ConfigChangedEvent, coordinator: LifecycleCoordinator) {
         logger.info("Handling config changed event.")
+        subHandle?.close()
+        subHandle = null
         rpcSubscription?.close()
         rpcSubscription = subscriptionFactory.createRPCSubscription(
             rpcConfig = RPCConfig(
@@ -167,7 +169,6 @@ class MembershipPersistenceServiceImpl @Activate constructor(
             messagingConfig = event.config.getConfig(MESSAGING_CONFIG)
         ).also {
             it.start()
-            subHandle?.close()
             subHandle = coordinator.followStatusChangesByName(setOf(it.subscriptionName))
         }
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
@@ -139,12 +139,16 @@ class RegistrationManagementServiceImpl @Activate constructor(
                 } else {
                     logger.info("Setting deactive state due to receiving registration status ${event.status}")
                     coordinator.updateStatus(LifecycleStatus.DOWN)
+                    subRegistration?.close()
+                    subRegistration = null
                     subscription?.close()
                     subscription = null
                 }
             }
             is ConfigChangedEvent -> {
                 val messagingConfig = event.config.getConfig(MESSAGING_CONFIG)
+                subRegistration?.close()
+                subRegistration = null
                 subscription?.close()
                 subscription = subscriptionFactory.createStateAndEventSubscription(
                     SubscriptionConfig(
@@ -166,7 +170,6 @@ class RegistrationManagementServiceImpl @Activate constructor(
                     messagingConfig
                 ).also {
                     it.start()
-                    subRegistration?.close()
                     subRegistration = coordinator.followStatusChangesByName(setOf(it.subscriptionName))
                 }
             }

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImpl.kt
@@ -179,12 +179,16 @@ class SynchronisationProxyImpl @Activate constructor(
                     }
                 } else {
                     deactivate("Setting inactive state due to receiving registration status ${event.status}")
+                    subRegistration?.close()
+                    subRegistration = null
                     subscription?.close()
                     subscription = null
                 }
             }
             is ConfigChangedEvent -> {
                 val messagingConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG)
+                subRegistration?.close()
+                subRegistration = null
                 subscription?.close()
                 subscription = subscriptionFactory.createDurableSubscription(
                     SubscriptionConfig(CONSUMER_GROUP, SYNCHRONISATION_TOPIC),
@@ -193,7 +197,6 @@ class SynchronisationProxyImpl @Activate constructor(
                     null
                 ).also {
                     it.start()
-                    subRegistration?.close()
                     subRegistration = coordinator.followStatusChangesByName(setOf(it.subscriptionName))
                 }
 


### PR DESCRIPTION
Close the handle that follows the subscription state before closing the subscription.