### PR TITLE
CORE-6725: Add name to group plicy changes listener

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProvider.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProvider.kt
@@ -19,6 +19,9 @@ internal class ForwardingGroupPolicyProvider(coordinatorFactory: LifecycleCoordi
                                              virtualNodeInfoReadService: VirtualNodeInfoReadService,
                                              cpiInfoReadService: CpiInfoReadService,
                                              membershipQueryClient: MembershipQueryClient): LinkManagerGroupPolicyProvider {
+    private companion object {
+        const val LISTENER_NAME = "link.manager.group.policy.listener"
+    }
 
 
     private val dependentChildren = setOf(
@@ -47,7 +50,7 @@ internal class ForwardingGroupPolicyProvider(coordinatorFactory: LifecycleCoordi
     }
 
     override fun registerListener(groupPolicyListener: GroupPolicyListener) {
-        groupPolicyProvider.registerListener { holdingIdentity, groupPolicy ->
+        groupPolicyProvider.registerListener(LISTENER_NAME) { holdingIdentity, groupPolicy ->
             val groupInfo = toGroupInfo(holdingIdentity, groupPolicy)
             groupPolicyListener.groupAdded(groupInfo)
         }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/ForwardingGroupPolicyProviderTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mockConstruction
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -137,7 +138,7 @@ class ForwardingGroupPolicyProviderTest {
         val listener = mock<GroupPolicyListener>()
         forwardingGroupPolicyProvider.registerListener(listener)
         val capturedListener = argumentCaptor<(net.corda.virtualnode.HoldingIdentity, GroupPolicy) -> Unit>()
-        verify(realGroupPolicyProvider).registerListener(capturedListener.capture())
+        verify(realGroupPolicyProvider).registerListener(any(), capturedListener.capture())
 
         capturedListener.firstValue.invoke(alice, groupPolicy)
         verify(listener).groupAdded(groupInfo)

--- a/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
+++ b/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
@@ -21,7 +21,7 @@ interface GroupPolicyProvider : Lifecycle {
     /**
      * Registers a listener callback in order to be notified for creation of a new group policy or update of an existing one.
      *
-     * @param callback A call back that will be called when a new group is created of an exiting group had changed.
+     * @param callback A call back that will be called when a new group is created or an existing group changed.
      * @param name The listener name (the call back will be called only to one instance with that name).
      */
     fun registerListener(name: String, callback: (HoldingIdentity, GroupPolicy) -> Unit)

--- a/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
+++ b/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
@@ -20,6 +20,9 @@ interface GroupPolicyProvider : Lifecycle {
 
     /**
      * Registers a listener callback in order to be notified for creation of a new group policy or update of an existing one.
+     *
+     * @param callback A call back that will be called when a new group is created of an exiting group had changed.
+     * @param name The listener name (the call back will be called only to one instance with that name).
      */
-    fun registerListener(callback: (HoldingIdentity, GroupPolicy) -> Unit)
+    fun registerListener(name: String, callback: (HoldingIdentity, GroupPolicy) -> Unit)
 }

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupPolicyProvider.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupPolicyProvider.kt
@@ -43,7 +43,7 @@ class TestGroupPolicyProviderImpl @Activate constructor(
 
     override fun getGroupPolicy(holdingIdentity: HoldingIdentity) = policy
 
-    override fun registerListener(callback: (HoldingIdentity, GroupPolicy) -> Unit) {
+    override fun registerListener(name: String, callback: (HoldingIdentity, GroupPolicy) -> Unit) {
         with(UNIMPLEMENTED_FUNCTION) {
             logger.warn(this)
             throw UnsupportedOperationException(this)

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupPolicyProvider.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupPolicyProvider.kt
@@ -46,7 +46,7 @@ class TestGroupPolicyProviderImpl @Activate constructor(
 
     override fun getGroupPolicy(holdingIdentity: HoldingIdentity) = policies.get(holdingIdentity)
 
-    override fun registerListener(callback: (HoldingIdentity, GroupPolicy) -> Unit) {
+    override fun registerListener(name: String, callback: (HoldingIdentity, GroupPolicy) -> Unit) {
         with(UNIMPLEMENTED_FUNCTION) {
             logger.warn(this)
             throw UnsupportedOperationException(this)


### PR DESCRIPTION
This should allow all the instances of the group policy provider to accept changes (currently, since they all have the same name, only one will accept the change, and if it's not the link manager one, which is the only one that needs it, nothing will work).