### PR TITLE
NOTICK: trigger logging around releasable artifacts only in execution stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,8 +408,8 @@ def logArtifacts(Project project) {
             publication.artifacts.each { artifact ->
                 logger.quiet(" * ${artifact.file.name}")
             }
-        
         }
+    }
 }
 
 // report updatable dependencies: gradle dependencyUpdates

--- a/build.gradle
+++ b/build.gradle
@@ -402,12 +402,14 @@ subprojects {
 
 // helper to log artifacts we will or will not publish during a release process
 def logArtifacts(Project project) {
-    project.publishing.publications.each { publication ->
-        logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
-        publication.artifacts.each { artifact ->
-            logger.quiet(" * ${artifact.file.name}")
+    doLast {
+        project.publishing.publications.each { publication ->
+            logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
+            publication.artifacts.each { artifact ->
+                logger.quiet(" * ${artifact.file.name}")
+            }
+        
         }
-    }
 }
 
 // report updatable dependencies: gradle dependencyUpdates


### PR DESCRIPTION
- only print this info if we explicitly call the task, rater than during the configuration stage
- too much console noise with this in the configuration stage