### PR TITLE
NOTICK - ensure open-api diff doesn't consider doc changes

### DIFF
--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
@@ -101,7 +101,7 @@ class OpenApiCompatibilityTest {
         val stream = requireNotNull(javaClass.classLoader.getResourceAsStream("/swaggerBaseline.json"))
         return stream.use {
             val jsonString = String(it.readAllBytes())
-            Json.mapper().readValue(jsonString, OpenAPI::class.java)
+            Json.mapper().readValue(removeDocContentFromJson(jsonString), OpenAPI::class.java)
         }
     }
 
@@ -145,7 +145,8 @@ class OpenApiCompatibilityTest {
 
             val response = client.send(request, HttpResponse.BodyHandlers.ofString())
             val body = response.body()
-            body to Json.mapper().readValue(body, OpenAPI::class.java)
+            val jsonWithDocsRemoved = removeDocContentFromJson(body)
+            body to Json.mapper().readValue(jsonWithDocsRemoved, OpenAPI::class.java)
         }
     }
 }

--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/TestUtils.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/TestUtils.kt
@@ -1,5 +1,8 @@
 package net.corda.processors.rpc
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import java.net.ServerSocket
 import java.nio.file.Path
 
@@ -8,3 +11,18 @@ import java.nio.file.Path
 fun findFreePort() = ServerSocket(0).use { it.localPort }
 
 val multipartDir: Path = Path.of(System.getProperty("java.io.tmpdir"), "multipart")
+
+fun removeDocContentFromJson(jsonString: String): String {
+    val json = ObjectMapper().readTree(jsonString)
+    json.removeDocContent()
+    return json.toPrettyString()
+}
+
+fun JsonNode.removeDocContent() {
+    if(this is ObjectNode) {
+        this.remove(listOf("name", "title", "description"))
+    }
+    this.elements().forEach { node ->
+        node.removeDocContent()
+    }
+}

--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/TestUtilsTest.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/TestUtilsTest.kt
@@ -1,0 +1,58 @@
+package net.corda.processors.rpc
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TestUtilsTest {
+    @Test
+    fun testRemoveDocContentFromJson() {
+        val jsonString = """
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Corda HTTP RPC API",
+    "description" : "All the endpoints for publicly visible Open API calls",
+    "version" : "1"
+  },
+  "servers" : [ {
+    "url" : "/api/v1"
+  } ],
+  "tags" : [ {
+    "name" : "CPI Upload API",
+    "description" : "CPI Upload management endpoints.",
+    "keep": "this"
+  } ],
+  "nested" : {
+    "example": {
+        "title" : "Nested",
+        "description" : "Example",
+        "version" : "1"
+      }
+  }
+}
+        """.trimIndent()
+
+        val expectedJson = """
+            {
+              "openapi" : "3.0.1",
+              "info" : {
+                "version" : "1"
+              },
+              "servers" : [ {
+                "url" : "/api/v1"
+              } ],
+              "tags" : [ {
+                "keep" : "this"
+              } ],
+              "nested" : {
+                "example" : {
+                  "version" : "1"
+                }
+              }
+            }
+        """.trimIndent()
+
+        val result = removeDocContentFromJson(jsonString)
+        assertThat(result).isEqualTo(expectedJson)
+    }
+}


### PR DESCRIPTION
Change the open-api diff test to ignore `name`, `description` and `title` fields as they don't change the API spec.