### PR TITLE
NOTICK: No need for SigningService to be a prototype.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -13,9 +13,8 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [SigningService::class, SingletonSerializeAsToken::class], scope = PROTOTYPE)
+@Component(service = [ SigningService::class, SingletonSerializeAsToken::class ])
 class SigningServiceImpl @Activate constructor(
     @Reference(service = ExternalEventExecutor::class)
     private val externalEventExecutor: ExternalEventExecutor,


### PR DESCRIPTION
The point about declaring a service as "prototype" is that it allows each sandbox to create its own instance, _which is expected to be a singleton inside the sandbox._ The `SigningService` has no state of its own and so has no obvious need to be a prototype.