### PR TITLE
CORE-7123 Replace OTel with Prometheus

### DIFF
--- a/applications/workers/release/crypto-worker/build.gradle
+++ b/applications/workers/release/crypto-worker/build.gradle
@@ -32,8 +32,6 @@ dependencies {
     testRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
-    dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
-
     // This puts the jdbc driver into the docker image in the /opt/jdbc-driver folder
     // this folder can contain many jdbc drivers (and DataSourceFactory provider bundles).
     // Postgres doesn't need a DataSourceFactory provider bundle (e.g. pax-jdbc), because

--- a/applications/workers/release/db-worker/build.gradle
+++ b/applications/workers/release/db-worker/build.gradle
@@ -42,8 +42,6 @@ dependencies {
         exclude group: 'org.osgi'
     }
 
-    dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
-
     // This puts the jdbc driver into the docker image in the /opt/jdbc-driver folder
     // this folder can contain many jdbc drivers (and DataSourceFactory provider bundles).
     // Postgres doesn't need a DataSourceFactory provider bundle (e.g. pax-jdbc), because

--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -40,6 +40,4 @@ dependencies {
         exclude group: 'org.apache.felix'
         exclude group: 'org.osgi'
     }
-
-    dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
 }

--- a/applications/workers/release/member-worker/build.gradle
+++ b/applications/workers/release/member-worker/build.gradle
@@ -24,6 +24,4 @@ dependencies {
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
     runtimeOnly project(":libs:messaging:kafka-message-bus-impl")
-
-    dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
 }

--- a/applications/workers/release/p2p-gateway-worker/build.gradle
+++ b/applications/workers/release/p2p-gateway-worker/build.gradle
@@ -31,6 +31,4 @@ dependencies {
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
-
-    dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
 }

--- a/applications/workers/release/p2p-link-manager-worker/build.gradle
+++ b/applications/workers/release/p2p-link-manager-worker/build.gradle
@@ -30,6 +30,4 @@ dependencies {
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
-
-    dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
 }

--- a/applications/workers/release/rpc-worker/build.gradle
+++ b/applications/workers/release/rpc-worker/build.gradle
@@ -71,8 +71,6 @@ dependencies {
     e2eTestImplementation "net.corda:corda-topic-schema"
     e2eTestImplementation 'net.corda:corda-cipher-suite'
     e2eTestRuntimeOnly 'org.osgi:osgi.core'
-
-    dockerImage "io.opentelemetry.javaagent:opentelemetry-javaagent:$openTelemetryVersion"
 }
 
 tasks.register('e2eTest', Test) {

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -12,7 +12,6 @@ quasar {
     excludePackages = [
         'co.paralleluniverse**',
         'com.esotericsoftware.**',
-        'io.opentelemetry.**',
         'kotlin**',
         'org.apache.**',
         'org.objectweb.asm',

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -70,6 +70,17 @@ Worker name
 {{- end }}
 
 {{/*
+Worker annotations
+*/}}
+{{- define "corda.workerAnnotations" -}}
+{{ if .Values.metrics.scrape -}}
+prometheus.io/scrape: "true"
+prometheus.io/path: /metrics
+prometheus.io/port: "7000"
+{{- end }}
+{{- end }}
+
+{{/*
 Worker common labels
 */}}
 {{- define "corda.workerLabels" -}}
@@ -200,19 +211,6 @@ Worker environment variables
     {{- end -}}
     {{- if .Values.kafka.sasl.enabled }}
       -Djava.security.auth.login.config=/etc/config/jaas.conf
-    {{- end -}}
-    {{- if .Values.openTelemetry.enabled }}
-      -javaagent:/opt/override/opentelemetry-javaagent-1.15.0.jar
-      -Dotel.resource.attributes=service.name={{ .worker }}-worker,k8s.namespace.name=$(K8S_NAMESPACE),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
-      -Dotel.instrumentation.common.default-enabled=false
-      -Dotel.instrumentation.runtime-metrics.enabled=true
-      {{- if .Values.openTelemetry.endpoint }}
-      -Dotel.exporter.otlp.endpoint={{ .Values.openTelemetry.endpoint }}
-      -Dotel.exporter.otlp.protocol={{ .Values.openTelemetry.protocol }}
-      {{- else }}
-      -Dotel.metrics.exporter=logging
-      -Dotel.traces.exporter=logging
-      {{- end -}}
     {{- end }}
 - name: LOG4J_CONFIG_FILE
   value: "log4j2-console{{ if eq .Values.logging.format "json" }}-json{{ end }}.xml"

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -12,6 +12,8 @@ spec:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- include "corda.workerAnnotations" . | nindent 8 }}
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -12,6 +12,8 @@ spec:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- include "corda.workerAnnotations" . | nindent 8 }}
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -12,6 +12,8 @@ spec:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- include "corda.workerAnnotations" . | nindent 8 }}
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -12,6 +12,8 @@ spec:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- include "corda.workerAnnotations" . | nindent 8 }}
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -27,6 +27,8 @@ spec:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- include "corda.workerAnnotations" . | nindent 8 }}
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -12,6 +12,8 @@ spec:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- include "corda.workerAnnotations" . | nindent 8 }}
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -38,6 +38,8 @@ spec:
       {{- include "corda.workerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- include "corda.workerAnnotations" . | nindent 8 }}
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -147,6 +147,29 @@
                 "level": "warn"
             }]
         },
