### PR TITLE
CORE-6825: Automatically SetUp FlowTests

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -205,25 +205,26 @@ fun getHoldingIdShortHash(x500Name: String, groupId: String): String {
 
 /**
  * Transform a Corda Package Bundle (CPB) into a Corda Package Installer (CPI) by adding the default group policy
- * used by smoke tests and upload the resulting CPI to the system (override the existing one, if it already exists).
+ * used by smoke tests and upload the resulting CPI to the system if it doesn't already exist.
  */
-fun forceUploadCordaPackage(name: String, cpb: String, groupId: String): String {
+fun conditionallyUploadCordaPackage(name: String, cpb: String, groupId: String) {
     return cluster {
         endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
         val cpis = cpiList().toJson()["cpis"]
         val existingCpi = cpis.toList().firstOrNull { it["id"]["cpiName"].textValue() == name }
-        val uploadResponse = if (existingCpi == null ) cpiUpload(cpb, groupId) else forceCpiUpload(cpb, groupId)
-        assertThat(uploadResponse.code).isEqualTo(OK.statusCode)
-        assertThat(uploadResponse.toJson()["id"].textValue()).isNotEmpty
-        val responseStatusId = uploadResponse.toJson()["id"].textValue()
 
-        assertWithRetry {
-            command { cpiStatus(responseStatusId) }
-            condition { it.code == OK.statusCode && it.toJson()["status"].textValue() == OK.toString() }
+        if (existingCpi == null) {
+            val uploadResponse = cpiUpload(cpb, groupId)
+            assertThat(uploadResponse.code).isEqualTo(OK.statusCode)
+            assertThat(uploadResponse.toJson()["id"].textValue()).isNotEmpty
+            val responseStatusId = uploadResponse.toJson()["id"].textValue()
+
+            assertWithRetry {
+                command { cpiStatus(responseStatusId) }
+                condition { it.code == OK.statusCode && it.toJson()["status"].textValue() == OK.toString() }
+            }
         }
-
-        responseStatusId
     }
 }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -5,10 +5,13 @@ import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_FAILED
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_SUCCESS
 import net.corda.applications.workers.smoketest.RpcSmokeTestInput
+import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
+import net.corda.applications.workers.smoketest.TEST_CPI_NAME
 import net.corda.applications.workers.smoketest.X500_BOB
 import net.corda.applications.workers.smoketest.X500_CHARLIE
 import net.corda.applications.workers.smoketest.X500_DAVID
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
+import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
 import net.corda.applications.workers.smoketest.configWithDefaultsNode
 import net.corda.applications.workers.smoketest.getConfig
 import net.corda.applications.workers.smoketest.getFlowClasses
@@ -70,6 +73,9 @@ class FlowTests {
         @BeforeAll
         @JvmStatic
         internal fun beforeAll() {
+            // Upload test flows if not already uploaded
+            conditionallyUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID)
+
             // Make sure Virtual Nodes are created
             val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
             val charlieActualHoldingId = getOrCreateVirtualNodeFor(X500_CHARLIE)


### PR DESCRIPTION
Change 'FlowTests' to automatically upload the 'test-cordapp' CPI with required flows during the setup instead of requiring other tests to be executed as a pre requisite.