### PR TITLE
CORE-6762: Ensure calling getDefaults does not break default insertion for subsequent calls to the validator

### DIFF
--- a/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigurationValidatorImpl.kt
+++ b/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigurationValidatorImpl.kt
@@ -11,7 +11,6 @@ import com.networknt.schema.ValidationMessage
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigRenderOptions
-import java.io.InputStream
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.libs.configuration.validation.ConfigurationSchemaFetchException
@@ -21,6 +20,7 @@ import net.corda.schema.configuration.provider.SchemaProvider
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.versioning.Version
+import java.io.InputStream
 
 internal class ConfigurationValidatorImpl(private val schemaProvider: SchemaProvider) : ConfigurationValidator {
 
@@ -60,7 +60,7 @@ internal class ConfigurationValidatorImpl(private val schemaProvider: SchemaProv
         val configAsJSONNode = objectMapper.createObjectNode()
         val errors = try {
             val schema = getSchema(schemaInput, applyDefaults = true)
-            schema.walk(configAsJSONNode, false).validationMessages
+            schema.walk(configAsJSONNode, true).validationMessages
         } catch (e: Exception) {
             val message = "Could not retrieve schema defaults for key $key at schema version $version: ${e.message}"
             logger.error(message, e)

--- a/libs/configuration/configuration-validation/src/test/kotlin/net/corda/libs/configuration/validation/impl/ConfigurationValidatorImplTest.kt
+++ b/libs/configuration/configuration-validation/src/test/kotlin/net/corda/libs/configuration/validation/impl/ConfigurationValidatorImplTest.kt
@@ -66,6 +66,18 @@ class ConfigurationValidatorImplTest {
     }
 
     @Test
+    fun `calling get defaults before validate allows defaults to still be populated`() {
+        val validator = createSchemaValidator()
+        val smartConfig = loadData(VALID_DATA)
+        val defaults = validator.getDefaults(TEST_SCHEMA, TEST_VERSION)
+        val outputConfig = validator.validate(TEST_SCHEMA, TEST_VERSION, smartConfig, true)
+        assertThat(smartConfig).isNotEqualTo(outputConfig)
+        assertThat(outputConfig.getBoolean("testReference.bar")).isEqualTo(false)
+        assertThat(outputConfig.getInt("testObject.testPropertyB.b")).isEqualTo(2)
+        assertThat(defaults.getInt("testObject.testPropertyA.a")).isEqualTo(1)
+    }
+
+    @Test
     fun `invalid document against test schema`() {
         val json = loadData(INVALID_DATA)
         val validator = createSchemaValidator()
@@ -116,6 +128,8 @@ class ConfigurationValidatorImplTest {
         val expectedConfig = ConfigFactory.parseString("""
             testInteger=7
             testReference.bar=false
+            testReference.foo=[1,2,3]
+            testObject.testPropertyA.a=1
         """.trimIndent())
 
         val outputConfig = validator.getDefaults(TEST_SCHEMA, TEST_VERSION)

--- a/libs/configuration/configuration-validation/src/test/resources/data/valid.conf
+++ b/libs/configuration/configuration-validation/src/test/resources/data/valid.conf
@@ -3,3 +3,6 @@
     "foo": [1, 2, 3.14],
     "bar": false
 }
+"testObject": {
+  "testPropertyB": {}
+}

--- a/libs/configuration/configuration-validation/src/test/resources/schema/valid/test-reference.json
+++ b/libs/configuration/configuration-validation/src/test/resources/schema/valid/test-reference.json
@@ -3,12 +3,14 @@
   "$id": "https://corda.r3.com/schema/valid/test-reference.json",
   "title": "Test reference schema object",
   "type": "object",
+  "default": {},
   "properties": {
     "foo": {
       "type": "array",
       "items": {
         "type": "number"
-      }
+      },
+      "default": [1, 2, 3]
     },
     "bar": {
       "type": "boolean",

--- a/libs/configuration/configuration-validation/src/test/resources/schema/valid/test-schema.json
+++ b/libs/configuration/configuration-validation/src/test/resources/schema/valid/test-schema.json
@@ -16,6 +16,53 @@
     "testReference": {
       "$ref": "https://corda.r3.com/schema/valid/test-reference.json",
       "default": {}
+    },
+    "testObject": {
+      "type": "object",
+      "default": {
+        "testPropertyA": {
+          "a": 1
+        }
+      },
+      "properties": {
+        "testPropertyA": {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "testPropertyB": {
+          "type": "object",
+          "properties": {
+            "b": {
+              "type": "integer",
+              "default": 2
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "dependencies": {
+        "testPropertyA": {
+          "not": {
+            "required": [
+              "testPropertyB"
+            ]
+          }
+        },
+        "testPropertyB": {
+          "not": {
+            "required": [
+              "testPropertyA"
+            ]
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
There appears to be some sort of issue with the config validation library used by C5, whereby if the first walk of a schema is performed with validation turned off, subsequent walks may result in NPEs when trying to default objects. This was causing intermittent failures in the build. The `getDefaults` function does this, and so the validation library could break if a call to that function was the first usage of it. As this is used to get the default config for connecting to the database, an early call here is somewhat likely.

The fix proposed here is to turn on validation even when running `getDefaults`, which avoids the problem. (This makes `getDefaults` equivalent to `validate` with `applyDefaults` enabled against an empty config.)

I've added a unit test that would have hit the original problem, along with a schema update to the test schema that mirrors the problematic schema seen in the build (the linkmanager schema). I've also added an integration test that attempts to get defaults for most of the config sections, just to show that this is possible with the change. I couldn't do this for the security config though as there's a defaulting bug there anyway - potentially this will cause a problem with this PR, but the fix will require a separate change to the API repo.