### PR TITLE
NOTICK: Attempt to fix e2e instability 

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -180,8 +180,6 @@ pipeline {
                     }
                 }
                 sh '''\
-                    procno=$! # remember process number started in background
-                    trap "kill -9 ${procno}" EXIT
                     ./gradlew smokeTest ${GRADLE_PERFORMANCE_TUNING}
                     ./gradlew e2eTest ${GRADLE_PERFORMANCE_TUNING}
                 '''.stripIndent()

--- a/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
+++ b/.ci/e2eTests/utils/kubectl-port-forward-with-reconnect.sh
@@ -8,6 +8,6 @@ fi
 
 while true; do
 	kubectl --namespace "${1}" port-forward "${2}" "${3}:${4}" 2>&1
-	echo "kubectl port-forward connection to ${2}:${4} lost, sleeping 5 seconds before trying again..."
-	sleep 5
+	echo "kubectl port-forward connection to ${2}:${4} lost, sleeping 1 seconds before trying again..."
+	sleep 1
 done


### PR DESCRIPTION
- reduce timeout to 1 second from 5 for port forwarding retry in attempt to fix e2e test instability
- remove redundant trap call as all background processes will be killed when container is killed at end of a build