### PR TITLE
CORE-3344 Remove `serializeOutputStreamPool`

### DIFF
--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ByteBufferStreams.kt
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer
 import java.util.Arrays
 import kotlin.math.min
 
-fun <T> byteArrayOutput(task: (ByteBufferOutputStream) -> T): ByteArray {
+fun byteArrayOutput(task: (ByteBufferOutputStream) -> Unit): ByteArray {
     val byteBufferOutputStream = ByteBufferOutputStream(64 * 1024)
     task(byteBufferOutputStream)
     return byteBufferOutputStream.use {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPStreams.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPStreams.kt
@@ -7,14 +7,14 @@ import net.corda.internal.serialization.serializeOutputStreamPool
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.ByteBuffer
+import net.corda.internal.serialization.byteArrayOutput
 
 fun InputStream.asByteBuffer(): ByteBuffer {
     return if (this is ByteBufferInputStream) {
         byteBuffer // BBIS has no other state, so this is perfectly safe.
     } else {
-        ByteBuffer.wrap(serializeOutputStreamPool.run {
+        ByteBuffer.wrap(byteArrayOutput {
             copyTo(it)
-            it.toByteArray()
         })
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPStreams.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPStreams.kt
@@ -3,7 +3,6 @@ package net.corda.internal.serialization.amqp
 
 import net.corda.internal.serialization.ByteBufferInputStream
 import net.corda.internal.serialization.ByteBufferOutputStream
-import net.corda.internal.serialization.serializeOutputStreamPool
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.ByteBuffer
@@ -23,7 +22,7 @@ fun <T> OutputStream.alsoAsByteBuffer(remaining: Int, task: (ByteBuffer) -> T): 
     return if (this is ByteBufferOutputStream) {
         alsoAsByteBuffer(remaining, task)
     } else {
-        serializeOutputStreamPool.run {
+        ByteBufferOutputStream(64 * 1024).use {
             val result = it.alsoAsByteBuffer(remaining, task)
             it.copyTo(this)
             result


### PR DESCRIPTION
`serializeOutputStreamPool` re-uses buffers across calls to serialization. The reset method simply changes previously used streams (cached in `serializeOutputStreamPool`) length to 0. 

Since `serialization-amqp` is a corda module it means it will be a single sandbox and therefore `serializeOutputStreamPool` could be retrievable across different CorDapps and its cached streams could be read.

There should be a performance impact by this change since we now always create a new `ByteBufferOutputStream` across calls to serialization whereas before threads would also re-use cached `ByteBufferOutputStream`s in `serializeOutputStreamPool`.

- removes `serializeOutputStreamPool`.