### PR TITLE
Core 6690 consistent overrides

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -356,10 +356,19 @@ Cluster DB port
 {{- end -}}
 
 {{/*
-Cluster DB user
+Cluster DB user secret 
 */}}
 {{- define "corda.clusterDbUser" -}}
-{{- .Values.db.cluster.user | default "user" }}
+{{- if .Values.db.cluster.user.valueFrom.secretkeyRef.name }}
+- name: PGUSER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.cluster.user.valueFrom.secretkeyRef.name }}
+      key: {{ .Values.db.cluster.user.valueFrom.secretkeyRef.usernameKey }}
+{{- else }}
+- name: PGUSER
+  value: {{ .Values.db.cluster.user.value }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -370,8 +379,13 @@ Cluster DB name
 {{- end -}}
 
 {{/*
-Cluster DB secret name
+Cluster DB password secret 
 */}}
 {{- define "corda.clusterDbSecretName" -}}
-{{- .Values.db.cluster.existingSecret | default ( printf "%s-cluster-db" (include "corda.fullname" .) ) }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.db.cluster.password.valueFrom.secretkeyRef.name | default ( printf "%s-cluster-db" (include "corda.fullname" .) ) }}
+      key: {{ .Values.db.cluster.password.valueFrom.secretkeyRef.passwordKey | default "password"}}
 {{- end -}}
+

--- a/charts/corda/templates/cluster-db-secret.yaml
+++ b/charts/corda/templates/cluster-db-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.db.cluster.existingSecret }}
+{{- if not .Values.db.cluster.password.valueFrom.secretkeyRef.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,5 @@ metadata:
     {{- include "corda.labels" . | nindent 4 }}
 type: Opaque
 data:
-  password: {{ required "Must specify db.cluster.existingSecret or db.cluster.password" .Values.db.cluster.password | b64enc | quote }}
+  password: {{ required "Must specify db.cluster.password.valueFrom.secretRef.name or db.cluster.password.value" .Values.db.cluster.password.value | b64enc | quote }}
 {{- end }}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -39,12 +39,8 @@ spec:
           allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
-        {{- include "corda.workerEnv" . | nindent 10 }}
-          - name: DATABASE_PASS
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "corda.clusterDbSecretName" . }}
-                key: password
+        {{- include "corda.clusterDbUser" . | nindent 10 }}
+        {{- include "corda.clusterDbSecretName" . | nindent 10 }}
           - name: SALT
             valueFrom:
               secretKeyRef:
@@ -59,8 +55,8 @@ spec:
         {{- include "corda.workerKafkaArgs" . | nindent 10 }}
           - -spassphrase=$(PASSPHRASE)
           - -ssalt=$(SALT)
-          - -ddatabase.user={{ .Values.db.cluster.user }}
-          - -ddatabase.pass=$(DATABASE_PASS)
+          - -ddatabase.user=$(PGUSER)
+          - -ddatabase.pass=$(PGPASSWORD)
           - -ddatabase.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" .Values.db.cluster.host }}:{{ .Values.db.cluster.port }}/{{ .Values.db.cluster.database }}
           - -ddatabase.jdbc.directory=/opt/jdbc-driver
           - -ddatabase.pool.max_size={{ .Values.workers.crypto.clusterDbConnectionPool.maxSize }}

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -38,16 +38,13 @@ spec:
               name: working-volume
         - name: apply-db-schemas
           image: {{ include "corda.dbClientImage" . }}
-          command: [ 'sh', '-c', 'for f in /tmp/working_dir/*.sql; do psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done' ]
+          command: [ 'sh', '-c', 'for f in /tmp/working_dir/*.sql; do psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
           env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "corda.clusterDbSecretName" . }}
-                  key: password
+          {{- include "corda.clusterDbUser" . | nindent 12 }}
+          {{- include "corda.clusterDbSecretName" . | nindent 12 }}
         - name: create-initial-rbac-db-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -71,16 +68,13 @@ spec:
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
+          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
           env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "corda.clusterDbSecretName" . }}
-                  key: password
+          {{- include "corda.clusterDbUser" . | nindent 12 }}
+          {{- include "corda.clusterDbSecretName" . | nindent 12 }}
         - name: create-initial-crypto-db-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -104,16 +98,13 @@ spec:
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
+          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
           env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "corda.clusterDbSecretName" . }}
-                  key: password
+          {{- include "corda.clusterDbUser" . | nindent 12 }}
+          {{- include "corda.clusterDbSecretName" . | nindent 12 }}
         - name: create-initial-rpc-admin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -137,16 +128,13 @@ spec:
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/rbac-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
+          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/rbac-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
           env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "corda.clusterDbSecretName" . }}
