### PR TITLE
CORE-6517 - Add micrometer libraries to workers.

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -28,6 +28,12 @@ dependencies {
     implementation "info.picocli:picocli:$picocliVersion"
     implementation "io.javalin:javalin-osgi:$javalinVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation ("io.micrometer:micrometer-core:0.1.0-SNAPSHOT") {
+        // we don't need these in classpath, so excluding them to reduce dependencies.
+        exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
+        exclude group: 'org.latencyutils', module: 'LatencyUtils'
+    }
+    implementation "io.micrometer:micrometer-registry-prometheus:0.1.0-SNAPSHOT"
 
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly "org.apache.commons:commons-lang3:$commonsLangVersion"

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/MetricsServer.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/MetricsServer.kt
@@ -1,0 +1,12 @@
+package net.corda.applications.workers.workercommon
+
+interface MetricsServer {
+    /** Serves worker health and readiness on [port]. */
+    fun listen(port: Int)
+
+    /** Stops serving worker health and readiness. */
+    fun stop()
+
+    /** The port the health monitor listens on, once it has successfully managed to listen on a socket */
+    val port: Int?
+}

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/Constants.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/Constants.kt
@@ -3,5 +3,6 @@ package net.corda.applications.workers.workercommon.internal
 internal const val HTTP_OK_CODE = 200
 internal const val HTTP_SERVICE_UNAVAILABLE_CODE = 503
 internal const val HTTP_HEALTH_ROUTE = "/isHealthy"
+internal const val HTTP_METRICS_ROUTE = "/metrics"
 internal const val HTTP_STATUS_ROUTE = "/status"
 internal const val HEALTH_MONITOR_PORT = 7000

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/HealthMonitorImpl.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/HealthMonitorImpl.kt
@@ -2,6 +2,15 @@ package net.corda.applications.workers.workercommon.internal
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.javalin.Javalin
+import io.micrometer.core.instrument.Metrics
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics
+import io.micrometer.core.instrument.binder.system.UptimeMetrics
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
 import net.corda.applications.workers.workercommon.HealthMonitor
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.registry.LifecycleRegistry
@@ -29,9 +38,27 @@ internal class HealthMonitorImpl @Activate constructor(
     private companion object {
         val logger = contextLogger()
     }
+
     // The use of Javalin is temporary, and will be replaced in the future.
     private var server: Javalin? = null
     private val objectMapper = ObjectMapper()
+    private val prometheusRegistry: PrometheusMeterRegistry
+
+    init {
+        val metricsRegistry = Metrics.globalRegistry
+
+        logger.info("Creating Prometheus metric registry")
+        prometheusRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        metricsRegistry.add(prometheusRegistry)
+
+        ClassLoaderMetrics().bindTo(metricsRegistry)
+        JvmMemoryMetrics().bindTo(metricsRegistry)
+        JvmGcMetrics().bindTo(metricsRegistry)
+        ProcessorMetrics().bindTo(metricsRegistry)
+        JvmThreadMetrics().bindTo(metricsRegistry)
+        UptimeMetrics().bindTo(metricsRegistry)
+    }
+
 
     override fun listen(port: Int) {
         server = Javalin
@@ -53,6 +80,9 @@ internal class HealthMonitorImpl @Activate constructor(
                 val status = if (anyComponentsNotReady) HTTP_SERVICE_UNAVAILABLE_CODE else HTTP_OK_CODE
                 context.status(status)
                 context.result(objectMapper.writeValueAsString(lifecycleRegistry.componentStatus()))
+            }
+            .get(HTTP_METRICS_ROUTE) { context ->
+                context.result(prometheusRegistry.scrape())
             }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,19 @@ allprojects {
                     includeGroup 'antlr'
                 }
             }
+
+            // NOTE: this needs to be removed once Micrometer contains OSGi metadata
+            //   https://github.com/micrometer-metrics/micrometer/pull/3457
+            exclusiveContent {
+                forRepository {
+                    maven {
+                        url "$artifactoryContextUrl/corda-dependencies-dev"
+                    }
+                }
+                filter {
+                    includeGroup 'io.micrometer'
+                }
+            }
         }
     }
 


### PR DESCRIPTION
NOTE: the purpose of this PR is mainly to prove the OSGi metadata changes in the micrometer library, and that we are not bringing in un-desired dependencies.
Follow-up PRs will add additional metrics.

[Dependencies](https://gradle.dev.r3.com/s/ga2dzmn6ghqdk/dependencies?toggled=W1sxXSxbMSwxXSxbMSwxLFs2MDk4XV0sWzEsMSxbNjEwM11dXQ) brought in by micrometer:

<img width="443" alt="image" src="https://user-images.githubusercontent.com/5557551/194322117-85d8df1d-f41e-459c-adb4-a15730cf2642.png">

NOTES:

- External PR: https://github.com/micrometer-metrics/micrometer/pull/3457 for the metadata changes. 
- This takes a SNAPSHOT version from our local artifactory. This will need to be taken out if the above is released.
- I will raise a follow-up PR to rename `HealthMonitor` to something more generic as it is not just about health anymore.