### PR TITLE
NOTICK: Fix incorrect usage of JUnit @TestInstance and @Order.

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerFullTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerFullTest.kt
@@ -9,47 +9,37 @@ import net.corda.applications.workers.smoketest.registerMember
 import net.corda.applications.workers.smoketest.startRpcFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.TestInstance.Lifecycle
-import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 
 /**
  * This file uses a dedicated CPI, Group Id and X500 names from ConsensualLedgerConfig.
  */
-
 @Suppress("Unused", "FunctionName")
-@Order(25)
-@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-@TestInstance(Lifecycle.PER_CLASS)
+@TestInstance(PER_CLASS)
 class ConsensualLedgerFullTest {
 
-    companion object {
-        val aliceHoldingId: String = getHoldingIdShortHash(CONSENSUAL_X500_ALICE, CONSENSUAL_GROUP_ID)
-        val bobHoldingId: String = getHoldingIdShortHash(CONSENSUAL_X500_BOB, CONSENSUAL_GROUP_ID)
+    private val aliceHoldingId: String = getHoldingIdShortHash(CONSENSUAL_X500_ALICE, CONSENSUAL_GROUP_ID)
+    private val bobHoldingId: String = getHoldingIdShortHash(CONSENSUAL_X500_BOB, CONSENSUAL_GROUP_ID)
 
-        @BeforeAll
-        @JvmStatic
-        internal fun beforeAll() {
-            // Upload test flows if not already uploaded
-            conditionallyUploadCordaPackage(CONSENSUAL_TEST_CPI_NAME, CONSENSUAL_TEST_CPB_LOCATION,
-                CONSENSUAL_GROUP_ID, CONSENSUAL_TEST_STATIC_MEMBER_LIST)
+    @BeforeAll
+    fun beforeAll() {
+        // Upload test flows if not already uploaded
+        conditionallyUploadCordaPackage(CONSENSUAL_TEST_CPI_NAME, CONSENSUAL_TEST_CPB_LOCATION,
+            CONSENSUAL_GROUP_ID, CONSENSUAL_TEST_STATIC_MEMBER_LIST)
 
-            // Make sure Virtual Nodes are created
-            val aliceActualHoldingId = getOrCreateVirtualNodeFor(CONSENSUAL_X500_ALICE, CONSENSUAL_TEST_CPI_NAME)
-            val bobActualHoldingId = getOrCreateVirtualNodeFor(CONSENSUAL_X500_BOB, CONSENSUAL_TEST_CPI_NAME)
+        // Make sure Virtual Nodes are created
+        val aliceActualHoldingId = getOrCreateVirtualNodeFor(CONSENSUAL_X500_ALICE, CONSENSUAL_TEST_CPI_NAME)
+        val bobActualHoldingId = getOrCreateVirtualNodeFor(CONSENSUAL_X500_BOB, CONSENSUAL_TEST_CPI_NAME)
 
-            // Just validate the function and actual vnode holding ID hash are in sync
-            // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
-            assertThat(aliceActualHoldingId).isEqualTo(aliceHoldingId)
-            assertThat(bobActualHoldingId).isEqualTo(bobHoldingId)
+        // Just validate the function and actual vnode holding ID hash are in sync
+        // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
+        assertThat(aliceActualHoldingId).isEqualTo(aliceHoldingId)
+        assertThat(bobActualHoldingId).isEqualTo(bobHoldingId)
 
-            registerMember(aliceHoldingId)
-            registerMember(bobHoldingId)
-        }
-
+        registerMember(aliceHoldingId)
+        registerMember(bobHoldingId)
     }
 
     @Test

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
@@ -14,40 +14,32 @@ import net.corda.applications.workers.smoketest.startRpcFlow
 import net.corda.applications.workers.smoketest.TEST_STATIC_MEMBER_LIST
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.TestInstance.Lifecycle
-import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+
 /**
  * This file uses the flow tests' CPI, Group Id and X500 names.
  */
-
 @Suppress("Unused", "FunctionName")
-@Order(24)
-@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-@TestInstance(Lifecycle.PER_CLASS)
+@TestInstance(PER_CLASS)
 class ConsensualLedgerTests {
 
-    companion object {
-        val bobHoldingId: String = getHoldingIdShortHash(X500_BOB, GROUP_ID)
+    private val bobHoldingId: String = getHoldingIdShortHash(X500_BOB, GROUP_ID)
 
-        @BeforeAll
-        @JvmStatic
-        internal fun beforeAll() {
-            // Upload test flows if not already uploaded
-            conditionallyUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST)
+    @BeforeAll
+    fun beforeAll() {
+        // Upload test flows if not already uploaded
+        conditionallyUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST)
 
-            // Make sure Virtual Nodes are created
-            val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
+        // Make sure Virtual Nodes are created
+        val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
 
-            // Just validate the function and actual vnode holding ID hash are in sync
-            // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
-            assertThat(bobActualHoldingId).isEqualTo(bobHoldingId)
+        // Just validate the function and actual vnode holding ID hash are in sync
+        // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
+        assertThat(bobActualHoldingId).isEqualTo(bobHoldingId)
 
-            registerMember(bobHoldingId)
-        }
+        registerMember(bobHoldingId)
     }
 
     @Test


### PR DESCRIPTION
For JUnit 5:
- `@TestInstance(PER_CLASS)` means that JUnit reuses the same class instance to execute all of its `@Test` methods. This effectively means that a `@BeforeAll` method does not need to be `static`.
- `@TestMethodOrder(MethodOrderer.OrderAnnotation::class)` specifies that `@Order` controls the order in which a class's `@Test` _methods_ are executed.

Just checking whether this makes any difference.