### PR TITLE
CORE-6728: fix cli host in composite build to use default jar

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -407,7 +407,13 @@ if (compositeBuild.toBoolean() && file(cordaApiLocation).exists()) {
     }
 }
 if (compositeBuild.toBoolean() && file(cordaCliHostLocation).exists()) {
-    includeBuild(cordaCliHostLocation)
+    includeBuild(cordaCliHostLocation){
+        dependencySubstitution {
+            substitute module("net.corda.cli.host:corda-cli") with project(":app")
+            substitute module("net.corda.cli.host:api") with project(":api")
+            substitute module("net.corda.cli.host:plugins") with project(":plugins")
+        }
+    }
 }
 
 gradleEnterprise {

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -14,7 +14,7 @@ configurations {
 }
 
 dependencies {
-    cliHostDist "net.corda.cli.host:app:${pluginHostVersion}"
+    cliHostDist "net.corda.cli.host:corda-cli:${pluginHostVersion}"
 }
 
 def S3_BUCKET_URI_PROPERTY = 'maven.repo.s3'

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -14,25 +14,28 @@ configurations {
 }
 
 dependencies {
-    cliHostDist "net.corda.cli.host:corda-cli:${pluginHostVersion}"
+    cliHostDist "net.corda.cli.host:app:${pluginHostVersion}"
 }
 
 def S3_BUCKET_URI_PROPERTY = 'maven.repo.s3'
 
 tasks.register('copyCliFiles') {
     dependsOn subprojects.collect { it.tasks.named("cliPluginTask").get() }
-    copy {
-        from configurations.named('cliHostDist')
-        into "$buildDir/cli"
-        rename ('.*.jar', 'corda-cli.jar')
-    }
-    copy {
-        from subprojects.collect { it.tasks.named('cliPluginTask') }
-        into "$buildDir/cli/plugins"
-    }
-    copy {
-        from "$projectDir/installScripts"
-        into "$buildDir/cli"
+    doLast {
+        copy {
+            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            from configurations.named('cliHostDist')
+            into "$buildDir/cli"
+            rename ('.*.jar', 'corda-cli.jar')
+        }
+        copy {
+            from subprojects.collect { it.tasks.named('cliPluginTask') }
+            into "$buildDir/cli/plugins"
+        }
+        copy {
+            from "$projectDir/installScripts"
+            into "$buildDir/cli"
+        }
     }
 }
 
@@ -78,11 +81,14 @@ tasks.named('jar').configure {
 tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     def sourceTasks = subprojects.collect { it.tasks.named("cliPluginTask").get() }
     def cordaCliIncluded = gradle.includedBuilds.collect { it.name == "corda-cli-plugin-host" }.contains(true)
+    def cordaApiIncluded = gradle.includedBuilds.collect { it.name == "corda-api" }.contains(true)
 
-    if (cordaCliIncluded) {
+    if (cordaCliIncluded && cordaApiIncluded) {
         logger.lifecycle("corda-cli-plugin-host project detected in composite build logic, building base image from include project")
         dependsOn gradle.includedBuild("corda-cli-plugin-host").task(':app:publishOSGiImage')
+        dependsOn gradle.includedBuild("corda-api").task(':application:jar')
     }
+
     it.sourceFiles.setFrom(sourceTasks)
     it.subDir = "plugins/"
     it.setEntry = false

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -85,8 +85,8 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
 
     if (cordaCliIncluded && cordaApiIncluded) {
         logger.lifecycle("corda-cli-plugin-host project detected in composite build logic, building base image from include project")
-        dependsOn gradle.includedBuild("corda-cli-plugin-host").task(':app:publishOSGiImage')
         dependsOn gradle.includedBuild("corda-api").task(':application:jar')
+        dependsOn gradle.includedBuild("corda-cli-plugin-host").task(':app:publishOSGiImage')
     }
 
     it.sourceFiles.setFrom(sourceTasks)


### PR DESCRIPTION
see accompanying logic here https://github.com/corda/corda-cli-plugin-host/pull/92  whicih should be merged first.

This resolves a blocking issue on the composite build where it can not resolve not default jars.
Specifically update settings.gradle to call out the substitution logic

Also wrapping copy in a doLast as with out this issues evaluating cliHostDist in a composite build