### PR TITLE
CORE-6817 Refine JPA backing store transaction execution loop

### DIFF
--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -99,19 +99,13 @@ open class JPABackingStoreImpl @Activate constructor(
     }
 
     override fun start() {
-        log.info("Uniqueness checker starting.")
+        log.info("Backing store starting.")
         lifecycleCoordinator.start()
     }
 
     override fun stop() {
-        log.info("Uniqueness checker stopping.")
+        log.info("Backing store stopping.")
         lifecycleCoordinator.stop()
-    }
-
-    @Deactivate
-    fun close() {
-        entityManagerFactory.close()
-        stop()
     }
 
     protected open inner class SessionImpl(

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -39,7 +39,6 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import javax.persistence.EntityExistsException


### PR DESCRIPTION
### Summary

This PR makes the following minor changes to the JPA backing store transaction execution loop:

- Fix an off by one error in the retry loop. This was previously executing one time more than expected.
- Change "retry" terminology to "attempts" to make the logic clearer, since the execution loop runs once before any retries (i.e. start at attempt 1 up to max attempts, instead of 0 retries up to max retries - 1)
- Clean up exception message if the maximum attempts are reached, and also include the causing exception. This will likely not be used by the uniqueness checker (which should be shielded from DB level exception types), but may be useful to backing store tests that want to interrogate the specific exception that caused the failure.

Note that this logic will likely be further refined post-beta to review the exceptions being caught, and the exceptions thrown back to the uniqueness checker.

Minor fixes to the lifecycle logic have also been made:

- Logging now correctly refers to the backing store instead of uniqueness checker
- Removed the redundant `close` function (this was previously required for Lifecycle objects, but has now been removed)

### Testing

Ensured existing uniqueness checker integration tests (which indirectly invoke the JPA backing store) continue to pass with both HSQLDB and Postgres. Backing store level tests are being developed separately in CORE-6149 to test this functionality directly.