### PR TITLE
NOTICK: enable enviornemnt variables for multicluster test

### DIFF
--- a/applications/workers/release/rpc-worker/build.gradle
+++ b/applications/workers/release/rpc-worker/build.gradle
@@ -91,40 +91,22 @@ tasks.named('e2eTest') {
     if(System.getenv("JAVA_SECURITY_AUTH_LOGIN_CONFIG") != null) {
         jvmArgs "-Djava.security.auth.login.config=${System.getenv("JAVA_SECURITY_AUTH_LOGIN_CONFIG")}"
     }
-    if(System.getenv("E2E_CLUSTER_A_RPC_HOST") == null) {
-        systemProperty "E2E_CLUSTER_A_RPC_HOST", project.getProperties().getOrDefault("e2eClusterARpcHost","localhost")
-    }
-    if(System.getenv("E2E_CLUSTER_A_RPC_PORT") == null) {
-        systemProperty "E2E_CLUSTER_A_RPC_PORT", project.getProperties().getOrDefault("e2eClusterARpcPort","8888")
-    }
-    if(System.getenv("E2E_CLUSTER_B_RPC_HOST") == null) {
-        systemProperty "E2E_CLUSTER_B_RPC_HOST", project.getProperties().getOrDefault("e2eClusterBRpcHost","localhost")
-    }
-    if(System.getenv("E2E_CLUSTER_B_RPC_PORT") == null) {
-        systemProperty "E2E_CLUSTER_B_RPC_PORT", project.getProperties().getOrDefault("e2eClusterBRpcPort","8888")
-    }
-    if(System.getenv("E2E_CLUSTER_C_RPC_HOST") == null) {
-        systemProperty "E2E_CLUSTER_C_RPC_HOST", project.getProperties().getOrDefault("e2eClusterCRpcHost","localhost")
-    }
-    if(System.getenv("E2E_CLUSTER_C_RPC_PORT") == null) {
-        systemProperty "E2E_CLUSTER_C_RPC_PORT", project.getProperties().getOrDefault("e2eClusterCRpcPort","8888")
-    }
-    if(System.getenv("E2E_CLUSTER_A_P2P_HOST") == null) {
-        systemProperty "E2E_CLUSTER_A_P2P_HOST", project.getProperties().getOrDefault("e2eClusterAP2pHost","localhost")
-    }
-    if(System.getenv("E2E_CLUSTER_A_P2P_PORT") == null) {
-        systemProperty "E2E_CLUSTER_A_P2P_PORT", project.getProperties().getOrDefault("e2eClusterAP2pPort","8080")
-    }
-    if(System.getenv("E2E_CLUSTER_B_P2P_HOST") == null) {
-        systemProperty "E2E_CLUSTER_B_P2P_HOST", project.getProperties().getOrDefault("e2eClusterBP2pHost","localhost")
-    }
-    if(System.getenv("E2E_CLUSTER_C_P2P_PORT") == null) {
-        systemProperty "E2E_CLUSTER_C_P2P_PORT", project.getProperties().getOrDefault("e2eClusterBP2pPort","8080")
-    }
-    if(System.getenv("E2E_CLUSTER_C_P2P_HOST") == null) {
-        systemProperty "E2E_CLUSTER_C_P2P_HOST", project.getProperties().getOrDefault("e2eClusterCP2pHost","localhost")
-    }
-    if(System.getenv("E2E_CLUSTER_C_P2P_PORT") == null) {
-        systemProperty "E2E_CLUSTER_C_P2P_PORT", project.getProperties().getOrDefault("e2eClusterCP2pPort","8080")
+    ["A", "B", "C"].each {cluster ->
+        if(System.getenv("E2E_CLUSTER_{$cluster}_RPC_HOST") == null) {
+            environment "E2E_CLUSTER_{$cluster}_RPC_HOST",
+                    project.getProperties().getOrDefault("e2eCluster${cluster}RpcHost","localhost")
+        }
+        if(System.getenv("E2E_CLUSTER_${cluster}_RPC_PORT") == null) {
+            environment "E2E_CLUSTER_${cluster}_RPC_PORT",
+                    project.getProperties().getOrDefault("e2eCluster${cluster}RpcPort","8888")
+        }
+        if(System.getenv("E2E_CLUSTER_${cluster}_P2P_HOST") == null) {
+            environment "E2E_CLUSTER_{$cluster}_P2P_HOST",
+                    project.getProperties().getOrDefault("e2eCluster${cluster}P2pHost","localhost")
+        }
+        if(System.getenv("E2E_CLUSTER_${cluster}_P2P_PORT") == null) {
+            environment "E2E_CLUSTER_${cluster}_P2P_PORT",
+                    project.getProperties().getOrDefault("e2eCluster${cluster}P2pPort","8080")
+        }
     }
 }

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/E2eClusterConfig.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/E2eClusterConfig.kt
@@ -13,10 +13,10 @@ abstract class E2eClusterConfig {
         private const val DEFAULT_P2P_PORT = 8080
     }
 
-    val rpcHost: String get() = System.getProperty(rpcHostPropertyName) ?: DEFAULT_RPC_HOST
-    val rpcPort: Int get() = System.getProperty(rpcPortPropertyName)?.toInt() ?: DEFAULT_RPC_PORT
-    val p2pHost: String get() = System.getProperty(p2pHostPropertyName) ?: DEFAULT_P2P_HOST
-    val p2pPort: Int get() = System.getProperty(p2pPortPropertyName)?.toInt() ?: DEFAULT_P2P_PORT
+    val rpcHost: String get() = System.getenv(rpcHostPropertyName) ?: DEFAULT_RPC_HOST
+    val rpcPort: Int get() = System.getenv(rpcPortPropertyName)?.toInt() ?: DEFAULT_RPC_PORT
+    val p2pHost: String get() = System.getenv(p2pHostPropertyName) ?: DEFAULT_P2P_HOST
+    val p2pPort: Int get() = System.getenv(p2pPortPropertyName)?.toInt() ?: DEFAULT_P2P_PORT
 }
 
 internal object E2eClusterAConfig : E2eClusterConfig() {


### PR DESCRIPTION
Currently, if the environment variable is set, we will not set the property, and we will try to read the property...

With this change, if the environment variable is set, we will read it. If not, we will set it (from the properties).