### PR TITLE
CORE-7033 Uniqueness checker logging improvements

### DIFF
--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -34,6 +34,7 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckStateDetails
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
 import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
@@ -105,12 +106,12 @@ open class JPABackingStoreImpl @Activate constructor(
     }
 
     override fun start() {
-        log.info("Backing store starting.")
+        log.info("Backing store starting")
         lifecycleCoordinator.start()
     }
 
     override fun stop() {
-        log.info("Backing store stopping.")
+        log.info("Backing store stopping")
         lifecycleCoordinator.stop()
     }
 
@@ -146,11 +147,11 @@ open class JPABackingStoreImpl @Activate constructor(
                             //  won't be necessary
                             if (entityManager.transaction.isActive) {
                                 entityManager.transaction.rollback()
-                                contextLogger().info("Rolled back transaction.")
+                                log.debug { "Rolled back transaction" }
                             }
 
                             if (attemptNumber < MAX_ATTEMPTS) {
-                                contextLogger().warn(
+                                log.warn(
                                     "Retrying DB operation. The request might have been " +
                                             "handled by a different notary worker or a DB error " +
                                             "occurred when attempting to commit.",
@@ -167,13 +168,13 @@ open class JPABackingStoreImpl @Activate constructor(
                         else -> {
                             // TODO: Revisit handled exceptions, this is a subset of what
                             // we handled in C4
-                            contextLogger().warn("Unexpected error occurred", e)
+                            log.warn("Unexpected error occurred", e)
                             // We potentially leak a database connection, if we don't rollback. When
                             // the HSM signing operation throws an exception this code path is
                             // triggered.
                             if (entityManager.transaction.isActive) {
                                 entityManager.transaction.rollback()
-                                contextLogger().info("Rolled back transaction.")
+                                log.debug { "Rolled back transaction" }
                             }
                             throw e
                         }
@@ -351,7 +352,7 @@ open class JPABackingStoreImpl @Activate constructor(
 
     @VisibleForTesting
     fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
-        log.info("Backing store received event $event.")
+        log.info("Backing store received event $event")
         when (event) {
             is StartEvent -> {
                 dependentComponents.registerAndStartAll(coordinator)
@@ -375,7 +376,7 @@ open class JPABackingStoreImpl @Activate constructor(
                 coordinator.updateStatus(event.status)
             }
             else -> {
-                log.warn("Unexpected event $event!")
+                log.warn("Unexpected event ${event}, ignoring")
             }
         }
     }


### PR DESCRIPTION
### Summary
Currently, the uniqueness checker is a bit light on logging. This PR adds additional logging to provide some information as to how many requests are processed when, and also provides batch processing information for each holding id. This allows some rudimentary tracing of which requests are processed when. As part of these changes, existing log messages have also been reviewed for their content and logging levels. Most messages are raised on the debug level, in accordance with [these guidelines](https://github.com/corda/platform-eng-design/blob/master/core/corda-5/corda-5.0/standards/logging.md).

This PR also makes a change to the uniqueness check test flow, used by the smoke tests so that each new request generates unique transaction hashes. Previously fixed hashes were used, which would mean that multiple calls to the smoke test would actually simply return the results from the first call.

### Testing

Temporarily added log4j2 configuration to enable logging and set to debug level when running the uniqueness checker unit tests. Ran the tests, and ensured that logging output was as expected.

Spun up a cluster, ensuring that the debug log level was enabled on the DB worker. Ran the uniqueness checker smoke test. Ensured that the DB worker correctly output the new log messages introduced in this PR.