### PR TITLE
CORE-6814: update cli versioning in line with other C5 products

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -121,7 +121,7 @@ artifactoryPluginVersion = 4.28.2
 pf4jVersion=3.7.0
 
 # corda-cli plugin host
-pluginHostVersion=0.0.1-DevPreview-2-beta+
+pluginHostVersion=5.0.0-DevPreview-2-beta+
 systemLambdaVersion=1.2.1
 
 # DB integration tests


### PR DESCRIPTION
cli-host we will now produce artifacts under the versioning 5.0.0-DevPreview-2 updating runtime-os consumption in line with this

Not to be merged before https://github.com/corda/corda-cli-plugin-host/pull/102 