### PR TITLE
CORE-6376: update license details

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -151,3 +151,7 @@ org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
 #snyk version
 snykVersion = 0.4
+
+# License
+licenseName = Corda Pre-Release Software License Agreement
+licenseUrl = https://www.corda.net/wp-content/uploads/2021/09/Corda-Pre-Release-Software-License-Agreement.pdf


### PR DESCRIPTION
add license properties , these are picked up by logic in `corda-gradle-internal-plugins` when generating the `*.pom` files and embedded in there in the license section, required for maven staging checks