-                  key: password
+          {{- include "corda.clusterDbUser" . | nindent 12 }}
+          {{- include "corda.clusterDbSecretName" . | nindent 12 }}
         - name: create-db-users-and-grant
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -154,21 +142,18 @@ spec:
           command: [ '/bin/sh', '-e', '-c' ]
           args:
             - |
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} {{ include "corda.clusterDbUser" . }} -c "CREATE USER rbac_user WITH ENCRYPTED PASSWORD 'rbac_password'" || echo "User rbac_user already existed - skipping"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} {{ include "corda.clusterDbUser" . }} -c "GRANT USAGE ON SCHEMA RPC_RBAC to rbac_user;" || echo "Couldn't perform usage grant"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} {{ include "corda.clusterDbUser" . }} -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA RPC_RBAC to rbac_user;" || echo "Couldn't DML perform grant"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} {{ include "corda.clusterDbUser" . }} -c "CREATE USER crypto_user WITH ENCRYPTED PASSWORD 'crypto_password'" || echo "User crypto_user already existed - skipping"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} {{ include "corda.clusterDbUser" . }} -c "GRANT USAGE ON SCHEMA CRYPTO to crypto_user;" || echo "Couldn't perform usage grant"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} {{ include "corda.clusterDbUser" . }} -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA CRYPTO to crypto_user;" || echo "Couldn't DML perform grant"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} -c "CREATE USER rbac_user WITH ENCRYPTED PASSWORD 'rbac_password'" || echo "User rbac_user already existed - skipping"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT USAGE ON SCHEMA RPC_RBAC to rbac_user;" || echo "Couldn't perform usage grant"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA RPC_RBAC to rbac_user;" || echo "Couldn't DML perform grant"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "CREATE USER crypto_user WITH ENCRYPTED PASSWORD 'crypto_password'" || echo "User crypto_user already existed - skipping"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT USAGE ON SCHEMA CRYPTO to crypto_user;" || echo "Couldn't perform usage grant"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA CRYPTO to crypto_user;" || echo "Couldn't DML perform grant"
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
           env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "corda.clusterDbSecretName" . }}
-                  key: password
+          {{- include "corda.clusterDbUser" . | nindent 12 }}
+          {{- include "corda.clusterDbSecretName" . | nindent 12 }}
         - name: create-initial-crypto-worker-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -192,16 +177,13 @@ spec:
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -U {{ include "corda.clusterDbUser" . }} -f /tmp/working_dir/crypto-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
+          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/crypto-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
           env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "corda.clusterDbSecretName" . }}
-                  key: password
+          {{- include "corda.clusterDbUser" . | nindent 12 }}
+          {{- include "corda.clusterDbSecretName" . | nindent 12 }}
 
       volumes:
         - name: working-volume

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -39,12 +39,8 @@ spec:
           allowPrivilegeEscalation: false
         {{- include "corda.workerResources" . | nindent 8 }} 
         env:
-        {{- include "corda.workerEnv" . | nindent 10 }}
-          - name: DATABASE_PASS
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "corda.clusterDbSecretName" . }}
-                key: password
+        {{- include "corda.clusterDbUser" . | nindent 10 }}
+        {{- include "corda.clusterDbSecretName" . | nindent 10 }}
           - name: SALT
             valueFrom:
               secretKeyRef:
@@ -59,8 +55,8 @@ spec:
         {{- include "corda.workerKafkaArgs" . | nindent 10 }}
           - -spassphrase=$(PASSPHRASE)
           - -ssalt=$(SALT)
