### PR TITLE
CORE-7101 Rename `SandboxGroupContextService` to `SandboxGroupService`

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -2,7 +2,7 @@ package net.corda.example.vnode
 
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.v5.base.util.loggerFor
@@ -25,7 +25,7 @@ class VNodeServiceImpl @Activate constructor(
     private val flowSandboxService: FlowSandboxService,
 
     @Reference
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    private val sandboxGroupComponent: SandboxGroupComponent,
 
     @Reference
     private val cpiLoader: CpiLoader,
@@ -57,6 +57,6 @@ class VNodeServiceImpl @Activate constructor(
     }
 
     private fun setupSandboxCache() {
-        sandboxGroupContextComponent.initCache(1)
+        sandboxGroupComponent.initCache(1)
     }
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -28,7 +28,7 @@ import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
 import net.corda.flow.testing.fakes.FakeFlowFiberFactory
 import net.corda.flow.testing.fakes.FakeMembershipGroupReaderProvider
-import net.corda.flow.testing.fakes.FakeSandboxGroupContextComponent
+import net.corda.flow.testing.fakes.FakeSandboxGroupComponent
 import net.corda.flow.testing.tests.FLOW_NAME
 import net.corda.flow.utils.emptyKeyValuePairList
 import net.corda.flow.utils.keyValuePairListOf
@@ -72,8 +72,8 @@ class FlowServiceTestContext @Activate constructor(
     val flowFiberFactory: FakeFlowFiberFactory,
     @Reference(service = FakeMembershipGroupReaderProvider::class)
     val membershipGroupReaderProvider: FakeMembershipGroupReaderProvider,
-    @Reference(service = FakeSandboxGroupContextComponent::class)
-    val sandboxGroupContextComponent: FakeSandboxGroupContextComponent,
+    @Reference(service = FakeSandboxGroupComponent::class)
+    val sandboxGroupComponent: FakeSandboxGroupComponent,
     @Reference(service = VirtualNodeInfoReadServiceFake::class)
     val virtualNodeInfoReadService: VirtualNodeInfoReadServiceFake,
 ) : StepSetup, ThenSetup {
@@ -174,7 +174,7 @@ class FlowServiceTestContext @Activate constructor(
     }
 
     override fun sandboxCpk(cpkFileChecksum: SecureHash) {
-        sandboxGroupContextComponent.putCpk(cpkFileChecksum)
+        sandboxGroupComponent.putCpk(cpkFileChecksum)
     }
 
     override fun membershipGroupFor(owningMember: HoldingIdentity) {
@@ -198,7 +198,7 @@ class FlowServiceTestContext @Activate constructor(
         initiatingFlowClassName: String,
         initiatedFlowClassName: String
     ) {
-        sandboxGroupContextComponent.initiatingToInitiatedFlowPair(
+        sandboxGroupComponent.initiatingToInitiatedFlowPair(
             protocol,
             initiatingFlowClassName,
             initiatedFlowClassName
@@ -423,7 +423,7 @@ class FlowServiceTestContext @Activate constructor(
 
         virtualNodeInfoReadService.reset()
         cpiInfoReadService.reset()
-        sandboxGroupContextComponent.reset()
+        sandboxGroupComponent.reset()
         membershipGroupReaderProvider.reset()
     }
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupComponent.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupComponent.kt
@@ -9,7 +9,7 @@ import net.corda.sandbox.SandboxGroup
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.serialization.SerializationService
@@ -21,8 +21,8 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.propertytypes.ServiceRanking
 
 @ServiceRanking(Int.MAX_VALUE)
-@Component(service = [SandboxGroupContextComponent::class, FakeSandboxGroupContextComponent::class])
-class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
+@Component(service = [SandboxGroupComponent::class, FakeSandboxGroupComponent::class])
+class FakeSandboxGroupComponent : SandboxGroupComponent {
 
     private val availableCpk = mutableSetOf<SecureHash>()
     private var initiatingToInitiatedFlowsMap: Map<String, Pair<String, String>> = mapOf()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
@@ -18,7 +18,7 @@ import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putObjectByKey
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
 import net.corda.serialization.checkpoint.factory.CheckpointSerializerBuilderFactory
@@ -59,8 +59,8 @@ class FlowSandboxServiceImpl @Activate constructor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
     private val cpiInfoReadService: CpiInfoReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = SandboxDependencyInjectorFactory::class)
     private val dependencyInjectionFactory: SandboxDependencyInjectorFactory,
     @Reference(service = CheckpointSerializerBuilderFactory::class)
@@ -106,11 +106,11 @@ class FlowSandboxServiceImpl @Activate constructor(
             null
         )
 
-        if (!sandboxGroupContextComponent.hasCpks(vNodeContext.cpkFileChecksums)) {
+        if (!sandboxGroupComponent.hasCpks(vNodeContext.cpkFileChecksums)) {
             throw IllegalStateException("The sandbox can't find one or more of the CPKs for CPI '${cpiMetadata.cpiId}'")
         }
 
-        val sandboxGroupContext = sandboxGroupContextComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
+        val sandboxGroupContext = sandboxGroupComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
             initialiseSandbox(dependencyInjectionFactory, sandboxGroupContext, cpiMetadata)
         }
 
@@ -123,7 +123,7 @@ class FlowSandboxServiceImpl @Activate constructor(
         cpiMetadata: CpiMetadata
     ): AutoCloseable {
         val sandboxGroup = sandboxGroupContext.sandboxGroup
-        val customCrypto = sandboxGroupContextComponent.registerCustomCryptography(sandboxGroupContext)
+        val customCrypto = sandboxGroupComponent.registerCustomCryptography(sandboxGroupContext)
 
         val injectorService = dependencyInjectionFactory.create(sandboxGroupContext)
         sandboxGroupContext.putObjectByKey(FlowSandboxGroupContextImpl.DEPENDENCY_INJECTOR, injectorService)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
@@ -15,7 +15,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
@@ -58,7 +58,7 @@ class FlowService @Activate constructor(
                     coordinator.followStatusChangesByName(
                         setOf(
                             LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
-                            LifecycleCoordinatorName.forComponent<SandboxGroupContextComponent>(),
+                            LifecycleCoordinatorName.forComponent<SandboxGroupComponent>(),
                             LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
                             LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
                             LifecycleCoordinatorName.forComponent<FlowExecutor>(),

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
@@ -7,7 +7,7 @@ import net.corda.flow.MINIMUM_SMART_CONFIG
 import net.corda.flow.scheduler.FlowWakeUpScheduler
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.test.impl.LifecycleTest
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class FlowServiceTest {
         fun dependants(): Stream<Arguments> {
             return Stream.of(
                 Arguments.of(LifecycleCoordinatorName.forComponent<ConfigurationReadService>()),
-                Arguments.of(LifecycleCoordinatorName.forComponent<SandboxGroupContextComponent>()),
+                Arguments.of(LifecycleCoordinatorName.forComponent<SandboxGroupComponent>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<CpiInfoReadService>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<FlowExecutor>())
@@ -152,7 +152,7 @@ class FlowServiceTest {
     private fun getFlowServiceTestContext(): LifecycleTest<FlowService> {
         return LifecycleTest {
             addDependency<ConfigurationReadService>()
-            addDependency<SandboxGroupContextComponent>()
+            addDependency<SandboxGroupComponent>()
             addDependency<VirtualNodeInfoReadService>()
             addDependency<CpiInfoReadService>()
             addDependency<FlowExecutor>()

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxServiceFactory.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxServiceFactory.kt
@@ -3,13 +3,13 @@ package net.corda.persistence.common
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.persistence.common.internal.EntitySandboxServiceImpl
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.ComponentContext
 
 class EntitySandboxServiceFactory {
     fun create(
-        sandboxService: SandboxGroupContextComponent,
+        sandboxService: SandboxGroupComponent,
         cpiInfoService: CpiInfoReadService,
         virtualNodeInfoService: VirtualNodeInfoReadService,
         dbConnectionManager: DbConnectionManager,

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -24,7 +24,7 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putObjectByKey
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.serialization.SerializationCustomSerializer
@@ -62,7 +62,7 @@ import org.osgi.service.component.annotations.ReferencePolicy
 )
 class EntitySandboxServiceImpl @Activate constructor(
     @Reference
-    private val sandboxService: SandboxGroupContextComponent,
+    private val sandboxService: SandboxGroupComponent,
     @Reference
     private val cpiInfoService: CpiInfoReadService,
     @Reference

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -102,7 +102,7 @@ class PersistenceExceptionTests {
 
         val brokenEntitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 brokenCpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,
@@ -139,7 +139,7 @@ class PersistenceExceptionTests {
 
         val brokenEntitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 brokenCpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,
@@ -175,7 +175,7 @@ class PersistenceExceptionTests {
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,
@@ -214,7 +214,7 @@ class PersistenceExceptionTests {
         // We need a 'working' service to set up the test
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -717,7 +717,7 @@ class PersistenceServiceInternalTests {
 
     private fun createEntitySandbox(dbConnectionManager: DbConnectionManager = BasicMocks.dbConnectionManager()) =
         EntitySandboxServiceFactory().create(
-            virtualNode.sandboxGroupContextComponent,
+            virtualNode.sandboxGroupComponent,
             cpiInfoReadService,
             virtualNodeInfoReadService,
             dbConnectionManager,

--- a/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/SerializationTests.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/SerializationTests.kt
@@ -66,7 +66,7 @@ class SerializationTests {
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 BasicMocks.dbConnectionManager(),

--- a/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceServiceImpl.kt
+++ b/components/virtual-node/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceServiceImpl.kt
@@ -17,7 +17,7 @@ import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.v5.base.util.contextLogger
@@ -34,8 +34,8 @@ class FlowPersistenceServiceImpl  @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = VirtualNodeInfoReadService::class)
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
@@ -52,7 +52,7 @@ class FlowPersistenceServiceImpl  @Activate constructor(
 
     private val dependentComponents = DependentComponents.of(
         ::configurationReadService,
-        ::sandboxGroupContextComponent,
+        ::sandboxGroupComponent,
         ::virtualNodeInfoReadService,
         ::cpiInfoReadService,
     )

--- a/components/virtual-node/ledger-persistence-service-impl/src/integrationTest/kotlin/net/corda/ledger/persistence/impl/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/virtual-node/ledger-persistence-service-impl/src/integrationTest/kotlin/net/corda/ledger/persistence/impl/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -213,7 +213,7 @@ class ConsensualLedgerMessageProcessorTests {
         // set up sandbox
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                virtualNode.sandboxGroupComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager,

--- a/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/LedgerPersistenceServiceImpl.kt
+++ b/components/virtual-node/ledger-persistence-service-impl/src/main/kotlin/net/corda/ledger/persistence/impl/LedgerPersistenceServiceImpl.kt
@@ -17,7 +17,7 @@ import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.v5.base.util.contextLogger
@@ -34,8 +34,8 @@ class LedgerPersistenceServiceImpl  @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = VirtualNodeInfoReadService::class)
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
@@ -52,7 +52,7 @@ class LedgerPersistenceServiceImpl  @Activate constructor(
 
     private val dependentComponents = DependentComponents.of(
         ::configurationReadService,
-        ::sandboxGroupContextComponent,
+        ::sandboxGroupComponent,
         ::virtualNodeInfoReadService,
         ::cpiInfoReadService,
     )

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxgroupcontext.test
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
@@ -28,7 +28,7 @@ class VirtualNodeService @Activate constructor(
     private val virtualNodeLoader: VirtualNodeLoader,
 
     @Reference
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent
+    private val sandboxGroupComponent: SandboxGroupComponent
 ) {
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
@@ -37,7 +37,7 @@ class VirtualNodeService @Activate constructor(
     }
     init {
         // setting cache size to 2 as some tests require 2 concurrent sandboxes for validating they don't overlap
-        sandboxGroupContextComponent.initCache(2)
+        sandboxGroupComponent.initCache(2)
     }
 
     private val vnodes = mutableMapOf<SandboxGroupContext, VirtualNodeInfo>()
@@ -45,7 +45,7 @@ class VirtualNodeService @Activate constructor(
     @Suppress("unused")
     @Deactivate
     fun done() {
-        sandboxGroupContextComponent.close()
+        sandboxGroupComponent.close()
     }
 
     private fun getOrCreateSandbox(virtualNodeInfo: VirtualNodeInfo, type: SandboxGroupType): SandboxGroupContext {
@@ -58,8 +58,8 @@ class VirtualNodeService @Activate constructor(
             SingletonSerializeAsToken::class.java,
             null
         )
-        return sandboxGroupContextComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
-            sandboxGroupContextComponent.registerCustomCryptography(sandboxGroupContext)
+        return sandboxGroupComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
+            sandboxGroupComponent.registerCustomCryptography(sandboxGroupContext)
         }
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupComponent.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupComponent.kt
@@ -1,0 +1,7 @@
+package net.corda.sandboxgroupcontext.service
+
+import net.corda.lifecycle.Lifecycle
+import net.corda.sandboxgroupcontext.SandboxGroupService
+
+interface SandboxGroupComponent : SandboxGroupService, CacheConfiguration, Lifecycle
+

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupContextComponent.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupContextComponent.kt
@@ -1,7 +1,0 @@
-package net.corda.sandboxgroupcontext.service
-
-import net.corda.lifecycle.Lifecycle
-import net.corda.sandboxgroupcontext.SandboxGroupContextService
-
-interface SandboxGroupContextComponent : SandboxGroupContextService, CacheConfiguration, Lifecycle
-

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupServiceImpl.kt
@@ -1,4 +1,4 @@
-@file:JvmName("SandboxGroupContextServiceUtils")
+@file:JvmName("SandboxGroupServiceUtils")
 package net.corda.sandboxgroupcontext.service.impl
 
 import java.security.AccessControlContext
@@ -14,7 +14,7 @@ import net.corda.sandboxgroupcontext.CORDA_SANDBOX_FILTER
 import net.corda.sandboxgroupcontext.CORDA_SYSTEM_FILTER
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
-import net.corda.sandboxgroupcontext.SandboxGroupContextService
+import net.corda.sandboxgroupcontext.SandboxGroupService
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.debug
@@ -38,7 +38,7 @@ import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO
 private typealias ServiceDefinition = Pair<ServiceObjects<out Any>, List<Class<*>>>
 
 /**
- * This is the underlying implementation of the [SandboxGroupContextService]
+ * This is the underlying implementation of the [SandboxGroupService]
  *
  * Use this service via the mutable and immutable interfaces to create a "virtual node",
  * and retrieve the same instance "later".
@@ -46,18 +46,18 @@ private typealias ServiceDefinition = Pair<ServiceObjects<out Any>, List<Class<*
  * This is a per-process service, but it must return the "same instance" for a given [VirtualNodeContext]
  * in EVERY process.
  */
-class SandboxGroupContextServiceImpl(
+class SandboxGroupServiceImpl(
     private val sandboxCreationService: SandboxCreationService,
     private val cpkReadService: CpkReadService,
     private val serviceComponentRuntime: ServiceComponentRuntime,
     private val bundleContext: BundleContext,
     var cache: SandboxGroupContextCache
-) : SandboxGroupContextService {
+) : SandboxGroupService {
     private companion object {
         private const val SANDBOX_FACTORY_FILTER = "(&($SERVICE_SCOPE=$SCOPE_PROTOTYPE)(!$CORDA_SANDBOX_FILTER)(!$CORDA_SYSTEM_FILTER))"
         private const val SYSTEM_FACTORY_FILTER = "(&($SERVICE_SCOPE=$SCOPE_PROTOTYPE)(!$CORDA_SANDBOX_FILTER)$CORDA_SYSTEM_FILTER)"
 
-        private val logger = loggerFor<SandboxGroupContextServiceImpl>()
+        private val logger = loggerFor<SandboxGroupServiceImpl>()
 
         private val sandboxServiceProperties = Hashtable<String, Any?>().apply {
             put(CORDA_SANDBOX, true)

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupServiceImplTest.kt
@@ -8,7 +8,7 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putUniqueObject
 import net.corda.sandboxgroupcontext.service.impl.CloseableSandboxGroupContext
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCache
-import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextServiceImpl
+import net.corda.sandboxgroupcontext.service.impl.SandboxGroupServiceImpl
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -39,9 +39,9 @@ class StubSandboxGroupContextCache: SandboxGroupContextCache {
     }
 }
 
-class SandboxGroupContextServiceImplTest {
+class SandboxGroupServiceImplTest {
 
-    private lateinit var service: SandboxGroupContextServiceImpl
+    private lateinit var service: SandboxGroupServiceImpl
     private val holdingIdentity = createTestHoldingIdentity("CN=Foo, O=Foo Corp, L=LDN, C=GB", "bar")
     private val mainBundle = "MAIN BUNDLE"
 
@@ -82,7 +82,7 @@ class SandboxGroupContextServiceImplTest {
 
     @BeforeEach
     fun beforeEach() {
-        service = SandboxGroupContextServiceImpl(
+        service = SandboxGroupServiceImpl(
             Helpers.mockSandboxCreationService(listOf(cpks)),
             cpkServiceImpl,
             scr,
@@ -167,7 +167,7 @@ class SandboxGroupContextServiceImplTest {
 
         val cpkService = CpkReadServiceFake(cpks1 + cpks2 + cpks3)
 
-        val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
+        val service = SandboxGroupServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
 
         val dog1 = Dog("Rover", "Woof!")
         val dog2 = Dog("Rover", "Bark!")
@@ -221,7 +221,7 @@ class SandboxGroupContextServiceImplTest {
         val sandboxCreationService = Helpers.mockSandboxCreationService(listOf(cpks1))
         val cpkService = CpkReadServiceFake(cpks1)
         val mockCache = mock<SandboxGroupContextCache>()
-        val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, mockCache)
+        val service = SandboxGroupServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, mockCache)
 
         service.remove(ctx1)
 
@@ -240,7 +240,7 @@ class SandboxGroupContextServiceImplTest {
         val service = existingCpks.let {
             val sandboxCreationService = Helpers.mockSandboxCreationService(listOf(it))
             val cpkService = CpkReadServiceFake(it)
-            SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
+            SandboxGroupServiceImpl(sandboxCreationService, cpkService, scr, bundleContext, cache)
         }
 
         val existingCpkChecksums = existingCpks.map {

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/MutableSandboxGroupContext.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/MutableSandboxGroupContext.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxgroupcontext
 /**
  * All objects that are [put] into the context are held by their `(type, key)` tuple.
  *
- * An instance of this interface is returned to the initializer via [SandboxGroupContextService].
+ * An instance of this interface is returned to the initializer via [SandboxGroupService].
  *
  * Attempts to [put] another object with the same `(type,key)` throws an [IllegalArgumentException]
  *

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupService.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupService.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxgroupcontext
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.v5.crypto.SecureHash
 
-interface SandboxGroupContextService: AutoCloseable {
+interface SandboxGroupService: AutoCloseable {
     /**
      * This function creates and returns a "fully constructed" node that is ready to
      * execute a flow with no further configuration required.  Your supplied initializer will be run
@@ -12,7 +12,7 @@ interface SandboxGroupContextService: AutoCloseable {
      * A mutable interface is passed so that the initializer can add per CPI custom objects that are
      * cached together with their SandboxGroup.  The initializer must return an `AutoCloseable` object.
      *
-     * The lifetime of the [SandboxGroupContext] will be managed by the [SandboxGroupContextService]
+     * The lifetime of the [SandboxGroupContext] will be managed by the [SandboxGroupService]
      * implementation subject to some lifetime policy (e.g. resource pressure).
      *
      * Your initializer should be idempotent across a process, and also across different processes running on the same

--- a/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
+++ b/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
@@ -15,7 +15,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.processors.flow.FlowProcessor
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.session.mapper.service.FlowMapperService
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
@@ -42,8 +42,8 @@ class FlowProcessorImpl @Activate constructor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
     private val cpiInfoReadService: CpiInfoReadService,
-    @Reference(service = SandboxGroupContextComponent::class)
-    private val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    @Reference(service = SandboxGroupComponent::class)
+    private val sandboxGroupComponent: SandboxGroupComponent,
     @Reference(service = MembershipGroupReaderProvider::class)
     private val membershipGroupReaderProvider: MembershipGroupReaderProvider
 ) : FlowProcessor {
@@ -59,7 +59,7 @@ class FlowProcessorImpl @Activate constructor(
         ::flowP2PFilterService,
         ::virtualNodeInfoReadService,
         ::cpiInfoReadService,
-        ::sandboxGroupContextComponent,
+        ::sandboxGroupComponent,
         ::membershipGroupReaderProvider
     )
     private val lifecycleCoordinator = coordinatorFactory.createCoordinator<FlowProcessorImpl>(dependentComponents, ::eventHandler)

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
@@ -3,7 +3,7 @@ package net.corda.db.persistence.testkit.components
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.sandboxgroupcontext.service.SandboxGroupComponent
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
@@ -25,11 +25,11 @@ class VirtualNodeService @Activate constructor(
     private val virtualNodeLoader: VirtualNodeLoader,
 
     @Reference
-    val sandboxGroupContextComponent: SandboxGroupContextComponent,
+    val sandboxGroupComponent: SandboxGroupComponent,
 ) {
     init {
         // Needs this since we do not have a config service running:  it will fail to start otherwise.
-        sandboxGroupContextComponent.initCache(2)
+        sandboxGroupComponent.initCache(2)
     }
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
@@ -42,7 +42,7 @@ class VirtualNodeService @Activate constructor(
     @Suppress("unused")
     @Deactivate
     fun done() {
-        sandboxGroupContextComponent.close()
+        sandboxGroupComponent.close()
     }
 
     private fun getOrCreateSandbox(virtualNodeInfo: VirtualNodeInfo): SandboxGroupContext {
@@ -55,8 +55,8 @@ class VirtualNodeService @Activate constructor(
             SingletonSerializeAsToken::class.java,
             null
         )
-        return sandboxGroupContextComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
-            sandboxGroupContextComponent.registerCustomCryptography(sandboxGroupContext)
+        return sandboxGroupComponent.getOrCreate(vNodeContext) { _, sandboxGroupContext ->
+            sandboxGroupComponent.registerCustomCryptography(sandboxGroupContext)
         }
     }
 


### PR DESCRIPTION
A new service will be added using `SandboxGroupContextService`'s name and splitting the PRs in two simplifies the diffs.