### PR TITLE
CORE-6709: Serialize and deserialize a Pair inside the smoke test

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
@@ -1,0 +1,55 @@
+package net.corda.applications.workers.smoketest.flow
+
+import net.corda.applications.workers.smoketest.GROUP_ID
+import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_SUCCESS
+import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
+import net.corda.applications.workers.smoketest.TEST_CPI_NAME
+import net.corda.applications.workers.smoketest.TEST_STATIC_MEMBER_LIST
+import net.corda.applications.workers.smoketest.X500_BOB
+import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
+import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
+import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
+import net.corda.applications.workers.smoketest.registerMember
+import net.corda.applications.workers.smoketest.startRpcFlow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class AmqpSerializationTests {
+
+    companion object {
+        private const val AmqpSerializationTestFlow = "net.cordapp.testing.smoketests.flow.AmqpSerializationTestFlow"
+
+        @BeforeAll
+        @JvmStatic
+        internal fun beforeAll() {
+            // Upload test flows if not already uploaded
+            conditionallyUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST)
+
+            // Make sure Virtual Nodes are created
+            val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
+
+            // Just validate the function and actual vnode holding ID hash are in sync
+            // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
+            assertThat(bobActualHoldingId).isEqualTo(FlowTests.bobHoldingId)
+
+            registerMember(FlowTests.bobHoldingId)
+        }
+    }
+
+    @Test
+    fun `Serialize and deserialize a Pair`() {
+
+        val requestId = startRpcFlow(FlowTests.bobHoldingId, emptyMap(), AmqpSerializationTestFlow)
+        val result = awaitRpcFlowFinished(FlowTests.bobHoldingId, requestId)
+
+        val flowResult = result.flowResult
+
+        assertAll(
+            { assertThat(result.flowError).isNull() },
+            { assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS) },
+            { assertThat(flowResult).isEqualTo("SerializableClass(pair=(A, B))") },
+        )
+    }
+}

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -62,6 +62,7 @@ class FlowTests {
 
         val expectedFlows = listOf(
             "net.cordapp.testing.smoketests.virtualnode.ReturnAStringFlow",
+            "net.cordapp.testing.smoketests.flow.AmqpSerializationTestFlow",
             "net.cordapp.testing.smoketests.flow.RpcSmokeTestFlow",
             "net.cordapp.testing.testflows.TestFlow",
             "net.cordapp.testing.testflows.BrokenProtocolFlow",

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/AmqpSerializationTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/AmqpSerializationTestFlow.kt
@@ -1,0 +1,27 @@
+package net.cordapp.testing.smoketests.flow
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
+
+class AmqpSerializationTestFlow : RPCStartableFlow {
+
+    @CordaInject
+    lateinit var serializationService: SerializationService
+
+    @CordaSerializable
+    data class SerializableClass(val pair: Pair<String, String>)
+
+    override fun call(requestBody: RPCRequestData): String = try {
+        val pair = SerializableClass(Pair("A", "B"))
+
+        val serializedBytes = serializationService.serialize(pair)
+        val deserialize = serializationService.deserialize(serializedBytes, SerializableClass::class.java)
+
+        deserialize.toString()
+    } catch (e: Exception) {
+        e.toString()
+    }
+}


### PR DESCRIPTION
Adds a smoke test that runs a Kotlin Pair class through the AMQP serializer.