### PR TITLE
NOTICK: incorrect path for installer

### DIFF
--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -57,7 +57,7 @@ tasks.register("cliS3Download", Copy) {
     dependsOn cleanDir
     description 'Copy corda-cli install scripts to a location in build dir and update to use correct version'
     if (project.hasProperty(S3_BUCKET_URI_PROPERTY)) {
-        def s3Url = System.getenv('HTTPS_PATH') + project.group.replace('.','/') + "/corda-cli-installer/$version/corda-cli-installer-$version"
+        def s3Url = System.getenv('HTTPS_PATH') + '/'+ project.group.replace('.','/') + "/corda-cli-downloader/$version/corda-cli-downloader-$version"
         logger.info ("S3 Https URL: $s3Url")
         from 'templateScripts'
         into 'build/generatedScripts'


### PR DESCRIPTION
`corda-cli-installer `is no longer valid `corda-cli-downloader` is the correct path also adding in a missing / 