### PR TITLE
CORE-6583 - Fix issue where configuration is consumed after subscription is started for inbound processing

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -117,7 +117,9 @@ internal class SessionManagerImpl(
 
     private val sessionNegotiationLock = ReentrantReadWriteLock()
 
-    private val config = AtomicReference<SessionManagerConfig>()
+    private val config = AtomicReference(
+        SessionManagerConfig(1000000, 4)
+    )
 
     private val heartbeatManager: HeartbeatManager = HeartbeatManager(
         publisherFactory,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -117,6 +117,8 @@ internal class SessionManagerImpl(
 
     private val sessionNegotiationLock = ReentrantReadWriteLock()
 
+    // This default needs to be removed and the lifecycle dependency graph adjusted to ensure the inbound subscription starts only after
+    // the configuration has been received and the session manager has started (see CORE-6730).
     private val config = AtomicReference(
         SessionManagerConfig(1000000, 4)
     )


### PR DESCRIPTION
Adding a default configuration for the session manager to ensure that even if the session manager starts after the inbound subscription (under race conditions), messages in the inbound path will be processed successfully. This is a temporary, sub-optimal (but less risky) fix for DP2 given the time constraints that will be addressed more appropriately by adjusting the lifecycle dependency graph (see https://r3-cev.atlassian.net/browse/CORE-6730 for more details).