### PR TITLE
NOTICK visible for testing

### DIFF
--- a/components/configuration/configuration-rpcops-service-impl/src/main/kotlin/net/corda/configuration/rpcops/impl/v1/ConfigRPCOpsImpl.kt
+++ b/components/configuration/configuration-rpcops-service-impl/src/main/kotlin/net/corda/configuration/rpcops/impl/v1/ConfigRPCOpsImpl.kt
@@ -42,7 +42,7 @@ import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.schema.Schemas.Config.Companion.CONFIG_MGMT_REQUEST_TOPIC
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.versioning.Version

--- a/components/domino-logic/build.gradle
+++ b/components/domino-logic/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(":libs:configuration:configuration-core")
     implementation project(":components:configuration:configuration-read-service")
     implementation project(":libs:messaging:messaging")
+    implementation project(":libs:utilities")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBase.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBase.kt
@@ -21,7 +21,7 @@ import net.corda.lifecycle.domino.logic.DominoTileState.StoppedDueToError
 import net.corda.lifecycle.domino.logic.NamedLifecycle
 import net.corda.messaging.api.subscription.SubscriptionBase
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(":libs:cache:cache-caffeine")
     implementation project(':components:p2p-test:stub-crypto-processor')
     implementation project(":components:crypto:crypto-client")
