### PR TITLE
NOTICK: Allow :testing:sandboxes to include a filter when fetching services.

### DIFF
--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
@@ -12,9 +12,14 @@ interface SandboxSetup {
     fun start()
     fun shutdown()
 
-    fun <T> getService(serviceType: Class<T>, timeout: Long): T
+    fun <T> getService(serviceType: Class<T>, filter: String?, timeout: Long): T
+    fun <T> getService(serviceType: Class<T>, timeout: Long): T = getService(serviceType, null, timeout)
 }
 
 inline fun <reified T> SandboxSetup.fetchService(timeout: Long): T {
     return getService(T::class.java, timeout)
+}
+
+inline fun <reified T> SandboxSetup.fetchService(filter: String?, timeout: Long): T {
+    return getService(T::class.java, filter, timeout)
 }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -131,11 +131,11 @@ class SandboxSetupImpl @Activate constructor(
      * this reference when we've finished with it to allow the
      * service to be destroyed.
      */
-    override fun <T> getService(serviceType: Class<T>, timeout: Long): T {
+    override fun <T> getService(serviceType: Class<T>, filter: String?, timeout: Long): T {
         val bundleContext = componentContext.bundleContext
         var remainingMillis = timeout.coerceAtLeast(0)
         while (true) {
-            bundleContext.getServiceReference(serviceType)?.let { ref ->
+            bundleContext.getServiceReferences(serviceType, filter).maxOrNull()?.let { ref ->
                 val service = bundleContext.getService(ref)
                 if (service != null) {
                     cleanups.add(AutoCloseable { bundleContext.ungetService(ref) })
@@ -149,6 +149,7 @@ class SandboxSetupImpl @Activate constructor(
             Thread.sleep(waitMillis)
             remainingMillis -= waitMillis
         }
-        throw TimeoutException("Service $serviceType did not arrive in $timeout milliseconds")
+        val serviceDescription = serviceType.name + (filter?.let { f -> ", filter=$f" } ?: "")
+        throw TimeoutException("Service $serviceDescription did not arrive in $timeout milliseconds")
     }
 }


### PR DESCRIPTION
The purpose of the filter is to disambiguate multiple services which all implement the same service interface, e.g.:
```kotlin
val first = fetchService<MyApi>("(component.name=com.example.MyFirstImpl)", 30000)
val second = fetchService<MyApi>("(component.name=com.example.MySecondImpl)", 30000)
```