### PR TITLE
NOTICK: DP2 fix missing poms URLS

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -122,6 +122,7 @@ publishing {
             pom {
                 name = 'corda-combined-worker'
                 description = 'corda-combined-worker'
+                url = 'https://github.com/corda/corda-runtime-os'
 
                 scm {
                     url = 'https://github.com/corda/corda-runtime-os'

--- a/simulator/api/build.gradle
+++ b/simulator/api/build.gradle
@@ -35,6 +35,7 @@ publishing {
             pom {
                 name = 'corda-simulator-api'
                 description = 'corda-simulator-api'
+                url = 'https://github.com/corda/corda-runtime-os'
 
                 scm {
                     url = 'https://github.com/corda/corda-runtime-os'

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -40,6 +40,7 @@ publishing {
             pom {
                 name = 'corda-simulator-runtime'
                 description = 'corda-simulator-runtime'
+                url = 'https://github.com/corda/corda-runtime-os'
 
                 scm {
                     url = 'https://github.com/corda/corda-runtime-os'


### PR DESCRIPTION
maven central checks not just the SCM tag for a url but also expects a top level URL 