### PR TITLE
CORE-6691: Set up CODEOWNERS for Corda Helm chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,6 @@ CODEOWNERS         @corda/blt @corda/corda5-team-leads
 /libs/http-rpc/                               @corda/http-rpc
 /libs/permissions/                            @corda/http-rpc
 /processors/rpc-processor/                    @corda/http-rpc
+
+# Corda Helm chart for cluster management team
+/charts/corda/                                @corda/cluster-management


### PR DESCRIPTION
* Add new file path /charts/corda/ to be monitor by corda/cluster-management team in the repo codeowner file.