### PR TITLE
CORE-7226: Configure Worker ReadinessProbe

### DIFF
--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -79,6 +79,12 @@ spec:
             containerPort: 10045
         {{- end }}
         {{- if not .Values.workers.crypto.debug.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: monitor
+          periodSeconds: 10
+          failureThreshold: 1
         livenessProbe:
           httpGet:
             path: /isHealthy

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -78,6 +78,12 @@ spec:
             containerPort: 10045
         {{- end }}
         {{- if not .Values.workers.db.debug.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: monitor
+          periodSeconds: 10
+          failureThreshold: 1
         livenessProbe:
           httpGet:
             path: /isHealthy

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -56,6 +56,12 @@ spec:
             containerPort: 10045
         {{- end }}
         {{- if not .Values.workers.flow.debug.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: monitor
+          periodSeconds: 10
+          failureThreshold: 1
         livenessProbe:
           httpGet:
             path: /isHealthy

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -44,6 +44,12 @@ spec:
             containerPort: 10045
         {{- end }}
         {{- if not .Values.workers.membership.debug.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: monitor
+          periodSeconds: 10
+          failureThreshold: 1
         livenessProbe:
           httpGet:
             path: /isHealthy

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -76,6 +76,12 @@ spec:
           - name: monitor
             containerPort: 7000
         {{- if not .Values.workers.p2pGateway.debug.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: monitor
+          periodSeconds: 10
+          failureThreshold: 1
         livenessProbe:
           httpGet:
             path: /isHealthy

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -59,6 +59,12 @@ spec:
             containerPort: 10045
         {{- end }}
         {{- if not .Values.workers.p2pLinkManager.debug.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: monitor
+          periodSeconds: 10
+          failureThreshold: 1
         livenessProbe:
           httpGet:
             path: /isHealthy


### PR DESCRIPTION
Update the helm chart so all worker pods have the kubernetes
'readinessProbe' configured as an 'httpGet' querying the '/status'
endpoint. The '/status' endpoint is already implemented by the
'WorkerMonitor' in all workers and checks whether all required
components have the 'UP' status.