+    implementation project(":libs:utilities")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "io.netty:netty-codec-http:$nettyVersion"

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
@@ -12,7 +12,7 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.gateway.messaging.SigningMode
 import net.corda.p2p.gateway.messaging.internal.InboundMessageHandler
 import net.corda.p2p.gateway.messaging.internal.OutboundMessageHandler
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 
 /**
  * The Gateway is a light component which facilitates the sending and receiving of P2P messages.

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
@@ -12,7 +12,7 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.SessionPartitions
 import net.corda.schema.Schemas.P2P.Companion.SESSION_OUT_PARTITIONS
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 

--- a/components/http-rpc-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/HttpRpcGatewayEventHandler.kt
+++ b/components/http-rpc-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/HttpRpcGatewayEventHandler.kt
@@ -40,7 +40,7 @@ import net.corda.schema.configuration.ConfigKeys.RPC_WEBSOCKET_CONNECTION_IDLE_T
 import net.corda.utilities.NetworkHostAndPort
 import net.corda.utilities.PathProvider
 import net.corda.utilities.TempPathProvider
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import java.util.function.Supplier
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
@@ -17,7 +17,7 @@ import net.corda.lifecycle.domino.logic.util.ResourcesHolder
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import java.time.Duration
 import java.util.concurrent.*

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -56,7 +56,7 @@ import net.corda.schema.Schemas.P2P.Companion.LINK_OUT_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.SESSION_OUT_PARTITIONS
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.virtualnode.HoldingIdentity

--- a/components/permissions/permission-management-service/build.gradle
+++ b/components/permissions/permission-management-service/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation project(":components:configuration:configuration-read-service")
     implementation project(":libs:configuration:configuration-core")
     implementation project(':libs:messaging:messaging')
+    implementation project(":libs:utilities")
     api project(':libs:permissions:permission-manager')
     api project(':libs:permissions:permission-validation')
     implementation project(':libs:permissions:permission-management-cache')

--- a/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
+++ b/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
@@ -29,7 +29,7 @@ import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_MGMT_REQ_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.ConfigKeys.RPC_CONFIG
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 
 @Suppress("LongParameterList")

--- a/components/permissions/permission-rpc-ops-impl/build.gradle
+++ b/components/permissions/permission-rpc-ops-impl/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation project(':libs:permissions:permission-common')
     implementation project(":libs:http-rpc:http-rpc-common")
     implementation project(":libs:http-rpc:http-rpc")
+    implementation project(":libs:utilities")
 
     implementation project(':components:permissions:permission-management-service')
 

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionEndpointEventHandler.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionEndpointEventHandler.kt
@@ -10,7 +10,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.permissions.management.PermissionManagementService
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 

--- a/components/permissions/permission-storage-reader-service/build.gradle
+++ b/components/permissions/permission-storage-reader-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(':libs:permissions:permission-management-cache')
     implementation project(':libs:permissions:permission-storage-reader')
     implementation project(':libs:permissions:permission-storage-common')
+    implementation project(":libs:utilities")
 
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "javax.persistence:javax.persistence-api"

--- a/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
+++ b/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
@@ -26,7 +26,7 @@ import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
 import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import javax.persistence.EntityManagerFactory

--- a/components/permissions/permission-storage-writer-service/build.gradle
+++ b/components/permissions/permission-storage-writer-service/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation project(':libs:messaging:messaging')
     implementation project(':libs:permissions:permission-storage-common')
     implementation project(':libs:permissions:permission-storage-writer')
+    implementation project(":libs:utilities")
 
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation 'javax.persistence:javax.persistence-api'

--- a/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
+++ b/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
@@ -22,7 +22,7 @@ import net.corda.permissions.storage.reader.PermissionStorageReaderService
 import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_MGMT_REQ_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 
 @Suppress("LongParameterList")

--- a/components/rbac-security-manager-service/build.gradle
+++ b/components/rbac-security-manager-service/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation project(':components:permissions:permission-management-service')
     implementation project(':libs:http-rpc:rbac-security-manager')
+    implementation project(":libs:utilities")
 
     api project(":libs:lifecycle:lifecycle")
     api project(':libs:http-rpc:http-rpc-security-read')

--- a/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
+++ b/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
@@ -14,7 +14,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.permissions.management.PermissionManagementService
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component

--- a/components/uniqueness/backing-store-impl/build.gradle
+++ b/components/uniqueness/backing-store-impl/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation project(':libs:db:db-admin-impl')
     implementation project(":libs:uniqueness:jpa-backing-store-datamodel")
     implementation project(":libs:uniqueness:common")
+    implementation project(":libs:utilities")
 
     // For JSON serialization to DB
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -34,7 +34,7 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResultFailure
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateDetails
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import org.osgi.service.component.annotations.Activate

--- a/components/virtual-node/cpi-upload-rpcops-service/build.gradle
+++ b/components/virtual-node/cpi-upload-rpcops-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation "net.corda:corda-avro-schema"
     implementation 'net.corda:corda-topic-schema'
     implementation project(":libs:packaging:packaging")
+    implementation project(":libs:utilities")
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
     testImplementation project(':libs:virtual-node:cpi-upload-manager-impl')

--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/common/CpiUploadRPCOpsHandler.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/common/CpiUploadRPCOpsHandler.kt
@@ -12,7 +12,7 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StopEvent
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 
 /**

--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/service/impl/CpiUploadRPCOpsServiceHandler.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/service/impl/CpiUploadRPCOpsServiceHandler.kt
@@ -17,7 +17,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 
 /**

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
@@ -29,7 +29,7 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.PathProvider
 import net.corda.utilities.TempPathProvider
 import net.corda.utilities.WorkspacePathProvider
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
@@ -9,7 +9,7 @@ import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.CpkReader
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import java.nio.file.Files

--- a/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImpl.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImpl.kt
@@ -38,7 +38,7 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
 import net.corda.schema.configuration.MessagingConfig
 import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CPK_WRITE_INTERVAL_MS
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug

--- a/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/kafka/impl/CpkChecksumsCacheImpl.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/kafka/impl/CpkChecksumsCacheImpl.kt
@@ -11,7 +11,7 @@ import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash

--- a/components/virtual-node/ledger-persistence-service-impl/build.gradle
+++ b/components/virtual-node/ledger-persistence-service-impl/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(':libs:flows:external-event-responses')
     implementation project(':libs:ledger:ledger-common-impl')
     implementation project(":libs:messaging:messaging")
+    implementation project(':libs:utilities')
     implementation project(':libs:virtual-node:sandbox-group-context')
 
     // TODO This might not be needed if code is refactored so that WireTransactionSerializer is not used and

--- a/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/internal/ConsensualLedgerRepository.kt
+++ b/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/internal/ConsensualLedgerRepository.kt
@@ -5,7 +5,7 @@ import net.corda.ledger.common.impl.transaction.PrivacySaltImpl
 import net.corda.ledger.common.impl.transaction.TransactionMetaData.Companion.CPK_IDENTIFIERS_KEY
 import net.corda.ledger.common.impl.transaction.WireTransaction
 import net.corda.v5.application.marshalling.JsonMarshallingService
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.types.toHexString
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.DigestService

--- a/libs/http-rpc/http-rpc-client/build.gradle
+++ b/libs/http-rpc/http-rpc-client/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(":libs:http-rpc:http-rpc-common")
     implementation project(":libs:http-rpc:http-rpc-tools")
     implementation project(":libs:http-rpc:json-serialization")
+    implementation project(":libs:utilities")
 
     implementation "com.konghq:unirest-java:$unirestVersion"
     implementation "com.konghq:unirest-objectmapper-jackson:$unirestVersion"

--- a/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/HttpRpcClient.kt
+++ b/libs/http-rpc/http-rpc-client/src/main/kotlin/net/corda/httprpc/client/HttpRpcClient.kt
@@ -5,7 +5,7 @@ import net.corda.httprpc.client.config.HttpRpcClientConfig
 import net.corda.httprpc.client.connect.HttpRpcClientProxyHandler
 import net.corda.httprpc.client.connect.HttpRpcConnectionListenerDistributor
 import net.corda.httprpc.client.connect.remote.RemoteUnirestClient
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/ParametersTransformer.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/ParametersTransformer.kt
@@ -7,7 +7,7 @@ import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.server.impl.apigen.models.EndpointParameter
 import net.corda.httprpc.server.impl.apigen.models.ParameterType
 import net.corda.httprpc.server.impl.apigen.models.GenericParameterizedType
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.httprpc.annotations.isHttpRpcParameterAnnotation

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
@@ -33,7 +33,7 @@ import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.Data
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaRefObjectModel
 import net.corda.httprpc.tools.HttpPathUtils.joinResourceAndEndpointPaths
 import net.corda.httprpc.tools.HttpPathUtils.toOpenApiPath
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.trace
 import org.eclipse.jetty.http.HttpStatus
 import org.slf4j.LoggerFactory

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/OpenApiExample.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/OpenApiExample.kt
@@ -1,6 +1,6 @@
 package net.corda.httprpc.server.impl.apigen.processing.openapi.schema
 
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.trace
 import org.slf4j.LoggerFactory
 import java.text.SimpleDateFormat

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
@@ -21,7 +21,7 @@ import net.corda.httprpc.server.impl.context.ContextUtils.invokeHttpMethod
 import net.corda.utilities.classload.executeWithThreadContextClassLoader
 import net.corda.utilities.classload.OsgiClassLoader
 import net.corda.utilities.executeWithStdErrSuppressed
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace

--- a/libs/http-rpc/http-rpc-stubs-impl/build.gradle
+++ b/libs/http-rpc/http-rpc-stubs-impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api project(":libs:http-rpc:ssl-cert-read")
     implementation project(":libs:http-rpc:http-rpc-security-read")
     implementation project(":libs:http-rpc:http-rpc-common")
+    implementation project(":libs:utilities")
 
     implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
 }

--- a/libs/http-rpc/http-rpc-stubs-impl/src/main/kotlin/net/corda/httprpc/ssl/impl/SslCertReadServiceStubImpl.kt
+++ b/libs/http-rpc/http-rpc-stubs-impl/src/main/kotlin/net/corda/httprpc/ssl/impl/SslCertReadServiceStubImpl.kt
@@ -2,7 +2,7 @@ package net.corda.httprpc.ssl.impl
 
 import net.corda.httprpc.ssl.KeyStoreInfo
 import net.corda.httprpc.ssl.SslCertReadService
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import java.io.File
 import java.nio.file.Files

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializationScheme.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializationScheme.kt
@@ -43,7 +43,7 @@ import net.corda.internal.serialization.amqp.custom.ZonedDateTimeSerializer
 import net.corda.sandbox.SandboxGroup
 import net.corda.serialization.SerializationContext
 import net.corda.utilities.toSynchronised
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.types.ByteSequence
 import net.corda.v5.serialization.SerializationCustomSerializer
 import net.corda.v5.serialization.SerializedBytes

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationScheme.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationScheme.kt
@@ -7,7 +7,7 @@ import net.corda.serialization.SerializationContext
 import net.corda.serialization.SerializationEncoding
 import net.corda.serialization.SerializationFactory
 import net.corda.serialization.SerializationMagic
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.types.ByteSequence
 import net.corda.v5.serialization.SerializationCustomSerializer
 import net.corda.v5.serialization.SerializedBytes

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPExceptions.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/AMQPExceptions.kt
@@ -1,6 +1,6 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import org.slf4j.Logger
 import java.io.NotSerializableException
 import java.lang.reflect.Type

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
@@ -8,7 +8,7 @@ import net.corda.internal.serialization.encodingNotPermittedFormat
 import net.corda.internal.serialization.model.TypeIdentifier
 import net.corda.serialization.EncodingAllowList
 import net.corda.serialization.SerializationContext
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.types.ByteSequence
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/VisibleForTesting.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/VisibleForTesting.kt
@@ -1,0 +1,20 @@
+package net.corda.utilities
+
+/** The annotated entity should have a more restricted visibility but needs to be visible for tests.
+ *
+ * This annotation is to be used on any class, method or property that needs package or public visibilty
+ * purely for testing purpose, and should only be used internally in production code.
+ * Technically, it has no effect on the code - there is no mechanism to enforce that the annotated entity is only used
+ * where it is intended to be used. It is purely a marker that the visibility of the annotated entity is chosen for
+ * testing purposes, and it should not be relied upon for API purposes.
+ * */
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPEALIAS
+)
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+annotation class VisibleForTesting

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:membership:membership-datamodel')
     implementation project(":libs:permissions:permission-datamodel")
+    implementation project(":libs:utilities")
     implementation project(':libs:virtual-node:cpi-datamodel')
     implementation project(":libs:virtual-node:virtual-node-datamodel")
     implementation project(":libs:virtual-node:virtual-node-info")

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
@@ -16,7 +16,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.VersionedRecord
-import net.corda.v5.base.annotations.VisibleForTesting
+import net.corda.utilities.VisibleForTesting
 import org.slf4j.LoggerFactory
 
 /**


### PR DESCRIPTION
Create and reference a `@VisibleForTesting` annotation in runtime-os and stop using the one from corda-api - that can be deleted once this is merged.