### PR TITLE
CORE-5539: Revert Force Upload CPI in FlowTests

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -74,9 +74,6 @@ class FlowTests {
         @BeforeAll
         @JvmStatic
         internal fun beforeAll() {
-            // Make sure test flows are deployed
-            forceUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID)
-
             // Make sure Virtual Nodes are created
             val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
             val charlieActualHoldingId = getOrCreateVirtualNodeFor(X500_CHARLIE)


### PR DESCRIPTION
Force uploading the cpi as part of the test setup is causing flakiness in builds, revert back to the old approach for the time being to avoid blocking other builds.