### PR TITLE
CORE-6772: ensure shell scripts have the correct line endings when checked out on any machine

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 #
 # https://help.github.com/articles/dealing-with-line-endings/
 #
+# Ensure shell scripts have the correct line endings on check out
+*.sh            text eol=lf
+
 # These are explicitly windows files and should use crlf
 *.bat           text eol=crlf
-


### PR DESCRIPTION
Address issue where line endings are incorrect in some *.sh files, this presents issues when running them on unix systems.

This change ensure on checkout all users have the correct line endings in shell scripts, and there fore Build systems have the correct line endings in these scripts when packaging / publishing 
