### PR TITLE
CORE-6660: Amend QueryPermissions string

### DIFF
--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
@@ -30,7 +30,7 @@ class UserAdminSubcommand : HttpRpcCommand(), Callable<Int> {
 
         // Permission manipulation permissions ;-)
         "CreatePermission" to "POST:/api/v1/permission",
-        "QueryPermissions" to "GET:/api/v1/permission",
+        "QueryPermissions" to "GET:/api/v1/permission?.*",
         "GetPermission" to "GET:/api/v1/permission/$UUID_REGEX",
 
         // Role manipulation permissions


### PR DESCRIPTION
Discovered it to be incorrect during Dev testing. Since `GET:/api/v1/permission` may have a variable number of query parameters, we need to alter the underlying permission.