### PR TITLE
CORE-4779 Assert class gets loaded from different class loaders when deserialized from different sandbox groups

### DIFF
--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -150,20 +150,18 @@ class AMQPwithOSGiSerializationTests {
             val factory11 = testDefaultFactory(sandboxGroup1)
             val factory2 = testDefaultFactory(sandboxGroup2)
 
-            // Initialise the serialisation context
+            // Initialise two different serialization contexts one per sandbox group
             val testSerializationContext1 = testSerializationContext.withSandboxGroup(sandboxGroup1)
             val testSerializationContext2 = testSerializationContext.withSandboxGroup(sandboxGroup2)
 
-            // Serialise our object
+            // Serialise our object using `sandboxGroup1` context
             val cashClass = sandboxGroup1.loadClassFromMainBundles("net.cordapp.bundle1.Cash")
             val cashInstance = cashClass.getConstructor(Int::class.java).newInstance(100)
-
             val serialised = SerializationOutput(factory1).serialize(cashInstance, testSerializationContext1)
 
-            // Perform deserialisation and check if the correct class is deserialised
+            // Perform deserialisations and check if the correct classes are deserialised
             val deserialised1 =
                 DeserializationInput(factory11).deserializeAndReturnEnvelope(serialised, testSerializationContext1)
-
             val deserialised2 =
                 DeserializationInput(factory2).deserializeAndReturnEnvelope(serialised, testSerializationContext2)
 
@@ -176,8 +174,6 @@ class AMQPwithOSGiSerializationTests {
             assertThat(expectedClass2).isEqualTo(deserialisedClass2)
             assertThat(deserialisedClass1).isNotEqualTo(deserialisedClass2)
             assertThat(classLoader1).isNotEqualTo(classLoader2)
-        } catch (e: Exception) {
-            println(e)
         } finally {
             sandboxFactory.unloadSandboxGroup(sandboxGroup1)
             sandboxFactory.unloadSandboxGroup(sandboxGroup2)

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -141,6 +141,50 @@ class AMQPwithOSGiSerializationTests {
     }
 
     @Test
+    fun `same class gets loaded from different class loaders when deserialized from different sandbox groups`() {
+        val sandboxGroup1 = sandboxFactory.loadSandboxGroup("META-INF/TestSerializable4-workflows.cpb")
+        val sandboxGroup2 = sandboxFactory.loadSandboxGroup("META-INF/TestSerializable4-workflows.cpb")
+        try {
+            // Initialised two serialisation factories to avoid having successful tests due to caching
+            val factory1 = testDefaultFactory(sandboxGroup1)
+            val factory11 = testDefaultFactory(sandboxGroup1)
+            val factory2 = testDefaultFactory(sandboxGroup2)
+
+            // Initialise the serialisation context
+            val testSerializationContext1 = testSerializationContext.withSandboxGroup(sandboxGroup1)
+            val testSerializationContext2 = testSerializationContext.withSandboxGroup(sandboxGroup2)
+
+            // Serialise our object
+            val cashClass = sandboxGroup1.loadClassFromMainBundles("net.cordapp.bundle1.Cash")
+            val cashInstance = cashClass.getConstructor(Int::class.java).newInstance(100)
+
+            val serialised = SerializationOutput(factory1).serialize(cashInstance, testSerializationContext1)
+
+            // Perform deserialisation and check if the correct class is deserialised
+            val deserialised1 =
+                DeserializationInput(factory11).deserializeAndReturnEnvelope(serialised, testSerializationContext1)
+
+            val deserialised2 =
+                DeserializationInput(factory2).deserializeAndReturnEnvelope(serialised, testSerializationContext2)
+
+            val expectedClass2 = sandboxGroup2.loadClassFromMainBundles("net.cordapp.bundle1.Cash")
+            val deserialisedClass1 = deserialised1.obj::class.java
+            val deserialisedClass2 = deserialised2.obj::class.java
+            val classLoader1 = deserialisedClass1.classLoader
+            val classLoader2 = deserialisedClass2.classLoader
+            assertThat(cashClass).isEqualTo(deserialisedClass1)
+            assertThat(expectedClass2).isEqualTo(deserialisedClass2)
+            assertThat(deserialisedClass1).isNotEqualTo(deserialisedClass2)
+            assertThat(classLoader1).isNotEqualTo(classLoader2)
+        } catch (e: Exception) {
+            println(e)
+        } finally {
+            sandboxFactory.unloadSandboxGroup(sandboxGroup1)
+            sandboxFactory.unloadSandboxGroup(sandboxGroup2)
+        }
+    }
+
+    @Test
     fun `amqp to be serialized objects can only live in cpk's main bundle`() {
         val sandboxGroup = sandboxFactory.loadSandboxGroup("META-INF/TestSerializableCpk-using-lib.cpb")
         try {


### PR DESCRIPTION
[CORE-4779](https://r3-cev.atlassian.net/browse/CORE-4779) suggests that when AMQP serializing a class using a sandbox group context A and then deserializing the bytes using sandbox group context B (which has also loaded the same bundle) we would get the same `Class` reference. 
However this does not seem to be the case; `Class` reference of deserialized object from sandbox group context B is different than `Class` reference of deserialized object from sandbox group context A, both coming from bundle class loaders of the respective sandbox groups.

- adds test asserting same class gets loaded from different class loaders when deserialized from different sandbox groups.

