### PR TITLE
NOTICK: Remove unnecessary messaging dependency from sandboxing component.

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/build.gradle
+++ b/components/virtual-node/sandbox-group-context-service/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     implementation project(":libs:cache:cache-caffeine")
     implementation project(":libs:configuration:configuration-core")
     implementation project(":libs:crypto:crypto-core")
-    implementation project(":libs:messaging:messaging")
 
     implementation project(':libs:packaging:packaging-core')
     implementation project(':libs:virtual-node:sandbox-group-context')


### PR DESCRIPTION
The sandboxing component doesn't use a single messaging class, so there's no reason to depend on it.