### PR TITLE
NOTICK: Handle gracefully when permissions are added twice

### DIFF
--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
@@ -2,6 +2,7 @@ package net.corda.cli.plugin.initialRbac.commands
 
 import net.corda.cli.plugins.common.HttpRpcClientUtils.createHttpRpcClient
 import net.corda.cli.plugins.common.HttpRpcClientUtils.executeWithRetry
+import net.corda.cli.plugins.common.HttpRpcClientUtils.ignore
 import net.corda.cli.plugins.common.HttpRpcCommand
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.CreatePermissionType
@@ -95,7 +96,7 @@ class UserAdminSubcommand : HttpRpcCommand(), Callable<Int> {
                 roleEndpoint.createRole(CreateRoleType(USER_ADMIN_ROLE, null)).responseBody.id
             }
             permissionIds.forEach { permId ->
-                executeWithRetry(waitDuration, "Adding permission: $permId") {
+                executeWithRetry(waitDuration, "Adding permission: $permId", onAlreadyExists = ::ignore) {
                     roleEndpoint.addPermission(roleId, permId)
                 }
             }

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
@@ -2,6 +2,7 @@ package net.corda.cli.plugin.initialRbac.commands
 
 import net.corda.cli.plugins.common.HttpRpcClientUtils.createHttpRpcClient
 import net.corda.cli.plugins.common.HttpRpcClientUtils.executeWithRetry
+import net.corda.cli.plugins.common.HttpRpcClientUtils.ignore
 import net.corda.cli.plugins.common.HttpRpcCommand
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.CreatePermissionType
@@ -84,7 +85,7 @@ class VNodeCreatorSubcommand : HttpRpcCommand(), Callable<Int> {
                 roleEndpoint.createRole(CreateRoleType(VNODE_CREATOR_ROLE, null)).responseBody.id
             }
             permissionIds.forEach { permId ->
-                executeWithRetry(waitDuration, "Adding permission: $permId") {
+                executeWithRetry(waitDuration, "Adding permission: $permId", onAlreadyExists = ::ignore) {
                     roleEndpoint.addPermission(roleId, permId)
                 }
             }

--- a/tools/plugins/plugins-http-rpc/build.gradle
+++ b/tools/plugins/plugins-http-rpc/build.gradle
@@ -9,5 +9,8 @@ dependencies {
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
 
+    compileOnly "net.corda:corda-base"
+    compileOnly platform("net.corda:corda-api:$cordaApiVersion")
+
     api project(':libs:http-rpc:http-rpc-client')
 }

--- a/tools/plugins/plugins-http-rpc/src/main/kotlin/net/corda/cli/plugins/common/HttpRpcClientUtils.kt
+++ b/tools/plugins/plugins-http-rpc/src/main/kotlin/net/corda/cli/plugins/common/HttpRpcClientUtils.kt
@@ -34,7 +34,7 @@ object HttpRpcClientUtils {
 
     fun <T> executeWithRetry(
         waitDuration: Duration, operationName: String,
-        onAlreadyExists: (ResourceAlreadyExistsException) -> T = { throw it },
+        onAlreadyExists: (ResourceAlreadyExistsException) -> T = ::reThrow,
         block: () -> T
     ): T {
         logger.info("Performing $operationName")
@@ -57,6 +57,11 @@ object HttpRpcClientUtils {
 
         errOut.error("Unable to perform $operationName", lastException)
         throw lastException!!
+    }
+
+    fun reThrow(ex: ResourceAlreadyExistsException): Nothing {
+        logger.info("Re-throwing", ex)
+        throw ex
     }
 
     fun ignore(ex: ResourceAlreadyExistsException) {

--- a/tools/plugins/plugins-http-rpc/src/main/kotlin/net/corda/cli/plugins/common/HttpRpcClientUtils.kt
+++ b/tools/plugins/plugins-http-rpc/src/main/kotlin/net/corda/cli/plugins/common/HttpRpcClientUtils.kt
@@ -3,6 +3,7 @@ package net.corda.cli.plugins.common
 import net.corda.httprpc.RpcOps
 import net.corda.httprpc.client.HttpRpcClient
 import net.corda.httprpc.client.config.HttpRpcClientConfig
+import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
@@ -31,7 +32,11 @@ object HttpRpcClientUtils {
         )
     }
 
-    fun <T> executeWithRetry(waitDuration: Duration, operationName: String, block: () -> T): T {
+    fun <T> executeWithRetry(
+        waitDuration: Duration, operationName: String,
+        onAlreadyExists: (ResourceAlreadyExistsException) -> T = { throw it },
+        block: () -> T
+    ): T {
         logger.info("Performing $operationName")
         val endTime = System.currentTimeMillis() + waitDuration.toMillis()
         var lastException: Exception?
@@ -39,6 +44,8 @@ object HttpRpcClientUtils {
         do {
             try {
                 return block()
+            } catch (ex: ResourceAlreadyExistsException) {
+                return onAlreadyExists(ex)
             } catch (ex: Exception) {
                 lastException = ex
                 logger.warn("Cannot perform $operationName yet", ex)
@@ -50,5 +57,9 @@ object HttpRpcClientUtils {
 
         errOut.error("Unable to perform $operationName", lastException)
         throw lastException!!
+    }
+
+    fun ignore(ex: ResourceAlreadyExistsException) {
+        logger.debug("Ignoring", ex)
     }
 }


### PR DESCRIPTION
Underlying exception that may be intermittently reported was:
```
Unable to perform Adding permission: 5bd34e87-40c7-470e-adbb-7e90c167b37e
net.corda.httprpc.exception.ResourceAlreadyExistsException: "{\n    \"title\": \"Permission '5bd34e87-40c7-470e-adbb-7e90c167b37e' is already associated with Role '6fa1c363-2d68-4da0-ad2b-64d97ea5906c'.\",\n    \"status\": 409,\n    \"type\": \"https://javalin.io/documentation#error-responses\",\n    \"details\": {\"code\":\"CONFLICT\"}\n}"
	at net.corda.httprpc.client.connect.remote.RemoteUnirestClient.doCall(RemoteClient.kt:111) ~[?:?]
	at net.corda.httprpc.client.connect.remote.RemoteUnirestClient.call(RemoteClient.kt:55) ~[?:?]
	at net.corda.httprpc.client.connect.HttpRpcClientProxyHandler.invoke(HttpRpcClientProxyHandler.kt:115) ~[?:?]
	at com.sun.proxy.$Proxy27.addPermission(Unknown Source) ~[?:?]
	at net.corda.cli.plugin.initialRbac.commands.UserAdminSubcommand$call$1$2$1.invoke(UserAdminSubcommand.kt:99) ~[?:?]
	at net.corda.cli.plugin.initialRbac.commands.UserAdminSubcommand$call$1$2$1.invoke(UserAdminSubcommand.kt:98) ~[?:?]
	at net.corda.cli.plugins.common.HttpRpcClientUtils.executeWithRetry(HttpRpcClientUtils.kt:41) ~[?:?]
	at net.corda.cli.plugin.initialRbac.commands.UserAdminSubcommand.call(UserAdminSubcommand.kt:98) ~[?:?]
	at net.corda.cli.plugin.initialRbac.commands.UserAdminSubcommand.call(UserAdminSubcommand.kt:20) ~[?:?]
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953) ~[cli.jar:?]
	at picocli.CommandLine.access$1300(CommandLine.java:145) ~[cli.jar:?]
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358) ~[cli.jar:?]
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2352) ~[cli.jar:?]
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2314) ~[cli.jar:?]
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179) ~[cli.jar:?]
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2316) ~[cli.jar:?]
	at picocli.CommandLine.execute(CommandLine.java:2078) ~[cli.jar:?]
	at net.corda.cli.application.Boot.run(Boot.kt:73) ~[cli.jar:?]
	at net.corda.cli.application.BootKt.main(Boot.kt:18) ~[cli.jar:?]
```