### PR TITLE
NOTICK: fix build pin to correct version for DP2

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -104,7 +104,7 @@ pipeline {
         } 			
         stage('start combined worker') {       
             environment {
-                JAR_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar"
+                JAR_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-DevPreview-2-SNAPSHOT.jar"
                 JDBC_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/drivers"
                 VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true"
                 LOG4J_PARAMETERS = "-Dlog4j2.debug=-false -Dlog4j.configurationFile=log4j2-console.xml"

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResources) {
     from(configurations.cpis) {
         into 'META-INF'
-        rename "(.+)-\\d+.+-package.cpb", "\$1.cpb"
+        rename "(.+)(-(?:\\d+\\.*)+-.+)(-package.cpb)\$", "\$1\$2"
     }
 
     // Put the flow-worker-dev-for-cache-testing cpb into a different folder
@@ -85,7 +85,7 @@ def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResourc
     def cacheTestingDir = "META-INF" + File.separator + "cache-invalidation-testing"
     from(cpiForFlowCacheTest) {
         into cacheTestingDir
-        rename "(.+)-\\d+.+-package.cpb", "flow-worker-dev.cpb"
+        rename "(.+)(-(?:\\d+\\.*)+-.+)(-package.cpb)\$", "flow-worker-dev.cpb"
     }
 }
 

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResources) {
     from(configurations.cpis) {
         into 'META-INF'
-        rename "(.+)(-(?:\\d+\\.*)+.-.+)(-package.cpb)\$", "\$1\$2"
+        rename "(.+)(-(?:\\d+\\.*)+.-.+)(-package.cpb)\$", "\$1\$3"
     }
 
     // Put the flow-worker-dev-for-cache-testing cpb into a different folder

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResources) {
     from(configurations.cpis) {
         into 'META-INF'
-        rename "(.+)(-(?:\\d+\\.*)+-.+)(-package.cpb)\$", "\$1\$2"
+        rename "(.+)(-(?:\\d+\\.*)+.-.+)(-package.cpb)\$", "\$1\$2"
     }
 
     // Put the flow-worker-dev-for-cache-testing cpb into a different folder
@@ -85,7 +85,7 @@ def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResourc
     def cacheTestingDir = "META-INF" + File.separator + "cache-invalidation-testing"
     from(cpiForFlowCacheTest) {
         into cacheTestingDir
-        rename "(.+)(-(?:\\d+\\.*)+-.+)(-package.cpb)\$", "flow-worker-dev.cpb"
+        rename "(.+)(-(?:\\d+\\.*)+.-.+)(-package.cpb)\$", "flow-worker-dev.cpb"
     }
 }
 

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResources) {
     from(configurations.cpis) {
         into 'META-INF'
-        rename "(.+)(-(?:\\d+\\.*)+.-.+)(-package.cpb)\$", "\$1\$3"
+        rename "(.+)(-(?:\\d+\\.*)+.-.+-package)(\\.cpb)\$", "\$1\$3"
     }
 
     // Put the flow-worker-dev-for-cache-testing cpb into a different folder
@@ -85,7 +85,7 @@ def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResourc
     def cacheTestingDir = "META-INF" + File.separator + "cache-invalidation-testing"
     from(cpiForFlowCacheTest) {
         into cacheTestingDir
-        rename "(.+)(-(?:\\d+\\.*)+.-.+)(-package.cpb)\$", "flow-worker-dev.cpb"
+        rename "(.+)(-(?:\\d+\\.*)+.-.+-package)(\\.cpb)\$", "flow-worker-dev.cpb"
     }
 }
 


### PR DESCRIPTION
fixing version to unblock, this should be updated to be retrieved dynamically though and not hard coded 