### PR TITLE
NOTICK: Why on Earth have these been declared as "system services"?

### DIFF
--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
@@ -21,7 +21,11 @@ import java.security.NoSuchAlgorithmException
 import java.security.Provider
 import java.util.concurrent.ConcurrentHashMap
 
-@Component(service = [ DigestService::class, SingletonSerializeAsToken::class ], scope = PROTOTYPE, property=["corda.system=true"])
+@Component(
+    service = [ DigestService::class, SingletonSerializeAsToken::class ],
+    property = [ "corda.system=true" ],
+    scope = PROTOTYPE
+)
 class DigestServiceImpl @Activate constructor(
     @Reference(service = CipherSchemeMetadata::class)
     private val schemeMetadata: CipherSchemeMetadata,

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleTreeFactoryImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleTreeFactoryImpl.kt
@@ -13,7 +13,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [MerkleTreeFactory::class, SingletonSerializeAsToken::class], scope = PROTOTYPE, property=["corda.system=true"])
+@Component(service = [MerkleTreeFactory::class, SingletonSerializeAsToken::class], scope = PROTOTYPE)
 class MerkleTreeFactoryImpl @Activate constructor(
     @Reference(service = MerkleTreeProvider::class)
     private val merkleTreeProvider: MerkleTreeProvider

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleTreeProviderImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleTreeProviderImpl.kt
@@ -20,9 +20,9 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope
 
 @Component(
-    service = [MerkleTreeProvider::class, SingletonSerializeAsToken::class],
-    scope = ServiceScope.PROTOTYPE,
-    property=["corda.system=true"])
+    service = [ MerkleTreeProvider::class, SingletonSerializeAsToken::class ],
+    scope = ServiceScope.PROTOTYPE
+)
 class MerkleTreeProviderImpl @Activate constructor(
     @Reference(service = DigestService::class)
     private val digestService: DigestService,


### PR DESCRIPTION
All three of these services implement `net.corda.v5.*` interfaces, and so are allowed under the security policy. So why are we also declaring them to be "system services"?

**I am actually more worried about how they expect the OSGi framework to inject them as references inside other sandbox services, because our current sandbox service model doesn't support this case!**

`DigestService` is expected to be a singleton inside the sandbox, but `PROTOTYPE` scope means that everyone who asks for a reference can receive a new instance. This isn't what we want!