### PR TITLE
CORE-6418 Do not throw in `ExternalEventFactory`

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
@@ -307,7 +307,7 @@ class CryptoFlowOpsBusProcessorTests {
                         value = transformer.createSign(
                             UUID.randomUUID().toString(),
                             tenantId,
-                            publicKey,
+                            publicKey.encoded,
                             SignatureSpec.EDDSA_ED25519,
                             data,
                             operationContext,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -27,7 +27,7 @@ class SigningServiceImpl @Activate constructor(
     override fun sign(bytes: ByteArray, publicKey: PublicKey, signatureSpec: SignatureSpec): DigitalSignature.WithKey {
         return externalEventExecutor.execute(
             CreateSignatureExternalEventFactory::class.java,
-            SignParameters(bytes, publicKey, signatureSpec)
+            SignParameters(bytes, keyEncodingService.encodeAsByteArray(publicKey), signatureSpec)
         )
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/CreateSignatureExternalEventFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/CreateSignatureExternalEventFactory.kt
@@ -8,6 +8,7 @@ import net.corda.flow.external.events.factory.ExternalEventRecord
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.schema.Schemas
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -28,7 +29,7 @@ class CreateSignatureExternalEventFactory @Activate constructor(
         val flowOpsRequest = cryptoFlowOpsTransformer.createSign(
             requestId = flowExternalEventContext.requestId,
             tenantId = checkpoint.holdingIdentity.shortHash.value,
-            publicKey = parameters.publicKey,
+            encodedPublicKeyBytes = parameters.encodedPublicKeyBytes,
             signatureSpec = parameters.signatureSpec,
             data = parameters.bytes,
             context = emptyMap(),
@@ -41,3 +42,5 @@ class CreateSignatureExternalEventFactory @Activate constructor(
         return cryptoFlowOpsTransformer.transform(response) as DigitalSignature.WithKey
     }
 }
+
+data class SignParameters(val bytes: ByteArray, val encodedPublicKeyBytes: ByteArray, val signatureSpec: SignatureSpec)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/SignParameters.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/SignParameters.kt
@@ -1,6 +1,0 @@
-package net.corda.flow.application.crypto.external.events
-
-import java.security.PublicKey
-import net.corda.v5.crypto.SignatureSpec
-
-data class SignParameters(val bytes: ByteArray, val publicKey: PublicKey, val signatureSpec: SignatureSpec)

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/CryptoFlowOpsTransformer.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/CryptoFlowOpsTransformer.kt
@@ -43,7 +43,7 @@ interface CryptoFlowOpsTransformer {
     fun createSign(
         requestId: String,
         tenantId: String,
-        publicKey: PublicKey,
+        encodedPublicKeyBytes: ByteArray,
         signatureSpec: SignatureSpec,
         data: ByteArray,
         context: Map<String, String> = EMPTY_CONTEXT,

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
@@ -69,7 +69,7 @@ class CryptoFlowOpsTransformerImpl(
     override fun createSign(
         requestId: String,
         tenantId: String,
-        publicKey: PublicKey,
+        encodedPublicKeyBytes: ByteArray,
         signatureSpec: SignatureSpec,
         data: ByteArray,
         context: Map<String, String>,
@@ -79,7 +79,7 @@ class CryptoFlowOpsTransformerImpl(
             requestId = requestId,
             tenantId = tenantId,
             request = SignFlowCommand(
-                ByteBuffer.wrap(keyEncodingService.encodeAsByteArray(publicKey)),
+                ByteBuffer.wrap(encodedPublicKeyBytes),
                 signatureSpec.toWire(serializer),
                 ByteBuffer.wrap(data),
                 context.toWire()

--- a/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
+++ b/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
@@ -214,7 +214,7 @@ class CryptoFlowOpsTransformerImplTests {
             buildTransformer().createSign(
                 UUID.randomUUID().toString(),
                 knownTenantId,
-                publicKey,
+                publicKey.encoded,
                 SignatureSpec.EDDSA_ED25519,
                 data,
                 knownOperationContext,
@@ -240,7 +240,7 @@ class CryptoFlowOpsTransformerImplTests {
             buildTransformer().createSign(
                 UUID.randomUUID().toString(),
                 knownTenantId,
-                publicKey,
+                publicKey.encoded,
                 SignatureSpec.EDDSA_ED25519,
                 data,
                 emptyMap(),

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/external/events/factory/ExternalEventFactory.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/external/events/factory/ExternalEventFactory.kt
@@ -32,6 +32,10 @@ interface ExternalEventFactory<PARAMETERS : Any, RESPONSE: Any, RESUME> {
      *
      * External processors receive the [ExternalEventRecord.payload] contained in [ExternalEventRecord].
      *
+     * Exceptions must not be thrown from this method, otherwise the flow will fail without a chance to handle the
+     * error. The data passed into this method should be verified beforehand, so that once passed in, it is guaranteed
+     * to succeed.
+     *
      * @param checkpoint The [FlowCheckpoint] which can be modified if required.
      * @param flowExternalEventContext The [ExternalEventContext] that should be embedded into the event sent to the
      * external processor.
@@ -49,6 +53,9 @@ interface ExternalEventFactory<PARAMETERS : Any, RESPONSE: Any, RESUME> {
      * [resumeWith] is called to create a [RESUME] to resume the flow with.
      *
      * This is called after receiving a response from an external processor and before the calling flow resumes.
+     *
+     * Exceptions must not be thrown from this method, otherwise the flow will fail without a chance to handle the
+     * error. Instead, validate the response in the flow after it has resumed and throw an exception if needed.
      *
      * @param checkpoint The [FlowCheckpoint] which can be modified if required.
      * @param response The [RESPONSE] received from an external processor.

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -705,7 +705,7 @@ class CryptoProcessorTests {
             val event = transformer.createSign(
                 requestId = requestId,
                 tenantId = tenantId,
-                publicKey = publicKey,
+                encodedPublicKeyBytes = publicKey.encoded,
                 signatureSpec = spec,
                 data = data,
                 flowExternalEventContext = ExternalEventContext(requestId, key, KeyValuePairList(emptyList()))
@@ -751,7 +751,7 @@ class CryptoProcessorTests {
             val event = transformer.createSign(
                 requestId = requestId,
                 tenantId = tenantId,
-                publicKey = publicKey,
+                encodedPublicKeyBytes = publicKey.encoded,
                 signatureSpec = spec,
                 data = data,
                 flowExternalEventContext = ExternalEventContext(requestId, key, KeyValuePairList(emptyList()))


### PR DESCRIPTION
Document that we should not throw in any `ExternalEventFactory`s.

Change some signing code to ensure this is true.