### PR TITLE
CORE-5480:  investigate multi arch building of images 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,4 +16,5 @@ cordaPipeline(
     publishToMavenS3Repository: true,
     // allow publishing an installer to a download site
     publishToDownloadSiteTask: ':tools:plugins:publish',
+    gradleAdditionalArgs: '-PcliBaseTag=5.0.0-alpha-1664297524432' // just while testing PR
     )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,5 +16,4 @@ cordaPipeline(
     publishToMavenS3Repository: true,
     // allow publishing an installer to a download site
     publishToDownloadSiteTask: ':tools:plugins:publish',
-    gradleAdditionalArgs: '-PcliBaseTag=5.0.0-alpha-1664297524432' // just while testing PR
     )

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -247,6 +247,11 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             platformSet.add(new Platform("arm64", "linux"))
             builder.setPlatforms(platformSet)
             tagPrefix = "arm64-"
+        } else {
+            logger.quiet("Detected amd64 host, switching Jib to produce amd64 images")
+            Set<Platform> platformSet = new HashSet<Platform>()
+            platformSet.add(new Platform("amd64", "linux"))
+            builder.setPlatforms(platformSet)        
         }
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -237,21 +237,14 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
         if (System.getenv().containsKey("JENKINS_URL")) {
             logger.quiet("Running on CI server - producing arm64 and amd64 images")
-            Set<Platform> platformSet = new HashSet<Platform>()
-            platformSet.add(new Platform("arm64", "linux"))
-            platformSet.add(new Platform("amd64", "linux"))
-            builder.setPlatforms(platformSet)
+            builder.addPlatform("arm64","linux")
         } else if (System.properties['os.arch'] == "aarch64") { 
             logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")
-            Set<Platform> platformSet = new HashSet<Platform>()
-            platformSet.add(new Platform("arm64", "linux"))
-            builder.setPlatforms(platformSet)
+            builder.setPlatforms(Set.of(new Platform("arm64", "linux")))
             tagPrefix = "arm64-"
         } else {
-            logger.quiet("Detected amd64 host, switching Jib to produce amd64 images")
-            Set<Platform> platformSet = new HashSet<Platform>()
-            platformSet.add(new Platform("amd64", "linux"))
-            builder.setPlatforms(platformSet)        
+            logger.quiet("Detected amd64 host, producing amd64 images")
+            // Default JIB configuration no specific action needed
         }
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -235,7 +235,13 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
-        if (System.properties['os.arch'] == "aarch64") {
+        if (System.getenv().containsKey("JENKINS_URL")) {
+            logger.quiet("Running on CI server - producing arm64 and amd64 images")
+            Set<Platform> platformSet = new HashSet<Platform>()
+            platformSet.add(new Platform("arm64", "linux"))
+            platformSet.add(new Platform("amd64", "linux"))
+            builder.setPlatforms(platformSet)
+        } else if (System.properties['os.arch'] == "aarch64") { 
             logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")
             Set<Platform> platformSet = new HashSet<Platform>()
             platformSet.add(new Platform("arm64", "linux"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -115,7 +115,7 @@ jettyVersion = 9.4.47.v20220610
 compositeBuild=false
 cordaApiLocation=../corda-api
 cordaCliHostLocation=../corda-cli-plugin-host
-jibCoreVersion=0.16.0
+jibCoreVersion=0.22.0
 artifactoryPluginVersion = 4.28.2
 
 # PF4J


### PR DESCRIPTION
Allow our CIs to produce multi arch compatible images and remove the need for a dedicated ARM job.

- Jenkins will produce 1 image, but it's manifest file will have 2 different architecture types. Local users with ARM machines (M1s etc) may still build from source if they wish.

sample output of  ` docker manifest inspect corda-os-docker.software.r3.com/corda-os-plugins:preTest-07a105ad8`  after this change from a image produced by this PR

```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 925,
         "digest": "sha256:f0003d0e0e260c54af9d831ed41fecf1c4962df7ce906e8204a3bf86acd07de7",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 925,
         "digest": "sha256:1d7e4bd880ee3ef88d0cf7db1b81bd8f3cd2f734b875253ae0ef3e6ddef47985",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

Here we see both Arch types supported


