### PR TITLE
CORE-7169 Use PublicKeys instead of Parties in ConsensualStates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.417-beta+
+cordaApiVersion=5.0.0.418-alpha-1666084209068
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.418-alpha-1666084209068
+cordaApiVersion=5.0.0.418-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/ledger/ledger-consensual-impl/src/main/kotlin/net/corda/ledger/consensual/impl/transaction/ConsensualLedgerTransactionImpl.kt
+++ b/libs/ledger/ledger-consensual-impl/src/main/kotlin/net/corda/ledger/consensual/impl/transaction/ConsensualLedgerTransactionImpl.kt
@@ -51,9 +51,7 @@ class ConsensualLedgerTransactionImpl(
      */
     fun verify(){
         val requiredSigningKeysFromStates = states
-            .map{it.participants}
-            .flatten()
-            .map{it.owningKey}
+            .flatMap{it.participants}
         require(requiredSigningKeys == requiredSigningKeysFromStates) {
             "Deserialized required signing keys from WireTx do not match with the ones derived from the states!"
         }

--- a/libs/ledger/ledger-consensual-impl/src/main/kotlin/net/corda/ledger/consensual/impl/transaction/ConsensualTransactionBuilderImpl.kt
+++ b/libs/ledger/ledger-consensual-impl/src/main/kotlin/net/corda/ledger/consensual/impl/transaction/ConsensualTransactionBuilderImpl.kt
@@ -92,9 +92,7 @@ class ConsensualTransactionBuilderImpl(
 
     private fun calculateComponentGroupLists(): List<List<ByteArray>> {
         val requiredSigningKeys = states
-            .map { it.participants }
-            .flatten()
-            .map { it.owningKey }
+            .flatMap { it.participants }
             .distinct()
 
         val componentGroupLists = mutableListOf<List<ByteArray>>()

--- a/libs/ledger/ledger-consensual-impl/src/test/kotlin/net/corda/ledger/consensual/impl/ConsensualTransactionMocks.kt
+++ b/libs/ledger/ledger-consensual-impl/src/test/kotlin/net/corda/ledger/consensual/impl/ConsensualTransactionMocks.kt
@@ -8,19 +8,18 @@ import net.corda.ledger.consensual.impl.transaction.TRANSACTION_META_DATA_CONSEN
 import net.corda.ledger.consensual.impl.transaction.factory.getCpiSummary
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.v5.application.crypto.SigningService
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
-import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.security.KeyPairGenerator
+import java.security.PublicKey
 
 class TestConsensualState(
     val testField: String,
-    override val participants: List<Party>
+    override val participants: List<PublicKey>
 ) : ConsensualState {
     override fun verify(ledgerTransaction: ConsensualLedgerTransaction) {}
     override fun equals(other: Any?): Boolean {
@@ -40,10 +39,8 @@ class ConsensualTransactionMocks {
             it.initialize(512)
         }
 
-        val testMemberX500Name = MemberX500Name("R3", "London", "GB")
-        val testPublicKey = kpg.genKeyPair().public
-        val testParty = Party(testMemberX500Name, testPublicKey)
-        val testConsensualState = TestConsensualState("test", listOf(testParty))
+        val testPublicKey: PublicKey = kpg.genKeyPair().public
+        val testConsensualState = TestConsensualState("test", listOf(testPublicKey))
 
         fun mockTransactionMetaData() =
             TransactionMetaData(

--- a/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
+++ b/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
@@ -13,12 +13,12 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransactionVerifier
+import java.security.PublicKey
 
 /**
  * Example consensual flow. Currently, does almost nothing other than verify that
@@ -33,7 +33,7 @@ class ConsensualDemoFlow : RPCStartableFlow {
 
     class TestConsensualState(
         val testField: String,
-        override val participants: List<Party>
+        override val participants: List<PublicKey>
     ) : ConsensualState {
         override fun verify(ledgerTransaction: ConsensualLedgerTransaction) {}
     }
@@ -65,8 +65,8 @@ class ConsensualDemoFlow : RPCStartableFlow {
                 TestConsensualState(
                     "test",
                     listOf(
-                        Party(alice.name, alice.ledgerKeys.first()),
-                        Party(bob.name, bob.ledgerKeys.first()),
+                        alice.ledgerKeys.first(),
+                        bob.ledgerKeys.first(),
                     )
                 )
 

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/ledger/ConsensualSignedTransactionSerializationFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/ledger/ConsensualSignedTransactionSerializationFlow.kt
@@ -10,17 +10,17 @@ import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
+import java.security.PublicKey
 
 @Suppress("unused")
 class ConsensualSignedTransactionSerializationFlow : RPCStartableFlow {
     data class ResultMessage(val serializedLength: Int)
 
     class TestConsensualState(
-        val testField: String, override val participants: List<Party>
+        val testField: String, override val participants: List<PublicKey>
     ) : ConsensualState {
         override fun verify(ledgerTransaction: ConsensualLedgerTransaction) {}
     }
@@ -47,7 +47,7 @@ class ConsensualSignedTransactionSerializationFlow : RPCStartableFlow {
         try {
             val member = memberLookup.myInfo()
 
-            val testConsensualState = TestConsensualState("test", listOf(Party(member.name, member.ledgerKeys.first())))
+            val testConsensualState = TestConsensualState("test", listOf(member.ledgerKeys.first()))
             val txBuilder = consensualLedgerService.getTransactionBuilder()
             val signedTransaction = txBuilder
                 .withStates(testConsensualState)


### PR DESCRIPTION
Use PublicKeys instead of Parties in ConsensualStates

API: https://github.com/corda/corda-api/pull/654