### PR TITLE
CORE-6681: ensure snake yaml uses 1.32 for Deteck plugin transitive dependency 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,6 +330,13 @@ subprojects {
         }
     }
 
+    // required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
+    pluginManager.withPlugin('io.gitlab.arturbosch.detekt') {
+      dependencies {
+            detekt "org.yaml:snakeyaml:$snakeyamlVersion"
+      }
+    }
+
     tasks.named("detekt").configure {
         if(file("$projectDir/detekt-baseline.xml").exists()){
             baseline = file("$projectDir/detekt-baseline.xml")

--- a/build.gradle
+++ b/build.gradle
@@ -330,11 +330,15 @@ subprojects {
         }
     }
 
-    // required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
-    pluginManager.withPlugin('io.gitlab.arturbosch.detekt') {
-      dependencies {
-            detekt "org.yaml:snakeyaml:$snakeyamlVersion"
-      }
+    pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
+        dependencies {
+        detekt "io.gitlab.arturbosch.detekt:detekt-cli:$detektPluginVersion"
+            constraints {
+                detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
+                    because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
+                }
+            }
+        }
     }
 
     tasks.named("detekt").configure {


### PR DESCRIPTION
io.gitlab.arturbosch.detekt pulls in a transitive dependency on snake yaml 1.31 , until Deteck bump their version in a later release we need to force gradle to use the same version of snake yaml decaled in our gradle.properties file (1.32)