-          - -ddatabase.user={{ .Values.db.cluster.user }}
-          - -ddatabase.pass=$(DATABASE_PASS)
+          - -ddatabase.user=$(PGUSER)
+          - -ddatabase.pass=$(PGPASSWORD)
           - -ddatabase.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" .Values.db.cluster.host }}:{{ .Values.db.cluster.port }}/{{ .Values.db.cluster.database }}
           - -ddatabase.jdbc.directory=/opt/jdbc-driver
           - -ddatabase.pool.max_size={{ .Values.workers.db.clusterDbConnectionPool.maxSize }}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -246,13 +246,71 @@
                             ]
                         },
                         "user": {
-                            "type": "string",
-                            "default": "user",
-                            "title": "the cluster database user",
-                            "examples": [
-                                "user"
+                            "type": "object",
+                            "default": {},
+                            "title": "the cluster database username",
+                            "required": [
+                                "value",
+                                "valueFrom"
                             ],
-                            "minLength": 1
+                            "additionalProperties": false,
+                            "properties": {
+                                "value": {
+                                    "type": "string",
+                                    "default": "user",
+                                    "title": "the cluster db username",
+                                    "example": [{
+                                        "value": "user"
+                                    }]
+                                },
+                                "valueFrom": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "the username secret configuration",
+                                    "required": [
+                                        "secretkeyRef"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "secretkeyRef": {
+                                            "type": "object",
+                                            "default": {},
+                                            "title": "the username secret key reference",
+                                            "required": [
+                                                "name",
+                                                "usernameKey"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "the username secret name",
+                                                    "examples": [
+                                                        ""
+                                                    ]
+                                                },
+                                                "usernameKey": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "the username secret key ",
+                                                    "examples": [
+                                                        ""
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "examples": [{
+                                        "valueFrom:": {
+                                          "secretkeyRef": {
+                                              "name": "",
+                                              "usernameKey": ""
+                                          }
+                                        }
+                                    }]
+                                }
+                            }
                         },
                         "database": {
                             "type": "string",
@@ -264,29 +322,84 @@
                             "minLength": 1
                         },
                         "password": {
-                            "type": "string",
-                            "default": "",
-                            "title": "the cluster database password (ignored if existingSecret is set, otherwise required)",
-                            "examples": [
-                                "password"
-                            ]
-                        },
-                        "existingSecret": {
-                            "type": "string",
-                            "default": "",
-                            "title": "the name of an existing secret containing the cluster database password with a key of 'password'",
-                            "examples": [
-                                "postgresql-secret"
-                            ]
+                            "type": "object",
+                            "default": {},
+                            "title": "the cluster database password",
+                            "required": [
+                                "value",
+                                "valueFrom"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "value": {
+                                    "type": "string",
+                                    "default": "user",
+                                    "title": "the cluster db password",
+                                    "example": [{
+                                        "value": "password"
+                                    }]
+                                },
+                                "valueFrom": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "the password secret configuration",
+                                    "required": [
+                                        "secretkeyRef"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "secretkeyRef": {
+                                            "type": "object",
+                                            "default": {},
+                                            "title": "the password secret key reference",
+                                            "required": [
+                                                "name",
+                                                "passwordKey"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "the password secret name",
+                                                    "examples": [
+                                                        ""
+                                                    ]
+                                                },
+                                                "passwordKey": {
+                                                    "type": "string",
+                                                    "default": "",
+                                                    "title": "the password secret key ",
+                                                    "examples": [
+                                                        ""
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "examples": [{
+                                        "valueFrom:": {
+                                          "secretkeyRef": {
+                                              "name": "",
+                                              "usernameKey": ""
+                                          }
+                                        }
+                                    }]
+                                }
+                            }
                         }
                     },
                     "examples": [{
                         "host": "postgresql.example.com",
                         "type": "postgresql",
                         "port": 5432,
-                        "user": "user",
-                        "database": "cordacluster",
-                        "existingSecret": "postgresql-secret"
+                        "user": {
+                            "value": "user"
+                        },
+                        "password": {
+                            "value": "password"
+                        },
+                        "database": "cordacluster"
                     }]
                 },
                 "clientImage": {

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -61,7 +61,7 @@ db:
     port: 5432
     # -- the cluster database user
     user:
-      # -- the cluster username
+      # -- the cluster db username
       value: user
       # -- the username secret configuration
       valueFrom: 

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -51,7 +51,7 @@ nodeSelector: {}
 
 # Database configuration
 db:
-  # Cluster database configuration
+  # Cluster database 
   cluster:
     # -- the cluster database host (required)
     host: ""
@@ -60,13 +60,30 @@ db:
     # -- the cluster database port
     port: 5432
     # -- the cluster database user
-    user: user
-    # -- the name of the cluster database
-    database: cordacluster
+    user:
+      # -- the cluster username
+      value: user
+      # -- the username secret configuration
+      valueFrom: 
+        # -- the username secret key reference
+        secretkeyRef:
+          # -- the username secret name 
+          name: ""
+          # the username secret key 
+          usernameKey: ""
     # -- the cluster database password (ignored if existingSecret is set, otherwise required)
-    password: ""
-    # -- the name of an existing secret containing the cluster database password with a key of 'password'
-    existingSecret: ""
+    password: 
+      # -- the cluster passowrd
+      value: "" 
+      # -- the password secret configuration
+      valueFrom:
+        # -- the password secret key reference
+        secretkeyRef:
+          # -- the password secret name
+          name: ""
+          # -- the password secret key
+          passwordKey: ""
+    database: cordacluster
   clientImage:
     # -- registry for image containing a db client, used to set up the db
     registry: ""
@@ -75,7 +92,7 @@ db:
     # -- tag for image containing a db client, used to set up the db
     tag: "14.4"
 
-# Kafka configuration
+# Kafka 
 kafka:
   # -- comma-separated list of Kafka bootstrap servers (required)
   bootstrapServers: ""


### PR DESCRIPTION
This ticket is incomplete however I recommend we merge what has been done as a-lot has changed. This PR is to make changes so that the Corda workers can query an existing secret for both the db password and username
 
To test the changes the following should be put in your overrides 
```yaml
db:
  cluster:
    host: prereqs-postgresql 
    password:
      valueFrom:
        secretkeyRef:
          name: test-secret
          passwordKey: password 

    user:
      valueFrom: 
        secretkeyRef:
          name: test-secret2
          usernameKey: namename
```
For this deployment i created a secret for the username and one for the password. It was also tested using the same secret and no secret at all.
