### PR TITLE
CORE-7119: allow optional override of multi arch on jenkins

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -240,7 +240,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
         if (System.getenv().containsKey("JENKINS_URL") && multiArch.get()) {
-            logger.quiet("Running on CI server - producing arm64 and amd64 images")
+            logger.quiet("${multiArch.get() ? 'Running on CI server - producing arm64 and amd64 images' : 'Running on CI server but multiArch flag set to false - producing amd64 images'}")
             builder.addPlatform("arm64","linux")
         } else if (System.properties['os.arch'] == "aarch64") { 
             logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -138,6 +138,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
     final MapProperty<String, String> environment =
             getObjects().mapProperty(String, String).empty()
 
+    @Input
+    final Property<Boolean> multiArch =
+            getObjects().property(Boolean).convention(true)           
+
     DeployableContainerBuilder() {
         description = 'Creates a new "corda-dev" image with the file specified in "overrideFilePath".'
         group = 'publishing'
@@ -235,7 +239,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
-        if (System.getenv().containsKey("JENKINS_URL")) {
+        if (System.getenv().containsKey("JENKINS_URL") && multiArch.get()) {
             logger.quiet("Running on CI server - producing arm64 and amd64 images")
             builder.addPlatform("arm64","linux")
         } else if (System.properties['os.arch'] == "aarch64") { 

--- a/buildSrc/src/main/groovy/corda.docker-app.gradle
+++ b/buildSrc/src/main/groovy/corda.docker-app.gradle
@@ -56,4 +56,8 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('useDockerDaemon')) {
         useDaemon = useDockerDaemon.toBoolean()
     }
+
+    if (project.hasProperty('multiArchSupport')) {
+        multiArch = multiArchSupport.toBoolean()
+    }
 }

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -137,6 +137,10 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('useDockerDaemon')) {
         useDaemon = useDockerDaemon.toBoolean()
     }
+
+    if (project.hasProperty('multiArchSupport')) {
+        multiArch = multiArchSupport.toBoolean()
+    }
 }
 
 def s3Script = null


### PR DESCRIPTION
Occasionally on Jenkins we may need to override the ability to produce multi architecture images.

- introduce new property `multiArch` which defaults to true and add to task `publishOSGiImage` allowing us to override this from the command line if needed in certain CI jobs.

This is useful as Jib does not allow publishing of multiArch images to a local docker daemon only to a remote, so in some instances such as utility jobs for container scanning we may want to produce image locally on the server before scanning. 