### PR TITLE
CORE-6894: generate SBOM on nightly run of CI

### DIFF
--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -10,5 +10,6 @@ cordaPipeline(
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: true,
-    gradleAdditionalArgs: '-Dscan.tag.Nightly-Build'
+    gradleAdditionalArgs: '-Dscan.tag.Nightly-Build',
+    generateSbom: true
     )


### PR DESCRIPTION
follow on from the following changes to generate a software Bill of Materials as part of our CI system if certain conditions are met

- https://github.com/corda/corda-shared-build-pipeline-steps/pull/360
- https://github.com/corda/corda-shared-build-pipeline-steps/pull/358

Nightly Changes tested here:
https://ci02.dev.r3.com/job/Corda5/view/Corda%205%20Nightly%20Jobs/job/Nightlys/job/Corda-Runtime-OS/job/Linux/job/release%252Fos%252F5.0/185