### PR TITLE
CORE-5539: Add Config Change Smoke Test

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -157,12 +157,12 @@ pipeline {
 
                 sh '''\
                     # Forward ports for testing
-                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "prereqs-kafka-0" "9092" > forward.txt 2>&1 &
-                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-rpc-worker" "8888" >> forward.txt 2>&1 &
-                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-crypto-worker" "7001:7000" >> forward.txt 2>&1 &
-                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-db-worker" "7002:7000" >> forward.txt 2>&1 &
-                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-flow-worker" "7003:7000" >> forward.txt 2>&1 &
-                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-rpc-worker" "7004:7000" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "prereqs-kafka-0" "9092" "9092" > forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-rpc-worker" "8888" "8888" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-crypto-worker" "7001" "7000" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-db-worker" "7002" "7000" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-flow-worker" "7003" "7000" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-rpc-worker" "7004" "7000" >> forward.txt 2>&1 &
                     procno=$! # remember process number started in background
                     trap "kill -9 ${procno}" EXIT
 

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -157,16 +157,17 @@ pipeline {
 
                 sh '''\
                     # Forward ports for testing
-                    nohup kubectl port-forward -n "${NAMESPACE}" prereqs-kafka-0 9092 > forward.txt 2>&1 &
-                    nohup kubectl port-forward -n "${NAMESPACE}" deploy/corda-rpc-worker 8888 >> forward.txt 2>&1 &
-                    nohup kubectl port-forward -n "${NAMESPACE}" deploy/corda-crypto-worker 7001:7000 >> forward.txt 2>&1 &
-                    nohup kubectl port-forward -n "${NAMESPACE}" deploy/corda-db-worker 7002:7000 >> forward.txt 2>&1 &
-                    nohup kubectl port-forward -n "${NAMESPACE}" deploy/corda-flow-worker 7003:7000 >> forward.txt 2>&1 &
-                    nohup kubectl port-forward -n "${NAMESPACE}" deploy/corda-rpc-worker 7004:7000 >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "prereqs-kafka-0" "9092" > forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-rpc-worker" "8888" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-crypto-worker" "7001:7000" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-db-worker" "7002:7000" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-flow-worker" "7003:7000" >> forward.txt 2>&1 &
+                    nohup .ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh "${NAMESPACE}" "deployment/corda-rpc-worker" "7004:7000" >> forward.txt 2>&1 &
                     procno=$! # remember process number started in background
                     trap "kill -9 ${procno}" EXIT
 
-                    ./gradlew cleanE2eTest smokeTest e2eTest ${GRADLE_PERFORMANCE_TUNING}
+                    ./gradlew smokeTest ${GRADLE_PERFORMANCE_TUNING}
+                    ./gradlew e2eTest ${GRADLE_PERFORMANCE_TUNING}
                 '''.stripIndent()
             }
             post {

--- a/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
+++ b/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+while true;
+	do kubectl --namespace "${1}" port-forward "${2}" "${3}" 2>&1
+done

--- a/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
+++ b/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
@@ -6,7 +6,7 @@ if [ "$#" -ne 4 ]; then
     exit 1
 fi
 
-while [[ "$(nc -z localhost ${3})" != "0" ]]; do
+while true; do
 	kubectl --namespace "${1}" port-forward "${2}" "${3}:${4}" 2>&1
 	echo "kubectl port-forward connection to ${2}:${4} lost, sleeping 5 seconds before trying again..."
 	sleep 5

--- a/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
+++ b/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
-while true;
-	do kubectl --namespace "${1}" port-forward "${2}" "${3}" 2>&1
+if [ "$#" -ne 4 ]; then
+    echo "Illegal Parameter Count!!"
+    echo "Usage: ${0##*/} Namespace ResourceName LocalPort TargetPort"
+    exit 1
+fi
+
+while [[ "$(nc -z localhost ${3})" != "0" ]]; do
+	kubectl --namespace "${1}" port-forward "${2}" "${3}:${4}" 2>&1
+	echo "kubectl port-forward connection to ${2}:${4} lost, sleeping 5 seconds before trying again..."
+	sleep 5
 done

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.2"
 
+    // Avoid having the schema names and keys scattered across projects
+    smokeTestImplementation "net.corda:corda-config-schema:$cordaApiVersion"
+
     // But building a cpb for use in a test is ok.
     cpis project(path: ':testing:cpbs:flow-worker-dev', configuration: 'cordaCPB')
     cpiForFlowCacheTest project(path: ':testing:cpbs:flow-worker-dev-for-cache-testing', configuration: 'cordaCPB')

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -1,0 +1,82 @@
+package net.corda.applications.workers.smoketest
+
+import com.fasterxml.jackson.databind.JsonNode
+import net.corda.applications.workers.smoketest.virtualnode.helpers.assertWithRetryIgnoringExceptions
+import net.corda.applications.workers.smoketest.virtualnode.helpers.cluster
+import net.corda.httprpc.ResponseCode.OK
+import net.corda.test.util.eventually
+import org.apache.commons.text.StringEscapeUtils
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import java.io.IOException
+import java.time.Duration
+
+fun JsonNode.sourceConfigNode(): JsonNode =
+    this["sourceConfig"].textValue().toJson()
+
+fun JsonNode.configWithDefaultsNode(): JsonNode =
+    this["configWithDefaults"].textValue().toJson()
+
+/**
+ * Get the current configuration (as a [JsonNode]) for the specified [section].
+ */
+fun getConfig(section: String): JsonNode {
+    return cluster {
+        endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+
+        assertWithRetryIgnoringExceptions {
+            command { getConfig(section) }
+            condition { it.code == OK.statusCode }
+        }.body.toJson()
+    }
+}
+
+/**
+ * Update the cluster configuration with the specified [config] for the requested [section].
+ * The currently installed schema and configuration versions are automatically obtained from the running system
+ * before updating.
+ */
+fun updateConfig(config: String, section: String) {
+    return cluster {
+        endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+
+        assertWithRetryIgnoringExceptions {
+            command {
+                val currentConfig = getConfig(section).body.toJson()
+                val currentSchemaVersion = currentConfig["schemaVersion"]
+
+                putConfig(
+                    StringEscapeUtils.escapeJson(config), section,
+                    currentConfig["version"].toString(),
+                    currentSchemaVersion["major"].toString(),
+                    currentSchemaVersion["minor"].toString()
+                )
+            }
+
+            condition { it.code == OK.statusCode }
+        }
+    }
+}
+
+/**
+ * Wait for the REST API on the rpc-worker to become unavailable and available again, asserting that the expected
+ * configuration change took place.
+ */
+fun waitForConfigurationChange(section: String, key: String, value: String, timeout: Duration = Duration.ofMinutes(1)) {
+    cluster {
+        endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+
+        // Wait for the service to become unavailable
+        eventually(timeout) {
+            assertThatThrownBy {
+                getConfig(section)
+            }.hasCauseInstanceOf(IOException::class.java)
+        }
+
+        // Wait for the service to become available again and have the expected configuration value
+        assertWithRetryIgnoringExceptions {
+            timeout(timeout)
+            command { getConfig(section) }
+            condition { it.code == OK.statusCode && it.body.toJson().sourceConfigNode()[key].asInt().toString() == value }
+        }
+    }
+}

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -1,20 +1,27 @@
 package net.corda.applications.workers.smoketest
 
+import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
 import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CONFIG_INTERVAL_MS
+import net.corda.schema.configuration.ReconciliationConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 
 @Order(40)
 class ConfigTests {
+
     @Test
     fun `get config includes defaults`() {
-        val existing = getConfig(RECONCILIATION_CONFIG)
-        val sourceConfigValues = existing.sourceConfigNode().count()
-        val defaultedConfigValues = existing.configWithDefaultsNode().count()
-
-        assertThat(defaultedConfigValues).isGreaterThan(sourceConfigValues)
+        val defaultedConfigValues = getConfig(RECONCILIATION_CONFIG).configWithDefaultsNode()
+        ReconciliationConfig::class.java.declaredFields
+            .filter { it.name != "INSTANCE" }
+            .map { it.get(ConfigKeys) as String }
+            .forEach {
+                assertThat(defaultedConfigValues[it].asText())
+                    .isNotBlank
+                    .withFailMessage("missing $it configuration key")
+            }
     }
 
     @Test

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -7,9 +7,9 @@ import java.time.Duration
 import java.util.UUID
 import net.corda.applications.workers.smoketest.virtualnode.helpers.assertWithRetry
 import net.corda.applications.workers.smoketest.virtualnode.helpers.cluster
-import net.corda.applications.workers.smoketest.virtualnode.toJson
+import net.corda.httprpc.ResponseCode.OK
 import org.apache.commons.text.StringEscapeUtils.escapeJson
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 
 const val SMOKE_TEST_CLASS_NAME = "net.cordapp.flowworker.development.smoketests.flow.RpcSmokeTestFlow"
 const val RPC_FLOW_STATUS_SUCCESS = "COMPLETED"
@@ -123,7 +123,7 @@ fun getOrCreateVirtualNodeFor(x500: String): String {
     return cluster {
         endpoint(CLUSTER_URI, USERNAME, PASSWORD)
         val cpis = cpiList().toJson()["cpis"]
-        val json = cpis.toList().first { it["id"]["cpiName"].textValue() == CPI_NAME }
+        val json = cpis.toList().first { it["id"]["cpiName"].textValue() == TEST_CPI_NAME }
         val hash = truncateLongHash(json["cpiFileChecksum"].textValue())
 
         val vNodesJson = assertWithRetry {
@@ -143,7 +143,7 @@ fun getOrCreateVirtualNodeFor(x500: String): String {
         }
 
         val holdingId = vNodeJson["holdingIdentity"]["shortHash"].textValue()
-        Assertions.assertThat(holdingId).isNotNull.isNotEmpty
+        assertThat(holdingId).isNotNull.isNotEmpty
         holdingId
     }
 }
@@ -159,7 +159,7 @@ fun registerMember(holdingIdentityId: String) {
         }.toJson()
 
         val registrationStatus = membershipJson["registrationStatus"].textValue()
-        Assertions.assertThat(registrationStatus).isEqualTo("SUBMITTED")
+        assertThat(registrationStatus).isEqualTo("SUBMITTED")
     }
 }
 
@@ -201,6 +201,30 @@ fun getHoldingIdShortHash(x500Name: String, groupId: String): String {
     return digest.digest(s.toByteArray())
         .joinToString("") { byte -> "%02x".format(byte).uppercase() }
         .substring(0, 12)
+}
+
+/**
+ * Transform a Corda Package Bundle (CPB) into a Corda Package Installer (CPI) by adding the default group policy
+ * used by smoke tests and upload the resulting CPI to the system (override the existing one, if it already exists).
+ */
+fun forceUploadCordaPackage(name: String, cpb: String, groupId: String): String {
+    return cluster {
+        endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+
+        val cpis = cpiList().toJson()["cpis"]
+        val existingCpi = cpis.toList().firstOrNull { it["id"]["cpiName"].textValue() == name }
+        val uploadResponse = if (existingCpi == null ) cpiUpload(cpb, groupId) else forceCpiUpload(cpb, groupId)
+        assertThat(uploadResponse.code).isEqualTo(OK.statusCode)
+        assertThat(uploadResponse.toJson()["id"].textValue()).isNotEmpty
+        val responseStatusId = uploadResponse.toJson()["id"].textValue()
+
+        assertWithRetry {
+            command { cpiStatus(responseStatusId) }
+            condition { it.code == OK.statusCode && it.toJson()["status"].textValue() == OK.toString() }
+        }
+
+        responseStatusId
+    }
 }
 
 class RpcSmokeTestInput {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
@@ -16,14 +16,17 @@ const val X500_ALICE = "CN=Alice, OU=Application, O=R3, L=London, C=GB"
 //Charlie and David for use in multiple flow status endpoints. Number of flows they start is asserted. Do not start flows using these names
 const val X500_CHARLIE = "CN=Charlie, OU=Application, O=R3, L=Dublin, C=IE"
 const val X500_DAVID = "CN=David, OU=Application, O=R3, L=Dublin, C=IE"
-const val CPI_NAME = "flow-worker-dev"
 
 const val USERNAME = "admin"
 const val PASSWORD = "admin"
 const val GROUP_ID = "7c5d6948-e17b-44e7-9d1c-fa4a3f667cad"
 
-val CLUSTER_URI = URI(System.getProperty("rpcHost"))
+// The CPB and CPI used in smoke tests
+const val TEST_CPI_NAME = "flow-worker-dev"
+const val TEST_CPB_LOCATION = "/META-INF/flow-worker-dev.cpb"
+const val CACHE_INVALIDATION_TEST_CPB = "/META-INF/cache-invalidation-testing/flow-worker-dev.cpb"
 
+val CLUSTER_URI = URI(System.getProperty("rpcHost"))
 
 // BUG:  Not sure if we should be requiring clients to use a method similar to this because we
 // return a full hash (64 chars?) but the same API only accepts the first 12 chars.
@@ -32,6 +35,8 @@ fun truncateLongHash(shortHash:String):String {
 }
 
 fun String.toJson(): JsonNode = ObjectMapper().readTree(this)
+
+fun <K, V> Map<K, V>.toJsonString(): String = ObjectMapper().writeValueAsString(this)
 
 fun Any.contextLogger(): Logger = LoggerFactory.getLogger(javaClass.enclosingClass)
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -1,23 +1,31 @@
 package net.corda.applications.workers.smoketest.flow
 
-import java.util.UUID
 import net.corda.applications.workers.smoketest.FlowStatus
 import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_FAILED
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_SUCCESS
 import net.corda.applications.workers.smoketest.RpcSmokeTestInput
+import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
+import net.corda.applications.workers.smoketest.TEST_CPI_NAME
 import net.corda.applications.workers.smoketest.X500_BOB
 import net.corda.applications.workers.smoketest.X500_CHARLIE
 import net.corda.applications.workers.smoketest.X500_DAVID
-import net.corda.applications.workers.smoketest.awaitMultipleRpcFlowFinished
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
+import net.corda.applications.workers.smoketest.configWithDefaultsNode
 import net.corda.applications.workers.smoketest.createKeyFor
+import net.corda.applications.workers.smoketest.forceUploadCordaPackage
+import net.corda.applications.workers.smoketest.getConfig
 import net.corda.applications.workers.smoketest.getFlowClasses
 import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
 import net.corda.applications.workers.smoketest.getRpcFlowResult
 import net.corda.applications.workers.smoketest.registerMember
 import net.corda.applications.workers.smoketest.startRpcFlow
+import net.corda.applications.workers.smoketest.toJsonString
+import net.corda.applications.workers.smoketest.updateConfig
+import net.corda.applications.workers.smoketest.waitForConfigurationChange
+import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
+import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
@@ -28,6 +36,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.TestMethodOrder
+import java.util.UUID
 
 @Suppress("Unused")
 @Order(20)
@@ -62,13 +71,13 @@ class FlowTests {
             "net.cordapp.flowworker.development.testflows.UniquenessCheckTestFlow",
         ) + invalidConstructorFlowNames + dependencyInjectionFlowNames
 
-        /*
-         * when debugging if you want to run the tests multiple times comment out the @BeforeAll
-         * attribute to disable the vnode creation after the first run.
-         */
         @BeforeAll
         @JvmStatic
         internal fun beforeAll() {
+            // Make sure test flows are deployed
+            forceUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID)
+
+            // Make sure Virtual Nodes are created
             val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
             val charlieActualHoldingId = getOrCreateVirtualNodeFor(X500_CHARLIE)
             val davidActualHoldingId = getOrCreateVirtualNodeFor(X500_DAVID)
@@ -109,10 +118,16 @@ class FlowTests {
             data = mapOf("echo_value" to "hello")
         }
 
-        startRpcFlow(davidHoldingId, requestBody)
-        startRpcFlow(davidHoldingId, requestBody)
+        val flowIds = mutableListOf(
+            startRpcFlow(davidHoldingId, requestBody),
+            startRpcFlow(davidHoldingId, requestBody)
+        )
 
-        awaitMultipleRpcFlowFinished(davidHoldingId, 2)
+        flowIds.forEach {
+            val flowResult = awaitRpcFlowFinished(davidHoldingId, it)
+            assertThat(flowResult.flowError).isNull()
+            assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        }
     }
 
     @Test
@@ -608,5 +623,56 @@ class FlowTests {
             )
         val result = awaitRpcFlowFinished(bobHoldingId, requestID)
         assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+    }
+
+    @Test
+    fun `cluster configuration changes are picked up and workers continue to operate normally`() {
+        val currentConfigValue = getConfig(MESSAGING_CONFIG).configWithDefaultsNode()[MAX_ALLOWED_MSG_SIZE].asInt()
+        val newConfigurationValue = (currentConfigValue * 1.5).toInt()
+
+        // Update cluster configuration (ConfigProcessor should kick off on all workers at this point)
+        updateConfig(mapOf(MAX_ALLOWED_MSG_SIZE to newConfigurationValue).toJsonString(), MESSAGING_CONFIG)
+
+        // Wait for the rpc-worker to reload the configuration and come back up
+        waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue.toString())
+
+        try {
+            // Execute some flows which require functionality from different workers and make sure they succeed
+            val flowIds = mutableListOf(
+                startRpcFlow(
+                    bobHoldingId,
+                    RpcSmokeTestInput().apply {
+                        command = "persistence_persist"
+                        data = mapOf("id" to UUID.randomUUID().toString())
+                    }
+                ),
+
+                startRpcFlow(
+                    bobHoldingId,
+                    RpcSmokeTestInput().apply {
+                        command = "crypto_sign_and_verify"
+                        data = mapOf("publicKey" to createKeyFor(bobHoldingId, UUID.randomUUID().toString(), "LEDGER", "CORDA.RSA"))
+                    }
+                ),
+
+                startRpcFlow(
+                    bobHoldingId,
+                    RpcSmokeTestInput().apply {
+                        command = "lookup_member_by_x500_name"
+                        data = mapOf("id" to X500_CHARLIE)
+                    }
+                )
+            )
+
+            flowIds.forEach {
+                val flowResult = awaitRpcFlowFinished(bobHoldingId, it)
+                assertThat(flowResult.flowError).isNull()
+                assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+            }
+        } finally {
+            // Be a good neighbour and rollback the configuration change back to what it was
+            updateConfig(mapOf(MAX_ALLOWED_MSG_SIZE to currentConfigValue).toJsonString(), MESSAGING_CONFIG)
+            waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, currentConfigValue.toString())
+        }
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/AssertWithRetryBuilder.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/AssertWithRetryBuilder.kt
@@ -88,6 +88,18 @@ fun assertWithRetry(initialize: AssertWithRetryBuilder.() -> Unit): SimpleRespon
 
 /**
  * Same as [assertWithRetry], but exceptions thrown are also ignored during the retry process.
+ *
+ * This method should be preferred over [assertWithRetry] when the actual [AssertWithRetryArgs.command] might
+ * receive ignorable transient exceptions during its execution that have nothing to do with the actual
+ * [AssertWithRetryArgs.condition] that needs to be asserted.
+ *
+ * As an example, it might be used to wrap HTTP calls which could fail due to transient connectivity errors but
+ * eventually succeed:
+ *
+ *      val response = assertWithRetryIgnoringExceptions {
+ *          command { httpRequest(body) }
+ *          condition { it.code == 200 }
+ *      }
  */
 fun assertWithRetryIgnoringExceptions(initialize: AssertWithRetryBuilder.() -> Unit): SimpleResponse {
     val args = AssertWithRetryArgs()

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
@@ -129,6 +129,29 @@ class ClusterBuilder {
         """{ "clientRequestId" : "$clientRequestId", "flowClassName" : "$flowClassName", "requestData" : 
             |"$requestData" }""".trimMargin()
 
+    /** Get cluster configuration for the specified section */
+    fun getConfig(section: String) = get("/api/v1/config/$section")
+
+    /** Update the cluster configuration for the specified section and versions */
+    fun putConfig(config: String,
+                  section: String,
+                  configVersion: String,
+                  schemaMajorVersion: String,
+                  schemaMinorVersion: String) : SimpleResponse {
+        val payload = """
+            {
+                "config": "$config",
+                "schemaVersion": {
+                  "major": "$schemaMajorVersion",
+                  "minor": "$schemaMinorVersion"
+                },
+                "section": "$section",
+                "version": "$configVersion"
+            }
+            """.trimIndent()
+
+        return put("/api/v1/config", payload)
+    }
 }
 
 fun <T> cluster(initialize: ClusterBuilder.() -> T):T = ClusterBuilder().let(initialize)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/SimpleResponse.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/SimpleResponse.kt
@@ -1,4 +1,9 @@
 package net.corda.applications.workers.smoketest.virtualnode.helpers
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+
 /** Simplified response in case we switch underlying web clients, again */
-data class SimpleResponse(val code: Int, val body: String, val url: String)
+data class SimpleResponse(val code: Int, val body: String, val url: String) {
+    fun toJson(): JsonNode = ObjectMapper().readTree(this.body)!!
+}


### PR DESCRIPTION
Add new smoke test to make a configuration change (triggering a full
reload on all workers) and execute some flows exercising multiple
features from different workers afterwards.
Amend retry logic in tests, disable parallel execution of 'e2eTest' and
'smokeTest' gradle tasks in CI, and automatically reconnect 'kubectl'
port-forwarding upon failure in CI to prevent flakiness (by design, the
automatic reload triggered on the rpc-worker causes the internal HTTP
server to become unavailable for a small period of time).

- Automatically restart kubectl port-forward in Jenkins jobs.
- Execute 'e2eTest' and 'smokeTest' gradle tasks serially in Jenkins.
- Update 'FlowTests' to automatically install prerequisites as part of
  the setup logic instead of requiring external intervention.
- Fix assertions within 'VirtualNodeRpcTest' to correctly detect
  conflict errors when uploading CPIs.
- Add helper methods to make the interaction with REST configuration
  endpoints easier.
- Improve 'assertWithRetry' to allow ignoring exceptions thrown while
  executing the retry logic.
- Refactor 'ConfigTests' to use new helper methods and avoid
  duplicating logic across tests.
- Create new smoke test flow within 'RpcSmokeTestFlow' to exercise
  membership lookup.
- Add 'corda-config-schema' as a dependency to 'workers-smoke-test' in
  order to use already defined constants instead of duplicating the
  keys across modules.
- Prevent test 'start multiple RPC flow and validate they complete'
  from failing when executed multiple times by specifically checking
  the result of the flows fired by the test instead of all flows for a
  particular 'holdingID'.
