### PR TITLE
CORE-5088 Consensual ledger persistence

### DIFF
--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceService.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceService.kt
@@ -1,9 +1,9 @@
 package net.corda.ledger.consensual.flow.impl.persistence
 
 import net.corda.ledger.common.data.transaction.CordaPackageSummary
-import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 
 /**
  * [ConsensualLedgerPersistenceService] allows to insert and find consensual signed transactions in the persistent store provided
@@ -11,7 +11,7 @@ import net.corda.v5.crypto.SecureHash
  */
 interface ConsensualLedgerPersistenceService {
     /**
-     * Persist a [ConsensualSignedTransactionContainer] to the store.
+     * Persist a [ConsensualSignedTransaction] to the store.
      *
      * @param transaction Consensual signed transaction to persist.
      * @param transactionStatus Transaction's status
@@ -20,7 +20,7 @@ interface ConsensualLedgerPersistenceService {
      *
      * @throws CordaPersistenceException if an error happens during persist operation.
      */
-    fun persist(transaction: ConsensualSignedTransactionContainer, transactionStatus: String): List<CordaPackageSummary>
+    fun persist(transaction: ConsensualSignedTransaction, transactionStatus: String): List<CordaPackageSummary>
 
     /**
      * Find a consensual signed transaction in the persistence context given it's [id].
@@ -31,5 +31,5 @@ interface ConsensualLedgerPersistenceService {
      *
      * @throws CordaPersistenceException if an error happens during find operation.
      */
-    fun find(id: SecureHash): ConsensualSignedTransactionContainer?
+    fun find(id: SecureHash): ConsensualSignedTransaction?
 }

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceService.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceService.kt
@@ -1,8 +1,9 @@
 package net.corda.ledger.consensual.flow.impl.persistence
 
+import net.corda.ledger.common.data.transaction.CordaPackageSummary
+import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 
 /**
  * [ConsensualLedgerPersistenceService] allows to insert and find consensual signed transactions in the persistent store provided
@@ -10,13 +11,16 @@ import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
  */
 interface ConsensualLedgerPersistenceService {
     /**
-     * Persist a [ConsensualSignedTransaction] to the store.
+     * Persist a [ConsensualSignedTransactionContainer] to the store.
      *
      * @param transaction Consensual signed transaction to persist.
+     * @param transactionStatus Transaction's status
+     *
+     * @return list of [CordaPackageSummary] for missing CPKs (that were not linked)
      *
      * @throws CordaPersistenceException if an error happens during persist operation.
      */
-    fun persist(transaction: ConsensualSignedTransaction)
+    fun persist(transaction: ConsensualSignedTransactionContainer, transactionStatus: String): List<CordaPackageSummary>
 
     /**
      * Find a consensual signed transaction in the persistence context given it's [id].
@@ -27,5 +31,5 @@ interface ConsensualLedgerPersistenceService {
      *
      * @throws CordaPersistenceException if an error happens during find operation.
      */
-    fun find(id: SecureHash): ConsensualSignedTransaction?
+    fun find(id: SecureHash): ConsensualSignedTransactionContainer?
 }

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/external/events/PersistTransactionExternalEventFactory.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/external/events/PersistTransactionExternalEventFactory.kt
@@ -14,8 +14,8 @@ class PersistTransactionExternalEventFactory : AbstractConsensualLedgerExternalE
     constructor(clock: Clock) : super(clock)
 
     override fun createRequest(parameters: PersistTransactionParameters): Any {
-        return PersistTransaction(parameters.transaction)
+        return PersistTransaction(parameters.transaction, parameters.transactionStatus)
     }
 }
 
