### PR TITLE
NOTICK: Ensure loggers are private.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreFactoryImpl.kt
@@ -15,8 +15,8 @@ import org.osgi.service.component.annotations.Component
 @Component(service = [FlowProtocolStoreFactory::class])
 class FlowProtocolStoreFactoryImpl : FlowProtocolStoreFactory {
 
-    companion object {
-        val logger = contextLogger()
+    private companion object {
+        private val logger = contextLogger()
     }
 
     private fun extractDataForFlow(

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -16,7 +16,7 @@ import java.time.Instant
 
 class MemberInfoExtension {
     companion object {
-        val logger = contextLogger()
+        private val logger = contextLogger()
 
         /** Key name for ledger keys property. */
         const val LEDGER_KEYS = "corda.ledger.keys"

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v1/CpkLoaderV1.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v1/CpkLoaderV1.kt
@@ -20,7 +20,6 @@ import net.corda.libs.packaging.core.exception.PackagingException
 import net.corda.libs.packaging.internal.CpkImpl
 import net.corda.libs.packaging.internal.CpkLoader
 import net.corda.libs.packaging.internal.FormatVersionReader
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import java.io.IOException
@@ -43,8 +42,6 @@ import java.util.jar.Manifest
 import java.util.zip.ZipEntry
 
 internal object CpkLoaderV1 : CpkLoader {
-    private val logger = loggerFor<CpkLoaderV1>()
-
     internal const val CPK_TYPE = "Corda-CPK-Type"
 
     @Suppress("LongParameterList")

--- a/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/MemberProcessorImpl.kt
+++ b/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/MemberProcessorImpl.kt
@@ -60,8 +60,8 @@ class MemberProcessorImpl @Activate constructor(
     private val synchronisationProxy: SynchronisationProxy,
 ) : MemberProcessor {
 
-    companion object {
-        val logger = contextLogger()
+    private companion object {
+        private val logger = contextLogger()
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/lifecycle/MemberProcessorLifecycleHandler.kt
+++ b/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/lifecycle/MemberProcessorLifecycleHandler.kt
@@ -14,8 +14,8 @@ import net.corda.v5.base.util.debug
 class MemberProcessorLifecycleHandler(
     private val configurationReadService: ConfigurationReadService
 ) : LifecycleEventHandler {
-    companion object {
-        val logger = contextLogger()
+    private companion object {
+        private val logger = contextLogger()
     }
 
     override fun processEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {


### PR DESCRIPTION
Logger should be private fields so that other modules cannot accidentally import them.

I found these by asking IntelliJ to suggest import candidates for a `logger` field in each of our applications.