### PR TITLE
CORE-6663: Permission Management improvements

### DIFF
--- a/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
+++ b/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
@@ -40,7 +40,6 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
-import java.util.UUID
 
 @Component(service = [PermissionManagementCacheService::class])
 class PermissionManagementCacheService @Activate constructor(
@@ -60,10 +59,7 @@ class PermissionManagementCacheService @Activate constructor(
 
     private companion object {
         val log = contextLogger()
-        // Cache may exist on multiple Workers, i.e. in the separate VMs. Therefore, since we do have just a single
-        // instance of cache per VM it is OK to have just a single consumer in VM. But different VMs need to have
-        // different consumer groups or else permission cache content will not be delivered to them.
-        val CONSUMER_GROUP = "PERMISSION_MANAGEMENT_SERVICE-${UUID.randomUUID()}"
+        const val CONSUMER_GROUP = "PERMISSION_MANAGEMENT_SERVICE"
     }
 
     /**

--- a/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
+++ b/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
@@ -40,6 +40,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
+import java.util.UUID
 
 @Component(service = [PermissionManagementCacheService::class])
 class PermissionManagementCacheService @Activate constructor(
@@ -59,7 +60,10 @@ class PermissionManagementCacheService @Activate constructor(
 
     private companion object {
         val log = contextLogger()
-        const val CONSUMER_GROUP = "PERMISSION_SERVICE"
+        // Cache may exist on multiple Workers, i.e. in the separate VMs. Therefore, since we do have just a single
+        // instance of cache per VM it is OK to have just a single consumer in VM. But different VMs need to have
+        // different consumer groups or else permission cache content will not be delivered to them.
+        val CONSUMER_GROUP = "PERMISSION_MANAGEMENT_SERVICE-${UUID.randomUUID()}"
     }
 
     /**

--- a/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/PermissionManagementService.kt
+++ b/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/PermissionManagementService.kt
@@ -73,11 +73,7 @@ class PermissionManagementService @Activate constructor(
      * Validator for performing permission validation operations using the permission system.
      */
     val permissionValidator: PermissionValidator
-        get() {
-            return checkNotNull(handler.permissionValidator) {
-                "Permission Validator is null. Getter should be called only after service is UP."
-            }
-        }
+        get() = handler.permissionValidator
 
     /**
      * Service that exposes functionality to perform basic authentication using the permission system.

--- a/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
+++ b/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
@@ -54,10 +54,16 @@ internal class PermissionManagementServiceEventHandler(
     @VisibleForTesting
     internal var rpcSender: RPCSender<PermissionManagementRequest, PermissionManagementResponse>? = null
 
+    @Volatile
     internal var permissionManager: PermissionManager? = null
-    internal var permissionValidator: PermissionValidator? = null
+
+    internal val permissionValidator: PermissionValidator
+        get() = permissionValidationService.permissionValidator
+
+    @Volatile
     internal var basicAuthenticationService: BasicAuthenticationService? = null
 
+    @Volatile
     private var configSubscription: AutoCloseable? = null
 
     override fun processEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
@@ -86,14 +92,13 @@ internal class PermissionManagementServiceEventHandler(
                             coordinator,
                             setOf(BOOT_CONFIG, MESSAGING_CONFIG, RPC_CONFIG)
                         )
-                        permissionValidator = permissionValidationService.permissionValidator
                     }
                     LifecycleStatus.DOWN -> {
+                        log.info("Transitioning DOWN.")
                         permissionManager?.stop()
                         permissionManager = null
                         basicAuthenticationService?.stop()
                         basicAuthenticationService = null
-                        permissionValidator = null
                         coordinator.updateStatus(LifecycleStatus.DOWN)
                     }
                     LifecycleStatus.ERROR -> {
@@ -123,7 +128,6 @@ internal class PermissionManagementServiceEventHandler(
                 permissionManager = null
                 registrationHandle?.close()
                 registrationHandle = null
-                permissionValidator = null
                 coordinator.updateStatus(LifecycleStatus.DOWN)
             }
         }

--- a/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
+++ b/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
@@ -29,7 +29,6 @@ import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
@@ -51,10 +50,7 @@ class PermissionValidationCacheService @Activate constructor(
 
     private companion object {
         val log = contextLogger()
-        // Cache may exist on multiple Workers, i.e. in the separate VMs. Therefore, since we do have just a single
-        // instance of cache per VM it is OK to have just a single consumer in VM. But different VMs need to have
-        // different consumer groups or else permission cache content will not be delivered to them.
-        val CONSUMER_GROUP = "PERMISSION_VALIDATION_SERVICE-${UUID.randomUUID()}"
+        const val CONSUMER_GROUP = "PERMISSION_VALIDATION_SERVICE"
     }
 
     /**

--- a/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
+++ b/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
@@ -29,6 +29,7 @@ import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
@@ -50,7 +51,10 @@ class PermissionValidationCacheService @Activate constructor(
 
     private companion object {
         val log = contextLogger()
-        const val CONSUMER_GROUP = "PERMISSION_SERVICE"
+        // Cache may exist on multiple Workers, i.e. in the separate VMs. Therefore, since we do have just a single
+        // instance of cache per VM it is OK to have just a single consumer in VM. But different VMs need to have
+        // different consumer groups or else permission cache content will not be delivered to them.
+        val CONSUMER_GROUP = "PERMISSION_VALIDATION_SERVICE-${UUID.randomUUID()}"
     }
 
     /**

--- a/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
+++ b/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
@@ -49,10 +49,9 @@ class PermissionValidationService @Activate constructor(
      */
     val permissionValidator: PermissionValidator
         get() {
-            checkNotNull(_permissionValidator) {
+            return checkNotNull(_permissionValidator) {
                 "Permission Validator is null. Getter should be called only after service is UP."
             }
-            return _permissionValidator!!
         }
 
     private fun eventHandler(event: LifecycleEvent) {

--- a/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
+++ b/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
@@ -78,7 +78,7 @@ class RBACSecurityManagerService @Activate constructor(
                     LifecycleStatus.UP -> {
                         innerSecurityManager?.stop()
                         innerSecurityManager = RBACSecurityManager(
-                            permissionManagementService.permissionValidator,
+                            permissionManagementService::permissionValidator,
                             permissionManagementService.basicAuthenticationService
                         )
                         coordinator.updateStatus(LifecycleStatus.UP)

--- a/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACAuthorizingSubject.kt
+++ b/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACAuthorizingSubject.kt
@@ -2,12 +2,13 @@ package net.corda.httprpc.security.read.rbac
 
 import net.corda.httprpc.security.AuthorizingSubject
 import net.corda.libs.permission.PermissionValidator
+import java.util.function.Supplier
 
 /**
  * Authorizing Subject for the Role Based Access Control permission system.
  */
 class RBACAuthorizingSubject(
-    private val permissionValidator: PermissionValidator,
+    private val permissionValidatorSupplier: Supplier<PermissionValidator>,
     override val principal: String
 ) : AuthorizingSubject {
 
@@ -15,6 +16,6 @@ class RBACAuthorizingSubject(
      * Use the permission validator to determine if this user is authorized for the requested action.
      */
     override fun isPermitted(action: String, vararg arguments: String): Boolean {
-        return permissionValidator.authorizeUser(principal, action)
+        return permissionValidatorSupplier.get().authorizeUser(principal, action)
     }
 }

--- a/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACSecurityManager.kt
+++ b/libs/http-rpc/rbac-security-manager/src/main/kotlin/net/corda/httprpc/security/read/rbac/RBACSecurityManager.kt
@@ -7,9 +7,10 @@ import net.corda.httprpc.security.read.Password
 import net.corda.httprpc.security.read.RPCSecurityManager
 import net.corda.libs.permission.PermissionValidator
 import net.corda.libs.permissions.manager.BasicAuthenticationService
+import java.util.function.Supplier
 
 class RBACSecurityManager(
-    private val permissionValidator: PermissionValidator,
+    private val permissionValidatorSupplier: Supplier<PermissionValidator>,
     private val basicAuthenticationService: BasicAuthenticationService
 ) : RPCSecurityManager {
 
@@ -24,7 +25,7 @@ class RBACSecurityManager(
     }
 
     override fun buildSubject(principal: String): AuthorizingSubject {
-        return RBACAuthorizingSubject(permissionValidator, principal)
+        return RBACAuthorizingSubject(permissionValidatorSupplier, principal)
     }
 
     private var running = false

--- a/libs/http-rpc/rbac-security-manager/src/test/kotlin/net/corda/httprpc/security/read/rbac/RBACSecurityManagerTest.kt
+++ b/libs/http-rpc/rbac-security-manager/src/test/kotlin/net/corda/httprpc/security/read/rbac/RBACSecurityManagerTest.kt
@@ -16,7 +16,7 @@ class RBACSecurityManagerTest {
 
     private val validator = mock<PermissionValidator>()
     private val basicAuthenticationService = mock<BasicAuthenticationService>()
-    private val manager = RBACSecurityManager(validator, basicAuthenticationService)
+    private val manager = RBACSecurityManager({ validator }, basicAuthenticationService)
 
     @Test
     fun `unauthenticated user throws FailedLoginException`() {


### PR DESCRIPTION
Make retrieval of PermissionValidator dynamic
I.e. it is accessed via property/Supplier. This reducees the amount of state we retain at tuntime and should solve any race conditions when PermissionManagementService and PermissionValidationService concurrently processing lifecycle events. 