### PR TITLE
CORE-6900: Refactored out CPK / osgi references from Serialization

### DIFF
--- a/libs/ledger/ledger-common-serialization/src/integrationTest/kotlin/net/corda/ledger/common/transaction/serialization/test/WireTransactionAMQPSerializationTest.kt
+++ b/libs/ledger/ledger-common-serialization/src/integrationTest/kotlin/net/corda/ledger/common/transaction/serialization/test/WireTransactionAMQPSerializationTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.common.transaction.serialization.test
 
 import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
+import net.corda.internal.serialization.amqp.ClassloadingContextImpl
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.ObjectAndEnvelope
 import net.corda.internal.serialization.amqp.SerializationOutput
@@ -82,7 +83,7 @@ class WireTransactionAMQPSerializationTest {
     }
 
     private fun testDefaultFactory(sandboxGroup: SandboxGroup): SerializerFactory =
-        SerializerFactoryBuilder.build(sandboxGroup, allowEvolution = true).also{
+        SerializerFactoryBuilder.build(ClassloadingContextImpl(sandboxGroup), allowEvolution = true).also{
             it.register(wireTransactionSerializer, it)
         }
 

--- a/libs/ledger/ledger-consensual-serialization/src/integrationTest/kotlin/net/corda/ledger/consensual/transaction/serialization/test/ConsensualSignedTransactionAMQPSerializationTest.kt
+++ b/libs/ledger/ledger-consensual-serialization/src/integrationTest/kotlin/net/corda/ledger/consensual/transaction/serialization/test/ConsensualSignedTransactionAMQPSerializationTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.consensual.transaction.serialization.test
 
 import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
+import net.corda.internal.serialization.amqp.ClassloadingContextImpl
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.ObjectAndEnvelope
 import net.corda.internal.serialization.amqp.SerializationOutput
@@ -110,7 +111,7 @@ class ConsensualSignedTransactionAMQPSerializationTest {
     }
 
     private fun testDefaultFactory(sandboxGroup: SandboxGroup): SerializerFactory =
-        SerializerFactoryBuilder.build(sandboxGroup, allowEvolution = true).also{
+        SerializerFactoryBuilder.build(ClassloadingContextImpl(sandboxGroup), allowEvolution = true).also{
             registerCustomSerializers(it)
             it.register(publickeySerializer, it)
             it.register(partySerializer, it)

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxGroup.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxGroup.kt
@@ -7,7 +7,7 @@ import org.osgi.framework.Bundle
 /**
  * A group of sandboxes with visibility of one another.
  *
- * @property cpks The CPKs this sandbox group is constructed from.
+ * @property metadata The CPKs this sandbox group is constructed from.
  */
 interface SandboxGroup: SingletonSerializeAsToken {
     val metadata: Map<Bundle, CpkMetadata>

--- a/libs/serialization/serialization-amqp/cpk-four/src/main/kotlin/net/cordapp/bundle4/Transfer.kt
+++ b/libs/serialization/serialization-amqp/cpk-four/src/main/kotlin/net/cordapp/bundle4/Transfer.kt
@@ -1,9 +1,9 @@
 package net.cordapp.bundle4
 
-import net.cordapp.bundle5.Container
+import net.corda.v5.base.annotations.CordaSerializable
 import net.cordapp.bundle2.Document
 import net.cordapp.bundle3.Obligation
-import net.corda.v5.base.annotations.CordaSerializable
+import net.cordapp.bundle5.Container
 
 @CordaSerializable
 class Transfer(val obligation: Obligation, val document: Document, val id: Container<Int>) {

--- a/libs/serialization/serialization-amqp/cpk-three/src/main/kotlin/net/cordapp/bundle3/Obligation.kt
+++ b/libs/serialization/serialization-amqp/cpk-three/src/main/kotlin/net/cordapp/bundle3/Obligation.kt
@@ -1,8 +1,8 @@
 package net.cordapp.bundle3
 
+import net.corda.v5.base.annotations.CordaSerializable
 import net.cordapp.bundle1.Cash
 import net.cordapp.bundle2.Document
-import net.corda.v5.base.annotations.CordaSerializable
 
 @CordaSerializable
 class Obligation(val amount: Cash) {

--- a/libs/serialization/serialization-amqp/detekt-baseline.xml
+++ b/libs/serialization/serialization-amqp/detekt-baseline.xml
@@ -1,28 +1,28 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Boolean&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Byte&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Char&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Double&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Float&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Int&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Long&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Short&gt;</ID>
-    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.IA$Array&lt;Int&gt;</ID>
-    <ID>ArrayPrimitive:LocalTypeModelTests.kt$LocalTypeModelTests.Concrete$Array&lt;Int&gt;</ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Boolean></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Byte></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Char></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Double></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Float></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Int></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Long></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.C$Array&lt;Short></ID>
+    <ID>ArrayPrimitive:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests.IA$Array&lt;Int></ID>
+    <ID>ArrayPrimitive:LocalTypeModelTests.kt$LocalTypeModelTests.Concrete$Array&lt;Int></ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.AMQPExceptions.kt:84</ID>
-    <ID>ChainWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:204</ID>
-    <ID>ChainWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:51</ID>
+    <ID>ChainWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:203</ID>
+    <ID>ChainWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:50</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:78</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.AMQPTypeIdentifiers.kt:22</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.CustomSerializerRegistry.kt:186</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.CustomSerializerRegistry.kt:187</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:126</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:127</ID>
+    <ID>ChainWrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:186</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:187</ID>
-    <ID>ChainWrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:188</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.SerializationHelper.kt:132</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.SerializationHelper.kt:133</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.TransformsSchema.kt:310</ID>
@@ -30,18 +30,18 @@
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.custom.ThrowableTest.kt:84</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.custom.ThrowableTest.kt:85</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.amqp.custom.ThrowableTest.kt:86</ID>
-    <ID>ChainWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:187</ID>
+    <ID>ChainWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:171</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.model.LocalPropertyInformation.kt:67</ID>
-    <ID>ChainWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:493</ID>
-    <ID>ChainWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:530</ID>
+    <ID>ChainWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:485</ID>
+    <ID>ChainWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:524</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.model.LocalTypeModel.kt:78</ID>
-    <ID>ChainWrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:246</ID>
     <ID>ChainWrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:247</ID>
+    <ID>ChainWrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:248</ID>
     <ID>CommentSpacing:net.corda.internal.serialization.amqp.SupportedTransforms.kt:72</ID>
     <ID>CommentSpacing:net.corda.internal.serialization.amqp.TransformTypes.kt:42</ID>
     <ID>CommentSpacing:net.corda.internal.serialization.amqp.TransformTypes.kt:45</ID>
     <ID>ComplexCondition:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$c.isWhitespace() || c.isJavaIdentifierPart() || c.isJavaIdentifierStart() || c == '.' || c == ',' || c == '?' || c == '*'</ID>
-    <ID>ComplexCondition:DeserializationInput.kt$DeserializationInput$type != TypeIdentifier.UnknownType.getLocalType(sandboxGroup) &amp;&amp; serializer.type != type &amp;&amp; with(serializer.type) { !isSubClassOf(type) &amp;&amp; !materiallyEquivalentTo(type) }</ID>
+    <ID>ComplexCondition:DeserializationInput.kt$DeserializationInput$type != TypeIdentifier.UnknownType.getLocalType(classloadingContext) &amp;&amp; serializer.type != type &amp;&amp; with(serializer.type) { !isSubClassOf(type) &amp;&amp; !materiallyEquivalentTo(type) }</ID>
     <ID>ComplexCondition:Schema.kt$obj == null || obj is DescribedType || obj is Binary || forGenericType(type).run { isPrimitive(this) || this == TopType }</ID>
     <ID>ComplexMethod:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$private fun validate(typeString: String)</ID>
     <ID>ComplexMethod:TypeModellingFingerPrinter.kt$FingerPrintingState$private fun fingerprintNewType(type: LocalTypeInformation)</ID>
@@ -51,14 +51,14 @@
     <ID>ConstructorParameterNaming:CorDappSerializerTests.kt$CorDappSerializerTests.ExampleInternalProxySerializer.Proxy$val proxy_a_: String</ID>
     <ID>ConstructorParameterNaming:CorDappSerializerTests.kt$CorDappSerializerTests.HasWibbleProxy.Proxy$val proxy_a_: String</ID>
     <ID>ConstructorParameterNaming:CorDappSerializerTests.kt$CorDappSerializerTests.NeedsProxyGenBoundedProxySerializer.Proxy$val proxy_a_: Bound</ID>
-    <ID>ConstructorParameterNaming:CorDappSerializerTests.kt$CorDappSerializerTests.NeedsProxyGenContainerProxySerializer.Proxy$val proxy_a_: List&lt;*&gt;</ID>
+    <ID>ConstructorParameterNaming:CorDappSerializerTests.kt$CorDappSerializerTests.NeedsProxyGenContainerProxySerializer.Proxy$val proxy_a_: List&lt;*></ID>
     <ID>ConstructorParameterNaming:CorDappSerializerTests.kt$CorDappSerializerTests.NeedsProxyGenProxySerializer.Proxy$val proxy_a_: Any?</ID>
     <ID>ConstructorParameterNaming:CorDappSerializerTests.kt$CorDappSerializerTests.NeedsProxyProxySerializer.Proxy$val proxy_a_: String</ID>
     <ID>ConstructorParameterNaming:GenericsTests.kt$GenericsTests.InnerA$val a_a: Int</ID>
     <ID>ConstructorParameterNaming:GenericsTests.kt$GenericsTests.InnerB$val a_b: Int</ID>
     <ID>ConstructorParameterNaming:GenericsTests.kt$GenericsTests.InnerC$val a_c: String</ID>
     <ID>ConstructorParameterNaming:PrivatePropertyTests.kt$PrivatePropertyTests.C$val CCC: String</ID>
-    <ID>ConstructorParameterNaming:TypeIdentifier.kt$ReconstitutedParameterizedType$private val _actualTypeArguments: Array&lt;Type&gt;</ID>
+    <ID>ConstructorParameterNaming:TypeIdentifier.kt$ReconstitutedParameterizedType$private val _actualTypeArguments: Array&lt;Type></ID>
     <ID>ConstructorParameterNaming:TypeIdentifier.kt$ReconstitutedParameterizedType$private val _ownerType: Type?</ID>
     <ID>ConstructorParameterNaming:TypeIdentifier.kt$ReconstitutedParameterizedType$private val _rawType: Type</ID>
     <ID>EmptyFunctionBlock:AMQPPrimitiveSerializer.kt$AMQPPrimitiveSerializer${ }</ID>
@@ -67,7 +67,7 @@
     <ID>EmptyFunctionBlock:CorDappCustomSerializer.kt$CorDappCustomSerializer${}</ID>
     <ID>EmptyFunctionBlock:CustomSerializer.kt$CustomSerializer.CustomSerializerImpl${}</ID>
     <ID>EmptyFunctionBlock:EvolutionObjectBuilderRenamedPropertyTests.kt$EvolutionObjectBuilderRenamedPropertyTests.TemplateContract${}</ID>
-    <ID>EmptyFunctionBlock:LocalTypeModelTests.kt$LocalTypeModelTests.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:LocalTypeModelTests.kt$LocalTypeModelTests.&lt;no name provided>${}</ID>
     <ID>EmptyFunctionBlock:ObjectBuilder.kt$ConstructorBasedObjectBuilder${}</ID>
     <ID>EmptyFunctionBlock:SerializationOutputTests.kt$SerializationOutputTests.FooContract${}</ID>
     <ID>FinalNewline:net.corda.internal.serialization.NotSerializableExceptions.kt:1</ID>
@@ -126,7 +126,6 @@
     <ID>FinalNewline:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:1</ID>
     <ID>FinalNewline:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:1</ID>
     <ID>FinalNewline:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:1</ID>
-    <ID>FinalNewline:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:1</ID>
     <ID>FinalNewline:net.corda.internal.serialization.model.DefaultCacheProvider.kt:1</ID>
     <ID>FinalNewline:net.corda.internal.serialization.model.EnumTransforms.kt:1</ID>
     <ID>FinalNewline:net.corda.internal.serialization.model.LocalPropertyInformation.kt:1</ID>
@@ -141,47 +140,19 @@
     <ID>ForbiddenComment:SerializationScheme.kt$SerializationFactoryImpl$// TODO: This is read-mostly. Probably a faster implementation to be found.</ID>
     <ID>ForbiddenComment:TransformTypes.kt$TransformTypes$// TODO: annotated with some annotation</ID>
     <ID>ForbiddenComment:TransformTypes.kt$TransformTypes$// TODO: it would be awesome to auto build this list by scanning for transform annotations themselves</ID>
-    <ID>FunctionNaming:SerializationOutput.kt$SerializationOutput$protected fun &lt;T : Any&gt; _serialize(obj: T, context: SerializationContext): SerializedBytes&lt;T&gt;</ID>
+    <ID>FunctionNaming:SerializationOutput.kt$SerializationOutput$protected fun &lt;T : Any> _serialize(obj: T, context: SerializationContext): SerializedBytes&lt;T></ID>
     <ID>ImplicitDefaultLocale:Schema.kt$Descriptor$String.format("0x%08x:0x%08x", code.toLong().shr(32), code.toLong().and(0xffff))</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.DeserializeAndReturnEnvelopeTests.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.EnumTransformationTests.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.PrivatePropertyTests.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.RoundTripTests.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.SerializationPropertyOrdering.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.TransformTypes.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.custom.BigIntegerTest.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.custom.CurrencyTest.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.custom.ThrowableTest.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.custom.X509CRLTest.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.custom.X509CertificateTest.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.custom.ZoneIdTest.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.AMQPPrimitiveSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.CustomSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.model.LocalTypeModelTests.kt:3</ID>
-    <ID>ImportOrdering:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:3</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:53</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:54</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:57</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:58</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:59</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:71</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:72</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:73</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:74</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:75</ID>
-    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:76</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:22</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:23</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:26</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:27</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:28</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:40</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:41</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:42</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:43</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:44</ID>
+    <ID>Indentation:net.corda.internal.serialization.AMQPSerializationScheme.kt:45</ID>
     <ID>Indentation:net.corda.internal.serialization.ByteBufferStreams.kt:14</ID>
     <ID>Indentation:net.corda.internal.serialization.ByteBufferStreams.kt:15</ID>
     <ID>Indentation:net.corda.internal.serialization.ByteBufferStreams.kt:16</ID>
@@ -210,20 +181,21 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPExceptions.kt:69</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPExceptions.kt:82</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPExceptions.kt:83</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:126</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:127</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:128</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:129</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:132</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:133</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:134</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:135</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:139</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:140</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:141</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:154</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:155</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:156</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:157</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:158</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:175</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:176</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:177</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:184</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:185</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:186</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:187</ID>
@@ -239,10 +211,10 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:197</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:198</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:199</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:200</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:205</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:204</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:212</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:213</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:214</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:216</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:217</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:218</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:219</ID>
@@ -250,19 +222,18 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:221</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:222</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:223</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:224</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:52</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:51</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:58</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:59</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:60</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:61</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:64</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:67</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:63</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:66</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:87</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:88</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:89</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:90</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:91</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:92</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:93</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:79</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:80</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.AMQPSerializer.kt:35</ID>
@@ -508,43 +479,27 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:68</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:71</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:93</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:20</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:21</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:22</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:26</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:27</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:28</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:41</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.FingerPrinterTesting.kt:54</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.FingerPrinterTesting.kt:55</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:108</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:109</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:110</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:111</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:112</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:113</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:114</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:115</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:132</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:161</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:170</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:131</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:160</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:169</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:186</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:187</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:188</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:206</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:207</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:208</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:209</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:210</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:212</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:213</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:214</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:215</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:216</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:246</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:248</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:245</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:247</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:271</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:272</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:273</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:274</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:280</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:281</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:282</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalTypeModelConfigurationImpl.kt:28</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalTypeModelConfigurationImpl.kt:33</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.LocalTypeModelConfigurationImpl.kt:34</ID>
@@ -582,44 +537,39 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.PrivatePropertyTests.kt:79</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PrivatePropertyTests.kt:96</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:100</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:101</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:109</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:110</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:111</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:112</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:143</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:164</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:165</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:166</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:222</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:223</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:241</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:242</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:243</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:252</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:124</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:125</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:126</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:182</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:183</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:201</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:202</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:203</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:212</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:37</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:38</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:39</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:40</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:41</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:50</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:51</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:52</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:53</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:58</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:59</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:60</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:61</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:68</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:67</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:94</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:95</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:96</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:97</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:98</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:99</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:154</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:150</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:151</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:155</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:159</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:160</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:156</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:182</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:185</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:186</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:189</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.RoundTripTests.kt:190</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.Schema.kt:127</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.Schema.kt:128</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.Schema.kt:129</ID>
@@ -650,17 +600,11 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutput.kt:20</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutput.kt:21</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutput.kt:30</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1026</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1042</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1043</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1044</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:233</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:234</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:235</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:236</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:237</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:508</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:670</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1036</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1052</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1053</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1054</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:677</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializationPropertyOrdering.kt:29</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializationPropertyOrdering.kt:45</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializationPropertyOrdering.kt:76</ID>
@@ -674,35 +618,35 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactory.kt:29</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactory.kt:30</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactory.kt:31</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:106</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:107</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:108</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:109</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:110</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:111</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:112</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:113</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:114</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:115</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:116</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:117</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:118</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:119</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:124</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:125</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:126</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:120</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:121</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:122</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:127</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:128</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:129</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:151</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:152</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:153</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:154</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:130</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:131</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:132</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:156</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:157</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:158</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:159</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:160</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:161</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:162</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:163</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:164</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:165</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:166</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:167</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:168</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:64</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:66</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:68</ID>
@@ -747,8 +691,8 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.TransformsSchema.kt:299</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TransformsSchema.kt:309</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TransformsSchema.kt:310</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.TypeModellingFingerPrinterTests.kt:22</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.TypeModellingFingerPrinterTests.kt:37</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.TypeModellingFingerPrinterTests.kt:26</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.TypeModellingFingerPrinterTests.kt:41</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:21</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:22</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:23</ID>
@@ -771,9 +715,9 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:68</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:69</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:70</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:13</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:14</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:15</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:16</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:41</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:42</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:43</ID>
@@ -842,182 +786,168 @@
     <ID>Indentation:net.corda.internal.serialization.amqp.custom.YearSerializer.kt:18</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.custom.ZonedDateTimeSerializer.kt:18</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.custom.ZonedDateTimeSerializer.kt:21</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:105</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:141</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:142</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:143</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:144</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:125</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:126</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:127</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:128</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:129</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:130</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:131</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:132</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:145</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:146</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:147</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:148</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:161</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:171</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:192</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:201</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:203</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:212</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:214</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:222</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:224</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:233</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:235</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:92</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:155</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:176</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:185</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:187</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:196</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:198</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:206</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:208</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:217</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:219</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:76</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:89</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:111</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:96</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:51</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:66</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:37</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:44</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:45</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:51</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:58</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:59</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:65</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:102</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:129</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:130</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:131</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:132</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:133</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:134</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:151</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:158</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:113</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:114</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:115</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:116</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:117</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:118</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:135</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:142</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:144</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:160</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:176</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:187</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:194</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:50</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:51</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:52</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:53</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:54</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:55</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:56</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:57</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:58</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:59</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:63</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:76</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:88</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:89</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:90</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:94</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:95</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:96</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:171</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:178</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:34</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:35</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:36</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:37</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:38</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:39</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:40</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:41</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:42</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:43</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:47</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:60</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:72</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:73</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:74</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:78</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:79</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:80</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:86</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:100</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:101</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:102</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:105</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:106</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:107</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:108</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:109</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:110</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:114</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:115</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:116</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:111</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:112</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:117</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:122</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:123</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:124</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:120</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:121</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:125</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:126</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:127</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:132</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:135</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:136</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:140</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:141</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:142</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:157</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:158</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:143</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:144</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:145</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:146</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:159</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:160</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:161</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:165</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:166</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:167</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:168</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:169</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:170</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:171</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:173</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:174</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:175</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:176</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:177</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:178</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:179</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:180</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:181</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:182</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:183</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:184</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:185</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:186</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:187</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:188</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:189</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:190</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:191</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:192</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:193</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:194</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:195</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:196</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:200</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:201</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:197</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:202</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:203</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:204</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:205</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:209</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:210</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:211</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:212</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:213</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:216</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:217</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:218</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:219</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:220</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:224</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:225</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:221</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:222</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:223</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:226</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:227</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:228</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:231</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:232</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:229</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:233</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:234</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:235</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:236</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:237</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:238</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:241</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:242</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:243</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:244</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:248</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:239</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:240</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:246</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:249</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:250</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:251</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:252</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:253</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:254</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:255</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:261</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:264</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:267</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:58</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:59</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:60</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:64</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:65</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:66</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:70</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:74</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:75</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:76</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:79</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:80</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:81</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:82</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:84</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:85</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:86</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:89</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:90</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:91</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:92</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:95</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:96</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:97</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:93</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:94</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:98</ID>
+    <ID>Indentation:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:99</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:45</ID>
     <ID>Indentation:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:53</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:13</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:15</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:16</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:17</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:18</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:19</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:20</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:21</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:26</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:27</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:28</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:29</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:30</ID>
-    <ID>Indentation:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:31</ID>
     <ID>Indentation:net.corda.internal.serialization.model.EnumTransforms.kt:120</ID>
     <ID>Indentation:net.corda.internal.serialization.model.EnumTransforms.kt:133</ID>
     <ID>Indentation:net.corda.internal.serialization.model.EnumTransforms.kt:138</ID>
@@ -1111,22 +1041,21 @@
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformation.kt:412</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformation.kt:413</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformation.kt:416</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:117</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:140</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:118</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:141</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:142</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:143</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:147</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:144</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:148</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:149</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:167</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:150</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:168</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:169</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:170</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:173</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:182</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:171</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:174</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:183</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:189</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:184</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:190</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:191</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:192</ID>
@@ -1135,7 +1064,7 @@
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:195</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:196</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:197</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:200</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:198</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:201</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:202</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:203</ID>
@@ -1143,13 +1072,13 @@
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:205</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:206</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:207</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:297</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:349</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:352</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:208</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:298</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:350</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:353</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:354</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:355</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:375</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:356</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:376</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:377</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:378</ID>
@@ -1161,72 +1090,66 @@
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:384</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:385</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:386</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:389</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:387</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:390</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:391</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:394</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:392</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:395</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:411</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:396</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:412</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:413</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:419</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:414</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:420</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:428</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:421</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:429</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:430</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:431</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:438</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:432</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:439</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:440</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:441</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:442</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:446</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:443</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:447</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:448</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:449</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:450</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:451</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:453</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:452</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:454</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:455</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:456</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:457</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:458</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:459</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:462</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:460</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:463</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:464</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:465</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:467</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:468</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:471</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:472</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:473</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:480</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:481</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:482</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:483</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:484</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:485</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:486</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:487</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:52</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:474</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:475</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:476</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:477</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:478</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:479</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:525</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:526</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:527</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:528</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:529</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:53</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:531</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:532</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:533</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:534</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:535</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:54</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:541</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:542</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:543</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:544</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:545</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:546</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:547</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:548</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:549</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:55</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:550</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:551</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:552</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:553</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:76</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:56</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:77</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:78</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:79</ID>
@@ -1236,8 +1159,9 @@
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:83</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:84</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:85</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:90</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:94</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:86</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:91</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:95</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeModel.kt:68</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeModel.kt:69</ID>
     <ID>Indentation:net.corda.internal.serialization.model.LocalTypeModel.kt:78</ID>
@@ -1281,29 +1205,29 @@
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:162</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:163</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:164</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:192</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:202</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:248</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:249</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:252</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:253</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:196</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:206</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:254</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:261</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:262</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:265</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:266</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:255</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:258</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:259</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:260</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:267</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:315</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:316</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:317</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:268</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:271</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:272</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:273</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:322</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:323</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:324</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:329</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:330</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:331</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:332</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:333</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:335</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:337</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:338</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:339</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:340</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:342</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:68</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:69</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeIdentifier.kt:70</ID>
@@ -1329,60 +1253,60 @@
     <ID>Indentation:net.corda.internal.serialization.model.TypeLoader.kt:38</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeLoader.kt:39</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeLoader.kt:40</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:102</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:103</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:104</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:108</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:105</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:109</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:118</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:170</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:110</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:119</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:171</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:172</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:175</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:173</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:176</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:177</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:178</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:179</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:180</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:183</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:181</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:184</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:185</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:186</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:187</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:188</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:191</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:189</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:192</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:193</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:194</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:195</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:196</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:199</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:197</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:200</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:201</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:202</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:203</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:204</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:215</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:218</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:205</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:216</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:219</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:220</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:221</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:222</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:223</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:227</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:230</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:246</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:224</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:228</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:231</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:247</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:37</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:248</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:38</ID>
     <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:39</ID>
-    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:51</ID>
-    <ID>LongMethod:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$private fun buildNonAtomic(rawType: Class&lt;*&gt;, type: Type, typeIdentifier: TypeIdentifier, typeParameterInformation: List&lt;LocalTypeInformation&gt;): LocalTypeInformation</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:40</ID>
+    <ID>Indentation:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:52</ID>
+    <ID>LongMethod:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$private fun buildNonAtomic(rawType: Class&lt;*>, type: Type, typeIdentifier: TypeIdentifier, typeParameterInformation: List&lt;LocalTypeInformation>): LocalTypeInformation</ID>
     <ID>LongParameterList:AMQPSerializer.kt$AMQPSerializer$(obj: Any, data: Data, type: Type, output: SerializationOutput, context: SerializationContext, debugIndent: Int = 0)</ID>
-    <ID>LongParameterList:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$( override val sandboxGroup: SandboxGroup, private val typeModel: LocalTypeModel, private val fingerPrinter: FingerPrinter, private val descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry, private val primitiveSerializerFactory: Function&lt;Class&lt;*&gt;, AMQPSerializer&lt;Any&gt;&gt;, private val isPrimitiveType: Predicate&lt;Class&lt;*&gt;&gt;, private val customSerializerRegistry: CustomSerializerRegistry, private val onlyCustomSerializers: Boolean)</ID>
-    <ID>LongParameterList:LocalTypeModel.kt$BaseLocalTypes$( val collectionClass: Class&lt;*&gt;, val enumSetClass: Class&lt;*&gt;, val exceptionClass: Class&lt;*&gt;, val mapClass: Class&lt;*&gt;, val stringClass: Class&lt;*&gt;, val isEnum: Predicate&lt;Class&lt;*&gt;&gt;, val enumConstants: Function&lt;Class&lt;*&gt;, Array&lt;out Any&gt;&gt;, val enumConstantNames: Function&lt;Class&lt;*&gt;, List&lt;String&gt;&gt; )</ID>
+    <ID>LongParameterList:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$( override val classloadingContext: ClassloadingContext, private val typeModel: LocalTypeModel, private val fingerPrinter: FingerPrinter, private val descriptorBasedSerializerRegistry: DescriptorBasedSerializerRegistry, private val primitiveSerializerFactory: Function&lt;Class&lt;*>, AMQPSerializer&lt;Any>>, private val isPrimitiveType: Predicate&lt;Class&lt;*>>, private val customSerializerRegistry: CustomSerializerRegistry, private val onlyCustomSerializers: Boolean)</ID>
+    <ID>LongParameterList:LocalTypeModel.kt$BaseLocalTypes$( val collectionClass: Class&lt;*>, val enumSetClass: Class&lt;*>, val exceptionClass: Class&lt;*>, val mapClass: Class&lt;*>, val stringClass: Class&lt;*>, val isEnum: Predicate&lt;Class&lt;*>>, val enumConstants: Function&lt;Class&lt;*>, Array&lt;out Any>>, val enumConstantNames: Function&lt;Class&lt;*>, List&lt;String>> )</ID>
     <ID>LongParameterList:ObjectSerializer.kt$ComposableObjectWriter$( obj: Any, data: Data, @Suppress("UNUSED_PARAMETER") type: Type, output: SerializationOutput, context: SerializationContext, debugIndent: Int )</ID>
-    <ID>LongParameterList:ObjectSerializer.kt$EvolutionObjectSerializer.Companion$(localTypeInformation: LocalTypeInformation.Composable, remoteTypeInformation: RemoteTypeInformation.Composable, constructor: LocalConstructorInformation, properties: Map&lt;String, LocalPropertyInformation&gt;, mustPreserveData: Boolean, sandboxGroup: SandboxGroup)</ID>
+    <ID>LongParameterList:ObjectSerializer.kt$EvolutionObjectSerializer.Companion$(localTypeInformation: LocalTypeInformation.Composable, remoteTypeInformation: RemoteTypeInformation.Composable, constructor: LocalConstructorInformation, properties: Map&lt;String, LocalPropertyInformation>, mustPreserveData: Boolean, classloadingContext: ClassloadingContext)</ID>
     <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.CHOICE$7</ID>
     <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.COMPOSITE_TYPE$5</ID>
     <ID>MagicNumber:AMQPDescriptorRegistry.kt$AMQPDescriptorRegistry.FIELD$4</ID>
@@ -1415,25 +1339,28 @@
     <ID>MagicNumber:Schema.kt$RestrictedType.Companion$5</ID>
     <ID>MagicNumber:TransformsSchema.kt$UnknownTestTransform.Companion$3</ID>
     <ID>MatchingDeclarationName:SupportedTransforms.kt$SupportedTransform</ID>
-    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel$cache.getOrPut(typeDescriptor) { interpretationState.run { typeNotation.name.getTypeIdentifier(sandboxGroup).interpretIdentifier(sandboxGroup) } }</ID>
+    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel$cache.getOrPut(typeDescriptor) { interpretationState.run { typeNotation.name.getTypeIdentifier(classloadingContext).interpretIdentifier(classloadingContext) } }</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel$fun</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel$throw NotSerializableException("Cannot resolve cyclic reference to ${typeInformation.typeIdentifier}")</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$*</ID>
-    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$notationLookup[identifier]?.interpretNotation(identifier, sandboxGroup) ?: interpretNoNotation(sandboxGroup)</ID>
+    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$notationLookup[identifier]?.interpretNotation(identifier, classloadingContext) ?: interpretNoNotation(classloadingContext)</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$private</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$return</ID>
-    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$val constants = choices.asSequence().mapIndexed { index, choice -&gt; choice.name to index }.toMap(LinkedHashMap())</ID>
-    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$val properties = fields.asSequence().sortedBy { it.name }.map { it.interpret(sandboxGroup) }.toMap(LinkedHashMap())</ID>
+    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$val constants = choices.asSequence().mapIndexed { index, choice -> choice.name to index }.toMap(LinkedHashMap())</ID>
+    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$AMQPRemoteTypeModel.InterpretationState$val properties = fields.asSequence().sortedBy { it.name }.map { it.interpret(classloadingContext) }.toMap(LinkedHashMap())</ID>
+    <ID>MaxLineLength:AMQPRemoteTypeModel.kt$private fun String.getTypeIdentifier(classloadingContext: ClassloadingContext)</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModelTests.kt$AMQPRemoteTypeModelTests$return</ID>
-    <ID>MaxLineLength:AMQPRemoteTypeModelTests.kt$AMQPRemoteTypeModelTests$val values = typeModel.interpret(SerializationSchemas(schema.schema, schema.transformsSchema), factory.sandboxGroup).values</ID>
+    <ID>MaxLineLength:AMQPRemoteTypeModelTests.kt$AMQPRemoteTypeModelTests$val values = typeModel.interpret(SerializationSchemas(schema.schema, schema.transformsSchema), factory.classloadingContext).values</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModelTests.kt$AMQPRemoteTypeModelTests.C$class</ID>
     <ID>MaxLineLength:AMQPRemoteTypeModelTests.kt$AMQPRemoteTypeModelTests.Superclass$open</ID>
     <ID>MaxLineLength:AMQPSerializer.kt$AMQPSerializer$*</ID>
-    <ID>MaxLineLength:AMQPTestUtils.kt$SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup(), descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry)</ID>
-    <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$else -&gt; throw IllegalTypeNameParserStateException("Type name '$typeString' contains illegal character '$c'")</ID>
+    <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$else -> throw IllegalTypeNameParserStateException("Type name '$typeString' contains illegal character '$c'")</ID>
     <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$throw IllegalTypeNameParserStateException("Nested depth of type parameters exceeds maximum of $MAX_TYPE_PARAM_DEPTH")</ID>
+    <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingArray$TypeIdentifier.forClass(Primitives.unwrap(componentType.getLocalType(classloadingContext).asClass()))</ID>
     <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingArray$data</ID>
+    <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingArray$private</ID>
     <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingParameterList$data</ID>
+    <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingRawType$'>' -> parent?.addParameter(getTypeIdentifier())?.accept(c, classloadingContext) ?: notInParameterList(c)</ID>
     <ID>MaxLineLength:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser.ParseState.ParsingRawType$data</ID>
     <ID>MaxLineLength:AMQPTypeIdentifiers.kt$AMQPTypeIdentifiers$is TypeIdentifier.Parameterised</ID>
     <ID>MaxLineLength:AMQPTypeIdentifiers.kt$AMQPTypeIdentifiers$private val primitiveByteArrayType = TypeIdentifier.ArrayOf(TypeIdentifier.forClass(Byte::class.javaPrimitiveType!!))</ID>
@@ -1442,10 +1369,10 @@
     <ID>MaxLineLength:BitSetSerializer.kt$BitSetSerializer$*</ID>
     <ID>MaxLineLength:CertPathTest.kt$CertPathTest$val certificate = certificateFactory.generateCertificate(ByteArrayInputStream(TestCertificate.r3comCert.toByteArray()))</ID>
     <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer$override</ID>
+    <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer$private val outboundType = resolveTypeVariables(declaredType.actualTypeArguments[0], null, factory.classloadingContext)</ID>
     <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer$private val typeNotation: TypeNotation = RestrictedType(AMQPTypeIdentifiers.nameForType(declaredType), null, emptyList(), "list", Descriptor(typeDescriptor), emptyList())</ID>
     <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer.Companion$*</ID>
-    <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer.Companion$fun</ID>
-    <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer.Companion$is TypeIdentifier.Parameterised -&gt; erasedInformation.withElementType(declaredTypeInformation.elementType, sandboxGroup)</ID>
+    <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer.Companion$is TypeIdentifier.Parameterised -> erasedInformation.withElementType(declaredTypeInformation.elementType, classloadingContext)</ID>
     <ID>MaxLineLength:CollectionSerializer.kt$CollectionSerializer.Companion$private</ID>
     <ID>MaxLineLength:ComposableTypePropertySerializer.kt$ComposableTypePropertySerializer.Companion$*</ID>
     <ID>MaxLineLength:ComposableTypePropertySerializer.kt$ComposableTypePropertySerializer.Companion$PropertyReadStrategy.make(name, propertyInformation.type.typeIdentifier, propertyInformation.type.observedType)</ID>
@@ -1453,7 +1380,7 @@
     <ID>MaxLineLength:ComposableTypePropertySerializer.kt$DescribedTypeReadStrategy$*</ID>
     <ID>MaxLineLength:ComposableTypePropertySerializer.kt$EvolutionPropertyWriteStrategy$override</ID>
     <ID>MaxLineLength:ComposableTypePropertySerializer.kt$PropertyReader$*</ID>
-    <ID>MaxLineLength:ComposableTypePropertySerializer.kt$PropertyReader.Companion$is LocalPropertyInformation.PrivateConstructorPairedProperty -&gt; FieldReader(propertyInformation.observedField)</ID>
+    <ID>MaxLineLength:ComposableTypePropertySerializer.kt$PropertyReader.Companion$is LocalPropertyInformation.PrivateConstructorPairedProperty -> FieldReader(propertyInformation.observedField)</ID>
     <ID>MaxLineLength:ComposableTypePropertySerializer.kt$PropertyWriteStrategy$fun</ID>
     <ID>MaxLineLength:ComposableTypePropertySerializer.kt$PropertyWriteStrategy.Companion$fun</ID>
     <ID>MaxLineLength:CurrencyTest.kt$CurrencyTest.Companion$fun</ID>
@@ -1463,28 +1390,28 @@
     <ID>MaxLineLength:CustomSerializerRegistry.kt$CachingCustomSerializerRegistry$logger.debug { "action=\"Using custom serializer\", class=${clazz.typeName}, declaredType=${declaredType.typeName}" }</ID>
     <ID>MaxLineLength:CustomSerializerRegistry.kt$CachingCustomSerializerRegistry$logger.warn("Duplicate custom serializers detected for $clazz: ${declaredSerializers.map { it::class.qualifiedName }}")</ID>
     <ID>MaxLineLength:CustomSerializerRegistry.kt$CachingCustomSerializerRegistry$logger.warn("Illegal custom serializer detected for $clazz: ${declaredSerializers.first()::class.qualifiedName}")</ID>
-    <ID>MaxLineLength:CustomSerializerRegistry.kt$CachingCustomSerializerRegistry$private val customSerializersCache: MutableMap&lt;CustomSerializerIdentifier, CustomSerializerLookupResult&gt; = DefaultCacheProvider.createCache()</ID>
+    <ID>MaxLineLength:CustomSerializerRegistry.kt$CachingCustomSerializerRegistry$private val customSerializersCache: MutableMap&lt;CustomSerializerIdentifier, CustomSerializerLookupResult> = DefaultCacheProvider.createCache()</ID>
     <ID>MaxLineLength:CustomSerializerRegistry.kt$CachingCustomSerializerRegistry.CustomSerializerLookupResult$CustomSerializerFound : CustomSerializerLookupResult</ID>
     <ID>MaxLineLength:CustomSerializerRegistry.kt$DuplicateCustomSerializerException$*</ID>
     <ID>MaxLineLength:CustomSerializerRegistry.kt$IllegalCustomSerializerException$*</ID>
-    <ID>MaxLineLength:CustomSerializerRegistryTests.kt$CustomSerializerRegistryTests$private fun CustomSerializerRegistry.find(clazz: Class&lt;*&gt;): AMQPSerializer&lt;Any&gt;?</ID>
+    <ID>MaxLineLength:CustomSerializerRegistryTests.kt$CustomSerializerRegistryTests$private fun CustomSerializerRegistry.find(clazz: Class&lt;*>): AMQPSerializer&lt;Any>?</ID>
     <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput$// It must be a reference to an instance that has already been read, cheaply and quickly returning it by reference.</ID>
     <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput$fun</ID>
     <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput$if</ID>
     <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput$serializerFactory.get(obj::class.java, type).readObject(obj, serializationSchemas, metadata, this, context)</ID>
     <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput$throw NotSerializableException("Internal deserialization failure: ${e.javaClass.name}: ${e.message}").apply { initCause(e) }</ID>
-    <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput$val serializer = serializerFactory.get(obj.descriptor.toString(), serializationSchemas, metadata, sandboxGroup)</ID>
+    <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput$val serializer = serializerFactory.get(obj.descriptor.toString(), serializationSchemas, metadata, classloadingContext)</ID>
     <ID>MaxLineLength:DeserializationInput.kt$DeserializationInput.Companion$fun</ID>
-    <ID>MaxLineLength:DeserializeAndReturnEnvelopeTests.kt$DeserializeAndReturnEnvelopeTests$assertEquals(null, obj.envelope.schema.types.find { it.name == "java.lang.Comparable&lt;${classTestName("Foo")}&gt;" })</ID>
-    <ID>MaxLineLength:DeserializeMapTests.kt$DeserializeMapTests$"Class \"java.util.Dictionary&lt;java.lang.String, java.lang.Integer&gt;\" is not annotated with @CordaSerializable"</ID>
+    <ID>MaxLineLength:DeserializeAndReturnEnvelopeTests.kt$DeserializeAndReturnEnvelopeTests$assertEquals(null, obj.envelope.schema.types.find { it.name == "java.lang.Comparable&lt;${classTestName("Foo")}>" })</ID>
+    <ID>MaxLineLength:DeserializeMapTests.kt$DeserializeMapTests$"Class \"java.util.Dictionary&lt;java.lang.String, java.lang.Integer>\" is not annotated with @CordaSerializable"</ID>
     <ID>MaxLineLength:DeserializeMapTests.kt$DeserializeMapTests$"Map type class java.util.HashMap is unstable under iteration. Suggested fix: use java.util.LinkedHashMap instead."</ID>
     <ID>MaxLineLength:DeserializeMapTests.kt$DeserializeMapTests$"Unable to serialise deprecated type class java.util.Hashtable. Suggested fix: prefer java.util.map implementations"</ID>
     <ID>MaxLineLength:DeserializeSimpleTypesTests.kt$DeserializeSimpleTypesTests$garbo [class </ID>
     <ID>MaxLineLength:EnumEvolutionSerializer.kt$EnumEvolutionSerializer$val converted = conversions[enumName] ?: throw AMQPNotSerializableException(type, "No rule to evolve enum constant $type::$enumName")</ID>
     <ID>MaxLineLength:EnumEvolutionSerializer.kt$EnumEvolutionSerializer$val ordinal = ordinals[converted] ?: throw AMQPNotSerializableException(type, "Ordinal not found for enum value $type::$converted")</ID>
-    <ID>MaxLineLength:EnumEvolvabilityTests.kt$EnumEvolvabilityTests$assertThrows&lt;NotSerializableException&gt; { TestSerializationOutput(VERBOSE, sf).serializeAndReturnSchema(C(NotAnnotated.A)) }</ID>
+    <ID>MaxLineLength:EnumEvolvabilityTests.kt$EnumEvolvabilityTests$assertThrows&lt;NotSerializableException> { TestSerializationOutput(VERBOSE, sf).serializeAndReturnSchema(C(NotAnnotated.A)) }</ID>
     <ID>MaxLineLength:EnumEvolvabilityTests.kt$EnumEvolvabilityTests$assertTrue(envelope.transformsSchema.types[WithUnknownTest::class.java.name]!!.containsKey(TransformTypes.Unknown))</ID>
-    <ID>MaxLineLength:EnumEvolvabilityTests.kt$EnumEvolvabilityTests$val envelope = DeserializationInput(sf).deserializeAndReturnEnvelope(SerializedBytes&lt;WrapsUnknown&gt;(sb1)).envelope</ID>
+    <ID>MaxLineLength:EnumEvolvabilityTests.kt$EnumEvolvabilityTests$val envelope = DeserializationInput(sf).deserializeAndReturnEnvelope(SerializedBytes&lt;WrapsUnknown>(sb1)).envelope</ID>
     <ID>MaxLineLength:EnumTransforms.kt$EnumTransforms$"Rename chain from $chainStart to $chainEnd does not end with a known constant in ${constants.keys}"</ID>
     <ID>MaxLineLength:EnumTransforms.kt$EnumTransforms$*</ID>
     <ID>MaxLineLength:EnumTransforms.kt$EnumTransforms$// If there is an existing chain, ending at the "from" node of this edge, then there is a chain from that chain's start</ID>
@@ -1492,27 +1419,29 @@
     <ID>MaxLineLength:EnumTransforms.kt$EnumTransforms$throw InvalidEnumTransformsException("Rename from $from to $to would rename existing constant in $constants.keys")</ID>
     <ID>MaxLineLength:Envelope.kt$Envelope$data</ID>
     <ID>MaxLineLength:Envelope.kt$Envelope.Companion$// We need to cope with objects serialised without the transforms header and without metadata element in the envelope</ID>
-    <ID>MaxLineLength:Envelope.kt$Envelope.Companion$ENVELOPE_WITH_TRANSFORMS, ENVELOPE_WITH_METADATA -&gt; TransformsSchema.newInstance(list[TRANSFORMS_SCHEMA_IDX])</ID>
-    <ID>MaxLineLength:ErrorMessagesTests.kt$ErrorMessagesTests$"Property '$property' or its getter is non public, this renders class 'class $testname\$C' unserializable -&gt; class $testname\$C"</ID>
+    <ID>MaxLineLength:Envelope.kt$Envelope.Companion$ENVELOPE_WITH_TRANSFORMS, ENVELOPE_WITH_METADATA -> TransformsSchema.newInstance(list[TRANSFORMS_SCHEMA_IDX])</ID>
+    <ID>MaxLineLength:ErrorMessagesTests.kt$ErrorMessagesTests$"Property '$property' or its getter is non public, this renders class 'class $testname\$C' unserializable -> class $testname\$C"</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$// or changes to the type itself - such as adding an interface - that do not change its serialisation/deserialisation</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$else</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$private</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$properties.asSequence().zip(localTypeInformation.properties.values.asSequence())</ID>
-    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$properties: Map&lt;String, RemotePropertyInformation&gt;</ID>
+    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$properties: Map&lt;String, RemotePropertyInformation></ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$return EnumEvolutionSerializer(localTypeInformation.observedType, localSerializerFactory, baseTypes, conversions, localOrdinals)</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$return primitiveBoxedTypes[primitiveType] ?: throw IllegalStateException("Unknown primitive type '$primitiveType'")</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$val bestMatchEvolutionConstructor = findEvolverConstructor(localTypeInformation.evolutionConstructors, properties)</ID>
-    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$val convertedOrdinals = remoteOrdinals.asSequence().map { (member, ord) -&gt; ord to conversions[member]!! }.toMap()</ID>
-    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$val propertyTypes = properties.mapValues { (_, info) -&gt; info.type.typeIdentifier.getLocalType(localSerializerFactory.sandboxGroup).asClass() }</ID>
-    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$val remoteClass = remoteProperty.type.typeIdentifier.getLocalType(localSerializerFactory.sandboxGroup).asClass()</ID>
+    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$val convertedOrdinals = remoteOrdinals.asSequence().map { (member, ord) -> ord to conversions[member]!! }.toMap()</ID>
+    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$val propertyTypes = properties.mapValues { (_, info) -> info.type.typeIdentifier.getLocalType(localSerializerFactory.classloadingContext).asClass() }</ID>
+    <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$val remoteClass = remoteProperty.type.typeIdentifier.getLocalType(localSerializerFactory.classloadingContext).asClass()</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$||</ID>
     <ID>MaxLineLength:EvolutionSerializerFactory.kt$EvolutionSerializerFactory$*</ID>
     <ID>MaxLineLength:EvolutionSerializerFactoryTests.kt$EvolutionSerializerFactoryTests$assertTrue(e.message!!.contains("Non-null value 1 provided for property b, which is not supported in this version"))</ID>
-    <ID>MaxLineLength:EvolutionSerializerFactoryTests.kt$EvolutionSerializerFactoryTests$val withNonNullTarget = DeserializationInput(nonStrictFactory).deserialize(SerializedBytes&lt;C&gt;(withoutNullUrl.readBytes()))</ID>
-    <ID>MaxLineLength:EvolutionSerializerFactoryTests.kt$EvolutionSerializerFactoryTests$val withNullTarget = DeserializationInput(strictFactory).deserialize(SerializedBytes&lt;C&gt;(withNullUrl.readBytes()))</ID>
+    <ID>MaxLineLength:EvolutionSerializerFactoryTests.kt$EvolutionSerializerFactoryTests$val withNonNullTarget = DeserializationInput(nonStrictFactory).deserialize(SerializedBytes&lt;C>(withoutNullUrl.readBytes()))</ID>
+    <ID>MaxLineLength:EvolutionSerializerFactoryTests.kt$EvolutionSerializerFactoryTests$val withNullTarget = DeserializationInput(strictFactory).deserialize(SerializedBytes&lt;C>(withNullUrl.readBytes()))</ID>
     <ID>MaxLineLength:EvolvabilityTests.kt$EvolvabilityTests$// File(URI("$localPath/$resource")).writeBytes(SerializationOutput(sf).serialize(CC(1, "hello", "world", 2)).bytes)</ID>
     <ID>MaxLineLength:FingerPrinterTesting.kt$FingerPrinterTestingTests$val customSerializerRegistry: CustomSerializerRegistry = CachingCustomSerializerRegistry(descriptorBasedSerializerRegistry)</ID>
+    <ID>MaxLineLength:GenericsTests.kt$GenericsTests$factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())</ID>
     <ID>MaxLineLength:GenericsTests.kt$GenericsTests$val bytes = SerializationOutput(factory).serializeAndReturnSchema(Wrapper(1, G1("hi"), G2("bye"))).apply { printSchema() }</ID>
+    <ID>MaxLineLength:GenericsTests.kt$GenericsTests$val factories = listOf(factory, SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()))</ID>
     <ID>MaxLineLength:GenericsTests.kt$GenericsTests.LTransactionState$data</ID>
     <ID>MaxLineLength:GenericsTests.kt$GenericsTests.StateWrapper$data</ID>
     <ID>MaxLineLength:InputStreamTest.kt$InputStreamTest$assertArrayEquals(testResource().readBytes().drop(bytesToDrop).toByteArray(), deserializedInputStream.readAllBytes())</ID>
@@ -1532,9 +1461,9 @@
     <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$is LocalTypeInformation.ACollection</ID>
     <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$is LocalTypeInformation.AMap</ID>
     <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$private</ID>
-    <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$private val serializersByActualAndDeclaredType: MutableMap&lt;ActualAndDeclaredType, AMQPSerializer&lt;Any&gt;&gt; = DefaultCacheProvider.createCache()</ID>
-    <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$private val serializersByTypeId: MutableMap&lt;TypeIdentifier, AMQPSerializer&lt;Any&gt;&gt; = DefaultCacheProvider.createCache()</ID>
-    <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$val actualType: Type = inferTypeVariables(actualClass, declaredClass, declaredType, sandboxGroup) ?: declaredType</ID>
+    <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$private val serializersByActualAndDeclaredType: MutableMap&lt;ActualAndDeclaredType, AMQPSerializer&lt;Any>> = DefaultCacheProvider.createCache()</ID>
+    <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$private val serializersByTypeId: MutableMap&lt;TypeIdentifier, AMQPSerializer&lt;Any>> = DefaultCacheProvider.createCache()</ID>
+    <ID>MaxLineLength:LocalSerializerFactory.kt$DefaultLocalSerializerFactory$val actualType: Type = inferTypeVariables(actualClass, declaredClass, declaredType, classloadingContext) ?: declaredType</ID>
     <ID>MaxLineLength:LocalSerializerFactory.kt$LocalSerializerFactory$*</ID>
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation$*</ID>
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation.ACollection$data</ID>
@@ -1549,14 +1478,14 @@
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation.Atomic$data</ID>
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation.Companion$*</ID>
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation.Companion$throw IllegalStateException("Should not be attempting to build new type information when populating a cycle")</ID>
-    <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation.NonComposable$val nonComposableTypes: Set&lt;NonComposable&gt; get() = nonComposableSubtypes.flatMapTo(LinkedHashSet()) { it.nonComposableTypes } + this</ID>
+    <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation.NonComposable$val nonComposableTypes: Set&lt;NonComposable> get() = nonComposableSubtypes.flatMapTo(LinkedHashSet()) { it.nonComposableTypes } + this</ID>
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformation.Singleton$data</ID>
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformationPrettyPrinter$private</ID>
     <ID>MaxLineLength:LocalTypeInformation.kt$LocalTypeInformationPrettyPrinter$private data</ID>
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$*</ID>
-    <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$constructorInformation.parameters[index].isMandatory &amp;&amp; index !in indicesAddressedByProperties -&gt; parameter</ID>
+    <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$constructorInformation.parameters[index].isMandatory &amp;&amp; index !in indicesAddressedByProperties -> parameter</ID>
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$constructorInformation: LocalConstructorInformation</ID>
-    <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$is TypeIdentifier.Parameterised -&gt; buildForParameterised(rawType, type as ParameterizedType, typeIdentifier, isOpaque)</ID>
+    <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$is TypeIdentifier.Parameterised -> buildForParameterised(rawType, type as ParameterizedType, typeIdentifier, isOpaque)</ID>
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$it.name ?: throw IllegalStateException("Unnamed parameter in constructor $observedConstructor")</ID>
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$name to LocalPropertyInformation.ReadOnlyProperty(descriptor.getter, paramTypeInformation, isMandatory)</ID>
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$private</ID>
@@ -1567,7 +1496,7 @@
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$suppressValidation { buildNonAtomic(rawType, type, typeIdentifier, buildTypeParameterInformation(type)) }</ID>
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$throw NotSerializableException("Type '${type.typeName} has synthetic fields and is likely a nested inner class.")</ID>
     <ID>MaxLineLength:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$val</ID>
-    <ID>MaxLineLength:LocalTypeInformationBuilder.kt$private inline val Class&lt;*&gt;.isTypeWithoutConstructor: Boolean get() = !isConcreteClass || isSynthetic || isAnonymousClass</ID>
+    <ID>MaxLineLength:LocalTypeInformationBuilder.kt$private inline val Class&lt;*>.isTypeWithoutConstructor: Boolean get() = !isConcreteClass || isSynthetic || isAnonymousClass</ID>
     <ID>MaxLineLength:LocalTypeModel.kt$ConfigurableLocalTypeModel$*</ID>
     <ID>MaxLineLength:LocalTypeModel.kt$ConfigurableLocalTypeModel.BuilderLookup$override</ID>
     <ID>MaxLineLength:LocalTypeModel.kt$LocalTypeLookup$*</ID>
@@ -1578,15 +1507,15 @@
     <ID>MaxLineLength:LocalTypeModelTests.kt$LocalTypeModelTests.NonComposableNested$class</ID>
     <ID>MaxLineLength:MapSerializer.kt$MapSerializer$class</ID>
     <ID>MaxLineLength:MapSerializer.kt$MapSerializer$override</ID>
-    <ID>MaxLineLength:MapSerializer.kt$MapSerializer$val entries: Iterable&lt;Pair&lt;Any?, Any?&gt;&gt; = (obj as Map&lt;*, *&gt;).map { readEntry(serializationSchemas, metadata, input, it, context) }</ID>
+    <ID>MaxLineLength:MapSerializer.kt$MapSerializer$val entries: Iterable&lt;Pair&lt;Any?, Any?>> = (obj as Map&lt;*, *>).map { readEntry(serializationSchemas, metadata, input, it, context) }</ID>
     <ID>MaxLineLength:MapSerializer.kt$MapSerializer.Companion$else</ID>
-    <ID>MaxLineLength:MapSerializer.kt$MapSerializer.Companion$else -&gt; erasedInformation.withParameters(LocalTypeInformation.Unknown, LocalTypeInformation.Unknown, sandboxGroup)</ID>
+    <ID>MaxLineLength:MapSerializer.kt$MapSerializer.Companion$else -> erasedInformation.withParameters(LocalTypeInformation.Unknown, LocalTypeInformation.Unknown, classloadingContext)</ID>
     <ID>MaxLineLength:MapSerializer.kt$MapSerializer.Companion$fun</ID>
     <ID>MaxLineLength:MapSerializer.kt$MapSerializer.Companion$private</ID>
     <ID>MaxLineLength:ObjectBuilder.kt$ConstructorBasedObjectBuilder$"Argument indexes must be in ${params.indices}. Slot to arg indexes passed in are ${slotToCtorArgIdx.toList()}"</ID>
     <ID>MaxLineLength:ObjectBuilder.kt$EvolutionObjectBuilder.Companion$*</ID>
     <ID>MaxLineLength:ObjectBuilder.kt$ObjectBuilder.Companion$*</ID>
-    <ID>MaxLineLength:ObjectBuilder.kt$ObjectBuilder.Companion$is LocalPropertyInformation.PrivateConstructorPairedProperty -&gt; property.constructorSlot.parameterIndex</ID>
+    <ID>MaxLineLength:ObjectBuilder.kt$ObjectBuilder.Companion$is LocalPropertyInformation.PrivateConstructorPairedProperty -> property.constructorSlot.parameterIndex</ID>
     <ID>MaxLineLength:ObjectBuilder.kt$ObjectBuilder.Companion$private</ID>
     <ID>MaxLineLength:ObjectBuilder.kt$ObjectBuilderProvider$*</ID>
     <ID>MaxLineLength:ObjectSerializer.kt$AbstractObjectSerializer$override</ID>
@@ -1596,9 +1525,9 @@
     <ID>MaxLineLength:ObjectSerializer.kt$ComposableObjectSerializer$override fun writeClassInfo(output: SerializationOutput, context: SerializationContext)</ID>
     <ID>MaxLineLength:ObjectSerializer.kt$EvolutionObjectSerializer$override</ID>
     <ID>MaxLineLength:ObjectSerializer.kt$EvolutionObjectSerializer.Companion$ComposableTypePropertySerializer.makeForEvolution(name, isCalculated, property.type.typeIdentifier, type)</ID>
-    <ID>MaxLineLength:ObjectSerializer.kt$EvolutionObjectSerializer.Companion$val propertySerializers = makePropertySerializers(properties, remoteTypeInformation.properties, sandboxGroup)</ID>
-    <ID>MaxLineLength:ObjectSerializer.kt$EvolutionObjectSerializer.Companion$val type = localProperty?.type?.observedType ?: property.type.typeIdentifier.getLocalType(sandboxGroup)</ID>
-    <ID>MaxLineLength:ObjectSerializer.kt$ObjectSerializer.Companion$serializers.isNotEmpty() -&gt; "Registered custom serializers:\n ${serializers.joinToString("\n ")}"</ID>
+    <ID>MaxLineLength:ObjectSerializer.kt$EvolutionObjectSerializer.Companion$val propertySerializers = makePropertySerializers(properties, remoteTypeInformation.properties, classloadingContext)</ID>
+    <ID>MaxLineLength:ObjectSerializer.kt$EvolutionObjectSerializer.Companion$val type = localProperty?.type?.observedType ?: property.type.typeIdentifier.getLocalType(classloadingContext)</ID>
+    <ID>MaxLineLength:ObjectSerializer.kt$ObjectSerializer.Companion$serializers.isNotEmpty() -> "Registered custom serializers:\n ${serializers.joinToString("\n ")}"</ID>
     <ID>MaxLineLength:ObjectSerializer.kt$ObjectSerializer.Companion$val writer = ComposableObjectWriter(typeNotation, typeInformation.interfacesOrEmptyList, propertySerializers)</ID>
     <ID>MaxLineLength:OptionalSerializer.kt$OptionalSerializer$* A serializer for [Optional] that uses a proxy object to write out the value stored in the optional or [Optional.EMPTY].</ID>
     <ID>MaxLineLength:OptionalSerializerTest.kt$OptionalSerializerTest$val</ID>
@@ -1608,7 +1537,6 @@
     <ID>MaxLineLength:PrivatePropertyTests.kt$PrivatePropertyTests$assertThat(typeInformation.properties["b"] is LocalPropertyInformation.PrivateConstructorPairedProperty).isTrue()</ID>
     <ID>MaxLineLength:PropertyDescriptor.kt$// Construct a map of PropertyDescriptors by name, by merging the raw field map with the map of classified property methods</ID>
     <ID>MaxLineLength:PropertyDescriptor.kt$// Merge the given method into a map of methods by method classifier, picking the least generic method for each classifier.</ID>
-    <ID>MaxLineLength:PropertyDescriptor.kt$?:</ID>
     <ID>MaxLineLength:PropertyDescriptor.kt$private</ID>
     <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$*</ID>
     <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$// Are the remote/local types evolvable? If so, ask the evolution serializer factory for a serializer, returning</ID>
@@ -1617,8 +1545,9 @@
     <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$// This will save us having to re-interpret the entire schema on re-entry when deserialising individual property values.</ID>
     <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$// serialiser (BlobInspectorTest uniquely breaks if we throw an exception here, and passes if we just warn and continue).</ID>
     <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$RemoteAndLocalTypeInformation(remoteInformation, localInformationByIdentifier.getValue(remoteInformation.typeIdentifier))</ID>
-    <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$getUncached(remoteLocalPair.remoteTypeInformation, remoteLocalPair.localTypeInformation, sandboxGroup, metadata)</ID>
+    <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$getUncached(remoteLocalPair.remoteTypeInformation, remoteLocalPair.localTypeInformation, classloadingContext, metadata)</ID>
     <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$private</ID>
+    <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$remoteTypeInformation.isCompatibleWith(localTypeInformation, classloadingContext, metadata) -> localSerializer</ID>
     <ID>MaxLineLength:RemoteSerializerFactory.kt$DefaultRemoteSerializerFactory$val</ID>
     <ID>MaxLineLength:RemoteTypeInformation.kt$RemoteTypeInformation$*</ID>
     <ID>MaxLineLength:RemoteTypeInformation.kt$RemoteTypeInformation.AnArray$data</ID>
@@ -1627,40 +1556,38 @@
     <ID>MaxLineLength:RemoteTypeInformation.kt$RemoteTypeInformation.Unparameterised$data</ID>
     <ID>MaxLineLength:RemoteTypeInformation.kt$RemoteTypeInformationPrettyPrinter$private data</ID>
     <ID>MaxLineLength:Schema.kt$CompositeType.Companion$return CompositeType(list[0] as String, list[1] as? String, uncheckedCast(list[2]), list[3] as Descriptor, uncheckedCast(list[4]))</ID>
-    <ID>MaxLineLength:Schema.kt$CompositeType.Companion$return newInstance(listOf(list[0], list[1], list[2], Descriptor.get(list[3]!!), (list[4] as List&lt;*&gt;).map { Field.get(it!!) }))</ID>
+    <ID>MaxLineLength:Schema.kt$CompositeType.Companion$return newInstance(listOf(list[0], list[1], list[2], Descriptor.get(list[3]!!), (list[4] as List&lt;*>).map { Field.get(it!!) }))</ID>
     <ID>MaxLineLength:Schema.kt$Field.Companion$return Field(list[0] as String, list[1] as String, uncheckedCast(list[2]), list[3] as? String, list[4] as? String, list[5] as Boolean, list[6] as Boolean)</ID>
     <ID>MaxLineLength:Schema.kt$RestrictedType.Companion$return RestrictedType(list[0] as String, list[1] as? String, uncheckedCast(list[2]), list[3] as String, list[4] as Descriptor, uncheckedCast(list[5]))</ID>
-    <ID>MaxLineLength:Schema.kt$RestrictedType.Companion$return newInstance(listOf(list[0], list[1], list[2], list[3], Descriptor.get(list[4]!!), (list[5] as List&lt;*&gt;).map { Choice.get(it!!) }))</ID>
+    <ID>MaxLineLength:Schema.kt$RestrictedType.Companion$return newInstance(listOf(list[0], list[1], list[2], list[3], Descriptor.get(list[4]!!), (list[5] as List&lt;*>).map { Choice.get(it!!) }))</ID>
     <ID>MaxLineLength:Schema.kt$fun typeDescriptorFor(typeId: TypeIdentifier): Symbol</ID>
     <ID>MaxLineLength:Schema.kt$return</ID>
     <ID>MaxLineLength:SerializationCompatibilityTests.kt$SerializationCompatibilityTests$assertThat(factory.get(StableFingerprintTest::class.java).typeDescriptor.toString()).isEqualTo("net.corda:zbvSPLDAvP9+Hlml5i3ZOw==")</ID>
     <ID>MaxLineLength:SerializationFormat.kt$SectionId.DATA_AND_STOP$/** Serialization data follows, and then discard the rest of the stream (if any) as legacy data may have trailing garbage. */</ID>
     <ID>MaxLineLength:SerializationFormat.kt$SectionId.ENCODING$/** The ordinal of a [CordaSerializationEncoding] follows, which should be used to decode the remainder of the stream. */</ID>
+    <ID>MaxLineLength:SerializationHelper.kt$is ParameterizedType</ID>
     <ID>MaxLineLength:SerializationOutput.kt$SerializationOutput$*</ID>
     <ID>MaxLineLength:SerializationOutput.kt$SerializationOutput$// Skip for primitive types as they are too small and overhead of referencing them will be much higher than their content</ID>
     <ID>MaxLineLength:SerializationOutput.kt$SerializationOutput$return BytesAndSchemas(blob, schema, TransformsSchema.build(schema, serializerFactory, metadata), Metadata())</ID>
-    <ID>MaxLineLength:SerializationOutput.kt$SerializationOutput$writeObject(obj, data, if (type == TypeIdentifier.UnknownType.getLocalType(context.currentSandboxGroup())) obj.javaClass else type, context, debugIndent)</ID>
+    <ID>MaxLineLength:SerializationOutput.kt$SerializationOutput$writeObject(obj, data, if (type == TypeIdentifier.UnknownType.getLocalType(context.currentClassloadingContext())) obj.javaClass else type, context, debugIndent)</ID>
     <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$// Ordinarily this might be considered high maintenance, but we promised wire compatibility, so they'd better not change!</ID>
-    <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$catchThrowable { input.deserialize(compressed, testSerializationContext.withEncodingWhitelist(encodingWhitelist)) }</ID>
-    <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$des.deserialize(OpaqueBytes(copy), NonZeroByte::class.java, testSerializationContext.withEncodingWhitelist(encodingWhitelist))</ID>
-    <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$freshDeserializationFactory: SerializerFactory = testDefaultFactoryNoEvolution()</ID>
-    <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$t.suppressed.zip(desThrowable.suppressed).forEach { (before, after) -&gt; assertSerializedThrowableEquivalent(before, after) }</ID>
-    <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$withSerializationContext: SerializationContext = testSerializationContext</ID>
+    <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$t.suppressed.zip(desThrowable.suppressed).forEach { (before, after) -> assertSerializedThrowableEquivalent(before, after) }</ID>
+    <ID>MaxLineLength:SerializationOutputTests.kt$SerializationOutputTests$val ser = SerializationOutput(SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()))</ID>
     <ID>MaxLineLength:SerializationScheme.kt$SerializationContextImpl$override</ID>
-    <ID>MaxLineLength:SerializationScheme.kt$SerializationContextImpl$override fun withEncodingWhitelist(encodingWhitelist: EncodingWhitelist)</ID>
+    <ID>MaxLineLength:SerializationScheme.kt$SerializationContextImpl$override fun withEncodingAllowList(encodingAllowList: EncodingAllowList)</ID>
     <ID>MaxLineLength:SerializationScheme.kt$SerializationContextImpl$override fun withPreferredSerializationVersion(magic: SerializationMagic)</ID>
     <ID>MaxLineLength:SerializationScheme.kt$SerializationFactoryImpl$"${if (magic == amqpMagic) "AMQP" else "UNKNOWN MAGIC"}] registeredSchemes are: $registeredSchemes"</ID>
     <ID>MaxLineLength:SerializationScheme.kt$SerializationFactoryImpl$private</ID>
-    <ID>MaxLineLength:SerializationScheme.kt$SerializationFactoryImpl$private val registeredSchemes: MutableCollection&lt;SerializationScheme&gt; = Collections.synchronizedCollection(mutableListOf())</ID>
+    <ID>MaxLineLength:SerializationScheme.kt$SerializationFactoryImpl$private val registeredSchemes: MutableCollection&lt;SerializationScheme> = Collections.synchronizedCollection(mutableListOf())</ID>
     <ID>MaxLineLength:SerializerFactoryBuilder.kt$NoEvolutionSerializerFactory$override</ID>
+    <ID>MaxLineLength:SerializerFactoryBuilder.kt$SerializerFactoryBuilder$val fingerPrinter = overrideFingerPrinter ?: TypeModellingFingerPrinter(customSerializerRegistry, classloadingContext)</ID>
     <ID>MaxLineLength:SingletonSerializeAsTokenTest.kt$SingletonSerializeAsTokenTest$fun</ID>
     <ID>MaxLineLength:StackTraceElementSerializer.kt$StackTraceElementSerializer$class</ID>
     <ID>MaxLineLength:SupportedTransforms.kt$SupportedTransform$*</ID>
-    <ID>MaxLineLength:TestSerializationContext.kt$MockSandboxGroup$private</ID>
     <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$val bytes = ThrowableEvolutionTests::class.java.getResource("ThrowableEvolutionTests.AddConstructorParametersException").readBytes()</ID>
-    <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$val deserializedException = DeserializationInput(sf).deserialize(SerializedBytes&lt;AddAndRemoveConstructorParametersException&gt;(bytes))</ID>
-    <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$val deserializedException = DeserializationInput(sf).deserialize(SerializedBytes&lt;AddConstructorParametersException&gt;(bytes))</ID>
-    <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$val deserializedException = DeserializationInput(sf).deserialize(SerializedBytes&lt;RemoveConstructorParametersException&gt;(bytes))</ID>
+    <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$val deserializedException = DeserializationInput(sf).deserialize(SerializedBytes&lt;AddAndRemoveConstructorParametersException>(bytes))</ID>
+    <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$val deserializedException = DeserializationInput(sf).deserialize(SerializedBytes&lt;AddConstructorParametersException>(bytes))</ID>
+    <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$val deserializedException = DeserializationInput(sf).deserialize(SerializedBytes&lt;RemoveConstructorParametersException>(bytes))</ID>
     <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests.AddAndRemoveConstructorParametersException$// class AddAndRemoveConstructorParametersException(message: String, val toBeRemoved: String) : CordaRuntimeException(message)</ID>
     <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests.AddAndRemoveConstructorParametersException$class</ID>
     <ID>MaxLineLength:ThrowableEvolutionTests.kt$ThrowableEvolutionTests.RemoveConstructorParametersException$// class RemoveConstructorParametersException(message: String, val toBeRemoved: String) : CordaRuntimeException(message)</ID>
@@ -1669,11 +1596,13 @@
     <ID>MaxLineLength:TransformsSchema.kt$TransformsAnnotationProcessor$* Processes the annotations applied to classes intended for serialisation, to get the transforms that can be applied to them.</ID>
     <ID>MaxLineLength:TransformsSchema.kt$TransformsAnnotationProcessor$private</ID>
     <ID>MaxLineLength:TypeIdentifier.kt$TypeIdentifier.Companion$*</ID>
-    <ID>MaxLineLength:TypeIdentifier.kt$TypeIdentifier.Companion$is GenericArrayType -&gt; ArrayOf(forGenericType(type.genericComponentType.resolveAgainst(resolutionContext)))</ID>
+    <ID>MaxLineLength:TypeIdentifier.kt$TypeIdentifier.Companion$is GenericArrayType -> ArrayOf(forGenericType(type.genericComponentType.resolveAgainst(resolutionContext)))</ID>
     <ID>MaxLineLength:TypeIdentifier.kt$TypeIdentifier.Parameterised$data</ID>
+    <ID>MaxLineLength:TypeIdentifier.kt$TypeIdentifier.UnknownType$override fun getLocalType(classloadingContext: ClassloadingContext, metadata: Metadata): Type</ID>
+    <ID>MaxLineLength:TypeLoader.kt$ClassTypeLoader$identifier to cache.computeIfAbsent(identifier) { identifier.getLocalType(classloadingContext, metadata) }</ID>
     <ID>MaxLineLength:TypeModellingFingerPrinter.kt$FingerPrintingState$writer.writeAlreadySeen()</ID>
     <ID>MaxLineLength:TypeParameterUtils.kt$// The actual class can never have type variables resolved, due to the JVM's use of type erasure, so let's try and resolve them</ID>
-    <ID>MaxLineLength:TypeParameterUtils.kt$inferTypeVariables(actualClass.componentType, declaredComponent.asClass(), declaredComponent, sandboxGroup)?.asArray(sandboxGroup)</ID>
+    <ID>MaxLineLength:TypeParameterUtils.kt$inferTypeVariables(actualClass.componentType, declaredComponent.asClass(), declaredComponent, classloadingContext)?.asArray(classloadingContext)</ID>
     <ID>MaxLineLength:TypeParameterUtils.kt$private</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.PathUtils.kt:11</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.SerializationCompatibilityTests.kt:19</ID>
@@ -1683,16 +1612,18 @@
     <ID>MaximumLineLength:net.corda.internal.serialization.SerializationScheme.kt:64</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.SerializationScheme.kt:82</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.SerializationScheme.kt:88</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:100</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:109</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:116</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:124</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:148</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:35</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:46</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:52</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:80</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:87</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:108</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:115</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:123</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:147</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:183</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:206</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:34</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:45</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:51</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:79</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:86</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:98</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:99</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:36</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:40</ID>
@@ -1700,13 +1631,15 @@
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:78</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:121</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:145</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:155</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:156</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:65</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:70</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:88</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParserTests.kt:114</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParserTests.kt:224</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParserTests.kt:88</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParserTests.kt:94</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:96</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParserTests.kt:117</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParserTests.kt:91</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParserTests.kt:97</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifiers.kt:65</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.AMQPTypeIdentifiers.kt:70</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.ComposableTypePropertySerializer.kt:110</ID>
@@ -1731,9 +1664,9 @@
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializationInput.kt:72</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializationInput.kt:89</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializeAndReturnEnvelopeTests.kt:72</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:113</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:127</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:96</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:102</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:119</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:133</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.EnumEvolvabilityTests.kt:464</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.EnumEvolvabilityTests.kt:467</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.EnumEvolvabilityTests.kt:75</ID>
@@ -1760,28 +1693,33 @@
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.EvolutionSerializerFactoryTests.kt:70</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.FingerPrinterTesting.kt:39</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:105</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:180</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:236</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:246</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:254</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:262</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:534</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.GenericsTests.kt:536</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:126</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:127</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:128</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:206</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:212</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:240</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:245</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:247</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:255</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:263</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:278</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:288</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:205</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:211</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:239</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:244</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:246</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:254</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:262</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:277</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:287</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.ObjectBuilder.kt:121</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.ObjectBuilder.kt:141</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.ObjectBuilder.kt:226</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PrivatePropertyTests.kt:149</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PrivatePropertyTests.kt:44</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:143</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:175</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:188</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:229</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:135</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:148</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:189</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.RemoteSerializerFactory.kt:133</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.RemoteSerializerFactory.kt:155</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.RemoteSerializerFactory.kt:157</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.RemoteSerializerFactory.kt:162</ID>
@@ -1793,14 +1731,13 @@
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.Schema.kt:263</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.Schema.kt:270</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.Schema.kt:31</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationHelper.kt:86</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutput.kt:123</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutput.kt:65</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:234</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:237</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:513</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:572</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:871</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:171</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:1017</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:579</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:140</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:176</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.SingletonSerializeAsTokenTest.kt:36</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.ThrowableEvolutionTests.kt:40</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.ThrowableEvolutionTests.kt:48</ID>
@@ -1822,39 +1759,36 @@
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.custom.StackTraceElementSerializer.kt:5</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.custom.ThrowableSerializer.kt:85</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.custom.ThrowableSerializer.kt:95</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:109</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:190</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:174</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:93</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:111</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:113</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:116</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:121</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:45</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:61</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:87</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:92</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:30</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:76</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:55</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:56</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:121</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:153</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:42</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:49</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:69</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:73</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:79</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:83</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:97</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:129</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:131</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:185</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:192</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:208</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:229</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:253</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:254</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:263</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:266</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:69</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:84</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.testutils.AMQPTestUtils.kt:52</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt:12</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:105</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:137</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:26</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:33</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:53</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:57</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:63</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:67</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:81</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:114</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:116</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:170</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:177</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:193</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:214</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:238</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:239</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:248</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:251</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:53</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:68</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.EnumTransforms.kt:120</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.EnumTransforms.kt:95</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalPropertyInformation.kt:26</ID>
@@ -1874,41 +1808,43 @@
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformation.kt:371</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformation.kt:397</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformation.kt:80</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:110</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:114</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:183</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:229</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:247</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:266</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:111</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:115</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:184</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:230</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:248</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:267</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:286</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:301</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:334</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:340</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:384</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:388</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:393</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:397</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:268</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:287</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:302</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:335</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:341</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:385</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:389</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:394</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:398</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:420</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:475</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:477</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:484</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:506</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:399</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:421</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:467</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:469</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:476</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:498</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModel.kt:22</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModel.kt:77</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:178</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:210</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:28</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:74</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:157</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:189</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:27</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.LocalTypeModelTests.kt:73</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.RemoteTypeInformation.kt:103</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.RemoteTypeInformation.kt:110</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.RemoteTypeInformation.kt:129</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.RemoteTypeInformation.kt:146</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.RemoteTypeInformation.kt:96</ID>
     <ID>MaximumLineLength:net.corda.internal.serialization.model.TypeIdentifier.kt:118</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.TypeIdentifier.kt:238</ID>
-    <ID>MaximumLineLength:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:177</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.TypeIdentifier.kt:146</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.TypeIdentifier.kt:242</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.TypeLoader.kt:47</ID>
+    <ID>MaximumLineLength:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:178</ID>
     <ID>MemberNameEqualsClassName:Schema.kt$Descriptor.Companion$@JvmField val DESCRIPTOR = AMQPDescriptorRegistry.OBJECT_DESCRIPTOR.amqpDescriptor</ID>
     <ID>NewLineAtEndOfFile:AMQPExceptions.kt$net.corda.internal.serialization.amqp.AMQPExceptions.kt</ID>
     <ID>NewLineAtEndOfFile:AMQPPrimitiveSerializer.kt$net.corda.internal.serialization.amqp.standard.AMQPPrimitiveSerializer.kt</ID>
@@ -1960,7 +1896,6 @@
     <ID>NewLineAtEndOfFile:StaticInitialisationOfSerializedObjectTest.kt$net.corda.internal.serialization.amqp.StaticInitialisationOfSerializedObjectTest.kt</ID>
     <ID>NewLineAtEndOfFile:StreamTests.kt$net.corda.internal.serialization.amqp.StreamTests.kt</ID>
     <ID>NewLineAtEndOfFile:TestCertificate.kt$net.corda.internal.serialization.amqp.custom.TestCertificate.kt</ID>
-    <ID>NewLineAtEndOfFile:TestSerializationContext.kt$net.corda.internal.serialization.amqp.testutils.TestSerializationContext.kt</ID>
     <ID>NewLineAtEndOfFile:ThrowableEvolutionTests.kt$net.corda.internal.serialization.amqp.ThrowableEvolutionTests.kt</ID>
     <ID>NewLineAtEndOfFile:TypeIdentifier.kt$net.corda.internal.serialization.model.TypeIdentifier.kt</ID>
     <ID>NewLineAtEndOfFile:TypeIdentifierTests.kt$net.corda.internal.serialization.model.TypeIdentifierTests.kt</ID>
@@ -1976,14 +1911,14 @@
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.ComposableTypePropertySerializer.kt:39</ID>
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:659</ID>
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:670</ID>
-    <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:306</ID>
-    <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:167</ID>
+    <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:305</ID>
+    <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:172</ID>
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.TransformsSchema.kt:239</ID>
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.custom.DayOfWeekSerializer.kt:17</ID>
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.custom.MonthDayTest.kt:21</ID>
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.custom.YearMonthTest.kt:15</ID>
     <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.custom.ZonedDateTimeTest.kt:29</ID>
-    <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:268</ID>
+    <ID>NoBlankLineBeforeRbrace:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:253</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.SerializationFormat.kt:70</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.amqp.CorDappSerializerTests.kt:127</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:673</ID>
@@ -2002,7 +1937,7 @@
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.amqp.custom.InputStreamTest.kt:59</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.amqp.custom.MonthSerializer.kt:19</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.amqp.custom.ThrowableSerializer.kt:118</ID>
-    <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:198</ID>
+    <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:182</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.model.LocalPropertyInformation.kt:62</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.model.LocalTypeInformation.kt:419</ID>
     <ID>NoConsecutiveBlankLines:net.corda.internal.serialization.model.RemoteTypeInformation.kt:182</ID>
@@ -2047,17 +1982,31 @@
     <ID>NoLineBreakBeforeAssignment:net.corda.internal.serialization.amqp.custom.YearSerializer.kt:18</ID>
     <ID>NoLineBreakBeforeAssignment:net.corda.internal.serialization.amqp.custom.ZonedDateTimeSerializer.kt:18</ID>
     <ID>NoLineBreakBeforeAssignment:net.corda.internal.serialization.amqp.custom.ZonedDateTimeSerializer.kt:21</ID>
-    <ID>NoMultipleSpaces:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:802</ID>
+    <ID>NoMultipleSpaces:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:809</ID>
     <ID>NoMultipleSpaces:net.corda.internal.serialization.amqp.custom.ClassSerializer.kt:23</ID>
-    <ID>NoMultipleSpaces:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:61</ID>
+    <ID>NoMultipleSpaces:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:45</ID>
     <ID>NoMultipleSpaces:net.corda.internal.serialization.model.LocalTypeInformation.kt:74</ID>
     <ID>NoTrailingSpaces:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:69</ID>
     <ID>NoTrailingSpaces:net.corda.internal.serialization.amqp.custom.PairSerializer.kt:20</ID>
     <ID>NoTrailingSpaces:net.corda.internal.serialization.amqp.custom.ThrowableTest.kt:48</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:52</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:54</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:58</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:61</ID>
+    <ID>NoUnusedImports:net.corda.internal.serialization.AMQPSerializationScheme.kt:12</ID>
+    <ID>NoUnusedImports:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:5</ID>
+    <ID>NoUnusedImports:net.corda.internal.serialization.amqp.RemoteSerializerFactory.kt:8</ID>
+    <ID>NoUnusedImports:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:11</ID>
+    <ID>NoUnusedImports:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:11</ID>
+    <ID>NoWildcardImports:net.corda.internal.serialization.AMQPSerializationScheme.kt:11</ID>
+    <ID>NoWildcardImports:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:3</ID>
+    <ID>NoWildcardImports:net.corda.internal.serialization.amqp.standard.CollectionSerializer.kt:3</ID>
+    <ID>NoWildcardImports:net.corda.internal.serialization.amqp.standard.CustomSerializer.kt:3</ID>
+    <ID>NoWildcardImports:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:3</ID>
+    <ID>NoWildcardImports:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:3</ID>
+    <ID>NoWildcardImports:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:3</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:21</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:23</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:123</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:57</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:60</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:98</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:36</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPSerializer.kt:34</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.AMQPSerializer.kt:35</ID>
@@ -2100,46 +2049,42 @@
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:95</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.GenericsTests.kt:534</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.GenericsTests.kt:536</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:115</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:206</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:114</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:205</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.ObjectBuilder.kt:141</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.RemoteSerializerFactory.kt:155</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.Schema.kt:133</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.Schema.kt:247</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.Schema.kt:252</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.SerializationOutput.kt:21</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:232</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:237</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:112</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:129</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:115</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.SupportedTransforms.kt:21</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TransformsSchema.kt:219</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:35</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:13</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:16</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:12</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:30</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:58</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:80</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:86</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.AMQPPrimitiveSerializer.kt:44</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:104</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:105</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:160</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:161</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:170</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:171</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:191</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:192</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:202</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:203</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:213</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:214</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:223</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:224</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:234</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:235</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:91</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:92</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:144</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:145</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:154</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:155</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:175</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:176</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:186</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:187</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:197</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:198</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:207</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:208</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:218</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:219</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:75</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:76</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:88</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:89</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:110</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:111</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:95</ID>
@@ -2149,39 +2094,40 @@
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:51</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:65</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:66</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:36</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:37</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:50</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:51</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:64</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:65</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:150</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:151</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:157</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:158</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:79</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:113</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:114</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:127</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:131</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:134</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:135</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:157</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:179</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:180</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:204</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:134</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:135</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:141</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:142</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:53</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:63</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:112</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:116</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:119</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:120</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:142</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:164</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:165</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:189</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:193</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:196</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:197</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:205</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:208</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:211</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:212</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:220</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:223</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:228</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:247</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:249</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:263</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:266</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:79</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:82</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:89</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:92</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:213</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:232</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:234</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:248</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:251</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:63</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:66</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:73</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:76</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:97</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:98</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:44</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:45</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:52</ID>
@@ -2205,23 +2151,24 @@
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:290</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:321</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:322</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:325</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:351</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:361</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:369</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:371</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:170</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:188</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:171</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:189</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:199</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:190</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:200</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:229</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:301</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:418</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:420</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:51</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:55</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:201</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:230</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:302</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:419</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:421</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:52</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:56</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeModel.kt:69</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeModelTests.kt:74</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.LocalTypeModelTests.kt:73</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:103</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:110</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:117</ID>
@@ -2229,15 +2176,15 @@
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:129</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:143</ID>
     <ID>ParameterListWrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:146</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:238</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:324</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:104</ID>
-    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:39</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:242</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:331</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:105</ID>
+    <ID>ParameterListWrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:40</ID>
     <ID>ReturnCount:ByteBufferStreams.kt$ByteBufferInputStream$@Throws(IOException::class) override fun read(b: ByteArray, offset: Int, length: Int): Int</ID>
-    <ID>ReturnCount:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$private fun buildNonAtomic(rawType: Class&lt;*&gt;, type: Type, typeIdentifier: TypeIdentifier, typeParameterInformation: List&lt;LocalTypeInformation&gt;): LocalTypeInformation</ID>
+    <ID>ReturnCount:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$private fun buildNonAtomic(rawType: Class&lt;*>, type: Type, typeIdentifier: TypeIdentifier, typeParameterInformation: List&lt;LocalTypeInformation>): LocalTypeInformation</ID>
     <ID>ReturnCount:LocalTypeInformationBuilder.kt$LocalTypeInformationBuilder$private fun makeConstructorPairedProperty(constructorIndex: Int, descriptor: PropertyDescriptor, constructorInformation: LocalConstructorInformation): LocalPropertyInformation?</ID>
-    <ID>ReturnCount:LocalTypeInformationBuilder.kt$private fun constructorForDeserialization(type: Type): KFunction&lt;Any&gt;?</ID>
-    <ID>ReturnCount:TypeParameterUtils.kt$private fun inferTypeVariables(actualClass: Class&lt;*&gt;, declaredClass: Class&lt;*&gt;, declaredType: ParameterizedType, sandboxGroup: SandboxGroup): Type?</ID>
+    <ID>ReturnCount:LocalTypeInformationBuilder.kt$private fun constructorForDeserialization(type: Type): KFunction&lt;Any>?</ID>
+    <ID>ReturnCount:TypeParameterUtils.kt$private fun inferTypeVariables(actualClass: Class&lt;*>, declaredClass: Class&lt;*>, declaredType: ParameterizedType, classloadingContext: ClassloadingContext): Type?</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.NotSerializableExceptions.kt:14</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.AMQPExceptions.kt:60</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.AMQPExceptions.kt:66</ID>
@@ -2255,10 +2202,10 @@
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:543</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:38</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:53</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:115</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:114</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.LocalTypeModelConfigurationImpl.kt:23</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:201</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.RoundTripTests.kt:114</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:161</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.RoundTripTests.kt:110</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.ThrowableEvolutionTests.kt:92</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.custom.DayOfWeekTest.kt:12</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.custom.DayOfWeekTest.kt:19</ID>
@@ -2269,12 +2216,12 @@
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.custom.MonthTest.kt:19</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.custom.PairSerializer.kt:21</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.custom.UnitSerializer.kt:6</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:35</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:53</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.CustomSerializer.kt:180</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:127</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:204</ID>
-    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:220</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:19</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:37</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.CustomSerializer.kt:166</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:112</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:189</ID>
+    <ID>SpacingAroundColon:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:205</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.model.EnumTransforms.kt:8</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.model.LocalTypeInformation.kt:197</ID>
     <ID>SpacingAroundColon:net.corda.internal.serialization.model.LocalTypeModel.kt:58</ID>
@@ -2283,13 +2230,12 @@
     <ID>SpacingAroundComma:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:56</ID>
     <ID>SpacingAroundComma:net.corda.internal.serialization.amqp.SerializationPropertyOrdering.kt:39</ID>
     <ID>SpacingAroundComma:net.corda.internal.serialization.amqp.SerializationPropertyOrdering.kt:49</ID>
-    <ID>SpacingAroundComma:net.corda.internal.serialization.amqp.TypeModellingFingerPrinterTests.kt:18</ID>
     <ID>SpacingAroundCurly:net.corda.internal.serialization.amqp.EnumTransformationTests.kt:46</ID>
     <ID>SpacingAroundCurly:net.corda.internal.serialization.amqp.ThrowableEvolutionTests.kt:92</ID>
     <ID>SpacingAroundCurly:net.corda.internal.serialization.amqp.TransformsSchema.kt:267</ID>
     <ID>SpacingAroundCurly:net.corda.internal.serialization.amqp.custom.TestCertificate.kt:5</ID>
     <ID>SpacingAroundCurly:net.corda.internal.serialization.amqp.custom.YearMonthTest.kt:20</ID>
-    <ID>SpacingAroundCurly:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:552</ID>
+    <ID>SpacingAroundCurly:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:546</ID>
     <ID>SpacingAroundCurly:net.corda.internal.serialization.model.RemoteTypeInformation.kt:148</ID>
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.amqp.AMQPTypeIdentifierParser.kt:57</ID>
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.amqp.AMQPTypeIdentifiers.kt:54</ID>
@@ -2305,7 +2251,7 @@
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.amqp.TransformsSchema.kt:275</ID>
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:11</ID>
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:50</ID>
-    <ID>SpacingAroundKeyword:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:92</ID>
+    <ID>SpacingAroundKeyword:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:76</ID>
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.model.LocalTypeInformation.kt:102</ID>
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.model.LocalTypeInformation.kt:114</ID>
     <ID>SpacingAroundKeyword:net.corda.internal.serialization.model.LocalTypeInformation.kt:293</ID>
@@ -2337,7 +2283,7 @@
     <ID>ThrowingExceptionsWithoutMessageOrCause:ByteBufferStreams.kt$ByteBufferInputStream$IndexOutOfBoundsException()</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:SerializationScheme.kt$SerializationFactoryImpl$Exception()</ID>
     <ID>ThrowsCount:AMQPTypeIdentifierParser.kt$AMQPTypeIdentifierParser$private fun validate(typeString: String)</ID>
-    <ID>ThrowsCount:EnumTransforms.kt$EnumTransforms$private fun validateNoCycles(constants: Map&lt;String, Int&gt;)</ID>
+    <ID>ThrowsCount:EnumTransforms.kt$EnumTransforms$private fun validateNoCycles(constants: Map&lt;String, Int>)</ID>
     <ID>ThrowsCount:PropertyDescriptor.kt$PropertyDescriptor$fun validate()</ID>
     <ID>TooGenericExceptionCaught:AMQPExceptions.kt$th: Throwable</ID>
     <ID>TooGenericExceptionCaught:DeserializationInput.kt$DeserializationInput$e: Exception</ID>
@@ -2384,9 +2330,16 @@
     <ID>UtilityClassWithPublicConstructor:ReusableSerialiseDeserializeAssert.kt$ReusableSerialiseDeserializeAssert</ID>
     <ID>UtilityClassWithPublicConstructor:StaticInitialisationOfSerializedObjectTest.kt$C</ID>
     <ID>UtilityClassWithPublicConstructor:TestCertificate.kt$TestCertificate</ID>
-    <ID>Wrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:52</ID>
-    <ID>Wrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:54</ID>
-    <ID>Wrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:72</ID>
+    <ID>WildcardImport:AMQPSerializationScheme.kt$import net.corda.internal.serialization.amqp.custom.*</ID>
+    <ID>WildcardImport:ArraySerializer.kt$import net.corda.internal.serialization.amqp.*</ID>
+    <ID>WildcardImport:CollectionSerializer.kt$import net.corda.internal.serialization.amqp.*</ID>
+    <ID>WildcardImport:CustomSerializer.kt$import net.corda.internal.serialization.amqp.*</ID>
+    <ID>WildcardImport:EnumSerializer.kt$import net.corda.internal.serialization.amqp.*</ID>
+    <ID>WildcardImport:MapSerializer.kt$import net.corda.internal.serialization.amqp.*</ID>
+    <ID>WildcardImport:ObjectSerializer.kt$import net.corda.internal.serialization.amqp.*</ID>
+    <ID>Wrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:21</ID>
+    <ID>Wrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:23</ID>
+    <ID>Wrapping:net.corda.internal.serialization.AMQPSerializationScheme.kt:41</ID>
     <ID>Wrapping:net.corda.internal.serialization.ByteBufferStreams.kt:16</ID>
     <ID>Wrapping:net.corda.internal.serialization.SerializationServiceImpl.kt:22</ID>
     <ID>Wrapping:net.corda.internal.serialization.SerializationServiceImpl.kt:24</ID>
@@ -2398,13 +2351,13 @@
     <ID>Wrapping:net.corda.internal.serialization.SerializationServiceImpl.kt:57</ID>
     <ID>Wrapping:net.corda.internal.serialization.SerializationServiceImpl.kt:62</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPExceptions.kt:84</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:141</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:158</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:177</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:198</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:224</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:58</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:61</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:140</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:157</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:176</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:197</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:223</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:57</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModel.kt:60</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:55</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:62</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.AMQPRemoteTypeModelTests.kt:65</ID>
@@ -2448,10 +2401,10 @@
     <ID>Wrapping:net.corda.internal.serialization.amqp.CustomSerializerRegistry.kt:28</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.CustomSerializerRegistry.kt:35</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.CustomSerializerRegistry.kt:36</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:113</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:127</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:140</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:96</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:102</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:119</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:133</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeMapTests.kt:146</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:491</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:493</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.DeserializeSimpleTypesTests.kt:617</ID>
@@ -2480,27 +2433,24 @@
     <ID>Wrapping:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:58</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:59</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.EvolutionSerializerFactory.kt:71</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.EvolvabilityTests.kt:537</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.EvolvabilityTests.kt:538</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.FingerPrinterTesting.kt:55</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:115</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:188</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:114</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:187</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:244</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:245</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:246</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:247</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:248</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:282</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.LocalSerializerFactory.kt:281</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.PrivatePropertyTests.kt:131</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:166</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:221</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:222</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:223</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:41</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:53</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:61</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.RoundTripTests.kt:158</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.RoundTripTests.kt:161</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.RoundTripTests.kt:190</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:126</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:181</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:182</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:183</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:40</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:52</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.PropertyDescriptor.kt:60</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.RoundTripTests.kt:154</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.RoundTripTests.kt:157</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.RoundTripTests.kt:186</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.Schema.kt:133</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.Schema.kt:247</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.Schema.kt:252</ID>
@@ -2509,20 +2459,19 @@
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutput.kt:104</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutput.kt:21</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutput.kt:89</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:232</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:237</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:373</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:374</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:507</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:375</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:508</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:859</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:861</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:112</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:119</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:129</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:163</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:172</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:180</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:511</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:866</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:868</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:878</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializationOutputTests.kt:881</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:115</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:122</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:168</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:177</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:185</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:77</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:88</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.SerializerFactoryBuilder.kt:89</ID>
@@ -2539,71 +2488,70 @@
     <ID>Wrapping:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:35</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:46</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.TypeNotationGenerator.kt:70</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:13</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:16</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:12</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.TypeParameterUtils.kt:43</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.custom.ClassSerializer.kt:40</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:104</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:160</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:170</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:191</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:202</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:213</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:214</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:223</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:234</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:91</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:144</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:154</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:175</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:186</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:197</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:198</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:207</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:218</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:75</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ArraySerializer.kt:88</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:110</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:79</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.CorDappCustomSerializer.kt:95</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:47</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:50</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumEvolutionSerializer.kt:65</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:36</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:37</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:45</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:50</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:51</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:59</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:64</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.EnumSerializer.kt:65</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:150</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:157</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:176</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:186</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:187</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:194</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:49</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:134</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:141</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:160</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:170</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:171</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:178</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:33</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:44</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:59</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:60</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:75</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:76</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:90</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:96</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:102</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:110</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:113</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:114</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:127</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:134</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:135</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:179</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:180</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:184</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:185</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:204</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:211</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:212</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:220</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:74</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.MapSerializer.kt:80</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:112</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:119</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:120</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:164</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:165</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:169</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:170</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:189</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:196</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:197</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:205</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:208</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:213</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:223</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:228</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:238</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:244</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:247</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:249</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:79</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:82</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:85</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:229</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:232</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:234</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:63</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:66</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:69</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:70</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:73</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:76</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:81</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:86</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:89</ID>
-    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:92</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:94</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:97</ID>
+    <ID>Wrapping:net.corda.internal.serialization.amqp.standard.ObjectSerializer.kt:98</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:44</ID>
     <ID>Wrapping:net.corda.internal.serialization.amqp.standard.SingletonSerializer.kt:52</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.EnumTransforms.kt:120</ID>
@@ -2627,45 +2575,45 @@
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:351</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:361</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformation.kt:369</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:143</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:149</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:170</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:181</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:183</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:188</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:144</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:150</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:171</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:182</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:184</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:189</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:199</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:190</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:200</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:296</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:201</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:297</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:413</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:418</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:420</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:431</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:442</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:457</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:486</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:487</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:51</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:55</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:89</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:298</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:414</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:419</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:421</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:432</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:443</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:458</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:478</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:479</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:52</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:56</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:90</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeInformationBuilder.kt:91</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.LocalTypeModel.kt:69</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:117</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:120</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.RemoteTypeInformation.kt:143</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:116</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:164</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:249</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:254</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:262</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:267</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:317</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:255</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:260</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:268</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:273</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:324</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifier.kt:331</ID>
     <ID>Wrapping:net.corda.internal.serialization.model.TypeIdentifierTests.kt:47</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:104</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:109</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:247</ID>
-    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:39</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:105</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:110</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:248</ID>
+    <ID>Wrapping:net.corda.internal.serialization.model.TypeModellingFingerPrinter.kt:40</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -1,6 +1,7 @@
 package net.corda.serialization.amqp.test
 
 import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
+import net.corda.internal.serialization.amqp.ClassloadingContextImpl
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.ObjectAndEnvelope
 import net.corda.internal.serialization.amqp.SerializationOutput
@@ -68,7 +69,7 @@ class AMQPwithOSGiSerializationTests {
     }
 
     private fun testDefaultFactory(sandboxGroup: SandboxGroup): SerializerFactory =
-        SerializerFactoryBuilder.build(sandboxGroup, allowEvolution = true)
+        SerializerFactoryBuilder.build(ClassloadingContextImpl(sandboxGroup), allowEvolution = true)
 
     @Throws(NotSerializableException::class)
     inline fun <reified T : Any> DeserializationInput.deserializeAndReturnEnvelope(

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializerFactories.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializerFactories.kt
@@ -3,7 +3,7 @@ package net.corda.internal.serialization
 
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
-import net.corda.internal.serialization.amqp.currentSandboxGroup
+import net.corda.internal.serialization.amqp.currentClassloadingContext
 import net.corda.serialization.SerializationContext
 
 // Allow us to create a SerializerFactory.
@@ -16,7 +16,7 @@ fun createSerializerFactoryFactory(): SerializerFactoryFactory = SerializerFacto
 open class SerializerFactoryFactoryImpl : SerializerFactoryFactory {
     override fun make(context: SerializationContext): SerializerFactory {
         return SerializerFactoryBuilder.build(
-            context.currentSandboxGroup(),
+            context.currentClassloadingContext(),
             mustPreserveDataWhenEvolving = context.preventDataLoss
         )
     }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ClassloadingContext.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ClassloadingContext.kt
@@ -1,0 +1,14 @@
+package net.corda.internal.serialization.amqp
+
+interface ClassloadingContext {
+
+    fun getClass(className: String, serialisedClassTag: String): Class<*>
+
+    fun loadClassFromPublicBundles(className: String): Class<*>?
+
+    fun loadClassFromMainBundles(className: String): Class<*>
+
+    fun <T : Any> loadClassFromMainBundles(className: String, type: Class<T>): Class<out T>
+
+    fun getEvolvableTag(klass: Class<*>): String
+}

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ClassloadingContextImpl.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ClassloadingContextImpl.kt
@@ -1,0 +1,31 @@
+package net.corda.internal.serialization.amqp
+
+import net.corda.sandbox.SandboxGroup
+
+/**
+ * This interface isolates the methods from SandboxGroup which are used in serialization, enabling non-OSGi
+ * test contexts to use serialization libraries and mock this class without importing references to OSGi.
+ *
+ * @param sandboxGroup The sandbox group to which to delegate methods.
+ */
+class ClassloadingContextImpl(private val sandboxGroup: SandboxGroup) : ClassloadingContext {
+    override fun getClass(className: String, serialisedClassTag: String): Class<*> {
+        return sandboxGroup.getClass(className, serialisedClassTag)
+    }
+
+    override fun loadClassFromPublicBundles(className: String): Class<*>? {
+        return sandboxGroup.loadClassFromPublicBundles(className)
+    }
+
+    override fun loadClassFromMainBundles(className: String): Class<*> {
+        return sandboxGroup.loadClassFromMainBundles(className)
+    }
+
+    override fun <T : Any> loadClassFromMainBundles(className: String, type: Class<T>): Class<out T> {
+        return sandboxGroup.loadClassFromMainBundles(className, type)
+    }
+
+    override fun getEvolvableTag(klass: Class<*>): String {
+        return sandboxGroup.getEvolvableTag(klass)
+    }
+}

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
@@ -191,12 +191,12 @@ class DeserializationInput constructor(
             }
             objectRetrieved
         } else {
-            val sandboxGroup = context.currentSandboxGroup()
+            val classloadingContext = context.currentClassloadingContext()
             val objectRead = when (obj) {
                 is DescribedType -> {
                     // Look up serializer in factory by descriptor
-                    val serializer = serializerFactory.get(obj.descriptor.toString(), serializationSchemas, metadata, sandboxGroup)
-                    if (type != TypeIdentifier.UnknownType.getLocalType(sandboxGroup) && serializer.type != type && with(serializer.type) {
+                    val serializer = serializerFactory.get(obj.descriptor.toString(), serializationSchemas, metadata, classloadingContext)
+                    if (type != TypeIdentifier.UnknownType.getLocalType(classloadingContext) && serializer.type != type && with(serializer.type) {
                         !isSubClassOf(type) && !materiallyEquivalentTo(type)
                     }
                     ) {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactory.kt
@@ -96,7 +96,7 @@ class DefaultEvolutionSerializerFactory(
         properties.asSequence().zip(localTypeInformation.properties.values.asSequence()).forEach { (remote, localProperty) ->
             val (name, remoteProperty) = remote
             val localClass = localProperty.type.observedType.asClass()
-            val remoteClass = remoteProperty.type.typeIdentifier.getLocalType(localSerializerFactory.sandboxGroup).asClass()
+            val remoteClass = remoteProperty.type.typeIdentifier.getLocalType(localSerializerFactory.classloadingContext).asClass()
 
             if (!localClass.isAssignableFrom(remoteClass) && remoteClass != primitiveTypes[localClass]) {
                 throw EvolutionSerializationException(this,
@@ -109,7 +109,7 @@ class DefaultEvolutionSerializerFactory(
     // provided property types.
     private fun findEvolverConstructor(constructors: List<EvolutionConstructorInformation>,
                                        properties: Map<String, RemotePropertyInformation>): EvolutionConstructorInformation? {
-        val propertyTypes = properties.mapValues { (_, info) -> info.type.typeIdentifier.getLocalType(localSerializerFactory.sandboxGroup).asClass() }
+        val propertyTypes = properties.mapValues { (_, info) -> info.type.typeIdentifier.getLocalType(localSerializerFactory.classloadingContext).asClass() }
 
         // Evolver constructors are listed in ascending version order, so we just want the last that matches.
         return constructors.lastOrNull { (_, evolverProperties) ->
@@ -199,6 +199,6 @@ class DefaultEvolutionSerializerFactory(
             constructor,
             properties,
             mustPreserveDataWhenEvolving,
-            localSerializerFactory.sandboxGroup
+            localSerializerFactory.classloadingContext
         )
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
@@ -120,7 +120,7 @@ open class SerializationOutput constructor(
         if (obj == null) {
             data.putNull()
         } else {
-            writeObject(obj, data, if (type == TypeIdentifier.UnknownType.getLocalType(context.currentSandboxGroup())) obj.javaClass else type, context, debugIndent)
+            writeObject(obj, data, if (type == TypeIdentifier.UnknownType.getLocalType(context.currentClassloadingContext())) obj.javaClass else type, context, debugIndent)
         }
     }
 
@@ -132,7 +132,7 @@ open class SerializationOutput constructor(
      * Attaches information about the CPKs associated with the serialised objects to the metadata
      */
     private fun putTypeToMetadata(type: Type, context: SerializationContext) {
-        val classTag = context.currentSandboxGroup().getEvolvableTag(type.asClass())
+        val classTag = context.currentClassloadingContext().getEvolvableTag(type.asClass())
         if (!metadata.containsKey(type.typeName)) {
             val key = type.asClass().name
             metadata.putValue(key, classTag)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformTypes.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/TransformTypes.kt
@@ -1,9 +1,9 @@
 package net.corda.internal.serialization.amqp
 
+import net.corda.internal.serialization.NotSerializableWithReasonException
 import net.corda.v5.serialization.annotations.CordaSerializationTransformEnumDefault
 import net.corda.v5.serialization.annotations.CordaSerializationTransformEnumDefaults
 import net.corda.v5.serialization.annotations.CordaSerializationTransformRename
-import net.corda.internal.serialization.NotSerializableWithReasonException
 import org.apache.qpid.proton.amqp.DescribedType
 import org.apache.qpid.proton.codec.DescribedTypeConstructor
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ClassSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ClassSerializer.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.amqp.custom
 
 import net.corda.internal.serialization.amqp.AMQPNotSerializableException
-import net.corda.internal.serialization.amqp.currentSandboxGroup
+import net.corda.internal.serialization.amqp.currentClassloadingContext
 import net.corda.serialization.InternalDirectSerializer
 import net.corda.serialization.InternalDirectSerializer.ReadObject
 import net.corda.serialization.InternalDirectSerializer.WriteObject
@@ -30,7 +30,7 @@ class ClassSerializer : InternalDirectSerializer<Class<*>> {
         logger.trace { "serializer=custom, type=ClassSerializer, name=\"$className\"" }
 
         return try {
-            context.currentSandboxGroup().loadClassFromMainBundles(className)
+            context.currentClassloadingContext().loadClassFromMainBundles(className)
         } catch (e: ClassNotFoundException) {
             throw AMQPNotSerializableException(
                 type,

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
@@ -1,8 +1,8 @@
 package net.corda.internal.serialization.amqp.custom
 
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
 import net.corda.internal.serialization.amqp.GetterReader
-import net.corda.internal.serialization.amqp.currentSandboxGroup
+import net.corda.internal.serialization.amqp.LocalSerializerFactory
+import net.corda.internal.serialization.amqp.currentClassloadingContext
 import net.corda.internal.serialization.model.LocalConstructorInformation
 import net.corda.internal.serialization.model.LocalTypeInformation
 import net.corda.serialization.InternalProxySerializer
@@ -69,7 +69,7 @@ class ThrowableSerializer(
     @Suppress("NestedBlockDepth")
     override fun fromProxy(proxy: ThrowableProxy, context: SerializationContext): Throwable {
         try {
-            val clazz = context.currentSandboxGroup().loadClassFromMainBundles(proxy.exceptionClass)
+            val clazz = context.currentClassloadingContext().loadClassFromMainBundles(proxy.exceptionClass)
 
             // If it is a CordaRuntimeException, we can seek any constructor and then set the properties
             // Otherwise we just make a CordaRuntimeException

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/AMQPPrimitiveSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/AMQPPrimitiveSerializer.kt
@@ -2,10 +2,10 @@ package net.corda.internal.serialization.amqp.standard
 
 import net.corda.internal.serialization.amqp.AMQPSerializer
 import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers
+import net.corda.internal.serialization.amqp.DeserializationInput
+import net.corda.internal.serialization.amqp.Metadata
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.serialization.SerializationContext
 import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.amqp.Symbol

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -1,23 +1,7 @@
 package net.corda.internal.serialization.amqp.standard
 
+import net.corda.internal.serialization.amqp.*
 import net.corda.internal.serialization.model.resolveAgainst
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
-import net.corda.internal.serialization.amqp.AMQPSerializer
-import net.corda.internal.serialization.amqp.componentType
-import net.corda.internal.serialization.amqp.isArray
-import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers
-import net.corda.internal.serialization.amqp.asClass
-import net.corda.internal.serialization.amqp.TypeNotation
-import net.corda.internal.serialization.amqp.RestrictedType
-import net.corda.internal.serialization.amqp.Descriptor
-import net.corda.internal.serialization.amqp.SerializationOutput
-import net.corda.internal.serialization.amqp.withDescribed
-import net.corda.internal.serialization.amqp.withList
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.redescribe
-import net.corda.internal.serialization.amqp.AMQPNotSerializableException
 import net.corda.serialization.SerializationContext
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
@@ -1,23 +1,8 @@
 package net.corda.internal.serialization.amqp.standard
 
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
-import net.corda.internal.serialization.amqp.AMQPSerializer
-import net.corda.internal.serialization.amqp.AMQPNotSerializableException
-import net.corda.internal.serialization.amqp.TypeNotation
-import net.corda.internal.serialization.amqp.RestrictedType
-import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers
-import net.corda.internal.serialization.amqp.Descriptor
-import net.corda.internal.serialization.amqp.resolveTypeVariables
-import net.corda.internal.serialization.amqp.SerializationOutput
-import net.corda.internal.serialization.amqp.withDescribed
-import net.corda.internal.serialization.amqp.withList
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.ifThrowsAppend
+import net.corda.internal.serialization.amqp.*
 import net.corda.internal.serialization.model.LocalTypeInformation
 import net.corda.internal.serialization.model.TypeIdentifier
-import net.corda.sandbox.SandboxGroup
 import net.corda.serialization.SerializationContext
 import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
@@ -58,9 +43,13 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
          * Replace erased collection types with parameterised types with wildcard type parameters, so that they are represented
          * appropriately in the AMQP schema.
          */
-        fun resolveDeclared(declaredTypeInformation: LocalTypeInformation.ACollection, sandboxGroup: SandboxGroup): LocalTypeInformation.ACollection {
+        fun resolveDeclared(
+            declaredTypeInformation: LocalTypeInformation.ACollection,
+            classloadingContext: ClassloadingContext
+        ): LocalTypeInformation.ACollection {
+
             if (declaredTypeInformation.typeIdentifier.erased in supportedTypeIdentifiers)
-                return reparameterise(declaredTypeInformation, sandboxGroup)
+                return reparameterise(declaredTypeInformation, classloadingContext)
 
             throw NotSerializableException(
                 "Cannot derive collection type for declared type: " +
@@ -71,10 +60,10 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
         fun resolveActual(
             actualClass: Class<*>,
             declaredTypeInformation: LocalTypeInformation.ACollection,
-            sandboxGroup: SandboxGroup
+            classloadingContext: ClassloadingContext
         ): LocalTypeInformation.ACollection {
             if (declaredTypeInformation.typeIdentifier.erased in supportedTypeIdentifiers)
-                return reparameterise(declaredTypeInformation, sandboxGroup)
+                return reparameterise(declaredTypeInformation, classloadingContext)
 
             val collectionClass = findMostSuitableCollectionType(actualClass)
             val erasedInformation = LocalTypeInformation.ACollection(
@@ -84,15 +73,21 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
             )
 
             return when (declaredTypeInformation.typeIdentifier) {
-                is TypeIdentifier.Parameterised -> erasedInformation.withElementType(declaredTypeInformation.elementType, sandboxGroup)
-                else -> erasedInformation.withElementType(LocalTypeInformation.Unknown, sandboxGroup)
+                is TypeIdentifier.Parameterised -> erasedInformation.withElementType(declaredTypeInformation.elementType, classloadingContext)
+                else -> erasedInformation.withElementType(LocalTypeInformation.Unknown, classloadingContext)
             }
         }
 
-        private fun reparameterise(typeInformation: LocalTypeInformation.ACollection, sandboxGroup: SandboxGroup): LocalTypeInformation.ACollection =
+        private fun reparameterise(
+            typeInformation: LocalTypeInformation.ACollection,
+            classloadingContext: ClassloadingContext
+        ): LocalTypeInformation.ACollection =
             when (typeInformation.typeIdentifier) {
                 is TypeIdentifier.Parameterised -> typeInformation
-                is TypeIdentifier.Erased -> typeInformation.withElementType(LocalTypeInformation.Unknown, sandboxGroup)
+                is TypeIdentifier.Erased -> typeInformation.withElementType(
+                    LocalTypeInformation.Unknown,
+                    classloadingContext
+                )
                 else -> throw NotSerializableException(
                     "Unexpected type identifier ${typeInformation.typeIdentifier.prettyPrint(false)} " +
                         "for collection type ${typeInformation.prettyPrint(false)}"
@@ -115,7 +110,7 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
 
     private val typeNotation: TypeNotation = RestrictedType(AMQPTypeIdentifiers.nameForType(declaredType), null, emptyList(), "list", Descriptor(typeDescriptor), emptyList())
 
-    private val outboundType = resolveTypeVariables(declaredType.actualTypeArguments[0], null, factory.sandboxGroup)
+    private val outboundType = resolveTypeVariables(declaredType.actualTypeArguments[0], null, factory.classloadingContext)
     private val inboundType = declaredType.actualTypeArguments[0]
 
     override fun writeClassInfo(output: SerializationOutput, context: SerializationContext) = ifThrowsAppend(declaredType::getTypeName) {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
@@ -1,24 +1,24 @@
 package net.corda.internal.serialization.amqp.standard
 
-import net.corda.internal.serialization.amqp.SerializerFactory
-import net.corda.internal.serialization.amqp.AMQPSerializer
-import net.corda.internal.serialization.amqp.SerializerFor
 import net.corda.internal.serialization.amqp.AMQPNotSerializableException
-import net.corda.internal.serialization.amqp.typeDescriptorFor
+import net.corda.internal.serialization.amqp.AMQPSerializer
 import net.corda.internal.serialization.amqp.Descriptor
+import net.corda.internal.serialization.amqp.DeserializationInput
+import net.corda.internal.serialization.amqp.Metadata
 import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.SerializationSchemas
+import net.corda.internal.serialization.amqp.SerializerFactory
+import net.corda.internal.serialization.amqp.SerializerFor
+import net.corda.internal.serialization.amqp.asClass
+import net.corda.internal.serialization.amqp.typeDescriptorFor
 import net.corda.internal.serialization.amqp.withDescribed
 import net.corda.internal.serialization.amqp.withList
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.asClass
 import net.corda.serialization.SerializationContext
 import net.corda.v5.serialization.SerializationCustomSerializer
 import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
-import java.lang.reflect.Type
 import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 
 /**
  * Index into the types list of the parent type of the serializer object, should be the

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CustomSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CustomSerializer.kt
@@ -1,20 +1,6 @@
 package net.corda.internal.serialization.amqp.standard
 
-import net.corda.internal.serialization.amqp.AMQPSerializer
-import net.corda.internal.serialization.amqp.SerializerFor
-import net.corda.internal.serialization.amqp.Descriptor
-import net.corda.internal.serialization.amqp.SerializationOutput
-import net.corda.internal.serialization.amqp.withDescribed
-import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers
-import net.corda.internal.serialization.amqp.DESCRIPTOR_DOMAIN
-import net.corda.internal.serialization.amqp.TypeNotation
-import net.corda.internal.serialization.amqp.RestrictedType
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.typeDescriptorFor
-import net.corda.internal.serialization.amqp.SerializerFactory
-import net.corda.internal.serialization.amqp.withList
+import net.corda.internal.serialization.amqp.*
 import net.corda.internal.serialization.model.FingerprintWriter
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.serialization.InternalDirectSerializer

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/EnumEvolutionSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/EnumEvolutionSerializer.kt
@@ -1,13 +1,13 @@
 package net.corda.internal.serialization.amqp.standard
 
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
-import net.corda.internal.serialization.amqp.AMQPSerializer
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.AMQPNotSerializableException
-import net.corda.internal.serialization.amqp.asClass
+import net.corda.internal.serialization.amqp.AMQPSerializer
+import net.corda.internal.serialization.amqp.DeserializationInput
+import net.corda.internal.serialization.amqp.LocalSerializerFactory
+import net.corda.internal.serialization.amqp.Metadata
 import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.SerializationSchemas
+import net.corda.internal.serialization.amqp.asClass
 import net.corda.internal.serialization.model.BaseLocalTypes
 import net.corda.serialization.SerializationContext
 import org.apache.qpid.proton.codec.Data

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/EnumSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/EnumSerializer.kt
@@ -1,20 +1,6 @@
 package net.corda.internal.serialization.amqp.standard
 
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
-import net.corda.internal.serialization.amqp.AMQPSerializer
-import net.corda.internal.serialization.amqp.TypeNotation
-import net.corda.internal.serialization.amqp.RestrictedType
-import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers
-import net.corda.internal.serialization.amqp.Descriptor
-import net.corda.internal.serialization.amqp.Choice
-import net.corda.internal.serialization.amqp.SerializationOutput
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.asClass
-import net.corda.internal.serialization.amqp.AMQPNotSerializableException
-import net.corda.internal.serialization.amqp.withDescribed
-import net.corda.internal.serialization.amqp.withList
+import net.corda.internal.serialization.amqp.*
 import net.corda.serialization.SerializationContext
 import org.apache.qpid.proton.codec.Data
 import java.lang.reflect.Type

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/SingletonSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/SingletonSerializer.kt
@@ -1,15 +1,15 @@
 package net.corda.internal.serialization.amqp.standard
 
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
 import net.corda.internal.serialization.amqp.AMQPSerializer
-import net.corda.internal.serialization.amqp.TypeNotation
-import net.corda.internal.serialization.amqp.RestrictedType
 import net.corda.internal.serialization.amqp.Descriptor
-import net.corda.internal.serialization.amqp.SerializationOutput
-import net.corda.internal.serialization.amqp.withDescribed
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
 import net.corda.internal.serialization.amqp.DeserializationInput
+import net.corda.internal.serialization.amqp.LocalSerializerFactory
+import net.corda.internal.serialization.amqp.Metadata
+import net.corda.internal.serialization.amqp.RestrictedType
+import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.SerializationSchemas
+import net.corda.internal.serialization.amqp.TypeNotation
+import net.corda.internal.serialization.amqp.withDescribed
 import net.corda.internal.serialization.model.LocalTypeInformation
 import net.corda.serialization.SerializationContext
 import org.apache.qpid.proton.codec.Data

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.model
 
+import net.corda.internal.serialization.amqp.ClassloadingContext
 import net.corda.internal.serialization.amqp.Metadata
-import net.corda.sandbox.SandboxGroup
 import net.corda.v5.base.util.contextLogger
 import java.io.NotSerializableException
 import java.lang.reflect.Type
@@ -17,7 +17,7 @@ interface TypeLoader {
      */
     fun load(
             remoteTypeInformation: Collection<RemoteTypeInformation>,
-            sandboxGroup: SandboxGroup,
+            classloadingContext: ClassloadingContext,
             metadata: Metadata
     ): Map<TypeIdentifier, Type>
 }
@@ -36,7 +36,7 @@ class ClassTypeLoader: TypeLoader {
 
     override fun load(
             remoteTypeInformation: Collection<RemoteTypeInformation>,
-            sandboxGroup: SandboxGroup,
+            classloadingContext: ClassloadingContext,
             metadata: Metadata
     ): Map<TypeIdentifier, Type> {
         val remoteInformationByIdentifier = remoteTypeInformation.associateBy { it.typeIdentifier }
@@ -44,7 +44,7 @@ class ClassTypeLoader: TypeLoader {
         // Grab all the types we can from the cache, or the classloader.
         val resolvedTypes = remoteInformationByIdentifier.asSequence().mapNotNull { (identifier, _) ->
             try {
-                identifier to cache.computeIfAbsent(identifier) { identifier.getLocalType(sandboxGroup, metadata) }
+                identifier to cache.computeIfAbsent(identifier) { identifier.getLocalType(classloadingContext, metadata) }
             } catch (ex: ClassNotFoundException) {
                 null
             }

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaEvolutionTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaEvolutionTests.java
@@ -1,12 +1,12 @@
 package net.corda.internal.serialization.amqp;
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
+import net.corda.internal.serialization.amqp.testutils.AMQPTestUtilsKt;
 import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.serialization.SerializedBytes;
-import net.corda.internal.serialization.amqp.testutils.AMQPTestUtilsKt;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.IOException;
 import java.io.NotSerializableException;

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaGenericsTest.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaGenericsTest.java
@@ -1,10 +1,10 @@
 package net.corda.internal.serialization.amqp;
 
+import net.corda.internal.serialization.amqp.custom.BigIntegerSerializer;
 import net.corda.internal.serialization.amqp.helper.TestSerializationContext;
+import net.corda.internal.serialization.amqp.testutils.AMQPTestUtilsKt;
 import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.serialization.SerializedBytes;
-import net.corda.internal.serialization.amqp.custom.BigIntegerSerializer;
-import net.corda.internal.serialization.amqp.testutils.AMQPTestUtilsKt;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -19,8 +19,8 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static net.corda.internal.serialization.amqp.testutils.AMQPTestUtilsKt.testDefaultFactory;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("unchecked")
 @Timeout(value = 30, unit = TimeUnit.SECONDS)

--- a/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaPrivatePropertyTests.java
+++ b/libs/serialization/serialization-amqp/src/test/java/net/corda/internal/serialization/amqp/JavaPrivatePropertyTests.java
@@ -10,8 +10,8 @@ import java.io.NotSerializableException;
 import java.util.concurrent.TimeUnit;
 
 import static net.corda.internal.serialization.amqp.testutils.AMQPTestUtilsKt.testDefaultFactory;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 public class JavaPrivatePropertyTests {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/AMQPRemoteTypeModelTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/AMQPRemoteTypeModelTests.kt
@@ -74,8 +74,8 @@ class AMQPRemoteTypeModelTests {
     private fun getRemoteType(obj: Any): RemoteTypeInformation {
         val schema = SerializationOutput(factory).serializeAndReturnSchema(obj)
         schema.schema.types.forEach { println(it) }
-        val values = typeModel.interpret(SerializationSchemas(schema.schema, schema.transformsSchema), factory.sandboxGroup).values
-        return values.find { it.typeIdentifier.getLocalType(factory.sandboxGroup).accessAsClass().isAssignableFrom(obj::class.java) } ?:
+        val values = typeModel.interpret(SerializationSchemas(schema.schema, schema.transformsSchema), factory.classloadingContext).values
+        return values.find { it.typeIdentifier.getLocalType(factory.classloadingContext).accessAsClass().isAssignableFrom(obj::class.java) } ?:
         throw IllegalArgumentException(
             "Can't find ${obj::class.java.name} in ${values.map { it.typeIdentifier.name}}")
     }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParserTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/AMQPTypeIdentifierParserTests.kt
@@ -43,7 +43,7 @@ class AMQPTypeIdentifierParserTests {
         assertFailsWith<IllegalTypeNameParserStateException> {
             AMQPTypeIdentifierParser.parse(
                 "string" + "[]".repeat(33),
-                testSerializationContext.currentSandboxGroup()
+                testSerializationContext.currentClassloadingContext()
             )
         }
     }
@@ -74,7 +74,7 @@ class AMQPTypeIdentifierParserTests {
         assertFailsWith<IllegalTypeNameParserStateException> {
             AMQPTypeIdentifierParser.parse(
                 "WithParameter<".repeat(33) + ">".repeat(33),
-                testSerializationContext.currentSandboxGroup()
+                testSerializationContext.currentClassloadingContext()
             )
         }
     }
@@ -206,7 +206,7 @@ class AMQPTypeIdentifierParserTests {
     private inline fun <reified T> assertParseResult(typeString: String) {
         assertEquals(
             TypeIdentifier.forGenericType(typeOf<T>()),
-            AMQPTypeIdentifierParser.parse(typeString, testSerializationContext.currentSandboxGroup())
+            AMQPTypeIdentifierParser.parse(typeString, testSerializationContext.currentClassloadingContext())
         )
     }
 
@@ -226,7 +226,7 @@ class AMQPTypeIdentifierParserTests {
         val nameForType = AMQPTypeIdentifiers.nameForType(type)
         val parsedIdentifier = AMQPTypeIdentifierParser.parse(
             nameForType,
-            testSerializationContext.currentSandboxGroup()
+            testSerializationContext.currentClassloadingContext()
         )
         assertEquals(expectedIdentifierPrettyPrint, parsedIdentifier.prettyPrint())
     }
@@ -236,7 +236,7 @@ class AMQPTypeIdentifierParserTests {
     }
 
     private fun verify(typeName: String) {
-        val sandboxGroup = testSerializationContext.currentSandboxGroup()
+        val sandboxGroup = testSerializationContext.currentClassloadingContext()
         val type = AMQPTypeIdentifierParser.parse(typeName, sandboxGroup).getLocalType(sandboxGroup)
         assertEquals(normalise(typeName), normalise(type.typeName))
     }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/CorDappSerializerTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/CorDappSerializerTests.kt
@@ -22,7 +22,7 @@ class CorDappSerializerTests {
 
     private fun proxyFactory(
             serializers: List<SerializationCustomSerializer<*, *>>
-    ) = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()).apply {
+    ) = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()).apply {
         serializers.forEach {
             registerExternal(it, this)
         }
@@ -97,7 +97,7 @@ class CorDappSerializerTests {
 	fun testWithAllowListBlocked() {
         data class A(val a: Int, val b: NeedsProxy)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.registerExternal(NeedsProxyProxySerializer(), factory)
 
         val tv1 = 100

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeAndReturnEnvelopeTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeAndReturnEnvelopeTests.kt
@@ -1,11 +1,11 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.internal.serialization.amqp.testutils.deserializeAndReturnEnvelope
 import net.corda.internal.serialization.amqp.testutils.serialize
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
 import net.corda.internal.serialization.amqp.testutils.testName
+import net.corda.v5.base.annotations.CordaSerializable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.util.concurrent.TimeUnit

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeMapTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeMapTests.kt
@@ -9,7 +9,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
 import java.io.NotSerializableException
-import java.util.*
+import java.util.AbstractMap
+import java.util.Dictionary
+import java.util.Hashtable
+import java.util.NavigableMap
+import java.util.SortedMap
+import java.util.TreeMap
+import java.util.WeakHashMap
 import java.util.concurrent.TimeUnit
 
 @Timeout(value = 30, unit = TimeUnit.SECONDS)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -1,12 +1,12 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.internal.serialization.amqp.testutils.TestSerializationOutput
 import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.serialize
 import net.corda.internal.serialization.amqp.testutils.serializeAndReturnSchema
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactory
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactoryNoEvolution
+import net.corda.v5.base.annotations.CordaSerializable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.lang.Character.valueOf

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTests.kt
@@ -220,7 +220,7 @@ class EnumTests {
     fun enumNotOnAllowListFails() {
         data class C(val c: Bras)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
 
         Assertions.assertThatThrownBy {
             TestSerializationOutput(VERBOSE, factory).serialize(C(Bras.UNDERWIRE))
@@ -231,7 +231,7 @@ class EnumTests {
     fun enumAnnotated() {
         @CordaSerializable data class C(val c: AnnotatedBras)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
 
         // if it all works, this won't explode
         TestSerializationOutput(VERBOSE, factory).serialize(C(AnnotatedBras.UNDERWIRE))
@@ -240,10 +240,10 @@ class EnumTests {
     @Test
     fun deserializeCustomisedEnum() {
         val input = CustomEnumWrapper(CustomEnum.ONE)
-        val factory1 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory1 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val serialized = TestSerializationOutput(VERBOSE, factory1).serialize(input)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val output = DeserializationInput(factory2).deserialize(serialized)
 
         assertEquals(input, output)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTransformationTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EnumTransformationTests.kt
@@ -6,6 +6,7 @@ import net.corda.v5.serialization.annotations.CordaSerializationTransformEnumDef
 import net.corda.v5.serialization.annotations.CordaSerializationTransformEnumDefaults
 import net.corda.v5.serialization.annotations.CordaSerializationTransformRename
 import net.corda.v5.serialization.annotations.CordaSerializationTransformRenames
+
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ErrorMessagesTests.kt
@@ -1,6 +1,5 @@
 package net.corda.internal.serialization.amqp
 
-import java.io.NotSerializableException
 import net.corda.internal.serialization.amqp.testutils.TestSerializationOutput
 import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.testDefaultFactory
@@ -9,6 +8,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.io.NotSerializableException
 
 class ErrorMessagesTests {
     companion object {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactoryTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionSerializerFactoryTests.kt
@@ -1,10 +1,10 @@
 package net.corda.internal.serialization.amqp
 
 import net.corda.internal.serialization.amqp.helper.testSerializationContext
-import net.corda.v5.serialization.SerializedBytes
 import net.corda.internal.serialization.amqp.testutils.deserialize
 import net.corda.internal.serialization.amqp.testutils.testName
 import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.serialization.SerializedBytes
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
@@ -17,13 +17,13 @@ import kotlin.test.assertTrue
 class EvolutionSerializerFactoryTests {
 
     private val nonStrictFactory = SerializerFactoryBuilder.build(
-        testSerializationContext.currentSandboxGroup(),
+        testSerializationContext.currentClassloadingContext(),
         descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry(),
         mustPreserveDataWhenEvolving = false
     )
 
     private val strictFactory = SerializerFactoryBuilder.build(
-        testSerializationContext.currentSandboxGroup(),
+        testSerializationContext.currentClassloadingContext(),
         descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry(),
         mustPreserveDataWhenEvolving = true
     )

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolvabilityTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolvabilityTests.kt
@@ -534,7 +534,7 @@ class EvolvabilityTests {
         val model = AMQPRemoteTypeModel()
         val remoteTypeInfo = model.interpret(
             SerializationSchemas(newVersion.schema, newVersion.transformsSchema),
-            testSerializationContext.currentSandboxGroup()
+            testSerializationContext.currentClassloadingContext()
         )
         println(remoteTypeInfo)
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/FingerPrinterTesting.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/FingerPrinterTesting.kt
@@ -51,7 +51,7 @@ class FingerPrinterTestingTests {
         data class C(val a: Int, val b: Long)
 
         val factory = SerializerFactoryBuilder.build(
-            testSerializationContext.currentSandboxGroup(),
+            testSerializationContext.currentClassloadingContext(),
             overrideFingerPrinter = FingerPrinterTesting()
         )
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/GenericsTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/GenericsTests.kt
@@ -145,8 +145,8 @@ class GenericsTests {
         @CordaSerializable
         data class Wrapper<T : Any>(val a: Int, val b: SerializedBytes<T>)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val ser = SerializationOutput(factory)
 
         val gBytes = ser.serialize(G(1))
@@ -176,8 +176,8 @@ class GenericsTests {
         @CordaSerializable
         data class Wrapper<T : Any>(val c: Container<T>)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factories = listOf(factory, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
+        val factories = listOf(factory, SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()))
         val ser = SerializationOutput(factory)
 
         ser.serialize(Wrapper(Container(InnerA(1)))).apply {
@@ -209,8 +209,8 @@ class GenericsTests {
         data class Wrapper<T : Any>(val c: Container<T>)
 
         val factorys = listOf(
-            SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()),
-            SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+            SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()),
+            SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         )
 
         val ser = SerializationOutput(factorys[0])
@@ -233,7 +233,7 @@ class GenericsTests {
 
     private fun forceWildcardSerialize(
         a: ForceWildcard<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
     ): SerializedBytes<*> {
         val bytes = SerializationOutput(factory).serializeAndReturnSchema(a)
         bytes.printSchema()
@@ -243,7 +243,7 @@ class GenericsTests {
     @Suppress("UNCHECKED_CAST")
     private fun forceWildcardDeserializeString(
         bytes: SerializedBytes<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
     ) {
         DeserializationInput(factory).deserialize(bytes as SerializedBytes<ForceWildcard<String>>)
     }
@@ -251,7 +251,7 @@ class GenericsTests {
     @Suppress("UNCHECKED_CAST")
     private fun forceWildcardDeserializeDouble(
         bytes: SerializedBytes<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
     ) {
         DeserializationInput(factory).deserialize(bytes as SerializedBytes<ForceWildcard<Double>>)
     }
@@ -259,7 +259,7 @@ class GenericsTests {
     @Suppress("UNCHECKED_CAST")
     private fun forceWildcardDeserialize(
         bytes: SerializedBytes<*>,
-        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        factory: SerializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
     ) {
         DeserializationInput(factory).deserialize(bytes as SerializedBytes<ForceWildcard<*>>)
     }
@@ -272,7 +272,7 @@ class GenericsTests {
 
     @Test
     fun forceWildcardSharedFactory() {
-        val f = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val f = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         forceWildcardDeserializeString(forceWildcardSerialize(ForceWildcard("hello"), f), f)
         forceWildcardDeserializeDouble(forceWildcardSerialize(ForceWildcard(3.0), f), f)
     }
@@ -286,7 +286,7 @@ class GenericsTests {
 
     @Test
     fun forceWildcardDeserializeSharedFactory() {
-        val f = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val f = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         forceWildcardDeserialize(forceWildcardSerialize(ForceWildcard("hello"), f), f)
         forceWildcardDeserialize(forceWildcardSerialize(ForceWildcard(10), f), f)
         forceWildcardDeserialize(forceWildcardSerialize(ForceWildcard(20.0), f), f)
@@ -330,14 +330,14 @@ class GenericsTests {
         // attempt at having a class loader without some of the derived non core types loaded and thus
         // possibly altering how we serialise things
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val ser2 = TestSerializationOutput(VERBOSE, factory2).serializeAndReturnSchema(state)
 
         //  now deserialise those objects
         val factory3 = testDefaultFactory()
         DeserializationInput(factory3).deserializeAndReturnEnvelope(ser1.obj)
 
-        val factory4 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory4 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         DeserializationInput(factory4).deserializeAndReturnEnvelope(ser2.obj)
     }
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ListsSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/ListsSerializationTests.kt
@@ -8,7 +8,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.io.NotSerializableException
-import kotlin.collections.ArrayList
 
 @Timeout(value = 30)
 class ListsSerializationTests {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/OptionalSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/OptionalSerializationTests.kt
@@ -17,7 +17,7 @@ class OptionalSerializationTests {
     @Test
     fun setupEnclosedSerializationTest() {
         fun `java optionals should serialize`() {
-            val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+            val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
             factory.register(OptionalSerializer(), factory)
             val obj = Optional.ofNullable("YES")
             val bytes = TestSerializationOutput(true, factory).serialize(obj)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -1,21 +1,5 @@
 package net.corda.internal.serialization.amqp
 
-import java.io.IOException
-import java.io.InputStream
-import java.io.NotSerializableException
-import java.math.BigDecimal
-import java.time.DayOfWeek
-import java.time.Month
-import java.util.Currency
-import java.util.Date
-import java.util.EnumMap
-import java.util.NavigableMap
-import java.util.Objects
-import java.util.Random
-import java.util.SortedSet
-import java.util.TreeMap
-import java.util.TreeSet
-import java.util.UUID
 import net.corda.internal.serialization.CordaSerializationEncoding
 import net.corda.internal.serialization.SnappyEncodingAllowList
 import net.corda.internal.serialization.amqp.custom.BigDecimalSerializer
@@ -60,6 +44,22 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
+import java.io.IOException
+import java.io.InputStream
+import java.io.NotSerializableException
+import java.math.BigDecimal
+import java.time.DayOfWeek
+import java.time.Month
+import java.util.Currency
+import java.util.Date
+import java.util.EnumMap
+import java.util.NavigableMap
+import java.util.Objects
+import java.util.Random
+import java.util.SortedSet
+import java.util.TreeMap
+import java.util.TreeSet
+import java.util.UUID
 
 object AckWrapper {
     @CordaSerializable
@@ -391,7 +391,7 @@ class SerializationOutputTests {
     @Test
     fun `test annotation allow listing`() {
         val obj = AnnotatedWoo(5)
-        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()))
     }
 
     @Test
@@ -490,7 +490,7 @@ class SerializationOutputTests {
 
     @Test
     fun `class constructor is invoked on deserialisation`() {
-        val serializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val serializerFactory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val ser = SerializationOutput(serializerFactory)
         val des = DeserializationInput(serializerFactory)
         val serialisedOne = ser.serialize(NonZeroByte(1)).bytes
@@ -524,22 +524,22 @@ class SerializationOutputTests {
     @Test
     fun `test annotation is inherited`() {
         val obj = InheritAnnotation("blah")
-        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()))
     }
 
     @Test
     fun `generics from java are supported`() {
         val obj = DummyOptional("YES")
-        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        serdes(obj, SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()))
     }
 
     @Test
     fun `test throwables serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory2)
 
@@ -551,11 +551,11 @@ class SerializationOutputTests {
 
     @Test
     fun `test complex throwables serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory2)
 
@@ -581,11 +581,11 @@ class SerializationOutputTests {
 
     @Test
     fun `test suppressed throwables serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory)
 
@@ -605,11 +605,11 @@ class SerializationOutputTests {
 
     @Test
     fun `test flow corda exception subclasses serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.register(ThrowableSerializer(factory), factory)
         factory.register(StackTraceElementSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory2.register(ThrowableSerializer(factory2), factory2)
         factory2.register(StackTraceElementSerializer(), factory2)
 
@@ -712,8 +712,8 @@ class SerializationOutputTests {
         val b = ByteArray(2)
         val obj = Bob(listOf(a, b, a))
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val obj2 = serdes(obj, factory, factory2, expectedEqual = false, expectDeserializedEqual = false)
 
         assertNotSame(obj2.byteArrays[0], obj2.byteArrays[2])
@@ -727,8 +727,8 @@ class SerializationOutputTests {
         val a = listOf("a", "b")
         val obj = Vic(a, a)
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val objCopy = serdes(obj, factory, factory2)
         assertSame(objCopy.a, objCopy.b)
     }
@@ -744,8 +744,8 @@ class SerializationOutputTests {
     fun `test private constructor`() {
         val obj = Spike()
 
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         assertThrows<NotSerializableException> { serdes(obj, factory, factory2) }
     }
 
@@ -754,10 +754,10 @@ class SerializationOutputTests {
 
     @Test
     fun `test toString custom serializer`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.register(BigDecimalSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory2.register(BigDecimalSerializer(), factory2)
 
         val obj = BigDecimals(BigDecimal.TEN, BigDecimal.TEN)
@@ -770,10 +770,10 @@ class SerializationOutputTests {
 
     @Test
     fun `test byte arrays not reference counted`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.register(BigDecimalSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory2.register(BigDecimalSerializer(), factory2)
 
         val bytes = ByteArray(1)
@@ -798,10 +798,10 @@ class SerializationOutputTests {
 
     @Test
     fun `test InputStream serialize`() {
-        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory.register(InputStreamSerializer(), factory)
 
-        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         factory2.register(InputStreamSerializer(), factory2)
         val bytes = ByteArray(10) { it.toByte() }
         val obj = bytes.inputStream()
@@ -1014,7 +1014,7 @@ class SerializationOutputTests {
 
     @Test
     fun `compression reduces number of bytes significantly`() {
-        val ser = SerializationOutput(SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup()))
+        val ser = SerializationOutput(SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext()))
         val obj = ByteArray(20000)
         val uncompressedSize = ser.serialize(obj).bytes.size
         val compressedSize = ser.serialize(obj, CordaSerializationEncoding.SNAPPY).bytes.size

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/StaticInitialisationOfSerializedObjectTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/StaticInitialisationOfSerializedObjectTest.kt
@@ -50,7 +50,7 @@ class StaticInitialisationOfSerializedObjectTest {
 	fun kotlinObjectWithCompanionObject() {
         data class D(val c: C)
 
-        val sf = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val sf = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
 
         val typeMap = sf::class.java.getDeclaredField("serializersByType")
         typeMap.isAccessible = true
@@ -83,7 +83,7 @@ class StaticInitialisationOfSerializedObjectTest {
 //        val sc = SerializationOutput(sf1).serialize(D(C2(20)))
 //        File(URI("$localPath/$resource")).writeBytes(sc.bytes)
 
-        val sf2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
+        val sf2 = SerializerFactoryBuilder.build(testSerializationContext.currentClassloadingContext())
         val bytes = url.readBytes()
 
         assertThatThrownBy {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/TypeModellingFingerPrinterTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/TypeModellingFingerPrinterTests.kt
@@ -17,7 +17,7 @@ class TypeModellingFingerPrinterTests {
     val customRegistry = CachingCustomSerializerRegistry(descriptorBasedSerializerRegistry)
     val fingerprinter = TypeModellingFingerPrinter(
         customRegistry,
-        testSerializationContext.currentSandboxGroup(),
+        testSerializationContext.currentClassloadingContext(),
         true
     )
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/BigIntegerTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/BigIntegerTest.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.amqp.custom
 
-import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.serializeDeserializeAssert
 import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.factory
+import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.serializeDeserializeAssert
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.TypeNotation
 import net.corda.internal.serialization.amqp.helper.testSerializationContext

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/CurrencyTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/CurrencyTest.kt
@@ -7,8 +7,8 @@ import net.corda.internal.serialization.amqp.TypeNotation
 import net.corda.internal.serialization.amqp.helper.testSerializationContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.Currency

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableTest.kt
@@ -7,13 +7,13 @@ import net.corda.internal.serialization.amqp.TypeNotation
 import net.corda.internal.serialization.amqp.helper.testSerializationContext
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.fail
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Test
 
 class ThrowableTest {
     class TestException(override val message: String) : CordaRuntimeException(message)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/X509CRLTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/X509CRLTest.kt
@@ -6,10 +6,10 @@ import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.TypeNotation
 import net.corda.internal.serialization.amqp.helper.testSerializationContext
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.Test
-import java.security.cert.CertificateFactory
+import org.junit.jupiter.api.fail
 import java.security.cert.CRL
+import java.security.cert.CertificateFactory
 
 class X509CRLTest {
     private fun generateCRL(resourceName: String): CRL {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/X509CertificateTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/X509CertificateTest.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.amqp.custom
 
-import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.serializeDeserializeAssert
 import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.factory
+import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.serializeDeserializeAssert
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.TypeNotation
 import net.corda.internal.serialization.amqp.helper.testSerializationContext

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ZoneIdTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ZoneIdTest.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.amqp.custom
 
-import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.serializeDeserializeAssert
 import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.factory
+import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert.Companion.serializeDeserializeAssert
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.TypeNotation
 import net.corda.internal.serialization.amqp.helper.testSerializationContext

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/testutils/AMQPTestUtils.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/testutils/AMQPTestUtils.kt
@@ -11,7 +11,7 @@ import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
 import net.corda.internal.serialization.amqp.TransformsSchema
-import net.corda.internal.serialization.amqp.currentSandboxGroup
+import net.corda.internal.serialization.amqp.currentClassloadingContext
 import net.corda.internal.serialization.amqp.helper.testSerializationContext
 import net.corda.serialization.SerializationContext
 import net.corda.serialization.SerializationEncoding
@@ -51,7 +51,7 @@ fun testDefaultFactory(
         DefaultDescriptorBasedSerializerRegistry()
 ) =
     SerializerFactoryBuilder.build(
-        testSerializationContext.currentSandboxGroup(),
+        testSerializationContext.currentClassloadingContext(),
         descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry
     )
 
@@ -61,7 +61,7 @@ fun testDefaultFactoryNoEvolution(
         DefaultDescriptorBasedSerializerRegistry()
 ): SerializerFactory =
     SerializerFactoryBuilder.build(
-        testSerializationContext.currentSandboxGroup(),
+        testSerializationContext.currentClassloadingContext(),
         descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry,
         allowEvolution = false
     )

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/model/LocalTypeModelTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/model/LocalTypeModelTests.kt
@@ -3,11 +3,11 @@ package net.corda.internal.serialization.model
 import com.google.common.reflect.TypeToken
 import net.corda.internal.serialization.amqp.AMQPSerializer
 import net.corda.internal.serialization.amqp.CachingCustomSerializerRegistry
-import net.corda.internal.serialization.amqp.standard.CustomSerializer
 import net.corda.internal.serialization.amqp.CustomSerializerRegistry
 import net.corda.internal.serialization.amqp.DefaultDescriptorBasedSerializerRegistry
-import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.LocalTypeModelConfigurationImpl
+import net.corda.internal.serialization.amqp.SerializerFactory
+import net.corda.internal.serialization.amqp.standard.CustomSerializer
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.serialization.SerializationCustomSerializer

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/model/TypeIdentifierTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/model/TypeIdentifierTests.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.model
 
 import com.google.common.reflect.TypeToken
-import net.corda.internal.serialization.amqp.currentSandboxGroup
+import net.corda.internal.serialization.amqp.currentClassloadingContext
 import net.corda.internal.serialization.amqp.helper.testSerializationContext
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -72,7 +72,7 @@ class TypeIdentifierTests {
 
     private fun assertRoundtrips(original: Type) {
         val identifier = TypeIdentifier.forGenericType(original)
-        val localType = identifier.getLocalType(testSerializationContext.currentSandboxGroup())
+        val localType = identifier.getLocalType(testSerializationContext.currentClassloadingContext())
         assertIdentified(localType, identifier.prettyPrint())
     }
 }

--- a/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/test/KryoCheckpointTest.kt
+++ b/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/test/KryoCheckpointTest.kt
@@ -1,11 +1,11 @@
 package net.corda.kryoserialization.test
 
-import net.cordapp.bundle1.Cash
 import net.corda.sandbox.SandboxException
 import net.corda.serialization.checkpoint.factory.CheckpointSerializerBuilderFactory
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
+import net.cordapp.bundle1.Cash
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.BeforeAll
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
-import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.common.annotation.InjectBundleContext
 import org.osgi.test.common.annotation.InjectService
+import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
 import java.nio.file.Path
 import java.util.concurrent.Executors

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
@@ -22,9 +22,9 @@ import net.corda.kryoserialization.serializers.LinkedHashMapEntrySerializer
 import net.corda.kryoserialization.serializers.LinkedHashMapIteratorSerializer
 import net.corda.kryoserialization.serializers.LinkedListItrSerializer
 import net.corda.kryoserialization.serializers.LoggerSerializer
+import net.corda.kryoserialization.serializers.NonSerializableSerializer
 import net.corda.kryoserialization.serializers.ThrowableSerializer
 import net.corda.kryoserialization.serializers.X509CertificateSerializer
-import net.corda.kryoserialization.serializers.NonSerializableSerializer
 import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.utilities.LazyMappedList
 import org.apache.avro.specific.SpecificRecord

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/KryoCheckpointSerializer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/KryoCheckpointSerializer.kt
@@ -1,10 +1,10 @@
 package net.corda.kryoserialization
 
 import com.esotericsoftware.kryo.Kryo
-import java.io.ByteArrayInputStream
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.uncheckedCast
+import java.io.ByteArrayInputStream
 
 class KryoCheckpointSerializer(
     private val kryo: Kryo,

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializer.kt
@@ -5,7 +5,7 @@ import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import java.lang.reflect.Field
-import java.util.*
+import java.util.LinkedList
 
 /**
  * The [ListIterator] has a problem with the default Quasar/Kryo serialisation

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/KryoStreamsTest.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/KryoStreamsTest.kt
@@ -10,7 +10,7 @@ import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.BufferOverflowException
-import java.util.*
+import java.util.Random
 import java.util.zip.DeflaterOutputStream
 import java.util.zip.InflaterInputStream
 

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializerTest.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializerTest.kt
@@ -5,7 +5,7 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.*
+import java.util.LinkedList
 
 internal class LinkedListItrSerializerTest {
     @Test

--- a/testing/test-serialization/build.gradle
+++ b/testing/test-serialization/build.gradle
@@ -12,7 +12,6 @@ dependencies {
 
     api "net.corda:corda-application"
     implementation project(":libs:serialization:serialization-amqp")
-    implementation project(":libs:sandbox")
     implementation project(":libs:serialization:serialization-internal")
     implementation project(":libs:crypto:crypto-serialization-impl")
     implementation project(':components:flow:flow-service')

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
@@ -3,14 +3,13 @@
 package net.corda.internal.serialization.amqp.helper
 
 import net.corda.internal.serialization.SerializationContextImpl
+import net.corda.internal.serialization.amqp.ClassloadingContext
 import net.corda.internal.serialization.amqp.amqpMagic
-import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.sandbox.SandboxGroup
 import net.corda.serialization.SerializationContext
-import org.osgi.framework.Bundle
 
-private class MockSandboxGroup(private val classLoader: ClassLoader = ClassLoader.getSystemClassLoader()) : SandboxGroup {
-    override val metadata: Map<Bundle, CpkMetadata> = emptyMap()
+private class MockSandboxGroup(
+    private val classLoader: ClassLoader = ClassLoader.getSystemClassLoader()
+) : ClassloadingContext {
 
     override fun loadClassFromMainBundles(className: String): Class<*> =
         Class.forName(className, false, classLoader)
@@ -20,7 +19,6 @@ private class MockSandboxGroup(private val classLoader: ClassLoader = ClassLoade
     override fun loadClassFromPublicBundles(className: String): Class<*>? =
         Class.forName(className, false, classLoader)
 
-    override fun getStaticTag(klass: Class<*>): String = "S;bundle;sandbox"
     override fun getEvolvableTag(klass: Class<*>) = "E;bundle;sandbox"
 }
 

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationService.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationService.kt
@@ -8,7 +8,7 @@ import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
-import net.corda.internal.serialization.amqp.currentSandboxGroup
+import net.corda.internal.serialization.amqp.currentClassloadingContext
 import net.corda.internal.serialization.registerCustomSerializers
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
@@ -22,7 +22,7 @@ class TestSerializationService {
                 DefaultDescriptorBasedSerializerRegistry(),
         ): SerializerFactory =
             SerializerFactoryBuilder.build(
-                testSerializationContext.currentSandboxGroup(),
+                testSerializationContext.currentClassloadingContext(),
                 descriptorBasedSerializerRegistry = descriptorBasedSerializerRegistry,
                 allowEvolution = false
             ).also {


### PR DESCRIPTION
Currently, all non-OSGi references to serialization libraries have to bring in dependencies on OSGi and core CPK classes, despite not actually using them. By isolating the rest of the methods on SandboxGroup which are used, we eliminate those dependencies. This will be important for Simulator, which has to publish its runtime dependencies to Maven Central.