### PR TITLE
NOTICK: fix install script for cli host - no directory to cd into here causes a failure 

### DIFF
--- a/tools/plugins/templateScripts/corda-cli-downloader.sh
+++ b/tools/plugins/templateScripts/corda-cli-downloader.sh
@@ -40,9 +40,7 @@ fi
 
 # unzip the archive
 cd "$tempDir" || exit
-unzip corda-cli-dist.zip
-
-cd corda-cli-dist
+unzip corda-cli-*.zip
 
 usr=$(id -u)
 grp=$(id -g)


### PR DESCRIPTION
Fixing error in script logic there is nothing to `cd` into here as the zip is inflated directly into the temp dir `cd corda-cli-dist` causes a failure.

also using * to cater for any versioning appending to zip, this is in line with other calls in this file. 

Verified locally as working with these changes 