### PR TITLE
CORE-7101 Current sandbox thread local

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -2,7 +2,7 @@ package net.corda.example.vnode
 
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.v5.base.util.loggerFor
@@ -25,7 +25,7 @@ class VNodeServiceImpl @Activate constructor(
     private val flowSandboxService: FlowSandboxService,
 
     @Reference
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    private val sandboxGroupComponent: SandboxGroupComponent,
 
     @Reference
     private val cpiLoader: CpiLoader,
@@ -57,6 +57,6 @@ class VNodeServiceImpl @Activate constructor(
     }
 
     private fun setupSandboxCache() {
-        sandboxGroupContextComponent.initCache(1)
+        sandboxGroupComponent.initCache(1)
     }
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -28,7 +28,7 @@ import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
 import net.corda.flow.testing.fakes.FakeFlowFiberFactory
 import net.corda.flow.testing.fakes.FakeMembershipGroupReaderProvider
-import net.corda.flow.testing.fakes.FakeSandboxGroupContextComponent
+import net.corda.flow.testing.fakes.FakeSandboxGroupComponent
 import net.corda.flow.testing.tests.FLOW_NAME
 import net.corda.flow.utils.emptyKeyValuePairList
 import net.corda.flow.utils.keyValuePairListOf
@@ -72,8 +72,8 @@ class FlowServiceTestContext @Activate constructor(
     val flowFiberFactory: FakeFlowFiberFactory,
     @Reference(service = FakeMembershipGroupReaderProvider::class)
     val membershipGroupReaderProvider: FakeMembershipGroupReaderProvider,
-    @Reference(service = FakeSandboxGroupContextComponent::class)
-    val sandboxGroupContextComponent: FakeSandboxGroupContextComponent,
+    @Reference(service = FakeSandboxGroupComponent::class)
+    val sandboxGroupContextComponent: FakeSandboxGroupComponent,
     @Reference(service = VirtualNodeInfoReadServiceFake::class)
     val virtualNodeInfoReadService: VirtualNodeInfoReadServiceFake,
 ) : StepSetup, ThenSetup {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupComponent.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupComponent.kt
@@ -9,7 +9,7 @@ import net.corda.sandbox.SandboxGroup
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.serialization.SerializationService
@@ -21,8 +21,8 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.propertytypes.ServiceRanking
 
 @ServiceRanking(Int.MAX_VALUE)
-@Component(service = [SandboxGroupContextComponent::class, FakeSandboxGroupContextComponent::class])
-class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
+@Component(service = [SandboxGroupComponent::class, FakeSandboxGroupComponent::class])
+class FakeSandboxGroupComponent : SandboxGroupComponent {
 
     private val availableCpk = mutableSetOf<SecureHash>()
     private var initiatingToInitiatedFlowsMap: Map<String, Pair<String, String>> = mapOf()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
@@ -4,6 +4,7 @@ import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.state.FlowStack
 import net.corda.membership.read.MembershipGroupReader
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
@@ -13,7 +14,8 @@ class FlowFiberExecutionContext(
     val flowCheckpoint: FlowCheckpoint,
     val sandboxGroupContext: FlowSandboxGroupContext,
     val holdingIdentity: HoldingIdentity,
-    val membershipGroupReader: MembershipGroupReader
+    val membershipGroupReader: MembershipGroupReader,
+    val sandboxGroupContextService: SandboxGroupContextService
 ) : NonSerializable {
     val memberX500Name: MemberX500Name = holdingIdentity.x500Name
     val flowStackService: FlowStack = flowCheckpoint.flowStack

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventProcessorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventProcessorFactoryImpl.kt
@@ -22,7 +22,6 @@ class FlowEventProcessorFactoryImpl @Activate constructor(
     private val flowEventExceptionProcessor: FlowEventExceptionProcessor,
     @Reference(service = FlowEventContextConverter::class)
     private val flowEventContextConverter: FlowEventContextConverter
-
 ) : FlowEventProcessorFactory {
 
     override fun create(config: SmartConfig): StateAndEventProcessor<String, Checkpoint, FlowEvent> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
@@ -6,6 +6,7 @@ import net.corda.flow.pipeline.exceptions.FlowTransientException
 import net.corda.flow.pipeline.factory.FlowFiberExecutionContextFactory
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -16,7 +17,9 @@ class FlowFiberExecutionContextFactoryImpl @Activate constructor(
     @Reference(service = FlowSandboxService::class)
     private val flowSandboxService: FlowSandboxService,
     @Reference(service = MembershipGroupReaderProvider::class)
-    private val membershipGroupReaderProvider: MembershipGroupReaderProvider
+    private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
+    @Reference(service = SandboxGroupContextService::class)
+    private val sandboxGroupContextService: SandboxGroupContextService
 ) : FlowFiberExecutionContextFactory {
 
     override fun createFiberExecutionContext(
@@ -32,7 +35,8 @@ class FlowFiberExecutionContextFactoryImpl @Activate constructor(
             checkpoint,
             sandbox,
             checkpoint.holdingIdentity,
-            membershipGroupReaderProvider.getGroupReader(checkpoint.holdingIdentity)
+            membershipGroupReaderProvider.getGroupReader(checkpoint.holdingIdentity),
+            sandboxGroupContextService
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
@@ -18,7 +18,7 @@ import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putObjectByKey
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
 import net.corda.serialization.checkpoint.factory.CheckpointSerializerBuilderFactory
@@ -59,8 +59,8 @@ class FlowSandboxServiceImpl @Activate constructor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
     private val cpiInfoReadService: CpiInfoReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = SandboxDependencyInjectorFactory::class)
     private val dependencyInjectionFactory: SandboxDependencyInjectorFactory,
     @Reference(service = CheckpointSerializerBuilderFactory::class)
@@ -106,11 +106,11 @@ class FlowSandboxServiceImpl @Activate constructor(
             null
         )
 
-        if (!sandboxGroupContextComponent.hasCpks(vNodeContext.cpkFileChecksums)) {
+        if (!sandboxGroupComponent.hasCpks(vNodeContext.cpkFileChecksums)) {
             throw IllegalStateException("The sandbox can't find one or more of the CPKs for CPI '${cpiMetadata.cpiId}'")
         }
 
-        val sandboxGroupContext = sandboxGroupContextComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
+        val sandboxGroupContext = sandboxGroupComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
             initialiseSandbox(dependencyInjectionFactory, sandboxGroupContext, cpiMetadata)
         }
 
@@ -123,7 +123,7 @@ class FlowSandboxServiceImpl @Activate constructor(
         cpiMetadata: CpiMetadata
     ): AutoCloseable {
         val sandboxGroup = sandboxGroupContext.sandboxGroup
-        val customCrypto = sandboxGroupContextComponent.registerCustomCryptography(sandboxGroupContext)
+        val customCrypto = sandboxGroupComponent.registerCustomCryptography(sandboxGroupContext)
 
         val injectorService = dependencyInjectionFactory.create(sandboxGroupContext)
         sandboxGroupContext.putObjectByKey(FlowSandboxGroupContextImpl.DEPENDENCY_INJECTOR, injectorService)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
@@ -15,7 +15,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
@@ -58,7 +58,7 @@ class FlowService @Activate constructor(
                     coordinator.followStatusChangesByName(
                         setOf(
                             LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
-                            LifecycleCoordinatorName.forComponent<SandboxGroupContextComponent>(),
+                            LifecycleCoordinatorName.forComponent<SandboxGroupComponent>(),
                             LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
                             LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
                             LifecycleCoordinatorName.forComponent<FlowExecutor>(),

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -13,6 +13,7 @@ import net.corda.flow.pipeline.sandbox.SandboxDependencyInjector;
 import net.corda.flow.state.FlowCheckpoint;
 import net.corda.flow.state.FlowContext;
 import net.corda.membership.read.MembershipGroupReader;
+import net.corda.sandboxgroupcontext.SandboxGroupContextService;
 import net.corda.serialization.checkpoint.CheckpointSerializer;
 import net.corda.v5.application.messaging.FlowSession;
 import net.corda.v5.base.types.MemberX500Name;
@@ -42,7 +43,8 @@ public class FlowSessionImplJavaTest {
             mock(FlowCheckpoint.class),
             flowSandboxGroupContext,
             createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group1"),
-            mock(MembershipGroupReader.class)
+            mock(MembershipGroupReader.class),
+            mock(SandboxGroupContextService.class)
     );
     private final FlowFiber flowFiber = new FakeFiber(flowFiberExecutionContext);
     private final FlowFiberService flowFiberService = mock(FlowFiberService.class);

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
@@ -10,6 +10,7 @@ import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.state.FlowContext
 import net.corda.flow.state.FlowStack
 import net.corda.membership.read.MembershipGroupReader
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.virtualnode.HoldingIdentity
 import org.mockito.kotlin.mock
@@ -21,6 +22,7 @@ class MockFlowFiberService : FlowFiberService {
     val flowCheckpoint = mock<FlowCheckpoint>()
     val flowStack = mock<FlowStack>()
     private val checkpointSerializer = mock<CheckpointSerializer>()
+    private val sandboxGroupContextService = mock<SandboxGroupContextService>()
     val sandboxGroupContext = mock<FlowSandboxGroupContext>()
     val holdingIdentity = HoldingIdentity(BOB_X500_NAME, "group1")
     private val membershipGroupReader = mock<MembershipGroupReader>()
@@ -45,12 +47,14 @@ class MockFlowFiberService : FlowFiberService {
         whenever(flowCheckpoint.flowStack).thenReturn(flowStack)
         whenever(sandboxGroupContext.dependencyInjector).thenReturn(sandboxDependencyInjector)
         whenever(sandboxGroupContext.checkpointSerializer).thenReturn(checkpointSerializer)
+        whenever(sandboxGroupContextService.getCurrent()).thenReturn(sandboxGroupContext)
 
         flowFiberExecutionContext = FlowFiberExecutionContext(
             flowCheckpoint,
             sandboxGroupContext,
             holdingIdentity,
-            membershipGroupReader
+            membershipGroupReader,
+            sandboxGroupContextService
         )
 
         whenever(flowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
@@ -18,7 +18,7 @@ class FlowFiberExecutionContextTest {
     @Test
     fun `getMemberX500Name returns x500name parsed from holding identity`() {
         val holdingIdentity = HoldingIdentity(BOB_X500_NAME, "group1")
-        val context = FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock())
+        val context = FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock(), mock())
         assertThat(context.memberX500Name).isEqualTo(BOB_X500_NAME)
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
@@ -74,7 +74,7 @@ class RPCRequestDataImplTest {
         }
         whenever(checkpoint.flowStartContext).thenReturn(startContext)
         val holdingIdentity = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "12345")
-        val executionContext = FlowFiberExecutionContext(checkpoint, mock(), holdingIdentity, mock())
+        val executionContext = FlowFiberExecutionContext(checkpoint, mock(), holdingIdentity, mock(), mock())
         whenever(fiber.getExecutionContext()).thenReturn(executionContext)
         whenever(fiberService.getExecutingFiber()).thenReturn(fiber)
         return fiberService

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowFiberExecutionContextFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowFiberExecutionContextFactoryImplTest.kt
@@ -11,6 +11,7 @@ import net.corda.flow.pipeline.sandbox.SandboxDependencyInjector
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
@@ -24,11 +25,13 @@ class FlowFiberExecutionContextFactoryImplTest {
     private val sandboxGroupContext = mock<FlowSandboxGroupContext>()
     private val checkpointSerializer = mock<CheckpointSerializer>()
     private val sandboxDependencyInjector = mock<SandboxDependencyInjector>()
+    private val sandboxGroupContextService = mock<SandboxGroupContextService>()
     private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider>()
     private val membershipGroupReader = mock<MembershipGroupReader>()
     private val flowFiberExecutionContextFactory = FlowFiberExecutionContextFactoryImpl(
         flowSandboxService,
-        membershipGroupReaderProvider
+        membershipGroupReaderProvider,
+        sandboxGroupContextService
     )
 
     @Test
@@ -56,6 +59,7 @@ class FlowFiberExecutionContextFactoryImplTest {
         assertThat(result.sandboxGroupContext).isSameAs(sandboxGroupContext)
         assertThat(result.membershipGroupReader).isSameAs(membershipGroupReader)
         assertThat(result.memberX500Name).isEqualTo(BOB_X500_NAME)
+        assertThat(result.sandboxGroupContextService).isEqualTo(sandboxGroupContextService)
 
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
@@ -74,6 +74,7 @@ class FlowRunnerImplTest {
             flowCheckpoint,
             sandboxGroupContext,
             BOB_X500_HOLDING_IDENTITY.toCorda(),
+            mock(),
             mock()
         )
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
@@ -7,7 +7,7 @@ import net.corda.flow.MINIMUM_SMART_CONFIG
 import net.corda.flow.scheduler.FlowWakeUpScheduler
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.test.impl.LifecycleTest
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class FlowServiceTest {
         fun dependants(): Stream<Arguments> {
             return Stream.of(
                 Arguments.of(LifecycleCoordinatorName.forComponent<ConfigurationReadService>()),
-                Arguments.of(LifecycleCoordinatorName.forComponent<SandboxGroupContextComponent>()),
+                Arguments.of(LifecycleCoordinatorName.forComponent<SandboxGroupComponent>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<CpiInfoReadService>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<FlowExecutor>())
@@ -152,7 +152,7 @@ class FlowServiceTest {
     private fun getFlowServiceTestContext(): LifecycleTest<FlowService> {
         return LifecycleTest {
             addDependency<ConfigurationReadService>()
-            addDependency<SandboxGroupContextComponent>()
+            addDependency<SandboxGroupComponent>()
             addDependency<VirtualNodeInfoReadService>()
             addDependency<CpiInfoReadService>()
             addDependency<FlowExecutor>()

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxServiceFactory.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxServiceFactory.kt
@@ -3,13 +3,13 @@ package net.corda.persistence.common
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.persistence.common.internal.EntitySandboxServiceImpl
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.ComponentContext
 
 class EntitySandboxServiceFactory {
     fun create(
-        sandboxService: SandboxGroupContextComponent,
+        sandboxService: SandboxGroupComponent,
         cpiInfoService: CpiInfoReadService,
         virtualNodeInfoService: VirtualNodeInfoReadService,
         dbConnectionManager: DbConnectionManager,

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -24,7 +24,7 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putObjectByKey
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.serialization.SerializationCustomSerializer
@@ -62,7 +62,7 @@ import org.osgi.service.component.annotations.ReferencePolicy
 )
 class EntitySandboxServiceImpl @Activate constructor(
     @Reference
-    private val sandboxService: SandboxGroupContextComponent,
+    private val sandboxService: SandboxGroupComponent,
     @Reference
     private val cpiInfoService: CpiInfoReadService,
     @Reference

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -28,6 +28,7 @@ import net.corda.persistence.common.exceptions.NotReadyException
 import net.corda.persistence.common.exceptions.VirtualNodeException
 import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_SERIALIZER
 import net.corda.persistence.common.EntitySandboxServiceFactory
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
@@ -68,6 +69,7 @@ class PersistenceExceptionTests {
     private lateinit var cpiInfoReadService: CpiInfoReadService
     private lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
     private lateinit var externalEventResponseFactory: ExternalEventResponseFactory
+    private lateinit var sandboxContextService: SandboxGroupContextService
 
     @BeforeAll
     fun setup(
@@ -85,6 +87,7 @@ class PersistenceExceptionTests {
             cpiInfoReadService = setup.fetchService(timeout = 5000)
             virtualNodeInfoReadService = setup.fetchService(timeout = 5000)
             externalEventResponseFactory = setup.fetchService(timeout = 5000)
+            sandboxContextService = setup.fetchService(timeout = 5000)
         }
     }
 
@@ -109,8 +112,12 @@ class PersistenceExceptionTests {
                 BasicMocks.componentContext()
             )
 
-        val processor =
-            EntityMessageProcessor(brokenEntitySandboxService, externalEventResponseFactory, this::noOpPayloadCheck)
+        val processor = EntityMessageProcessor(
+            brokenEntitySandboxService,
+            externalEventResponseFactory,
+            sandboxContextService,
+            this::noOpPayloadCheck
+        )
 
         // Now "send" the request for processing and "receive" the responses.
         val responses = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), ignoredRequest)))
@@ -146,8 +153,12 @@ class PersistenceExceptionTests {
                 BasicMocks.componentContext()
             )
 
-        val processor =
-            EntityMessageProcessor(brokenEntitySandboxService, externalEventResponseFactory, this::noOpPayloadCheck)
+        val processor = EntityMessageProcessor(
+            brokenEntitySandboxService,
+            externalEventResponseFactory,
+            sandboxContextService,
+            this::noOpPayloadCheck
+        )
 
         // Now "send" the request for processing and "receive" the responses.
         val responses = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), ignoredRequest)))
@@ -182,8 +193,12 @@ class PersistenceExceptionTests {
                 BasicMocks.componentContext()
             )
 
-        val processor =
-            EntityMessageProcessor(entitySandboxService, externalEventResponseFactory, this::noOpPayloadCheck)
+        val processor = EntityMessageProcessor(
+            entitySandboxService,
+            externalEventResponseFactory,
+            sandboxContextService,
+            this::noOpPayloadCheck
+        )
 
         // Now "send" the request for processing and "receive" the responses.
         val responses = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), badRequest)))

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -102,7 +102,7 @@ class PersistenceExceptionTests {
 
         val brokenEntitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 brokenCpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,
@@ -139,7 +139,7 @@ class PersistenceExceptionTests {
 
         val brokenEntitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 brokenCpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,
@@ -175,7 +175,7 @@ class PersistenceExceptionTests {
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,
@@ -214,7 +214,7 @@ class PersistenceExceptionTests {
         // We need a 'working' service to set up the test
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -717,7 +717,7 @@ class PersistenceServiceInternalTests {
 
     private fun createEntitySandbox(dbConnectionManager: DbConnectionManager = BasicMocks.dbConnectionManager()) =
         EntitySandboxServiceFactory().create(
-            virtualNode.sandboxGroupContextComponent,
+            virtualNode.sandboxGroupComponent,
             cpiInfoReadService,
             virtualNodeInfoReadService,
             dbConnectionManager,

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/SerializationTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/SerializationTests.kt
@@ -66,7 +66,7 @@ class SerializationTests {
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 BasicMocks.dbConnectionManager(),

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/EntityProcessorFactoryImpl.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/EntityProcessorFactoryImpl.kt
@@ -10,6 +10,7 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.persistence.common.EntitySandboxService
 import net.corda.persistence.common.PayloadChecker
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.schema.Schemas
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -25,7 +26,9 @@ class EntityProcessorFactoryImpl @Activate constructor(
     @Reference
     private val entitySandboxService: EntitySandboxService,
     @Reference(service = ExternalEventResponseFactory::class)
-    private val externalEventResponseFactory: ExternalEventResponseFactory
+    private val externalEventResponseFactory: ExternalEventResponseFactory,
+    @Reference(service = SandboxGroupContextService::class)
+    private val sandboxGroupContextService: SandboxGroupContextService
 ) : EntityProcessorFactory {
     companion object {
         internal const val GROUP_NAME = "persistence.entity.processor"
@@ -38,6 +41,7 @@ class EntityProcessorFactoryImpl @Activate constructor(
         val processor = EntityMessageProcessor(
             entitySandboxService,
             externalEventResponseFactory,
+            sandboxGroupContextService,
             PayloadChecker(config)::checkSize
         )
 

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceServiceImpl.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceServiceImpl.kt
@@ -17,7 +17,7 @@ import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.v5.base.util.contextLogger
@@ -34,8 +34,8 @@ class FlowPersistenceServiceImpl  @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = VirtualNodeInfoReadService::class)
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
@@ -52,7 +52,7 @@ class FlowPersistenceServiceImpl  @Activate constructor(
 
     private val dependentComponents = DependentComponents.of(
         ::configurationReadService,
-        ::sandboxGroupContextComponent,
+        ::sandboxGroupComponent,
         ::virtualNodeInfoReadService,
         ::cpiInfoReadService,
     )

--- a/components/virtual-node/ledger-persistence-service-impl/src/integrationTest/kotlin/net/corda/ledger/persistence/impl/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/virtual-node/ledger-persistence-service-impl/src/integrationTest/kotlin/net/corda/ledger/persistence/impl/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -61,6 +61,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.time.Instant
 import java.util.UUID
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 
 /**
  * To use Postgres rather than in-memory (HSQL):
@@ -94,6 +95,7 @@ class ConsensualLedgerMessageProcessorTests {
     private lateinit var virtualNode: VirtualNodeService
     private lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
     private lateinit var externalEventResponseFactory: ExternalEventResponseFactory
+    private lateinit var sandboxGroupContextService: SandboxGroupContextService
     private lateinit var deserializer: CordaAvroDeserializer<EntityResponse>
 
     @InjectService
@@ -127,6 +129,7 @@ class ConsensualLedgerMessageProcessorTests {
             )
             deserializer = setup.fetchService<CordaAvroSerializationFactory>(timeout = 10000)
                 .createAvroDeserializer({}, EntityResponse::class.java)
+            sandboxGroupContextService = setup.fetchService(timeout = 10000)
         }
     }
 
@@ -177,7 +180,9 @@ class ConsensualLedgerMessageProcessorTests {
             merkleTreeProvider,
             digestService,
             jsonMarshallingService,
-            this::noOpPayloadCheck)
+            sandboxGroupContextService,
+            this::noOpPayloadCheck
+        )
         val requestId = UUID.randomUUID().toString()
         val records = listOf(Record(TOPIC, requestId, request))
 

--- a/components/virtual-node/ledger-persistence-service-impl/src/integrationTest/kotlin/net/corda/ledger/persistence/impl/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/virtual-node/ledger-persistence-service-impl/src/integrationTest/kotlin/net/corda/ledger/persistence/impl/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -213,7 +213,7 @@ class ConsensualLedgerMessageProcessorTests {
         // set up sandbox
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,

--- a/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/ConsensualLedgerProcessorFactoryImpl.kt
+++ b/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/ConsensualLedgerProcessorFactoryImpl.kt
@@ -9,6 +9,7 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.persistence.common.EntitySandboxService
 import net.corda.persistence.common.PayloadChecker
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.schema.Schemas
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.cipher.suite.DigestService
@@ -31,7 +32,9 @@ class ConsensualLedgerProcessorFactoryImpl @Activate constructor(
     @Reference(service = DigestService::class)
     private val digestService: DigestService,
     @Reference(service = JsonMarshallingService::class)
-    private val jsonMarshallingService: JsonMarshallingService
+    private val jsonMarshallingService: JsonMarshallingService,
+    @Reference(service = SandboxGroupContextService::class)
+    private val sandboxGroupContextService: SandboxGroupContextService
 ) : ConsensualLedgerProcessorFactory {
     companion object {
         internal const val GROUP_NAME = "persistence.ledger.processor"
@@ -47,6 +50,7 @@ class ConsensualLedgerProcessorFactoryImpl @Activate constructor(
             merkleTreeProvider,
             digestService,
             jsonMarshallingService,
+            sandboxGroupContextService,
             PayloadChecker(config)::checkSize
         )
 

--- a/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/LedgerPersistenceServiceImpl.kt
+++ b/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/LedgerPersistenceServiceImpl.kt
@@ -17,7 +17,7 @@ import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.v5.base.util.contextLogger
@@ -34,8 +34,8 @@ class LedgerPersistenceServiceImpl  @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = VirtualNodeInfoReadService::class)
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
@@ -52,7 +52,7 @@ class LedgerPersistenceServiceImpl  @Activate constructor(
 
     private val dependentComponents = DependentComponents.of(
         ::configurationReadService,
-        ::sandboxGroupContextComponent,
+        ::sandboxGroupComponent,
         ::virtualNodeInfoReadService,
         ::cpiInfoReadService,
     )

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxgroupcontext.test
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
@@ -28,7 +28,7 @@ class VirtualNodeService @Activate constructor(
     private val virtualNodeLoader: VirtualNodeLoader,
 
     @Reference
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent
+    private val sandboxGroupComponent: SandboxGroupComponent
 ) {
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
@@ -37,7 +37,7 @@ class VirtualNodeService @Activate constructor(
     }
     init {
         // setting cache size to 2 as some tests require 2 concurrent sandboxes for validating they don't overlap
-        sandboxGroupContextComponent.initCache(2)
+        sandboxGroupComponent.initCache(2)
     }
 
     private val vnodes = mutableMapOf<SandboxGroupContext, VirtualNodeInfo>()
@@ -45,7 +45,7 @@ class VirtualNodeService @Activate constructor(
     @Suppress("unused")
     @Deactivate
     fun done() {
-        sandboxGroupContextComponent.close()
+        sandboxGroupComponent.close()
     }
 
     private fun getOrCreateSandbox(virtualNodeInfo: VirtualNodeInfo, type: SandboxGroupType): SandboxGroupContext {
@@ -58,8 +58,8 @@ class VirtualNodeService @Activate constructor(
             SingletonSerializeAsToken::class.java,
             null
         )
-        return sandboxGroupContextComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
-            sandboxGroupContextComponent.registerCustomCryptography(sandboxGroupContext)
+        return sandboxGroupComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
+            sandboxGroupComponent.registerCustomCryptography(sandboxGroupContext)
         }
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupComponent.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupComponent.kt
@@ -1,0 +1,7 @@
+package net.corda.sandboxgroupcontext.service
+
+import net.corda.lifecycle.Lifecycle
+import net.corda.sandboxgroupcontext.SandboxGroupService
+
+interface SandboxGroupComponent : SandboxGroupService, CacheConfiguration, Lifecycle
+

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupContextComponent.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupContextComponent.kt
@@ -1,7 +1,0 @@
-package net.corda.sandboxgroupcontext.service
-
-import net.corda.lifecycle.Lifecycle
-import net.corda.sandboxgroupcontext.SandboxGroupContextService
-
-interface SandboxGroupContextComponent : SandboxGroupContextService, CacheConfiguration, Lifecycle
-

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupComponentImpl.kt
@@ -19,7 +19,7 @@ import net.corda.sandbox.SandboxCreationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
@@ -38,9 +38,9 @@ import java.util.Collections.unmodifiableList
  * that has a lifecycle.
  */
 @Suppress("Unused", "LongParameterList")
-@Component(service = [SandboxGroupContextComponent::class])
+@Component(service = [SandboxGroupComponent::class])
 @RequireSandboxHooks
-class SandboxGroupContextComponentImpl @Activate constructor(
+class SandboxGroupComponentImpl @Activate constructor(
     @Reference(service = CpkReadService::class)
     private val cpkReadService: CpkReadService,
     @Reference(service = ConfigurationReadService::class)
@@ -52,7 +52,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     @Reference
     private val serviceComponentRuntime: ServiceComponentRuntime,
     private val bundleContext: BundleContext
-) : SandboxGroupContextComponent {
+) : SandboxGroupComponent {
     companion object {
         private val logger = contextLogger()
 
@@ -90,8 +90,8 @@ class SandboxGroupContextComponentImpl @Activate constructor(
         const val SANDBOX_CACHE_SIZE_DEFAULT: Long = 2
     }
 
-    private var sandboxGroupContextService: SandboxGroupContextServiceImpl? = null
-    private val coordinator = coordinatorFactory.createCoordinator<SandboxGroupContextComponent>(::eventHandler)
+    private var sandboxGroupContextService: SandboxGroupServiceImpl? = null
+    private val coordinator = coordinatorFactory.createCoordinator<SandboxGroupComponent>(::eventHandler)
     private var registrationHandle: RegistrationHandle? = null
     private var configHandle: AutoCloseable? = null
 
@@ -222,7 +222,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
 
     override fun initCache(cacheSize: Long) {
         logger.info("Initialising Sandbox cache with size: $cacheSize")
-        sandboxGroupContextService = SandboxGroupContextServiceImpl(
+        sandboxGroupContextService = SandboxGroupServiceImpl(
             sandboxCreationService,
             cpkReadService,
             serviceComponentRuntime,

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -1,387 +1,59 @@
-@file:JvmName("SandboxGroupContextServiceUtils")
 package net.corda.sandboxgroupcontext.service.impl
 
-import java.security.AccessControlContext
-import java.security.AccessControlException
-import java.util.Collections.singleton
-import java.util.Hashtable
-import net.corda.cpk.read.CpkReadService
-import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.sandbox.SandboxCreationService
-import net.corda.sandbox.SandboxException
-import net.corda.sandboxgroupcontext.CORDA_SANDBOX
-import net.corda.sandboxgroupcontext.CORDA_SANDBOX_FILTER
-import net.corda.sandboxgroupcontext.CORDA_SYSTEM_FILTER
-import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
 import net.corda.sandboxgroupcontext.SandboxGroupContextService
-import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.debug
-import net.corda.v5.base.util.loggerFor
-import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.extensions.DigestAlgorithmFactory
-import org.osgi.framework.Bundle
-import org.osgi.framework.BundleContext
-import org.osgi.framework.Constants.OBJECTCLASS
-import org.osgi.framework.Constants.SCOPE_PROTOTYPE
-import org.osgi.framework.Constants.SCOPE_SINGLETON
-import org.osgi.framework.Constants.SERVICE_SCOPE
-import org.osgi.framework.FrameworkUtil
-import org.osgi.framework.ServiceObjects
-import org.osgi.framework.ServicePermission
-import org.osgi.framework.ServicePermission.GET
-import org.osgi.framework.ServiceRegistration
-import org.osgi.service.component.runtime.ServiceComponentRuntime
-import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.trace
+import net.corda.v5.serialization.SingletonSerializeAsToken
+import org.osgi.service.component.annotations.Component
 
-private typealias ServiceDefinition = Pair<ServiceObjects<out Any>, List<Class<*>>>
+@Component(service = [SandboxGroupContextService::class, SingletonSerializeAsToken::class])
+class SandboxGroupContextServiceImpl : SandboxGroupContextService, SingletonSerializeAsToken {
 
-/**
- * This is the underlying implementation of the [SandboxGroupContextService]
- *
- * Use this service via the mutable and immutable interfaces to create a "virtual node",
- * and retrieve the same instance "later".
- *
- * This is a per-process service, but it must return the "same instance" for a given [VirtualNodeContext]
- * in EVERY process.
- */
-class SandboxGroupContextServiceImpl(
-    private val sandboxCreationService: SandboxCreationService,
-    private val cpkReadService: CpkReadService,
-    private val serviceComponentRuntime: ServiceComponentRuntime,
-    private val bundleContext: BundleContext,
-    var cache: SandboxGroupContextCache
-) : SandboxGroupContextService {
     private companion object {
-        private const val SANDBOX_FACTORY_FILTER = "(&($SERVICE_SCOPE=$SCOPE_PROTOTYPE)(!$CORDA_SANDBOX_FILTER)(!$CORDA_SYSTEM_FILTER))"
-        private const val SYSTEM_FACTORY_FILTER = "(&($SERVICE_SCOPE=$SCOPE_PROTOTYPE)(!$CORDA_SANDBOX_FILTER)$CORDA_SYSTEM_FILTER)"
+        val log = contextLogger()
+    }
 
-        private val logger = loggerFor<SandboxGroupContextServiceImpl>()
-
-        private val sandboxServiceProperties = Hashtable<String, Any?>().apply {
-            put(CORDA_SANDBOX, true)
+    override fun setCurrent(sandboxGroupContext: SandboxGroupContext) {
+        log.trace {
+            "Setting current sandbox group context [$sandboxGroupContext] on thread [${Thread.currentThread().name}] for holding " +
+                    "identity [${sandboxGroupContext.virtualNodeContext.holdingIdentity}]"
         }
+        currentSandboxGroupContext.set(sandboxGroupContext)
+    }
 
-        private fun <R> runIgnoringExceptions(action: () -> R) {
-            try {
-                action()
-            } catch(e: Exception) {
-                logger.warn("Ignoring exception", e)
+    override fun getCurrent(): SandboxGroupContext {
+        val current = currentSandboxGroupContext.get()
+        return if (current != null) {
+            log.trace {
+                "Retrieved current sandbox group context [$current] for thread [${Thread.currentThread().name}] with holding identity " +
+                        "[${current.virtualNodeContext.holdingIdentity}]"
             }
+            current
+        } else {
+            log.error("No current sandbox group context set for thread [${Thread.currentThread().name}]")
+            throw IllegalStateException("No current sandbox group context set for thread")
         }
-
-        private fun ComponentDescriptionDTO.toShortString(): String
-            = "Component(class=$implementationClass, services=${serviceInterfaces.joinToString()}, scope=$scope, enabled=$defaultEnabled)"
     }
 
-    fun remove(virtualNodeContext: VirtualNodeContext) {
-        cache.remove(virtualNodeContext)
-    }
+    override fun removeCurrent() {
+        val current = currentSandboxGroupContext.get()
+        currentSandboxGroupContext.remove()
 
-    override fun getOrCreate(
-
-        virtualNodeContext: VirtualNodeContext,
-        initializer: SandboxGroupContextInitializer
-    ): SandboxGroupContext {
-        return cache.get(virtualNodeContext) {
-            val cpks = virtualNodeContext.cpkFileChecksums.mapNotNull { cpkReadService.get(it) }
-            if (cpks.size != virtualNodeContext.cpkFileChecksums.size) {
-                logger.error("Not all CPKs could be retrieved for this virtual node context ($virtualNodeContext)")
-                logger.error("Wanted all of:  ${virtualNodeContext.cpkFileChecksums}")
-                val receivedIdentifiers = cpks.map { it.metadata.cpkId }
-                val missing = setOf(virtualNodeContext.cpkFileChecksums) - setOf(receivedIdentifiers)
-                logger.error("Returned:  $receivedIdentifiers")
-                logger.error("Missing:  $missing")
-                throw CordaRuntimeException("Not all CPKs could be retrieved for this virtual node context ($virtualNodeContext)\"")
+        if (current != null) {
+            log.trace {
+                "Removed current sandbox group context [$current] for thread [${Thread.currentThread().name}] with holding identity " +
+                        "[${current.virtualNodeContext.holdingIdentity}]"
             }
-
-            val sandboxGroup = sandboxCreationService.createSandboxGroup(cpks, virtualNodeContext.sandboxGroupType.name)
-
-            // Default implementation doesn't do anything on close()`
-            val sandboxGroupContext = SandboxGroupContextImpl(virtualNodeContext, sandboxGroup)
-
-            // Register common OSGi services for use within this sandbox.
-            val commonServiceRegistrations = registerCommonServices(virtualNodeContext, sandboxGroup.metadata.keys)
-
-            // Run the caller's initializer.
-            val initializerAutoCloseable =
-                initializer.initializeSandboxGroupContext(virtualNodeContext.holdingIdentity, sandboxGroupContext)
-
-            // Wrapped SandboxGroupContext, specifically to set closeable and forward on all other calls.
-
-            // Calling close also removes us from the contexts map and unloads the [SandboxGroup].
-            val newContext = CloseableSandboxGroupContextImpl(sandboxGroupContext) {
-                // These objects might still be in a sandbox, so close them whilst the sandbox is still valid.
-                initializerAutoCloseable.close()
-
-                // Remove this sandbox's common services.
-                commonServiceRegistrations?.forEach { closeable ->
-                    runIgnoringExceptions(closeable::close)
-                }
-
-                // And unload the (OSGi) sandbox group
-                sandboxCreationService.unloadSandboxGroup(sandboxGroupContext.sandboxGroup)
-            }
-            newContext
-        }
-    }
-
-    private fun registerCommonServices(vnc: VirtualNodeContext, bundles: Iterable<Bundle>): List<AutoCloseable>? {
-        val bundleContext = bundles.firstOrNull()?.bundleContext ?: return null
-        return (fetchCommonServices(vnc, bundles) + fetchSystemServices(vnc)).mapNotNull { requirement ->
-            registerCommonServiceFor(requirement.first, requirement.second, bundleContext)
-        }
-    }
-
-    /**
-     * Locate suitable "prototype-scope" OSGi services to instantiate inside
-     * the sandbox. We assume that the OSGi isolation hooks protect us from
-     * finding any pre-existing services inside the sandbox itself.
-     */
-    private fun fetchCommonServices(vnc: VirtualNodeContext, bundles: Iterable<Bundle>): List<ServiceDefinition> {
-        // Access control context for the sandbox's "main" bundles.
-        // All "main" bundles are assumed to have equal access rights.
-        val accessControlContext = bundles.first().adapt(AccessControlContext::class.java)
-        val serviceFilter = vnc.serviceFilter?.let { filter -> "(&$SANDBOX_FACTORY_FILTER$filter)" } ?: SANDBOX_FACTORY_FILTER
-        val serviceMarkerTypeName = vnc.serviceMarkerType.name
-        return bundleContext.getServiceReferences(vnc.serviceMarkerType, serviceFilter).mapNotNull { serviceRef ->
-            try {
-                @Suppress("unchecked_cast")
-                (serviceRef.getProperty(OBJECTCLASS) as? Array<String> ?: emptyArray())
-                    .filterNot(serviceMarkerTypeName::equals)
-                    .filter { checkServicePermission(accessControlContext, it) }
-                    .mapNotNullTo(ArrayList(), bundles::loadCommonService)
-                    .takeIf(List<*>::isNotEmpty)
-                    ?.let { injectables ->
-                        // Every service object must implement the service
-                        // marker type and at least one other type too.
-                        logger.debug { "Fetching common service: $serviceRef holding id ${vnc.holdingIdentity}" }
-                        injectables += vnc.serviceMarkerType
-                        bundleContext.getServiceObjects(serviceRef)?.let { serviceObj ->
-                            serviceObj to injectables
-                        }
-                    }
-            } catch (e: Exception) {
-                logger.warn("Failed to identify injectable services from $serviceRef", e)
-                null
-            }
-        }
-    }
-
-    private fun fetchSystemServices(vnc: VirtualNodeContext): List<ServiceDefinition> {
-        val serviceFilter = vnc.serviceFilter?.let { filter -> "(&$SYSTEM_FACTORY_FILTER$filter)" } ?: SYSTEM_FACTORY_FILTER
-        val serviceMarkerTypeName = vnc.serviceMarkerType.name
-        return bundleContext.getServiceReferences(vnc.serviceMarkerType, serviceFilter).mapNotNull { serviceRef ->
-            try {
-                @Suppress("unchecked_cast")
-                (serviceRef.getProperty(OBJECTCLASS) as? Array<String> ?: emptyArray())
-                    .filterNot(serviceMarkerTypeName::equals)
-                    .mapNotNullTo(ArrayList(), singleton(serviceRef.bundle)::loadCommonService)
-                    .takeIf(List<*>::isNotEmpty)
-                    ?.let { injectables ->
-                        // Every service object must implement the service
-                        // marker type and at least one other type too.
-                        logger.debug { "Fetching system service: $serviceRef holding id ${vnc.holdingIdentity}" }
-                        injectables += vnc.serviceMarkerType
-                        bundleContext.getServiceObjects(serviceRef)?.let { serviceObj ->
-                            serviceObj to injectables
-                        }
-                    }
-            } catch (e: Exception) {
-                logger.warn("Failed to identify injectable system services from $serviceRef", e)
-                null
-            }
-        }
-    }
-
-    private fun registerCommonServiceFor(
-        serviceFactory: ServiceObjects<out Any>,
-        serviceClasses: Iterable<Class<*>>,
-        bundleContext: BundleContext
-    ): AutoCloseable? {
-        val serviceObj = try {
-            serviceFactory.service ?: return null
-        } catch (e: Exception) {
-            logger.warn("Service ${serviceFactory.serviceReference} is not available.", e)
-            throw SandboxException("Service ${serviceFactory.serviceReference} is unavailable", e)
-        }
-        return try {
-            val serviceRegistration = bundleContext.registerService(
-                serviceClasses.mapTo(LinkedHashSet(), Class<*>::getName).toTypedArray(),
-                serviceObj,
-                sandboxServiceProperties
+        } else {
+            // An exception is created here, so that the warning provides a stacktrace that can be used to determine where the thread
+            // local is being incorrectly set or removed.
+            log.warn(
+                "No current sandbox group context to remove for thread [${Thread.currentThread().name}]",
+                IllegalStateException("No current sandbox group context to remove for thread")
             )
-            logger.info("Registered sandbox service [{}] for bundle [{}][{}]",
-                serviceClasses.joinToString(transform = Class<*>::getName),
-                bundleContext.bundle.symbolicName,
-                bundleContext.bundle.bundleId
-            )
-            CommonServiceRegistration(serviceFactory, serviceObj, serviceRegistration)
-        } catch (e: Exception) {
-            logger.warn("Cannot create sandbox service ${serviceObj::class.java.name}", e)
-            @Suppress("unchecked_cast")
-            (serviceFactory as ServiceObjects<Any>).ungetService(serviceObj)
-            null
         }
-    }
-
-    override fun registerMetadataServices(
-        sandboxGroupContext: SandboxGroupContext,
-        serviceNames: (CpkMetadata) -> Iterable<String>,
-        isMetadataService: (Class<*>) -> Boolean,
-        serviceMarkerType: Class<*>
-    ): AutoCloseable {
-        val groupMetadata = sandboxGroupContext.sandboxGroup.metadata
-        val services = groupMetadata.flatMap { (mainBundle, cpkMetadata) ->
-            // Fetch metadata classes provided by each CPK main bundle.
-            serviceNames(cpkMetadata).mapNotNull { serviceName ->
-                mainBundle.loadMetadataService(serviceName, isMetadataService)
-            }
-        }
-
-        // Register each metadata service as an OSGi service for its host main bundle.
-        val registrations = registerMetadataServices(serviceMarkerType.name, services)
-        return AutoCloseable {
-            registrations.forEach { registration ->
-                runIgnoringExceptions(registration::close)
-            }
-        }
-    }
-
-    private fun registerMetadataServices(
-        serviceMarkerTypeName: String,
-        services: Iterable<Pair<Class<*>, Bundle>>
-    ): List<AutoCloseable> {
-        val extraCloseables = mutableListOf<AutoCloseable>()
-        return services.mapNotNull { (serviceClass, serviceBundle) ->
-            try {
-                val serviceContext = serviceBundle.bundleContext
-                val component = serviceComponentRuntime.getComponentDescriptionDTOs(serviceBundle).find { description ->
-                    description.implementationClass == serviceClass.name
-                }
-                val serviceInterfaces = mutableSetOf(serviceMarkerTypeName)
-                val serviceObj = if (component == null) {
-                    serviceInterfaces += serviceClass.name
-                    serviceClass.getConstructor().newInstance()
-                } else if (component.defaultEnabled
-                    && component.scope == SCOPE_SINGLETON
-                    && component.implementationClass in component.serviceInterfaces) {
-                    serviceInterfaces += component.serviceInterfaces
-                    serviceContext.getServiceReference(component.implementationClass)?.let { reference ->
-                        serviceContext.getService(reference)?.also {
-                            // Ensure we can "unget" this service later.
-                            extraCloseables.add(AutoCloseable { serviceContext.ungetService(reference) })
-                        }
-                    } ?: throw IllegalStateException("No ${component.toShortString()} active for bundle $serviceBundle")
-                } else {
-                    logger.warn("Ignoring misconfigured OSGi ${component.toShortString()} for service ${serviceClass.name}")
-                    return@mapNotNull null
-                }
-
-                // Register this service object with the OSGi framework.
-                val registration = serviceContext.registerService(
-                    serviceInterfaces.toTypedArray(),
-                    serviceObj,
-                    sandboxServiceProperties
-                )
-
-                logger.info("Registered Metadata Service [{}] for bundle [{}][{}]",
-                    serviceInterfaces.joinToString(), serviceBundle.symbolicName, serviceBundle.bundleId)
-
-                // Return an AutoCloseable that can unregister this service.
-                AutoCloseable(registration::unregister)
-            } catch (e: Exception) {
-                logger.warn("Cannot create service ${serviceClass.name}", e)
-                null
-            }
-        } + extraCloseables
-    }
-
-    override fun registerCustomCryptography(sandboxGroupContext: SandboxGroupContext): AutoCloseable {
-        return registerMetadataServices(
-            sandboxGroupContext,
-            serviceNames = { metadata -> metadata.cordappManifest.digestAlgorithmFactories },
-            serviceMarkerType = DigestAlgorithmFactory::class.java
-        )
-    }
-
-    override fun hasCpks(cpkChecksums: Set<SecureHash>): Boolean {
-        val missingCpks = cpkChecksums.filter {
-            cpkReadService.get(it) == null
-        }
-
-        if(logger.isInfoEnabled && missingCpks.isNotEmpty()) {
-            logger.info("CPK(s) not (yet) found in cache: $missingCpks")
-        }
-
-        return missingCpks.isEmpty()
-    }
-
-    override fun close() {
-        cache.close()
-    }
-
-    private class CommonServiceRegistration(
-        private val serviceFactory: ServiceObjects<out Any>,
-        private val serviceObj: Any,
-        private val serviceRegistration: ServiceRegistration<*>
-    ) : AutoCloseable {
-        override fun close() {
-            runIgnoringExceptions(serviceRegistration::unregister)
-            @Suppress("unchecked_cast")
-            runIgnoringExceptions { (serviceFactory as ServiceObjects<Any>).ungetService(serviceObj) }
-        }
-    }
-
-    /**
-     * Check whether this [accessControlContext] is allowed to GET service [serviceType].
-     */
-    private fun checkServicePermission(accessControlContext: AccessControlContext, serviceType: String): Boolean {
-        val sm = System.getSecurityManager()
-        if (sm != null) {
-            try {
-                sm.checkPermission(ServicePermission(serviceType, GET), accessControlContext)
-            } catch (ace: AccessControlException) {
-                logger.error("This service failed GET permission check: $serviceType")
-                return false
-            }
-        }
-        return true
     }
 }
 
-/**
- * Try to load an interface for a service in the core platform.
- * Returns `null` if none of these [Bundle]s has a wiring for
- * that service interface.
- */
-private fun Iterable<Bundle>.loadCommonService(serviceClassName: String): Class<*>? {
-    forEach { bundle ->
-        try {
-            return bundle.loadClass(serviceClassName).takeIf(Class<*>::isInterface)
-        } catch (_: ClassNotFoundException) {
-        }
-    }
-    return null
-}
-
-/**
- * Locate the metadata service implementation called [serviceClassName] within this
- * [Bundle].
- */
-private fun Bundle.loadMetadataService(serviceClassName: String, isMetadataService: (Class<*>) -> Boolean): Pair<Class<*>, Bundle>? {
-    try {
-        val serviceClass = loadClass(serviceClassName)
-        if (isMetadataService(serviceClass)) {
-            val serviceBundle = FrameworkUtil.getBundle(serviceClass)
-            // Check that this is the correct bundle, rather
-            // than being one that it only has a wiring for.
-            if (serviceBundle === this) {
-                return serviceClass to serviceBundle
-            }
-        }
-    } catch (_: ClassNotFoundException) {
-    }
-    return null
-}
+private val currentSandboxGroupContext = ThreadLocal<SandboxGroupContext>()

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupServiceImpl.kt
@@ -1,0 +1,387 @@
+@file:JvmName("SandboxGroupContextServiceUtils")
+package net.corda.sandboxgroupcontext.service.impl
+
+import java.security.AccessControlContext
+import java.security.AccessControlException
+import java.util.Collections.singleton
+import java.util.Hashtable
+import net.corda.cpk.read.CpkReadService
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.sandbox.SandboxCreationService
+import net.corda.sandbox.SandboxException
+import net.corda.sandboxgroupcontext.CORDA_SANDBOX
+import net.corda.sandboxgroupcontext.CORDA_SANDBOX_FILTER
+import net.corda.sandboxgroupcontext.CORDA_SYSTEM_FILTER
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
+import net.corda.sandboxgroupcontext.SandboxGroupService
+import net.corda.sandboxgroupcontext.VirtualNodeContext
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.util.debug
+import net.corda.v5.base.util.loggerFor
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.extensions.DigestAlgorithmFactory
+import org.osgi.framework.Bundle
+import org.osgi.framework.BundleContext
+import org.osgi.framework.Constants.OBJECTCLASS
+import org.osgi.framework.Constants.SCOPE_PROTOTYPE
+import org.osgi.framework.Constants.SCOPE_SINGLETON
+import org.osgi.framework.Constants.SERVICE_SCOPE
+import org.osgi.framework.FrameworkUtil
+import org.osgi.framework.ServiceObjects
+import org.osgi.framework.ServicePermission
+import org.osgi.framework.ServicePermission.GET
+import org.osgi.framework.ServiceRegistration
+import org.osgi.service.component.runtime.ServiceComponentRuntime
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO
+
+private typealias ServiceDefinition = Pair<ServiceObjects<out Any>, List<Class<*>>>
+
+/**
+ * This is the underlying implementation of the [SandboxGroupService]
+ *
+ * Use this service via the mutable and immutable interfaces to create a "virtual node",
+ * and retrieve the same instance "later".
+ *
+ * This is a per-process service, but it must return the "same instance" for a given [VirtualNodeContext]
+ * in EVERY process.
+ */
+class SandboxGroupServiceImpl(
+    private val sandboxCreationService: SandboxCreationService,
+    private val cpkReadService: CpkReadService,
+    private val serviceComponentRuntime: ServiceComponentRuntime,
+    private val bundleContext: BundleContext,
+    var cache: SandboxGroupContextCache
+) : SandboxGroupService {
+    private companion object {
+        private const val SANDBOX_FACTORY_FILTER = "(&($SERVICE_SCOPE=$SCOPE_PROTOTYPE)(!$CORDA_SANDBOX_FILTER)(!$CORDA_SYSTEM_FILTER))"
+        private const val SYSTEM_FACTORY_FILTER = "(&($SERVICE_SCOPE=$SCOPE_PROTOTYPE)(!$CORDA_SANDBOX_FILTER)$CORDA_SYSTEM_FILTER)"
+
+        private val logger = loggerFor<SandboxGroupServiceImpl>()
+
+        private val sandboxServiceProperties = Hashtable<String, Any?>().apply {
+            put(CORDA_SANDBOX, true)
+        }
+
+        private fun <R> runIgnoringExceptions(action: () -> R) {
+            try {
+                action()
+            } catch(e: Exception) {
+                logger.warn("Ignoring exception", e)
+            }
+        }
+
+        private fun ComponentDescriptionDTO.toShortString(): String
+            = "Component(class=$implementationClass, services=${serviceInterfaces.joinToString()}, scope=$scope, enabled=$defaultEnabled)"
+    }
+
+    fun remove(virtualNodeContext: VirtualNodeContext) {
+        cache.remove(virtualNodeContext)
+    }
+
+    override fun getOrCreate(
+
+        virtualNodeContext: VirtualNodeContext,
+        initializer: SandboxGroupContextInitializer
+    ): SandboxGroupContext {
+        return cache.get(virtualNodeContext) {
+            val cpks = virtualNodeContext.cpkFileChecksums.mapNotNull { cpkReadService.get(it) }
+            if (cpks.size != virtualNodeContext.cpkFileChecksums.size) {
+                logger.error("Not all CPKs could be retrieved for this virtual node context ($virtualNodeContext)")
+                logger.error("Wanted all of:  ${virtualNodeContext.cpkFileChecksums}")
+                val receivedIdentifiers = cpks.map { it.metadata.cpkId }
+                val missing = setOf(virtualNodeContext.cpkFileChecksums) - setOf(receivedIdentifiers)
+                logger.error("Returned:  $receivedIdentifiers")
+                logger.error("Missing:  $missing")
+                throw CordaRuntimeException("Not all CPKs could be retrieved for this virtual node context ($virtualNodeContext)\"")
+            }
+
+            val sandboxGroup = sandboxCreationService.createSandboxGroup(cpks, virtualNodeContext.sandboxGroupType.name)
+
+            // Default implementation doesn't do anything on close()`
+            val sandboxGroupContext = SandboxGroupContextImpl(virtualNodeContext, sandboxGroup)
+
+            // Register common OSGi services for use within this sandbox.
+            val commonServiceRegistrations = registerCommonServices(virtualNodeContext, sandboxGroup.metadata.keys)
+
+            // Run the caller's initializer.
+            val initializerAutoCloseable =
+                initializer.initializeSandboxGroupContext(virtualNodeContext.holdingIdentity, sandboxGroupContext)
+
+            // Wrapped SandboxGroupContext, specifically to set closeable and forward on all other calls.
+
+            // Calling close also removes us from the contexts map and unloads the [SandboxGroup].
+            val newContext = CloseableSandboxGroupContextImpl(sandboxGroupContext) {
+                // These objects might still be in a sandbox, so close them whilst the sandbox is still valid.
+                initializerAutoCloseable.close()
+
+                // Remove this sandbox's common services.
+                commonServiceRegistrations?.forEach { closeable ->
+                    runIgnoringExceptions(closeable::close)
+                }
+
+                // And unload the (OSGi) sandbox group
+                sandboxCreationService.unloadSandboxGroup(sandboxGroupContext.sandboxGroup)
+            }
+            newContext
+        }
+    }
+
+    private fun registerCommonServices(vnc: VirtualNodeContext, bundles: Iterable<Bundle>): List<AutoCloseable>? {
+        val bundleContext = bundles.firstOrNull()?.bundleContext ?: return null
+        return (fetchCommonServices(vnc, bundles) + fetchSystemServices(vnc)).mapNotNull { requirement ->
+            registerCommonServiceFor(requirement.first, requirement.second, bundleContext)
+        }
+    }
+
+    /**
+     * Locate suitable "prototype-scope" OSGi services to instantiate inside
+     * the sandbox. We assume that the OSGi isolation hooks protect us from
+     * finding any pre-existing services inside the sandbox itself.
+     */
+    private fun fetchCommonServices(vnc: VirtualNodeContext, bundles: Iterable<Bundle>): List<ServiceDefinition> {
+        // Access control context for the sandbox's "main" bundles.
+        // All "main" bundles are assumed to have equal access rights.
+        val accessControlContext = bundles.first().adapt(AccessControlContext::class.java)
+        val serviceFilter = vnc.serviceFilter?.let { filter -> "(&$SANDBOX_FACTORY_FILTER$filter)" } ?: SANDBOX_FACTORY_FILTER
+        val serviceMarkerTypeName = vnc.serviceMarkerType.name
+        return bundleContext.getServiceReferences(vnc.serviceMarkerType, serviceFilter).mapNotNull { serviceRef ->
+            try {
+                @Suppress("unchecked_cast")
+                (serviceRef.getProperty(OBJECTCLASS) as? Array<String> ?: emptyArray())
+                    .filterNot(serviceMarkerTypeName::equals)
+                    .filter { checkServicePermission(accessControlContext, it) }
+                    .mapNotNullTo(ArrayList(), bundles::loadCommonService)
+                    .takeIf(List<*>::isNotEmpty)
+                    ?.let { injectables ->
+                        // Every service object must implement the service
+                        // marker type and at least one other type too.
+                        logger.debug { "Fetching common service: $serviceRef holding id ${vnc.holdingIdentity}" }
+                        injectables += vnc.serviceMarkerType
+                        bundleContext.getServiceObjects(serviceRef)?.let { serviceObj ->
+                            serviceObj to injectables
+                        }
+                    }
+            } catch (e: Exception) {
+                logger.warn("Failed to identify injectable services from $serviceRef", e)
+                null
+            }
+        }
+    }
+
+    private fun fetchSystemServices(vnc: VirtualNodeContext): List<ServiceDefinition> {
+        val serviceFilter = vnc.serviceFilter?.let { filter -> "(&$SYSTEM_FACTORY_FILTER$filter)" } ?: SYSTEM_FACTORY_FILTER
+        val serviceMarkerTypeName = vnc.serviceMarkerType.name
+        return bundleContext.getServiceReferences(vnc.serviceMarkerType, serviceFilter).mapNotNull { serviceRef ->
+            try {
+                @Suppress("unchecked_cast")
+                (serviceRef.getProperty(OBJECTCLASS) as? Array<String> ?: emptyArray())
+                    .filterNot(serviceMarkerTypeName::equals)
+                    .mapNotNullTo(ArrayList(), singleton(serviceRef.bundle)::loadCommonService)
+                    .takeIf(List<*>::isNotEmpty)
+                    ?.let { injectables ->
+                        // Every service object must implement the service
+                        // marker type and at least one other type too.
+                        logger.debug { "Fetching system service: $serviceRef holding id ${vnc.holdingIdentity}" }
+                        injectables += vnc.serviceMarkerType
+                        bundleContext.getServiceObjects(serviceRef)?.let { serviceObj ->
+                            serviceObj to injectables
+                        }
+                    }
+            } catch (e: Exception) {
+                logger.warn("Failed to identify injectable system services from $serviceRef", e)
+                null
+            }
+        }
+    }
+
+    private fun registerCommonServiceFor(
+        serviceFactory: ServiceObjects<out Any>,
+        serviceClasses: Iterable<Class<*>>,
+        bundleContext: BundleContext
+    ): AutoCloseable? {
+        val serviceObj = try {
+            serviceFactory.service ?: return null
+        } catch (e: Exception) {
+            logger.warn("Service ${serviceFactory.serviceReference} is not available.", e)
+            throw SandboxException("Service ${serviceFactory.serviceReference} is unavailable", e)
+        }
+        return try {
+            val serviceRegistration = bundleContext.registerService(
+                serviceClasses.mapTo(LinkedHashSet(), Class<*>::getName).toTypedArray(),
+                serviceObj,
+                sandboxServiceProperties
+            )
+            logger.info("Registered sandbox service [{}] for bundle [{}][{}]",
+                serviceClasses.joinToString(transform = Class<*>::getName),
+                bundleContext.bundle.symbolicName,
+                bundleContext.bundle.bundleId
+            )
+            CommonServiceRegistration(serviceFactory, serviceObj, serviceRegistration)
+        } catch (e: Exception) {
+            logger.warn("Cannot create sandbox service ${serviceObj::class.java.name}", e)
+            @Suppress("unchecked_cast")
+            (serviceFactory as ServiceObjects<Any>).ungetService(serviceObj)
+            null
+        }
+    }
+
+    override fun registerMetadataServices(
+        sandboxGroupContext: SandboxGroupContext,
+        serviceNames: (CpkMetadata) -> Iterable<String>,
+        isMetadataService: (Class<*>) -> Boolean,
+        serviceMarkerType: Class<*>
+    ): AutoCloseable {
+        val groupMetadata = sandboxGroupContext.sandboxGroup.metadata
+        val services = groupMetadata.flatMap { (mainBundle, cpkMetadata) ->
+            // Fetch metadata classes provided by each CPK main bundle.
+            serviceNames(cpkMetadata).mapNotNull { serviceName ->
+                mainBundle.loadMetadataService(serviceName, isMetadataService)
+            }
+        }
+
+        // Register each metadata service as an OSGi service for its host main bundle.
+        val registrations = registerMetadataServices(serviceMarkerType.name, services)
+        return AutoCloseable {
+            registrations.forEach { registration ->
+                runIgnoringExceptions(registration::close)
+            }
+        }
+    }
+
+    private fun registerMetadataServices(
+        serviceMarkerTypeName: String,
+        services: Iterable<Pair<Class<*>, Bundle>>
+    ): List<AutoCloseable> {
+        val extraCloseables = mutableListOf<AutoCloseable>()
+        return services.mapNotNull { (serviceClass, serviceBundle) ->
+            try {
+                val serviceContext = serviceBundle.bundleContext
+                val component = serviceComponentRuntime.getComponentDescriptionDTOs(serviceBundle).find { description ->
+                    description.implementationClass == serviceClass.name
+                }
+                val serviceInterfaces = mutableSetOf(serviceMarkerTypeName)
+                val serviceObj = if (component == null) {
+                    serviceInterfaces += serviceClass.name
+                    serviceClass.getConstructor().newInstance()
+                } else if (component.defaultEnabled
+                    && component.scope == SCOPE_SINGLETON
+                    && component.implementationClass in component.serviceInterfaces) {
+                    serviceInterfaces += component.serviceInterfaces
+                    serviceContext.getServiceReference(component.implementationClass)?.let { reference ->
+                        serviceContext.getService(reference)?.also {
+                            // Ensure we can "unget" this service later.
+                            extraCloseables.add(AutoCloseable { serviceContext.ungetService(reference) })
+                        }
+                    } ?: throw IllegalStateException("No ${component.toShortString()} active for bundle $serviceBundle")
+                } else {
+                    logger.warn("Ignoring misconfigured OSGi ${component.toShortString()} for service ${serviceClass.name}")
+                    return@mapNotNull null
+                }
+
+                // Register this service object with the OSGi framework.
+                val registration = serviceContext.registerService(
+                    serviceInterfaces.toTypedArray(),
+                    serviceObj,
+                    sandboxServiceProperties
+                )
+
+                logger.info("Registered Metadata Service [{}] for bundle [{}][{}]",
+                    serviceInterfaces.joinToString(), serviceBundle.symbolicName, serviceBundle.bundleId)
+
+                // Return an AutoCloseable that can unregister this service.
+                AutoCloseable(registration::unregister)
+            } catch (e: Exception) {
+                logger.warn("Cannot create service ${serviceClass.name}", e)
+                null
+            }
+        } + extraCloseables
+    }
+
+    override fun registerCustomCryptography(sandboxGroupContext: SandboxGroupContext): AutoCloseable {
+        return registerMetadataServices(
+            sandboxGroupContext,
+            serviceNames = { metadata -> metadata.cordappManifest.digestAlgorithmFactories },
+            serviceMarkerType = DigestAlgorithmFactory::class.java
+        )
+    }
+
+    override fun hasCpks(cpkChecksums: Set<SecureHash>): Boolean {
+        val missingCpks = cpkChecksums.filter {
+            cpkReadService.get(it) == null
+        }
+
+        if(logger.isInfoEnabled && missingCpks.isNotEmpty()) {
+            logger.info("CPK(s) not (yet) found in cache: $missingCpks")
+        }
+
+        return missingCpks.isEmpty()
+    }
+
+    override fun close() {
+        cache.close()
+    }
+
+    private class CommonServiceRegistration(
+        private val serviceFactory: ServiceObjects<out Any>,
+        private val serviceObj: Any,
+        private val serviceRegistration: ServiceRegistration<*>
+    ) : AutoCloseable {
+        override fun close() {
+            runIgnoringExceptions(serviceRegistration::unregister)
+            @Suppress("unchecked_cast")
+            runIgnoringExceptions { (serviceFactory as ServiceObjects<Any>).ungetService(serviceObj) }
+        }
+    }
+
+    /**
+     * Check whether this [accessControlContext] is allowed to GET service [serviceType].
+     */
+    private fun checkServicePermission(accessControlContext: AccessControlContext, serviceType: String): Boolean {
+        val sm = System.getSecurityManager()
+        if (sm != null) {
+            try {
+                sm.checkPermission(ServicePermission(serviceType, GET), accessControlContext)
+            } catch (ace: AccessControlException) {
+                logger.error("This service failed GET permission check: $serviceType")
+                return false
+            }
+        }
+        return true
+    }
+}
+
+/**
+ * Try to load an interface for a service in the core platform.
+ * Returns `null` if none of these [Bundle]s has a wiring for
+ * that service interface.
+ */
+private fun Iterable<Bundle>.loadCommonService(serviceClassName: String): Class<*>? {
+    forEach { bundle ->
+        try {
+            return bundle.loadClass(serviceClassName).takeIf(Class<*>::isInterface)
+        } catch (_: ClassNotFoundException) {
+        }
+    }
+    return null
+}
+
+/**
+ * Locate the metadata service implementation called [serviceClassName] within this
+ * [Bundle].
+ */
+private fun Bundle.loadMetadataService(serviceClassName: String, isMetadataService: (Class<*>) -> Boolean): Pair<Class<*>, Bundle>? {
+    try {
+        val serviceClass = loadClass(serviceClassName)
+        if (isMetadataService(serviceClass)) {
+            val serviceBundle = FrameworkUtil.getBundle(serviceClass)
+            // Check that this is the correct bundle, rather
+            // than being one that it only has a wiring for.
+            if (serviceBundle === this) {
+                return serviceClass to serviceBundle
+            }
+        }
+    } catch (_: ClassNotFoundException) {
+    }
+    return null
+}

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupServiceImplTest.kt
@@ -8,7 +8,7 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putUniqueObject
 import net.corda.sandboxgroupcontext.service.impl.CloseableSandboxGroupContext
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCache
-import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextServiceImpl
+import net.corda.sandboxgroupcontext.service.impl.SandboxGroupServiceImpl
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -39,9 +39,9 @@ class StubSandboxGroupContextCache: SandboxGroupContextCache {
     }
 }
 
-class SandboxGroupContextServiceImplTest {
+class SandboxGroupServiceImplTest {
 
-    private lateinit var service: SandboxGroupContextServiceImpl
+    private lateinit var service: SandboxGroupServiceImpl
     private val holdingIdentity = createTestHoldingIdentity("CN=Foo, O=Foo Corp, L=LDN, C=GB", "bar")
     private val mainBundle = "MAIN BUNDLE"
 
@@ -82,7 +82,7 @@ class SandboxGroupContextServiceImplTest {
 
     @BeforeEach
     fun beforeEach() {
-        service = SandboxGroupContextServiceImpl(
+        service = SandboxGroupServiceImpl(
             Helpers.mockSandboxCreationService(listOf(cpks)),
             cpkServiceImpl,
             scr,
@@ -167,7 +167,7 @@ class SandboxGroupContextServiceImplTest {
 
         val cpkService = CpkReadServiceFake(cpks1 + cpks2 + cpks3)
 
-        val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
+        val service = SandboxGroupServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
 
         val dog1 = Dog("Rover", "Woof!")
         val dog2 = Dog("Rover", "Bark!")
@@ -221,7 +221,7 @@ class SandboxGroupContextServiceImplTest {
         val sandboxCreationService = Helpers.mockSandboxCreationService(listOf(cpks1))
         val cpkService = CpkReadServiceFake(cpks1)
         val mockCache = mock<SandboxGroupContextCache>()
-        val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, mockCache)
+        val service = SandboxGroupServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, mockCache)
 
         service.remove(ctx1)
 
@@ -240,7 +240,7 @@ class SandboxGroupContextServiceImplTest {
         val service = existingCpks.let {
             val sandboxCreationService = Helpers.mockSandboxCreationService(listOf(it))
             val cpkService = CpkReadServiceFake(it)
-            SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
+            SandboxGroupServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
         }
 
         val existingCpkChecksums = existingCpks.map {

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/MutableSandboxGroupContext.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/MutableSandboxGroupContext.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxgroupcontext
 /**
  * All objects that are [put] into the context are held by their `(type, key)` tuple.
  *
- * An instance of this interface is returned to the initializer via [SandboxGroupContextService].
+ * An instance of this interface is returned to the initializer via [SandboxGroupService].
  *
  * Attempts to [put] another object with the same `(type,key)` throws an [IllegalArgumentException]
  *

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextService.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextService.kt
@@ -1,124 +1,30 @@
 package net.corda.sandboxgroupcontext
 
-import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.v5.crypto.SecureHash
-
-interface SandboxGroupContextService: AutoCloseable {
-    /**
-     * This function creates and returns a "fully constructed" node that is ready to
-     * execute a flow with no further configuration required.  Your supplied initializer will be run
-     * during the [getOrCreate] call.
-     *
-     * A mutable interface is passed so that the initializer can add per CPI custom objects that are
-     * cached together with their SandboxGroup.  The initializer must return an `AutoCloseable` object.
-     *
-     * The lifetime of the [SandboxGroupContext] will be managed by the [SandboxGroupContextService]
-     * implementation subject to some lifetime policy (e.g. resource pressure).
-     *
-     * Your initializer should be idempotent across a process, and also across different processes running on the same
-     * system, i.e. for a given set of identical inputs, the constructed objects should be identical in terms of data.
-     *
-     * This function will be implemented as a pure function, i.e. if the "virtual node" already exists an
-     * is constructed, that should be returned, and the [initializer] will not be run on subsequent calls
-     * of [getOrCreate].
-     *
-     * Initializers (functional interface [SandboxGroupContextInitializer]) are expected to be:
-     *
-     *     fun initialize(holdingIdentity: HoldingIdentity, ctx: MutableSandboxGroupContext) : AutoCloseable {
-     *       val someObject = SomeObject() // : AutoCloseable
-     *       val otherObject = OtherObject() // : AutoCloseable
-     *       val anotherObject = AnotherObject() // NOT AutoCloseable
-     *       ctx.putObject(someKey, someObject)
-     *       ctx.putObject(otherObjectKey, otherObject)
-     *       ctx.putUniqueObject(anotherObject)
-     *       return object : AutoCloseable {
-     *         override fun close() {
-     *           someObject.close()
-     *           otherObject.close()
-     *         }
-     *       }
-     *     }
-     *
-     *     private var ctx : SandboxGroupContext? = null
-     *
-     *     fun setUp() {
-     *       if (! service.hasCpks(cpkIdentifiers)) { /* some retry logic */ }
-     *       ctx = service.getOrCreate(VirtualNodeContext(holdingIdentity, cpkIdentifiers, type), ::initialize)
-     *       val someObject = ctx!!.getObject<SomeObject>(someKey)
-     *       val anotherObject = ctx!!.getUniqueObject<AnotherObject>()
-     *       someObject.doThing()
-     *       anotherObject.doSomethingElse()
-     *    }
-     *
-     *    fun doSomethingElse(virtualNodeContext: VirtualNodeContext) {
-     *       ctx!!.getObject<SomeObject>(someKey)!!.doThing()
-     *       ctx!!.getUniqueObject<AnotherObject>()!!.doSomethingElse()
-     *    }
-     *
-     * @throws Exception or "something" if the requested [CPK]s cannot be found in the local package cache.
-     *
-     * @return a non-null [SandboxGroupContext] instance
-     */
-    fun getOrCreate(
-        virtualNodeContext: VirtualNodeContext,
-        initializer: SandboxGroupContextInitializer
-    ): SandboxGroupContext
+/**
+ * [SandboxGroupContextService] allows the current sandbox's [SandboxGroupContext] to be set, retrieved and removed.
+ *
+ * [SandboxGroupContextService] relies on a [ThreadLocal] to provide access to the current sandbox wherever this service is used.
+ *
+ * Generally, few callers should call [setCurrent] and [removeCurrent] and should be reserved for the setup and cleanup code that is
+ * run when setting up a new sandbox (or retrieving from one a cache) and cleaning up resources when the thread using the sandbox has
+ * completed processing.
+ */
+interface SandboxGroupContextService {
 
     /**
-     * This function registers instances of the service classes
-     * identified within the [SandboxGroup][net.corda.sandbox.SandboxGroup]'s
-     * [CpkMetadata].
-     * Each OSGi service will be a singleton containing an extra
-     * `corda.sandbox=true` service property.
-     *
-     * Each service is always registered as an instance of
-     * [VirtualNodeContext.serviceMarkerType]. If the service
-     * is already an OSGi component then it is also registered
-     * with that component's service interfaces. Otherwise it
-     * is also registered with the service's class.
-     *
-     * The OSGi framework itself will insist that each metadata
-     * service also implements [VirtualNodeContext.serviceMarkerType].
-     *
-     * You should register these metadata services as part of the
-     * [SandboxGroupContextInitializer].
-     *
-     * @param sandboxGroupContext
-     * @param serviceNames A lambda to extract the service class names from the CPK metadata.
-     * @param isMetadataService A lambda to validate that each class is compatible with this metadata service type.
-     * @param serviceMarkerType A common base type that all service implementations must share.
-     *
-     * @return an [AutoCloseable] for unregistering the services.
-     *
+     * Sets the current [SandboxGroupContext] that is tied to the executing thread.
      */
-    fun registerMetadataServices(
-        sandboxGroupContext: SandboxGroupContext,
-        serviceNames: (CpkMetadata) -> Iterable<String>,
-        isMetadataService: (Class<*>) -> Boolean = { true },
-        serviceMarkerType: Class<*> = sandboxGroupContext.virtualNodeContext.serviceMarkerType
-    ): AutoCloseable
+    fun setCurrent(sandboxGroupContext: SandboxGroupContext)
 
     /**
-     * This function registers any [DigestAlgorithmFactory][net.corda.v5.cipher.suite.DigestAlgorithmFactory]
-     * instances that exist inside the [SandboxGroup][net.corda.sandbox.SandboxGroup]'s CPKs.
-     * The [DigestAlgorithmFactoryProvider][net.corda.crypto.core.DigestAlgorithmFactoryProvider]
-     * component will discover these services when the sandbox uses its
-     * [DigestService][net.corda.v5.cipher.suite.DigestService] for the first time.
+     * Gets the current [SandboxGroupContext] of the executing thread.
      *
-     * @param sandboxGroupContext
-     *
-     * @return an [AutoCloseable] for unregistering the services.
+     * @return The current [SandboxGroupContext].
      */
-    fun registerCustomCryptography(
-        sandboxGroupContext: SandboxGroupContext
-    ): AutoCloseable
+    fun getCurrent(): SandboxGroupContext
 
     /**
-     * Does the service 'contain' the cpks in its cache?
-     *
-     *     if (service.hasCpks(virtualNodeContext.cpkIdentifiers.map { it.fileChecksum })) {
-     *        service.getOrCreate(virtualNodeContext) { .... }
-     *     }
+     * Removes the current [SandboxGroupContext] from the executing thread.
      */
-    fun hasCpks(cpkChecksums: Set<SecureHash>) : Boolean
+    fun removeCurrent()
 }

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupService.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupService.kt
@@ -1,0 +1,124 @@
+package net.corda.sandboxgroupcontext
+
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.v5.crypto.SecureHash
+
+interface SandboxGroupService: AutoCloseable {
+    /**
+     * This function creates and returns a "fully constructed" node that is ready to
+     * execute a flow with no further configuration required.  Your supplied initializer will be run
+     * during the [getOrCreate] call.
+     *
+     * A mutable interface is passed so that the initializer can add per CPI custom objects that are
+     * cached together with their SandboxGroup.  The initializer must return an `AutoCloseable` object.
+     *
+     * The lifetime of the [SandboxGroupContext] will be managed by the [SandboxGroupService]
+     * implementation subject to some lifetime policy (e.g. resource pressure).
+     *
+     * Your initializer should be idempotent across a process, and also across different processes running on the same
+     * system, i.e. for a given set of identical inputs, the constructed objects should be identical in terms of data.
+     *
+     * This function will be implemented as a pure function, i.e. if the "virtual node" already exists an
+     * is constructed, that should be returned, and the [initializer] will not be run on subsequent calls
+     * of [getOrCreate].
+     *
+     * Initializers (functional interface [SandboxGroupContextInitializer]) are expected to be:
+     *
+     *     fun initialize(holdingIdentity: HoldingIdentity, ctx: MutableSandboxGroupContext) : AutoCloseable {
+     *       val someObject = SomeObject() // : AutoCloseable
+     *       val otherObject = OtherObject() // : AutoCloseable
+     *       val anotherObject = AnotherObject() // NOT AutoCloseable
+     *       ctx.putObject(someKey, someObject)
+     *       ctx.putObject(otherObjectKey, otherObject)
+     *       ctx.putUniqueObject(anotherObject)
+     *       return object : AutoCloseable {
+     *         override fun close() {
+     *           someObject.close()
+     *           otherObject.close()
+     *         }
+     *       }
+     *     }
+     *
+     *     private var ctx : SandboxGroupContext? = null
+     *
+     *     fun setUp() {
+     *       if (! service.hasCpks(cpkIdentifiers)) { /* some retry logic */ }
+     *       ctx = service.getOrCreate(VirtualNodeContext(holdingIdentity, cpkIdentifiers, type), ::initialize)
+     *       val someObject = ctx!!.getObject<SomeObject>(someKey)
+     *       val anotherObject = ctx!!.getUniqueObject<AnotherObject>()
+     *       someObject.doThing()
+     *       anotherObject.doSomethingElse()
+     *    }
+     *
+     *    fun doSomethingElse(virtualNodeContext: VirtualNodeContext) {
+     *       ctx!!.getObject<SomeObject>(someKey)!!.doThing()
+     *       ctx!!.getUniqueObject<AnotherObject>()!!.doSomethingElse()
+     *    }
+     *
+     * @throws Exception or "something" if the requested [CPK]s cannot be found in the local package cache.
+     *
+     * @return a non-null [SandboxGroupContext] instance
+     */
+    fun getOrCreate(
+        virtualNodeContext: VirtualNodeContext,
+        initializer: SandboxGroupContextInitializer
+    ): SandboxGroupContext
+
+    /**
+     * This function registers instances of the service classes
+     * identified within the [SandboxGroup][net.corda.sandbox.SandboxGroup]'s
+     * [CpkMetadata].
+     * Each OSGi service will be a singleton containing an extra
+     * `corda.sandbox=true` service property.
+     *
+     * Each service is always registered as an instance of
+     * [VirtualNodeContext.serviceMarkerType]. If the service
+     * is already an OSGi component then it is also registered
+     * with that component's service interfaces. Otherwise it
+     * is also registered with the service's class.
+     *
+     * The OSGi framework itself will insist that each metadata
+     * service also implements [VirtualNodeContext.serviceMarkerType].
+     *
+     * You should register these metadata services as part of the
+     * [SandboxGroupContextInitializer].
+     *
+     * @param sandboxGroupContext
+     * @param serviceNames A lambda to extract the service class names from the CPK metadata.
+     * @param isMetadataService A lambda to validate that each class is compatible with this metadata service type.
+     * @param serviceMarkerType A common base type that all service implementations must share.
+     *
+     * @return an [AutoCloseable] for unregistering the services.
+     *
+     */
+    fun registerMetadataServices(
+        sandboxGroupContext: SandboxGroupContext,
+        serviceNames: (CpkMetadata) -> Iterable<String>,
+        isMetadataService: (Class<*>) -> Boolean = { true },
+        serviceMarkerType: Class<*> = sandboxGroupContext.virtualNodeContext.serviceMarkerType
+    ): AutoCloseable
+
+    /**
+     * This function registers any [DigestAlgorithmFactory][net.corda.v5.cipher.suite.DigestAlgorithmFactory]
+     * instances that exist inside the [SandboxGroup][net.corda.sandbox.SandboxGroup]'s CPKs.
+     * The [DigestAlgorithmFactoryProvider][net.corda.crypto.core.DigestAlgorithmFactoryProvider]
+     * component will discover these services when the sandbox uses its
+     * [DigestService][net.corda.v5.cipher.suite.DigestService] for the first time.
+     *
+     * @param sandboxGroupContext
+     *
+     * @return an [AutoCloseable] for unregistering the services.
+     */
+    fun registerCustomCryptography(
+        sandboxGroupContext: SandboxGroupContext
+    ): AutoCloseable
+
+    /**
+     * Does the service 'contain' the cpks in its cache?
+     *
+     *     if (service.hasCpks(virtualNodeContext.cpkIdentifiers.map { it.fileChecksum })) {
+     *        service.getOrCreate(virtualNodeContext) { .... }
+     *     }
+     */
+    fun hasCpks(cpkChecksums: Set<SecureHash>) : Boolean
+}

--- a/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
+++ b/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
@@ -15,7 +15,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.processors.flow.FlowProcessor
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.session.mapper.service.FlowMapperService
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
@@ -42,8 +42,8 @@ class FlowProcessorImpl @Activate constructor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
     private val cpiInfoReadService: CpiInfoReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = MembershipGroupReaderProvider::class)
     private val membershipGroupReaderProvider: MembershipGroupReaderProvider
 ) : FlowProcessor {
@@ -59,7 +59,7 @@ class FlowProcessorImpl @Activate constructor(
         ::flowP2PFilterService,
         ::virtualNodeInfoReadService,
         ::cpiInfoReadService,
-        ::sandboxGroupContextComponent,
+        ::sandboxGroupComponent,
         ::membershipGroupReaderProvider
     )
     private val lifecycleCoordinator = coordinatorFactory.createCoordinator<FlowProcessorImpl>(dependentComponents, ::eventHandler)

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
@@ -3,7 +3,7 @@ package net.corda.db.persistence.testkit.components
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
@@ -25,11 +25,11 @@ class VirtualNodeService @Activate constructor(
     private val virtualNodeLoader: VirtualNodeLoader,
 
     @Reference
-    val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    val sandboxGroupComponent: SandboxGroupComponent,
 ) {
     init {
         // Needs this since we do not have a config service running:  it will fail to start otherwise.
-        sandboxGroupContextComponent.initCache(2)
+        sandboxGroupComponent.initCache(2)
     }
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
@@ -42,7 +42,7 @@ class VirtualNodeService @Activate constructor(
     @Suppress("unused")
     @Deactivate
     fun done() {
-        sandboxGroupContextComponent.close()
+        sandboxGroupComponent.close()
     }
 
     private fun getOrCreateSandbox(virtualNodeInfo: VirtualNodeInfo): SandboxGroupContext {
@@ -55,8 +55,8 @@ class VirtualNodeService @Activate constructor(
             SingletonSerializeAsToken::class.java,
             null
         )
-        return sandboxGroupContextComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
-            sandboxGroupContextComponent.registerCustomCryptography(sandboxGroupContext)
+        return sandboxGroupComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
+            sandboxGroupComponent.registerCustomCryptography(sandboxGroupContext)
         }
     }
 

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
@@ -7,39 +7,45 @@ import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.membership.read.MembershipGroupReader
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class TestFlowFiberServiceWithSerialization : FlowFiberService, SingletonSerializeAsToken {
-    private val mockFlowFiber: FlowFiber
-    private val mockFlowSandboxGroupContext = mock(FlowSandboxGroupContext::class.java)
+    private val mockFlowFiber = mock<FlowFiber>()
+    private val mockFlowSandboxGroupContext = mock<FlowSandboxGroupContext>()
+    private val membershipGroupReader = mock<MembershipGroupReader>()
+    private val sandboxGroupContextService = mock<SandboxGroupContextService>()
 
-    init{
-        val membershipGroupReader: MembershipGroupReader = mock(MembershipGroupReader::class.java)
+    init {
         val bobX500 = "CN=Bob, O=Bob Corp, L=LDN, C=GB"
         val bobX500Name = MemberX500Name.parse(bobX500)
-        val holdingIdentity =  HoldingIdentity(bobX500Name,"group1")
+        val holdingIdentity = HoldingIdentity(bobX500Name, "group1")
         val flowFiberExecutionContext = FlowFiberExecutionContext(
             mock(FlowCheckpoint::class.java),
             mockFlowSandboxGroupContext,
             holdingIdentity,
-            membershipGroupReader
+            membershipGroupReader,
+            sandboxGroupContextService
         )
 
-        mockFlowFiber = mock(FlowFiber::class.java)
-        Mockito.`when`(mockFlowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)
+        whenever(sandboxGroupContextService.getCurrent()).thenReturn(mockFlowSandboxGroupContext)
+        whenever(mockFlowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)
 
     }
+
     override fun getExecutingFiber(): FlowFiber {
         return mockFlowFiber
     }
 
-    fun configureSerializer(registerMoreSerializers: (it: SerializerFactory) -> Unit, schemeMetadata: CipherSchemeMetadata){
+    fun configureSerializer(registerMoreSerializers: (it: SerializerFactory) -> Unit, schemeMetadata: CipherSchemeMetadata) {
         val serializer = TestSerializationService.getTestSerializationService(registerMoreSerializers, schemeMetadata)
-        Mockito.`when`(mockFlowSandboxGroupContext.amqpSerializer).thenReturn(serializer)
+        whenever(mockFlowSandboxGroupContext.amqpSerializer).thenReturn(serializer)
     }
 }


### PR DESCRIPTION
Create `SandboxGroupContextService` to set, get and remove the current `SandboxGroupContext` on a thread.

This service can then be OSGI injected into other services to retrieve the current sandbox. The thead local concept is private to the service.

Rename the existing `SandboxGroupContextService` to `SandboxGroupService`.