### PR TITLE
CORE-6663: Improve logging for smoke tests

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     smokeTestImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     smokeTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
-    smokeTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+    smokeTestRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 }
 
 def smokeTestResources = tasks.named('processSmokeTestResources', ProcessResources) {

--- a/applications/workers/workers-smoketest/src/smokeTest/resources/log4j2-test.xml
+++ b/applications/workers/workers-smoketest/src/smokeTest/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Current logging setup did not output any timestamps which was rather inconvenient when fixing CI related failures, as it was impossible to reconcile Worker log with what was happening on Smoke test side.