-data class PersistTransactionParameters(val transaction: ByteBuffer)
+data class PersistTransactionParameters(val transaction: ByteBuffer, val transactionStatus: String)

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -22,9 +22,9 @@ class ConsensualSignedTransactionImpl(
     private val serializationService: SerializationService,
     private val signingService: SigningService,
     private val digitalSignatureVerificationService: DigitalSignatureVerificationService,
-    val wireTransaction: WireTransaction,
+    override val wireTransaction: WireTransaction,
     override val signatures: List<DigitalSignatureAndMetadata>
-): ConsensualSignedTransaction
+): ConsensualSignedTransactionInternal
 {
 
     init {

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
@@ -1,0 +1,13 @@
+package net.corda.ledger.consensual.flow.impl.transaction
+
+import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
+import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
+
+/**
+ * This interface adds [WireTransaction] to interface [ConsensualSignedTransaction] so that there is possible conversion
+ * to and from [ConsensualSignedTransactionContainer].
+ */
+interface ConsensualSignedTransactionInternal: ConsensualSignedTransaction {
+    val wireTransaction: WireTransaction
+}

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
@@ -1,12 +1,13 @@
 package net.corda.ledger.consensual.flow.impl.persistence
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.ledger.common.data.transaction.CordaPackageSummary
+import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.AbstractConsensualLedgerExternalEventFactory
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.serialization.SerializedBytes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -48,21 +49,25 @@ class ConsensualLedgerPersistenceServiceImplTest {
 
     @Test
     fun `persist executes successfully`() {
-        consensualLedgerPersistenceService.persist(mock())
+        val expectedObj = mock<CordaPackageSummary>()
+        whenever(serializationService.deserialize<CordaPackageSummary>(any<ByteArray>(), any())).thenReturn(expectedObj)
+
+        assertThat(consensualLedgerPersistenceService.persist(mock(), "V")).isEqualTo(listOf(expectedObj))
 
         verify(serializationService).serialize(any())
+        verify(serializationService).deserialize<CordaPackageSummary>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(PersistTransactionExternalEventFactory::class.java)
     }
 
     @Test
     fun `find executes successfully`() {
-        val expectedObj = mock<ConsensualSignedTransaction>()
+        val expectedObj = mock<ConsensualSignedTransactionContainer>()
         val testId = SecureHash.parse("SHA256:1234567890123456")
-        whenever(serializationService.deserialize<ConsensualSignedTransaction>(any<ByteArray>(), any())).thenReturn(expectedObj)
+        whenever(serializationService.deserialize<ConsensualSignedTransactionContainer>(any<ByteArray>(), any())).thenReturn(expectedObj)
 
         assertThat(consensualLedgerPersistenceService.find(testId)).isEqualTo(expectedObj)
 
-        verify(serializationService).deserialize<ConsensualSignedTransaction>(any<ByteArray>(), any())
+        verify(serializationService).deserialize<ConsensualSignedTransactionContainer>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(FindTransactionExternalEventFactory::class.java)
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
@@ -2,10 +2,16 @@ package net.corda.ledger.consensual.flow.impl.persistence
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.ledger.common.data.transaction.CordaPackageSummary
+import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.AbstractConsensualLedgerExternalEventFactory
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
+import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
+import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.DigitalSignatureVerificationService
+import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SerializedBytes
@@ -26,8 +32,10 @@ class ConsensualLedgerPersistenceServiceImplTest {
         private val serializedBytes = SerializedBytes<Any>(byteBuffer.array())
     }
 
-    private val serializationService = mock<SerializationService>()
     private val externalEventExecutor = mock<ExternalEventExecutor>()
+    private val serializationService = mock<SerializationService>()
+    private val signingService = mock<SigningService>()
+    private val digitalSignatureVerificationService = mock<DigitalSignatureVerificationService>()
 
     private lateinit var consensualLedgerPersistenceService: ConsensualLedgerPersistenceService
 
@@ -35,8 +43,9 @@ class ConsensualLedgerPersistenceServiceImplTest {
 
     @BeforeEach
     fun setup() {
-        consensualLedgerPersistenceService =
-            ConsensualLedgerPersistenceServiceImpl(externalEventExecutor, serializationService)
+        consensualLedgerPersistenceService = ConsensualLedgerPersistenceServiceImpl(
+                externalEventExecutor, serializationService, signingService, digitalSignatureVerificationService
+        )
 
         whenever(serializationService.serialize(any())).thenReturn(serializedBytes)
         whenever(
@@ -51,8 +60,11 @@ class ConsensualLedgerPersistenceServiceImplTest {
     fun `persist executes successfully`() {
         val expectedObj = mock<CordaPackageSummary>()
         whenever(serializationService.deserialize<CordaPackageSummary>(any<ByteArray>(), any())).thenReturn(expectedObj)
+        val transaction = mock<ConsensualSignedTransactionInternal>()
+        whenever(transaction.wireTransaction).thenReturn(mock())
+        whenever(transaction.signatures).thenReturn(mock())
 
-        assertThat(consensualLedgerPersistenceService.persist(mock(), "V")).isEqualTo(listOf(expectedObj))
+        assertThat(consensualLedgerPersistenceService.persist(transaction, "V")).isEqualTo(listOf(expectedObj))
 
         verify(serializationService).serialize(any())
         verify(serializationService).deserialize<CordaPackageSummary>(any<ByteArray>(), any())
@@ -61,13 +73,22 @@ class ConsensualLedgerPersistenceServiceImplTest {
 
     @Test
     fun `find executes successfully`() {
-        val expectedObj = mock<ConsensualSignedTransactionContainer>()
+        val wireTransaction = mock<WireTransaction>()
+        val signatures = listOf(mock<DigitalSignatureAndMetadata>())
+        val expectedObj = ConsensualSignedTransactionImpl(
+            serializationService,
+            signingService,
+            digitalSignatureVerificationService,
+            wireTransaction,
+            signatures
+        )
         val testId = SecureHash.parse("SHA256:1234567890123456")
-        whenever(serializationService.deserialize<ConsensualSignedTransactionContainer>(any<ByteArray>(), any())).thenReturn(expectedObj)
+        whenever(serializationService.deserialize<ConsensualSignedTransactionContainer>(any<ByteArray>(), any()))
+            .thenReturn(ConsensualSignedTransactionContainer(wireTransaction, signatures))
 
         assertThat(consensualLedgerPersistenceService.find(testId)).isEqualTo(expectedObj)
 
-        verify(serializationService).deserialize<ConsensualSignedTransactionContainer>(any<ByteArray>(), any())
+        verify(serializationService).deserialize<ConsensualSignedTransactionInternal>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(FindTransactionExternalEventFactory::class.java)
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/external/events/AbstractConsensualLedgerExternalEventFactoryTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/external/events/AbstractConsensualLedgerExternalEventFactoryTest.kt
@@ -18,7 +18,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
-val TEST_CLOCK = Clock.fixed(Instant.now(), ZoneId.of("UTC"))
+val TEST_CLOCK: Clock = Clock.fixed(Instant.now(), ZoneId.of("UTC"))
 val ALICE_X500_HOLDING_IDENTITY = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group1")
 
 class AbstractConsensualLedgerExternalEventFactoryTest {

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/external/events/PersistTransactionExternalEventFactoryTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/external/events/PersistTransactionExternalEventFactoryTest.kt
@@ -28,11 +28,12 @@ class PersistTransactionExternalEventFactoryTest {
         whenever(checkpoint.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
 
         val transaction = ByteBuffer.wrap(byteArrayOf(1))
+        val transactionStatus = "V"
 
         val externalEventRecord = PersistTransactionExternalEventFactory(testClock).createExternalEvent(
             checkpoint,
             externalEventContext,
-            PersistTransactionParameters(transaction)
+            PersistTransactionParameters(transaction, transactionStatus)
         )
         assertEquals(Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC, externalEventRecord.topic)
         assertNull(externalEventRecord.key)
@@ -40,7 +41,7 @@ class PersistTransactionExternalEventFactoryTest {
             ConsensualLedgerRequest(
                 testClock.instant(),
                 ALICE_X500_HOLDING_IDENTITY,
-                PersistTransaction(transaction),
+                PersistTransaction(transaction, transactionStatus),
                 externalEventContext
             ),
             externalEventRecord.payload

--- a/components/ledger/ledger-consensual-flow/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/components/ledger/ledger-consensual-flow/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/components/ledger/ledger-consensual-persistence-impl/build.gradle
+++ b/components/ledger/ledger-consensual-persistence-impl/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     implementation project(':libs:flows:external-event-responses')
     implementation project(':libs:ledger:ledger-common-data')
-    implementation project(':components:ledger:ledger-common-flow')
+    implementation project(':libs:ledger:ledger-consensual-data')
     implementation project(":libs:messaging:messaging")
     implementation project(':libs:utilities')
     implementation project(':libs:virtual-node:sandbox-group-context')
@@ -44,6 +44,7 @@ dependencies {
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-db-schema'
     implementation "net.corda:corda-ledger-common"
+    implementation "net.corda:corda-ledger-consensual"
     implementation 'net.corda:corda-topic-schema'
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation 'org.slf4j:slf4j-api'
@@ -72,7 +73,9 @@ dependencies {
     integrationTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 
     integrationTestImplementation project(':libs:db:db-admin-impl')
+    integrationTestImplementation project(':libs:db:db-orm-impl')
     integrationTestImplementation project(':libs:ledger:ledger-common-data')
+    integrationTestImplementation project(':libs:serialization:serialization-amqp')
     integrationTestImplementation project(':libs:serialization:serialization-internal')
     integrationTestImplementation project(":testing:db-message-bus-testkit")
     integrationTestImplementation project(':testing:ledger:ledger-common-testkit')
@@ -103,4 +106,7 @@ def integrationTestResources = tasks.named('processIntegrationTestResources', Pr
 
 tasks.named('testingBundle', Bundle) {
     dependsOn integrationTestResources
+    bnd '''\
+    DynamicImport-Package: org.hibernate.proxy
+    '''
 }

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -65,6 +65,7 @@ import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
 import java.nio.ByteBuffer
 import java.nio.file.Path
+import java.security.PublicKey
 import java.time.Instant
 import java.util.UUID
 
@@ -110,6 +111,7 @@ class ConsensualLedgerMessageProcessorTests {
     @InjectService
     lateinit var jsonMarshallingService: JsonMarshallingService
     private lateinit var wireTransactionSerializer: InternalCustomSerializer<WireTransaction>
+    private lateinit var publicKeySerializer: InternalCustomSerializer<PublicKey>
     private lateinit var ctx: DbTestContext
 
     @BeforeAll
@@ -130,6 +132,10 @@ class ConsensualLedgerMessageProcessorTests {
             virtualNodeInfoReadService = setup.fetchService(timeout = 10000)
             wireTransactionSerializer = setup.fetchService(
                 "(component.name=net.corda.ledger.common.data.transaction.serializer.amqp.WireTransactionSerializer)",
+                10000
+            )
+            publicKeySerializer = setup.fetchService(
+                "(component.name=net.corda.crypto.impl.serialization.PublicKeySerializer)",
                 10000
             )
             deserializer = setup.fetchService<CordaAvroSerializationFactory>(timeout = 10000)
@@ -214,7 +220,7 @@ class ConsensualLedgerMessageProcessorTests {
 
         val componentContext = Mockito.mock(ComponentContext::class.java)
         whenever(componentContext.locateServices(INTERNAL_CUSTOM_SERIALIZERS))
-            .thenReturn(arrayOf(wireTransactionSerializer))
+            .thenReturn(arrayOf(wireTransactionSerializer, publicKeySerializer))
 
         // set up sandbox
         val entitySandboxService =

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -20,10 +20,16 @@ import net.corda.db.persistence.testkit.fake.FakeDbConnectionManager
 import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.persistence.testkit.helpers.SandboxHelper.getSerializer
 import net.corda.db.schema.DbSchema
-import net.corda.db.testkit.DbUtils
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
+import net.corda.ledger.common.data.transaction.TransactionMetaData
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
+import net.corda.ledger.common.testkit.cpiPackgeSummaryExample
+import net.corda.ledger.common.testkit.cpkPackageSummaryListExample
 import net.corda.ledger.common.testkit.getWireTransactionExample
+import net.corda.ledger.common.testkit.signatureWithMetaDataExample
+import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl
+import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
 import net.corda.ledger.consensual.persistence.impl.processor.ConsensualLedgerMessageProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.orm.JpaEntitiesSet
@@ -35,13 +41,13 @@ import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.v5.application.marshalling.JsonMarshallingService
+import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.DigestService
 import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -99,10 +105,8 @@ class ConsensualLedgerMessageProcessorTests {
 
     @InjectService
     lateinit var digestService: DigestService
-
     @InjectService
     lateinit var merkleTreeProvider: MerkleTreeProvider
-
     @InjectService
     lateinit var jsonMarshallingService: JsonMarshallingService
     private lateinit var wireTransactionSerializer: InternalCustomSerializer<WireTransaction>
@@ -136,44 +140,19 @@ class ConsensualLedgerMessageProcessorTests {
     @BeforeEach
     fun beforeEach() {
         ctx = createDbTestContext()
-        // Each test is likely to leave junk lying around in the tables before the next test.
-        // We can't trust deleting the tables because tests can run concurrently.
     }
-
-    /* Simple wrapper to serialize bytes correctly during test */
-    private fun SandboxGroupContext.serialize(obj: Any): ByteBuffer {
-        val serializer = getSerializer(SANDBOX_SERIALIZER)
-        //val serializer = serializationService
-        return ByteBuffer.wrap(serializer.serialize(obj).bytes)
-    }
-
-    /* Simple wrapper to serialize bytes correctly during test */
-    private fun DbTestContext.serialize(obj: Any) = sandbox.serialize(obj)
-
-    /* Simple wrapper to deserialize */
-    private fun SandboxGroupContext.deserialize(bytes: ByteBuffer) =
-        getSerializer(SANDBOX_SERIALIZER).deserialize(bytes.array(), Any::class.java)
-
-    /* Simple wrapper to deserialize */
-    private fun DbTestContext.deserialize(bytes: ByteBuffer) = sandbox.deserialize(bytes)
-
-    private fun noOpPayloadCheck(bytes: ByteBuffer) = bytes
 
     @Test
-    fun `persistTransaction for consensual ledger deserialises the tx and persists`() {
-        // Native SQL is used that is specific to Postgres and won't work with in-memory DB
-        Assumptions.assumeFalse(DbUtils.isInMemory, "Skipping this test when run against in-memory DB.")
+    fun `persistTransaction for consensual ledger deserialises the transaction and persists`() {
+        val transaction = createTestTransaction()
 
-        // create ConsensualSignedTransactionImpl instance (or WireTransaction at first)
-        val tx = getWireTransactionExample(digestService, merkleTreeProvider, jsonMarshallingService)
-        logger.info("WireTransaction: ", tx)
-
-        // serialise tx into bytebuffer and add to PersistTransaction payload
-        val serializedTransaction = ctx.serialize(tx)
-        val persistTransaction = PersistTransaction(serializedTransaction)
+        // Serialise tx into bytebuffer and add to PersistTransaction payload
+        val serializedTransaction = ctx.serialize(transaction)
+        val transactionStatus = "V"
+        val persistTransaction = PersistTransaction(serializedTransaction, transactionStatus)
         val request = createRequest(ctx.virtualNodeInfo.holdingIdentity, persistTransaction)
 
-        // send request to message processor
+        // Send request to message processor
         val processor = ConsensualLedgerMessageProcessor(
             ctx.entitySandboxService,
             externalEventResponseFactory,
@@ -185,12 +164,12 @@ class ConsensualLedgerMessageProcessorTests {
         val requestId = UUID.randomUUID().toString()
         val records = listOf(Record(TOPIC, requestId, request))
 
-        // process the messages. This should result in ConsensualStateDAO persisting things to the DB
+        // Process the messages (this should persist transaction to the DB)
         var responses = assertSuccessResponses(processor.onNext(records))
         assertThat(responses.size).isEqualTo(1)
 
-        // check that we wrote the expected things to the DB
-        val findRequest = createRequest(ctx.virtualNodeInfo.holdingIdentity, FindTransaction(tx.id.toHexString()))
+        // Check that we wrote the expected things to the DB
+        val findRequest = createRequest(ctx.virtualNodeInfo.holdingIdentity, FindTransaction(transaction.id.toHexString()))
         responses = assertSuccessResponses(processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), findRequest))))
 
         assertThat(responses.size).isEqualTo(1)
@@ -199,13 +178,36 @@ class ConsensualLedgerMessageProcessorTests {
         assertThat(response.error).isNull()
         val entityResponse = deserializer.deserialize(response.payload.array())!!
         assertThat(entityResponse.results.size).isEqualTo(1)
-        assertThat(entityResponse.results.first()).isEqualTo(serializedTransaction) // need to reconstruct tx from the serialised response
+        assertThat(entityResponse.results.first()).isEqualTo(serializedTransaction)
+        val retrievedTransaction = ctx.deserialize<ConsensualSignedTransactionContainer>(serializedTransaction)
+        assertThat(retrievedTransaction).isEqualTo(transaction)
+    }
+
+    private fun createTestTransaction(): ConsensualSignedTransactionContainer {
+        val consensualTransactionMetaDataExample = TransactionMetaData(linkedMapOf(
+            TransactionMetaData.LEDGER_MODEL_KEY to ConsensualLedgerTransactionImpl::class.java.canonicalName,
+            TransactionMetaData.LEDGER_VERSION_KEY to "1.0",
+            TransactionMetaData.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,
+            TransactionMetaData.PLATFORM_VERSION_KEY to 123,
+            TransactionMetaData.CPI_METADATA_KEY to cpiPackgeSummaryExample,
+            TransactionMetaData.CPK_METADATA_KEY to cpkPackageSummaryListExample
+        ))
+        val wireTransaction = getWireTransactionExample(
+            digestService,
+            merkleTreeProvider,
+            jsonMarshallingService,
+            consensualTransactionMetaDataExample
+        )
+        return  ConsensualSignedTransactionContainer(
+            wireTransaction,
+            listOf(signatureWithMetaDataExample)
+        )
     }
 
     private fun createDbTestContext(): DbTestContext {
         val virtualNodeInfo = virtualNode.load(Resources.EXTENDABLE_CPB)
 
-        val testId = (0..1000000).random() // keeping this shorter than UUID.
+        val testId = (0..1000000).random()
         val schemaName = "consensual_ledger_test_$testId"
         val dbConnection = Pair(virtualNodeInfo.vaultDmlConnectionId, "connection-1")
         val dbConnectionManager = FakeDbConnectionManager(listOf(dbConnection), schemaName)
@@ -254,6 +256,15 @@ class ConsensualLedgerMessageProcessorTests {
         )
     }
 
+    private fun createRequest(
+        holdingId: net.corda.virtualnode.HoldingIdentity,
+        request: Any,
+        externalEventContext: ExternalEventContext = EXTERNAL_EVENT_CONTEXT
+    ): ConsensualLedgerRequest {
+        logger.info("Consensual ledger persistence request: ${request.javaClass.simpleName} $request")
+        return ConsensualLedgerRequest(Instant.now(), holdingId.toAvro(), request, externalEventContext)
+    }
+
     private fun assertSuccessResponses(records: List<Record<*, *>>): List<Record<*, *>> {
         records.forEach {
             val flowEvent = it.value as FlowEvent
@@ -266,24 +277,19 @@ class ConsensualLedgerMessageProcessorTests {
         return records
     }
 
-    private fun assertFailureResponses(records: List<Record<*, *>>): List<Record<*, *>> {
-        records.forEach {
-            val flowEvent = it.value as FlowEvent
-            val response = flowEvent.payload as ExternalEventResponse
-            if (response.error == null) {
-                logger.error("Incorrect successful response: ${response.error}")
-            }
-            assertThat(response.error).isNotNull()
-        }
-        return records
-    }
+    /* Simple wrapper to serialize bytes correctly during test */
+    private fun SandboxGroupContext.serialize(obj: Any) =
+        ByteBuffer.wrap(getSerializer(SANDBOX_SERIALIZER).serialize(obj).bytes)
 
-    private fun createRequest(
-        holdingId: net.corda.virtualnode.HoldingIdentity,
-        request: Any,
-        externalEventContext: ExternalEventContext = EXTERNAL_EVENT_CONTEXT
-    ): ConsensualLedgerRequest {
-        logger.info("Consensual ledger persistence request: ${request.javaClass.simpleName} $request")
-        return ConsensualLedgerRequest(Instant.now(), holdingId.toAvro(), request, externalEventContext)
-    }
+    /* Simple wrapper to serialize bytes correctly during test */
+    private fun DbTestContext.serialize(obj: Any) = sandbox.serialize(obj)
+
+    /* Simple wrapper to deserialize */
+    private inline fun <reified T : Any> SandboxGroupContext.deserialize(bytes: ByteBuffer) =
+        getSerializer(SANDBOX_SERIALIZER).deserialize<T>(bytes.array())
+
+    /* Simple wrapper to deserialize */
+    private inline fun <reified T : Any> DbTestContext.deserialize(bytes: ByteBuffer) = sandbox.deserialize<T>(bytes)
+
+    private fun noOpPayloadCheck(bytes: ByteBuffer) = bytes
 }

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerRepositoryTest.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerRepositoryTest.kt
@@ -1,0 +1,409 @@
+package net.corda.ledger.consensual.persistence.impl.processor.tests
+
+import net.corda.db.admin.impl.ClassloaderChangeLog
+import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
+import net.corda.db.schema.DbSchema
+import net.corda.db.testkit.DbUtils
+import net.corda.internal.serialization.SerializationContextImpl
+import net.corda.internal.serialization.SerializationServiceImpl
+import net.corda.internal.serialization.amqp.DefaultDescriptorBasedSerializerRegistry
+import net.corda.internal.serialization.amqp.DeserializationInput
+import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.SerializerFactory
+import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
+import net.corda.internal.serialization.amqp.amqpMagic
+import net.corda.internal.serialization.registerCustomSerializers
+import net.corda.ledger.common.data.transaction.CordaPackageSummary
+import net.corda.ledger.common.data.transaction.PrivacySaltImpl
+import net.corda.ledger.common.data.transaction.TransactionMetaData
+import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
+import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
+import net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel.ConsensualCpkEntity
+import net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel.ConsensualLedgerEntities
+import net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel.ConsensualTransactionComponentEntity
+import net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel.ConsensualTransactionEntity
+import net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel.ConsensualTransactionSignatureEntity
+import net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel.ConsensualTransactionStatusEntity
+import net.corda.ledger.consensual.persistence.impl.repository.ConsensualLedgerRepository
+import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
+import net.corda.orm.utils.transaction
+import net.corda.sandbox.SandboxCreationService
+import net.corda.sandbox.SandboxGroup
+import net.corda.serialization.InternalCustomSerializer
+import net.corda.serialization.SerializationContext
+import net.corda.testing.sandboxes.SandboxSetup
+import net.corda.testing.sandboxes.fetchService
+import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.DigitalSignatureMetadata
+import net.corda.v5.application.marshalling.JsonMarshallingService
+import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.types.toHexString
+import net.corda.v5.cipher.suite.DigestService
+import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.v5.crypto.DigitalSignature
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.io.TempDir
+import org.osgi.framework.BundleContext
+import org.osgi.test.common.annotation.InjectBundleContext
+import org.osgi.test.common.annotation.InjectService
+import org.osgi.test.junit5.context.BundleContextExtension
+import org.osgi.test.junit5.service.ServiceExtension
+import java.nio.file.Path
+import java.security.KeyPairGenerator
+import java.security.MessageDigest
+import java.security.PublicKey
+import java.security.spec.ECGenParameterSpec
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import javax.persistence.EntityManagerFactory
+import kotlin.random.Random
+
+@ExtendWith(ServiceExtension::class, BundleContextExtension::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ConsensualLedgerRepositoryTest {
+    @RegisterExtension
+    private val lifecycle = EachTestLifecycle()
+    @InjectService
+    lateinit var digestService: DigestService
+    @InjectService
+    lateinit var merkleTreeProvider: MerkleTreeProvider
+    @InjectService
+    lateinit var jsonMarshallingService: JsonMarshallingService
+
+    private lateinit var serializationService: SerializationService
+    private lateinit var emptySandboxGroup: SandboxGroup
+    private lateinit var repository: ConsensualLedgerRepository
+    private val emConfig = DbUtils.getEntityManagerConfiguration("ledger_db_for_test")
+    private val entityManagerFactory: EntityManagerFactory
+
+    companion object {
+        private const val MIGRATION_FILE_LOCATION = "net/corda/db/schema/vnode-vault/db.changelog-master.xml"
+        private val seedSequence = AtomicInteger((0..Int.MAX_VALUE/2).random())
+    }
+
+    init {
+        val dbChange = ClassloaderChangeLog(
+            linkedSetOf(
+                ClassloaderChangeLog.ChangeLogResourceFiles(
+                    DbSchema::class.java.packageName,
+                    listOf(MIGRATION_FILE_LOCATION),
+                    DbSchema::class.java.classLoader
+                )
+            )
+        )
+        emConfig.dataSource.connection.use { connection ->
+            LiquibaseSchemaMigratorImpl().updateDb(connection, dbChange)
+        }
+        entityManagerFactory = EntityManagerFactoryFactoryImpl().create(
+            "test_unit",
+            ConsensualLedgerEntities.classes.toList(),
+            emConfig
+        )
+    }
+
+    @BeforeAll
+    fun setup(
+        @InjectService(timeout = 1000)
+        sandboxSetup: SandboxSetup,
+        @InjectBundleContext
+        bundleContext: BundleContext,
+        @TempDir
+        testDirectory: Path
+    ) {
+        sandboxSetup.configure(bundleContext, testDirectory)
+        lifecycle.accept(sandboxSetup) { setup ->
+            val sandboxCreationService = setup.fetchService<SandboxCreationService>(timeout = 1500)
+            val publicKeySerializer = setup.fetchService<InternalCustomSerializer<PublicKey>>(
+                "(component.name=net.corda.crypto.impl.serialization.PublicKeySerializer)",
+                1500
+            )
+            emptySandboxGroup = sandboxCreationService.createSandboxGroup(emptyList())
+            serializationService = getTestSerializationService(emptySandboxGroup) {
+                it.register(publicKeySerializer, it)
+            }
+            repository = ConsensualLedgerRepository(merkleTreeProvider, digestService, jsonMarshallingService, serializationService)
+            setup.withCleanup {
+                sandboxCreationService.unloadSandboxGroup(emptySandboxGroup)
+            }
+        }
+    }
+
+    private fun getTestSerializationService(
+        sandboxGroup: SandboxGroup,
+        registerMoreSerializers: (it: SerializerFactory) -> Unit,
+    ) : SerializationService {
+        val serializationContext = SerializationContextImpl(
+            preferredSerializationVersion = amqpMagic,
+            properties = mutableMapOf(),
+            objectReferencesEnabled = false,
+            useCase = SerializationContext.UseCase.Testing,
+            encoding = null,
+            sandboxGroup = sandboxGroup
+        )
+        val factory = SerializerFactoryBuilder.build(
+            sandboxGroup,
+            descriptorBasedSerializerRegistry = DefaultDescriptorBasedSerializerRegistry(),
+            allowEvolution = false
+        ).also {
+            registerCustomSerializers(it)
+            registerMoreSerializers(it)
+        }
+        return SerializationServiceImpl(
+            SerializationOutput(factory),
+            DeserializationInput(factory),
+            serializationContext)
+    }
+
+    @Suppress("Unused")
+    @AfterAll
+    fun cleanup() {
+        emConfig.close()
+        entityManagerFactory.close()
+    }
+
+    @Test
+    fun `can read signed transaction`() {
+        val account = "Account"
+        val signedTransaction = createSignedTransaction()
+        val cpks = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        val existingCpks = cpks.take(2)
+        entityManagerFactory.transaction { em ->
+            val createdTs = Instant.now()
+            val dbExistingCpks = existingCpks.mapIndexed { i, cpk ->
+                ConsensualCpkEntity(cpk.fileChecksum, cpk.name, cpk.signerSummaryHash!!, cpk.version, "file$i".toByteArray(), createdTs)
+            }.onEach(em::persist)
+
+            ConsensualTransactionEntity(
+                signedTransaction.id.toHexString(),
+                signedTransaction.wireTransaction.privacySalt.bytes,
+                account,
+                Instant.now()
+            ).apply {
+                components.addAll(
+                    signedTransaction.wireTransaction.componentGroupLists.flatMapIndexed { groupIndex, componentGroup ->
+                        componentGroup.mapIndexed { leafIndex: Int, component ->
+                            ConsensualTransactionComponentEntity(
+                                this,
+                                groupIndex,
+                                leafIndex,
+                                component,
+                                MessageDigest.getInstance("SHA-256").digest(component).toHexString(),
+                                createdTs
+                            )
+                        }
+                    }
+                )
+                statuses.addAll(listOf(
+                    ConsensualTransactionStatusEntity(this, "V", Instant.now())
+                ))
+                signatures.addAll(
+                    signedTransaction.signatures.mapIndexed { index, signature ->
+                        ConsensualTransactionSignatureEntity(
+                            this,
+                            index,
+                            serializationService.serialize(signature).bytes,
+                            MessageDigest.getInstance("SHA-256").digest(signature.by.encoded).toHexString(),
+                            createdTs
+                        )
+                    }
+                )
+                this.cpks.addAll(dbExistingCpks)
+                em.persist(this)
+            }
+        }
+
+        val dbSignedTransaction = entityManagerFactory.createEntityManager().transaction { em ->
+            repository.findTransaction(em, signedTransaction.id.toHexString())
+        }
+
+        assertThat(dbSignedTransaction).isEqualTo(signedTransaction)
+    }
+
+    @Test
+    fun `can persist signed transaction`() {
+        val account = "Account"
+        val transactionStatus = "V"
+        val signedTransaction = createSignedTransaction()
+
+        // Persist transaction
+        entityManagerFactory.createEntityManager().transaction { em ->
+            repository.persistTransaction(em, signedTransaction, transactionStatus, account)
+        }
+
+        // Verify persisted data
+        entityManagerFactory.transaction { em ->
+            val dbTransaction = em.find(ConsensualTransactionEntity::class.java, signedTransaction.id.toHexString())
+
+            assertThat(dbTransaction).isNotNull
+            assertThat(dbTransaction.privacySalt).isEqualTo(signedTransaction.wireTransaction.privacySalt.bytes)
+            assertThat(dbTransaction.accountId).isEqualTo(account)
+            assertThat(dbTransaction.created).isNotNull
+            val createdTs = dbTransaction.created
+
+            val componentGroupLists = signedTransaction.wireTransaction.componentGroupLists
+            assertThat(dbTransaction.components).isNotNull
+            assertThat(dbTransaction.components.size).isEqualTo(componentGroupLists.size)
+            dbTransaction.components
+                .sortedWith(compareBy<ConsensualTransactionComponentEntity> { it.groupIndex }.thenBy { it.leafIndex })
+                .groupBy { it.groupIndex }.values
+                .zip(componentGroupLists)
+                .forEachIndexed { groupIndex, (dbComponentGroup, componentGroup) ->
+                    assertThat(dbComponentGroup.size).isEqualTo(componentGroup.size)
+                    dbComponentGroup.zip(componentGroup)
+                        .forEachIndexed { leafIndex, (dbComponent, component) ->
+                            assertThat(dbComponent.groupIndex).isEqualTo(groupIndex)
+                            assertThat(dbComponent.leafIndex).isEqualTo(leafIndex)
+                            assertThat(dbComponent.data).isEqualTo(component)
+                            assertThat(dbComponent.hash).isEqualTo(
+                                MessageDigest.getInstance("SHA-256").digest(component).toHexString())
+                            assertThat(dbComponent.created).isEqualTo(createdTs)
+                        }
+                }
+
+            assertThat(dbTransaction.statuses).isNotNull
+            assertThat(dbTransaction.statuses.size).isEqualTo(1)
+            val dbStatus = dbTransaction.statuses.first()
+            assertThat(dbStatus.status).isEqualTo(transactionStatus)
+            assertThat(dbStatus.created).isEqualTo(createdTs)
+
+            val signatures = signedTransaction.signatures
+            assertThat(dbTransaction.signatures).isNotNull
+            assertThat(dbTransaction.signatures.size).isEqualTo(signatures.size)
+            dbTransaction.signatures
+                .sortedBy { it.index }
+                .zip(signatures)
+                .forEachIndexed { index, (dbSignature, signature) ->
+                    assertThat(dbSignature.index).isEqualTo(index)
+                    assertThat(dbSignature.signature).isEqualTo(serializationService.serialize(signature).bytes)
+                    assertThat(dbSignature.publicKeyHash).isEqualTo(
+                        MessageDigest.getInstance("SHA-256").digest(signature.by.encoded).toHexString())
+                    assertThat(dbSignature.created).isEqualTo(createdTs)
+                }
+        }
+    }
+
+    @Test
+    fun `can persist links between signed transaction and existing CPKs`() {
+        val account = "Account"
+        val signedTransaction = createSignedTransaction()
+        val cpks = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        val existingCpks = cpks.take(2)
+        entityManagerFactory.transaction { em ->
+            existingCpks.mapIndexed { i, cpk ->
+                ConsensualCpkEntity(cpk.fileChecksum, cpk.name, cpk.signerSummaryHash!!, cpk.version, "file$i".toByteArray(), Instant.now())
+            }.forEach(em::persist)
+
+            ConsensualTransactionEntity(
+                signedTransaction.id.toHexString(),
+                signedTransaction.wireTransaction.privacySalt.bytes,
+                account,
+                Instant.now()
+            ).apply(em::persist)
+        }
+
+        // Persist transaction CPKs
+        val persistedCpkCount = entityManagerFactory.createEntityManager().transaction { em ->
+            repository.persistTransactionCpk(em, signedTransaction)
+        }
+
+        // Verify persisted data
+        assertThat(persistedCpkCount).isEqualTo(existingCpks.size)
+        entityManagerFactory.transaction { em ->
+            val dbTransaction = em.find(ConsensualTransactionEntity::class.java, signedTransaction.id.toHexString())
+
+            assertThat(dbTransaction.cpks).isNotNull
+            assertThat(dbTransaction.cpks.size).isEqualTo(existingCpks.size)
+            dbTransaction.cpks
+                .sortedBy { it.name }
+                .zip(existingCpks)
+                .forEachIndexed { index, (dbCpk, cpk) ->
+                    assertThat(dbCpk.fileChecksum).isEqualTo(cpk.fileChecksum)
+                    assertThat(dbCpk.name).isEqualTo(cpk.name)
+                    assertThat(dbCpk.signerSummaryHash).isEqualTo(cpk.signerSummaryHash)
+                    assertThat(dbCpk.version).isEqualTo(cpk.version)
+                    assertThat(dbCpk.data).isEqualTo("file$index".toByteArray())
+                    assertThat(dbCpk.created).isNotNull
+                }
+        }
+    }
+
+    @Test
+    fun `can find file checksums of CPKs linked to transaction`() {
+        val account = "Account"
+        val signedTransaction = createSignedTransaction()
+        val cpks = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        val existingCpks = cpks.take(2)
+        entityManagerFactory.transaction { em ->
+            val dbExistingCpks = existingCpks.mapIndexed { i, cpk ->
+                ConsensualCpkEntity(cpk.fileChecksum, cpk.name, cpk.signerSummaryHash!!, cpk.version, "file$i".toByteArray(), Instant.now())
+            }.onEach(em::persist)
+
+            ConsensualTransactionEntity(
+                signedTransaction.id.toHexString(),
+                signedTransaction.wireTransaction.privacySalt.bytes,
+                account,
+                Instant.now()
+            ).apply {
+                this.cpks.addAll(dbExistingCpks)
+                em.persist(this)
+            }
+        }
+
+        val cpkChecksums = entityManagerFactory.createEntityManager().transaction { em ->
+            repository.findTransactionCpkChecksums(em, signedTransaction)
+        }
+
+        assertThat(cpkChecksums).isEqualTo(existingCpks.map { it.fileChecksum }.toSet())
+    }
+
+    private fun createSignedTransaction(seed: String = seedSequence.incrementAndGet().toString()): ConsensualSignedTransactionContainer {
+        val cpks = listOf(
+            CordaPackageSummary("$seed-cpk1", "signerSummaryHash1", "1.0", "$seed-fileChecksum1"),
+            CordaPackageSummary("$seed-cpk2", "signerSummaryHash2", "2.0", "$seed-fileChecksum2"),
+            CordaPackageSummary("$seed-cpk3", "signerSummaryHash3", "3.0", "$seed-fileChecksum3"),
+        )
+        val transactionMetaData = TransactionMetaData(
+            LinkedHashMap<String, Any>().apply {
+                put(TransactionMetaData.DIGEST_SETTINGS_KEY, WireTransactionDigestSettings.defaultValues)
+                put(TransactionMetaData.CPK_METADATA_KEY, cpks)
+            }
+        )
+        val componentGroupLists: List<List<ByteArray>> = listOf(
+            listOf(jsonMarshallingService.format(transactionMetaData).toByteArray(Charsets.UTF_8)),
+            listOf("group2_component1".toByteArray()),
+            listOf("group3_component1".toByteArray())
+        )
+        val privacySalt = PrivacySaltImpl(Random.nextBytes(32))
+        val wireTransaction = WireTransaction(
+            merkleTreeProvider,
+            digestService,
+            jsonMarshallingService,
+            privacySalt,
+            componentGroupLists
+        )
+        val publicKey = KeyPairGenerator.getInstance("EC")
+            .apply { initialize(ECGenParameterSpec("secp256r1")) }
+            .generateKeyPair().public
+        val signatures = listOf(
+            DigitalSignatureAndMetadata(
+                DigitalSignature.WithKey(
+                    publicKey,
+                    "signature".toByteArray(),
+                    mapOf("contextKey1" to "contextValue1")),
+                DigitalSignatureMetadata(
+                    Instant.now(),
+                    mapOf("propertyKey1" to "propertyValue1")
+                )
+            )
+        )
+        return ConsensualSignedTransactionContainer(wireTransaction, signatures)
+    }
+}

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualCpkEntity.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualCpkEntity.kt
@@ -1,0 +1,59 @@
+package net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel
+
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Lob
+import javax.persistence.Table
+
+@Entity
+@Table(name = "consensual_cpk")
+data class ConsensualCpkEntity(
+    @Id
+    @Column(name = "file_checksum", nullable = false)
+    val fileChecksum: String,
+
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "signer_summary_hash", nullable = false)
+    val signerSummaryHash: String,
+
+    @Column(name = "version", nullable = false)
+    val version: String,
+
+    @Column(name = "data", nullable = false)
+    @Lob
+    val data: ByteArray,
+
+    @Column(name = "created", nullable = false)
+    val created: Instant
+
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ConsensualCpkEntity
+
+        if (fileChecksum != other.fileChecksum) return false
+        if (name != other.name) return false
+        if (signerSummaryHash != other.signerSummaryHash) return false
+        if (version != other.version) return false
+        if (!data.contentEquals(other.data)) return false
+        if (created != other.created) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = fileChecksum.hashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + signerSummaryHash.hashCode()
+        result = 31 * result + version.hashCode()
+        result = 31 * result + data.contentHashCode()
+        result = 31 * result + created.hashCode()
+        return result
+    }
+}

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualLedgerEntities.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualLedgerEntities.kt
@@ -1,0 +1,11 @@
+package net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel
+
+object ConsensualLedgerEntities {
+    val classes = setOf(
+        ConsensualCpkEntity::class.java,
+        ConsensualTransactionComponentEntity::class.java,
+        ConsensualTransactionEntity::class.java,
+        ConsensualTransactionSignatureEntity::class.java,
+        ConsensualTransactionStatusEntity::class.java
+    )
+}

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionComponentEntity.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionComponentEntity.kt
@@ -1,0 +1,72 @@
+package net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel
+
+import java.io.Serializable
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.IdClass
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "consensual_transaction_component")
+@IdClass(ConsensualTransactionComponentEntityId::class)
+data class ConsensualTransactionComponentEntity(
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    val transaction: ConsensualTransactionEntity,
+
+    @Id
+    @Column(name = "group_idx", nullable = false)
+    val groupIndex: Int,
+
+    @Id
+    @Column(name = "leaf_idx", nullable = false)
+    val leafIndex: Int,
+
+    @Column(name = "data", nullable = false)
+    val data: ByteArray,
+
+    @Column(name = "hash", nullable = false)
+    val hash: String,
+
+    @Column(name = "created", nullable = false)
+    val created: Instant
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ConsensualTransactionComponentEntity
+
+        if (transaction != other.transaction) return false
+        if (groupIndex != other.groupIndex) return false
+        if (leafIndex != other.leafIndex) return false
+        if (!data.contentEquals(other.data)) return false
+        if (hash != other.hash) return false
+        if (created != other.created) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = transaction.hashCode()
+        result = 31 * result + groupIndex
+        result = 31 * result + leafIndex
+        result = 31 * result + data.contentHashCode()
+        result = 31 * result + hash.hashCode()
+        result = 31 * result + created.hashCode()
+        return result
+    }
+}
+
+@Embeddable
+data class ConsensualTransactionComponentEntityId(
+    val transaction: ConsensualTransactionEntity,
+    val groupIndex: Int,
+    val leafIndex: Int
+) : Serializable

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionEntity.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionEntity.kt
@@ -1,0 +1,67 @@
+package net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel
+
+import java.time.Instant
+import javax.persistence.CascadeType
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.JoinTable
+import javax.persistence.ManyToMany
+import javax.persistence.OneToMany
+import javax.persistence.Table
+
+@Entity
+@Table(name = "consensual_transaction")
+data class ConsensualTransactionEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    val id: String,
+
+    @Column(name = "privacy_salt", nullable = false)
+    val privacySalt: ByteArray,
+
+    @Column(name = "account_id", nullable = false)
+    val accountId: String,
+
+    @Column(name = "created", nullable = false)
+    val created: Instant,
+) {
+    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val components: MutableList<ConsensualTransactionComponentEntity> = mutableListOf()
+
+    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val statuses: MutableList<ConsensualTransactionStatusEntity> = mutableListOf()
+
+    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val signatures: MutableList<ConsensualTransactionSignatureEntity> = mutableListOf()
+
+    @ManyToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE])
+    @JoinTable(name = "consensual_transaction_cpk",
+        joinColumns = [JoinColumn(name = "transaction_id")],
+        inverseJoinColumns = [JoinColumn(name = "file_checksum")]
+    )
+    val cpks: MutableSet<ConsensualCpkEntity> = mutableSetOf()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ConsensualTransactionEntity
+
+        if (id != other.id) return false
+        if (!privacySalt.contentEquals(other.privacySalt)) return false
+        if (accountId != other.accountId) return false
+        if (created != other.created) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + privacySalt.contentHashCode()
+        result = 31 * result + accountId.hashCode()
+        result = 31 * result + created.hashCode()
+        return result
+    }
+}

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionSignatureEntity.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionSignatureEntity.kt
@@ -1,0 +1,65 @@
+package net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel
+
+import java.io.Serializable
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.IdClass
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "consensual_transaction_signature")
+@IdClass(ConsensualTransactionSignatureEntityId::class)
+data class ConsensualTransactionSignatureEntity(
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    val transaction: ConsensualTransactionEntity,
+
+    @Id
+    @Column(name = "signature_idx", nullable = false)
+    val index: Int,
+
+    @Column(name = "signature", nullable = false)
+    val signature: ByteArray,
+
+    @Column(name = "pub_key_hash", nullable = false)
+    val publicKeyHash: String,
+
+    @Column(name = "created", nullable = false)
+    val created: Instant
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ConsensualTransactionSignatureEntity
+
+        if (transaction != other.transaction) return false
+        if (index != other.index) return false
+        if (!signature.contentEquals(other.signature)) return false
+        if (publicKeyHash != other.publicKeyHash) return false
+        if (created != other.created) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = transaction.hashCode()
+        result = 31 * result + index
+        result = 31 * result + signature.contentHashCode()
+        result = 31 * result + publicKeyHash.hashCode()
+        result = 31 * result + created.hashCode()
+        return result
+    }
+}
+
+@Embeddable
+data class ConsensualTransactionSignatureEntityId(
+    val transaction: ConsensualTransactionEntity,
+    val index: Int
+) : Serializable

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionStatusEntity.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/datamodel/ConsensualTransactionStatusEntity.kt
@@ -1,0 +1,35 @@
+package net.corda.ledger.consensual.persistence.impl.processor.tests.datamodel
+
+import java.io.Serializable
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.IdClass
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "consensual_transaction_status")
+@IdClass(ConsensualTransactionStatusEntityId::class)
+data class ConsensualTransactionStatusEntity(
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    val transaction: ConsensualTransactionEntity,
+
+    @Id
+    @Column(name = "status", nullable = false)
+    val status: String,
+
+    @Column(name = "created", nullable = false)
+    val created: Instant
+)
+
+@Embeddable
+data class ConsensualTransactionStatusEntityId(
+    val transaction: ConsensualTransactionEntity,
+    val status: String
+) : Serializable

--- a/components/ledger/ledger-consensual-persistence-impl/src/main/java/net/corda/ledger/consensual/persistence/impl/repository/package-info.java
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/java/net/corda/ledger/consensual/persistence/impl/repository/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.consensual.persistence.impl.repository;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/processor/ConsensualLedgerMessageProcessor.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/processor/ConsensualLedgerMessageProcessor.kt
@@ -6,7 +6,7 @@ import net.corda.data.ledger.consensual.PersistTransaction
 import net.corda.data.persistence.ConsensualLedgerRequest
 import net.corda.data.persistence.EntityResponse
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
-import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
 import net.corda.ledger.consensual.persistence.impl.repository.ConsensualLedgerRepository
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
@@ -19,6 +19,7 @@ import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
@@ -82,22 +83,35 @@ class ConsensualLedgerMessageProcessor(
         // get the per-sandbox entity manager and serialization services
         val entityManagerFactory = sandbox.getEntityManagerFactory()
         val serializationService = sandbox.getSerializationService()
-        val consensualLedgerRepository = ConsensualLedgerRepository(merkleTreeProvider, digestService, jsonMarshallingService)
+        val repository = ConsensualLedgerRepository(
+            merkleTreeProvider, digestService, jsonMarshallingService, serializationService
+        )
 
         return entityManagerFactory.createEntityManager().transaction { em ->
             when (val req = request.request) {
-                is PersistTransaction -> responseFactory.successResponse(
-                    request.flowExternalEventContext,
-                    consensualLedgerRepository.persistTransaction(em, serializationService.deserialize(req), request.account())
-                )
+                is PersistTransaction -> {
+                    val transaction = serializationService.deserialize(req)
+                    repository.persistTransaction(em, transaction, req.status, request.account())
+                    val cpkMetadata = transaction.cpkMetadata()
+                    val missingCpks = if (repository.persistTransactionCpk(em, transaction) < cpkMetadata.size) {
+                        val persistedCpks = repository.findTransactionCpkChecksums(em, transaction)
+                        cpkMetadata.filterNot { persistedCpks.contains(it.fileChecksum) }
+                    } else {
+                        emptyList()
+                    }
+                    responseFactory.successResponse(
+                        request.flowExternalEventContext,
+                        EntityResponse(missingCpks.map { serializationService.serialized(it) })
+                    )
+                }
 
                 is FindTransaction -> responseFactory.successResponse(
                     request.flowExternalEventContext,
-                    createEntityResponse(
-                        consensualLedgerRepository.findTransaction(em, req.id),
-                        serializationService
-                    )
-                )
+                    EntityResponse(
+                        listOfNotNull(repository.findTransaction(em, req.id))
+                            .map { serializationService.serialized(it) }
+                    ))
+
                 else -> {
                     responseFactory.fatalErrorResponse(request.flowExternalEventContext, CordaRuntimeException("Unknown command"))
                 }
@@ -109,12 +123,10 @@ class ConsensualLedgerMessageProcessor(
         flowExternalEventContext.contextProperties.items.find { it.key == CORDA_ACCOUNT }?.value
             ?: throw NullParameterException("Flow external event context property '$CORDA_ACCOUNT' not set")
 
-    private fun createEntityResponse(obj: Any?, serializationService: SerializationService) =
-        obj?.let {
-            val serializedObj = serializationService.serialize(obj)
-            EntityResponse(listOf(ByteBuffer.wrap(serializedObj.bytes)))
-        } ?: EntityResponse(emptyList())
+    private fun ConsensualSignedTransactionContainer.cpkMetadata() = wireTransaction.metadata.getCpkMetadata()
+
+    private fun SerializationService.serialized(obj: Any) = ByteBuffer.wrap(serialize(obj).bytes)
 
     private fun SerializationService.deserialize(persistTransaction: PersistTransaction) =
-        deserialize(persistTransaction.transaction.array(), WireTransaction::class.java)
+        deserialize<ConsensualSignedTransactionContainer>(persistTransaction.transaction.array())
 }

--- a/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ConsensualLedgerRepository.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ConsensualLedgerRepository.kt
@@ -1,15 +1,17 @@
 package net.corda.ledger.consensual.persistence.impl.repository
 
-import net.corda.data.persistence.EntityResponse
 import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.consensual.data.transaction.ConsensualSignedTransactionContainer
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
+import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.types.toHexString
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.DigestService
 import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SecureHash
 import java.security.MessageDigest
 import java.time.Instant
 import javax.persistence.EntityManager
@@ -22,35 +24,16 @@ import javax.persistence.Tuple
 class ConsensualLedgerRepository(
     private val merkleTreeProvider: MerkleTreeProvider,
     private val digestService: DigestService,
-    private val jsonMarshallingService: JsonMarshallingService
+    private val jsonMarshallingService: JsonMarshallingService,
+    private val serializationService: SerializationService
 ) {
     companion object {
         private val logger = contextLogger()
         private val componentGroupListsTuplesMapper = ComponentGroupListsTuplesMapper()
     }
 
-    // TODO This should probably take a ConsensualSignedTransactionImpl which includes WireTransaction and signers.
-    fun persistTransaction(entityManager: EntityManager, transaction: WireTransaction, account :String): EntityResponse {
-        val now = Instant.now()
-        persistTransaction(entityManager, now, transaction, account)
-        transaction.componentGroupLists.mapIndexed { groupIndex, leaves ->
-            leaves.mapIndexed { leafIndex, bytes ->
-                persistComponentLeaf(entityManager, now, transaction, groupIndex, leafIndex, bytes)
-            }
-        }
-        persistTransactionStatus(entityManager, now, transaction, "Faked") // TODO where to get the status from
-        // TODO when and what do we write to the signatures table?
-        // TODO when and what do we write to the CPKs table?
-        persistCpk(entityManager, now, transaction)
-        persistTransactionCpk(entityManager, transaction)
-
-        // construct response
-        return EntityResponse(emptyList())
-    }
-
-    /** Reads [WireTransaction] with given [id] from database. */
-    fun findTransaction(entityManager: EntityManager, id: String): WireTransaction? {
-
+    /** Reads [ConsensualSignedTransactionContainer] with given [id] from database. */
+    fun findTransaction(entityManager: EntityManager, id: String): ConsensualSignedTransactionContainer? {
         val rows = entityManager.createNativeQuery(
             """
                 SELECT tx.id, tx.privacy_salt, tx.account_id, tx.created, txc.group_idx, txc.leaf_idx, txc.data, txc.hash
@@ -65,21 +48,73 @@ class ConsensualLedgerRepository(
 
         if (rows.isEmpty()) return null
 
-        val firstRowColumns = rows.first()
-        val privacySalt = PrivacySaltImpl(firstRowColumns[1] as ByteArray)
-        val componentGroupLists = rows.mapTuples(componentGroupListsTuplesMapper)
-        return WireTransaction(merkleTreeProvider, digestService, jsonMarshallingService, privacySalt, componentGroupLists)
+        val wireTransaction = WireTransaction(
+            merkleTreeProvider,
+            digestService,
+            jsonMarshallingService,
+            PrivacySaltImpl(rows.first()[1] as ByteArray),
+            rows.mapTuples(componentGroupListsTuplesMapper))
+
+        return ConsensualSignedTransactionContainer(
+            wireTransaction,
+            findSignatures(entityManager, id))
     }
 
-    /** Persists [tx] data to database. */
-    private fun persistTransaction(entityManager: EntityManager, timestamp: Instant, tx: WireTransaction, account: String) {
+    /** Reads [DigitalSignatureAndMetadata] for signed transaction with given [transactionId] from database. */
+    private fun findSignatures(
+        entityManager: EntityManager,
+        transactionId: String
+    ): List<DigitalSignatureAndMetadata> {
+        return entityManager.createNativeQuery(
+            """
+                SELECT signature
+                FROM {h-schema}consensual_transaction_signature
+                WHERE transaction_id = :transactionId
+                ORDER BY signature_idx""",
+            Tuple::class.java)
+            .setParameter("transactionId", transactionId)
+            .resultListAsTuples()
+            .map { r -> serializationService.deserialize(r.get(0) as ByteArray) }
+    }
+
+    /** Persists [signedTransaction] data to database and link it to existing CPKs. */
+    fun persistTransaction(
+        entityManager: EntityManager,
+        signedTransaction: ConsensualSignedTransactionContainer,
+        status: String,
+        account :String
+    ) {
+        val transactionId = signedTransaction.id.toHexString()
+        val wireTransaction = signedTransaction.wireTransaction
+        val now = Instant.now()
+        persistTransaction(entityManager, now, wireTransaction, account)
+        // Persist component group lists
+        wireTransaction.componentGroupLists.mapIndexed { groupIndex, leaves ->
+            leaves.mapIndexed { leafIndex, bytes ->
+                persistComponentLeaf(entityManager, now, transactionId, groupIndex, leafIndex, bytes)
+            }
+        }
+        persistTransactionStatus(entityManager, now, transactionId, status)
+        // Persist signatures
+        signedTransaction.signatures.forEachIndexed { index, digitalSignatureAndMetadata ->
+            persistSignature(entityManager, now, transactionId, index, digitalSignatureAndMetadata)
+        }
+    }
+
+    /** Persists [wireTransaction] data to database. */
+    private fun persistTransaction(
+        entityManager: EntityManager,
+        timestamp: Instant,
+        wireTransaction: WireTransaction,
+        account: String
+    ) {
         entityManager.createNativeQuery(
             """
-                INSERT INTO {h-schema}consensual_transaction(id, privacy_salt, account_id, created)
-                VALUES (:id, :privacySalt, :accountId, :createdAt)"""
+            INSERT INTO {h-schema}consensual_transaction(id, privacy_salt, account_id, created)
+            VALUES (:id, :privacySalt, :accountId, :createdAt)"""
         )
-            .setParameter("id", tx.id.toHexString())
-            .setParameter("privacySalt", tx.privacySalt.bytes)
+            .setParameter("id", wireTransaction.id.toHexString())
+            .setParameter("privacySalt", wireTransaction.privacySalt.bytes)
             .setParameter("accountId", account)
             .setParameter("createdAt", timestamp)
             .executeUpdate()
@@ -90,24 +125,21 @@ class ConsensualLedgerRepository(
     private fun persistComponentLeaf(
         entityManager: EntityManager,
         timestamp: Instant,
-        tx: WireTransaction,
+        transactionId: String,
         groupIndex: Int,
         leafIndex: Int,
         data: ByteArray
-    ) {
-        val dataDigest = MessageDigest.getInstance(DigestAlgorithmName.SHA2_256.name)
-        val hash = dataDigest.digest(data).toHexString()
-
-        entityManager.createNativeQuery(
+    ): Int {
+        return entityManager.createNativeQuery(
             """
-                INSERT INTO {h-schema}consensual_transaction_component(transaction_id, group_idx, leaf_idx, data, hash, created)
-                VALUES(:transactionId, :groupIndex, :leafIndex, :data, :hash, :createdAt)"""
+            INSERT INTO {h-schema}consensual_transaction_component(transaction_id, group_idx, leaf_idx, data, hash, created)
+            VALUES(:transactionId, :groupIndex, :leafIndex, :data, :hash, :createdAt)"""
         )
-            .setParameter("transactionId", tx.id.toHexString())
+            .setParameter("transactionId", transactionId)
             .setParameter("groupIndex", groupIndex)
             .setParameter("leafIndex", leafIndex)
             .setParameter("data", data)
-            .setParameter("hash", hash)
+            .setParameter("hash", data.hashAsHexString())
             .setParameter("createdAt", timestamp)
             .executeUpdate()
     }
@@ -116,62 +148,79 @@ class ConsensualLedgerRepository(
     private fun persistTransactionStatus(
         entityManager: EntityManager,
         timestamp: Instant,
-        tx: WireTransaction,
+        transactionId: String,
         status: String
-    ) {
-        entityManager.createNativeQuery(
+    ): Int {
+        return entityManager.createNativeQuery(
             """
-                INSERT INTO {h-schema}consensual_transaction_status(transaction_id, status, created)
-                VALUES (:txId, :status, :createdAt)"""
+            INSERT INTO {h-schema}consensual_transaction_status(transaction_id, status, created)
+            VALUES (:txId, :status, :createdAt)"""
         )
-            .setParameter("txId", tx.id.toHexString())
+            .setParameter("txId", transactionId)
             .setParameter("status", status)
             .setParameter("createdAt", timestamp)
             .executeUpdate()
     }
 
-    /** Persists CPK to database. */
-    private fun persistCpk(
+    /** Persists transaction's [signature] to database. */
+    private fun persistSignature(
         entityManager: EntityManager,
         timestamp: Instant,
-        tx: WireTransaction
-    ) {
-        val cpkIdentifiers = tx.metadata.getCpkMetadata()
-        logger.info("cpkIdentifiers = [$cpkIdentifiers]")
-        val fileHash = SecureHash.parse("SHA-256:1234567890123456")
-        val name = "cpk-name"
-        val signerHash = SecureHash.parse("SHA-256:0000000000000000")
-        val version = 1
-        val data = ByteArray(10000)
-
-        entityManager.createNativeQuery(
+        transactionId: String,
+        index: Int,
+        signature: DigitalSignatureAndMetadata
+    ): Int {
+        return entityManager.createNativeQuery(
             """
-                INSERT INTO {h-schema}consensual_cpk(file_hash, name, signer_hash, version, data, created)
-                VALUES (:fileHash, :name, :signerHash, :version, :data, :createdAt) ON CONFLICT DO NOTHING""")
-            .setParameter("fileHash", fileHash.toHexString())
-            .setParameter("name", name)
-            .setParameter("signerHash", signerHash.toHexString())
-            .setParameter("version", version)
-            .setParameter("data", data)
+            INSERT INTO {h-schema}consensual_transaction_signature(transaction_id, signature_idx, signature, pub_key_hash, created)
+            VALUES (:transactionId, :signatureIdx, :signature, :publicKeyHash, :createdAt)"""
+        )
+            .setParameter("transactionId", transactionId)
+            .setParameter("signatureIdx", index)
+            .setParameter("signature", serializationService.serialize(signature).bytes)
+            .setParameter("publicKeyHash", signature.by.encoded.hashAsHexString())
             .setParameter("createdAt", timestamp)
             .executeUpdate()
     }
 
-    /** Persists link between [tx] and it's CPK data to database. */
-    private fun persistTransactionCpk(
+    /** Persists link between [signedTransaction] and it's CPK data to database. */
+    fun persistTransactionCpk(
         entityManager: EntityManager,
-        tx: WireTransaction
-    ) {
-        // TODO get values from transaction metadata
-        val fileHash = SecureHash.parse("SHA-256:1234567890123456")
-        entityManager.createNativeQuery(
+        signedTransaction: ConsensualSignedTransactionContainer
+    ): Int {
+        val cpkMetadata = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        return entityManager.createNativeQuery(
             """
-                INSERT INTO {h-schema}consensual_transaction_cpk(transaction_id, file_hash)
-                VALUES (:transactionId, :fileHash)""")
-            .setParameter("transactionId", tx.id.toHexString())
-            .setParameter("fileHash", fileHash.toHexString())
+            INSERT INTO {h-schema}consensual_transaction_cpk
+            SELECT :transactionId, file_checksum
+            FROM {h-schema}consensual_cpk
+            WHERE file_checksum in (:fileChecksums)"""
+        )
+            .setParameter("transactionId", signedTransaction.id.toHexString())
+            .setParameter("fileChecksums", cpkMetadata.map { it.fileChecksum })
             .executeUpdate()
     }
+
+    /** Finds file checksums of CPKs linked to transaction. */
+    fun findTransactionCpkChecksums(
+        entityManager: EntityManager,
+        signedTransaction: ConsensualSignedTransactionContainer,
+    ): Set<String> {
+        val cpkMetadata = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        return entityManager.createNativeQuery(
+            """
+            SELECT file_checksum
+            FROM {h-schema}consensual_transaction_cpk
+            WHERE file_checksum in (:fileChecksums)""",
+            Tuple::class.java
+        )
+            .setParameter("fileChecksums", cpkMetadata.map { it.fileChecksum })
+            .resultListAsTuples()
+            .mapTo(HashSet()) { r -> r.get(0) as String }
+    }
+
+    private fun ByteArray.hashAsHexString() =
+        MessageDigest.getInstance(DigestAlgorithmName.SHA2_256.name).digest(this).toHexString()
 
     @Suppress("UNCHECKED_CAST")
     private fun Query.resultListAsTuples() = resultList as List<Tuple>

--- a/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ConsensualLedgerRepository.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/repository/ConsensualLedgerRepository.kt
@@ -7,12 +7,10 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
-import net.corda.v5.base.types.toHexString
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.DigestService
 import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.v5.crypto.DigestAlgorithmName
-import java.security.MessageDigest
 import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.Query
@@ -53,11 +51,13 @@ class ConsensualLedgerRepository(
             digestService,
             jsonMarshallingService,
             PrivacySaltImpl(rows.first()[1] as ByteArray),
-            rows.mapTuples(componentGroupListsTuplesMapper))
+            rows.mapTuples(componentGroupListsTuplesMapper)
+        )
 
         return ConsensualSignedTransactionContainer(
             wireTransaction,
-            findSignatures(entityManager, id))
+            findSignatures(entityManager, id)
+        )
     }
 
     /** Reads [DigitalSignatureAndMetadata] for signed transaction with given [transactionId] from database. */
@@ -220,7 +220,7 @@ class ConsensualLedgerRepository(
     }
 
     private fun ByteArray.hashAsHexString() =
-        MessageDigest.getInstance(DigestAlgorithmName.SHA2_256.name).digest(this).toHexString()
+        digestService.hash(this, DigestAlgorithmName.SHA2_256).toHexString()
 
     @Suppress("UNCHECKED_CAST")
     private fun Query.resultListAsTuples() = resultList as List<Tuple>

--- a/components/ledger/ledger-consensual-persistence-impl/test.bndrun
+++ b/components/ledger/ledger-consensual-persistence-impl/test.bndrun
@@ -33,6 +33,7 @@
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='net.corda.ledger-common-data',\
+    bnd.identity;id='net.corda.crypto-serialization-impl',\
     bnd.identity;id='net.bytebuddy.byte-buddy',\
     bnd.identity;id='org.hsqldb.hsqldb',\
     bnd.identity;id='org.osgi.service.jdbc',\

--- a/components/persistence/persistence-service-common/build.gradle
+++ b/components/persistence/persistence-service-common/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     implementation project(':components:virtual-node:virtual-node-info-read-service')
 
     implementation project(':libs:flows:external-event-responses')
-    implementation project(":libs:crypto:crypto-serialization-impl")
     implementation project(":libs:crypto:cipher-suite-impl")
     implementation project(":libs:messaging:messaging")
     implementation project(':libs:serialization:serialization-amqp')
@@ -30,6 +29,8 @@ dependencies {
     implementation project(':libs:virtual-node:sandbox-group-context')
 
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+
+    runtimeOnly project(":libs:crypto:crypto-serialization-impl")
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/components/persistence/persistence-service-common/build.gradle
+++ b/components/persistence/persistence-service-common/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation project(':components:virtual-node:virtual-node-info-read-service')
 
     implementation project(':libs:flows:external-event-responses')
+    implementation project(":libs:crypto:crypto-serialization-impl")
+    implementation project(":libs:crypto:cipher-suite-impl")
     implementation project(":libs:messaging:messaging")
     implementation project(':libs:serialization:serialization-amqp')
     implementation project(':libs:serialization:serialization-internal')

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -1,6 +1,8 @@
 package net.corda.persistence.common.internal
 
+import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.cpiinfo.read.CpiInfoReadService
+import net.corda.crypto.impl.serialization.PublicKeySerializer
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_EMF
 import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_SERIALIZER
@@ -190,6 +192,8 @@ class EntitySandboxServiceImpl @Activate constructor(
         // we might struggle to deserialize some entities.
         val factory = SerializerFactoryBuilder.build(ctx.sandboxGroup)
         registerCustomSerializers(factory)
+        //TODO Where is the right place for this?
+        factory.register(PublicKeySerializer(CipherSchemeMetadataImpl()), factory)
         internalCustomSerializers.forEach { factory.register(it, factory) }
 
         val cpkSerializers = cpks.flatMap { it.cordappManifest.serializers }.toSet()

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -1,8 +1,6 @@
 package net.corda.persistence.common.internal
 
-import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.cpiinfo.read.CpiInfoReadService
-import net.corda.crypto.impl.serialization.PublicKeySerializer
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_EMF
 import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_SERIALIZER
@@ -192,8 +190,6 @@ class EntitySandboxServiceImpl @Activate constructor(
         // we might struggle to deserialize some entities.
         val factory = SerializerFactoryBuilder.build(ctx.sandboxGroup)
         registerCustomSerializers(factory)
-        //TODO Where is the right place for this?
-        factory.register(PublicKeySerializer(CipherSchemeMetadataImpl()), factory)
         internalCustomSerializers.forEach { factory.register(it, factory) }
 
         val cpkSerializers = cpks.flatMap { it.cordappManifest.serializers }.toSet()

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.421-beta+
+cordaApiVersion=5.0.0.422-alpha-1666731836205
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.422-alpha-1666731836205
+cordaApiVersion=5.0.0.422-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/crypto/cipher-suite-impl/src/main/java/net/corda/cipher/suite/impl/package-info.java
+++ b/libs/crypto/cipher-suite-impl/src/main/java/net/corda/cipher/suite/impl/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.cipher.suite.impl;
+
+import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
- [x] Refactor to work with ConsensualSignedTransactionContainer instead of WireTransaction
- [x] Persist transaction status from request
- [x] Persist transaction signatures
- [x] Persist serialized DigitalSignatureAndMetadata
- [x] Link transaction only to existing CPKs
- [x] Persist public key hash to "consensual_transaction_signature" DB table
- [x] Refactor message processor to return missing CPKs when persisting transaction
- [x] Return missing CPKs when persisting transaction in ledger-consensual-flow
- [x] Remove dependencies on unnecessary flow components
- [x] Add integration test for ConsensualLedgerRepository