### PR TITLE
CORE-5375: Incorporate use of changesetId into runtime

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -653,7 +653,8 @@ internal class DatabaseCpiPersistenceTest {
                     "resources/$changeLog"
                 ),
                 newRandomSecureHash().toString(),
-                changeLog
+                changeLog,
+                UUID.randomUUID()
             )
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
@@ -21,7 +21,7 @@ import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.*
+import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class LiquibaseExtractorHelpersTest {

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/cpi/LiquibaseExtractorHelpersTest.kt
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class LiquibaseExtractorHelpersTest {
@@ -43,6 +44,7 @@ internal class LiquibaseExtractorHelpersTest {
         private val notLiquibase = """
                 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
                 <hello></hello>""".trimIndent()
+        private val fakeId = UUID.randomUUID()
 
         private const val notXml = "this is not xml"
     }
@@ -93,7 +95,7 @@ internal class LiquibaseExtractorHelpersTest {
         )
 
         val obj = LiquibaseExtractorHelpers()
-        val entities = jarWithLiquibase().inputStream().use { obj.getEntities(cpk, it) }
+        val entities = jarWithLiquibase().inputStream().use { obj.getEntities(cpk, it, fakeId) }
 
         assertThat(entities.size).isEqualTo(1)
     }
@@ -108,7 +110,7 @@ internal class LiquibaseExtractorHelpersTest {
         )
 
         val obj = LiquibaseExtractorHelpers()
-        val entities = cpkWithNestedJar().inputStream().use { obj.getEntities(cpk, it) }
+        val entities = cpkWithNestedJar().inputStream().use { obj.getEntities(cpk, it, fakeId) }
 
         assertThat(entities.size).isEqualTo(1)
     }
@@ -123,7 +125,7 @@ internal class LiquibaseExtractorHelpersTest {
         )
 
         val obj = LiquibaseExtractorHelpers()
-        val entities = jarWithoutLiquibase().inputStream().use { obj.getEntities(cpk, it) }
+        val entities = jarWithoutLiquibase().inputStream().use { obj.getEntities(cpk, it, fakeId) }
 
         assertThat(entities.size).isEqualTo(0)
     }
@@ -138,7 +140,7 @@ internal class LiquibaseExtractorHelpersTest {
         )
 
         val obj = LiquibaseExtractorHelpers()
-        val entities = jarWithBrokenLiquibase().inputStream().use { obj.getEntities(cpk, it) }
+        val entities = jarWithBrokenLiquibase().inputStream().use { obj.getEntities(cpk, it, fakeId) }
 
         assertThat(entities.size).isEqualTo(0)
     }
@@ -154,7 +156,7 @@ internal class LiquibaseExtractorHelpersTest {
 
 
         val obj = LiquibaseExtractorHelpers()
-        val entities = jarWithOtherXmlResource().inputStream().use { obj.getEntities(cpk, it) }
+        val entities = jarWithOtherXmlResource().inputStream().use { obj.getEntities(cpk, it, fakeId) }
 
         assertThat(entities.size).isEqualTo(0)
     }
