### PR TITLE
NOTICK: Don't publish internal sandbox testing artifact.

### DIFF
--- a/testing/sandboxes/build.gradle
+++ b/testing/sandboxes/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'corda.common-publishing'
     id 'corda.common-library'
 }
 


### PR DESCRIPTION
The sandbox testing artifact is only for local testing and is not supported for use in any other Gradle projects.