### PR TITLE
CORE-6728: Link HTTP RPC Client directly from selected plugins

### DIFF
--- a/buildSrc/src/main/groovy/corda.cli-plugin-packager.gradle
+++ b/buildSrc/src/main/groovy/corda.cli-plugin-packager.gradle
@@ -15,9 +15,6 @@ configurations {
         visible = false
 
         exclude group: 'net.corda.kotlin'
-        exclude group: 'net.corda', module: 'corda-http-rpc-client'
-        exclude group: 'net.corda', module: 'corda-http-rpc'
-        exclude group: 'net.corda', module: 'http-rpc'
         exclude group: 'net.corda', module: 'corda-api'
         exclude group: 'org.jetbrains.kotlin'
         exclude group: 'org.slf4j'

--- a/gradle.properties
+++ b/gradle.properties
@@ -121,7 +121,7 @@ artifactoryPluginVersion = 4.28.2
 pf4jVersion=3.7.0
 
 # corda-cli plugin host
-pluginHostVersion=0.0.1-DevPreview-2-beta+
+pluginHostVersion=0.0.1-DevPreview-2-alpha-1663230151845
 systemLambdaVersion=1.2.1
 
 # DB integration tests

--- a/gradle.properties
+++ b/gradle.properties
@@ -121,7 +121,7 @@ artifactoryPluginVersion = 4.28.2
 pf4jVersion=3.7.0
 
 # corda-cli plugin host
-pluginHostVersion=0.0.1-DevPreview-2-alpha-1663230151845
+pluginHostVersion=0.0.1-DevPreview-2-beta+
 systemLambdaVersion=1.2.1
 
 # DB integration tests

--- a/libs/http-rpc/http-rpc-client/build.gradle
+++ b/libs/http-rpc/http-rpc-client/build.gradle
@@ -12,12 +12,11 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-application"
 
-
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
     implementation "net.corda:corda-crypto"
 
-    implementation project(":libs:http-rpc:http-rpc")
+    api project(":libs:http-rpc:http-rpc")
     implementation project(":libs:http-rpc:http-rpc-common")
     implementation project(":libs:http-rpc:http-rpc-tools")
     implementation project(":libs:http-rpc:json-serialization")

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -14,9 +14,8 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
-    compileOnly project(":libs:http-rpc:http-rpc")
-    compileOnly project(":libs:http-rpc:http-rpc-client")
 
+    implementation project(":libs:http-rpc:http-rpc-client")
     implementation project(":components:membership:membership-http-rpc")
 
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation project(":libs:virtual-node:virtual-node-endpoints-maintenance")
     implementation project(":libs:virtual-node:cpi-upload-endpoints")
 
-    compileOnly project(":libs:http-rpc:http-rpc-client")
+    implementation project(":libs:http-rpc:http-rpc-client")
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"


### PR DESCRIPTION
Previously it was relying on Plugin Host to provide HTTP RPC Client.

Only to be merged after Plugin Host PR: https://github.com/corda/corda-cli-plugin-host/pull/90 is merged

With updated packaging plugins sizes look as follows:
```
   Length Name
   ------ ----
  6972848 db-config-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
  8323390 initial-config-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
   528716 mgm-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
 10783614 network-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
 11666739 package-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
  6995128 secret-config-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
    74332 topic-config-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
 13667147 virtual-node-cli-plugin-5.0.0.0-DevPreview-2-SNAPSHOT.jar
 ```
 I have also done a round of local testing making sure that `corda-cli vnode reset` command works as expected and perform remote communication with Combined Worker.