### PR TITLE
NOTICK: Implement test sandbox cleanups as a stack, and allow extra cleanups.

### DIFF
--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
@@ -14,6 +14,8 @@ interface SandboxSetup {
 
     fun <T> getService(serviceType: Class<T>, filter: String?, timeout: Long): T
     fun <T> getService(serviceType: Class<T>, timeout: Long): T = getService(serviceType, null, timeout)
+
+    fun withCleanup(closeable: AutoCloseable)
 }
 
 inline fun <reified T> SandboxSetup.fetchService(timeout: Long): T {


### PR DESCRIPTION
Ensure we execute the clean-up handlers in the opposite order they were allocated in. Also allow us to add extra clean-up handlers into the stack.