### PR TITLE
CORE-6663: Common Worker health check improvements

### DIFF
--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/Constants.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/Constants.kt
@@ -6,3 +6,4 @@ internal const val HTTP_HEALTH_ROUTE = "/isHealthy"
 internal const val HTTP_METRICS_ROUTE = "/metrics"
 internal const val HTTP_STATUS_ROUTE = "/status"
 internal const val WORKER_MONITOR_PORT = 7000
+internal const val NO_CACHE = "no-cache"

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/WorkerMonitorImpl.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/WorkerMonitorImpl.kt
@@ -2,6 +2,7 @@ package net.corda.applications.workers.workercommon.internal
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.javalin.Javalin
+import io.javalin.core.util.Header
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
@@ -73,16 +74,23 @@ internal class WorkerMonitorImpl @Activate constructor(
                     HTTP_SERVICE_UNAVAILABLE_CODE
                 }
                 context.status(status)
+                context.header(Header.CACHE_CONTROL, NO_CACHE)
             }
             .get(HTTP_STATUS_ROUTE) { context ->
-                val anyComponentsNotReady = componentWithStatus(setOf(LifecycleStatus.DOWN, LifecycleStatus.ERROR))
-                    .isNotEmpty()
-                val status = if (anyComponentsNotReady) HTTP_SERVICE_UNAVAILABLE_CODE else HTTP_OK_CODE
+                val notReadyComponents = componentWithStatus(setOf(LifecycleStatus.DOWN, LifecycleStatus.ERROR))
+                val status = if (notReadyComponents.isEmpty()) {
+                    HTTP_OK_CODE
+                } else {
+                    logger.warn("There are components with error or down state: $notReadyComponents.")
+                    HTTP_SERVICE_UNAVAILABLE_CODE
+                }
                 context.status(status)
                 context.result(objectMapper.writeValueAsString(lifecycleRegistry.componentStatus()))
+                context.header(Header.CACHE_CONTROL, NO_CACHE)
             }
             .get(HTTP_METRICS_ROUTE) { context ->
                 context.result(prometheusRegistry.scrape())
+                context.header(Header.CACHE_CONTROL, NO_CACHE)
             }
     }
 

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -101,14 +101,18 @@ tasks.register('smokeTest', Test) {
 
     def combinedWorker = project.getProperties().getOrDefault("isCombinedWorker",false)
     systemProperty "rpcHost", project.getProperties().getOrDefault("rpcHost","https://localhost:8888/")
+
+    // Note these port values have to match what is setup as part of port forwarding at cluster bootstrap time.
+    // E.g. during Jenkins pipeline setup.
     systemProperty "cryptoWorkerHealthHttp",
             project.getProperties().getOrDefault("cryptoWorkerHealthHttp",combinedWorker ? null : "http://localhost:7001/")
-    systemProperty "dbWorkerHealthHttp",
-            project.getProperties().getOrDefault("dbWorkerHealthHttp",combinedWorker ? null : "http://localhost:7002/")
+    systemProperty "rpcWorkerHealthHttp",
+            project.getProperties().getOrDefault("rpcWorkerHealthHttp",combinedWorker ? null : "http://localhost:7002/")
     systemProperty "flowWorkerHealthHttp",
             project.getProperties().getOrDefault("flowWorkerHealthHttp",combinedWorker ? null : "http://localhost:7003/")
-    systemProperty "rpcWorkerHealthHttp",
-            project.getProperties().getOrDefault("rpcWorkerHealthHttp",combinedWorker ? null : "http://localhost:7004/")
+    systemProperty "dbWorkerHealthHttp",
+            project.getProperties().getOrDefault("dbWorkerHealthHttp",combinedWorker ? null : "http://localhost:7004/")
+
     systemProperty "combinedWorkerHealthHttp",
             project.getProperties().getOrDefault("combinedWorkerHealthHttp",combinedWorker ? "http://localhost:7000/" : null)
 }


### PR DESCRIPTION
1. Put `no-cache` header to the responses produced by the monitporing endpoint.
2. Improve logging when worker is not ready.
3. Fix-up swapped health check ports between RPC Worker and DB Worker.