### PR TITLE
Fix to allow corda-cli.cmd to be run from any dir

### DIFF
--- a/tools/plugins/installScripts/install.ps1
+++ b/tools/plugins/installScripts/install.ps1
@@ -9,7 +9,7 @@ Write-Output "copying files and plugins"
 Copy-Item -Path ".\*" -Destination $cliHomeDir -Recurse
 
 Write-Output "Creating corda-cli Script"
-$cliCommand = "$ENV:JAVA_HOME\bin\java -Dpf4j.pluginsDir=$cliHomeDir\plugins -jar corda-cli.jar %*"
+$cliCommand = "$ENV:JAVA_HOME\bin\java -Dpf4j.pluginsDir=$cliHomeDir\plugins -jar $cliHomeDir\corda-cli.jar %*"
 New-Item "$cliHomeDir\corda-cli.cmd" -ItemType File -Value $cliCommand
 
 if($addToPath) {


### PR DESCRIPTION
A quick fix to allow corda-cli.cmd to be run from any directory.
Tested by removing an existing install.  Then modifying the old install.ps1 where it was unzipped and running.
Then I checked the corda-cli.cmd by eye and went to a different directory than where it gets installed and ran "corda-cli mgm groupPolicy".   I saw that it successfully generated a group policy.
I then ran the CSDE tasks that make use for corda-cli.jar that gets installed with and used by corda-cli they worked correctly.
 
 **WARNING** I've yet not built a fresh zip file from the Intellij project or build pipeline yet.  I'm not sure how to do that right now.