### PR TITLE
CORE-6699 Make number of partitions configurable

### DIFF
--- a/applications/tools/p2p-test/app-simulator/README.md
+++ b/applications/tools/p2p-test/app-simulator/README.md
@@ -68,12 +68,17 @@ In the receiver mode, the configuration file should have the following form:
 {
     parallelClients: 1
     simulatorMode: "RECEIVER"
+    topicCreationParams {
+        numPartitions: 10
+	    replicationFactor: 3
+    }
 }
 ```
 
 The following configuration options are optional:
 * `parallelClients`: the number of parallel clients/threads consuming messages from Kafka. Default: 1.
-
+* `numPartitions`: the number of partitions for the app.received_msg topic. Default: 10.
+* `replicationFactor`: the replication factor for the app.received_msg topic. Default: 1.
 ### Database Sink mode
 
 In this mode, the tool will copy all the metadata from the Kafka topic (`app.received_msg`) into the specified database for further analysis.

--- a/applications/tools/p2p-test/app-simulator/README.md
+++ b/applications/tools/p2p-test/app-simulator/README.md
@@ -70,7 +70,7 @@ In the receiver mode, the configuration file should have the following form:
     simulatorMode: "RECEIVER"
     topicCreationParams {
         numPartitions: 10
-	    replicationFactor: 3
+	replicationFactor: 3
     }
 }
 ```

--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator/templates/app-simulator-receiver.yaml
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator/templates/app-simulator-receiver.yaml
@@ -41,8 +41,8 @@ spec:
           args:
             - "--mode RECEIVER"
             - "--clients {{ .Values.appSimulators.receiver.parallelClientsPerReplica }}"
-            - "--tnumPartitions={{ .Values.appSimulators.receiver.topicCreation.numPartitions }}"
-            - "--treplicationFactor={{ .Values.appSimulators.receiver.topicCreation.replicationFactor }}"
+            - "-tnumPartitions={{ .Values.appSimulators.receiver.topicCreation.numPartitions }}"
+            - "-treplicationFactor={{ .Values.appSimulators.receiver.topicCreation.replicationFactor }}"
             {{- include "appSimulator.kafkaArgs" . | nindent 12 }}
           env:
             - name: JAVA_TOOL_OPTIONS

--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator/templates/app-simulator-receiver.yaml
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator/templates/app-simulator-receiver.yaml
@@ -41,6 +41,8 @@ spec:
           args:
             - "--mode RECEIVER"
             - "--clients {{ .Values.appSimulators.receiver.parallelClientsPerReplica }}"
+            - "--tnumPartitions={{ .Values.appSimulators.receiver.topicCreation.numPartitions }}"
+            - "--treplicationFactor={{ .Values.appSimulators.receiver.topicCreation.replicationFactor }}"
             {{- include "appSimulator.kafkaArgs" . | nindent 12 }}
           env:
             - name: JAVA_TOOL_OPTIONS

--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator/values.yaml
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator/values.yaml
@@ -143,6 +143,11 @@ appSimulators:
       enabled: false
       # -- if debug is enabled, suspend the receiver app simulator worker until the debugger is attached
       suspend: false
+    topicCreation:
+      # - the number of partitions for the p2p.app.received_msg topic
+      numPartitions: 10
+      # - the replicationFactor for the p2p.app.received_msg topic
+      replicationFactor: 1
   dbSink:
     enabled: false
     # -- database sink app simulator replica count

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulatorTopicCreator.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulatorTopicCreator.kt
@@ -6,26 +6,28 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.schema.configuration.BootConfig
 import java.util.Properties
 
