### PR TITLE
NOTICK: allow resolution of corda cli host DP2 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,9 @@ allprojects {
                 //   $ cd profiler
                 //   $ ../gradlew publishToMavenLocal
                 includeGroup 'com.yourkit.corda'
+
+                // corda-cli-plugin-host
+                includeGroup 'net.corda.cli.host'
             }
         }
 


### PR DESCRIPTION
issue observed when working locally that a build could not resolve corda-cli host from the `engineering-tools-maven` for the DP2 brnach. 

Explicitly allowing this group from the repo in question solves this issue 