### PR TITLE
CORE-5908- refactor virtual node management processor

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
@@ -205,15 +205,17 @@ internal class VirtualNodeEntityRepository(private val entityManagerFactory: Ent
         }
     }
 
-    internal fun setVirtualNodeState(entityManager: EntityManager, holdingIdentityShortHash: String, newState: String): VirtualNodeEntity {
-        entityManager.transaction {
-            // Lookup virtual node and grab the latest one based on the cpi Version.
-            val latestVirtualNodeInstance = it.findVirtualNode(holdingIdentityShortHash)
-                ?: throw VirtualNodeNotFoundException(holdingIdentityShortHash)
-            val updatedVirtualNodeInstance = latestVirtualNodeInstance.apply {
-                update(newState)
+    internal fun setVirtualNodeState(holdingIdentityShortHash: String, newState: String): VirtualNodeEntity {
+        return entityManagerFactory.use { em ->
+            em.transaction {
+                // Lookup virtual node and grab the latest one based on the cpi Version.
+                val latestVirtualNodeInstance = it.findVirtualNode(holdingIdentityShortHash)
+                    ?: throw VirtualNodeNotFoundException(holdingIdentityShortHash)
+                val updatedVirtualNodeInstance = latestVirtualNodeInstance.apply {
+                    update(newState)
+                }
+                it.merge(updatedVirtualNodeInstance)
             }
-            return it.merge(updatedVirtualNodeInstance)
         }
     }
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
@@ -94,7 +94,14 @@ internal class VirtualNodeWriterFactory(
 
         val processor = VirtualNodeWriterProcessor(
             createVirtualNodeHandler,
-            changeVirtualNodeStateHandler
+            changeVirtualNodeStateHandler,
+            vnodePublisher,
+            dbConnectionManager,
+            virtualNodeEntityRepository,
+            vnodeDbFactory,
+            groupPolicyParser,
+            UTCClock(),
+            getChangeLogs
         )
 
         return subscriptionFactory.createRPCSubscription(rpcConfig, messagingConfig, processor)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
@@ -95,12 +95,8 @@ internal class VirtualNodeWriterFactory(
         val processor = VirtualNodeWriterProcessor(
             createVirtualNodeHandler,
             changeVirtualNodeStateHandler,
-            vnodePublisher,
             dbConnectionManager,
             virtualNodeEntityRepository,
-            vnodeDbFactory,
-            groupPolicyParser,
-            UTCClock(),
             getChangeLogs
         )
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -1,81 +1,41 @@
 package net.corda.virtualnode.write.db.impl.writer
 
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import javax.persistence.EntityManager
+import javax.sql.DataSource
 import net.corda.data.ExceptionEnvelope
-import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
-import net.corda.data.virtualnode.VirtualNodeCreateResponse
 import net.corda.data.virtualnode.VirtualNodeDBResetRequest
 import net.corda.data.virtualnode.VirtualNodeDBResetResponse
 import net.corda.data.virtualnode.VirtualNodeManagementRequest
 import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.data.virtualnode.VirtualNodeStateChangeRequest
-import net.corda.data.virtualnode.VirtualNodeStateChangeResponse
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.connection.manager.DbConnectionManager
-import net.corda.db.connection.manager.VirtualNodeDbType
-import net.corda.db.connection.manager.VirtualNodeDbType.CRYPTO
-import net.corda.db.connection.manager.VirtualNodeDbType.UNIQUENESS
 import net.corda.db.connection.manager.VirtualNodeDbType.VAULT
 import net.corda.db.core.CloseableDataSource
-import net.corda.db.core.DbPrivilege
-import net.corda.db.core.DbPrivilege.DDL
-import net.corda.db.core.DbPrivilege.DML
-import net.corda.layeredpropertymap.toAvro
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogAuditEntity
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.cpi.datamodel.findDbChangeLogAuditForCpi
 import net.corda.libs.cpi.datamodel.findDbChangeLogForCpi
 import net.corda.libs.packaging.core.CpiIdentifier
-import net.corda.libs.virtualnode.common.exception.CpiNotFoundException
-import net.corda.libs.virtualnode.common.exception.VirtualNodeAlreadyExistsException
-import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.Root.MGM_DEFAULT_GROUP_ID
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
 import net.corda.messaging.api.processor.RPCResponderProcessor
 import net.corda.messaging.api.publisher.Publisher
-import net.corda.messaging.api.records.Record
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
-import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
-import net.corda.schema.Schemas.VirtualNode.Companion.VIRTUAL_NODE_INFO_TOPIC
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.util.debug
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.ShortHash
-import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.VirtualNodeState
-import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
-import java.lang.System.currentTimeMillis
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
-import javax.persistence.EntityManager
-import javax.sql.DataSource
-import kotlin.system.measureTimeMillis
+import net.corda.virtualnode.write.db.impl.writer.management.VirtualNodeManagementHandler
 
-/**
- * An RPC responder processor that handles virtual node creation requests.
- *
- * For each virtual node creation request, persists the created virtual node to the cluster database publishes it to
- * Kafka.
- *
- * @property vnodePublisher Used to publish to Kafka.
- * @property virtualNodeEntityRepository Used to retrieve and store virtual nodes and related entities.
- * @property vnodeDbFactory Used to construct a mapping object which holds the multiple database connections we have.
- * @property groupPolicyParser Parses group policy JSON strings and returns MemberInfo structures
- * @property clock A clock instance used to add timestamps to what the records we publish. This is configurable rather
- *           than always simply the system wall clock time so that we can control everything in tests.
- * @property getChangelogs an overridable function to obtain the changelogs for a CPI. The default looks up in the database.
- *           Takes an EntityManager (since that lets us continue a transaction) and a CpiIdentifier as a parameter and
- *           returns a list of CpkDbChangeLogEntity.
- */
-@Suppress("LongParameterList", "TooManyFunctions")
 internal class VirtualNodeWriterProcessor(
+    private val createVirtualNodeHandler: VirtualNodeManagementHandler<VirtualNodeCreateRequest>,
+    private val changeVirtualNodeStateHandler: VirtualNodeManagementHandler<VirtualNodeStateChangeRequest>,
     private val vnodePublisher: Publisher,
     private val dbConnectionManager: DbConnectionManager,
     private val virtualNodeEntityRepository: VirtualNodeEntityRepository,
@@ -87,136 +47,7 @@ internal class VirtualNodeWriterProcessor(
 
     companion object {
         private val logger = contextLogger()
-        const val PUBLICATION_TIMEOUT_SECONDS = 30L
         val systemTerminatorTag = "${VAULT.name}-system-final"
-    }
-
-    @Suppress("ReturnCount", "ComplexMethod")
-    private fun createVirtualNode(
-        instant: Instant,
-        create: VirtualNodeCreateRequest,
-        respFuture: CompletableFuture<VirtualNodeManagementResponse>
-    ) {
-        // TODO - replace this with real metrics
-        logger.info("Create new Virtual Node: ${create.x500Name} and ${create.cpiFileChecksum}")
-        val startMillis = currentTimeMillis()
-
-        measureTimeMillis {
-            create.validationError()?.let { errMsg ->
-                handleException(respFuture, IllegalArgumentException(errMsg))
-                return
-            }
-        }.also {
-            logger.debug {"[Create ${create.x500Name}] validation took $it ms, elapsed " +
-                    "${currentTimeMillis() - startMillis} ms"}
-        }
-
-
-        try {
-            val cpiMetadata: CpiMetadataLite?
-            measureTimeMillis {
-                cpiMetadata = virtualNodeEntityRepository.getCpiMetadataByChecksum(create.cpiFileChecksum)
-                if (cpiMetadata == null) {
-                    handleException(
-                        respFuture,
-                        CpiNotFoundException("CPI with file checksum ${create.cpiFileChecksum} was not found.")
-                    )
-                    return
-                }
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] get metadata took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            // Generate group ID for MGM
-            val groupId = cpiMetadata!!.mgmGroupId.let {
-                if (it == MGM_DEFAULT_GROUP_ID) UUID.randomUUID().toString() else it
-            }
-            val holdingId = HoldingIdentity(MemberX500Name.parse(create.getX500CanonicalName()), groupId)
-            measureTimeMillis {
-                if (virtualNodeEntityRepository.virtualNodeExists(holdingId, cpiMetadata.id)) {
-                    handleException(
-                        respFuture,
-                        VirtualNodeAlreadyExistsException(
-                            "Virtual node for CPI with file checksum ${create.cpiFileChecksum} and x500Name " +
-                                    "${create.x500Name} already exists."
-                        )
-                    )
-                    return
-                }
-                checkUniqueId(holdingId)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] validate holding ID took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            val vNodeDbs:  Map<VirtualNodeDbType, VirtualNodeDb>
-            measureTimeMillis {
-                vNodeDbs = vnodeDbFactory.createVNodeDbs(holdingId.shortHash, create)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] creating vnode DBs took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            measureTimeMillis {
-                createSchemasAndUsers(holdingId, vNodeDbs.values)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] creating vnode DB Schemas and users took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            measureTimeMillis {
-                runDbMigrations(holdingId, vNodeDbs.values)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] DB migrations took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            val vaultDb = vNodeDbs[VAULT]
-            if (null == vaultDb) {
-                handleException(respFuture, VirtualNodeWriteServiceException("Vault DB not configured"))
-                return
-            } else {
-                measureTimeMillis {
-                    runCpiMigrations(cpiMetadata, vaultDb)
-                }.also {
-                    logger.debug {"[Create ${create.x500Name}] CPI DB migrations took $it ms, elapsed " +
-                            "${currentTimeMillis() - startMillis} ms"}
-                }
-            }
-
-            val dbConnections: VirtualNodeDbConnections
-            measureTimeMillis {
-                dbConnections =
-                    persistHoldingIdAndVirtualNode(holdingId, vNodeDbs, cpiMetadata.id, create.updateActor)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] persisting VNode to DB took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            measureTimeMillis {
-                publishVNodeInfo(holdingId, cpiMetadata, dbConnections)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] persisting VNode Info to Kafka took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            measureTimeMillis {
-                publishMgmInfo(holdingId, cpiMetadata.groupPolicy)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] persisting Mgm Info to Kafka took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-
-            measureTimeMillis {
-                sendSuccessfulResponse(respFuture, instant, holdingId, cpiMetadata, dbConnections)
-            }.also {
-                logger.debug {"[Create ${create.x500Name}] send response to RPC gateway took $it ms, elapsed " +
-                        "${currentTimeMillis() - startMillis} ms"}
-            }
-        } catch (e: Exception) {
-            handleException(respFuture, e)
-        }
     }
 
     private fun resetVirtualNodeDb(
@@ -302,251 +133,20 @@ internal class VirtualNodeWriterProcessor(
         LiquibaseSchemaMigratorImpl().rollBackDb(connection, dbChange, tagToRollbackTo)
     }
 
-    // State change request produced by VirtualNodeMaintenanceRPCOpsImpl
-    private fun changeVirtualNodeState(
-        instant: Instant,
-        stateChangeRequest: VirtualNodeStateChangeRequest,
-        respFuture: CompletableFuture<VirtualNodeManagementResponse>
-    ) {
-
-        // Attempt and update, and on failure, pass the error back to the RPC processor
-        try {
-            val em = dbConnectionManager.getClusterEntityManagerFactory().createEntityManager()
-            val updatedVirtualNodeEntity = em.use { entityManager ->
-                virtualNodeEntityRepository.setVirtualNodeState(
-                    entityManager,
-                    stateChangeRequest.holdingIdentityShortHash,
-                    stateChangeRequest.newState
-                )
-            }
-
-            val virtualNodeInfo = with(updatedVirtualNodeEntity) {
-                val cpiMetadata = virtualNodeEntityRepository.getCPIMetadataByNameAndVersion(
-                    this.cpiName,
-                    this.cpiVersion
-                ) ?: throw CpiNotFoundException(
-                    "No corresponding meta data found for cpi for ${this.holdingIdentity.holdingIdentityShortHash}"
-                )
-                val holdingIdentity = HoldingIdentity(
-                    MemberX500Name.parse(this.holdingIdentity.x500Name),
-                    this.holdingIdentity.mgmGroupId
-                )
-                val cpiIdentifier = CpiIdentifier(
-                    cpiMetadata.id.name,
-                    cpiMetadata.id.version,
-                    cpiMetadata.id.signerSummaryHash
-                )
-                VirtualNodeInfo(
-                    holdingIdentity,
-                    cpiIdentifier,
-                    this.holdingIdentity.vaultDDLConnectionId,
-                    this.holdingIdentity.vaultDMLConnectionId!!,
-                    this.holdingIdentity.cryptoDDLConnectionId,
-                    this.holdingIdentity.cryptoDMLConnectionId!!,
-                    this.holdingIdentity.uniquenessDDLConnectionId,
-                    this.holdingIdentity.uniquenessDMLConnectionId!!,
-                    this.holdingIdentity.hsmConnectionId,
-                    VirtualNodeState.valueOf(this.virtualNodeState),
-                    this.entityVersion,
-                    this.insertTimestamp!!
-                )
-            }.toAvro()
-
-            val virtualNodeRecord = Record(
-                VIRTUAL_NODE_INFO_TOPIC,
-                virtualNodeInfo.holdingIdentity,
-                virtualNodeInfo
-            )
-
-            try {
-                // TODO - CORE-3319 - Strategy for DB and Kafka retries.
-                val future = vnodePublisher.publish(listOf(virtualNodeRecord)).first()
-
-                // TODO - CORE-3730 - Define timeout policy.
-                future.get()
-            } catch (e: Exception) {
-                throw VirtualNodeWriteServiceException(
-                    "Record $virtualNodeRecord was written to the database, but couldn't be published. Cause: $e", e
-                )
-            }
-
-            val response = VirtualNodeManagementResponse(
-                instant,
-                VirtualNodeStateChangeResponse(
-                    stateChangeRequest.holdingIdentityShortHash,
-                    stateChangeRequest.newState
-                )
-            )
-            respFuture.complete(response)
-        } catch (e: Exception) {
-            respFuture.complete(
-                VirtualNodeManagementResponse(
-                    instant,
-                    VirtualNodeManagementResponseFailure(
-                        ExceptionEnvelope(
-                            e::class.java.name,
-                            e.message
-                        )
-                    )
-                )
-            )
-        }
-    }
-
     /**
-     * For each [request], the processor attempts to commit a new virtual node to the cluster database. If successful,
-     * the created virtual node is then published by the [vnodePublisher] to the `VIRTUAL_NODE_INFO_TOPIC` topic.
-     *
-     * If both steps succeed, [respFuture] is completed successfully. Otherwise, it is completed unsuccessfully.
+     * For each management request the processor calls out to the corresponding handler to perform the operation.
      */
     override fun onNext(
         request: VirtualNodeManagementRequest,
         respFuture: CompletableFuture<VirtualNodeManagementResponse>
     ) {
         when (val typedRequest = request.request) {
-            is VirtualNodeCreateRequest -> createVirtualNode(request.timestamp, typedRequest, respFuture)
-            is VirtualNodeStateChangeRequest -> changeVirtualNodeState(request.timestamp, typedRequest, respFuture)
+            is VirtualNodeCreateRequest -> createVirtualNodeHandler.handle(request.timestamp, typedRequest, respFuture)
+            is VirtualNodeStateChangeRequest -> changeVirtualNodeStateHandler.handle(request.timestamp, typedRequest, respFuture)
             is VirtualNodeDBResetRequest -> resetVirtualNodeDb(request.timestamp, typedRequest, respFuture)
             else -> throw VirtualNodeWriteServiceException("Unknown management request of type: ${typedRequest::class.java.name}")
         }
     }
-
-    private fun VirtualNodeCreateRequest.validationError(): String? {
-        if (cpiFileChecksum.isNullOrBlank()) {
-            return "CPI file checksum value is missing"
-        }
-
-        if (!vaultDdlConnection.isNullOrBlank() && vaultDmlConnection.isNullOrBlank()) {
-            return "If Vault DDL connection is provided, Vault DML connection needs to be provided as well."
-        }
-
-        if (!cryptoDdlConnection.isNullOrBlank() && cryptoDmlConnection.isNullOrBlank()) {
-            return "If Crypto DDL connection is provided, Crypto DML connection needs to be provided as well."
-        }
-
-        if (!uniquenessDdlConnection.isNullOrBlank() && uniquenessDmlConnection.isNullOrBlank()) {
-            return "If Uniqueness DDL connection is provided, Uniqueness DML connection needs to be provided as well."
-        }
-
-        try {
-            MemberX500Name.parse(x500Name)
-        } catch (e: Exception) {
-            return "X500 name \"$x500Name\" could not be parsed. Cause: ${e.message}"
-        }
-        return null
-    }
-
-    private fun VirtualNodeCreateRequest.getX500CanonicalName(): String {
-        // TODO replace toString with method that returns canonical name
-        return MemberX500Name.parse(x500Name).toString()
-    }
-
-    private fun checkUniqueId(holdingId: HoldingIdentity) {
-        virtualNodeEntityRepository.getHoldingIdentity(holdingId.shortHash)?.let { storedHoldingId ->
-            if (storedHoldingId != holdingId) {
-                throw VirtualNodeWriteServiceException(
-                    "New holding identity $holdingId has a short hash that collided with existing holding identity $storedHoldingId."
-                )
-            }
-        }
-    }
-
-    private fun createSchemasAndUsers(holdingIdentity: HoldingIdentity, vNodeDbs: Collection<VirtualNodeDb>) {
-        try {
-            vNodeDbs.filter { it.isClusterDb }.forEach { it.createSchemasAndUsers() }
-        } catch (e: Exception) {
-            throw VirtualNodeWriteServiceException(
-                "Error creating virtual node DB schemas and users for holding identity $holdingIdentity", e
-            )
-        }
-    }
-
-    private fun persistHoldingIdAndVirtualNode(
-        holdingIdentity: HoldingIdentity,
-        vNodeDbs: Map<VirtualNodeDbType, VirtualNodeDb>,
-        cpiId: CpiIdentifier,
-        updateActor: String
-    ): VirtualNodeDbConnections {
-        try {
-            return dbConnectionManager.getClusterEntityManagerFactory().createEntityManager()
-                .transaction { entityManager ->
-                    val dbConnections =
-                        VirtualNodeDbConnections(
-                            putConnection(entityManager, vNodeDbs, VAULT, DDL, updateActor),
-                            putConnection(entityManager, vNodeDbs, VAULT, DML, updateActor)!!,
-                            putConnection(entityManager, vNodeDbs, CRYPTO, DDL, updateActor),
-                            putConnection(entityManager, vNodeDbs, CRYPTO, DML, updateActor)!!,
-                            putConnection(entityManager, vNodeDbs, UNIQUENESS, DDL, updateActor),
-                            putConnection(entityManager, vNodeDbs, UNIQUENESS, DML, updateActor)!!,
-                        )
-                    virtualNodeEntityRepository.putHoldingIdentity(entityManager, holdingIdentity, dbConnections)
-                    virtualNodeEntityRepository.putVirtualNode(entityManager, holdingIdentity, cpiId)
-                    dbConnections
-                }
-        } catch (e: Exception) {
-            throw VirtualNodeWriteServiceException(
-                "Error persisting virtual node for holding identity $holdingIdentity",
-                e
-            )
-        }
-    }
-
-    private fun putConnection(
-        entityManager: EntityManager,
-        vNodeDbs: Map<VirtualNodeDbType, VirtualNodeDb>,
-        dbType: VirtualNodeDbType,
-        dbPrivilege: DbPrivilege,
-        updateActor: String
-    ): UUID? {
-        return vNodeDbs[dbType]?.let { vNodeDb ->
-            vNodeDb.dbConnections[dbPrivilege]?.let { dbConnection ->
-                with(dbConnection) {
-                    dbConnectionManager.putConnection(
-                        entityManager,
-                        name,
-                        dbPrivilege,
-                        config,
-                        description,
-                        updateActor
-                    )
-                }
-            }
-        }
-    }
-
-    private fun runDbMigrations(holdingIdentity: HoldingIdentity, vNodeDbs: Collection<VirtualNodeDb>) {
-        try {
-            vNodeDbs.forEach { it.runDbMigration(systemTerminatorTag) }
-        } catch (e: Exception) {
-            throw VirtualNodeWriteServiceException(
-                "Error running virtual node DB migration for holding identity $holdingIdentity",
-                e
-            )
-        }
-    }
-
-    private fun runCpiMigrations(cpiMetadata: CpiMetadataLite, vaultDb: VirtualNodeDb) =
-        // we could potentially do one transaction per CPK; it seems more useful to blow up the
-        // who migration if any CPK fails though, so that they can be iterative developed and repeated
-        dbConnectionManager.getClusterEntityManagerFactory().createEntityManager().transaction {
-            val changelogs = getChangelogs(it, cpiMetadata.id)
-            changelogs.map { cl -> cl.id.cpkName }.distinct().sorted().forEach { cpkName ->
-                val cpkChangelogs = changelogs.filter { cl2 -> cl2.id.cpkName == cpkName }
-                logger.info("Doing ${cpkChangelogs.size} migrations for $cpkName")
-                val dbChange = VirtualNodeDbChangeLog(cpkChangelogs)
-                val changesetId = cpkChangelogs.first().changesetId
-                try {
-                    vaultDb.runCpiMigrations(dbChange, changesetId.toString())
-                } catch (e: Exception) {
-                    logger.error("Virtual node liquibase DB migration failure on CPK $cpkName with error $e")
-                    throw VirtualNodeWriteServiceException(
-                        "Error running virtual node DB migration for CPI liquibase migrations",
-                        e
-                    )
-                }
-                logger.info("Completed ${cpkChangelogs.size} migrations for $cpkName")
-            }
-        }
 
     private fun runCpiResyncMigrations(dataSource: CloseableDataSource, changelogs: List<CpkDbChangeLogEntity>) {
         changelogs.map { cl -> cl.id.cpkName }.distinct().sorted().forEach { cpkName ->
@@ -558,78 +158,6 @@ internal class VirtualNodeWriterProcessor(
                 connection,
                 VirtualNodeDbChangeLog(cpkChangelogs),
                 tag = newChangeSetId.toString()
-            )
-        }
-    }
-
-    private fun createVirtualNodeRecord(
-        holdingIdentity: HoldingIdentity,
-        cpiMetadata: CpiMetadataLite,
-        dbConnections: VirtualNodeDbConnections
-    ):
-        Record<net.corda.data.identity.HoldingIdentity, net.corda.data.virtualnode.VirtualNodeInfo> {
-
-        val cpiIdentifier = CpiIdentifier(cpiMetadata.id.name, cpiMetadata.id.version, cpiMetadata.id.signerSummaryHash)
-        val virtualNodeInfo = with(dbConnections) {
-            VirtualNodeInfo(
-                holdingIdentity,
-                cpiIdentifier,
-                vaultDdlConnectionId,
-                vaultDmlConnectionId,
-                cryptoDdlConnectionId,
-                cryptoDmlConnectionId,
-                uniquenessDdlConnectionId,
-                uniquenessDmlConnectionId,
-                timestamp = clock.instant(),
-                state = VirtualNodeInfo.DEFAULT_INITIAL_STATE
-            )
-                .toAvro()
-        }
-        return Record(VIRTUAL_NODE_INFO_TOPIC, virtualNodeInfo.holdingIdentity, virtualNodeInfo)
-    }
-
-    private fun publishVNodeInfo(
-        holdingIdentity: HoldingIdentity,
-        cpiMetadata: CpiMetadataLite,
-        dbConnections: VirtualNodeDbConnections
-    ) {
-        val virtualNodeRecord = createVirtualNodeRecord(holdingIdentity, cpiMetadata, dbConnections)
-        try {
-            // TODO - CORE-3319 - Strategy for DB and Kafka retries.
-            val future = vnodePublisher.publish(listOf(virtualNodeRecord)).first()
-
-            // TODO - CORE-3730 - Define timeout policy.
-            future.get()
-        } catch (e: Exception) {
-            throw VirtualNodeWriteServiceException(
-                "Record $virtualNodeRecord was written to the database, but couldn't be published. Cause: $e", e
-            )
-        }
-    }
-
-    private fun publishMgmInfo(holdingIdentity: HoldingIdentity, groupPolicyJson: String) {
-        val mgmInfo = groupPolicyParser.run {
-            getMgmInfo(holdingIdentity, groupPolicyJson)
-        }
-        if (mgmInfo == null) {
-            logger.info("No MGM information found in group policy. MGM member info not published.")
-            return
-        }
-        val mgmHoldingIdentity = HoldingIdentity(mgmInfo.name, mgmInfo.groupId)
-        val mgmRecord = Record(
-            MEMBER_LIST_TOPIC,
-            "${holdingIdentity.shortHash}-${mgmHoldingIdentity.shortHash}",
-            PersistentMemberInfo(
-                holdingIdentity.toAvro(),
-                mgmInfo.memberProvidedContext.toAvro(),
-                mgmInfo.mgmProvidedContext.toAvro()
-            )
-        )
-        try {
-            vnodePublisher.publish(listOf(mgmRecord)).first().get(PUBLICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        } catch (e: Exception) {
-            throw VirtualNodeWriteServiceException(
-                "MGM member info for Group ID: ${mgmInfo.groupId} could not be published. Cause: $e", e
             )
         }
     }
@@ -646,47 +174,4 @@ internal class VirtualNodeWriterProcessor(
             .toSet() as Set<String>
         ).map { UUID.fromString(it) }.toSet()
 
-    private fun sendSuccessfulResponse(
-        respFuture: CompletableFuture<VirtualNodeManagementResponse>,
-        instant: Instant,
-        holdingIdentity: HoldingIdentity,
-        cpiMetadata: CpiMetadataLite,
-        dbConnections: VirtualNodeDbConnections
-    ) {
-        val response = VirtualNodeManagementResponse(
-            instant,
-            VirtualNodeCreateResponse(
-                holdingIdentity.x500Name.toString(), cpiMetadata.id.toAvro(), cpiMetadata.fileChecksum,
-                holdingIdentity.groupId, holdingIdentity.toAvro(), holdingIdentity.shortHash.value,
-                dbConnections.vaultDdlConnectionId?.toString(),
-                dbConnections.vaultDmlConnectionId.toString(),
-                dbConnections.cryptoDdlConnectionId?.toString(),
-                dbConnections.cryptoDmlConnectionId.toString(),
-                dbConnections.uniquenessDdlConnectionId?.toString(),
-                dbConnections.uniquenessDmlConnectionId.toString(),
-                null,
-                VirtualNodeInfo.DEFAULT_INITIAL_STATE.name
-            )
-        )
-        respFuture.complete(response)
-    }
-
-    /** Completes the [respFuture] with an [ExceptionEnvelope]. */
-    @Suppress("LongParameterList")
-    private fun handleException(
-        respFuture: CompletableFuture<VirtualNodeManagementResponse>,
-        e: Exception,
-    ): Boolean {
-        logger.error("Error while processing virtual node request: ${e.message}", e)
-        val response = VirtualNodeManagementResponse(
-            clock.instant(),
-            VirtualNodeManagementResponseFailure(
-                ExceptionEnvelope().apply {
-                    errorType = e::class.java.name
-                    errorMessage = e.message
-                }
-            )
-        )
-        return respFuture.complete(response)
-    }
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -22,12 +22,9 @@ import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.cpi.datamodel.findDbChangeLogAuditForCpi
 import net.corda.libs.cpi.datamodel.findDbChangeLogForCpi
 import net.corda.libs.packaging.core.CpiIdentifier
-import net.corda.membership.lib.grouppolicy.GroupPolicyParser
 import net.corda.messaging.api.processor.RPCResponderProcessor
-import net.corda.messaging.api.publisher.Publisher
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
-import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
@@ -36,12 +33,8 @@ import net.corda.virtualnode.write.db.impl.writer.management.VirtualNodeManageme
 internal class VirtualNodeWriterProcessor(
     private val createVirtualNodeHandler: VirtualNodeManagementHandler<VirtualNodeCreateRequest>,
     private val changeVirtualNodeStateHandler: VirtualNodeManagementHandler<VirtualNodeStateChangeRequest>,
-    private val vnodePublisher: Publisher,
     private val dbConnectionManager: DbConnectionManager,
     private val virtualNodeEntityRepository: VirtualNodeEntityRepository,
-    private val vnodeDbFactory: VirtualNodeDbFactory,
-    private val groupPolicyParser: GroupPolicyParser,
-    private val clock: Clock,
     private val getChangelogs: (EntityManager, CpiIdentifier) -> List<CpkDbChangeLogEntity> = ::findDbChangeLogForCpi
 ) : RPCResponderProcessor<VirtualNodeManagementRequest, VirtualNodeManagementResponse> {
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/management/VirtualNodeManagementHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/management/VirtualNodeManagementHandler.kt
@@ -1,0 +1,9 @@
+package net.corda.virtualnode.write.db.impl.writer.management
+
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import net.corda.data.virtualnode.VirtualNodeManagementResponse
+
+interface VirtualNodeManagementHandler<REQUEST> {
+    fun handle(requestTimestamp: Instant, request: REQUEST, respFuture: CompletableFuture<VirtualNodeManagementResponse>)
+}

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/management/impl/ChangeVirtualNodeStateHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/management/impl/ChangeVirtualNodeStateHandler.kt
@@ -1,0 +1,119 @@
+package net.corda.virtualnode.write.db.impl.writer.management.impl
+
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import net.corda.data.ExceptionEnvelope
+import net.corda.data.virtualnode.VirtualNodeManagementResponse
+import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
+import net.corda.data.virtualnode.VirtualNodeStateChangeRequest
+import net.corda.data.virtualnode.VirtualNodeStateChangeResponse
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.virtualnode.common.exception.CpiNotFoundException
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.toAvro
+import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeEntityRepository
+import net.corda.virtualnode.write.db.impl.writer.management.VirtualNodeManagementHandler
+
+internal class ChangeVirtualNodeStateHandler(
+    private val vnodePublisher: Publisher,
+    private val virtualNodeEntityRepository: VirtualNodeEntityRepository,
+) : VirtualNodeManagementHandler<VirtualNodeStateChangeRequest> {
+
+    override fun handle(
+        requestTimestamp: Instant,
+        request: VirtualNodeStateChangeRequest,
+        respFuture: CompletableFuture<VirtualNodeManagementResponse>
+    ) {
+        try {
+            changeVirtualNodeState(requestTimestamp, request, respFuture)
+        } catch (e: Exception) {
+            respFuture.complete(
+                VirtualNodeManagementResponse(
+                    requestTimestamp,
+                    VirtualNodeManagementResponseFailure(
+                        ExceptionEnvelope(
+                            e::class.java.name,
+                            e.message
+                        )
+                    )
+                )
+            )
+        }
+    }
+
+    private fun changeVirtualNodeState(
+        requestTimestamp: Instant,
+        stateChangeRequest: VirtualNodeStateChangeRequest,
+        respFuture: CompletableFuture<VirtualNodeManagementResponse>
+    ) {
+
+        val updatedVirtualNodeEntity = virtualNodeEntityRepository.setVirtualNodeState(
+            stateChangeRequest.holdingIdentityShortHash,
+            stateChangeRequest.newState
+        )
+
+        val virtualNodeInfo = with(updatedVirtualNodeEntity) {
+            val cpiMetadata = virtualNodeEntityRepository.getCPIMetadataByNameAndVersion(
+                this.cpiName,
+                this.cpiVersion
+            ) ?: throw CpiNotFoundException(
+                "No corresponding meta data found for cpi for ${this.holdingIdentity.holdingIdentityShortHash}"
+            )
+            val holdingIdentity = HoldingIdentity(
+                net.corda.v5.base.types.MemberX500Name.parse(this.holdingIdentity.x500Name),
+                this.holdingIdentity.mgmGroupId
+            )
+            val cpiIdentifier = CpiIdentifier(
+                cpiMetadata.id.name,
+                cpiMetadata.id.version,
+                cpiMetadata.id.signerSummaryHash
+            )
+            VirtualNodeInfo(
+                holdingIdentity,
+                cpiIdentifier,
+                this.holdingIdentity.vaultDDLConnectionId,
+                this.holdingIdentity.vaultDMLConnectionId!!,
+                this.holdingIdentity.cryptoDDLConnectionId,
+                this.holdingIdentity.cryptoDMLConnectionId!!,
+                this.holdingIdentity.uniquenessDDLConnectionId,
+                this.holdingIdentity.uniquenessDMLConnectionId!!,
+                this.holdingIdentity.hsmConnectionId,
+                net.corda.virtualnode.VirtualNodeState.valueOf(this.virtualNodeState),
+                this.entityVersion,
+                this.insertTimestamp!!
+            )
+        }.toAvro()
+
+        val virtualNodeRecord = Record(
+            Schemas.VirtualNode.VIRTUAL_NODE_INFO_TOPIC,
+            virtualNodeInfo.holdingIdentity,
+            virtualNodeInfo
+        )
+
+        try {
+            // TODO - CORE-3319 - Strategy for DB and Kafka retries.
+            val future = vnodePublisher.publish(listOf(virtualNodeRecord)).first()
+
+            // TODO - CORE-3730 - Define timeout policy.
+            future.get()
+        } catch (e: Exception) {
+            throw VirtualNodeWriteServiceException(
+                "Record $virtualNodeRecord was written to the database, but couldn't be published. Cause: $e", e
+            )
+        }
+
+        val response = VirtualNodeManagementResponse(
+            requestTimestamp,
+            VirtualNodeStateChangeResponse(
+                stateChangeRequest.holdingIdentityShortHash,
+                stateChangeRequest.newState
+            )
+        )
+        respFuture.complete(response)
+    }
+}

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/management/impl/CreateVirtualNodeHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/management/impl/CreateVirtualNodeHandler.kt
@@ -1,0 +1,491 @@
+package net.corda.virtualnode.write.db.impl.writer.management.impl
+
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import javax.persistence.EntityManager
+import kotlin.system.measureTimeMillis
+import net.corda.data.ExceptionEnvelope
+import net.corda.data.membership.PersistentMemberInfo
+import net.corda.data.virtualnode.VirtualNodeCreateRequest
+import net.corda.data.virtualnode.VirtualNodeCreateResponse
+import net.corda.data.virtualnode.VirtualNodeManagementResponse
+import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
+import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.core.DbPrivilege
+import net.corda.layeredpropertymap.toAvro
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.findDbChangeLogForCpi
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.virtualnode.common.exception.CpiNotFoundException
+import net.corda.libs.virtualnode.common.exception.VirtualNodeAlreadyExistsException
+import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants
+import net.corda.membership.lib.grouppolicy.GroupPolicyParser
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.records.Record
+import net.corda.orm.utils.transaction
+import net.corda.schema.Schemas
+import net.corda.utilities.time.Clock
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.debug
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.toAvro
+import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
+import net.corda.virtualnode.write.db.impl.writer.CpiMetadataLite
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDb
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbConnections
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbFactory
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeEntityRepository
+import net.corda.virtualnode.write.db.impl.writer.management.VirtualNodeManagementHandler
+
+/**
+ * Handler to create virtual nodes.
+ *
+ * @property vnodePublisher Used to publish to Kafka.
+ * @property virtualNodeEntityRepository Used to retrieve and store virtual nodes and related entities.
+ * @property vnodeDbFactory Used to construct a mapping object which holds the multiple database connections we have.
+ * @property groupPolicyParser Parses group policy JSON strings and returns MemberInfo structures
+ * @property clock A clock instance used to add timestamps to what the records we publish. This is configurable rather
+ *           than always simply the system wall clock time so that we can control everything in tests.
+ * @property getChangelogs an overridable function to obtain the changelogs for a CPI. The default looks up in the database.
+ *           Takes an EntityManager (since that lets us continue a transaction) and a CpiIdentifier as a parameter and
+ *           returns a list of CpkDbChangeLogEntity.
+ */
+@Suppress("LongParameterList", "TooManyFunctions")
+internal class CreateVirtualNodeHandler(
+    private val vnodePublisher: Publisher,
+    private val dbConnectionManager: DbConnectionManager,
+    private val virtualNodeEntityRepository: VirtualNodeEntityRepository,
+    private val vnodeDbFactory: VirtualNodeDbFactory,
+    private val groupPolicyParser: GroupPolicyParser,
+    private val clock: Clock,
+    private val getChangelogs: (EntityManager, CpiIdentifier) -> List<CpkDbChangeLogEntity> = ::findDbChangeLogForCpi,
+) : VirtualNodeManagementHandler<VirtualNodeCreateRequest> {
+
+    private companion object {
+        val logger = contextLogger()
+        const val PUBLICATION_TIMEOUT_SECONDS = 30L
+    }
+
+    override fun handle(
+        requestTimestamp: Instant,
+        request: VirtualNodeCreateRequest,
+        respFuture: CompletableFuture<VirtualNodeManagementResponse>
+    ) {
+        createVirtualNode(requestTimestamp, request, respFuture)
+    }
+
+    /**
+     * For each [request], the processor attempts to commit a new virtual node to the cluster database. If successful,
+     * the created virtual node is then published by the [vnodePublisher] to the `VIRTUAL_NODE_INFO_TOPIC` topic.
+     *
+     * If both steps succeed, [respFuture] is completed successfully. Otherwise, it is completed unsuccessfully.
+     */
+    @Suppress("ReturnCount", "ComplexMethod", "LongMethod")
+    private fun createVirtualNode(
+        instant: Instant,
+        request: VirtualNodeCreateRequest,
+        respFuture: CompletableFuture<VirtualNodeManagementResponse>
+    ) {
+        // TODO - replace this with real metrics
+        logger.info("Create new Virtual Node: ${request.x500Name} and ${request.cpiFileChecksum}")
+        val startMillis = System.currentTimeMillis()
+
+        measureTimeMillis {
+            request.validationError()?.let { errMsg ->
+                handleException(respFuture, IllegalArgumentException(errMsg))
+                return
+            }
+        }.also {
+            logger.debug {
+                "[Create ${request.x500Name}] validation took $it ms, elapsed " +
+                        "${System.currentTimeMillis() - startMillis} ms"
+            }
+        }
+
+
+        try {
+            val cpiMetadata: CpiMetadataLite?
+            measureTimeMillis {
+                cpiMetadata = virtualNodeEntityRepository.getCpiMetadataByChecksum(request.cpiFileChecksum)
+                if (cpiMetadata == null) {
+                    handleException(
+                        respFuture,
+                        CpiNotFoundException("CPI with file checksum ${request.cpiFileChecksum} was not found.")
+                    )
+                    return
+                }
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] get metadata took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            // Generate group ID for MGM
+            val groupId = cpiMetadata!!.mgmGroupId.let {
+                if (it == GroupPolicyConstants.PolicyValues.Root.MGM_DEFAULT_GROUP_ID) UUID.randomUUID().toString() else it
+            }
+            val holdingId = HoldingIdentity(MemberX500Name.parse(request.getX500CanonicalName()), groupId)
+            measureTimeMillis {
+                if (virtualNodeEntityRepository.virtualNodeExists(holdingId, cpiMetadata.id)) {
+                    handleException(
+                        respFuture,
+                        VirtualNodeAlreadyExistsException(
+                            "Virtual node for CPI with file checksum ${request.cpiFileChecksum} and x500Name " +
+                                    "${request.x500Name} already exists."
+                        )
+                    )
+                    return
+                }
+                virtualNodeEntityRepository.checkUniqueId(holdingId)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] validate holding ID took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            val vNodeDbs: Map<VirtualNodeDbType, VirtualNodeDb>
+            measureTimeMillis {
+                vNodeDbs = vnodeDbFactory.createVNodeDbs(holdingId.shortHash, request)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] creating vnode DBs took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            measureTimeMillis {
+                createSchemasAndUsers(holdingId, vNodeDbs.values)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] creating vnode DB Schemas and users took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            measureTimeMillis {
+                runDbMigrations(holdingId, vNodeDbs.values)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] DB migrations took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            val vaultDb = vNodeDbs[VirtualNodeDbType.VAULT]
+            if (null == vaultDb) {
+                handleException(respFuture, VirtualNodeWriteServiceException("Vault DB not configured"))
+                return
+            } else {
+                measureTimeMillis {
+                    runCpiMigrations(cpiMetadata, vaultDb)
+                }.also {
+                    logger.debug {
+                        "[Create ${request.x500Name}] CPI DB migrations took $it ms, elapsed " +
+                                "${System.currentTimeMillis() - startMillis} ms"
+                    }
+                }
+            }
+
+            val dbConnections: VirtualNodeDbConnections
+            measureTimeMillis {
+                dbConnections =
+                    persistHoldingIdAndVirtualNode(holdingId, vNodeDbs, cpiMetadata.id, request.updateActor)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] persisting VNode to DB took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            measureTimeMillis {
+                publishVNodeInfo(holdingId, cpiMetadata, dbConnections)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] persisting VNode Info to Kafka took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            measureTimeMillis {
+                publishMgmInfo(holdingId, cpiMetadata.groupPolicy)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] persisting Mgm Info to Kafka took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+
+            measureTimeMillis {
+                sendSuccessfulResponse(respFuture, instant, holdingId, cpiMetadata, dbConnections)
+            }.also {
+                logger.debug {
+                    "[Create ${request.x500Name}] send response to RPC gateway took $it ms, elapsed " +
+                            "${System.currentTimeMillis() - startMillis} ms"
+                }
+            }
+        } catch (e: Exception) {
+            handleException(respFuture, e)
+        }
+    }
+
+    private fun VirtualNodeCreateRequest.validationError(): String? {
+        if (cpiFileChecksum.isNullOrBlank()) {
+            return "CPI file checksum value is missing"
+        }
+
+        if (!vaultDdlConnection.isNullOrBlank() && vaultDmlConnection.isNullOrBlank()) {
+            return "If Vault DDL connection is provided, Vault DML connection needs to be provided as well."
+        }
+
+        if (!cryptoDdlConnection.isNullOrBlank() && cryptoDmlConnection.isNullOrBlank()) {
+            return "If Crypto DDL connection is provided, Crypto DML connection needs to be provided as well."
+        }
+
+        if (!uniquenessDdlConnection.isNullOrBlank() && uniquenessDmlConnection.isNullOrBlank()) {
+            return "If Uniqueness DDL connection is provided, Uniqueness DML connection needs to be provided as well."
+        }
+
+        try {
+            MemberX500Name.parse(x500Name)
+        } catch (e: Exception) {
+            return "X500 name \"$x500Name\" could not be parsed. Cause: ${e.message}"
+        }
+        return null
+    }
+
+    private fun VirtualNodeCreateRequest.getX500CanonicalName(): String {
+        // TODO replace toString with method that returns canonical name
+        return MemberX500Name.parse(x500Name).toString()
+    }
+
+    private fun VirtualNodeEntityRepository.checkUniqueId(holdingId: HoldingIdentity) {
+        getHoldingIdentity(holdingId.shortHash)?.let { storedHoldingId ->
+            if (storedHoldingId != holdingId) {
+                throw VirtualNodeWriteServiceException(
+                    "New holding identity $holdingId has a short hash that collided with existing holding identity $storedHoldingId."
+                )
+            }
+        }
+    }
+
+    /** Completes the [respFuture] with an [ExceptionEnvelope]. */
+    @Suppress("LongParameterList")
+    private fun handleException(
+        respFuture: CompletableFuture<VirtualNodeManagementResponse>,
+        e: Exception,
+    ): Boolean {
+        logger.error("Error while processing virtual node request: ${e.message}", e)
+        val response = VirtualNodeManagementResponse(
+            clock.instant(),
+            VirtualNodeManagementResponseFailure(
+                ExceptionEnvelope().apply {
+                    errorType = e::class.java.name
+                    errorMessage = e.message
+                }
+            )
+        )
+        return respFuture.complete(response)
+    }
+
+    private fun createSchemasAndUsers(holdingIdentity: HoldingIdentity, vNodeDbs: Collection<VirtualNodeDb>) {
+        try {
+            vNodeDbs.filter { it.isClusterDb }.forEach { it.createSchemasAndUsers() }
+        } catch (e: Exception) {
+            throw VirtualNodeWriteServiceException(
+                "Error creating virtual node DB schemas and users for holding identity $holdingIdentity", e
+            )
+        }
+    }
+
+    private fun runDbMigrations(holdingIdentity: HoldingIdentity, vNodeDbs: Collection<VirtualNodeDb>) {
+        try {
+            vNodeDbs.forEach { it.runDbMigration() }
+        } catch (e: Exception) {
+            throw VirtualNodeWriteServiceException(
+                "Error running virtual node DB migration for holding identity $holdingIdentity",
+                e
+            )
+        }
+    }
+
+    private fun runCpiMigrations(cpiMetadata: CpiMetadataLite, vaultDb: VirtualNodeDb) =
+        // we could potentially do one transaction per CPK; it seems more useful to blow up the
+        // who migration if any CPK fails though, so that they can be iterative developed and repeated
+        dbConnectionManager.getClusterEntityManagerFactory().createEntityManager().transaction {
+            val changelogs = getChangelogs(it, cpiMetadata.id)
+            changelogs.map { cl -> cl.id.cpkName }.distinct().sorted().forEach { cpkName ->
+                val cpkChangelogs = changelogs.filter { cl2 -> cl2.id.cpkName == cpkName }
+                logger.info("Doing ${cpkChangelogs.size} migrations for $cpkName")
+                val dbChange = VirtualNodeDbChangeLog(cpkChangelogs)
+                try {
+                    vaultDb.runCpiMigrations(dbChange)
+                } catch (e: Exception) {
+                    logger.error("Virtual node liquibase DB migration failure on CPK $cpkName with error $e")
+                    throw VirtualNodeWriteServiceException(
+                        "Error running virtual node DB migration for CPI liquibase migrations",
+                        e
+                    )
+                }
+                logger.info("Completed ${cpkChangelogs.size} migrations for $cpkName")
+            }
+        }
+
+    private fun persistHoldingIdAndVirtualNode(
+        holdingIdentity: HoldingIdentity,
+        vNodeDbs: Map<VirtualNodeDbType, VirtualNodeDb>,
+        cpiId: CpiIdentifier,
+        updateActor: String
+    ): VirtualNodeDbConnections {
+        try {
+            return dbConnectionManager.getClusterEntityManagerFactory().createEntityManager()
+                .transaction { entityManager ->
+                    val dbConnections =
+                        VirtualNodeDbConnections(
+                            putConnection(entityManager, vNodeDbs, VirtualNodeDbType.VAULT, DbPrivilege.DDL, updateActor),
+                            putConnection(entityManager, vNodeDbs, VirtualNodeDbType.VAULT, DbPrivilege.DML, updateActor)!!,
+                            putConnection(entityManager, vNodeDbs, VirtualNodeDbType.CRYPTO, DbPrivilege.DDL, updateActor),
+                            putConnection(entityManager, vNodeDbs, VirtualNodeDbType.CRYPTO, DbPrivilege.DML, updateActor)!!,
+                            putConnection(entityManager, vNodeDbs, VirtualNodeDbType.UNIQUENESS, DbPrivilege.DDL, updateActor),
+                            putConnection(entityManager, vNodeDbs, VirtualNodeDbType.UNIQUENESS, DbPrivilege.DML, updateActor)!!,
+                        )
+                    virtualNodeEntityRepository.putHoldingIdentity(entityManager, holdingIdentity, dbConnections)
+                    virtualNodeEntityRepository.putVirtualNode(entityManager, holdingIdentity, cpiId)
+                    dbConnections
+                }
+        } catch (e: Exception) {
+            throw VirtualNodeWriteServiceException(
+                "Error persisting virtual node for holding identity $holdingIdentity",
+                e
+            )
+        }
+    }
+
+    private fun putConnection(
+        entityManager: EntityManager,
+        vNodeDbs: Map<VirtualNodeDbType, VirtualNodeDb>,
+        dbType: VirtualNodeDbType,
+        dbPrivilege: DbPrivilege,
+        updateActor: String
+    ): UUID? {
+        return vNodeDbs[dbType]?.let { vNodeDb ->
+            vNodeDb.dbConnections[dbPrivilege]?.let { dbConnection ->
+                with(dbConnection) {
+                    dbConnectionManager.putConnection(
+                        entityManager,
+                        name,
+                        dbPrivilege,
+                        config,
+                        description,
+                        updateActor
+                    )
+                }
+            }
+        }
+    }
+
+    private fun publishVNodeInfo(
+        holdingIdentity: HoldingIdentity,
+        cpiMetadata: CpiMetadataLite,
+        dbConnections: VirtualNodeDbConnections
+    ) {
+        val virtualNodeRecord = createVirtualNodeRecord(holdingIdentity, cpiMetadata, dbConnections)
+        try {
+            // TODO - CORE-3319 - Strategy for DB and Kafka retries.
+            val future = vnodePublisher.publish(listOf(virtualNodeRecord)).first()
+
+            // TODO - CORE-3730 - Define timeout policy.
+            future.get()
+        } catch (e: Exception) {
+            throw VirtualNodeWriteServiceException(
+                "Record $virtualNodeRecord was written to the database, but couldn't be published. Cause: $e", e
+            )
+        }
+    }
+
+    private fun createVirtualNodeRecord(
+        holdingIdentity: HoldingIdentity,
+        cpiMetadata: CpiMetadataLite,
+        dbConnections: VirtualNodeDbConnections
+    ):
+            Record<net.corda.data.identity.HoldingIdentity, net.corda.data.virtualnode.VirtualNodeInfo> {
+
+        val cpiIdentifier = CpiIdentifier(cpiMetadata.id.name, cpiMetadata.id.version, cpiMetadata.id.signerSummaryHash)
+        val virtualNodeInfo = with(dbConnections) {
+            VirtualNodeInfo(
+                holdingIdentity,
+                cpiIdentifier,
+                vaultDdlConnectionId,
+                vaultDmlConnectionId,
+                cryptoDdlConnectionId,
+                cryptoDmlConnectionId,
+                uniquenessDdlConnectionId,
+                uniquenessDmlConnectionId,
+                timestamp = clock.instant(),
+                state = VirtualNodeInfo.DEFAULT_INITIAL_STATE
+            )
+                .toAvro()
+        }
+        return Record(Schemas.VirtualNode.VIRTUAL_NODE_INFO_TOPIC, virtualNodeInfo.holdingIdentity, virtualNodeInfo)
+    }
+
+    private fun publishMgmInfo(holdingIdentity: HoldingIdentity, groupPolicyJson: String) {
+        val mgmInfo = groupPolicyParser.run {
+            getMgmInfo(holdingIdentity, groupPolicyJson)
+        }
+        if (mgmInfo == null) {
+            logger.info("No MGM information found in group policy. MGM member info not published.")
+            return
+        }
+        val mgmHoldingIdentity = HoldingIdentity(mgmInfo.name, mgmInfo.groupId)
+        val mgmRecord = Record(
+            Schemas.Membership.MEMBER_LIST_TOPIC,
+            "${holdingIdentity.shortHash}-${mgmHoldingIdentity.shortHash}",
+            PersistentMemberInfo(
+                holdingIdentity.toAvro(),
+                mgmInfo.memberProvidedContext.toAvro(),
+                mgmInfo.mgmProvidedContext.toAvro()
+            )
+        )
+        try {
+            vnodePublisher.publish(listOf(mgmRecord)).first().get(PUBLICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: Exception) {
+            throw VirtualNodeWriteServiceException(
+                "MGM member info for Group ID: ${mgmInfo.groupId} could not be published. Cause: $e", e
+            )
+        }
+    }
+
+    private fun sendSuccessfulResponse(
+        respFuture: CompletableFuture<VirtualNodeManagementResponse>,
+        instant: Instant,
+        holdingIdentity: HoldingIdentity,
+        cpiMetadata: CpiMetadataLite,
+        dbConnections: VirtualNodeDbConnections
+    ) {
+        val response = VirtualNodeManagementResponse(
+            instant,
+            VirtualNodeCreateResponse(
+                holdingIdentity.x500Name.toString(), cpiMetadata.id.toAvro(), cpiMetadata.fileChecksum,
+                holdingIdentity.groupId, holdingIdentity.toAvro(), holdingIdentity.shortHash.value,
+                dbConnections.vaultDdlConnectionId?.toString(),
+                dbConnections.vaultDmlConnectionId.toString(),
+                dbConnections.cryptoDdlConnectionId?.toString(),
+                dbConnections.cryptoDmlConnectionId.toString(),
+                dbConnections.uniquenessDdlConnectionId?.toString(),
+                dbConnections.uniquenessDmlConnectionId.toString(),
+                null,
+                VirtualNodeInfo.DEFAULT_INITIAL_STATE.name
+            )
+        )
+        respFuture.complete(response)
+    }
+}


### PR DESCRIPTION
As more and more changes are being added to this processor we need to refactor it before things get out of hand.

This will reduce merge conflicts as logic can be separated out for each operation.

Unit tests can be added for the handling of each message.