@@ -194,7 +196,7 @@ internal class LiquibaseExtractorHelpersTest {
         // We're testing a **CPI**, not a *CPK**, so we're persisting
         // the scripts using the "mock cpk" as the db key.
 
-        val entities = getInputStream(EXTENDABLE_CPB).use { obj.getEntities(cpk, it) }
+        val entities = getInputStream(EXTENDABLE_CPB).use { obj.getEntities(cpk, it, fakeId) }
 
         // "extendable-cpb" contains cats.cpk (3) and dogs.cpk (2) liquibase files.
         val expectedLiquibaseFileCount = 5
@@ -210,7 +212,7 @@ internal class LiquibaseExtractorHelpersTest {
         val entities = mutableListOf<CpkDbChangeLogEntity>()
         cpi.cpks.forEach { cpk ->
             Files.newInputStream(cpk.path!!).use {
-                entities += obj.getEntities(cpk, it)
+                entities += obj.getEntities(cpk, it, fakeId)
             }
         }
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbChangeLogImplementationTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbChangeLogImplementationTest.kt
@@ -1,8 +1,6 @@
 package net.corda.virtualnode.write.db.impl.tests
 
-import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
-import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogKey
@@ -11,8 +9,7 @@ import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import javax.persistence.EntityManagerFactory
+import java.util.*
 
 class VirtualNodeDbChangeLogImplementationTest  {
     // It hardly seems worth bringing in a template system for one expansion, so we'll just do string replacement on _INCLUDETARGET_
@@ -44,6 +41,7 @@ class VirtualNodeDbChangeLogImplementationTest  {
     companion object {
         private val logger = contextLogger()
         private val dbConfig = DbUtils.getEntityManagerConfiguration("test")
+        private val fakeId = UUID.randomUUID()
     }
 
     private final fun doMigration(includeElement: String, failureText: String? = null) {
@@ -53,8 +51,8 @@ class VirtualNodeDbChangeLogImplementationTest  {
             }
         val lbm = LiquibaseSchemaMigratorImpl()
         val primaryContent = primaryTemplate.replace("_INCLUDETARGET_", includeElement)
-        val primary = CpkDbChangeLogEntity(CpkDbChangeLogKey("myCoolCpk", "1", "42", "migration/db.changelog-master.xml"), "42", primaryContent)
-        val secondary = CpkDbChangeLogEntity(CpkDbChangeLogKey("myCoolCpk", "1", "42", "migration/dogs-migration-v1.0.xml"), "42", secondaryContent)
+        val primary = CpkDbChangeLogEntity(CpkDbChangeLogKey("myCoolCpk", "1", "42", "migration/db.changelog-master.xml"), "42", primaryContent, fakeId)
+        val secondary = CpkDbChangeLogEntity(CpkDbChangeLogKey("myCoolCpk", "1", "42", "migration/dogs-migration-v1.0.xml"), "42", secondaryContent, fakeId)
         val cl = VirtualNodeDbChangeLog(listOf(primary, secondary))
         assertThat(cl.masterChangeLogFiles.size).isEqualTo(1)
         if (failureText != null) {

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbChangeLogImplementationTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbChangeLogImplementationTest.kt
@@ -9,7 +9,7 @@ import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import java.util.*
+import java.util.UUID
 
 class VirtualNodeDbChangeLogImplementationTest  {
     // It hardly seems worth bringing in a template system for one expansion, so we'll just do string replacement on _INCLUDETARGET_

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeDbChangeLogTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeDbChangeLogTest.kt
@@ -7,8 +7,10 @@ import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.UUID
 
 class VirtualNodeDbChangeLogTest {
+    private val fakeId = UUID.randomUUID()
     private val masterFile1 = CpkDbChangeLogEntity(
         CpkDbChangeLogKey(
             "CPK1",
@@ -17,7 +19,8 @@ class VirtualNodeDbChangeLogTest {
             VirtualNodeDbChangeLog.MASTER_CHANGE_LOG
         ),
         "cpk1-checksum",
-        "migration1"
+        "migration1",
+        fakeId
     )
     private val otherFile1 = CpkDbChangeLogEntity(
         CpkDbChangeLogKey(
@@ -27,7 +30,8 @@ class VirtualNodeDbChangeLogTest {
             "another-one.xml"
         ),
         "cpk1-checksum",
-        "migration2"
+        "migration2",
+        fakeId
     )
     private val masterFile2 = CpkDbChangeLogEntity(
         CpkDbChangeLogKey(
@@ -37,7 +41,8 @@ class VirtualNodeDbChangeLogTest {
             VirtualNodeDbChangeLog.MASTER_CHANGE_LOG
         ),
         "cpk1-checksum",
-        "migration3"
+        "migration3",
+        fakeId
     )
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.420-alpha-1666620939926
+cordaApiVersion=5.0.0.420-alpha-1666623635713
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.420-alpha-1666623635713
+cordaApiVersion=5.0.0.420-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.419-beta+
+cordaApiVersion=5.0.0.420-alpha-1666620939926
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
@@ -4,12 +4,7 @@ import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
-import net.corda.libs.cpi.datamodel.CpiEntities
-import net.corda.libs.cpi.datamodel.CpkDbChangeLogAuditEntity
-import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
-import net.corda.libs.cpi.datamodel.CpkDbChangeLogKey
-import net.corda.libs.cpi.datamodel.findDbChangeLogAuditForCpi
-import net.corda.libs.cpi.datamodel.findDbChangeLogForCpi
+import net.corda.libs.cpi.datamodel.*
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
@@ -20,10 +15,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.*
 import javax.persistence.EntityManager
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CpkDbChangeLogEntityTest {
+    private val fakeId = UUID.randomUUID()
     private val dbConfig: EntityManagerConfiguration =
         DbUtils.getEntityManagerConfiguration("cpk_changelog_db")
 
@@ -65,13 +62,15 @@ class CpkDbChangeLogEntityTest {
             CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion,
                 cpk.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
-            "master-content"
+            "master-content",
+            fakeId
         )
         val changeLog2 = CpkDbChangeLogEntity(
             CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion,
                 cpk.metadata.id.cpkSignerSummaryHash, "other"),
             "other-checksum",
-            "other-content"
+            "other-content",
+            fakeId
         )
 
         transaction {
@@ -100,7 +99,8 @@ class CpkDbChangeLogEntityTest {
             CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion,
                 cpk.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
-            "master-content"
+            "master-content",
+            fakeId
         )
 
         val changeLog1Audit = CpkDbChangeLogAuditEntity(changeLog1)
@@ -156,7 +156,8 @@ class CpkDbChangeLogEntityTest {
             CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion,
                 cpk.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
-            "master-content"
+            "master-content",
+            fakeId
         )
 
         val changeLog1Audit = CpkDbChangeLogAuditEntity(changeLog1)
@@ -216,7 +217,8 @@ class CpkDbChangeLogEntityTest {
         val changeLog1 = CpkDbChangeLogEntity(
             CpkDbChangeLogKey(cpk.metadata.id.cpkName, cpk.metadata.id.cpkVersion, cpk.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
-            "master-content"
+            "master-content",
+            fakeId
         )
 
         transaction {
@@ -261,7 +263,8 @@ class CpkDbChangeLogEntityTest {
             </column>
         </createTable>
     </changeSet>
-</databaseChangeLog>"""
+</databaseChangeLog>""",
+            fakeId
         )
         val changeLog1b = CpkDbChangeLogEntity(
             CpkDbChangeLogKey(cpk1b.metadata.id.cpkName, cpk1b.metadata.id.cpkVersion, cpk1b.metadata.id.cpkSignerSummaryHash, "master"),
@@ -277,17 +280,20 @@ class CpkDbChangeLogEntityTest {
             </addColumn>  
         </createTable>
     </changeSet>
-</databaseChangeLog>"""
+</databaseChangeLog>""",
+            fakeId
         )
         val changeLog2 = CpkDbChangeLogEntity(
             CpkDbChangeLogKey(cpk1.metadata.id.cpkName, cpk1.metadata.id.cpkVersion, cpk1.metadata.id.cpkSignerSummaryHash, "other"),
             "other-checksum",
-            "other-content"
+            "other-content",
+            fakeId
         )
         val changeLog3 = CpkDbChangeLogEntity(
             CpkDbChangeLogKey(cpk2.metadata.id.cpkName, cpk2.metadata.id.cpkVersion, cpk2.metadata.id.cpkSignerSummaryHash, "master"),
             "master-checksum",
-            "master-content"
+            "master-content",
+            fakeId
         )
 
         transaction {

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpkDbChangeLogEntityTest.kt
@@ -4,7 +4,12 @@ import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
-import net.corda.libs.cpi.datamodel.*
+import net.corda.libs.cpi.datamodel.CpiEntities
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogAuditEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.CpkDbChangeLogKey
+import net.corda.libs.cpi.datamodel.findDbChangeLogAuditForCpi
+import net.corda.libs.cpi.datamodel.findDbChangeLogForCpi
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
@@ -15,7 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.util.*
+import java.util.UUID
 import javax.persistence.EntityManager
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogAuditEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogAuditEntity.kt
@@ -51,8 +51,8 @@ data class CpkDbChangeLogAuditKey(
     var cpkSignerSummaryHash: String,
     @Column(name = "cpk_file_checksum", nullable = false)
     val fileChecksum: String,
-    @Column(name = "change_uuid", nullable = false)
-    var changeUUID: UUID,
+    @Column(name = "changeset_id", nullable = false)
+    val changesetId: UUID,
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int,
     @Column(name = "file_path", nullable = false)

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogAuditEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogAuditEntity.kt
@@ -91,29 +91,3 @@ fun findDbChangeLogAuditForCpi(
     .setParameter("version", cpi.version)
     .setParameter("signerSummaryHash", cpi.signerSummaryHash?.toString() ?: "")
     .resultList
-
-/*
- * Find all the audit db changelogs for a CPI
- */
-fun findDbChangeLogAuditForCpi(
-    entityManager: EntityManager,
-    cpi: CpiIdentifier,
-    changeUUIDs: Set<UUID>
-): List<CpkDbChangeLogAuditEntity> = entityManager.createQuery(
-    "SELECT changelog " +
-        "FROM ${CpkDbChangeLogAuditEntity::class.simpleName} AS changelog INNER JOIN " +
-        "${CpiCpkEntity::class.simpleName} AS cpi " +
-        "ON changelog.id.cpkName = cpi.metadata.id.cpkName AND " +
-        "   changelog.id.cpkVersion = cpi.id.cpkVersion AND " +
-        "   changelog.id.cpkSignerSummaryHash = cpi.id.cpkSignerSummaryHash " +
-        "WHERE cpi.id.cpiName = :name AND " +
-        "      cpi.id.cpiVersion = :version AND " +
-        "      cpi.id.cpiSignerSummaryHash = :signerSummaryHash AND " +
-        "      changelog.id.changeUUID IN :changeUUIDs",
-    CpkDbChangeLogAuditEntity::class.java
-)
-    .setParameter("name", cpi.name)
-    .setParameter("version", cpi.version)
-    .setParameter("signerSummaryHash", cpi.signerSummaryHash?.toString() ?: "")
-    .setParameter("changeUUIDs", changeUUIDs)
-    .resultList

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkDbChangeLogEntity.kt
@@ -4,6 +4,7 @@ import net.corda.db.schema.DbSchema
 import net.corda.libs.packaging.core.CpiIdentifier
 import java.io.Serializable
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Embeddable
 import javax.persistence.EmbeddedId
@@ -24,6 +25,8 @@ class CpkDbChangeLogEntity(
     val fileChecksum: String,
     @Column(name = "content", nullable = false)
     val content: String,
+    @Column(name = "changeset_id", nullable = false)
+    val changesetId: UUID
 ) {
     // This structure does not distinguish the root changelogs from changelog include files
     // (or CSVs, which we do not need to support). So, to find the root, you need to look for a filename


### PR DESCRIPTION
Thin PR to incorporate https://github.com/corda/corda-api/pull/655. Will be used as a base for https://github.com/corda/corda-runtime-os/pull/2226