### PR TITLE
CORE-5088 Refactoring

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowRecordFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowRecordFactory.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.pipeline.factory
 
-import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
@@ -8,7 +7,6 @@ import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.output.FlowStatus
-import net.corda.data.persistence.EntityRequest
 import net.corda.messaging.api.records.Record
 
 /**
@@ -25,22 +23,6 @@ interface FlowRecordFactory {
      * @return a new instance of a [FlowEvent] record.
      */
     fun createFlowEventRecord(flowId: String, payload: Any): Record<String, FlowEvent>
-
-    /**
-     * Wrap an EntityRequest obj in a record to be sent to the crypto processor.
-     * @param requestId UUID of the request. Set as the record key.
-     * @param payload Request payload. Set as record value.
-     * @return Record to be sent to the crypto processor.
-     */
-    fun createFlowOpsRequestRecord(flowId: String, payload: FlowOpsRequest): Record<String, FlowOpsRequest>
-
-    /**
-     * Wrap an EntityRequest obj in a record to be sent to the db entity processor.
-     * @param requestId UUID of the request. Set as the record key.
-     * @param payload Request payload. Set as record value.
-     * @return Record to be sent to the db entity processor.
-     */
-    fun createEntityRequestRecord(requestId: String, payload: EntityRequest): Record<String, EntityRequest>
 
     /**
      * Creates a [FlowStatus] record

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowRecordFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowRecordFactoryImpl.kt
@@ -1,18 +1,14 @@
 package net.corda.flow.pipeline.factory.impl
 
-import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.output.FlowStatus
-import net.corda.data.persistence.EntityRequest
 import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.messaging.api.records.Record
-import net.corda.schema.Schemas
 import net.corda.schema.Schemas.Flow.Companion.FLOW_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.Companion.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.Companion.FLOW_STATUS_TOPIC
-import net.corda.schema.Schemas.Persistence.Companion.PERSISTENCE_ENTITY_PROCESSOR_TOPIC
 import org.osgi.service.component.annotations.Component
 
 @Component(service = [FlowRecordFactory::class])
@@ -23,22 +19,6 @@ class FlowRecordFactoryImpl : FlowRecordFactory {
             topic = FLOW_EVENT_TOPIC,
             key = flowId,
             value = FlowEvent(flowId, payload)
-        )
-    }
-
-    override fun createFlowOpsRequestRecord(flowId: String, payload: FlowOpsRequest): Record<String, FlowOpsRequest> {
-        return Record(
-            topic = Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC,
-            key = flowId,
-            value = payload
-        )
-    }
-
-    override fun createEntityRequestRecord(requestId: String, payload: EntityRequest): Record<String, EntityRequest> {
-        return Record(
-            topic = PERSISTENCE_ENTITY_PROCESSOR_TOPIC,
-            key = requestId,
-            value = payload
         )
     }
 

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -207,8 +207,8 @@ class ConsensualLedgerMessageProcessorTests {
 
         val testId = (0..1000000).random() // keeping this shorter than UUID.
         val schemaName = "consensual_ledger_test_$testId"
-        val animalDbConnection = Pair(virtualNodeInfo.vaultDmlConnectionId, "animals-node-$testId")
-        val dbConnectionManager = FakeDbConnectionManager(listOf(animalDbConnection), schemaName)
+        val dbConnection = Pair(virtualNodeInfo.vaultDmlConnectionId, "connection-1")
+        val dbConnectionManager = FakeDbConnectionManager(listOf(dbConnection), schemaName)
 
         val componentContext = Mockito.mock(ComponentContext::class.java)
         whenever(componentContext.locateServices(INTERNAL_CUSTOM_SERIALIZERS))
@@ -237,16 +237,16 @@ class ConsensualLedgerMessageProcessorTests {
             )
         )
 
-        lbm.updateDb(dbConnectionManager.getDataSource(animalDbConnection.first).connection, vaultSchema)
+        lbm.updateDb(dbConnectionManager.getDataSource(dbConnection.first).connection, vaultSchema)
 
         return DbTestContext(
             virtualNodeInfo,
             entitySandboxService,
             sandbox,
             dbConnectionManager.createEntityManagerFactory(
-                animalDbConnection.first,
+                dbConnection.first,
                 JpaEntitiesSet.create(
-                    animalDbConnection.second,
+                    dbConnection.second,
                     setOf()
                 )
             ),

--- a/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/ConsensualLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/ConsensualLedgerPersistenceServiceImpl.kt
@@ -41,10 +41,10 @@ class ConsensualLedgerPersistenceServiceImpl  @Activate constructor(
     @Reference(service = CpiInfoReadService::class)
     private val cpiInfoReadService: CpiInfoReadService,
     @Reference(service = ConsensualLedgerProcessorFactory::class)
-    private val entityProcessorFactory: ConsensualLedgerProcessorFactory
+    private val ledgerProcessorFactory: ConsensualLedgerProcessorFactory
 ) : ConsensualLedgerPersistenceService {
     private var configHandle: Resource? = null
-    private var entityProcessor: ConsensualLedgerProcessor? = null
+    private var ledgerProcessor: ConsensualLedgerProcessor? = null
 
     companion object {
         private val logger = contextLogger()
@@ -75,17 +75,17 @@ class ConsensualLedgerPersistenceServiceImpl  @Activate constructor(
                 }
             }
             is ConfigChangedEvent -> {
-                entityProcessor?.stop()
-                val newEntityProcessor = entityProcessorFactory.create(
+                ledgerProcessor?.stop()
+                val newLedgerProcessor = ledgerProcessorFactory.create(
                     event.config.getConfig(MESSAGING_CONFIG)
                 )
                 logger.debug("Starting LedgerPersistenceService.")
-                newEntityProcessor.start()
-                entityProcessor = newEntityProcessor
+                newLedgerProcessor.start()
+                ledgerProcessor = newLedgerProcessor
                 coordinator.updateStatus(LifecycleStatus.UP)
             }
             is StopEvent -> {
-                entityProcessor?.stop()
+                ledgerProcessor?.stop()
                 logger.debug { "Stopping LedgerPersistenceService." }
             }
         }

--- a/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ComponentGroupListsTuplesMapper.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ComponentGroupListsTuplesMapper.kt
@@ -1,0 +1,33 @@
+package net.corda.ledger.consensual.persistence.impl.repository
+
+import javax.persistence.Tuple
+
+/**
+ * Used by [ConsensualLedgerRepository.findTransaction] to map DB rows to transaction's components group lists
+ */
+class ComponentGroupListsTuplesMapper: TuplesMapper<List<ByteArray>> {
+    override fun map(tuples: List<Tuple>): List<List<ByteArray>> {
+        val componentGroupLists: MutableList<MutableList<ByteArray>> = mutableListOf()
+        var componentsList: MutableList<ByteArray> = mutableListOf()
+        var expectedGroupIdx = 0
+        tuples.forEach { columns ->
+            val groupIdx = (columns[4] as Number).toInt()
+            val leafIdx = (columns[5] as Number).toInt()
+            val data = columns[6] as ByteArray
+            while (groupIdx > expectedGroupIdx) {
+                // Add empty lists for missing group indices
+                componentGroupLists.add(componentsList)
+                componentsList = mutableListOf()
+                expectedGroupIdx++
+            }
+            check(componentsList.size == leafIdx) {
+                // Missing leaf indices indicate that data is corrupted
+                val id = columns[0] as String
+                "Missing data for transaction with ID: $id, groupIdx: $groupIdx, leafIdx: ${componentsList.size}"
+            }
+            componentsList.add(data)
+        }
+        componentGroupLists.add(componentsList)
+        return componentGroupLists
+    }
+}

