### PR TITLE
CORE-6376: DB admin + admin impl needs to be published for DP2

### DIFF
--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -3,8 +3,9 @@ plugins {
     id 'corda.common-publishing'
 }
 
-// temporary measure for DP2, required as a trasnitive dependecy by simulator modules 
-// This code marks this module as to be published externally. To be revisted prior to beta program.
+// Temporary measure for DP2, required as a transitive dependecy by simulator modules 
+// This code marks this module as to be published externally. 
+// TODO To be revisited prior to beta program.
 ext {
     releasable = true
 }

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 // temporary measure for DP2, required as a trasnitive dependecy by simulator modules 
-// to be revisted prior to beta program
+// This code marks this module as to be published externally. To be revisted prior to beta program.
 ext {
     releasable = true
 }

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Database Admin Implementation'
 
 dependencies {

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'corda.common-publishing'
 }
 
-// Temporary measure for DP2, required as a transitive dependecy by simulator modules 
+// Temporary measure for DP2, required as a transitive dependency by simulator modules 
 // This code marks this module as to be published externally. 
 // TODO To be revisited prior to beta program.
 ext {

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'corda.common-publishing'
 }
 
+// temporary measure for DP2, required as a trasnitive dependecy by simulator modules 
+// to be revisted prior to beta program
 ext {
     releasable = true
 }

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -3,8 +3,9 @@ plugins {
     id 'corda.common-publishing'
 }
 
-// temporary measure for DP2, required as a trasnitive dependecy by simulator modules 
-// This code marks this module as to be published externally. To be revisted prior to beta program.
+// Temporary measure for DP2, required as a transitive dependecy by simulator modules 
+// This code marks this module as to be published externally. 
+// TODO To be revisited prior to beta program.
 ext {
     releasable = true
 }

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 // temporary measure for DP2, required as a trasnitive dependecy by simulator modules 
-// to be revisted prior to beta program
+// This code marks this module as to be published externally. To be revisted prior to beta program.
 ext {
     releasable = true
 }

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'corda.common-publishing'
 }
 
-// Temporary measure for DP2, required as a transitive dependecy by simulator modules 
+// Temporary measure for DP2, required as a transitive dependency by simulator modules 
 // This code marks this module as to be published externally. 
 // TODO To be revisited prior to beta program.
 ext {

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'corda.common-publishing'
 }
 
+// temporary measure for DP2, required as a trasnitive dependecy by simulator modules 
+// to be revisted prior to beta program
 ext {
     releasable = true
 }

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Database Admin API'
 
 dependencies {


### PR DESCRIPTION
`simulator' module depends on this at runtime, sample apps / cordApps having a tetsRuntime dependency on simulator require this to be resolvable .

Logic in our internal Gradle plugins repo marks these modules for publishing to QA staging env once `releasable` property is set.

This is the equivalent of the whitelist we maintained in DP1 times