### PR TITLE
NOTICK: Register all sandbox hooks via a single component.

### DIFF
--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/CertificateTestUtils.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/CertificateTestUtils.kt
@@ -44,7 +44,6 @@ fun E2eCluster.generateCsr(
                 P2P_TENANT_ID,
                 tlsKeyId,
                 member.name,
-                HSM_CAT_TLS,
                 listOf(clusterConfig.p2pHost),
                 null
             )

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImpl.kt
@@ -90,7 +90,6 @@ class CertificatesRpcOpsImpl @Activate constructor(
         tenantId: String,
         keyId: String,
         x500Name: String,
-        certificateRole: String,
         subjectAlternativeNames: List<String>?,
         contextMap: Map<String, String?>?,
     ): String {

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImplTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRpcOpsImplTest.kt
@@ -102,7 +102,6 @@ class CertificatesRpcOpsImplTest {
         private val holdingIdentityShortHash = "id"
         private val keyId = "keyId"
         private val x500Name = "CN=Alice"
-        private val role = "TLS"
         private val publicKeyBytes = "123".toByteArray()
         private val key = mock<CryptoSigningKey> {
             on { publicKey } doReturn ByteBuffer.wrap(publicKeyBytes)
@@ -150,7 +149,6 @@ class CertificatesRpcOpsImplTest {
                     holdingIdentityShortHash,
                     keyId,
                     x500Name,
-                    role,
                     null,
                     null,
                 )
@@ -163,7 +161,6 @@ class CertificatesRpcOpsImplTest {
                 holdingIdentityShortHash,
                 keyId,
                 x500Name,
-                role,
                 null,
                 null,
             )
@@ -183,7 +180,6 @@ class CertificatesRpcOpsImplTest {
                 holdingIdentityShortHash,
                 keyId,
                 x500Name,
-                role,
                 null,
                 null,
             )
@@ -197,7 +193,6 @@ class CertificatesRpcOpsImplTest {
                 holdingIdentityShortHash,
                 keyId,
                 x500Name,
-                role,
                 listOf("www.alice.net", "alice.net"),
                 null,
             )
@@ -228,7 +223,6 @@ class CertificatesRpcOpsImplTest {
                 holdingIdentityShortHash,
                 keyId,
                 x500Name,
-                role,
                 null,
                 null,
             )
@@ -246,7 +240,6 @@ class CertificatesRpcOpsImplTest {
                 holdingIdentityShortHash,
                 keyId,
                 x500Name,
-                role,
                 null,
                 emptyMap(),
             )
@@ -264,7 +257,6 @@ class CertificatesRpcOpsImplTest {
                     holdingIdentityShortHash,
                     keyId,
                     x500Name,
-                    role,
                     null,
                     mapOf(SIGNATURE_SPEC to "Nop")
                 )
@@ -280,7 +272,6 @@ class CertificatesRpcOpsImplTest {
                     holdingIdentityShortHash,
                     keyId,
                     x500Name,
-                    role,
                     null,
                     null,
                 )

--- a/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/CertificatesRpcOps.kt
+++ b/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/CertificatesRpcOps.kt
@@ -51,7 +51,6 @@ interface CertificatesRpcOps : RpcOps {
      * @param tenantId The tenant ID.
      * @param keyId The Key ID.
      * @param x500Name A valid X500 name.
-     * @param certificateRole - The certificate role
      * @param subjectAlternativeNames - list of subject alternative DNS names
      * @param contextMap - Any additional attributes to add to the CSR.
      *
@@ -72,11 +71,6 @@ interface CertificatesRpcOps : RpcOps {
             required = true,
         )
         x500Name: String,
-        @HttpRpcRequestBodyParameter(
-            description = "Certificate role. For example: TLS, SESSION_INIT, ...",
-            required = true,
-        )
-        certificateRole: String,
         @HttpRpcRequestBodyParameter(
             description = "Subject alternative names",
             required = false,

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingCollisionBundleHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingCollisionBundleHook.kt
@@ -3,9 +3,6 @@ package net.corda.sandboxhooks.bundle
 import net.corda.sandbox.SandboxContextService
 import org.osgi.framework.Bundle
 import org.osgi.framework.hooks.bundle.CollisionHook
-import org.osgi.service.component.annotations.Activate
-import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
 
 /**
  * This hook modifies the logic for identifying collisions (i.e. bundles with the same symbolic name) when installing
@@ -19,11 +16,7 @@ import org.osgi.service.component.annotations.Reference
  * using a more sophisticated approach (e.g. avoiding collisions if two library bundles are from different CPKs).
  * Unfortunately, [CollisionHook] does not provide this information.
  */
-@Component(immediate = true)
-internal class IsolatingCollisionBundleHook @Activate constructor(
-    @Reference
-    private val sandboxService: SandboxContextService
-) : CollisionHook {
+class IsolatingCollisionBundleHook(private val sandboxService: SandboxContextService) : CollisionHook {
 
     // Note that `target` is not the bundle being installed, but the bundle whose context triggered the installation.
     override fun filterCollisions(operationType: Int, target: Bundle, collisionCandidates: MutableCollection<Bundle>) {

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingEventHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingEventHook.kt
@@ -4,20 +4,13 @@ import net.corda.sandbox.SandboxContextService
 import org.osgi.framework.BundleContext
 import org.osgi.framework.BundleEvent
 import org.osgi.framework.hooks.bundle.EventHook
-import org.osgi.service.component.annotations.Activate
-import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
 
 /**
  * This hook modifies the logic for which bundles receive bundle events (e.g. installation, start).
  *
  * We only allow a bundle to receive bundle events from bundles it has visibility of.
  */
-@Component(immediate = true)
-internal class IsolatingEventHook @Activate constructor(
-    @Reference
-    private val sandboxService: SandboxContextService
-) : EventHook {
+class IsolatingEventHook(private val sandboxService: SandboxContextService) : EventHook {
 
     override fun event(event: BundleEvent, contexts: MutableCollection<BundleContext>) {
         contexts.removeIf { context ->

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingFindBundleHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingFindBundleHook.kt
@@ -4,20 +4,13 @@ import net.corda.sandbox.SandboxContextService
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
 import org.osgi.framework.hooks.bundle.FindHook
-import org.osgi.service.component.annotations.Activate
-import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
 
 /**
  * This hook modifies the logic for how a bundle's context retrieves the list of all bundles.
  *
  * We only allow a bundle to find bundles it has visibility of.
  */
-@Component(immediate = true)
-internal class IsolatingFindBundleHook @Activate constructor(
-    @Reference
-    private val sandboxService: SandboxContextService
-) : FindHook {
+internal class IsolatingFindBundleHook(private val sandboxService: SandboxContextService) : FindHook {
 
     override fun find(context: BundleContext, bundles: MutableCollection<Bundle>) {
         bundles.removeIf { bundle ->

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingResolverBundleHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/bundle/IsolatingResolverBundleHook.kt
@@ -6,9 +6,6 @@ import org.osgi.framework.hooks.resolver.ResolverHookFactory
 import org.osgi.framework.wiring.BundleCapability
 import org.osgi.framework.wiring.BundleRequirement
 import org.osgi.framework.wiring.BundleRevision
-import org.osgi.service.component.annotations.Activate
-import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
 
 /**
  * This hook modifies the logic for resolving bundles.
@@ -61,10 +58,7 @@ internal class IsolatingResolverBundleHook(private val sandboxService: SandboxCo
 }
 
 /** A [ResolverHookFactory] implementation for creating [IsolatingResolverBundleHook]s. */
-@Component(immediate = true)
-@Suppress("unused")
-internal class IsolatingResolverBundleHookFactory @Activate constructor(
-        @Reference
+internal class IsolatingResolverBundleHookFactory(
         private val sandboxManagerService: SandboxContextService) : ResolverHookFactory {
 
     /** Returns an [IsolatingResolverBundleHook]. */

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/register/Registration.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/register/Registration.kt
@@ -1,0 +1,43 @@
+package net.corda.sandboxhooks.register
+
+import net.corda.sandbox.SandboxContextService
+import net.corda.sandboxhooks.bundle.IsolatingCollisionBundleHook
+import net.corda.sandboxhooks.bundle.IsolatingEventHook
+import net.corda.sandboxhooks.bundle.IsolatingFindBundleHook
+import net.corda.sandboxhooks.bundle.IsolatingResolverBundleHookFactory
+import net.corda.sandboxhooks.service.IsolatingEventListenerHook
+import net.corda.sandboxhooks.service.IsolatingFindServiceHook
+import org.osgi.framework.BundleContext
+import org.osgi.framework.hooks.bundle.CollisionHook
+import org.osgi.framework.hooks.bundle.EventHook
+import org.osgi.framework.hooks.resolver.ResolverHookFactory
+import org.osgi.framework.hooks.service.EventListenerHook
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+/**
+ * Register our sandbox hooks with the OSGi framework.
+ * Creating these hooks as individual OSGi components
+ * was causing circular dependency errors within the SCR
+ * as our applications started up. Avoid this problem by
+ * registering our hooks directly as OSGi services.
+ */
+@Suppress("unused")
+@Component(immediate = true, service = [])
+class Registration @Activate constructor(
+    @Reference
+    sandboxService: SandboxContextService,
+    bundleContext: BundleContext
+) {
+    init {
+        with(bundleContext) {
+            registerService(EventListenerHook::class.java, IsolatingEventListenerHook(sandboxService), null)
+            registerService(org.osgi.framework.hooks.service.FindHook::class.java, IsolatingFindServiceHook(sandboxService), null)
+            registerService(CollisionHook::class.java, IsolatingCollisionBundleHook(sandboxService), null)
+            registerService(EventHook::class.java, IsolatingEventHook(sandboxService), null)
+            registerService(org.osgi.framework.hooks.bundle.FindHook::class.java, IsolatingFindBundleHook(sandboxService),  null)
+            registerService(ResolverHookFactory::class.java, IsolatingResolverBundleHookFactory(sandboxService), null)
+        }
+    }
+}

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/service/IsolatingEventListenerHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/service/IsolatingEventListenerHook.kt
@@ -5,18 +5,13 @@ import org.osgi.framework.BundleContext
 import org.osgi.framework.ServiceEvent
 import org.osgi.framework.hooks.service.EventListenerHook
 import org.osgi.framework.hooks.service.ListenerHook
-import org.osgi.service.component.annotations.Activate
-import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
 
 /**
  * This hook modifies the logic for which bundles receive service events (e.g. registration, modification).
  *
  * We only allow a bundle to receive service events for bundles it has visibility of.
  */
-@Component(immediate = true)
-internal class IsolatingEventListenerHook @Activate constructor(
-        @Reference
+internal class IsolatingEventListenerHook(
         private val sandboxService: SandboxContextService
 ) : EventListenerHook {
 

--- a/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/service/IsolatingFindServiceHook.kt
+++ b/libs/sandbox-hooks/src/main/kotlin/net/corda/sandboxhooks/service/IsolatingFindServiceHook.kt
@@ -4,18 +4,13 @@ import net.corda.sandbox.SandboxContextService
 import org.osgi.framework.BundleContext
 import org.osgi.framework.ServiceReference
 import org.osgi.framework.hooks.service.FindHook
-import org.osgi.service.component.annotations.Activate
-import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
 
 /**
  * This hook modifies the logic for how a bundle's context finds a service reference.
  *
  * We only allow a bundle to find services in bundles it has visibility of.
  */
-@Component(immediate = true)
-internal class IsolatingFindServiceHook @Activate constructor(
-        @Reference
+internal class IsolatingFindServiceHook(
         private val sandboxService: SandboxContextService
 ) : FindHook {
 

--- a/libs/serialization/serialization-checkpoint-api/build.gradle
+++ b/libs/serialization/serialization-checkpoint-api/build.gradle
@@ -7,6 +7,7 @@ description 'Corda Checkpoint Serialization API'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
     api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     api "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-application"

--- a/libs/serialization/serialization-kryo/src/main/java/net/corda/kryoserialization/package-info.java
+++ b/libs/serialization/serialization-kryo/src/main/java/net/corda/kryoserialization/package-info.java
@@ -1,6 +1,4 @@
-@Export
 @QuasarIgnoreAllPackages
-package net.corda.serialization.checkpoint;
+package net.corda.kryoserialization;
 
 import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
-import org.osgi.annotation.bundle.Export;

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -2836,14 +2836,8 @@
         }
       },
       "GenerateCsrWrapperRequest" : {
-        "required" : [ "certificateRole", "x500Name" ],
+        "required" : [ "x500Name" ],
         "properties" : {
-          "certificateRole" : {
-            "type" : "string",
-            "description" : "Certificate role. For example: TLS, SESSION_INIT, ...",
-            "nullable" : false,
-            "example" : "string"
-          },
           "contextMap" : {
             "type" : "object",
             "additionalProperties" : {


### PR DESCRIPTION
Implementing a new OSGi `FindHook` as a separate OSGi component was triggering ~30 "Circular dependency" errors from the SCR as the application tried to boot.

Resolve this by installing our sandbox's OSGi hooks all at once via a single component, using a more "low-level" approach.

Also configure Quasar not to instrument either our Kryo or our checkpointing modules.