--- a/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/TuplesMapper.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/TuplesMapper.kt
@@ -1,0 +1,11 @@
+package net.corda.ledger.consensual.persistence.impl.repository
+
+import java.sql.SQLException
+import javax.persistence.Tuple
+
+interface TuplesMapper<T> {
+    @Throws(SQLException::class)
+    fun map(tuples: List<Tuple>): List<T>
+}
+
+fun <T> List<Tuple>.mapTuples(mapper: TuplesMapper<T>) = mapper.map(this)

--- a/components/ledger/ledger-consensual-persistence-impl/src/test/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ComponentGroupListsTuplesMapperTest.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/test/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ComponentGroupListsTuplesMapperTest.kt
@@ -5,10 +5,13 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.sql.Timestamp
+import javax.persistence.Tuple
 
-class ConsensualLedgerRepositoryTest {
+class ComponentGroupListsTuplesMapperTest {
     companion object {
         private const val id = "id1"
         private val privacySalt = ByteArray(32)
@@ -16,16 +19,21 @@ class ConsensualLedgerRepositoryTest {
         private val createdTs = Timestamp(0)
     }
 
+    private fun mockTuple(values: List<Any>) =
+        mock<Tuple>().apply {
+            whenever(this.get(anyInt())).thenAnswer { invocation -> values[invocation.arguments[0] as Int] }
+        }
+
     @Test
     fun `throws if leaf component is missing`() {
         val groupIdx = 1
         val leafIdx = 0
-        val rows = listOf<Any?>(
-            arrayOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx, ByteArray(16), "hash"),
-            arrayOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx + 2, ByteArray(16), "hash")
-        )
+        val rows = listOf(
+            listOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx, ByteArray(16), "hash"),
+            listOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx + 2, ByteArray(16), "hash")
+        ).map { mockTuple(it) }
         val exception = assertThrows<IllegalStateException> {
-            ConsensualLedgerRepository(mock(), mock(), mock()).queryRowsToComponentGroupLists(rows)
+            rows.mapTuples(ComponentGroupListsTuplesMapper())
         }
         assertEquals("Missing data for transaction with ID: id1, groupIdx: 1, leafIdx: 1", exception.message)
     }