+        "metrics": {
+            "type": "object",
+            "title": "Metrics configuration",
+            "additionalProperties": false,
+            "required": [
+                "scrape"
+            ],
+            "properties": {
+                "scrape": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "enable scraping of worker metrics through Prometheus annotations",
+                    "examples": [
+                        true
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "scrape": false
+                }
+            ]
+        },
         "dumpHostPath": {
             "type": "string",
             "default": "",
@@ -164,62 +187,6 @@
                 true
             ]
             
-        },
-        "openTelemetry": {
-            "type": "object",
-            "default": {},
-            "title": "open Telemetry configuration",
-            "required": [
-                "enabled"
-            ],
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "enables the Open Telemetry Java agent for the Corda workers",
-                    "examples": [
-                        false,
-                        true
-                    ]
-                },
-                "endpoint": {
-                    "type": ["string", "null"],
-                    "default": null,
-                    "title": "the Open Telemetry endpoint to use; telemetry will be logged locally if this is unset",
-                    "examples": [
-                        "https://otel.example.com:4317"
-                    ],
-                    "format": "uri"
-                },
-                "protocol": {
-                    "type": "string",
-                    "default": "",
-                    "title": "the Open Telemetry protocol the endpoint is using",
-                    "examples": [
-                        "grpc"
-                    ],
-                    "enum": ["grpc","http/protobuf"]
-                }
-            },
-            "if": {
-                "properties": {
-                    "enabled": {
-                        "const": true
-                    }
-                }
-            },
-            "then": {
-                "required": [
-                    "endpoint",
-                    "protocol"
-                ]
-            },
-            "examples": [{
-                "enabled": true,
-                "endpoint": "https://otel.example.com:4317",
-                "protocol": "grpc"
-            }]
         },
         "nodeSelector": {
             "type": "object",

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -35,20 +35,16 @@ logging:
   # -- log level; one of "all", "trace", "debug", "info", "warn" (the default), "error", "fatal", or "off"
   level: "warn"
 
+# Metrics configuration
+metrics:
+  # -- enable scraping of worker metrics through Prometheus annotations
+  scrape: true
+
 # -- Path on Kubernetes hosts to mount on Corda workers for collecting dumps
 dumpHostPath: ""
 
 # -- Enables capturing JVM heap dumps from Corda workers on an OutOfMemory error
 heapDumpOnOutOfMemoryError: false
-
-# Open Telemetry configuration
-openTelemetry:
-  # -- enables the Open Telemetry Java agent for the Corda workers
-  enabled: false
-  # -- the Open Telemetry endpoint to use e.g https://otel.example.com:4317; telemetry will be logged locally if this is unset
-  endpoint: null
-  # -- the Open Telemetry protocol the endpoint is using; one of `grpc` or `http/protobuf`
-  protocol: "grpc"
 
 # -- node labels for pod assignment, see https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -66,7 +66,6 @@ log4jVersion = 2.17.2
 nettyVersion = 4.1.79.Final
 # com.networknt:json-schema-validator cannot be upgraded beyond 1.0.66 because it becomes dependent on com.ethlo.time which is not OSGi compatible.
 networkntJsonSchemaVersion = 1.0.66
-openTelemetryVersion = 1.15.0
 osgiCmVersion = 1.6.1
 osgiNamespaceServiceVersion = 1.0.0
 osgiServiceComponentVersion = 1.5.0


### PR DESCRIPTION
Remove the Open Telemetry agent from the worker images and add the ability to annotate the workers for Prometheus to scrape the `/metrics` endpoints.