### PR TITLE
CORE-6714: DP2: Ensure java doc jars Published correctly for runtime-os

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,8 @@ cordaPipeline(
     createPostgresDb: true,
     publishOSGiImage: false, // dont merge back to release branch 
     publishPreTestImage: true,
-    publishHelmChart: false, // dont merge back to release branch 
+    publishHelmChart: false, // dont merge back to release branch
+    javadocJar: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: true,
     combinedWorkere2eTests: true,

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'corda.common-publishing'
     id 'corda.quasar-app'
     id 'corda.docker-app'
+    id 'corda.javadoc-generation'
 }
 
 ext {
@@ -99,9 +100,9 @@ tasks.named('jar', Jar) {
     dependsOn(download)
 }
 
-// Allow us to publish to S3 bucket for DP2 - to be extracted to plugin
-if (project.hasProperty('maven.repo.s3') && project.hasProperty('releasable')) {
-    publishing {
+publishing {
+    // Allow us to publish to S3 bucket for DP2 - to be extracted to plugin
+    if (project.hasProperty('maven.repo.s3') && project.hasProperty('releasable')) {
         repositories {
             maven {
                 url = project.findProperty('maven.repo.s3')
@@ -111,6 +112,13 @@ if (project.hasProperty('maven.repo.s3') && project.hasProperty('releasable')) {
                     sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
                 }
             }
+        }
+    }
+    publications {
+        maven(MavenPublication) {
+            artifactId 'corda-combined-worker'
+            groupId project.group
+            artifact javadocJar
         }
     }
 }

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -32,9 +32,7 @@ import org.osgi.service.component.annotations.Reference
 import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 
-/**
- * A worker that starts all processors.
- */
+/** A worker that starts all processors. */
 @Suppress("Unused", "LongParameterList")
 @Component(service = [Application::class])
 class CombinedWorker @Activate constructor(
@@ -66,9 +64,7 @@ class CombinedWorker @Activate constructor(
         private val logger = contextLogger()
     }
 
-    /**
-     * Parses the arguments, then initialises and starts the processors.
-     */
+    /** Parses the arguments, then initialises and starts the processors. */
     @Suppress("ComplexMethod")
     override fun startup(args: Array<String>) {
         logger.info("Combined worker starting.")
@@ -146,9 +142,7 @@ class CombinedWorker @Activate constructor(
     }
 }
 
-/**
- * Additional parameters for the combined worker are added here.
- */
+/** Additional parameters for the combined worker are added here. */
 private class CombinedWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -32,7 +32,9 @@ import org.osgi.service.component.annotations.Reference
 import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 
-/** A worker that starts all processors. */
+/**
+ * A worker that starts all processors.
+ */
 @Suppress("Unused", "LongParameterList")
 @Component(service = [Application::class])
 class CombinedWorker @Activate constructor(
@@ -64,7 +66,9 @@ class CombinedWorker @Activate constructor(
         private val logger = contextLogger()
     }
 
-    /** Parses the arguments, then initialises and starts the processors. */
+    /**
+     * Parses the arguments, then initialises and starts the processors.
+     */
     @Suppress("ComplexMethod")
     override fun startup(args: Array<String>) {
         logger.info("Combined worker starting.")
@@ -142,7 +146,9 @@ class CombinedWorker @Activate constructor(
     }
 }
 
-/** Additional parameters for the combined worker are added here. */
+/**
+ * Additional parameters for the combined worker are added here.
+ */
 private class CombinedWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ plugins {
     id 'corda.root-publish'
     id 'jacoco'
     id 'com.github.ben-manes.versions' // discover possible dependency version upgrades
+    id 'org.jetbrains.dokka' apply false
 }
 
 tasks.named("wrapper") {

--- a/buildSrc/src/main/groovy/corda.javadoc-generation.gradle
+++ b/buildSrc/src/main/groovy/corda.javadoc-generation.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'org.jetbrains.dokka'
+}
+
+tasks.register('javadocJar', Jar) {
+    description = 'Create JavaDoc Jar from dokka docs'
+    group = 'documentation'
+
+    dependsOn(dokkaHtml)
+    archiveBaseName = jar.archiveBaseName
+    archiveClassifier.set("javadoc")
+    from(dokkaHtml.outputDirectory)
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ internalPublishVersion=1.+
 internalDockerVersion=1.+
 dependencyCheckVersion=0.42.+
 snakeyamlVersion=1.32
+dokkaVersion = 1.7.+
 
 # Implementation dependency versions
 activationVersion = 1.2.0

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
+    id 'corda.javadoc-generation'
 }
 
 // Temporary measure for DP2, required as a transitive dependency by simulator modules 

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
+    id 'corda.javadoc-generation'
 }
 
 // Temporary measure for DP2, required as a transitive dependency by simulator modules 

--- a/libs/serialization/json-serializers/build.gradle
+++ b/libs/serialization/json-serializers/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
+    id 'corda.javadoc-generation'
 }
 
 ext {

--- a/settings.gradle
+++ b/settings.gradle
@@ -51,6 +51,7 @@ pluginManagement {
         id "org.gradle.test-retry" version gradleTestRetryPluginVersion
         id "com.jfrog.artifactory" version artifactoryPluginVersion
         id 'io.snyk.gradle.plugin.snykplugin' version snykVersion
+        id 'org.jetbrains.dokka' version dokkaVersion
     }
 }
 

--- a/simulator/api/build.gradle
+++ b/simulator/api/build.gradle
@@ -1,6 +1,7 @@
 
 plugins {
     id 'corda.common-publishing'
+    id 'corda.javadoc-generation'
 }
 
 ext {

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
+    id 'corda.javadoc-generation'
 }
 
 ext {


### PR DESCRIPTION
Publishing of the necessary javadocs for the following:
- corda-combined-worker
- corda-db-admin
- corda-db-admin-impl
- corda-json-serializers
- corda-simulator-api
- corda-simulator-runtime