### PR TITLE
NOTICK: Do not try to load sandbox classes from fragment bundles.

### DIFF
--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxConstants.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxConstants.kt
@@ -3,6 +3,8 @@
 package net.corda.sandbox.internal
 
 import net.corda.v5.crypto.SecureHash
+import org.osgi.framework.Bundle
+import org.osgi.framework.Constants
 
 // The index of the class tag identifier, version, tag type and class bundle name in all serialised class tags.
 internal const val CLASS_TAG_IDENTIFIER_IDX = 0
@@ -35,3 +37,7 @@ internal object ClassTagV1 {
 
 // The symbolic name of the `sandbox-hooks` bundle.
 internal const val SANDBOX_HOOKS_BUNDLE = "net.corda.sandbox-hooks"
+
+val Bundle.isFragment: Boolean get() {
+    return headers.get(Constants.FRAGMENT_HOST) != null
+}

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -40,11 +40,12 @@ internal class SandboxGroupImpl(
     override fun loadClassFromPublicBundles(className: String): Class<*>? {
         val clazz = publicSandboxes
             .flatMap(Sandbox::publicBundles)
-            .mapNotNullTo(HashSet()) { sandbox ->
+            .filterNot(Bundle::isFragment)
+            .mapNotNullTo(LinkedHashSet()) { bundle ->
                 try {
-                    sandbox.loadClass(className)
+                    bundle.loadClass(className)
                 } catch (e: ClassNotFoundException) {
-                    logger.info("Could not load class $className from sandbox ${sandbox}: ${e.message}")
+                    logger.info("Could not load class $className from bundle $bundle: ${e.message}")
                     null
                 }
             }.singleOrNull()
@@ -53,7 +54,6 @@ internal class SandboxGroupImpl(
         }
         return clazz
     }
-
 
     override fun loadClassFromMainBundles(className: String): Class<*> {
         return cpkSandboxes.mapNotNullTo(HashSet()) { sandbox ->

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -20,7 +20,6 @@ import org.osgi.framework.Bundle
 import org.osgi.framework.Bundle.RESOLVED
 import org.osgi.framework.BundleContext
 import org.osgi.framework.BundleException
-import org.osgi.framework.Constants.FRAGMENT_HOST
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -190,7 +189,7 @@ internal class SandboxServiceImpl @Activate constructor(
                 sandboxId,
                 securityDomain
             )
-            sandboxForbidsThat(isFragment(mainBundle)) {
+            sandboxForbidsThat(mainBundle.isFragment) {
                 "CPK main bundle $mainBundle cannot be a fragment"
             }
 
@@ -335,17 +334,13 @@ internal class SandboxServiceImpl @Activate constructor(
     private fun startBundles(bundles: Collection<Bundle>) {
         // OSGi merges fragments with their host bundle,
         // and so we only start non-fragment bundles.
-        bundles.filterNot(::isFragment).forEach { bundle ->
+        bundles.filterNot(Bundle::isFragment).forEach { bundle ->
             try {
                 bundle.start()
             } catch (e: BundleException) {
                 throw SandboxException("Bundle $bundle could not be started.", e)
             }
         }
-    }
-
-    private fun isFragment(bundle: Bundle): Boolean {
-        return bundle.headers.get(FRAGMENT_HOST) != null
     }
 }
 


### PR DESCRIPTION
Fragment bundles and framework extensions cannot load classes because they don't have a classloader of their own. So don't try to load classes from public sandbox bundles which are also fragments.