### PR TITLE
NOTICK: Tighten-up regex checks

### DIFF
--- a/tools/plugins/initial-rbac/build.gradle
+++ b/tools/plugins/initial-rbac/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 
     implementation project(":tools:plugins:plugins-http-rpc")
     implementation project(':libs:permissions:permission-endpoint')
+
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 cliPlugin {

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
@@ -21,7 +21,7 @@ internal object RoleCreationUtils {
 
     const val VNODE_SHORT_HASH_REGEX = "$UUID_CHARS{12}"
 
-    const val USER_REGEX = "[-._@a-zA-Z0-9]{3,250}"
+    const val USER_REGEX = "[-._@a-zA-Z0-9]{3,255}"
 
     /**
      * Checks if role already exists and then does nothing, else:

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
@@ -21,7 +21,7 @@ internal object RoleCreationUtils {
 
     const val VNODE_SHORT_HASH_REGEX = "[0-9a-fA-F]{12}"
 
-    const val USER_REGEX = "[-._@a-zA-Z0-9]*"
+    const val USER_REGEX = "[-._@a-zA-Z0-9]{3,250}"
 
     /**
      * Checks if role already exists and then does nothing, else:

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
@@ -16,6 +16,9 @@ import java.time.temporal.ChronoUnit
 
 internal object RoleCreationUtils {
 
+    private const val ALLOWED_CHARS = "[a-fA-F0-9]"
+    const val UUID_REGEX = "$ALLOWED_CHARS{8}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{12}"
+
     /**
      * Checks if role already exists and then does nothing, else:
      * - creates permissions;

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
@@ -16,10 +16,10 @@ import java.time.temporal.ChronoUnit
 
 internal object RoleCreationUtils {
 
-    private const val ALLOWED_CHARS = "[a-fA-F0-9]"
-    const val UUID_REGEX = "$ALLOWED_CHARS{8}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{12}"
+    private const val UUID_CHARS = "[a-fA-F0-9]"
+    const val UUID_REGEX = "$UUID_CHARS{8}-$UUID_CHARS{4}-$UUID_CHARS{4}-$UUID_CHARS{4}-$UUID_CHARS{12}"
 
-    const val VNODE_SHORT_HASH_REGEX = "[0-9a-fA-F]{12}"
+    const val VNODE_SHORT_HASH_REGEX = "$UUID_CHARS{12}"
 
     const val USER_REGEX = "[-._@a-zA-Z0-9]{3,250}"
 

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/RoleCreationUtils.kt
@@ -19,6 +19,10 @@ internal object RoleCreationUtils {
     private const val ALLOWED_CHARS = "[a-fA-F0-9]"
     const val UUID_REGEX = "$ALLOWED_CHARS{8}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{4}-$ALLOWED_CHARS{12}"
 
+    const val VNODE_SHORT_HASH_REGEX = "[0-9a-fA-F]{12}"
+
+    const val USER_REGEX = "[-._@a-zA-Z0-9]*"
+
     /**
      * Checks if role already exists and then does nothing, else:
      * - creates permissions;

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugin.initialRbac.commands
 
+import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.UUID_REGEX
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.checkOrCreateRole
 import net.corda.cli.plugins.common.HttpRpcCommand
 import picocli.CommandLine
@@ -18,25 +19,29 @@ private const val USER_ADMIN_ROLE = "UserAdminRole"
 )
 class UserAdminSubcommand : HttpRpcCommand(), Callable<Int> {
 
+    companion object {
+        const val USER_REGEX = "[-.@a-zA-Z0-9]*"
+    }
+
     private val permissionsToCreate: Map<String, String> = listOf(
         // User manipulation permissions
         "CreateUsers" to "POST:/api/v1/user",
-        "GetUsers" to "GET:/api/v1/user.*",
-        "AddRoleToUser" to "PUT:/api/v1/user/.*/role/.*",
-        "DeleteRoleFromUser" to "DELETE:/api/v1/user/.*/role/.*",
-        "GetPermissionsSummary" to "GET:/api/v1/user/.*/permissionSummary",
+        "GetUsers" to "GET:/api/v1/user?loginName=$USER_REGEX",
+        "AddRoleToUser" to "PUT:/api/v1/user/$USER_REGEX/role/$UUID_REGEX",
+        "DeleteRoleFromUser" to "DELETE:/api/v1/user/$USER_REGEX/role/$UUID_REGEX",
+        "GetPermissionsSummary" to "GET:/api/v1/user/$USER_REGEX/permissionSummary",
 
         // Permission manipulation permissions ;-)
         "CreatePermission" to "POST:/api/v1/permission",
         "QueryPermissions" to "GET:/api/v1/permission",
-        "GetPermission" to "GET:/api/v1/permission/.*",
+        "GetPermission" to "GET:/api/v1/permission/$UUID_REGEX",
 
         // Role manipulation permissions
         "GetRoles" to "GET:/api/v1/role",
         "CreateRole" to "POST:/api/v1/role",
-        "GetRole" to "GET:/api/v1/role/.*",
-        "AddPermissionToRole" to "PUT:/api/v1/role/.*/permission/.*",
-        "DeletePermissionFromRole" to "DELETE:/api/v1/role/.*/permission/.*"
+        "GetRole" to "GET:/api/v1/role/$UUID_REGEX",
+        "AddPermissionToRole" to "PUT:/api/v1/role/$UUID_REGEX/permission/$UUID_REGEX",
+        "DeletePermissionFromRole" to "DELETE:/api/v1/role/$UUID_REGEX/permission/$UUID_REGEX"
     ).toMap()
 
     override fun call(): Int {

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugin.initialRbac.commands
 
+import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.USER_REGEX
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.UUID_REGEX
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.checkOrCreateRole
 import net.corda.cli.plugins.common.HttpRpcCommand
@@ -18,10 +19,6 @@ private const val USER_ADMIN_ROLE = "UserAdminRole"
         - assigning/un-assigning permissions to roles"""]
 )
 class UserAdminSubcommand : HttpRpcCommand(), Callable<Int> {
-
-    companion object {
-        const val USER_REGEX = "[-.@a-zA-Z0-9]*"
-    }
 
     private val permissionsToCreate: Map<String, String> = listOf(
         // User manipulation permissions

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
@@ -1,6 +1,7 @@
 package net.corda.cli.plugin.initialRbac.commands
 
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.UUID_REGEX
+import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.VNODE_SHORT_HASH_REGEX
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.checkOrCreateRole
 import net.corda.cli.plugins.common.HttpRpcCommand
 import picocli.CommandLine
@@ -17,10 +18,6 @@ private const val VNODE_CREATOR_ROLE = "VNodeCreatorRole"
 )
 class VNodeCreatorSubcommand : HttpRpcCommand(), Callable<Int> {
 
-    private companion object {
-        const val SHORT_HASH_REGEX = "[0-9a-fA-F]{12}"
-    }
-
     private val permissionsToCreate: Map<String, String> = listOf(
         // CPI related
         "Get all CPIs" to "GET:/api/v1/cpi",
@@ -30,7 +27,7 @@ class VNodeCreatorSubcommand : HttpRpcCommand(), Callable<Int> {
         // vNode related
         "Create vNode" to "POST:/api/v1/virtualnode",
         "Get all vNodes" to "GET:/api/v1/virtualnode",
-        "Update vNode" to "PUT:/api/v1/virtualnode/$SHORT_HASH_REGEX" // TBC
+        "Update vNode" to "PUT:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX" // TBC
     ).toMap()
 
     override fun call(): Int {

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugin.initialRbac.commands
 
+import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.UUID_REGEX
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.checkOrCreateRole
 import net.corda.cli.plugins.common.HttpRpcCommand
 import picocli.CommandLine
@@ -16,16 +17,20 @@ private const val VNODE_CREATOR_ROLE = "VNodeCreatorRole"
 )
 class VNodeCreatorSubcommand : HttpRpcCommand(), Callable<Int> {
 
+    private companion object {
+        const val SHORT_HASH_REGEX = "[0-9a-fA-F]{12}"
+    }
+
     private val permissionsToCreate: Map<String, String> = listOf(
         // CPI related
         "Get all CPIs" to "GET:/api/v1/cpi",
         "CPI upload" to "POST:/api/v1/cpi",
-        "CPI upload status" to "GET:/api/v1/cpi/status/.*",
+        "CPI upload status" to "GET:/api/v1/cpi/status/$UUID_REGEX",
 
         // vNode related
         "Create vNode" to "POST:/api/v1/virtualnode",
         "Get all vNodes" to "GET:/api/v1/virtualnode",
-        "Update vNode" to "PUT:/api/v1/virtualnode.*" // TBC
+        "Update vNode" to "PUT:/api/v1/virtualnode/$SHORT_HASH_REGEX" // TBC
     ).toMap()
 
     override fun call(): Int {

--- a/tools/plugins/initial-rbac/src/test/kotlin/net/corda/cli/plugin/initialRbac/commands/TestPatternsMatch.kt
+++ b/tools/plugins/initial-rbac/src/test/kotlin/net/corda/cli/plugin/initialRbac/commands/TestPatternsMatch.kt
@@ -1,0 +1,43 @@
+package net.corda.cli.plugin.initialRbac.commands
+
+import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.USER_REGEX
+import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.UUID_REGEX
+import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.VNODE_SHORT_HASH_REGEX
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class TestPatternsMatch {
+
+    companion object {
+        private fun wildcardMatch(input: String, regex: String): Boolean {
+            return input.matches(regex.toRegex(RegexOption.IGNORE_CASE))
+        }
+    }
+
+    @Test
+    fun testUUID() {
+        val validUUIDString = UUID.randomUUID().toString()
+
+        assertTrue(wildcardMatch(validUUIDString, UUID_REGEX))
+        assertFalse(wildcardMatch("invalid", UUID_REGEX))
+    }
+
+    @Test
+    fun testVNodeShortHash() {
+        val validShortHashId = "ABCDEF123456"
+
+        assertTrue(wildcardMatch(validShortHashId, VNODE_SHORT_HASH_REGEX))
+        assertFalse(wildcardMatch("invalid", VNODE_SHORT_HASH_REGEX))
+    }
+
+    @Test
+    fun testUser() {
+        val validUserName = "joe.bloggs@company_1.com"
+
+        assertTrue(wildcardMatch(validUserName, USER_REGEX))
+        assertFalse(wildcardMatch("joe/bloggs", VNODE_SHORT_HASH_REGEX))
+        assertFalse(wildcardMatch("0", VNODE_SHORT_HASH_REGEX))
+    }
+}


### PR DESCRIPTION
Avoid using `.*` wildcard to avoid injection of `/` to allow navigating sub-resources/commands