### PR TITLE
CORE-3819: clean up Gradle Ent import task - this is triggered from Jenkins

### DIFF
--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -108,7 +108,6 @@ def importTask = tasks.register("importOSGiJUnitXml", ImportJUnitXmlReports) {
 }
 
 tasks.named('integrationTest') {
-    finalizedBy importTask
     dependsOn testOSGi
     enabled = false
 }

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -96,7 +96,6 @@ def testOSGi = tasks.register('testOSGi', TestOSGi) {
         testingBundle
     )
     bndrun = resolve.flatMap { it.outputBndrun }
-    finalizedBy importOSGiJunitXml
 }
 
 tasks.named('integrationTest') {

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -148,7 +148,6 @@ def importTask = tasks.register("importOSGiJUnitXml", ImportJUnitXmlReports) {
 tasks.named('integrationTest') {
     // By default this is expected to run against the in-memory db, effectively
     // running an in-mem version of the message pattern tests
-    finalizedBy importTask
     dependsOn dbIntegrationTest
 
     enabled = false


### PR DESCRIPTION
Not to be merged before https://github.com/corda/corda-shared-build-pipeline-steps/pull/347

We trigger this task as part of the Jenkins pipeline directly so no need to trigger via `finalizedBy `. Using the existing way meant this task was only triggered on passing builds not also failures - which means data was not being sent to Gradle Enterprise server  for these test failures . 