### PR TITLE
CORE-7101 Current sandbox thread local

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
@@ -4,15 +4,18 @@ import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.state.FlowStack
 import net.corda.membership.read.MembershipGroupReader
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 
+@Suppress("LongParameterList")
 class FlowFiberExecutionContext(
     val flowCheckpoint: FlowCheckpoint,
     val sandboxGroupContext: FlowSandboxGroupContext,
     val holdingIdentity: HoldingIdentity,
     val membershipGroupReader: MembershipGroupReader,
+    val currentSandboxGroupContext: CurrentSandboxGroupContext,
     val mdcLoggingData: Map<String, String>
 ) : NonSerializable {
     val memberX500Name: MemberX500Name = holdingIdentity.x500Name

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventProcessorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventProcessorFactoryImpl.kt
@@ -22,7 +22,6 @@ class FlowEventProcessorFactoryImpl @Activate constructor(
     private val flowEventExceptionProcessor: FlowEventExceptionProcessor,
     @Reference(service = FlowEventContextConverter::class)
     private val flowEventContextConverter: FlowEventContextConverter
-
 ) : FlowEventProcessorFactory {
 
     override fun create(config: SmartConfig): StateAndEventProcessor<String, Checkpoint, FlowEvent> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
@@ -6,6 +6,7 @@ import net.corda.flow.pipeline.exceptions.FlowTransientException
 import net.corda.flow.pipeline.factory.FlowFiberExecutionContextFactory
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -16,7 +17,9 @@ class FlowFiberExecutionContextFactoryImpl @Activate constructor(
     @Reference(service = FlowSandboxService::class)
     private val flowSandboxService: FlowSandboxService,
     @Reference(service = MembershipGroupReaderProvider::class)
-    private val membershipGroupReaderProvider: MembershipGroupReaderProvider
+    private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
+    @Reference(service = CurrentSandboxGroupContext::class)
+    private val currentSandboxGroupContext: CurrentSandboxGroupContext
 ) : FlowFiberExecutionContextFactory {
 
     override fun createFiberExecutionContext(
@@ -33,6 +36,7 @@ class FlowFiberExecutionContextFactoryImpl @Activate constructor(
             sandbox,
             checkpoint.holdingIdentity,
             membershipGroupReaderProvider.getGroupReader(checkpoint.holdingIdentity),
+            currentSandboxGroupContext,
             context.mdcProperties
         )
     }

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -13,6 +13,7 @@ import net.corda.flow.pipeline.sandbox.SandboxDependencyInjector;
 import net.corda.flow.state.FlowCheckpoint;
 import net.corda.flow.state.FlowContext;
 import net.corda.membership.read.MembershipGroupReader;
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext;
 import net.corda.serialization.checkpoint.CheckpointSerializer;
 import net.corda.v5.application.messaging.FlowSession;
 import net.corda.v5.base.types.MemberX500Name;
@@ -43,6 +44,7 @@ public class FlowSessionImplJavaTest {
             flowSandboxGroupContext,
             createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group1"),
             mock(MembershipGroupReader.class),
+            mock(CurrentSandboxGroupContext.class),
             Map.of()
     );
     private final FlowFiber flowFiber = new FakeFiber(flowFiberExecutionContext);

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
@@ -10,6 +10,7 @@ import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.state.FlowContext
 import net.corda.flow.state.FlowStack
 import net.corda.membership.read.MembershipGroupReader
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.virtualnode.HoldingIdentity
 import org.mockito.kotlin.mock
@@ -21,6 +22,7 @@ class MockFlowFiberService : FlowFiberService {
     val flowCheckpoint = mock<FlowCheckpoint>()
     val flowStack = mock<FlowStack>()
     private val checkpointSerializer = mock<CheckpointSerializer>()
+    private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     val sandboxGroupContext = mock<FlowSandboxGroupContext>()
     val holdingIdentity = HoldingIdentity(BOB_X500_NAME, "group1")
     private val membershipGroupReader = mock<MembershipGroupReader>()
@@ -45,12 +47,14 @@ class MockFlowFiberService : FlowFiberService {
         whenever(flowCheckpoint.flowStack).thenReturn(flowStack)
         whenever(sandboxGroupContext.dependencyInjector).thenReturn(sandboxDependencyInjector)
         whenever(sandboxGroupContext.checkpointSerializer).thenReturn(checkpointSerializer)
+        whenever(currentSandboxGroupContext.get()).thenReturn(sandboxGroupContext)
 
         flowFiberExecutionContext = FlowFiberExecutionContext(
             flowCheckpoint,
             sandboxGroupContext,
             holdingIdentity,
             membershipGroupReader,
+            currentSandboxGroupContext,
             emptyMap()
         )
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
@@ -18,7 +18,7 @@ class FlowFiberExecutionContextTest {
     @Test
     fun `getMemberX500Name returns x500name parsed from holding identity`() {
         val holdingIdentity = HoldingIdentity(BOB_X500_NAME, "group1")
-        val context = FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock(), emptyMap())
+        val context = FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock(), mock(), emptyMap())
         assertThat(context.memberX500Name).isEqualTo(BOB_X500_NAME)
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/RPCRequestDataImplTest.kt
@@ -74,7 +74,7 @@ class RPCRequestDataImplTest {
         }
         whenever(checkpoint.flowStartContext).thenReturn(startContext)
         val holdingIdentity = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "12345")
-        val executionContext = FlowFiberExecutionContext(checkpoint, mock(), holdingIdentity, mock(), emptyMap())
+        val executionContext = FlowFiberExecutionContext(checkpoint, mock(), holdingIdentity, mock(), mock(), emptyMap())
         whenever(fiber.getExecutionContext()).thenReturn(executionContext)
         whenever(fiberService.getExecutingFiber()).thenReturn(fiber)
         return fiberService

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowFiberExecutionContextFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowFiberExecutionContextFactoryImplTest.kt
@@ -11,6 +11,7 @@ import net.corda.flow.pipeline.sandbox.SandboxDependencyInjector
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
@@ -27,11 +28,13 @@ class FlowFiberExecutionContextFactoryImplTest {
     private val sandboxGroupContext = mock<FlowSandboxGroupContext>()
     private val checkpointSerializer = mock<CheckpointSerializer>()
     private val sandboxDependencyInjector = mock<SandboxDependencyInjector>()
+    private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider>()
     private val membershipGroupReader = mock<MembershipGroupReader>()
     private val flowFiberExecutionContextFactory = FlowFiberExecutionContextFactoryImpl(
         flowSandboxService,
-        membershipGroupReaderProvider
+        membershipGroupReaderProvider,
+        currentSandboxGroupContext
     )
 
     val mdcMock = Mockito.mockStatic(MDC::class.java).also {
@@ -70,6 +73,7 @@ class FlowFiberExecutionContextFactoryImplTest {
         assertThat(result.sandboxGroupContext).isSameAs(sandboxGroupContext)
         assertThat(result.membershipGroupReader).isSameAs(membershipGroupReader)
         assertThat(result.memberX500Name).isEqualTo(BOB_X500_NAME)
+        assertThat(result.currentSandboxGroupContext).isEqualTo(currentSandboxGroupContext)
 
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
@@ -76,6 +76,7 @@ class FlowRunnerImplTest {
             sandboxGroupContext,
             BOB_X500_HOLDING_IDENTITY.toCorda(),
             mock(),
+            mock(),
             emptyMap()
         )
     }

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/factory/TransactionMetadataFactoryImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/factory/TransactionMetadataFactoryImpl.kt
@@ -1,12 +1,12 @@
 package net.corda.ledger.common.flow.impl.transaction.factory
 
-import net.corda.flow.fiber.FlowFiberService
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
 import net.corda.ledger.common.flow.transaction.factory.TransactionMetadataFactory
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
@@ -21,8 +21,8 @@ import org.osgi.service.component.annotations.ServiceScope
     scope = ServiceScope.PROTOTYPE
 )
 class TransactionMetadataFactoryImpl @Activate constructor(
-    @Reference(service = FlowFiberService::class)
-    private val flowFiberService: FlowFiberService, // TODO CORE-7101 use CurrentSandboxService when it gets available
+    @Reference(service = CurrentSandboxGroupContext::class)
+    private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     @Reference(service = PlatformInfoProvider::class)
     private val platformInfoProvider: PlatformInfoProvider
 ) : TransactionMetadataFactory, UsedByFlow, SingletonSerializeAsToken {
@@ -40,10 +40,8 @@ class TransactionMetadataFactoryImpl @Activate constructor(
 
     // CORE-7127 Get rid of flowFiberService and access CPK information without fiber when the related solution gets
     // available.
-    private fun getCpkSummaries() = flowFiberService
-        .getExecutingFiber()
-        .getExecutionContext()
-        .sandboxGroupContext
+    private fun getCpkSummaries() = currentSandboxGroupContext
+        .get()
         .sandboxGroup
         .metadata
         .values

--- a/components/ledger/ledger-consensual-flow/build.gradle
+++ b/components/ledger/ledger-consensual-flow/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation project(':libs:flows:flow-api')
     implementation project(':components:ledger:ledger-common-flow-api')
     implementation project(':components:ledger:ledger-common-flow')
-    implementation project(':components:flow:flow-service')
     implementation project(':libs:serialization:serialization-checkpoint-api')
     implementation project(':libs:serialization:serialization-internal')
     implementation project(':libs:virtual-node:sandbox-group-context')

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -1,7 +1,6 @@
 package net.corda.ledger.consensual.flow.impl.transaction.factory
 
 import net.corda.common.json.validation.JsonValidator
-import net.corda.flow.fiber.FlowFiberService
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
@@ -13,6 +12,7 @@ import net.corda.ledger.consensual.data.transaction.ConsensualTransactionVerific
 import net.corda.ledger.consensual.data.transaction.TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
 import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
@@ -42,8 +42,8 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
     private val transactionMetadataFactory: TransactionMetadataFactory,
     @Reference(service = WireTransactionFactory::class)
     private val wireTransactionFactory: WireTransactionFactory,
-    @Reference(service = FlowFiberService::class)
-    private val flowFiberService: FlowFiberService,
+    @Reference(service = CurrentSandboxGroupContext::class)
+    private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     @Reference(service = JsonMarshallingService::class)
     private val jsonMarshallingService: JsonMarshallingService,
     @Reference(service = JsonValidator::class)
@@ -109,8 +109,7 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
     ): List<List<ByteArray>> {
 
         // TODO CORE-7101 use CurrentSandboxService when it gets available
-        val currentSandboxGroup =
-            flowFiberService.getExecutingFiber().getExecutionContext().sandboxGroupContext.sandboxGroup
+        val currentSandboxGroup = currentSandboxGroupContext.get().sandboxGroup
 
         val requiredSigningKeys = consensualTransactionBuilder
             .states

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation project(':libs:ledger:ledger-utxo-data')
     implementation project(':components:ledger:ledger-common-flow-api')
     implementation project(':components:ledger:ledger-common-flow')
-    implementation project(':components:flow:flow-service')
     implementation project(':libs:sandbox')
     implementation project(':libs:serialization:json-validator')
     implementation project(':libs:serialization:serialization-checkpoint-api')

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
@@ -1,0 +1,59 @@
+package net.corda.sandboxgroupcontext.service.impl
+
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.trace
+import net.corda.v5.serialization.SingletonSerializeAsToken
+import org.osgi.service.component.annotations.Component
+
+@Component(service = [CurrentSandboxGroupContext::class, SingletonSerializeAsToken::class])
+class CurrentSandboxGroupContextImpl : CurrentSandboxGroupContext, SingletonSerializeAsToken {
+
+    private companion object {
+        val log = contextLogger()
+
+        val currentSandboxGroupContext = ThreadLocal<SandboxGroupContext?>()
+    }
+
+    override fun set(sandboxGroupContext: SandboxGroupContext) {
+        log.trace {
+            "Setting current sandbox group context [$sandboxGroupContext] on thread [${Thread.currentThread().name}] for holding " +
+                    "identity [${sandboxGroupContext.virtualNodeContext.holdingIdentity}]"
+        }
+        currentSandboxGroupContext.set(sandboxGroupContext)
+    }
+
+    override fun get(): SandboxGroupContext {
+        val current = currentSandboxGroupContext.get()
+        return if (current != null) {
+            log.trace {
+                "Retrieved current sandbox group context [$current] for thread [${Thread.currentThread().name}] with holding identity " +
+                        "[${current.virtualNodeContext.holdingIdentity}]"
+            }
+            current
+        } else {
+            log.error("No current sandbox group context set for thread [${Thread.currentThread().name}]")
+            throw IllegalStateException("No current sandbox group context set for thread")
+        }
+    }
+
+    override fun remove() {
+        val current = currentSandboxGroupContext.get()
+        currentSandboxGroupContext.set(null)
+
+        if (current != null) {
+            log.trace {
+                "Removed current sandbox group context [$current] for thread [${Thread.currentThread().name}] with holding identity " +
+                        "[${current.virtualNodeContext.holdingIdentity}]"
+            }
+        } else {
+            // An exception is created here, so that the warning provides a stacktrace that can be used to determine where the thread
+            // local is being incorrectly set or removed.
+            log.warn(
+                "No current sandbox group context to remove for thread [${Thread.currentThread().name}]",
+                IllegalStateException("No current sandbox group context to remove for thread")
+            )
+        }
+    }
+}

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
@@ -12,8 +12,9 @@ import org.osgi.service.component.annotations.Component
 class CurrentSandboxGroupContextImpl : CurrentSandboxGroupContext, SingletonSerializeAsToken, UsedByFlow {
 
     private companion object {
+        @JvmField
         val log = contextLogger()
-
+        @JvmField
         val currentSandboxGroupContext = ThreadLocal<SandboxGroupContext?>()
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.sandboxgroupcontext.service.impl
 
+import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.v5.base.util.contextLogger
@@ -7,8 +8,8 @@ import net.corda.v5.base.util.trace
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Component
 
-@Component(service = [CurrentSandboxGroupContext::class, SingletonSerializeAsToken::class])
-class CurrentSandboxGroupContextImpl : CurrentSandboxGroupContext, SingletonSerializeAsToken {
+@Component(service = [CurrentSandboxGroupContext::class, UsedByFlow::class])
+class CurrentSandboxGroupContextImpl : CurrentSandboxGroupContext, SingletonSerializeAsToken, UsedByFlow {
 
     private companion object {
         val log = contextLogger()

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/CurrentSandboxGroupContextImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/CurrentSandboxGroupContextImplTest.kt
@@ -1,0 +1,49 @@
+package net.corda.sandboxgroupcontext.impl
+
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.service.impl.CurrentSandboxGroupContextImpl
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import kotlin.concurrent.thread
+
+class CurrentSandboxGroupContextImplTest {
+
+    private val currentSandboxGroupContext = CurrentSandboxGroupContextImpl()
+
+    @Test
+    fun `set, get and remove the sandbox group context thread local`() {
+        val sandboxGroupContextA = mock<SandboxGroupContext>()
+        val sandboxGroupContextB = mock<SandboxGroupContext>()
+
+        var failedAssertion: AssertionError? = null
+
+        val threadA = thread(start = true) {
+            try {
+                currentSandboxGroupContext.set(sandboxGroupContextA)
+                assertSame(sandboxGroupContextA, currentSandboxGroupContext.get())
+                currentSandboxGroupContext.remove()
+                assertThrows<IllegalStateException> { currentSandboxGroupContext.get() }
+            } catch (e: AssertionError) {
+                failedAssertion = e
+            }
+        }
+
+        val threadB = thread(start = true) {
+            try {
+                currentSandboxGroupContext.set(sandboxGroupContextB)
+                assertSame(sandboxGroupContextB, currentSandboxGroupContext.get())
+                currentSandboxGroupContext.remove()
+                assertThrows<IllegalStateException> { currentSandboxGroupContext.get() }
+            } catch (e: AssertionError) {
+                failedAssertion = e
+            }
+        }
+
+        threadA.join()
+        threadB.join()
+
+        failedAssertion?.let { throw it }
+    }
+}

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/CurrentSandboxGroupContext.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/CurrentSandboxGroupContext.kt
@@ -1,0 +1,30 @@
+package net.corda.sandboxgroupcontext
+
+/**
+ * [CurrentSandboxGroupContext] allows the current sandbox's [SandboxGroupContext] to be set, retrieved and removed.
+ *
+ * [CurrentSandboxGroupContext] relies on a [ThreadLocal] to provide access to the current sandbox wherever this service is used.
+ *
+ * Generally, few callers should call [set] and [remove] and should be reserved for the setup and cleanup code that is run when setting up
+ * a new sandbox (or retrieving from one a cache) and cleaning up resources when the thread using the sandbox has
+ * completed processing.
+ */
+interface CurrentSandboxGroupContext {
+
+    /**
+     * Sets the current [SandboxGroupContext] that is tied to the executing thread.
+     */
+    fun set(sandboxGroupContext: SandboxGroupContext)
+
+    /**
+     * Gets the current [SandboxGroupContext] of the executing thread.
+     *
+     * @return The current [SandboxGroupContext].
+     */
+    fun get(): SandboxGroupContext
+
+    /**
+     * Removes the current [SandboxGroupContext] from the executing thread.
+     */
+    fun remove()
+}

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/CurrentSandboxGroupContext.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/CurrentSandboxGroupContext.kt
@@ -5,9 +5,8 @@ package net.corda.sandboxgroupcontext
  *
  * [CurrentSandboxGroupContext] relies on a [ThreadLocal] to provide access to the current sandbox wherever this service is used.
  *
- * Generally, few callers should call [set] and [remove] and should be reserved for the setup and cleanup code that is run when setting up
- * a new sandbox (or retrieving from one a cache) and cleaning up resources when the thread using the sandbox has
- * completed processing.
+ * Generally, few callers should call [set] and [remove]. [set] should be called when a sandbox is created or retrieved from a cache.
+ * [remove] should be called when the code requiring the sandbox has executed and the sandbox needs cleaning up.
  */
 interface CurrentSandboxGroupContext {
 

--- a/testing/ledger/ledger-common-base-test/build.gradle
+++ b/testing/ledger/ledger-common-base-test/build.gradle
@@ -7,16 +7,21 @@ description 'Corda ledger common abstract test class with dependencies made avai
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
+    compileOnly 'org.osgi:osgi.core'
+
     api project(':testing:ledger:ledger-common-testkit')
     api project(':components:ledger:ledger-common-flow')
     api project(':libs:ledger:ledger-common-data')
 
     api project(':libs:crypto:cipher-suite-impl')
     api project(':libs:crypto:merkle-impl')
+    api project(':libs:virtual-node:sandbox-group-context')
     api project(':testing:test-serialization')
     api project(':components:flow:flow-service')
 
     implementation project(":libs:serialization:json-validator")
     implementation project(':libs:serialization:serialization-amqp')
     implementation project(':libs:serialization:serialization-internal')
+
+    implementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/CommonLedgerTest.kt
+++ b/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/CommonLedgerTest.kt
@@ -15,25 +15,37 @@ import net.corda.ledger.common.flow.impl.transaction.factory.TransactionMetadata
 import net.corda.ledger.common.flow.impl.transaction.serializer.kryo.WireTransactionKryoSerializer
 import net.corda.ledger.common.testkit.getWireTransactionExample
 import net.corda.ledger.common.testkit.mockPlatformInfoProvider
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 
 abstract class CommonLedgerTest {
+
+    val currentSandboxGroupContext: CurrentSandboxGroupContext = mockCurrentSandboxGroupContext()
+
     val cipherSchemeMetadata = CipherSchemeMetadataImpl()
+
     val digestService = DigestServiceImpl(PlatformDigestServiceImpl(cipherSchemeMetadata), null)
+
     val merkleTreeProvider = MerkleTreeProviderImpl(digestService)
+
     val jsonMarshallingService = JsonMarshallingServiceImpl()
+
     val jsonValidator = JsonValidatorImpl()
+
     val wireTransactionFactory = WireTransactionFactoryImpl(
         merkleTreeProvider, digestService, jsonMarshallingService, jsonValidator, cipherSchemeMetadata
     )
-    val flowFiberService = TestFlowFiberServiceWithSerialization()
+
+    val flowFiberService = TestFlowFiberServiceWithSerialization(currentSandboxGroupContext)
+
     val flowEngine = FlowEngineImpl(flowFiberService)
+
     val serializationServiceNullCfg = TestSerializationService.getTestSerializationService({}, cipherSchemeMetadata)
-    val transactionMetadataFactory =
-        TransactionMetadataFactoryImpl(flowFiberService, mockPlatformInfoProvider())
-    val wireTransactionKryoSerializer = WireTransactionKryoSerializer(
-        wireTransactionFactory
-    )
+    val transactionMetadataFactory = TransactionMetadataFactoryImpl(currentSandboxGroupContext, mockPlatformInfoProvider())
+
+    val wireTransactionKryoSerializer = WireTransactionKryoSerializer(wireTransactionFactory)
+
     val wireTransactionAMQPSerializer = WireTransactionSerializer(wireTransactionFactory)
+
     val serializationServiceWithWireTx = TestSerializationService.getTestSerializationService({
         it.register(wireTransactionAMQPSerializer, it)
     }, cipherSchemeMetadata)

--- a/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/MockCurrentSandboxGroupContext.kt
+++ b/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/MockCurrentSandboxGroupContext.kt
@@ -1,6 +1,5 @@
 package net.corda.ledger.common.test
 
-import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.internal.serialization.amqp.helper.MockitoHelper
 import net.corda.libs.packaging.core.CordappManifest
 import net.corda.libs.packaging.core.CordappType

--- a/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/MockCurrentSandboxGroupContext.kt
+++ b/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/MockCurrentSandboxGroupContext.kt
@@ -1,0 +1,63 @@
+package net.corda.ledger.common.test
+
+import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
+import net.corda.internal.serialization.amqp.helper.MockitoHelper
+import net.corda.libs.packaging.core.CordappManifest
+import net.corda.libs.packaging.core.CordappType
+import net.corda.libs.packaging.core.CpkFormatVersion
+import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.libs.packaging.core.CpkManifest
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.libs.packaging.core.CpkType
+import net.corda.sandbox.SandboxGroup
+import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
+import org.mockito.Mockito
+import org.osgi.framework.Bundle
+import java.time.Instant
+
+internal fun mockCurrentSandboxGroupContext(): CurrentSandboxGroupContext {
+
+    val sandboxGroupContext = Mockito.mock(SandboxGroupContext::class.java)
+    val currentSandboxGroupContext = Mockito.mock(CurrentSandboxGroupContext::class.java)
+    val mockSandboxGroup = Mockito.mock(SandboxGroup::class.java)
+
+    Mockito.`when`(mockSandboxGroup.metadata).thenReturn(mockCpkMetadata())
+    Mockito.`when`(mockSandboxGroup.getEvolvableTag(MockitoHelper.anyObject())).thenReturn("E;bundle;sandbox")
+    Mockito.`when`(currentSandboxGroupContext.get()).thenReturn(sandboxGroupContext)
+    Mockito.`when`(sandboxGroupContext.sandboxGroup).thenReturn(mockSandboxGroup)
+
+    return currentSandboxGroupContext
+}
+
+private fun mockCpkMetadata() = mapOf(
+    Mockito.mock(Bundle::class.java) to makeCpkMetadata(1, CordappType.CONTRACT),
+    Mockito.mock(Bundle::class.java) to makeCpkMetadata(2, CordappType.WORKFLOW),
+    Mockito.mock(Bundle::class.java) to makeCpkMetadata(3, CordappType.CONTRACT),
+)
+
+private fun makeCpkMetadata(i: Int, cordappType: CordappType) = CpkMetadata(
+    CpkIdentifier("MockCpk", "$i", null),
+    CpkManifest(CpkFormatVersion(1, 1)),
+    "mock-bundle-$i",
+    emptyList(),
+    emptyList(),
+    CordappManifest(
+        "mock-bundle-symbolic",
+        "$i",
+        1,
+        1,
+        cordappType,
+        "mock-shortname",
+        "r3",
+        i,
+        "None",
+        emptyMap()
+    ),
+    CpkType.UNKNOWN,
+    SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32) { i.toByte() }),
+    emptySet(),
+    Instant.now()
+)

--- a/testing/ledger/ledger-consensual-base-test/src/main/kotlin/net/corda/ledger/consensual/test/ConsensualLedgerTest.kt
+++ b/testing/ledger/ledger-consensual-base-test/src/main/kotlin/net/corda/ledger/consensual/test/ConsensualLedgerTest.kt
@@ -16,7 +16,7 @@ abstract class ConsensualLedgerTest : CommonLedgerTest() {
         mockTransactionSignatureService(),
         transactionMetadataFactory,
         wireTransactionFactory,
-        flowFiberService,
+        currentSandboxGroupContext,
         jsonMarshallingService,
         jsonValidator
     )

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -11,13 +11,13 @@ import net.corda.ledger.utxo.testkit.getUtxoSignedTransactionExample
 
 abstract class UtxoLedgerTest : CommonLedgerTest() {
     val utxoSignedTransactionFactory = UtxoSignedTransactionFactoryImpl(
+        currentSandboxGroupContext,
+        jsonMarshallingService,
+        jsonValidator,
         serializationServiceNullCfg,
         mockTransactionSignatureService(),
         transactionMetadataFactory,
-        wireTransactionFactory,
-        flowFiberService,
-        jsonMarshallingService,
-        jsonValidator
+        wireTransactionFactory
     )
     val utxoLedgerService = UtxoLedgerServiceImpl(utxoSignedTransactionFactory)
     val utxoSignedTransactionKryoSerializer = UtxoSignedTransactionKryoSerializer(

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
@@ -5,42 +5,23 @@ import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.state.FlowCheckpoint
-import net.corda.internal.serialization.amqp.SerializerFactory
-import net.corda.libs.packaging.core.CordappManifest
-import net.corda.libs.packaging.core.CordappType
-import net.corda.libs.packaging.core.CpkFormatVersion
-import net.corda.libs.packaging.core.CpkIdentifier
-import net.corda.libs.packaging.core.CpkManifest
-import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.libs.packaging.core.CpkType
 import net.corda.membership.read.MembershipGroupReader
-import net.corda.sandbox.SandboxGroup
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.cipher.suite.CipherSchemeMetadata
-import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import net.corda.virtualnode.HoldingIdentity
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
-import org.osgi.framework.Bundle
-import java.time.Instant
 
-class TestFlowFiberServiceWithSerialization : FlowFiberService, SingletonSerializeAsToken {
+class TestFlowFiberServiceWithSerialization(currentSandboxGroupContext: CurrentSandboxGroupContext) : FlowFiberService, SingletonSerializeAsToken {
     private val mockFlowFiber = mock(FlowFiber::class.java)
     private val mockFlowSandboxGroupContext = mock(FlowSandboxGroupContext::class.java)
     private val membershipGroupReader = mock(MembershipGroupReader::class.java)
-    private val currentSandboxGroupContext = mock(CurrentSandboxGroupContext::class.java)
-    private val mockSandboxGroup = mock(SandboxGroup::class.java)
 
     init {
         val bobX500 = "CN=Bob, O=Bob Corp, L=LDN, C=GB"
         val bobX500Name = MemberX500Name.parse(bobX500)
         val holdingIdentity =  HoldingIdentity(bobX500Name,"group1")
-        Mockito.`when`(mockSandboxGroup.metadata).thenReturn(mockCpkMetadata())
-        Mockito.`when`(mockSandboxGroup.getEvolvableTag(MockitoHelper.anyObject())).thenReturn("E;bundle;sandbox")
-        Mockito.`when`(mockFlowSandboxGroupContext.sandboxGroup).thenReturn(mockSandboxGroup)
         val flowFiberExecutionContext = FlowFiberExecutionContext(
             mock(FlowCheckpoint::class.java),
             mockFlowSandboxGroupContext,
@@ -50,48 +31,10 @@ class TestFlowFiberServiceWithSerialization : FlowFiberService, SingletonSeriali
             emptyMap()
         )
 
-        Mockito.`when`(currentSandboxGroupContext.get()).thenReturn(mockFlowSandboxGroupContext)
         Mockito.`when`(mockFlowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)
-        Mockito.`when`(mockSandboxGroup.metadata).thenReturn(emptyMap())
-        Mockito.`when`(mockFlowSandboxGroupContext.sandboxGroup).thenReturn(mockSandboxGroup)
     }
 
     override fun getExecutingFiber(): FlowFiber {
         return mockFlowFiber
     }
-
-    fun configureSerializer(registerMoreSerializers: (it: SerializerFactory) -> Unit, schemeMetadata: CipherSchemeMetadata) {
-        val serializer = TestSerializationService.getTestSerializationService(registerMoreSerializers, schemeMetadata)
-        Mockito.`when`(mockFlowSandboxGroupContext.amqpSerializer).thenReturn(serializer)
-    }
-
-    private fun mockCpkMetadata() = mapOf(
-        mock(Bundle::class.java) to makeCpkMetadata(1, CordappType.CONTRACT),
-        mock(Bundle::class.java) to makeCpkMetadata(2, CordappType.WORKFLOW),
-        mock(Bundle::class.java) to makeCpkMetadata(3, CordappType.CONTRACT),
-    )
-
-    private fun makeCpkMetadata(i: Int, cordappType: CordappType) = CpkMetadata(
-        CpkIdentifier("MockCpk", "$i", null),
-        CpkManifest(CpkFormatVersion(1, 1)),
-        "mock-bundle-$i",
-        emptyList(),
-        emptyList(),
-        CordappManifest(
-                "mock-bundle-symbolic",
-                "$i",
-                1,
-                1,
-                cordappType,
-                "mock-shortname",
-                "r3",
-                i,
-                "None",
-                emptyMap()
-                    ),
-        CpkType.UNKNOWN,
-        SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32) { i.toByte() }),
-        emptySet(),
-        Instant.now()
-    )
 }

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
@@ -15,8 +15,8 @@ import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.libs.packaging.core.CpkType
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.sandbox.SandboxGroup
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
@@ -38,7 +38,6 @@ class TestFlowFiberServiceWithSerialization : FlowFiberService, SingletonSeriali
         val bobX500 = "CN=Bob, O=Bob Corp, L=LDN, C=GB"
         val bobX500Name = MemberX500Name.parse(bobX500)
         val holdingIdentity =  HoldingIdentity(bobX500Name,"group1")
-        val mockSandboxGroup = mock(SandboxGroup::class.java)
         Mockito.`when`(mockSandboxGroup.metadata).thenReturn(mockCpkMetadata())
         Mockito.`when`(mockSandboxGroup.getEvolvableTag(MockitoHelper.anyObject())).thenReturn("E;bundle;sandbox")
         Mockito.`when`(mockFlowSandboxGroupContext.sandboxGroup).thenReturn(mockSandboxGroup)
@@ -63,7 +62,7 @@ class TestFlowFiberServiceWithSerialization : FlowFiberService, SingletonSeriali
 
     fun configureSerializer(registerMoreSerializers: (it: SerializerFactory) -> Unit, schemeMetadata: CipherSchemeMetadata) {
         val serializer = TestSerializationService.getTestSerializationService(registerMoreSerializers, schemeMetadata)
-        whenever(mockFlowSandboxGroupContext.amqpSerializer).thenReturn(serializer)
+        Mockito.`when`(mockFlowSandboxGroupContext.amqpSerializer).thenReturn(serializer)
     }
 
     private fun mockCpkMetadata() = mapOf(

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
@@ -13,7 +13,9 @@ import net.corda.virtualnode.HoldingIdentity
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
 
-class TestFlowFiberServiceWithSerialization(currentSandboxGroupContext: CurrentSandboxGroupContext) : FlowFiberService, SingletonSerializeAsToken {
+class TestFlowFiberServiceWithSerialization(
+    currentSandboxGroupContext: CurrentSandboxGroupContext
+) : FlowFiberService, SingletonSerializeAsToken {
     private val mockFlowFiber = mock(FlowFiber::class.java)
     private val mockFlowSandboxGroupContext = mock(FlowSandboxGroupContext::class.java)
     private val membershipGroupReader = mock(MembershipGroupReader::class.java)


### PR DESCRIPTION
Create `CurrentSandboxGroupContext` to set, get and remove the current `SandboxGroupContext` on a thread.

This service can then be OSGI injected into other services to retrieve the current sandbox. The thread local concept is private to the service.