### PR TITLE
CORE-7041: Remove warning from startup

### DIFF
--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -88,8 +88,6 @@ class MemberSynchronisationServiceImpl internal constructor(
         configurationReadService: ConfigurationReadService,
         @Reference(service = LifecycleCoordinatorFactory::class)
         coordinatorFactory: LifecycleCoordinatorFactory,
-        @Reference(service = CordaAvroSerializationFactory::class)
-        serializationFactory: CordaAvroSerializationFactory,
         @Reference(service = MemberInfoFactory::class)
         memberInfoFactory: MemberInfoFactory,
         @Reference(service = MembershipGroupReaderProvider::class)
@@ -108,7 +106,7 @@ class MemberSynchronisationServiceImpl internal constructor(
         publisherFactory,
         configurationReadService,
         coordinatorFactory,
-        serializationFactory,
+        cordaAvroSerializationFactory,
         memberInfoFactory,
         membershipGroupReaderProvider,
         Verifier(


### PR DESCRIPTION
The cause for this warning is Felix OSGi implementation. When it looks for the constructor, it looks at the constructors that has the same number of argument as the activated one (see [code](https://github.com/apache/felix-dev/blob/e34274d38ab29b017f265839c57fb82f9e789040/scr/src/main/java/org/apache/felix/scr/impl/inject/internal/ComponentConstructorImpl.java#L102)). So, all we have to do is to make sure the number of argument is different between the two constructors.

We had a duplicate argument, so removing it solved the issue.

(Comparing [the release log](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-e2e-tests/job/release%252Fos%252F5.0/lastSuccessfulBuild/artifact/logs-alice.txt) to [the branch logs](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-e2e-tests/job/PR-2291/1/artifact/logs-alice.txt))