-class AppSimulatorTopicCreator(private val bootstrapConfig: SmartConfig, private val topicAdmin: KafkaTopicAdmin)
-{
+class AppSimulatorTopicCreator(
+    private val bootstrapConfig: SmartConfig,
+    private val topicAdmin: KafkaTopicAdmin,
+    topicCreationParams: TopicCreationParams
+) {
     companion object {
         internal const val APP_RECEIVED_MESSAGES_TOPIC = "p2p.app.received_msg"
-        private const val APP_RECEIVED_MESSAGES_PARTITIONS = 10
-        private const val APP_RECEIVED_MESSAGES_REPLICATION = 1
-        private val APP_RECEIVED_MESSAGE_TOPIC_CONF = mapOf(
-            "topics" to listOf(
-                mapOf(
-                    "topicName" to APP_RECEIVED_MESSAGES_TOPIC,
-                    "numPartitions" to APP_RECEIVED_MESSAGES_PARTITIONS,
-                    "replicationFactor" to APP_RECEIVED_MESSAGES_REPLICATION,
-                    "config" to mapOf("cleanup.policy" to "delete")
-                )
-            )
-        )
     }
 
+    private val appReceivedMessageTopicConf = mapOf(
+        "topics" to listOf(
+            mapOf(
+                "topicName" to APP_RECEIVED_MESSAGES_TOPIC,
+                "numPartitions" to topicCreationParams.numPartitions,
+                "replicationFactor" to topicCreationParams.replicationFactor,
+                "config" to mapOf("cleanup.policy" to "delete")
+            )
+        )
+    )
+
     fun createTopic() {
-        val topicCreationConfig = ConfigFactory.parseMap(APP_RECEIVED_MESSAGE_TOPIC_CONF)
+        val topicCreationConfig = ConfigFactory.parseMap(appReceivedMessageTopicConf)
         topicAdmin.createTopics(
             bootstrapConfig.getConfig(BootConfig.BOOT_KAFKA_COMMON).toKafkaProperties(),
             topicCreationConfig.root().render()

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/ArgParsingUtils.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/ArgParsingUtils.kt
@@ -26,6 +26,23 @@ class ArgParsingUtils {
         }
 
         /***
+         * Get a topic creation parameter from the command line or the config file. Command line options override options in
+         * the config file.
+         */
+        fun getTopicCreationParameter(path: String, default: Int, configFromFile: Config, parameters: CliParameters): Int {
+            val stringParameter = getParameter(
+                path,
+                configFromFile.getConfigOrEmpty(AppSimulator.TOPIC_CREATION_PREFIX),
+                parameters.topicCreationParams
+            ) ?: return default
+            return try {
+                Integer.parseInt(stringParameter)
+            } catch (exception: NumberFormatException) {
+                throw InvalidArgumentException("Topic creation parameter $path = $stringParameter is not an integer.")
+            }
+        }
+
+        /***
          * Get a load generation parameter from the command line or the config file. Command line options override options in
          * the config file.
          */

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
@@ -26,7 +26,8 @@ import java.time.Instant
 class Receiver(private val subscriptionFactory: SubscriptionFactory,
                private val configMerger: ConfigMerger,
                private val topicAdmin: KafkaTopicAdmin,
-               private val commonConfig: CommonConfig
+               private val commonConfig: CommonConfig,
+               private val topicCreationParams: TopicCreationParams
     ): Closeable {
 
     companion object {
@@ -37,7 +38,7 @@ class Receiver(private val subscriptionFactory: SubscriptionFactory,
     private val subscriptions = mutableListOf<Subscription<*, *>>()
 
     fun start() {
-        AppSimulatorTopicCreator(commonConfig.bootConfig, topicAdmin).createTopic()
+        AppSimulatorTopicCreator(commonConfig.bootConfig, topicAdmin, topicCreationParams).createTopic()
         (1..commonConfig.clients).forEach { client ->
             val subscriptionConfig = SubscriptionConfig("app-simulator-receiver", commonConfig.parameters.receiveTopic,)
             val configWithInstanceId = commonConfig.bootConfig.withValue(


### PR DESCRIPTION
Make the number of partitions and replication factor for `p2p.app-received.messages` configurable. This can be set in the app simulator helm chart.

To test I deployed the app simulator and overrode the defaults to partitions 27 and a replicationFactor of 2:
```
db:
  appSimulator:
    user: postgres

appSimulators:
   receiver:
      enabled: true
      topicCreation:
         # - the number of partitions for the p2p.app.received_msg topic
         numPartitions: 27
         # - the replicationFactor for the p2p.app.received_msg topic
         replicationFactor: 2
```

Then checked the app simulator logs:

```
08:09:59.642 [main] INFO  net.corda.libs.messaging.topic.KafkaTopicUtils {} - Attempting to create topics: [(name=p2p.app.received_msg, numPartitions=27, replicationFactor=2, replicasAssignments=null, configs={cleanup.policy=delete})]
08:10:00.256 [main] INFO  net.corda.libs.messaging.topic.KafkaTopicUtils {} - [(name=p2p.app.received_msg, numPartitions=27, replicationFactor=2, replicasAssignments=null, configs={cleanup.policy=delete})] created successfully
```