@@ -34,15 +42,15 @@ class ConsensualLedgerRepositoryTest {
     fun `creates valid component group lists`() {
         val leafIdx = 0
         val groupIdx = 0
-        val rows = listOf<Any?>(
-            arrayOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx, "data00".toByteArray(), "hash00"),
-            arrayOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx + 1, "data01".toByteArray(), "hash01"),
-            arrayOf(id, privacySalt, accountId, createdTs, groupIdx + 2, leafIdx, "data20".toByteArray(), "hash20"),
-            arrayOf(id, privacySalt, accountId, createdTs, groupIdx + 2, leafIdx + 1, "data21".toByteArray(), "hash21"),
-            arrayOf(id, privacySalt, accountId, createdTs, groupIdx + 2, leafIdx + 2, "data22".toByteArray(), "hash22"),
-        )
+        val rows = listOf(
+            listOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx, "data00".toByteArray(), "hash00"),
+            listOf(id, privacySalt, accountId, createdTs, groupIdx, leafIdx + 1, "data01".toByteArray(), "hash01"),
+            listOf(id, privacySalt, accountId, createdTs, groupIdx + 2, leafIdx, "data20".toByteArray(), "hash20"),
+            listOf(id, privacySalt, accountId, createdTs, groupIdx + 2, leafIdx + 1, "data21".toByteArray(), "hash21"),
+            listOf(id, privacySalt, accountId, createdTs, groupIdx + 2, leafIdx + 2, "data22".toByteArray(), "hash22"),
+        ).map { mockTuple(it) }
 
-        val componentGroupLists = ConsensualLedgerRepository(mock(), mock(), mock()).queryRowsToComponentGroupLists(rows)
+        val componentGroupLists = rows.mapTuples(ComponentGroupListsTuplesMapper())
 
         val expectedLists = listOf(
             listOf("data00", "data01").toBytes(),

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/EntityProcessorFactoryImpl.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/EntityProcessorFactoryImpl.kt
@@ -18,11 +18,11 @@ import org.osgi.service.component.annotations.Reference
 @Suppress("UNUSED")
 @Component(service = [EntityProcessorFactory::class])
 class EntityProcessorFactoryImpl @Activate constructor(
-    @Reference
+    @Reference(service = SubscriptionFactory::class)
     private val subscriptionFactory: SubscriptionFactory,
-    @Reference
+    @Reference(service = PublisherFactory::class)
     private val publisherFactory: PublisherFactory,
-    @Reference
+    @Reference(service = EntitySandboxService::class)
     private val entitySandboxService: EntitySandboxService,
     @Reference(service = ExternalEventResponseFactory::class)
     private val externalEventResponseFactory: ExternalEventResponseFactory


### PR DESCRIPTION
Refactoring and small fixes:
- Deleted `createEntityRequestRecord` and `createFlowOpsRequestRecord` from `FlowRecordfactory` (https://github.com/corda/corda-runtime-os/pull/2224#discussion_r988185020)
- Added service value for @references that missed them (https://github.com/corda/corda-runtime-os/pull/1883#discussion_r980931660)
-  Logic that maps tuples to domain classes extracted to it's own class so it could be unit tested (https://github.com/corda/corda-runtime-os/pull/1883#discussion_r981101419)