### PR TITLE
CORE-7284 Set version information in the MemberInfo

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -68,7 +68,7 @@ class CpiValidatorImpl constructor(
                 cpi.metadata.groupPolicy!!
             )
         } catch (ex: MembershipSchemaValidationException) {
-            throw ValidationException("Group policy file in the CPI is invalid. ${ex.getErrorSummary()}", null, ex)
+            throw ValidationException("Group policy file in the CPI is invalid. ${ex.message}", null, ex)
         }
 
         publisher.update(requestId, "Checking group id in CPI")

--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(":components:membership:membership-persistence-client")
     implementation project(':components:membership:membership-p2p')
     implementation project(":components:membership:registration")
+    implementation project(":components:virtual-node:virtual-node-info-read-service")
     implementation project(":libs:configuration:configuration-core")
     implementation project(":libs:crypto:crypto-core")
     implementation project(":libs:lifecycle:lifecycle")

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -186,7 +186,7 @@ class MemberRegistrationIntegrationTest {
             configurationReadService.bootstrapConfig(bootConfig)
 
 
-            testVirtualNodeInfoReadService.setTestVirtualNodeInfo(
+            testVirtualNodeInfoReadService.putTestVirtualNodeInfo(
                 VirtualNodeInfo(
                     holdingIdentity = HoldingIdentity(memberName, groupId),
                     cpiIdentifier = CpiIdentifier(CPI_NAME, CPI_VERSION, null),

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -303,7 +303,6 @@ class MemberRegistrationIntegrationTest {
         }
     }
 
-
     private fun buildTestContext(member: HoldingIdentity): Map<String, String> {
         val sessionKeyId =
             cryptoOpsClient.generateKeyPair(

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -31,6 +31,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
@@ -58,6 +59,7 @@ import net.corda.utilities.concurrent.getOrThrow
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.publicKeyId
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -72,7 +74,7 @@ import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 @ExtendWith(ServiceExtension::class, DBSetup::class)
@@ -148,6 +150,7 @@ class MemberRegistrationIntegrationTest {
         const val PROTOCOL_KEY = "corda.endpoints.0.protocolVersion"
         const val PROTOCOL_VALUE = "1"
         const val CPI_VERSION = "1.1"
+        const val CPI_SIGNER_HASH = "ALG:A1B2C3D4"
         const val CPI_NAME = "cpi-name"
         const val TEST_SERIAL = 1
 
@@ -189,7 +192,7 @@ class MemberRegistrationIntegrationTest {
             testVirtualNodeInfoReadService.putTestVirtualNodeInfo(
                 VirtualNodeInfo(
                     holdingIdentity = HoldingIdentity(memberName, groupId),
-                    cpiIdentifier = CpiIdentifier(CPI_NAME, CPI_VERSION, null),
+                    cpiIdentifier = CpiIdentifier(CPI_NAME, CPI_VERSION, SecureHash.parse(CPI_SIGNER_HASH)),
                     cryptoDmlConnectionId = UUID.randomUUID(),
                     uniquenessDmlConnectionId = UUID.randomUUID(),
                     vaultDmlConnectionId = UUID.randomUUID(),
@@ -283,6 +286,7 @@ class MemberRegistrationIntegrationTest {
                     it.assertThat(getValue(GROUP_ID)).isEqualTo(groupId)
                     it.assertThat(getValue(MEMBER_CPI_NAME)).isEqualTo(CPI_NAME)
                     it.assertThat(getValue(MEMBER_CPI_VERSION)).isEqualTo(CPI_VERSION)
+                    it.assertThat(getValue(MEMBER_CPI_SIGNER_HASH)).isEqualTo(CPI_SIGNER_HASH)
                     it.assertThat(getValue(PLATFORM_VERSION)).isEqualTo(TEST_ACTIVE_PLATFORM_VERSION.toString())
                     it.assertThat(getValue(SOFTWARE_VERSION)).isEqualTo(TEST_SOFTWARE_VERSION)
                     it.assertThat(getValue(SERIAL)).isEqualTo(TEST_SERIAL.toString())

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestPlatformInfoProvider.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestPlatformInfoProvider.kt
@@ -1,0 +1,25 @@
+package net.corda.membership.impl.registration.dummy
+
+import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.membership.impl.registration.dummy.TestPlatformInfoProvider.Companion.TEST_ACTIVE_PLATFORM_VERSION
+import net.corda.membership.impl.registration.dummy.TestPlatformInfoProvider.Companion.TEST_LOCAL_WORKER_PLATFORM_VERSION
+import net.corda.membership.impl.registration.dummy.TestPlatformInfoProvider.Companion.TEST_SOFTWARE_VERSION
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.propertytypes.ServiceRanking
+
+interface TestPlatformInfoProvider : PlatformInfoProvider {
+    companion object {
+        const val TEST_ACTIVE_PLATFORM_VERSION = 5000
+        const val TEST_LOCAL_WORKER_PLATFORM_VERSION = 5001
+        const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSNOT-test"
+    }
+}
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [PlatformInfoProvider::class, TestPlatformInfoProvider::class])
+internal class TestPlatformInfoProviderImpl @Activate constructor() : TestPlatformInfoProvider {
+    override val activePlatformVersion = TEST_ACTIVE_PLATFORM_VERSION
+    override val localWorkerPlatformVersion = TEST_LOCAL_WORKER_PLATFORM_VERSION
+    override val localWorkerSoftwareVersion = TEST_SOFTWARE_VERSION
+}

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestVirtualNodeInfoReadService.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestVirtualNodeInfoReadService.kt
@@ -1,0 +1,61 @@
+package net.corda.membership.impl.registration.dummy
+
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.reconciliation.VersionedRecord
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.ShortHash
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoListener
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.propertytypes.ServiceRanking
+import java.util.stream.Stream
+
+interface TestVirtualNodeInfoReadService : VirtualNodeInfoReadService {
+    fun setTestVirtualNodeInfo(virtualNodeInfo: VirtualNodeInfo)
+}
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [VirtualNodeInfoReadService::class, TestVirtualNodeInfoReadService::class])
+internal class TestVirtualNodeInfoReadServiceImpl @Activate constructor() : TestVirtualNodeInfoReadService {
+
+    private val testVirtualNodeInfoList = mutableListOf<VirtualNodeInfo>()
+
+    override fun setTestVirtualNodeInfo(virtualNodeInfo: VirtualNodeInfo) {
+        testVirtualNodeInfoList.add(virtualNodeInfo)
+    }
+
+    override fun getAll(): List<VirtualNodeInfo> = testVirtualNodeInfoList
+
+    override fun get(holdingIdentity: HoldingIdentity): VirtualNodeInfo? {
+        return testVirtualNodeInfoList.firstOrNull { it.holdingIdentity ==  holdingIdentity }
+    }
+
+    override fun getByHoldingIdentityShortHash(holdingIdentityShortHash: ShortHash): VirtualNodeInfo? {
+        return testVirtualNodeInfoList.firstOrNull { it.holdingIdentity.shortHash ==  holdingIdentityShortHash }
+    }
+
+    override fun registerCallback(listener: VirtualNodeInfoListener): AutoCloseable {
+        return AutoCloseable { return@AutoCloseable }
+    }
+
+    override fun getAllVersionedRecords(): Stream<VersionedRecord<HoldingIdentity, VirtualNodeInfo>>? {
+        return null
+    }
+
+    override val lifecycleCoordinatorName: LifecycleCoordinatorName
+        get() = LifecycleCoordinatorName.forComponent<TestVirtualNodeInfoReadServiceImpl>()
+
+    override val isRunning: Boolean
+        get() = true
+
+    override fun start() {
+        return
+    }
+
+    override fun stop() {
+        return
+    }
+
+}

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestVirtualNodeInfoReadService.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestVirtualNodeInfoReadService.kt
@@ -13,7 +13,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking
 import java.util.stream.Stream
 
 interface TestVirtualNodeInfoReadService : VirtualNodeInfoReadService {
-    fun setTestVirtualNodeInfo(virtualNodeInfo: VirtualNodeInfo)
+    fun putTestVirtualNodeInfo(virtualNodeInfo: VirtualNodeInfo)
 }
 
 @ServiceRanking(Int.MAX_VALUE)
@@ -22,40 +22,31 @@ internal class TestVirtualNodeInfoReadServiceImpl @Activate constructor() : Test
 
     private val testVirtualNodeInfoList = mutableListOf<VirtualNodeInfo>()
 
-    override fun setTestVirtualNodeInfo(virtualNodeInfo: VirtualNodeInfo) {
+    override fun putTestVirtualNodeInfo(virtualNodeInfo: VirtualNodeInfo) {
         testVirtualNodeInfoList.add(virtualNodeInfo)
     }
 
     override fun getAll(): List<VirtualNodeInfo> = testVirtualNodeInfoList
 
-    override fun get(holdingIdentity: HoldingIdentity): VirtualNodeInfo? {
-        return testVirtualNodeInfoList.firstOrNull { it.holdingIdentity ==  holdingIdentity }
-    }
+    override fun get(holdingIdentity: HoldingIdentity) =
+        testVirtualNodeInfoList.firstOrNull {
+            it.holdingIdentity == holdingIdentity
+        }
 
-    override fun getByHoldingIdentityShortHash(holdingIdentityShortHash: ShortHash): VirtualNodeInfo? {
-        return testVirtualNodeInfoList.firstOrNull { it.holdingIdentity.shortHash ==  holdingIdentityShortHash }
-    }
+    override fun getByHoldingIdentityShortHash(holdingIdentityShortHash: ShortHash) =
+        testVirtualNodeInfoList.firstOrNull {
+            it.holdingIdentity.shortHash == holdingIdentityShortHash
+        }
 
-    override fun registerCallback(listener: VirtualNodeInfoListener): AutoCloseable {
-        return AutoCloseable { return@AutoCloseable }
-    }
 
-    override fun getAllVersionedRecords(): Stream<VersionedRecord<HoldingIdentity, VirtualNodeInfo>>? {
-        return null
-    }
+    override fun registerCallback(listener: VirtualNodeInfoListener) = AutoCloseable { return@AutoCloseable }
 
-    override val lifecycleCoordinatorName: LifecycleCoordinatorName
-        get() = LifecycleCoordinatorName.forComponent<TestVirtualNodeInfoReadServiceImpl>()
+    override val isRunning = true
+    override val lifecycleCoordinatorName =
+        LifecycleCoordinatorName.forComponent<TestVirtualNodeInfoReadServiceImpl>()
 
-    override val isRunning: Boolean
-        get() = true
-
-    override fun start() {
-        return
-    }
-
-    override fun stop() {
-        return
-    }
+    override fun getAllVersionedRecords(): Stream<VersionedRecord<HoldingIdentity, VirtualNodeInfo>>? = null
+    override fun stop() {}
+    override fun start() {}
 
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -375,14 +375,12 @@ class DynamicMemberRegistrationService @Activate constructor(
                 SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
                 MEMBER_CPI_NAME to cpi.name,
                 MEMBER_CPI_VERSION to cpi.version,
-                MEMBER_CPI_SIGNER_HASH to cpi.signerSummaryHash.toString(),
                 SERIAL to SERIAL_CONST,
             )
             val roleContext = roles.toMemberInfo { notaryKeys }
-            val optionalContext = mutableMapOf<String, String>()
-            cpi.signerSummaryHash?.let {
-                optionalContext.put(MEMBER_CPI_SIGNER_HASH, it.toString())
-            }
+            val optionalContext = cpi.signerSummaryHash?.let {
+                mapOf(MEMBER_CPI_SIGNER_HASH to it.toString())
+            } ?: emptyMap()
             return filteredContext +
                     sessionKeyContext +
                     ledgerKeyContext +

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -87,7 +87,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import java.nio.ByteBuffer
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -360,7 +360,7 @@ class DynamicMemberRegistrationService @Activate constructor(
             notaryKeys: List<KeyDetails>,
         ): Map<String, String> {
             val cpi = virtualNodeInfoReadService.get(member)?.cpiIdentifier
-                ?: throw CordaRuntimeException("Could not find virtual node info for member: [$member]")
+                ?: throw CordaRuntimeException("Could not find virtual node info for $member")
             return (
                 context.filterNot {
                     it.key.startsWith(LEDGER_KEYS) || it.key.startsWith(PARTY_SESSION_KEY)

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -133,7 +133,6 @@ class DynamicMemberRegistrationService @Activate constructor(
         const val NOTARY_KEY_ID = "corda.notary.keys.%s.id"
         const val LEDGER_KEY_SIGNATURE_SPEC = "$LEDGER_KEYS.%s.signature.spec"
         const val MEMBERSHIP_P2P_SUBSYSTEM = "membership"
-        const val SOFTWARE_VERSION_CONST = "5.0.0"
         const val SERIAL_CONST = "1"
 
         val notaryIdRegex = NOTARY_KEY_ID.format("[0-9]+").toRegex()
@@ -362,8 +361,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                         PARTY_NAME to member.x500Name.toString(),
                         GROUP_ID to member.groupId,
                         PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
-                        // temporarily hardcoded
-                        SOFTWARE_VERSION to SOFTWARE_VERSION_CONST,
+                        SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
                         SERIAL to SERIAL_CONST,
                     ) + roles.toMemberInfo { notaryKeys }
                 )

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextConstants.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextConstants.kt
@@ -1,0 +1,17 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
+
+internal const val GROUP_POLICY_PREFIX = "corda.group"
+internal const val GROUP_POLICY_PREFIX_WITH_DOT = "$GROUP_POLICY_PREFIX."
+internal const val REGISTRATION_PROTOCOL = "${GROUP_POLICY_PREFIX}.protocol.registration"
+internal const val SYNCHRONISATION_PROTOCOL = "${GROUP_POLICY_PREFIX}.protocol.synchronisation"
+internal const val P2P_MODE = "${GROUP_POLICY_PREFIX}.protocol.p2p.mode"
+internal const val SESSION_KEY_POLICY = "${GROUP_POLICY_PREFIX}.key.session.policy"
+internal const val PKI_SESSION = "${GROUP_POLICY_PREFIX}.pki.session"
+internal const val PKI_TLS = "${GROUP_POLICY_PREFIX}.pki.tls"
+internal const val TRUSTSTORE_SESSION = "${GROUP_POLICY_PREFIX}.truststore.session.%s"
+internal const val TRUSTSTORE_TLS = "${GROUP_POLICY_PREFIX}.truststore.tls.%s"
+internal const val SESSION_KEY_ID = "$PARTY_SESSION_KEY.id"
+internal const val ECDH_KEY_ID = "$ECDH_KEY.id"

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
@@ -1,0 +1,92 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.membership.impl.registration.dynamic.verifiers.OrderVerifier
+import net.corda.membership.impl.registration.dynamic.verifiers.P2pEndpointVerifier
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.NO_PKI
+import net.corda.membership.lib.schema.validation.MembershipSchemaValidationException
+import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
+import net.corda.schema.membership.MembershipSchema
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.versioning.Version
+
+internal class MGMRegistrationContextValidator(
+    private val membershipSchemaValidatorFactory: MembershipSchemaValidatorFactory,
+    private val orderVerifier: OrderVerifier = OrderVerifier(),
+    private val p2pEndpointVerifier: P2pEndpointVerifier = P2pEndpointVerifier(orderVerifier)
+) {
+
+    private companion object {
+        const val errorMessageTemplate = "No %s was provided."
+
+        val errorMessageMap = errorMessageTemplate.run {
+            mapOf(
+                SESSION_KEY_ID to format("session key"),
+                ECDH_KEY_ID to format("ECDH key"),
+                REGISTRATION_PROTOCOL to format("registration protocol"),
+                SYNCHRONISATION_PROTOCOL to format("synchronisation protocol"),
+                P2P_MODE to format("P2P mode"),
+                SESSION_KEY_POLICY to format("session key policy"),
+                PKI_SESSION to format("session PKI property"),
+                PKI_TLS to format("TLS PKI property"),
+            )
+        }
+    }
+
+    @Suppress("ThrowsCount")
+    @Throws(MGMRegistrationContextValidationException::class)
+    fun validate(context: Map<String, String>) {
+        try {
+            validateContextSchema(context)
+            validateContext(context)
+        } catch (ex: MembershipSchemaValidationException) {
+            throw MGMRegistrationContextValidationException(
+                "Onboarding MGM failed. ${ex.message}",
+                ex
+            )
+        } catch (ex: IllegalArgumentException) {
+            throw MGMRegistrationContextValidationException(
+                "Onboarding MGM failed. ${ex.message ?: "Reason unknown."}",
+                ex
+            )
+        } catch (ex: Exception) {
+            throw MGMRegistrationContextValidationException(
+                "Onboarding MGM failed. Unexpected error occurred during context validation. ${ex.message}",
+                ex
+            )
+        }
+    }
+
+    @Throws(MembershipSchemaValidationException::class)
+    private fun validateContextSchema(context: Map<String, String>) {
+        membershipSchemaValidatorFactory
+            .createValidator()
+            .validateRegistrationContext(
+                MembershipSchema.RegistrationContextSchema.Mgm,
+                Version(1, 0),
+                context
+            )
+    }
+
+    @Throws(IllegalArgumentException::class)
+    private fun validateContext(context: Map<String, String>) {
+        for (key in errorMessageMap.keys) {
+            context[key] ?: throw IllegalArgumentException(errorMessageMap[key])
+        }
+        p2pEndpointVerifier.verifyContext(context)
+        if (context[PKI_SESSION] != NO_PKI.toString()) {
+            context.keys.filter { TRUSTSTORE_SESSION.format("[0-9]+").toRegex().matches(it) }.apply {
+                require(isNotEmpty()) { "No session trust store was provided." }
+                require(orderVerifier.isOrdered(this, 4)) { "Provided session trust stores are incorrectly numbered." }
+            }
+        }
+        context.keys.filter { TRUSTSTORE_TLS.format("[0-9]+").toRegex().matches(it) }.apply {
+            require(isNotEmpty()) { "No TLS trust store was provided." }
+            require(orderVerifier.isOrdered(this, 4)) { "Provided TLS trust stores are incorrectly numbered." }
+        }
+    }
+}
+
+internal class MGMRegistrationContextValidationException(
+    val reason: String,
+    e: Throwable?
+) : CordaRuntimeException(reason, e)

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandler.kt
@@ -1,0 +1,50 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.layeredpropertymap.LayeredPropertyMapFactory
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.types.LayeredPropertyMap
+import net.corda.virtualnode.HoldingIdentity
+
+internal class MGMRegistrationGroupPolicyHandler(
+    private val layeredPropertyMapFactory: LayeredPropertyMapFactory,
+    private val membershipPersistenceClient: MembershipPersistenceClient
+) {
+
+    fun buildAndPersist(
+        holdingIdentity: HoldingIdentity,
+        context: Map<String, String>
+    ): LayeredPropertyMap {
+        val groupPolicyMap = context.filterKeys {
+            it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
+        }.mapKeys {
+            it.key.removePrefix(GROUP_POLICY_PREFIX_WITH_DOT)
+        }
+        val groupPolicy = layeredPropertyMapFactory.createMap(groupPolicyMap)
+        val groupPolicyPersistenceResult = membershipPersistenceClient.persistGroupPolicy(
+            holdingIdentity,
+            groupPolicy,
+        )
+        if (groupPolicyPersistenceResult is MembershipPersistenceResult.Failure) {
+            throw MGMRegistrationGroupPolicyHandlingException(
+                "Registration failed, persistence error. Reason: ${groupPolicyPersistenceResult.errorMsg}"
+            )
+        }
+
+        // Persist group parameters snapshot
+        val groupParametersPersistenceResult =
+            membershipPersistenceClient.persistGroupParametersInitialSnapshot(holdingIdentity)
+        if (groupParametersPersistenceResult is MembershipPersistenceResult.Failure) {
+            throw MGMRegistrationGroupPolicyHandlingException(
+                "Registration failed, persistence error. Reason: ${groupParametersPersistenceResult.errorMsg}"
+            )
+        }
+
+        return groupPolicy
+    }
+}
+
+internal class MGMRegistrationGroupPolicyHandlingException(
+    val reason: String
+) : CordaRuntimeException(reason)

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -1,0 +1,183 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureWithKey
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_HASH
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
+import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
+import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.registration.RegistrationRequest
+import net.corda.membership.lib.toWire
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.utilities.time.Clock
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.crypto.calculateHash
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import java.nio.ByteBuffer
+import java.security.PublicKey
+import java.util.*
+
+@Suppress("LongParameterList")
+internal class MGMRegistrationMemberInfoHandler(
+    private val clock: Clock,
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    private val cryptoOpsClient: CryptoOpsClient,
+    private val keyEncodingService: KeyEncodingService,
+    private val memberInfoFactory: MemberInfoFactory,
+    private val membershipPersistenceClient: MembershipPersistenceClient,
+    private val platformInfoProvider: PlatformInfoProvider,
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService
+) {
+
+    private companion object {
+        const val SERIAL_CONST = "1"
+        val logger = contextLogger()
+        val keyIdList = listOf(SESSION_KEY_ID, ECDH_KEY_ID)
+    }
+
+    private val keyValuePairListSerializer =
+        cordaAvroSerializationFactory.createAvroSerializer<KeyValuePairList> {
+            logger.error("Failed to serialize key value pair list.")
+        }
+
+    @Throws(MGMRegistrationMemberInfoHandlingException::class)
+    fun buildAndPersist(
+        registrationId: UUID,
+        holdingIdentity: HoldingIdentity,
+        context: Map<String, String>
+    ): MemberInfo {
+        return buildMgmInfo(holdingIdentity, context).also {
+            persistMemberInfo(holdingIdentity, it)
+            persistRegistrationRequest(registrationId, holdingIdentity, it)
+        }
+    }
+
+    private fun getKeyFromId(keyId: String, tenantId: String): PublicKey {
+        return cryptoOpsClient.lookup(
+            tenantId,
+            listOf(keyId)
+        ).firstOrNull()?.let {
+            try {
+                keyEncodingService.decodePublicKey(it.publicKey.array())
+            } catch (ex: RuntimeException) {
+                throw MGMRegistrationMemberInfoHandlingException(
+                    "Could not decode public key for tenant ID: " +
+                            "$tenantId under ID: $keyId.", ex
+                )
+            }
+        } ?: throw MGMRegistrationMemberInfoHandlingException(
+            "No key found for tenant: $tenantId under ID: $keyId."
+        )
+    }
+
+    private fun PublicKey.toPem(): String = keyEncodingService.encodeAsString(this)
+
+    private fun persistMemberInfo(holdingIdentity: HoldingIdentity, mgmInfo: MemberInfo) {
+        val persistenceResult = membershipPersistenceClient.persistMemberInfo(holdingIdentity, listOf(mgmInfo))
+        if (persistenceResult is MembershipPersistenceResult.Failure) {
+            throw MGMRegistrationMemberInfoHandlingException(
+                "Registration failed, persistence error. Reason: ${persistenceResult.errorMsg}"
+            )
+        }
+    }
+
+    private fun buildMgmInfo(
+        holdingIdentity: HoldingIdentity,
+        context: Map<String, String>
+    ): MemberInfo {
+        val cpi = virtualNodeInfoReadService.get(holdingIdentity)?.cpiIdentifier
+            ?: throw MGMRegistrationMemberInfoHandlingException(
+                "Could not find virtual node info for member ${holdingIdentity.shortHash}"
+            )
+        val sessionKey = getKeyFromId(context[SESSION_KEY_ID]!!, holdingIdentity.shortHash.value)
+        val ecdhKey = getKeyFromId(context[ECDH_KEY_ID]!!, holdingIdentity.shortHash.value)
+        val now = clock.instant().toString()
+        val optionalContext = mutableMapOf<String, String>()
+        cpi.signerSummaryHash?.let {
+            optionalContext.put(MEMBER_CPI_SIGNER_HASH, it.toString())
+        }
+        val memberContext = context.filterKeys {
+            !keyIdList.contains(it)
+        }.filterKeys {
+            !it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
+        } + mapOf(
+            GROUP_ID to holdingIdentity.groupId,
+            PARTY_NAME to holdingIdentity.x500Name.toString(),
+            PARTY_SESSION_KEY to sessionKey.toPem(),
+            SESSION_KEY_HASH to sessionKey.calculateHash().value,
+            ECDH_KEY to ecdhKey.toPem(),
+            PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
+            SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
+            MEMBER_CPI_NAME to cpi.name,
+            MEMBER_CPI_VERSION to cpi.version,
+            SERIAL to SERIAL_CONST,
+        ) + optionalContext
+        return memberInfoFactory.create(
+            memberContext = memberContext.toSortedMap(),
+            mgmContext = sortedMapOf(
+                CREATED_TIME to now,
+                MODIFIED_TIME to now,
+                STATUS to MEMBER_STATUS_ACTIVE,
+                IS_MGM to "true"
+            )
+        )
+    }
+
+    private fun persistRegistrationRequest(
+        registrationId: UUID,
+        holdingIdentity: HoldingIdentity,
+        mgmInfo: MemberInfo
+    ) {
+        val serializedMemberContext = keyValuePairListSerializer.serialize(
+            mgmInfo.memberProvidedContext.toWire()
+        ) ?: throw MGMRegistrationMemberInfoHandlingException(
+            "Failed to serialize the member context for this request."
+        )
+        val registrationRequestPersistenceResult = membershipPersistenceClient.persistRegistrationRequest(
+            viewOwningIdentity = holdingIdentity,
+            registrationRequest = RegistrationRequest(
+                status = RegistrationStatus.APPROVED,
+                registrationId = registrationId.toString(),
+                requester = holdingIdentity,
+                memberContext = ByteBuffer.wrap(serializedMemberContext),
+                signature = CryptoSignatureWithKey(
+                    ByteBuffer.wrap(byteArrayOf()),
+                    ByteBuffer.wrap(byteArrayOf()),
+                    KeyValuePairList(emptyList())
+                )
+            )
+        )
+        if (registrationRequestPersistenceResult is MembershipPersistenceResult.Failure) {
+            throw MGMRegistrationMemberInfoHandlingException(
+                "Registration failed, persistence error. Reason: ${registrationRequestPersistenceResult.errorMsg}"
+            )
+        }
+    }
+}
+
+internal class MGMRegistrationMemberInfoHandlingException(
+    val reason: String,
+    ex: Throwable? = null
+) : CordaRuntimeException(reason, ex)

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -114,10 +114,9 @@ internal class MGMRegistrationMemberInfoHandler(
         val sessionKey = getKeyFromId(context[SESSION_KEY_ID]!!, holdingIdentity.shortHash.value)
         val ecdhKey = getKeyFromId(context[ECDH_KEY_ID]!!, holdingIdentity.shortHash.value)
         val now = clock.instant().toString()
-        val optionalContext = mutableMapOf<String, String>()
-        cpi.signerSummaryHash?.let {
-            optionalContext.put(MEMBER_CPI_SIGNER_HASH, it.toString())
-        }
+        val optionalContext = cpi.signerSummaryHash?.let {
+            mapOf(MEMBER_CPI_SIGNER_HASH to it.toString())
+        } ?: emptyMap()
         val memberContext = context.filterKeys {
             !keyIdList.contains(it)
         }.filterKeys {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutputPublisher.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutputPublisher.kt
@@ -1,0 +1,68 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.data.membership.PersistentMemberInfo
+import net.corda.data.membership.event.MembershipEvent
+import net.corda.data.membership.event.registration.MgmOnboarded
+import net.corda.layeredpropertymap.toAvro
+import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
+import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas.Membership.Companion.EVENT_TOPIC
+import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.toAvro
+import java.util.concurrent.TimeUnit
+
+internal class MGMRegistrationOutputPublisher(
+    private val publisherFactory: () -> Publisher
+) {
+
+    private companion object {
+        const val PUBLICATION_TIMEOUT_SECONDS = 30L
+    }
+
+    fun publish(
+        mgmInfo: MemberInfo
+    ) {
+        val holdingIdentity = mgmInfo.holdingIdentity
+        val holdingIdentityShortHash = holdingIdentity.shortHash.value
+        val avroHoldingIdentity = holdingIdentity.toAvro()
+        val mgmRecord = Record(
+            MEMBER_LIST_TOPIC,
+            "$holdingIdentityShortHash-$holdingIdentityShortHash",
+            PersistentMemberInfo(
+                avroHoldingIdentity,
+                mgmInfo.memberProvidedContext.toAvro(),
+                mgmInfo.mgmProvidedContext.toAvro()
+            )
+        )
+
+        val eventRecord = Record(
+            EVENT_TOPIC,
+            holdingIdentityShortHash,
+            MembershipEvent(
+                MgmOnboarded(avroHoldingIdentity)
+            )
+        )
+
+        try {
+            publisherFactory
+                .invoke()
+                .publish(listOf(mgmRecord, eventRecord))
+                .first()
+                .get(
+                    PUBLICATION_TIMEOUT_SECONDS,
+                    TimeUnit.SECONDS
+                )
+        } catch (ex: CordaMessageAPIFatalException) {
+            throw MGMRegistrationOutputPublisherException(ex.message ?: "Unknown failure.", ex)
+        }
+    }
+}
+
+internal class MGMRegistrationOutputPublisherException(
+    val reason: String,
+    ex: Throwable
+) : CordaRuntimeException(reason, ex)

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutputPublisher.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutputPublisher.kt
@@ -51,11 +51,9 @@ internal class MGMRegistrationOutputPublisher(
             publisherFactory
                 .invoke()
                 .publish(listOf(mgmRecord, eventRecord))
-                .first()
-                .get(
-                    PUBLICATION_TIMEOUT_SECONDS,
-                    TimeUnit.SECONDS
-                )
+                .forEach {
+                    it.get(PUBLICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                }
         } catch (ex: CordaMessageAPIFatalException) {
             throw MGMRegistrationOutputPublisherException(ex.message ?: "Unknown failure.", ex)
         }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -225,7 +225,7 @@ class MGMRegistrationService @Activate constructor(
     }
 
     private inner class ActiveImpl : InnerRegistrationService {
-        @Suppress("LongMethod")
+        @Suppress("LongMethod", "ComplexMethod")
         override fun register(
             registrationId: UUID,
             member: HoldingIdentity,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -255,7 +255,7 @@ class MGMRegistrationService @Activate constructor(
             }
             try {
                 val cpi = virtualNodeInfoReadService.get(member)?.cpiIdentifier
-                    ?: throw CordaRuntimeException("Could not find virtual node info for member: [$member]")
+                    ?: throw CordaRuntimeException("Could not find virtual node info for member $member")
                 val sessionKey = getKeyFromId(context[SESSION_KEY_ID]!!, member.shortHash.value)
                 val ecdhKey = getKeyFromId(context[ECDH_KEY_ID]!!, member.shortHash.value)
                 val now = clock.instant().toString()

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -128,8 +128,6 @@ class MGMRegistrationService @Activate constructor(
         const val PKI_TLS = "$GROUP_POLICY_PREFIX.pki.tls"
         const val TRUSTSTORE_SESSION = "$GROUP_POLICY_PREFIX.truststore.session.%s"
         const val TRUSTSTORE_TLS = "$GROUP_POLICY_PREFIX.truststore.tls.%s"
-        const val PLATFORM_VERSION_CONST = "5000"
-        const val SOFTWARE_VERSION_CONST = "5.0.0"
         const val SERIAL_CONST = "1"
 
         val keyIdList = listOf(SESSION_KEY_ID, ECDH_KEY_ID)
@@ -263,9 +261,8 @@ class MGMRegistrationService @Activate constructor(
                     PARTY_SESSION_KEY to sessionKey.toPem(),
                     SESSION_KEY_HASH to sessionKey.calculateHash().value,
                     ECDH_KEY to ecdhKey.toPem(),
-                    // temporarily hardcoded
                     PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
-                    SOFTWARE_VERSION to SOFTWARE_VERSION_CONST,
+                    SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
                     SERIAL to SERIAL_CONST,
                 )
                 val mgmInfo = memberInfoFactory.create(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -4,14 +4,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.CordaAvroSerializationFactory
-import net.corda.data.KeyValuePairList
-import net.corda.data.crypto.wire.CryptoSignatureWithKey
-import net.corda.data.membership.PersistentMemberInfo
-import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.event.MembershipEvent
-import net.corda.data.membership.event.registration.MgmOnboarded
 import net.corda.layeredpropertymap.LayeredPropertyMapFactory
-import net.corda.layeredpropertymap.toAvro
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.lifecycle.LifecycleCoordinator
@@ -23,60 +16,28 @@ import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
-import net.corda.membership.impl.registration.dynamic.verifiers.OrderVerifier
-import net.corda.membership.impl.registration.dynamic.verifiers.P2pEndpointVerifier
-import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
-import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
-import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
-import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
-import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
-import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
-import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
-import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
-import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
-import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
-import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
-import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
-import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
-import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
-import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoFactory
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode
-import net.corda.membership.lib.registration.RegistrationRequest
-import net.corda.membership.lib.schema.validation.MembershipSchemaValidationException
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
-import net.corda.membership.lib.toWire
 import net.corda.membership.persistence.client.MembershipPersistenceClient
-import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.membership.registration.MemberRegistrationService
 import net.corda.membership.registration.MembershipRequestRegistrationOutcome
 import net.corda.membership.registration.MembershipRequestRegistrationResult
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.messaging.api.records.Record
-import net.corda.schema.Schemas.Membership.Companion.EVENT_TOPIC
-import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.schema.membership.MembershipSchema.RegistrationContextSchema
+import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.versioning.Version
 import net.corda.v5.cipher.suite.KeyEncodingService
-import net.corda.v5.crypto.calculateHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
-import net.corda.virtualnode.toAvro
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
-import java.nio.ByteBuffer
-import java.security.PublicKey
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
 @Component(service = [MemberRegistrationService::class])
@@ -98,7 +59,7 @@ class MGMRegistrationService @Activate constructor(
     @Reference(service = LayeredPropertyMapFactory::class)
     private val layeredPropertyMapFactory: LayeredPropertyMapFactory,
     @Reference(service = CordaAvroSerializationFactory::class)
-    cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
     @Reference(service = MembershipSchemaValidatorFactory::class)
     private val membershipSchemaValidatorFactory: MembershipSchemaValidatorFactory,
     @Reference(service = PlatformInfoProvider::class)
@@ -119,36 +80,6 @@ class MGMRegistrationService @Activate constructor(
 
     private companion object {
         val logger: Logger = contextLogger()
-        const val errorMessageTemplate = "No %s was provided."
-
-        const val GROUP_POLICY_PREFIX = "corda.group"
-        const val GROUP_POLICY_PREFIX_WITH_DOT = "$GROUP_POLICY_PREFIX."
-        const val PUBLICATION_TIMEOUT_SECONDS = 30L
-        const val SESSION_KEY_ID = "$PARTY_SESSION_KEY.id"
-        const val ECDH_KEY_ID = "$ECDH_KEY.id"
-        const val REGISTRATION_PROTOCOL = "$GROUP_POLICY_PREFIX.protocol.registration"
-        const val SYNCHRONISATION_PROTOCOL = "$GROUP_POLICY_PREFIX.protocol.synchronisation"
-        const val P2P_MODE = "$GROUP_POLICY_PREFIX.protocol.p2p.mode"
-        const val SESSION_KEY_POLICY = "$GROUP_POLICY_PREFIX.key.session.policy"
-        const val PKI_SESSION = "$GROUP_POLICY_PREFIX.pki.session"
-        const val PKI_TLS = "$GROUP_POLICY_PREFIX.pki.tls"
-        const val TRUSTSTORE_SESSION = "$GROUP_POLICY_PREFIX.truststore.session.%s"
-        const val TRUSTSTORE_TLS = "$GROUP_POLICY_PREFIX.truststore.tls.%s"
-        const val SERIAL_CONST = "1"
-
-        val keyIdList = listOf(SESSION_KEY_ID, ECDH_KEY_ID)
-        val errorMessageMap = errorMessageTemplate.run {
-            mapOf(
-                SESSION_KEY_ID to format("session key"),
-                ECDH_KEY_ID to format("ECDH key"),
-                REGISTRATION_PROTOCOL to format("registration protocol"),
-                SYNCHRONISATION_PROTOCOL to format("synchronisation protocol"),
-                P2P_MODE to format("P2P mode"),
-                SESSION_KEY_POLICY to format("session key policy"),
-                PKI_SESSION to format("session PKI property"),
-                PKI_TLS to format("TLS PKI property"),
-            )
-        }
     }
 
     // for watching the config changes
@@ -159,24 +90,16 @@ class MGMRegistrationService @Activate constructor(
 
     private var _publisher: Publisher? = null
 
-    private val orderVerifier = OrderVerifier()
-    private val p2pEndpointVerifier = P2pEndpointVerifier(orderVerifier)
-
     /**
      * Publisher for Kafka messaging. Recreated after every [MESSAGING_CONFIG] change.
      */
     private val publisher: Publisher
         get() = _publisher ?: throw IllegalArgumentException("Publisher is not initialized.")
 
-    private val keyValuePairListSerializer =
-        cordaAvroSerializationFactory.createAvroSerializer<KeyValuePairList> {
-            logger.error("Failed to serialize key value pair list.")
-        }
-
     // Component lifecycle coordinator
     private val coordinator = coordinatorFactory.createCoordinator(lifecycleCoordinatorName, ::handleEvent)
 
-    private val clock = UTCClock()
+    private val clock: Clock = UTCClock()
 
     private var impl: InnerRegistrationService = InactiveImpl
 
@@ -225,183 +148,71 @@ class MGMRegistrationService @Activate constructor(
     }
 
     private inner class ActiveImpl : InnerRegistrationService {
-        @Suppress("LongMethod", "ComplexMethod")
+
+        private val mgmRegistrationContextValidator = MGMRegistrationContextValidator(
+            membershipSchemaValidatorFactory
+        )
+        private val mgmRegistrationMemberInfoHandler = MGMRegistrationMemberInfoHandler(
+            clock,
+            cordaAvroSerializationFactory,
+            cryptoOpsClient,
+            keyEncodingService,
+            memberInfoFactory,
+            membershipPersistenceClient,
+            platformInfoProvider,
+            virtualNodeInfoReadService
+        )
+        private val mgmRegistrationGroupPolicyHandler = MGMRegistrationGroupPolicyHandler(
+            layeredPropertyMapFactory,
+            membershipPersistenceClient
+        )
+        private val mgmRegistrationOutputPublisher = MGMRegistrationOutputPublisher { publisher }
+
         override fun register(
             registrationId: UUID,
             member: HoldingIdentity,
             context: Map<String, String>
         ): MembershipRequestRegistrationResult {
-            try {
-                membershipSchemaValidatorFactory
-                    .createValidator()
-                    .validateRegistrationContext(
-                        RegistrationContextSchema.Mgm,
-                        Version(1, 0),
-                        context
-                    )
-            } catch (ex: MembershipSchemaValidationException) {
-                return MembershipRequestRegistrationResult(
-                    MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                    "Onboarding MGM failed. The registration context is invalid: " + ex.getErrorSummary()
-                )
-            }
-            try {
-                validateContext(context)
-            } catch (ex: IllegalArgumentException) {
-                return MembershipRequestRegistrationResult(
-                    MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                    "Onboarding MGM failed. The registration context is invalid: " + ex.message
-                )
-            }
-            try {
-                val cpi = virtualNodeInfoReadService.get(member)?.cpiIdentifier
-                    ?: throw CordaRuntimeException("Could not find virtual node info for member $member")
-                val sessionKey = getKeyFromId(context[SESSION_KEY_ID]!!, member.shortHash.value)
-                val ecdhKey = getKeyFromId(context[ECDH_KEY_ID]!!, member.shortHash.value)
-                val now = clock.instant().toString()
-                val memberContext = context.filterKeys {
-                    !keyIdList.contains(it)
-                }.filterKeys {
-                    !it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
-                } + mapOf(
-                    GROUP_ID to member.groupId,
-                    PARTY_NAME to member.x500Name.toString(),
-                    PARTY_SESSION_KEY to sessionKey.toPem(),
-                    SESSION_KEY_HASH to sessionKey.calculateHash().value,
-                    ECDH_KEY to ecdhKey.toPem(),
-                    PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
-                    SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
-                    MEMBER_CPI_NAME to cpi.name,
-                    MEMBER_CPI_VERSION to cpi.version,
-                    SERIAL to SERIAL_CONST,
-                )
-                val mgmInfo = memberInfoFactory.create(
-                    memberContext = memberContext.toSortedMap(),
-                    mgmContext = sortedMapOf(
-                        CREATED_TIME to now,
-                        MODIFIED_TIME to now,
-                        STATUS to MEMBER_STATUS_ACTIVE,
-                        IS_MGM to "true"
-                    )
-                )
+            return try {
+                mgmRegistrationContextValidator.validate(context)
 
-                val persistenceResult = membershipPersistenceClient.persistMemberInfo(member, listOf(mgmInfo))
-                if (persistenceResult is MembershipPersistenceResult.Failure) {
-                    return MembershipRequestRegistrationResult(
-                        MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                        "Registration failed, persistence error. Reason: ${persistenceResult.errorMsg}"
-                    )
-                }
-
-                val groupPolicyMap = context.filterKeys {
-                    it.startsWith(GROUP_POLICY_PREFIX_WITH_DOT)
-                }.mapKeys {
-                    it.key.removePrefix(GROUP_POLICY_PREFIX_WITH_DOT)
-                }
-                val groupPolicy = layeredPropertyMapFactory.createMap(groupPolicyMap)
-                val groupPolicyPersistenceResult = membershipPersistenceClient.persistGroupPolicy(
+                val mgmInfo = mgmRegistrationMemberInfoHandler.buildAndPersist(
+                    registrationId,
                     member,
-                    groupPolicy,
-                )
-                if (groupPolicyPersistenceResult is MembershipPersistenceResult.Failure) {
-                    return MembershipRequestRegistrationResult(
-                        MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                        "Registration failed, persistence error. Reason: ${groupPolicyPersistenceResult.errorMsg}"
-                    )
-                }
-
-                val serializedMemberContext = keyValuePairListSerializer.serialize(memberContext.toWire())
-                    ?: throw IllegalArgumentException("Failed to serialize the member context for this request.")
-                val registrationRequestPersistenceResult = membershipPersistenceClient.persistRegistrationRequest(
-                    viewOwningIdentity = member,
-                    registrationRequest = RegistrationRequest(
-                        status = RegistrationStatus.APPROVED,
-                        registrationId = registrationId.toString(),
-                        requester = member,
-                        memberContext = ByteBuffer.wrap(serializedMemberContext),
-                        signature = CryptoSignatureWithKey(
-                            ByteBuffer.wrap(byteArrayOf()),
-                            ByteBuffer.wrap(byteArrayOf()),
-                            KeyValuePairList(emptyList())
-                        )
-                    )
-                )
-                if (registrationRequestPersistenceResult is MembershipPersistenceResult.Failure) {
-                    return MembershipRequestRegistrationResult(
-                        MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                        "Registration failed, persistence error. Reason: ${registrationRequestPersistenceResult.errorMsg}"
-                    )
-                }
-
-                // Persist group parameters snapshot
-                val groupParametersPersistenceResult = membershipPersistenceClient.persistGroupParametersInitialSnapshot(member)
-                if (groupParametersPersistenceResult is MembershipPersistenceResult.Failure) {
-                    return MembershipRequestRegistrationResult(
-                        MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                        "Registration failed, persistence error. Reason: ${groupParametersPersistenceResult.errorMsg}"
-                    )
-                }
-
-                val mgmRecord = Record(
-                    MEMBER_LIST_TOPIC,
-                    "${member.shortHash}-${member.shortHash}",
-                    PersistentMemberInfo(
-                        member.toAvro(),
-                        mgmInfo.memberProvidedContext.toAvro(),
-                        mgmInfo.mgmProvidedContext.toAvro()
-                    )
+                    context
                 )
 
-                val eventRecord = Record(
-                    EVENT_TOPIC,
-                    "${member.shortHash}",
-                    MembershipEvent(
-                        MgmOnboarded(member.toAvro())
-                    )
+                mgmRegistrationGroupPolicyHandler.buildAndPersist(
+                    member,
+                    context
                 )
 
-                publisher.publish(listOf(mgmRecord, eventRecord)).first().get(PUBLICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                mgmRegistrationOutputPublisher.publish(mgmInfo)
+
+                MembershipRequestRegistrationResult(MembershipRequestRegistrationOutcome.SUBMITTED)
+            } catch (ex: MGMRegistrationContextValidationException) {
+                buildNotSubmittedResponse(ex.reason)
+            } catch (ex: MGMRegistrationMemberInfoHandlingException) {
+                buildNotSubmittedResponse(ex.reason)
+            } catch (ex: MGMRegistrationGroupPolicyHandlingException) {
+                buildNotSubmittedResponse(ex.reason)
+            } catch(ex: MGMRegistrationOutputPublisherException){
+                buildNotSubmittedResponse(ex.reason)
             } catch (e: Exception) {
-                logger.warn("Registration failed.", e)
-                return MembershipRequestRegistrationResult(
-                    MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                    "Registration failed. Reason: ${e.message}"
-                )
+                buildNotSubmittedResponse("Registration failed. Reason: ${e.message}")
             }
+        }
 
-            return MembershipRequestRegistrationResult(MembershipRequestRegistrationOutcome.SUBMITTED)
+        private fun buildNotSubmittedResponse(reason: String): MembershipRequestRegistrationResult {
+            return MembershipRequestRegistrationResult(
+                MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
+                reason
+            )
         }
 
         override fun close() {
             publisher.close()
         }
-
-        private fun validateContext(context: Map<String, String>) {
-            for (key in errorMessageMap.keys) {
-                context[key] ?: throw IllegalArgumentException(errorMessageMap[key])
-            }
-            p2pEndpointVerifier.verifyContext(context)
-            if (context[PKI_SESSION] != SessionPkiMode.NO_PKI.toString()) {
-                context.keys.filter { TRUSTSTORE_SESSION.format("[0-9]+").toRegex().matches(it) }.apply {
-                    require(isNotEmpty()) { "No session trust store was provided." }
-                    require(orderVerifier.isOrdered(this, 4)) { "Provided session trust stores are incorrectly numbered." }
-                }
-            }
-            context.keys.filter { TRUSTSTORE_TLS.format("[0-9]+").toRegex().matches(it) }.apply {
-                require(isNotEmpty()) { "No TLS trust store was provided." }
-                require(orderVerifier.isOrdered(this, 4)) { "Provided TLS trust stores are incorrectly numbered." }
-            }
-        }
-
-        private fun getKeyFromId(keyId: String, tenantId: String): PublicKey {
-            return with(cryptoOpsClient) {
-                lookup(tenantId, listOf(keyId)).firstOrNull()?.let {
-                    keyEncodingService.decodePublicKey(it.publicKey.array())
-                } ?: throw IllegalArgumentException("No key found for tenant: $tenantId under ID: $keyId.")
-            }
-        }
-
-        private fun PublicKey.toPem(): String = keyEncodingService.encodeAsString(this)
     }
 
     private fun handleEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
@@ -456,7 +267,8 @@ class MGMRegistrationService @Activate constructor(
         }
     }
 
-    // re-creates the publisher with the new config, sets the lifecycle status to UP when the publisher is ready for the first time
+    // re-creates the publisher with the new config
+    // sets the lifecycle status to UP when the publisher is ready for the first time
     private fun handleConfigChange(event: ConfigChangedEvent, coordinator: LifecycleCoordinator) {
         logger.info("Handling config changed event.")
         _publisher?.close()

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMember.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMember.kt
@@ -6,7 +6,6 @@ import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplate
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.MEMBER_STATUS
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.STATIC_MODIFIED_TIME
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.STATIC_SERIAL
-import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.STATIC_SOFTWARE_VERSION
 import net.corda.v5.membership.EndpointInfo
 import net.corda.utilities.time.UTCClock
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMember.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMember.kt
@@ -20,16 +20,12 @@ class StaticMember(
 ) : Map<String, Any> by staticMemberData {
 
     private companion object {
-        const val DEFAULT_SOFTWARE_VERSION = "5.0.0"
         const val DEFAULT_SERIAL = "1"
         private val clock = UTCClock()
     }
 
     val name: String?
         get() = getStringValue(StaticMemberTemplateExtension.NAME)
-
-    val softwareVersion: String
-        get() = getStringValue(STATIC_SOFTWARE_VERSION, DEFAULT_SOFTWARE_VERSION)!!
 
     val serial: String
         get() = getIntValueAsString(STATIC_SERIAL, DEFAULT_SERIAL)!!

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -217,7 +217,7 @@ class StaticMemberRegistrationService @Activate constructor(
      * Parses the static member list template, creates the MemberInfo for the registering member and the records for the
      * kafka publisher.
      */
-    @Suppress("MaxLineLength")
+    @Suppress("ThrowsCount")
     private fun parseMemberTemplate(
         registeringMember: HoldingIdentity,
         groupPolicy: GroupPolicy,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -254,10 +254,9 @@ class StaticMemberRegistrationService @Activate constructor(
         val cpi = virtualNodeInfoReadService.get(registeringMember)?.cpiIdentifier
             ?: throw CordaRuntimeException("Could not find virtual node info for member ${registeringMember.shortHash}")
 
-        val optionalContext = mutableMapOf<String, String>()
-        cpi.signerSummaryHash?.let {
-            optionalContext.put(MEMBER_CPI_SIGNER_HASH, it.toString())
-        }
+        val optionalContext = cpi.signerSummaryHash?.let {
+            mapOf(MEMBER_CPI_SIGNER_HASH to it.toString())
+        } ?: emptyMap()
         @Suppress("SpreadOperator")
         val memberContext = mapOf(
             PARTY_NAME to memberName.toString(),

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -258,7 +258,7 @@ class StaticMemberRegistrationService @Activate constructor(
                     listOf(keysFactory.getOrGenerateKeyPair(NOTARY))
                 }.toTypedArray(),
                 SESSION_KEY_HASH to memberKey.hash.toString(),
-                SOFTWARE_VERSION to staticMemberInfo.softwareVersion,
+                SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
                 PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
                 SERIAL to staticMemberInfo.serial,
             ),

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -251,7 +251,7 @@ class StaticMemberRegistrationService @Activate constructor(
         val memberKey = keysFactory.getOrGenerateKeyPair(CryptoConsts.Categories.LEDGER)
 
         val cpi = virtualNodeInfoReadService.get(registeringMember)?.cpiIdentifier
-            ?: throw CordaRuntimeException("Could not find virtual node info for member: [$registeringMember]")
+            ?: throw CordaRuntimeException("Could not find virtual node info for member $registeringMember")
 
         @Suppress("SpreadOperator")
         val memberInfo = memberInfoFactory.create(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
@@ -20,9 +20,9 @@ val testCpiSignerSummaryHash = SecureHash.parse("ALG:A1B2C3D4")
 fun buildTestVirtualNodeInfo(member: HoldingIdentity) = VirtualNodeInfo(
     holdingIdentity = member,
     cpiIdentifier = CpiIdentifier(TEST_CPI_NAME, TEST_CPI_VERSION, testCpiSignerSummaryHash),
-    vaultDmlConnectionId = UUID.randomUUID(),
-    cryptoDmlConnectionId = UUID.randomUUID(),
-    uniquenessDmlConnectionId = UUID.randomUUID(),
+    vaultDmlConnectionId = UUID(0, 1),
+    cryptoDmlConnectionId = UUID(0, 1),
+    uniquenessDmlConnectionId = UUID(0, 1),
     timestamp = Instant.ofEpochSecond(1)
 )
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
@@ -2,6 +2,7 @@ package net.corda.membership.impl.registration
 
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import org.mockito.kotlin.doReturn
@@ -14,11 +15,11 @@ const val TEST_CPI_VERSION = "1.1"
 const val TEST_PLATFORM_VERSION = 5000
 const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
 
-fun String.addIndex(arg: Int) = String.format(this, arg)
+val testCpiSignerSummaryHash = SecureHash.parse("ALG:A1B2C3D4")
 
 fun buildTestVirtualNodeInfo(member: HoldingIdentity) = VirtualNodeInfo(
     holdingIdentity = member,
-    cpiIdentifier = CpiIdentifier(TEST_CPI_NAME, TEST_CPI_VERSION, null),
+    cpiIdentifier = CpiIdentifier(TEST_CPI_NAME, TEST_CPI_VERSION, testCpiSignerSummaryHash),
     vaultDmlConnectionId = UUID.randomUUID(),
     cryptoDmlConnectionId = UUID.randomUUID(),
     uniquenessDmlConnectionId = UUID.randomUUID(),

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
@@ -1,0 +1,29 @@
+package net.corda.membership.impl.registration
+
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.time.Instant
+import java.util.*
+
+const val TEST_CPI_NAME = "cpi-name"
+const val TEST_CPI_VERSION = "1.1"
+const val TEST_PLATFORM_VERSION = 5000
+const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
+
+fun buildTestVirtualNodeInfo(member: HoldingIdentity) = VirtualNodeInfo(
+    holdingIdentity = member,
+    cpiIdentifier = CpiIdentifier(TEST_CPI_NAME, TEST_CPI_VERSION, null),
+    vaultDmlConnectionId = UUID.randomUUID(),
+    cryptoDmlConnectionId = UUID.randomUUID(),
+    uniquenessDmlConnectionId = UUID.randomUUID(),
+    timestamp = Instant.ofEpochSecond(1)
+)
+
+fun buildMockPlatformInfoProvider(): PlatformInfoProvider = mock {
+    on { activePlatformVersion } doReturn TEST_PLATFORM_VERSION
+    on { localWorkerSoftwareVersion } doReturn TEST_SOFTWARE_VERSION
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationTestUtils.kt
@@ -14,6 +14,8 @@ const val TEST_CPI_VERSION = "1.1"
 const val TEST_PLATFORM_VERSION = 5000
 const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
 
+fun String.addIndex(arg: Int) = String.format(this, arg)
+
 fun buildTestVirtualNodeInfo(member: HoldingIdentity) = VirtualNodeInfo(
     holdingIdentity = member,
     cpiIdentifier = CpiIdentifier(TEST_CPI_NAME, TEST_CPI_VERSION, null),

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -57,9 +57,9 @@ class StartRegistrationHandlerTest {
 
     private companion object {
         val clock = TestClock(Instant.ofEpochSecond(0))
-        val registrationId = UUID.randomUUID().toString()
+        val registrationId = UUID(0, 1).toString()
         val x500Name = MemberX500Name.parse("O=Tester,L=London,C=GB")
-        val groupId = UUID.randomUUID().toString()
+        val groupId = UUID(0, 1).toString()
         val holdingIdentity = HoldingIdentity(x500Name.toString(), groupId)
 
         val mgmX500Name = MemberX500Name.parse("O=TestMGM,L=London,C=GB")

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -26,6 +26,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
 import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
 import net.corda.membership.impl.registration.buildTestVirtualNodeInfo
+import net.corda.membership.impl.registration.addIndex
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
@@ -383,8 +384,6 @@ class DynamicMemberRegistrationServiceTest {
 
             val submittedMemberContext = memberContext.firstValue
 
-            fun String.format(arg: Int) = String.format(this, arg)
-
             assertThat(submittedMemberContext.items.map { it.key }).containsExactlyInAnyOrder(
                 GROUP_ID,
                 PARTY_NAME,
@@ -394,24 +393,17 @@ class DynamicMemberRegistrationServiceTest {
                 PLATFORM_VERSION,
                 REGISTRATION_ID,
                 SERIAL,
-                URL_KEY.format(0),
-                PROTOCOL_VERSION.format(0),
+                URL_KEY.addIndex(0),
+                PROTOCOL_VERSION.addIndex(0),
                 PARTY_SESSION_KEY,
                 SESSION_KEY_HASH,
                 SESSION_KEY_SIGNATURE_SPEC,
-                LEDGER_KEYS_KEY.format(0),
-                LEDGER_KEY_HASHES_KEY.format(0),
-                LEDGER_KEY_SIGNATURE_SPEC.format(0)
+                LEDGER_KEYS_KEY.addIndex(0),
+                LEDGER_KEY_HASHES_KEY.addIndex(0),
+                LEDGER_KEY_SIGNATURE_SPEC.addIndex(0)
             )
 
-            /*
-    "corda.ledger.keys.0.hash",
-    "corda.ledger.keys.0.pem",
-    "corda.ledger.keys.0.signature.spec",
-    "corda.session.key",
-    "corda.session.key.hash",
-    "corda.session.key.signature.spec"
-             */
+
         }
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -23,7 +23,26 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
+import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
+import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
+import net.corda.membership.impl.registration.buildTestVirtualNodeInfo
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_SIGNATURE_SPEC
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_SIGNATURE_SPEC
+import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.URL_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.ecdhKey
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
@@ -57,9 +76,11 @@ import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
@@ -89,8 +110,6 @@ class DynamicMemberRegistrationServiceTest {
         const val NOTARY_KEY_ID = "4"
         const val PUBLISHER_CLIENT_ID = "dynamic-member-registration-service"
         const val GROUP_NAME = "dummy_group"
-        const val TEST_PLATFORM_VERSION = 5000
-        const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
 
         val MEMBER_CONTEXT_BYTES = "2222".toByteArray()
         val REQUEST_BYTES = "3333".toByteArray()
@@ -215,8 +234,9 @@ class DynamicMemberRegistrationServiceTest {
     private val configurationReadService: ConfigurationReadService = mock {
         on { registerComponentForUpdates(eq(coordinator), any()) } doReturn configHandle
     }
+    private var memberContext: KArgumentCaptor<KeyValuePairList> = argumentCaptor()
     private val keyValuePairListSerializer: CordaAvroSerializer<Any> = mock {
-        on { serialize(any()) } doReturn MEMBER_CONTEXT_BYTES
+        on { serialize(memberContext.capture()) } doReturn MEMBER_CONTEXT_BYTES
     }
     private val registrationRequestSerializer: CordaAvroSerializer<Any> = mock {
         on { serialize(any()) } doReturn REQUEST_BYTES
@@ -250,6 +270,10 @@ class DynamicMemberRegistrationServiceTest {
     private val ephemeralKeyPairEncryptor: EphemeralKeyPairEncryptor = mock {
         on { encrypt(eq(ecdhKey), any(), any()) } doReturn datawithKey
     }
+    private val virtualNodeInfo = buildTestVirtualNodeInfo(member)
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { get(eq(member)) } doReturn virtualNodeInfo
+    }
     private val registrationService = DynamicMemberRegistrationService(
         publisherFactory,
         configurationReadService,
@@ -262,6 +286,7 @@ class DynamicMemberRegistrationServiceTest {
         membershipSchemaValidatorFactory,
         platformInfoProvider,
         ephemeralKeyPairEncryptor,
+        virtualNodeInfoReadService
     )
 
     private val context = mapOf(
@@ -306,332 +331,383 @@ class DynamicMemberRegistrationServiceTest {
         )
     }
 
-    @Test
-    fun `starting the service succeeds`() {
-        registrationService.start()
-        assertThat(registrationService.isRunning).isTrue
-        verify(coordinator).start()
-    }
-
-    @Test
-    fun `stopping the service succeeds`() {
-        registrationService.start()
-        registrationService.stop()
-        assertThat(registrationService.isRunning).isFalse
-        verify(coordinator).stop()
-    }
-
-    @Test
-    fun `registration successfully builds unauthenticated message and publishes it`() {
-        postConfigChangedEvent()
-        registrationService.start()
-        val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
-        val result = registrationService.register(registrationResultId, member, context)
-        verify(mockPublisher, times(1)).publish(capturedPublishedList.capture())
-        val publishedMessageList = capturedPublishedList.firstValue
-        SoftAssertions.assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
-            it.assertThat(publishedMessageList.size).isEqualTo(1)
-            val publishedMessage = publishedMessageList.first()
-            it.assertThat(publishedMessage.topic).isEqualTo(Schemas.P2P.P2P_OUT_TOPIC)
-            it.assertThat(publishedMessage.key).isEqualTo(memberId.value)
-            val unauthenticatedMessagePublished =
-                (publishedMessage.value as AppMessage).message as UnauthenticatedMessage
-            it.assertThat(unauthenticatedMessagePublished.header.source).isEqualTo(member.toAvro())
-            it.assertThat(unauthenticatedMessagePublished.header.destination).isEqualTo(mgm.toAvro())
-            it.assertThat(unauthenticatedMessagePublished.payload).isEqualTo(ByteBuffer.wrap(UNAUTH_REQUEST_BYTES))
-        }
-        registrationService.stop()
-    }
-
-    @Test
-    fun `registration successfully persist the status to new`() {
-        postConfigChangedEvent()
-        registrationService.start()
-        val status = argumentCaptor<RegistrationRequest>()
-        whenever(
-            membershipPersistenceClient.persistRegistrationRequest(
-                eq(member),
-                status.capture()
-            )
-        ).doReturn(
-            MembershipPersistenceResult.success()
-        )
-
-        registrationService.register(registrationResultId, member, context)
-
-        assertThat(status.firstValue.status).isEqualTo(RegistrationStatus.NEW)
-    }
-
-    @Test
-    fun `registration fails when coordinator is not running`() {
-        val registrationResult = registrationService.register(registrationResultId, member, mock())
-        assertThat(registrationResult).isEqualTo(
-            MembershipRequestRegistrationResult(
-                MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                "Registration failed. Reason: DynamicMemberRegistrationService is not running."
-            )
-        )
-    }
-
-    @Test
-    fun `registration fails when one or more context properties are missing`() {
-        postConfigChangedEvent()
-        val testProperties = mutableMapOf<String, String>()
-        registrationService.start()
-        context.entries.apply {
-            for (index in indices) {
-                val result = registrationService.register(registrationResultId, member, testProperties)
-                SoftAssertions.assertSoftly {
-                    it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-                }
-                elementAt(index).let { testProperties.put(it.key, it.value) }
+    @Nested
+    inner class SuccessfulRegistrationTests {
+        @Test
+        fun `registration successfully builds unauthenticated message and publishes it`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
+            val result = registrationService.register(registrationResultId, member, context)
+            verify(mockPublisher, times(1)).publish(capturedPublishedList.capture())
+            val publishedMessageList = capturedPublishedList.firstValue
+            SoftAssertions.assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
+                it.assertThat(publishedMessageList.size).isEqualTo(1)
+                val publishedMessage = publishedMessageList.first()
+                it.assertThat(publishedMessage.topic).isEqualTo(Schemas.P2P.P2P_OUT_TOPIC)
+                it.assertThat(publishedMessage.key).isEqualTo(memberId.value)
+                val unauthenticatedMessagePublished =
+                    (publishedMessage.value as AppMessage).message as UnauthenticatedMessage
+                it.assertThat(unauthenticatedMessagePublished.header.source).isEqualTo(member.toAvro())
+                it.assertThat(unauthenticatedMessagePublished.header.destination).isEqualTo(mgm.toAvro())
+                it.assertThat(unauthenticatedMessagePublished.payload).isEqualTo(ByteBuffer.wrap(UNAUTH_REQUEST_BYTES))
             }
+            registrationService.stop()
         }
-        registrationService.stop()
-    }
 
-    @Test
-    fun `registration fails when one or more context properties are numbered incorrectly`() {
-        postConfigChangedEvent()
-        val testProperties =
-            context + mapOf(
-                "corda.ledger.keys.100.id" to "9999"
-            )
-        registrationService.start()
-        val result = registrationService.register(registrationResultId, member, testProperties)
-        SoftAssertions.assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-            it.assertThat(result.message)
-                .isEqualTo(
-                    "Registration failed. " +
-                            "The registration context is invalid: Provided ledger key IDs are incorrectly numbered."
+        @Test
+        fun `registration successfully persist the status to new`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            val status = argumentCaptor<RegistrationRequest>()
+            whenever(
+                membershipPersistenceClient.persistRegistrationRequest(
+                    eq(member),
+                    status.capture()
                 )
+            ).doReturn(
+                MembershipPersistenceResult.success()
+            )
+
+            registrationService.register(registrationResultId, member, context)
+
+            assertThat(status.firstValue.status).isEqualTo(RegistrationStatus.NEW)
         }
-        registrationService.stop()
-    }
 
-    @Test
-    fun `registration fails when notary keys are numbered incorrectly`() {
-        postConfigChangedEvent()
-        val testProperties =
-            context + mapOf(
-                "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
-                "corda.notary.keys.100.id" to LEDGER_KEY_ID,
+        @Test
+        fun `registration context is constructed as expected`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            registrationService.register(registrationResultId, member, context)
+
+            val submittedMemberContext = memberContext.firstValue
+
+            fun String.format(arg: Int) = String.format(this, arg)
+
+            assertThat(submittedMemberContext.items.map { it.key }).containsExactlyInAnyOrder(
+                GROUP_ID,
+                PARTY_NAME,
+                MEMBER_CPI_NAME,
+                MEMBER_CPI_VERSION,
+                SOFTWARE_VERSION,
+                PLATFORM_VERSION,
+                REGISTRATION_ID,
+                SERIAL,
+                URL_KEY.format(0),
+                PROTOCOL_VERSION.format(0),
+                PARTY_SESSION_KEY,
+                SESSION_KEY_HASH,
+                SESSION_KEY_SIGNATURE_SPEC,
+                LEDGER_KEYS_KEY.format(0),
+                LEDGER_KEY_HASHES_KEY.format(0),
+                LEDGER_KEY_SIGNATURE_SPEC.format(0)
             )
-        registrationService.start()
 
-        val result = registrationService.register(registrationResultId, member, testProperties)
-
-        assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+            /*
+    "corda.ledger.keys.0.hash",
+    "corda.ledger.keys.0.pem",
+    "corda.ledger.keys.0.signature.spec",
+    "corda.session.key",
+    "corda.session.key.hash",
+    "corda.session.key.signature.spec"
+             */
+        }
     }
 
-    @Test
-    fun `registration pass when notary keys are numbered correctly`() {
-        postConfigChangedEvent()
-        val testProperties =
-            context + mapOf(
-                "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
-                "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+    @Nested
+    inner class FailedRegistrationTests {
+        @Test
+        fun `registration fails when coordinator is not running`() {
+            val registrationResult = registrationService.register(registrationResultId, member, mock())
+            assertThat(registrationResult).isEqualTo(
+                MembershipRequestRegistrationResult(
+                    MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
+                    "Registration failed. Reason: DynamicMemberRegistrationService is not running."
+                )
             )
-        registrationService.start()
+        }
 
-        val result = registrationService.register(registrationResultId, member, testProperties)
+        @Test
+        fun `registration fails when one or more context properties are missing`() {
+            postConfigChangedEvent()
+            val testProperties = mutableMapOf<String, String>()
+            registrationService.start()
+            context.entries.apply {
+                for (index in indices) {
+                    val result = registrationService.register(registrationResultId, member, testProperties)
+                    SoftAssertions.assertSoftly {
+                        it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                    }
+                    elementAt(index).let { testProperties.put(it.key, it.value) }
+                }
+            }
+            registrationService.stop()
+        }
 
-        assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
-    }
+        @Test
+        fun `registration fails when one or more context properties are numbered incorrectly`() {
+            postConfigChangedEvent()
+            val testProperties =
+                context + mapOf(
+                    "corda.ledger.keys.100.id" to "9999"
+                )
+            registrationService.start()
+            val result = registrationService.register(registrationResultId, member, testProperties)
+            SoftAssertions.assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                it.assertThat(result.message)
+                    .isEqualTo(
+                        "Registration failed. " +
+                                "The registration context is invalid: Provided ledger key IDs are incorrectly numbered."
+                    )
+            }
+            registrationService.stop()
+        }
 
-    @Test
-    fun `registration adds notary information when notary role is set`() {
-        val memberContext = argumentCaptor<KeyValuePairList>()
-        whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
-        postConfigChangedEvent()
-        val testProperties =
-            context + mapOf(
-                "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
-                "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+        @Test
+        fun `registration fails if the registration context doesn't match the schema`() {
+            postConfigChangedEvent()
+            val err = "ERROR-MESSAGE"
+            val errReason = "ERROR-REASON"
+            whenever(
+                membershipSchemaValidator.validateRegistrationContext(
+                    eq(MembershipSchema.RegistrationContextSchema.DynamicMember),
+                    any(),
+                    any()
+                )
+            ).doThrow(
+                MembershipSchemaValidationException(
+                    err,
+                    null,
+                    MembershipSchema.RegistrationContextSchema.DynamicMember,
+                    listOf(errReason)
+                )
             )
-        registrationService.start()
 
-        registrationService.register(registrationResultId, member, testProperties)
+            registrationService.start()
+            val result = registrationService.register(registrationResultId, member, context)
+            SoftAssertions.assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                it.assertThat(result.message).contains(err)
+                it.assertThat(result.message).contains(errReason)
+            }
+            registrationService.stop()
+        }
 
-        assertThat(memberContext.firstValue.toMap())
-            .containsEntry("corda.roles.0", "notary")
-            .containsKey("corda.notary.service.name")
-            .containsEntry("corda.notary.keys.0.id", "4")
-            .containsEntry("corda.notary.keys.0.pem", "1234")
-            .containsKey("corda.notary.keys.0.hash")
-            .containsEntry("corda.notary.keys.0.signature.spec", "SHA256withECDSA")
+        @Test
+        fun `registration fails if mgm's ecdh key is missing`() {
+            postConfigChangedEvent()
+            whenever(mgmInfo.ecdhKey).thenReturn(null)
+            registrationService.start()
+            val result = registrationService.register(registrationResultId, member, context)
+            SoftAssertions.assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                it.assertThat(result.message)
+                    .isEqualTo(
+                        "Registration failed. Reason: MGM's ECDH key is missing."
+                    )
+            }
+            registrationService.stop()
+        }
     }
 
-    @Test
-    fun `registration fails when notary service is invalid`() {
-        postConfigChangedEvent()
-        val testProperties =
-            context + mapOf(
-                "corda.roles" to "notary",
-                "corda.notary.service.name" to "Hello world",
+    @Nested
+    inner class NotaryRoleTests {
+        @Test
+        fun `registration fails when notary keys are numbered incorrectly`() {
+            postConfigChangedEvent()
+            val testProperties =
+                context + mapOf(
+                    "corda.roles.0" to "notary",
+                    "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                    "corda.notary.keys.100.id" to LEDGER_KEY_ID,
+                )
+            registrationService.start()
+
+            val result = registrationService.register(registrationResultId, member, testProperties)
+
+            assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+        }
+
+        @Test
+        fun `registration pass when notary keys are numbered correctly`() {
+            postConfigChangedEvent()
+            val testProperties =
+                context + mapOf(
+                    "corda.roles.0" to "notary",
+                    "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                )
+            registrationService.start()
+
+            val result = registrationService.register(registrationResultId, member, testProperties)
+
+            assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
+        }
+
+        @Test
+        fun `registration adds notary information when notary role is set`() {
+            val memberContext = argumentCaptor<KeyValuePairList>()
+            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
+            postConfigChangedEvent()
+            val testProperties =
+                context + mapOf(
+                    "corda.roles.0" to "notary",
+                    "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                )
+            registrationService.start()
+
+            registrationService.register(registrationResultId, member, testProperties)
+
+            assertThat(memberContext.firstValue.toMap())
+                .containsEntry("corda.roles.0", "notary")
+                .containsKey("corda.notary.service.name")
+                .containsEntry("corda.notary.keys.0.id", "4")
+                .containsEntry("corda.notary.keys.0.pem", "1234")
+                .containsKey("corda.notary.keys.0.hash")
+                .containsEntry("corda.notary.keys.0.signature.spec", "SHA256withECDSA")
+        }
+
+        @Test
+        fun `registration fails when notary service is invalid`() {
+            postConfigChangedEvent()
+            val testProperties =
+                context + mapOf(
+                    "corda.roles" to "notary",
+                    "corda.notary.service.name" to "Hello world",
+                )
+            registrationService.start()
+
+            val result = registrationService.register(registrationResultId, member, testProperties)
+
+            assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+        }
+
+        @Test
+        fun `registration pass when notary service is valid`() {
+            postConfigChangedEvent()
+            val testProperties =
+                context + mapOf(
+                    "corda.roles.0" to "notary",
+                    "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                )
+            registrationService.start()
+
+            val result = registrationService.register(registrationResultId, member, testProperties)
+
+            assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
+        }
+    }
+
+    @Nested
+    inner class LifecycleTests {
+        @Test
+        fun `starting the service succeeds`() {
+            registrationService.start()
+            assertThat(registrationService.isRunning).isTrue
+            verify(coordinator).start()
+        }
+
+        @Test
+        fun `stopping the service succeeds`() {
+            registrationService.start()
+            registrationService.stop()
+            assertThat(registrationService.isRunning).isFalse
+            verify(coordinator).stop()
+        }
+
+        @Test
+        fun `component handle created on start and closed on stop`() {
+            postStartEvent()
+
+            verify(componentHandle, never()).close()
+            verify(coordinator).followStatusChangesByName(eq(dependentComponents))
+
+            postStartEvent()
+
+            verify(componentHandle).close()
+            verify(coordinator, times(2)).followStatusChangesByName(eq(dependentComponents))
+
+            postStopEvent()
+            verify(componentHandle, times(2)).close()
+        }
+
+        @Test
+        fun `status set to down after stop`() {
+            postStopEvent()
+
+            verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+            verify(componentHandle, never()).close()
+            verify(configHandle, never()).close()
+            verify(mockPublisher, never()).close()
+        }
+
+        @Test
+        fun `registration status UP creates config handle and closes it first if it exists`() {
+            postStartEvent()
+            postRegistrationStatusChangeEvent(LifecycleStatus.UP)
+
+            val configArgs = argumentCaptor<Set<String>>()
+            verify(configHandle, never()).close()
+            verify(configurationReadService).registerComponentForUpdates(
+                eq(coordinator),
+                configArgs.capture()
             )
-        registrationService.start()
+            assertThat(configArgs.firstValue)
+                .isEqualTo(setOf(ConfigKeys.BOOT_CONFIG, ConfigKeys.MESSAGING_CONFIG))
 
-        val result = registrationService.register(registrationResultId, member, testProperties)
+            postRegistrationStatusChangeEvent(LifecycleStatus.UP)
+            verify(configHandle).close()
+            verify(configurationReadService, times(2)).registerComponentForUpdates(eq(coordinator), any())
 
-        assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-    }
+            postStopEvent()
+            verify(configHandle, times(2)).close()
+        }
 
-    @Test
-    fun `registration pass when notary service is valid`() {
-        postConfigChangedEvent()
-        val testProperties =
-            context + mapOf(
-                "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
-            )
-        registrationService.start()
+        @Test
+        fun `registration status DOWN sets status to DOWN`() {
+            postRegistrationStatusChangeEvent(LifecycleStatus.DOWN)
 
-        val result = registrationService.register(registrationResultId, member, testProperties)
+            verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+        }
 
-        assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
-    }
+        @Test
+        fun `registration status ERROR sets status to DOWN`() {
+            postRegistrationStatusChangeEvent(LifecycleStatus.ERROR)
 
-    @Test
-    fun `registration fails if the registration context doesn't match the schema`() {
-        postConfigChangedEvent()
-        val err = "ERROR-MESSAGE"
-        val errReason = "ERROR-REASON"
-        whenever(
-            membershipSchemaValidator.validateRegistrationContext(
-                eq(MembershipSchema.RegistrationContextSchema.DynamicMember),
-                any(),
+            verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+        }
+
+        @Test
+        fun `config changed event creates publisher`() {
+            postConfigChangedEvent()
+
+            val configCaptor = argumentCaptor<PublisherConfig>()
+            verify(mockPublisher, never()).close()
+            verify(publisherFactory).createPublisher(
+                configCaptor.capture(),
                 any()
             )
-        ).doThrow(
-            MembershipSchemaValidationException(
-                err,
-                null,
-                MembershipSchema.RegistrationContextSchema.DynamicMember,
-                listOf(errReason)
+            verify(mockPublisher).start()
+            verify(coordinator).updateStatus(eq(LifecycleStatus.UP), any())
+
+            with(configCaptor.firstValue) {
+                assertThat(clientId).isEqualTo(PUBLISHER_CLIENT_ID)
+            }
+
+            postConfigChangedEvent()
+            verify(mockPublisher).close()
+            verify(publisherFactory, times(2)).createPublisher(
+                configCaptor.capture(),
+                any()
             )
-        )
+            verify(mockPublisher, times(2)).start()
+            verify(coordinator, times(2)).updateStatus(eq(LifecycleStatus.UP), any())
 
-        registrationService.start()
-        val result = registrationService.register(registrationResultId, member, context)
-        SoftAssertions.assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-            it.assertThat(result.message).contains(err)
-            it.assertThat(result.message).contains(errReason)
+            postStopEvent()
+            verify(mockPublisher, times(3)).close()
         }
-        registrationService.stop()
-    }
-
-    @Test
-    fun `registration fails if mgm's ecdh key is missing`() {
-        postConfigChangedEvent()
-        whenever(mgmInfo.ecdhKey).thenReturn(null)
-        registrationService.start()
-        val result = registrationService.register(registrationResultId, member, context)
-        SoftAssertions.assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-            it.assertThat(result.message)
-                .isEqualTo(
-                    "Registration failed. Reason: MGM's ECDH key is missing."
-                )
-        }
-        registrationService.stop()
-    }
-
-    @Test
-    fun `component handle created on start and closed on stop`() {
-        postStartEvent()
-
-        verify(componentHandle, never()).close()
-        verify(coordinator).followStatusChangesByName(eq(dependentComponents))
-
-        postStartEvent()
-
-        verify(componentHandle).close()
-        verify(coordinator, times(2)).followStatusChangesByName(eq(dependentComponents))
-
-        postStopEvent()
-        verify(componentHandle, times(2)).close()
-    }
-
-    @Test
-    fun `status set to down after stop`() {
-        postStopEvent()
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-        verify(componentHandle, never()).close()
-        verify(configHandle, never()).close()
-        verify(mockPublisher, never()).close()
-    }
-
-    @Test
-    fun `registration status UP creates config handle and closes it first if it exists`() {
-        postStartEvent()
-        postRegistrationStatusChangeEvent(LifecycleStatus.UP)
-
-        val configArgs = argumentCaptor<Set<String>>()
-        verify(configHandle, never()).close()
-        verify(configurationReadService).registerComponentForUpdates(
-            eq(coordinator),
-            configArgs.capture()
-        )
-        assertThat(configArgs.firstValue)
-            .isEqualTo(setOf(ConfigKeys.BOOT_CONFIG, ConfigKeys.MESSAGING_CONFIG))
-
-        postRegistrationStatusChangeEvent(LifecycleStatus.UP)
-        verify(configHandle).close()
-        verify(configurationReadService, times(2)).registerComponentForUpdates(eq(coordinator), any())
-
-        postStopEvent()
-        verify(configHandle, times(2)).close()
-    }
-
-    @Test
-    fun `registration status DOWN sets status to DOWN`() {
-        postRegistrationStatusChangeEvent(LifecycleStatus.DOWN)
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-    }
-
-    @Test
-    fun `registration status ERROR sets status to DOWN`() {
-        postRegistrationStatusChangeEvent(LifecycleStatus.ERROR)
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-    }
-
-    @Test
-    fun `config changed event creates publisher`() {
-        postConfigChangedEvent()
-
-        val configCaptor = argumentCaptor<PublisherConfig>()
-        verify(mockPublisher, never()).close()
-        verify(publisherFactory).createPublisher(
-            configCaptor.capture(),
-            any()
-        )
-        verify(mockPublisher).start()
-        verify(coordinator).updateStatus(eq(LifecycleStatus.UP), any())
-
-        with(configCaptor.firstValue) {
-            assertThat(clientId).isEqualTo(PUBLISHER_CLIENT_ID)
-        }
-
-        postConfigChangedEvent()
-        verify(mockPublisher).close()
-        verify(publisherFactory, times(2)).createPublisher(
-            configCaptor.capture(),
-            any()
-        )
-        verify(mockPublisher, times(2)).start()
-        verify(coordinator, times(2)).updateStatus(eq(LifecycleStatus.UP), any())
-
-        postStopEvent()
-        verify(mockPublisher, times(3)).close()
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -509,7 +509,7 @@ class DynamicMemberRegistrationServiceTest {
             registrationService.start()
             val noVNodeMember = HoldingIdentity(
                 MemberX500Name.parse("O=Bob, C=IE, L=DUB"),
-                UUID.randomUUID().toString()
+                UUID(0, 1).toString()
             )
             whenever(virtualNodeInfoReadService.get(eq(noVNodeMember))).thenReturn(null)
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -80,19 +80,21 @@ import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 class DynamicMemberRegistrationServiceTest {
-    companion object {
-        private const val SESSION_KEY = "1234"
-        private const val SESSION_KEY_ID = "1"
-        private const val LEDGER_KEY = "5678"
-        private const val LEDGER_KEY_ID = "2"
-        private const val NOTARY_KEY = "2020"
-        private const val NOTARY_KEY_ID = "4"
-        private const val PUBLISHER_CLIENT_ID = "dynamic-member-registration-service"
-        private const val GROUP_NAME = "dummy_group"
+    private companion object {
+        const val SESSION_KEY = "1234"
+        const val SESSION_KEY_ID = "1"
+        const val LEDGER_KEY = "5678"
+        const val LEDGER_KEY_ID = "2"
+        const val NOTARY_KEY = "2020"
+        const val NOTARY_KEY_ID = "4"
+        const val PUBLISHER_CLIENT_ID = "dynamic-member-registration-service"
+        const val GROUP_NAME = "dummy_group"
+        const val TEST_PLATFORM_VERSION = 5000
+        const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
 
-        private val MEMBER_CONTEXT_BYTES = "2222".toByteArray()
-        private val REQUEST_BYTES = "3333".toByteArray()
-        private val UNAUTH_REQUEST_BYTES = "4444".toByteArray()
+        val MEMBER_CONTEXT_BYTES = "2222".toByteArray()
+        val REQUEST_BYTES = "3333".toByteArray()
+        val UNAUTH_REQUEST_BYTES = "4444".toByteArray()
     }
 
     private val ecdhKey: PublicKey = mock()
@@ -239,7 +241,8 @@ class DynamicMemberRegistrationServiceTest {
         on { createValidator() } doReturn membershipSchemaValidator
     }
     private val platformInfoProvider: PlatformInfoProvider = mock {
-        on { activePlatformVersion } doReturn 5000
+        on { activePlatformVersion } doReturn TEST_PLATFORM_VERSION
+        on { localWorkerSoftwareVersion } doReturn TEST_SOFTWARE_VERSION
     }
     private val datawithKey: EncryptedDataWithKey = mock {
         on { cipherText } doReturn "1234".toByteArray()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -26,13 +26,13 @@ import net.corda.lifecycle.StopEvent
 import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
 import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
 import net.corda.membership.impl.registration.buildTestVirtualNodeInfo
-import net.corda.membership.impl.registration.addIndex
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_SIGNATURE_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
@@ -390,18 +390,19 @@ class DynamicMemberRegistrationServiceTest {
                 PARTY_NAME,
                 MEMBER_CPI_NAME,
                 MEMBER_CPI_VERSION,
+                MEMBER_CPI_SIGNER_HASH,
                 SOFTWARE_VERSION,
                 PLATFORM_VERSION,
                 REGISTRATION_ID,
                 SERIAL,
-                URL_KEY.addIndex(0),
-                PROTOCOL_VERSION.addIndex(0),
+                URL_KEY.format(0),
+                PROTOCOL_VERSION.format(0),
                 PARTY_SESSION_KEY,
                 SESSION_KEY_HASH,
                 SESSION_KEY_SIGNATURE_SPEC,
-                LEDGER_KEYS_KEY.addIndex(0),
-                LEDGER_KEY_HASHES_KEY.addIndex(0),
-                LEDGER_KEY_SIGNATURE_SPEC.addIndex(0)
+                LEDGER_KEYS_KEY.format(0),
+                LEDGER_KEY_HASHES_KEY.format(0),
+                LEDGER_KEY_SIGNATURE_SPEC.format(0)
             )
         }
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
@@ -1,0 +1,141 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.URL_KEY
+import net.corda.membership.lib.schema.validation.MembershipSchemaValidationException
+import net.corda.membership.lib.schema.validation.MembershipSchemaValidator
+import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
+import net.corda.schema.membership.MembershipSchema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class MGMRegistrationContextValidatorTest {
+
+    private val membershipSchemaValidator: MembershipSchemaValidator = mock()
+    private val membershipSchemaValidatorFactory: MembershipSchemaValidatorFactory = mock {
+        on { createValidator() } doReturn membershipSchemaValidator
+    }
+
+    private val mgmRegistrationContextValidator = MGMRegistrationContextValidator(
+        membershipSchemaValidatorFactory
+    )
+
+    companion object {
+        private val validTestContext
+            get() = mutableMapOf(
+                SESSION_KEY_ID to "session key",
+                ECDH_KEY_ID to "ECDH key",
+                REGISTRATION_PROTOCOL to "registration protocol",
+                SYNCHRONISATION_PROTOCOL to "synchronisation protocol",
+                P2P_MODE to "P2P mode",
+                SESSION_KEY_POLICY to "session key policy",
+                PKI_SESSION to "session PKI property",
+                PKI_TLS to "TLS PKI property",
+                URL_KEY.format(0) to "https://localhost:8080",
+                PROTOCOL_VERSION.format(0) to "1",
+                TRUSTSTORE_SESSION.format(0) to "session truststore",
+                TRUSTSTORE_TLS.format(0) to "tls truststore"
+            )
+
+        @JvmStatic
+        fun contextKeys() = validTestContext.keys.toTypedArray()
+    }
+
+    @Test
+    fun `schema validation is for MGM context schema`() {
+        val contextSchemaCaptor = argumentCaptor<MembershipSchema.RegistrationContextSchema>()
+        whenever(
+            membershipSchemaValidator.validateRegistrationContext(
+                contextSchemaCaptor.capture(),
+                any(),
+                any()
+            )
+        ).then {
+            // do nothing
+        }
+
+        mgmRegistrationContextValidator.validate(validTestContext)
+
+        verify(membershipSchemaValidator).validateRegistrationContext(any(), any(), any())
+        val contextSchema = assertDoesNotThrow(contextSchemaCaptor::firstValue)
+        assertThat(contextSchema).isInstanceOf(MembershipSchema.RegistrationContextSchema.Mgm::class.java)
+    }
+
+    @Test
+    fun `schema validation is done on the same context passed to service`() {
+        val contextCaptor = argumentCaptor<Map<String, String>>()
+        whenever(
+            membershipSchemaValidator.validateRegistrationContext(
+                any(),
+                any(),
+                contextCaptor.capture()
+            )
+        ).then {
+            // do nothing
+        }
+
+        val testContext = validTestContext
+        mgmRegistrationContextValidator.validate(testContext)
+
+        verify(membershipSchemaValidator).validateRegistrationContext(any(), any(), any())
+        val contextSchema = assertDoesNotThrow(contextCaptor::firstValue)
+        assertThat(contextSchema).isEqualTo(testContext)
+    }
+
+    @Test
+    fun `schema validation failure is rethrown as a context validation exception`() {
+        whenever(
+            membershipSchemaValidator.validateRegistrationContext(
+                any(),
+                any(),
+                any()
+            )
+        ).doThrow(MembershipSchemaValidationException::class)
+
+        assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(validTestContext)
+        }
+        verify(membershipSchemaValidator).validateRegistrationContext(any(), any(), any())
+    }
+
+    @Test
+    fun `unexpected runtime exception during schema validation is rethrown as a context validation exception`() {
+        whenever(
+            membershipSchemaValidator.validateRegistrationContext(
+                any(),
+                any(),
+                any()
+            )
+        ).doThrow(RuntimeException::class)
+
+        assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(validTestContext)
+        }
+        verify(membershipSchemaValidator).validateRegistrationContext(any(), any(), any())
+    }
+
+
+    @ParameterizedTest(name = "context validation fails if {0} is missing and exception is caught and rethrown")
+    @MethodSource("contextKeys")
+    fun `context validation fails if {0} is missing and exception is caught and rethrown`(
+        input: String
+    ) {
+        val testContext = validTestContext
+        testContext.remove(input)
+
+        assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(testContext)
+        }
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 class MGMRegistrationGroupPolicyHandlerTest {
     private val testHoldingIdentity = HoldingIdentity(
         MemberX500Name.parse("O=Alice, L=Dublin, C=IE"),
-        UUID.randomUUID().toString()
+        UUID(0, 1).toString()
     )
 
     private val groupPolicyContextCaptor = argumentCaptor<Map<String, String>>()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
@@ -1,0 +1,112 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.layeredpropertymap.LayeredPropertyMapFactory
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.v5.base.types.LayeredPropertyMap
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.virtualnode.HoldingIdentity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class MGMRegistrationGroupPolicyHandlerTest {
+    private val testHoldingIdentity = HoldingIdentity(
+        MemberX500Name.parse("O=Alice, L=Dublin, C=IE"),
+        UUID.randomUUID().toString()
+    )
+
+    private val groupPolicyContextCaptor = argumentCaptor<Map<String, String>>()
+    private val groupPolicyContext
+        get() = assertDoesNotThrow(groupPolicyContextCaptor::firstValue)
+
+    private val mockLayeredPropertyMap: LayeredPropertyMap = mock()
+    private val layeredPropertyMapFactory: LayeredPropertyMapFactory = mock {
+        on { createMap(groupPolicyContextCaptor.capture()) } doReturn mockLayeredPropertyMap
+    }
+    private val membershipPersistenceClient: MembershipPersistenceClient = mock {
+        on {
+            persistGroupPolicy(eq(testHoldingIdentity), eq(mockLayeredPropertyMap))
+        } doReturn MembershipPersistenceResult.Success(0)
+
+        on {
+            persistGroupParametersInitialSnapshot(eq(testHoldingIdentity))
+        } doReturn MembershipPersistenceResult.Success(Unit)
+    }
+
+    private val testContext: Map<String, String> = mapOf(
+        REGISTRATION_PROTOCOL to "valid protocol",
+        SESSION_KEY_ID to "non group policy property"
+    )
+
+    private val mgmRegistrationGroupPolicyHandler = MGMRegistrationGroupPolicyHandler(
+        layeredPropertyMapFactory,
+        membershipPersistenceClient
+    )
+
+    @Test
+    fun `non group parameters are properly are filtered out of the context and the group policy prefix was removed`() {
+        assertThat(testContext).hasSize(2).withFailMessage(
+            "Test map is not as expected before testing. " +
+                    "Expected size 2 in order to verify results correctly."
+        )
+
+        mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
+
+        verify(layeredPropertyMapFactory).createMap(any())
+        assertThat(groupPolicyContext)
+            .hasSize(1)
+            .containsOnlyKeys(REGISTRATION_PROTOCOL.removePrefix(GROUP_POLICY_PREFIX_WITH_DOT))
+    }
+
+    @Test
+    fun `group parameters are persisted using the correct holding identity and map`() {
+        mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
+
+        verify(membershipPersistenceClient).persistGroupPolicy(
+            eq(testHoldingIdentity),
+            eq(mockLayeredPropertyMap)
+        )
+    }
+
+    @Test
+    fun `Failed group policy persistence is rethrown as group policy handling exception`() {
+        whenever (
+            membershipPersistenceClient.persistGroupPolicy(any(), any())
+        ) doReturn MembershipPersistenceResult.Failure("")
+
+        assertThrows<MGMRegistrationGroupPolicyHandlingException> {
+            mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
+        }
+        verify(membershipPersistenceClient).persistGroupPolicy(any(), any())
+    }
+
+    @Test
+    fun `Failed group parameters persistence is rethrown as group policy handling exception`() {
+        whenever (
+            membershipPersistenceClient.persistGroupParametersInitialSnapshot(any())
+        ) doReturn MembershipPersistenceResult.Failure("")
+
+        assertThrows<MGMRegistrationGroupPolicyHandlingException> {
+            mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
+        }
+        verify(membershipPersistenceClient).persistGroupParametersInitialSnapshot(any())
+    }
+
+    @Test
+    fun `Expected group policy object is returned`() {
+        val output = mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
+
+        assertThat(output)
+            .isEqualTo(mockLayeredPropertyMap)
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
@@ -66,21 +66,21 @@ class MGMRegistrationMemberInfoHandlerTest {
         const val GROUP_POLICY_PROPERTY_KEY = GROUP_POLICY_PREFIX_WITH_DOT + "test"
     }
 
-    private val registrationId = UUID.randomUUID()
+    private val registrationId = UUID(0, 1)
     private val cordaAvroSerializer: CordaAvroSerializer<KeyValuePairList> = mock {
         on { serialize(any()) } doReturn "".toByteArray()
     }
     private val holdingIdentity = HoldingIdentity(
         MemberX500Name.parse("O=Alice, L=London, C=GB"),
-        UUID.randomUUID().toString()
+        UUID(0, 1).toString()
     )
     private val cpiIdentifier = CpiIdentifier(TEST_CPI_NAME, TEST_CPI_VERSION, null)
     private val virtualNodeInfo = VirtualNodeInfo(
         holdingIdentity,
         cpiIdentifier,
-        vaultDmlConnectionId = UUID.randomUUID(),
-        cryptoDmlConnectionId = UUID.randomUUID(),
-        uniquenessDmlConnectionId = UUID.randomUUID(),
+        vaultDmlConnectionId = UUID(0, 1),
+        cryptoDmlConnectionId = UUID(0, 1),
+        uniquenessDmlConnectionId = UUID(0, 1),
         timestamp = Instant.ofEpochSecond(0)
     )
     private val publicKey: PublicKey = mock {
@@ -258,15 +258,10 @@ class MGMRegistrationMemberInfoHandlerTest {
             )
         }
 
-        assertThat(mgmContext).containsOnlyKeys(
-            CREATED_TIME,
-            MODIFIED_TIME,
-            STATUS,
-            IS_MGM
-        )
-
-        assertThat(mgmContext[STATUS]).isEqualTo(MEMBER_STATUS_ACTIVE)
-        assertThat(mgmContext[IS_MGM]).isEqualTo(true.toString())
+        assertThat(mgmContext)
+            .containsOnlyKeys(CREATED_TIME, MODIFIED_TIME, STATUS, IS_MGM)
+            .containsEntry(STATUS, MEMBER_STATUS_ACTIVE)
+            .containsEntry(IS_MGM, true.toString())
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
@@ -1,0 +1,393 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.CordaAvroSerializer
+import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSigningKey
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.membership.impl.registration.TEST_CPI_NAME
+import net.corda.membership.impl.registration.TEST_CPI_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
+import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
+import net.corda.membership.lib.MemberInfoExtension.Companion.URL_KEY
+import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.test.util.time.TestClock
+import net.corda.utilities.time.Clock
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.membership.MemberContext
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.nio.ByteBuffer
+import java.security.PublicKey
+import java.time.Instant
+import java.util.*
+
+class MGMRegistrationMemberInfoHandlerTest {
+
+    companion object {
+        const val EMPTY_STRING = ""
+        const val TEST_PLATFORM_VERSION = 5000
+        const val TEST_SOFTWARE_VERSION = "5.0.0.0-test"
+        const val GROUP_POLICY_PROPERTY_KEY = GROUP_POLICY_PREFIX_WITH_DOT + "test"
+    }
+
+    private val registrationId = UUID.randomUUID()
+    private val cordaAvroSerializer: CordaAvroSerializer<KeyValuePairList> = mock {
+        on { serialize(any()) } doReturn "".toByteArray()
+    }
+    private val holdingIdentity = HoldingIdentity(
+        MemberX500Name.parse("O=Alice, L=London, C=GB"),
+        UUID.randomUUID().toString()
+    )
+    private val cpiIdentifier = CpiIdentifier(TEST_CPI_NAME, TEST_CPI_VERSION, null)
+    private val virtualNodeInfo = VirtualNodeInfo(
+        holdingIdentity,
+        cpiIdentifier,
+        vaultDmlConnectionId = UUID.randomUUID(),
+        cryptoDmlConnectionId = UUID.randomUUID(),
+        uniquenessDmlConnectionId = UUID.randomUUID(),
+        timestamp = Instant.ofEpochSecond(0)
+    )
+    private val publicKey: PublicKey = mock {
+        on { encoded } doReturn EMPTY_STRING.toByteArray()
+    }
+    private val mockMemberContext: MemberContext = mock()
+    private val memberInfo: MemberInfo = mock {
+        on { memberProvidedContext } doReturn mockMemberContext
+    }
+    private val memberContextCaptor = argumentCaptor<SortedMap<String, String?>>()
+    private val memberContext
+        get() = assertDoesNotThrow { memberContextCaptor.firstValue }
+    private val mgmContextCaptor = argumentCaptor<SortedMap<String, String?>>()
+    private val mgmContext
+        get() = assertDoesNotThrow { mgmContextCaptor.firstValue }
+
+
+    private val clock: Clock = TestClock(Instant.ofEpochSecond(0))
+    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock {
+        on { createAvroSerializer<KeyValuePairList>(any()) } doReturn cordaAvroSerializer
+    }
+    private val cryptoOpsClient: CryptoOpsClient = mock {
+        on {
+            lookup(eq(holdingIdentity.shortHash.value), any())
+        } doReturn listOf(
+            CryptoSigningKey(
+                EMPTY_STRING,
+                EMPTY_STRING,
+                EMPTY_STRING,
+                EMPTY_STRING,
+                EMPTY_STRING,
+                ByteBuffer.wrap(EMPTY_STRING.toByteArray()),
+                EMPTY_STRING,
+                EMPTY_STRING,
+                0,
+                EMPTY_STRING,
+                Instant.ofEpochSecond(0)
+            )
+        )
+    }
+    private val keyEncodingService: KeyEncodingService = mock {
+        on { decodePublicKey(any<ByteArray>()) } doReturn publicKey
+        on { encodeAsString(any()) } doReturn EMPTY_STRING
+    }
+    private val memberInfoFactory: MemberInfoFactory = mock {
+        on { create(memberContextCaptor.capture(), mgmContextCaptor.capture()) } doReturn memberInfo
+    }
+    private val membershipPersistenceClient: MembershipPersistenceClient = mock {
+        on {
+            persistMemberInfo(eq(holdingIdentity), eq(listOf(memberInfo)))
+        } doReturn MembershipPersistenceResult.success()
+
+        on {
+            persistRegistrationRequest(any(), any())
+        } doReturn MembershipPersistenceResult.success()
+    }
+
+    private val platformInfoProvider: PlatformInfoProvider = mock {
+        on { activePlatformVersion } doReturn TEST_PLATFORM_VERSION
+        on { localWorkerSoftwareVersion } doReturn TEST_SOFTWARE_VERSION
+    }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { get(eq(holdingIdentity)) } doReturn virtualNodeInfo
+    }
+
+    private val mgmRegistrationMemberInfoHandler = MGMRegistrationMemberInfoHandler(
+        clock,
+        cordaAvroSerializationFactory,
+        cryptoOpsClient,
+        keyEncodingService,
+        memberInfoFactory,
+        membershipPersistenceClient,
+        platformInfoProvider,
+        virtualNodeInfoReadService
+    )
+
+    private val validTestContext
+        get() = mapOf(
+            SESSION_KEY_ID to "session key",
+            ECDH_KEY_ID to "ECDH key",
+            REGISTRATION_PROTOCOL to "registration protocol",
+            SYNCHRONISATION_PROTOCOL to "synchronisation protocol",
+            P2P_MODE to "P2P mode",
+            SESSION_KEY_POLICY to "session key policy",
+            PKI_SESSION to "session PKI property",
+            PKI_TLS to "TLS PKI property",
+            URL_KEY.format(0) to "https://localhost:8080",
+            PROTOCOL_VERSION.format(0) to "1",
+            TRUSTSTORE_SESSION.format(0) to "session truststore",
+            TRUSTSTORE_TLS.format(0) to "tls truststore",
+            GROUP_POLICY_PROPERTY_KEY to "should be filtered out"
+        )
+
+    @Test
+    fun `MGM info is returned if all is processed successfully`() {
+        val result = assertDoesNotThrow {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+
+        assertThat(result).isEqualTo(memberInfo)
+    }
+
+    @Test
+    fun `Expected services are called`() {
+        assertDoesNotThrow {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+
+        verify(membershipPersistenceClient).persistRegistrationRequest(any(), any())
+        verify(membershipPersistenceClient).persistMemberInfo(any(), any())
+        verify(cordaAvroSerializer).serialize(any())
+        verify(memberInfoFactory).create(any(), any<SortedMap<String, String?>>())
+        verify(platformInfoProvider).activePlatformVersion
+        verify(platformInfoProvider).localWorkerSoftwareVersion
+        verify(keyEncodingService, times(2)).encodeAsString(any())
+        verify(keyEncodingService, times(2)).decodePublicKey(any<ByteArray>())
+        verify(cryptoOpsClient, times(2)).lookup(any(), any())
+        verify(virtualNodeInfoReadService).get(any())
+    }
+
+    @Test
+    fun `Member context filters out group policy properties`() {
+        assertDoesNotThrow {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+
+        assertThat(memberContext).doesNotContainKey(GROUP_POLICY_PROPERTY_KEY)
+    }
+
+    @Test
+    fun `Member context is built as expected`() {
+        assertDoesNotThrow {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+
+        assertThat(memberContext).containsOnlyKeys(
+            GROUP_ID,
+            PARTY_NAME,
+            PARTY_SESSION_KEY,
+            SESSION_KEY_HASH,
+            ECDH_KEY,
+            PLATFORM_VERSION,
+            SOFTWARE_VERSION,
+            MEMBER_CPI_NAME,
+            MEMBER_CPI_VERSION,
+            SERIAL,
+            URL_KEY.format(0),
+            PROTOCOL_VERSION.format(0)
+        )
+    }
+
+    @Test
+    fun `MGM context is built as expected`() {
+        assertDoesNotThrow {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+
+        assertThat(mgmContext).containsOnlyKeys(
+            CREATED_TIME,
+            MODIFIED_TIME,
+            STATUS,
+            IS_MGM
+        )
+
+        assertThat(mgmContext[STATUS]).isEqualTo(MEMBER_STATUS_ACTIVE)
+        assertThat(mgmContext[IS_MGM]).isEqualTo(true.toString())
+    }
+
+    @Test
+    fun `expected exception thrown if CPI info cannot be found for holding identity`() {
+        whenever(
+            virtualNodeInfoReadService.get(
+                eq(holdingIdentity)
+            )
+        ).doReturn(null)
+        assertThrows<MGMRegistrationMemberInfoHandlingException> {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+        verify(virtualNodeInfoReadService).get(eq(holdingIdentity))
+        verify(cryptoOpsClient, never()).lookup(any(), any())
+    }
+
+    @Test
+    fun `expected exception thrown if key cannot be found for holding identity`() {
+        whenever(
+            cryptoOpsClient.lookup(
+                eq(holdingIdentity.shortHash.value),
+                eq(listOf(validTestContext[SESSION_KEY_ID]!!))
+            )
+        ).doReturn(emptyList())
+
+        assertThrows<MGMRegistrationMemberInfoHandlingException> {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+        verify(virtualNodeInfoReadService).get(eq(holdingIdentity))
+        verify(cryptoOpsClient).lookup(
+            eq(holdingIdentity.shortHash.value),
+            eq(listOf(validTestContext[SESSION_KEY_ID]!!))
+        )
+        verify(keyEncodingService, never()).decodePublicKey(any<ByteArray>())
+    }
+
+    @Test
+    fun `expected exception thrown if key cannot be decoded`() {
+        whenever(
+            keyEncodingService.decodePublicKey(any<ByteArray>())
+        ).doThrow(RuntimeException::class)
+
+        assertThrows<MGMRegistrationMemberInfoHandlingException> {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+        verify(virtualNodeInfoReadService).get(eq(holdingIdentity))
+        verify(cryptoOpsClient).lookup(any(), any())
+        verify(keyEncodingService).decodePublicKey(any<ByteArray>())
+    }
+
+    @Test
+    fun `expected exception thrown if member info persistence fails`() {
+        whenever(
+            membershipPersistenceClient.persistMemberInfo(
+                eq(holdingIdentity), eq(listOf(memberInfo))
+            )
+        ).doReturn(MembershipPersistenceResult.Failure(""))
+
+        assertThrows<MGMRegistrationMemberInfoHandlingException> {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+        verify(membershipPersistenceClient).persistMemberInfo(
+            eq(holdingIdentity),
+            eq(listOf(memberInfo))
+        )
+    }
+
+    @Test
+    fun `expected exception thrown if registration request persistence fails`() {
+        whenever(
+            membershipPersistenceClient.persistRegistrationRequest(
+                eq(holdingIdentity), any()
+            )
+        ).doReturn(MembershipPersistenceResult.Failure(""))
+
+        assertThrows<MGMRegistrationMemberInfoHandlingException> {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+        verify(membershipPersistenceClient).persistRegistrationRequest(
+            eq(holdingIdentity),
+            any()
+        )
+    }
+
+    @Test
+    fun `expected exception thrown if serializing the registration request fails`() {
+        whenever(
+            cordaAvroSerializer.serialize(
+                any()
+            )
+        ).doReturn(null)
+
+        assertThrows<MGMRegistrationMemberInfoHandlingException> {
+            mgmRegistrationMemberInfoHandler.buildAndPersist(
+                registrationId,
+                holdingIdentity,
+                validTestContext
+            )
+        }
+        verify(cordaAvroSerializer).serialize(any())
+    }
+
+
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutPublisherTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutPublisherTest.kt
@@ -1,0 +1,125 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.data.membership.PersistentMemberInfo
+import net.corda.data.membership.event.MembershipEvent
+import net.corda.data.membership.event.registration.MgmOnboarded
+import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas.Membership.Companion.EVENT_TOPIC
+import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.MGMContext
+import net.corda.v5.membership.MemberContext
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+class MGMRegistrationOutPublisherTest {
+
+    private val holdingIdentity = HoldingIdentity(
+        MemberX500Name.parse("O=Alice, L=London, C=GB"),
+        UUID.randomUUID().toString()
+    )
+    private val memberContext: MemberContext = mock {
+        on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn holdingIdentity.groupId
+    }
+    private val mgmContext: MGMContext = mock()
+    private val memberInfo: MemberInfo = mock {
+        on { mgmProvidedContext } doReturn mgmContext
+        on { memberProvidedContext } doReturn memberContext
+        on { name } doReturn holdingIdentity.x500Name
+    }
+    private val recordPublishFuture: CompletableFuture<Unit> = mock {
+        on { get(any(), any()) } doAnswer {}
+    }
+    private val publishedRecordsCaptor = argumentCaptor<List<Record<*, *>>>()
+    private val publishedRecords
+        get() = assertDoesNotThrow { publishedRecordsCaptor.firstValue }
+
+    private val publisher: Publisher = mock {
+        on { publish(publishedRecordsCaptor.capture()) } doReturn listOf(recordPublishFuture)
+    }
+
+    private val publisherFactory = { publisher }
+
+    private val mgmRegistrationOutputPublisher = MGMRegistrationOutputPublisher(
+        publisherFactory
+    )
+
+    @Test
+    fun `Publish runs successfully`() {
+        assertDoesNotThrow {
+            mgmRegistrationOutputPublisher.publish(memberInfo)
+        }
+
+        verify(publisher).publish(any())
+        verify(recordPublishFuture).get(any(), any())
+
+        assertThat(publishedRecords.map { it.topic }).containsExactlyInAnyOrder(
+            MEMBER_LIST_TOPIC,
+            EVENT_TOPIC
+        )
+
+        val shortHash = holdingIdentity.shortHash.value
+        publishedRecords.firstOrNull {
+            it.topic == EVENT_TOPIC
+        }?.let {
+            assertThat(it.key)
+                .isNotNull
+                .isEqualTo(shortHash)
+            assertThat(it.value).isInstanceOf(MembershipEvent::class.java)
+            val event = it.value as MembershipEvent
+            assertThat(event.event).isInstanceOf(MgmOnboarded::class.java)
+            val onboardedEvent = event.event as MgmOnboarded
+            val onboardedMgm = onboardedEvent.onboardedMgm
+            assertThat(
+                MemberX500Name.parse(onboardedMgm.x500Name)
+            ).isEqualTo(holdingIdentity.x500Name)
+            assertThat(
+                onboardedMgm.groupId
+            ).isEqualTo(holdingIdentity.groupId)
+        }
+
+        publishedRecords.firstOrNull {
+            it.topic == MEMBER_LIST_TOPIC
+        }?.let {
+            assertThat(it.key)
+                .isNotNull
+                .isEqualTo("$shortHash-$shortHash")
+            assertThat(it.value).isInstanceOf(PersistentMemberInfo::class.java)
+            val memberInfo = it.value as PersistentMemberInfo
+            val avroHoldingId = memberInfo.viewOwningMember
+            assertThat(
+                MemberX500Name.parse(avroHoldingId.x500Name)
+            ).isEqualTo(holdingIdentity.x500Name)
+            assertThat(
+                avroHoldingId.groupId
+            ).isEqualTo(holdingIdentity.groupId)
+        }
+    }
+
+    @Test
+    fun `Expected exception thrown is exception thrown from record publishing`() {
+        whenever(publisher.publish(any())).doThrow(CordaMessageAPIFatalException::class)
+
+        assertThrows<MGMRegistrationOutputPublisherException> {
+            mgmRegistrationOutputPublisher.publish(memberInfo)
+        }
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutputPublisherTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationOutputPublisherTest.kt
@@ -30,11 +30,11 @@ import org.mockito.kotlin.whenever
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
-class MGMRegistrationOutPublisherTest {
+class MGMRegistrationOutputPublisherTest {
 
     private val holdingIdentity = HoldingIdentity(
         MemberX500Name.parse("O=Alice, L=London, C=GB"),
-        UUID.randomUUID().toString()
+        UUID(0, 1).toString()
     )
     private val memberContext: MemberContext = mock {
         on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn holdingIdentity.groupId

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -27,6 +27,8 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
+import net.corda.membership.impl.registration.TEST_CPI_NAME
+import net.corda.membership.impl.registration.TEST_CPI_VERSION
 import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
 import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
 import net.corda.membership.impl.registration.addIndex
@@ -351,6 +353,8 @@ class MGMRegistrationServiceTest {
                 it.assertThat(getProperty(IS_MGM)).isEqualTo("true")
                 it.assertThat(getProperty(PLATFORM_VERSION)).isEqualTo(TEST_PLATFORM_VERSION.toString())
                 it.assertThat(getProperty(SOFTWARE_VERSION)).isEqualTo(TEST_SOFTWARE_VERSION)
+                it.assertThat(getProperty(MEMBER_CPI_VERSION)).isEqualTo(TEST_CPI_VERSION)
+                it.assertThat(getProperty(MEMBER_CPI_NAME)).isEqualTo(TEST_CPI_NAME)
                 it.assertThat(statusUpdate.firstValue.status).isEqualTo(RegistrationStatus.APPROVED)
                 it.assertThat(statusUpdate.firstValue.registrationId).isEqualTo(registrationRequest.toString())
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -29,6 +29,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
 import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
+import net.corda.membership.impl.registration.addIndex
 import net.corda.membership.impl.registration.buildMockPlatformInfoProvider
 import net.corda.membership.impl.registration.buildTestVirtualNodeInfo
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
@@ -79,6 +80,7 @@ import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
@@ -280,358 +282,367 @@ class MGMRegistrationServiceTest {
         )
     }
 
-    @Test
-    fun `starting the service succeeds`() {
-        registrationService.start()
-        assertThat(registrationService.isRunning).isTrue
-        verify(coordinator).start()
-    }
+    @Nested
+    inner class SuccessfulRegistrationTests {
+        @Test
+        fun `registration successfully builds MGM info and publishes it`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
 
-    @Test
-    fun `stopping the service succeeds`() {
-        registrationService.start()
-        registrationService.stop()
-        assertThat(registrationService.isRunning).isFalse
-        verify(coordinator).stop()
-    }
+            val result = registrationService.register(registrationRequest, mgm, properties)
 
-    @Test
-    fun `registration successfully builds MGM info and publishes it`() {
-        postConfigChangedEvent()
-        registrationService.start()
-        val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
+            verify(mockPublisher, times(1)).publish(capturedPublishedList.capture())
+            val publishedList = capturedPublishedList.firstValue
+            val publishedMgmInfo = publishedList.first()
+            val publishedEvent = publishedList.last()
+            assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
+                it.assertThat(publishedList).hasSize(2)
 
-        val result = registrationService.register(registrationRequest, mgm, properties)
+                it.assertThat(publishedMgmInfo.topic).isEqualTo(MEMBER_LIST_TOPIC)
+                it.assertThat(publishedEvent.topic).isEqualTo(EVENT_TOPIC)
 
-        verify(mockPublisher, times(1)).publish(capturedPublishedList.capture())
-        val publishedList = capturedPublishedList.firstValue
-        val publishedMgmInfo = publishedList.first()
-        val publishedEvent = publishedList.last()
-        assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
-            it.assertThat(publishedList).hasSize(2)
+                val expectedRecordKey = "$mgmId-$mgmId"
+                it.assertThat(publishedMgmInfo.key).isEqualTo(expectedRecordKey)
+                it.assertThat(publishedEvent.key).isEqualTo(mgmId.value)
 
-            it.assertThat(publishedMgmInfo.topic).isEqualTo(MEMBER_LIST_TOPIC)
-            it.assertThat(publishedEvent.topic).isEqualTo(EVENT_TOPIC)
+                val persistedMgm = publishedMgmInfo.value as PersistentMemberInfo
 
-            val expectedRecordKey = "$mgmId-$mgmId"
-            it.assertThat(publishedMgmInfo.key).isEqualTo(expectedRecordKey)
-            it.assertThat(publishedEvent.key).isEqualTo(mgmId.value)
-
-            val persistedMgm = publishedMgmInfo.value as PersistentMemberInfo
-
-            it.assertThat(persistedMgm.memberContext.items.map { item -> item.key })
-                .containsExactlyInAnyOrderElementsOf(
-                    listOf(
-                        GROUP_ID,
-                        PARTY_NAME,
-                        PARTY_SESSION_KEY,
-                        SESSION_KEY_HASH,
-                        ECDH_KEY,
-                        PLATFORM_VERSION,
-                        SOFTWARE_VERSION,
-                        MEMBER_CPI_NAME,
-                        MEMBER_CPI_VERSION,
-                        SERIAL,
-                        String.format(URL_KEY, 0),
-                        String.format(PROTOCOL_VERSION, 0),
+                it.assertThat(persistedMgm.memberContext.items.map { item -> item.key })
+                    .containsExactlyInAnyOrderElementsOf(
+                        listOf(
+                            GROUP_ID,
+                            PARTY_NAME,
+                            PARTY_SESSION_KEY,
+                            SESSION_KEY_HASH,
+                            ECDH_KEY,
+                            PLATFORM_VERSION,
+                            SOFTWARE_VERSION,
+                            MEMBER_CPI_NAME,
+                            MEMBER_CPI_VERSION,
+                            SERIAL,
+                            URL_KEY.addIndex(0),
+                            PROTOCOL_VERSION.addIndex(0),
+                        )
                     )
-                )
-            it.assertThat(persistedMgm.mgmContext.items.map { item -> item.key })
-                .containsExactlyInAnyOrderElementsOf(
-                    listOf(
-                        CREATED_TIME,
-                        MODIFIED_TIME,
-                        STATUS,
-                        IS_MGM
+                it.assertThat(persistedMgm.mgmContext.items.map { item -> item.key })
+                    .containsExactlyInAnyOrderElementsOf(
+                        listOf(
+                            CREATED_TIME,
+                            MODIFIED_TIME,
+                            STATUS,
+                            IS_MGM
+                        )
                     )
-                )
 
-            fun getProperty(prop: String): String {
-                return persistedMgm
-                    .memberContext.items.firstOrNull { item ->
+                fun getProperty(prop: String): String {
+                    return persistedMgm
+                        .memberContext.items.firstOrNull { item ->
+                            item.key == prop
+                        }?.value ?: persistedMgm.mgmContext.items.firstOrNull { item ->
                         item.key == prop
-                    }?.value ?: persistedMgm.mgmContext.items.firstOrNull { item ->
-                    item.key == prop
-                }?.value ?: fail("Could not find property within published member for test")
-            }
-
-            it.assertThat(getProperty(PARTY_NAME)).isEqualTo(mgmName.toString())
-            it.assertThat(getProperty(GROUP_ID)).isEqualTo(groupId)
-            it.assertThat(getProperty(STATUS)).isEqualTo(MEMBER_STATUS_ACTIVE)
-            it.assertThat(getProperty(IS_MGM)).isEqualTo("true")
-            it.assertThat(getProperty(PLATFORM_VERSION)).isEqualTo(TEST_PLATFORM_VERSION.toString())
-            it.assertThat(getProperty(SOFTWARE_VERSION)).isEqualTo(TEST_SOFTWARE_VERSION)
-            it.assertThat(statusUpdate.firstValue.status).isEqualTo(RegistrationStatus.APPROVED)
-            it.assertThat(statusUpdate.firstValue.registrationId).isEqualTo(registrationRequest.toString())
-
-
-            val membershipEvent = publishedEvent.value as MembershipEvent
-            it.assertThat(membershipEvent.event).isInstanceOf(MgmOnboarded::class.java)
-            val mgmOnboardedEvent = membershipEvent.event as MgmOnboarded
-            it.assertThat(mgmOnboardedEvent.onboardedMgm).isEqualTo(mgm.toAvro())
-        }
-        registrationService.stop()
-    }
-
-    @Test
-    fun `registration persist the group properties`() {
-        postConfigChangedEvent()
-        registrationService.start()
-        val groupProperties = argumentCaptor<LayeredPropertyMap>()
-        whenever(
-            membershipPersistenceClient
-                .persistGroupPolicy(
-                    eq(mgm),
-                    groupProperties.capture(),
-                )
-        ).thenReturn(MembershipPersistenceResult.Success(3))
-
-        registrationService.register(registrationRequest, mgm, properties)
-
-        assertThat(groupProperties.firstValue.entries)
-            .containsExactlyInAnyOrderElementsOf(
-                mapOf(
-                    "protocol.registration"
-                            to "net.corda.membership.impl.registration.dynamic.MemberRegistrationService",
-                    "protocol.synchronisation"
-                            to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
-                    "protocol.p2p.mode" to "AUTHENTICATION_ENCRYPTION",
-                    "key.session.policy" to "Combined",
-                    "pki.session" to "Standard",
-                    "pki.tls" to "C5",
-                    "truststore.session.0"
-                            to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
-                    "truststore.tls.0"
-                            to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
-                ).entries
-            )
-        registrationService.stop()
-    }
-
-    @Test
-    fun `registration persist the MGM member info`() {
-        postConfigChangedEvent()
-        registrationService.start()
-
-        registrationService.register(registrationRequest, mgm, properties)
-
-        verify(membershipPersistenceClient).persistMemberInfo(
-            eq(mgm),
-            argThat {
-                this.size == 1 &&
-                        this.first().isMgm &&
-                        this.first().name == mgmName
-            }
-        )
-    }
-
-    @Test
-    fun `registration persists initial group parameters snapshot`() {
-        postConfigChangedEvent()
-        registrationService.start()
-
-        registrationService.register(registrationRequest, mgm, properties)
-
-        verify(membershipPersistenceClient).persistGroupParametersInitialSnapshot(eq(mgm))
-    }
-
-    @Test
-    fun `registration failure to persist return an error`() {
-        postConfigChangedEvent()
-        registrationService.start()
-        whenever(membershipPersistenceClient.persistMemberInfo(eq(mgm), any()))
-            .doReturn(MembershipPersistenceResult.Failure("Nop"))
-
-        val result = registrationService.register(registrationRequest, mgm, properties)
-
-        assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-            it.assertThat(result.message).isEqualTo("Registration failed, persistence error. Reason: Nop")
-        }
-    }
-
-    @Test
-    fun `registration fails when coordinator is not running`() {
-        val registrationResult = registrationService.register(registrationRequest, mgm, mock())
-        assertThat(registrationResult).isEqualTo(
-            MembershipRequestRegistrationResult(
-                MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
-                "Registration failed. Reason: MGMRegistrationService is not running."
-            )
-        )
-    }
-
-    @Test
-    fun `registration fails when one or more properties are missing`() {
-        postConfigChangedEvent()
-        val testProperties = mutableMapOf<String, String>()
-        registrationService.start()
-        properties.entries.apply {
-            for (index in indices) {
-                val result = registrationService.register(registrationRequest, mgm, testProperties)
-                assertSoftly {
-                    it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                    }?.value ?: fail("Could not find property within published member for test")
                 }
-                elementAt(index).let { testProperties.put(it.key, it.value) }
+
+                it.assertThat(getProperty(PARTY_NAME)).isEqualTo(mgmName.toString())
+                it.assertThat(getProperty(GROUP_ID)).isEqualTo(groupId)
+                it.assertThat(getProperty(STATUS)).isEqualTo(MEMBER_STATUS_ACTIVE)
+                it.assertThat(getProperty(IS_MGM)).isEqualTo("true")
+                it.assertThat(getProperty(PLATFORM_VERSION)).isEqualTo(TEST_PLATFORM_VERSION.toString())
+                it.assertThat(getProperty(SOFTWARE_VERSION)).isEqualTo(TEST_SOFTWARE_VERSION)
+                it.assertThat(statusUpdate.firstValue.status).isEqualTo(RegistrationStatus.APPROVED)
+                it.assertThat(statusUpdate.firstValue.registrationId).isEqualTo(registrationRequest.toString())
+
+
+                val membershipEvent = publishedEvent.value as MembershipEvent
+                it.assertThat(membershipEvent.event).isInstanceOf(MgmOnboarded::class.java)
+                val mgmOnboardedEvent = membershipEvent.event as MgmOnboarded
+                it.assertThat(mgmOnboardedEvent.onboardedMgm).isEqualTo(mgm.toAvro())
+            }
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration persist the group properties`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            val groupProperties = argumentCaptor<LayeredPropertyMap>()
+            whenever(
+                membershipPersistenceClient
+                    .persistGroupPolicy(
+                        eq(mgm),
+                        groupProperties.capture(),
+                    )
+            ).thenReturn(MembershipPersistenceResult.Success(3))
+
+            registrationService.register(registrationRequest, mgm, properties)
+
+            assertThat(groupProperties.firstValue.entries)
+                .containsExactlyInAnyOrderElementsOf(
+                    mapOf(
+                        "protocol.registration"
+                                to "net.corda.membership.impl.registration.dynamic.MemberRegistrationService",
+                        "protocol.synchronisation"
+                                to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
+                        "protocol.p2p.mode" to "AUTHENTICATION_ENCRYPTION",
+                        "key.session.policy" to "Combined",
+                        "pki.session" to "Standard",
+                        "pki.tls" to "C5",
+                        "truststore.session.0"
+                                to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
+                        "truststore.tls.0"
+                                to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
+                    ).entries
+                )
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration persist the MGM member info`() {
+            postConfigChangedEvent()
+            registrationService.start()
+
+            registrationService.register(registrationRequest, mgm, properties)
+
+            verify(membershipPersistenceClient).persistMemberInfo(
+                eq(mgm),
+                argThat {
+                    this.size == 1 &&
+                            this.first().isMgm &&
+                            this.first().name == mgmName
+                }
+            )
+        }
+
+        @Test
+        fun `registration persists initial group parameters snapshot`() {
+            postConfigChangedEvent()
+            registrationService.start()
+
+            registrationService.register(registrationRequest, mgm, properties)
+
+            verify(membershipPersistenceClient).persistGroupParametersInitialSnapshot(eq(mgm))
+        }
+
+        @Test
+        fun `if session PKI mode is NoPKI, session trust root is optional`() {
+            postConfigChangedEvent()
+            val testProperties = properties.toMutableMap()
+            testProperties["corda.group.pki.session"] = "NoPKI"
+            testProperties.remove("corda.group.truststore.session.0")
+            registrationService.start()
+            val result = registrationService.register(registrationRequest, mgm, testProperties)
+            assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
+            }
+            registrationService.stop()
+        }
+    }
+
+    @Nested
+    inner class FailedRegistrationTests {
+        @Test
+        fun `registration failure to persist return an error`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            whenever(membershipPersistenceClient.persistMemberInfo(eq(mgm), any()))
+                .doReturn(MembershipPersistenceResult.Failure("Nop"))
+
+            val result = registrationService.register(registrationRequest, mgm, properties)
+
+            assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                it.assertThat(result.message).isEqualTo("Registration failed, persistence error. Reason: Nop")
             }
         }
-        registrationService.stop()
-    }
 
-    @Test
-    fun `registration fails when one or more properties are numbered incorrectly`() {
-        postConfigChangedEvent()
-        val testProperties =
-            properties + mapOf(
-                "corda.group.truststore.tls.100" to
-                        "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----"
-            )
-        registrationService.start()
-        val result = registrationService.register(registrationRequest, mgm, testProperties)
-        assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-            it.assertThat(result.message)
-                .isEqualTo(
-                    "Onboarding MGM failed. " +
-                            "The registration context is invalid: Provided TLS trust stores are incorrectly numbered."
+        @Test
+        fun `registration fails when coordinator is not running`() {
+            val registrationResult = registrationService.register(registrationRequest, mgm, mock())
+            assertThat(registrationResult).isEqualTo(
+                MembershipRequestRegistrationResult(
+                    MembershipRequestRegistrationOutcome.NOT_SUBMITTED,
+                    "Registration failed. Reason: MGMRegistrationService is not running."
                 )
+            )
         }
-        registrationService.stop()
+
+        @Test
+        fun `registration fails when one or more properties are missing`() {
+            postConfigChangedEvent()
+            val testProperties = mutableMapOf<String, String>()
+            registrationService.start()
+            properties.entries.apply {
+                for (index in indices) {
+                    val result = registrationService.register(registrationRequest, mgm, testProperties)
+                    assertSoftly {
+                        it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                    }
+                    elementAt(index).let { testProperties.put(it.key, it.value) }
+                }
+            }
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration fails when one or more properties are numbered incorrectly`() {
+            postConfigChangedEvent()
+            val testProperties =
+                properties + mapOf(
+                    "corda.group.truststore.tls.100" to
+                            "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----"
+                )
+            registrationService.start()
+            val result = registrationService.register(registrationRequest, mgm, testProperties)
+            assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                it.assertThat(result.message)
+                    .isEqualTo(
+                        "Onboarding MGM failed. " +
+                                "The registration context is invalid: Provided TLS trust stores are incorrectly numbered."
+                    )
+            }
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration fails if the registration context doesn't match the schema`() {
+            postConfigChangedEvent()
+            val err = "ERROR-MESSAGE"
+            val errReason = "ERROR-REASON"
+            whenever(
+                membershipSchemaValidator.validateRegistrationContext(
+                    eq(MembershipSchema.RegistrationContextSchema.Mgm),
+                    any(),
+                    any()
+                )
+            ).doThrow(
+                MembershipSchemaValidationException(
+                    err,
+                    null,
+                    MembershipSchema.RegistrationContextSchema.Mgm,
+                    listOf(errReason)
+                )
+            )
+
+            registrationService.start()
+            val result = registrationService.register(registrationRequest, mgm, properties)
+            assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                it.assertThat(result.message).contains(err)
+                it.assertThat(result.message).contains(errReason)
+            }
+            registrationService.stop()
+        }
     }
 
-    @Test
-    fun `registration fails if the registration context doesn't match the schema`() {
-        postConfigChangedEvent()
-        val err = "ERROR-MESSAGE"
-        val errReason = "ERROR-REASON"
-        whenever(
-            membershipSchemaValidator.validateRegistrationContext(
-                eq(MembershipSchema.RegistrationContextSchema.Mgm),
-                any(),
+    @Nested
+    inner class LifecycleTests {
+        @Test
+        fun `starting the service succeeds`() {
+            registrationService.start()
+            assertThat(registrationService.isRunning).isTrue
+            verify(coordinator).start()
+        }
+
+        @Test
+        fun `stopping the service succeeds`() {
+            registrationService.start()
+            registrationService.stop()
+            assertThat(registrationService.isRunning).isFalse
+            verify(coordinator).stop()
+        }
+
+        @Test
+        fun `component handle created on start and closed on stop`() {
+            postStartEvent()
+
+            verify(componentHandle, never()).close()
+            verify(coordinator).followStatusChangesByName(eq(dependentComponents))
+
+            postStartEvent()
+
+            verify(componentHandle).close()
+            verify(coordinator, times(2)).followStatusChangesByName(eq(dependentComponents))
+
+            postStopEvent()
+            verify(componentHandle, times(2)).close()
+        }
+
+        @Test
+        fun `status set to down after stop`() {
+            postStopEvent()
+
+            verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+            verify(componentHandle, never()).close()
+            verify(configHandle, never()).close()
+            verify(mockPublisher, never()).close()
+        }
+
+        @Test
+        fun `registration status UP creates config handle and closes it first if it exists`() {
+            postStartEvent()
+            postRegistrationStatusChangeEvent(LifecycleStatus.UP)
+
+            val configArgs = argumentCaptor<Set<String>>()
+            verify(configHandle, never()).close()
+            verify(configurationReadService).registerComponentForUpdates(
+                eq(coordinator),
+                configArgs.capture()
+            )
+            assertThat(configArgs.firstValue).isEqualTo(setOf(BOOT_CONFIG, MESSAGING_CONFIG))
+
+            postRegistrationStatusChangeEvent(LifecycleStatus.UP)
+            verify(configHandle).close()
+            verify(configurationReadService, times(2)).registerComponentForUpdates(eq(coordinator), any())
+
+            postStopEvent()
+            verify(configHandle, times(2)).close()
+        }
+
+        @Test
+        fun `registration status DOWN sets status to DOWN`() {
+            postRegistrationStatusChangeEvent(LifecycleStatus.DOWN)
+
+            verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+        }
+
+        @Test
+        fun `registration status ERROR sets status to DOWN`() {
+            postRegistrationStatusChangeEvent(LifecycleStatus.ERROR)
+
+            verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
+        }
+
+        @Test
+        fun `config changed event creates publisher`() {
+            postConfigChangedEvent()
+
+            val configCaptor = argumentCaptor<PublisherConfig>()
+            verify(mockPublisher, never()).close()
+            verify(publisherFactory).createPublisher(
+                configCaptor.capture(),
                 any()
             )
-        ).doThrow(
-            MembershipSchemaValidationException(
-                err,
-                null,
-                MembershipSchema.RegistrationContextSchema.Mgm,
-                listOf(errReason)
+            verify(mockPublisher).start()
+            verify(coordinator).updateStatus(eq(LifecycleStatus.UP), any())
+
+            with(configCaptor.firstValue) {
+                assertThat(clientId).isEqualTo(PUBLISHER_CLIENT_ID)
+            }
+
+            postConfigChangedEvent()
+            verify(mockPublisher).close()
+            verify(publisherFactory, times(2)).createPublisher(
+                configCaptor.capture(),
+                any()
             )
-        )
+            verify(mockPublisher, times(2)).start()
+            verify(coordinator, times(2)).updateStatus(eq(LifecycleStatus.UP), any())
 
-        registrationService.start()
-        val result = registrationService.register(registrationRequest, mgm, properties)
-        assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
-            it.assertThat(result.message).contains(err)
-            it.assertThat(result.message).contains(errReason)
+            postStopEvent()
+            verify(mockPublisher, times(3)).close()
         }
-        registrationService.stop()
-    }
-
-    @Test
-    fun `if session PKI mode is NoPKI, session trust root is optional`() {
-        postConfigChangedEvent()
-        val testProperties = properties.toMutableMap()
-        testProperties["corda.group.pki.session"] = "NoPKI"
-        testProperties.remove("corda.group.truststore.session.0")
-        registrationService.start()
-        val result = registrationService.register(registrationRequest, mgm, testProperties)
-        assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.SUBMITTED)
-        }
-        registrationService.stop()
-    }
-
-    @Test
-    fun `component handle created on start and closed on stop`() {
-        postStartEvent()
-
-        verify(componentHandle, never()).close()
-        verify(coordinator).followStatusChangesByName(eq(dependentComponents))
-
-        postStartEvent()
-
-        verify(componentHandle).close()
-        verify(coordinator, times(2)).followStatusChangesByName(eq(dependentComponents))
-
-        postStopEvent()
-        verify(componentHandle, times(2)).close()
-    }
-
-    @Test
-    fun `status set to down after stop`() {
-        postStopEvent()
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-        verify(componentHandle, never()).close()
-        verify(configHandle, never()).close()
-        verify(mockPublisher, never()).close()
-    }
-
-    @Test
-    fun `registration status UP creates config handle and closes it first if it exists`() {
-        postStartEvent()
-        postRegistrationStatusChangeEvent(LifecycleStatus.UP)
-
-        val configArgs = argumentCaptor<Set<String>>()
-        verify(configHandle, never()).close()
-        verify(configurationReadService).registerComponentForUpdates(
-            eq(coordinator),
-            configArgs.capture()
-        )
-        assertThat(configArgs.firstValue).isEqualTo(setOf(BOOT_CONFIG, MESSAGING_CONFIG))
-
-        postRegistrationStatusChangeEvent(LifecycleStatus.UP)
-        verify(configHandle).close()
-        verify(configurationReadService, times(2)).registerComponentForUpdates(eq(coordinator), any())
-
-        postStopEvent()
-        verify(configHandle, times(2)).close()
-    }
-
-    @Test
-    fun `registration status DOWN sets status to DOWN`() {
-        postRegistrationStatusChangeEvent(LifecycleStatus.DOWN)
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-    }
-
-    @Test
-    fun `registration status ERROR sets status to DOWN`() {
-        postRegistrationStatusChangeEvent(LifecycleStatus.ERROR)
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-    }
-
-    @Test
-    fun `config changed event creates publisher`() {
-        postConfigChangedEvent()
-
-        val configCaptor = argumentCaptor<PublisherConfig>()
-        verify(mockPublisher, never()).close()
-        verify(publisherFactory).createPublisher(
-            configCaptor.capture(),
-            any()
-        )
-        verify(mockPublisher).start()
-        verify(coordinator).updateStatus(eq(LifecycleStatus.UP), any())
-
-        with(configCaptor.firstValue) {
-            assertThat(clientId).isEqualTo(PUBLISHER_CLIENT_ID)
-        }
-
-        postConfigChangedEvent()
-        verify(mockPublisher).close()
-        verify(publisherFactory, times(2)).createPublisher(
-            configCaptor.capture(),
-            any()
-        )
-        verify(mockPublisher, times(2)).start()
-        verify(coordinator, times(2)).updateStatus(eq(LifecycleStatus.UP), any())
-
-        postStopEvent()
-        verify(mockPublisher, times(3)).close()
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -539,6 +539,20 @@ class MGMRegistrationServiceTest {
             }
             registrationService.stop()
         }
+
+        @Test
+        fun `registration fails when vnode info cannot be found`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            whenever(virtualNodeInfoReadService.get(eq(mgm))).doReturn(null)
+
+            val result = registrationService.register(registrationRequest, mgm, properties)
+
+            assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(MembershipRequestRegistrationOutcome.NOT_SUBMITTED)
+                it.assertThat(result.message).isNotNull.contains("Could not find virtual node info")
+            }
+        }
     }
 
     @Nested

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -31,7 +31,6 @@ import net.corda.membership.impl.registration.TEST_CPI_NAME
 import net.corda.membership.impl.registration.TEST_CPI_VERSION
 import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
 import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
-import net.corda.membership.impl.registration.addIndex
 import net.corda.membership.impl.registration.buildMockPlatformInfoProvider
 import net.corda.membership.impl.registration.buildTestVirtualNodeInfo
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
@@ -39,6 +38,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
@@ -323,9 +323,10 @@ class MGMRegistrationServiceTest {
                             SOFTWARE_VERSION,
                             MEMBER_CPI_NAME,
                             MEMBER_CPI_VERSION,
+                            MEMBER_CPI_SIGNER_HASH,
                             SERIAL,
-                            URL_KEY.addIndex(0),
-                            PROTOCOL_VERSION.addIndex(0),
+                            URL_KEY.format(0),
+                            PROTOCOL_VERSION.format(0),
                         )
                     )
                 it.assertThat(persistedMgm.mgmContext.items.map { item -> item.key })
@@ -504,7 +505,7 @@ class MGMRegistrationServiceTest {
                 it.assertThat(result.message)
                     .isEqualTo(
                         "Onboarding MGM failed. " +
-                                "The registration context is invalid: Provided TLS trust stores are incorrectly numbered."
+                                "Provided TLS trust stores are incorrectly numbered."
                     )
             }
             registrationService.stop()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -94,12 +94,14 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 
 class MGMRegistrationServiceTest {
-    companion object {
-        private const val SESSION_KEY_STRING = "1234"
-        private const val SESSION_KEY_ID = "1"
-        private const val ECDH_KEY_STRING = "5678"
-        private const val ECDH_KEY_ID = "2"
-        private const val PUBLISHER_CLIENT_ID = "mgm-registration-service"
+    private companion object {
+        const val SESSION_KEY_STRING = "1234"
+        const val SESSION_KEY_ID = "1"
+        const val ECDH_KEY_STRING = "5678"
+        const val ECDH_KEY_ID = "2"
+        const val PUBLISHER_CLIENT_ID = "mgm-registration-service"
+        const val TEST_PLATFORM_VERSION = 5000
+        const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
     }
 
     private val groupId = "43b5b6e6-4f2d-498f-8b41-5e2f8f97e7e8"
@@ -202,7 +204,8 @@ class MGMRegistrationServiceTest {
         on { createValidator() } doReturn membershipSchemaValidator
     }
     private val platformInfoProvider: PlatformInfoProvider = mock {
-        on { activePlatformVersion } doReturn 5000
+        on { activePlatformVersion } doReturn TEST_PLATFORM_VERSION
+        on { localWorkerSoftwareVersion } doReturn TEST_SOFTWARE_VERSION
     }
     private val registrationService = MGMRegistrationService(
         publisherFactory,
@@ -347,8 +350,11 @@ class MGMRegistrationServiceTest {
             it.assertThat(getProperty(GROUP_ID)).isEqualTo(groupId)
             it.assertThat(getProperty(STATUS)).isEqualTo(MEMBER_STATUS_ACTIVE)
             it.assertThat(getProperty(IS_MGM)).isEqualTo("true")
+            it.assertThat(getProperty(PLATFORM_VERSION)).isEqualTo(TEST_PLATFORM_VERSION.toString())
+            it.assertThat(getProperty(SOFTWARE_VERSION)).isEqualTo(TEST_SOFTWARE_VERSION)
             it.assertThat(statusUpdate.firstValue.status).isEqualTo(RegistrationStatus.APPROVED)
             it.assertThat(statusUpdate.firstValue.registrationId).isEqualTo(registrationRequest.toString())
+
 
             val membershipEvent = publishedEvent.value as MembershipEvent
             it.assertThat(membershipEvent.event).isInstanceOf(MgmOnboarded::class.java)
@@ -376,8 +382,10 @@ class MGMRegistrationServiceTest {
         assertThat(groupProperties.firstValue.entries)
             .containsExactlyInAnyOrderElementsOf(
                 mapOf(
-                    "protocol.registration" to "net.corda.membership.impl.registration.dynamic.MemberRegistrationService",
-                    "protocol.synchronisation" to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
+                    "protocol.registration"
+                            to "net.corda.membership.impl.registration.dynamic.MemberRegistrationService",
+                    "protocol.synchronisation"
+                            to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
                     "protocol.p2p.mode" to "AUTHENTICATION_ENCRYPTION",
                     "key.session.policy" to "Combined",
                     "pki.session" to "Standard",

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -21,6 +21,7 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -60,6 +61,7 @@ class RegistrationServiceLifecycleHandlerTest {
     private val hsmRegistrationClient: HSMRegistrationClient = mock()
     private val membershipSchemaValidatorFactory: MembershipSchemaValidatorFactory = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock()
 
     private val staticMemberRegistrationService = StaticMemberRegistrationService(
         groupPolicyProvider,
@@ -74,7 +76,8 @@ class RegistrationServiceLifecycleHandlerTest {
         mock(),
         membershipSchemaValidatorFactory,
         mock(),
-        platformInfoProvider
+        platformInfoProvider,
+        virtualNodeInfoReadService
     )
 
     private val registrationServiceLifecycleHandler = RegistrationServiceLifecycleHandler(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -479,6 +479,18 @@ class StaticMemberRegistrationServiceTest {
             }
             registrationService.stop()
         }
+
+        @Test
+        fun `registration fails when virtual node info is unavailable`() {
+            setUpPublisher()
+            registrationService.start()
+            whenever(virtualNodeInfoReadService.get((alice))).thenReturn(null)
+
+            val registrationResult = registrationService.register(registrationId, alice, mockContext)
+
+            assertThat(registrationResult.outcome).isEqualTo(NOT_SUBMITTED)
+            assertThat(registrationResult.message).isNotNull.contains("Could not find virtual node")
+        }
     }
 
     @Nested

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -79,7 +79,6 @@ import net.corda.v5.crypto.calculateHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.SoftAssertions
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -92,12 +92,14 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class StaticMemberRegistrationServiceTest {
-    companion object {
-        private const val DEFAULT_KEY = "3456"
-        private const val ALICE_KEY = "1234"
-        private const val BOB_KEY = "2345"
-        private const val CHARLIE_KEY = "6789"
-        private const val KEY_SCHEME = "corda.key.scheme"
+    private companion object {
+        const val DEFAULT_KEY = "3456"
+        const val ALICE_KEY = "1234"
+        const val BOB_KEY = "2345"
+        const val CHARLIE_KEY = "6789"
+        const val KEY_SCHEME = "corda.key.scheme"
+        const val TEST_PLATFORM_VERSION = 5000
+        const val TEST_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
     }
 
     private val alice = HoldingIdentity(aliceName, DUMMY_GROUP_ID)
@@ -156,9 +158,15 @@ class StaticMemberRegistrationServiceTest {
 
     private val cryptoOpsClient: CryptoOpsClient = mock {
         on { generateKeyPair(any(), any(), any(), any(), any<Map<String, String>>()) } doReturn defaultKey
-        on { generateKeyPair(any(), any(), eq("${aliceId.value}-LEDGER"), any(), any<Map<String, String>>()) } doReturn aliceKey
-        on { generateKeyPair(any(), any(), eq("${bobId.value}-LEDGER"), any(), any<Map<String, String>>()) } doReturn bobKey
-        on { generateKeyPair(any(), any(), eq("${charlieId.value}-LEDGER"), any(), any<Map<String, String>>()) } doReturn charlieKey
+        on {
+            generateKeyPair(any(), any(), eq("${aliceId.value}-LEDGER"), any(), any<Map<String, String>>())
+        } doReturn aliceKey
+        on {
+            generateKeyPair(any(), any(), eq("${bobId.value}-LEDGER"), any(), any<Map<String, String>>())
+        } doReturn bobKey
+        on {
+            generateKeyPair(any(), any(), eq("${charlieId.value}-LEDGER"), any(), any<Map<String, String>>())
+        } doReturn charlieKey
         on { lookup(any(), any()) } doReturn listOf(cryptoSigningKey)
     }
 
@@ -222,7 +230,8 @@ class StaticMemberRegistrationServiceTest {
         }
     }
     private val platformInfoProvider: PlatformInfoProvider = mock {
-        on { activePlatformVersion } doReturn 5000
+        on { activePlatformVersion } doReturn TEST_PLATFORM_VERSION
+        on { localWorkerSoftwareVersion } doReturn TEST_SOFTWARE_VERSION
     }
 
     private val registrationService = StaticMemberRegistrationService(
@@ -289,8 +298,8 @@ class StaticMemberRegistrationServiceTest {
             persistentMemberPublished.mgmContext.toSortedMap()
         )
         assertEquals(DUMMY_GROUP_ID, memberPublished.groupId)
-        assertNotNull(memberPublished.softwareVersion)
-        assertNotNull(memberPublished.platformVersion)
+        assertEquals(TEST_SOFTWARE_VERSION, memberPublished.softwareVersion)
+        assertEquals(TEST_PLATFORM_VERSION, memberPublished.platformVersion)
         assertNotNull(memberPublished.serial)
         assertNotNull(memberPublished.modifiedTime)
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -36,10 +36,10 @@ import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.
 import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithInvalidStaticNetworkTemplate
 import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithStaticNetwork
 import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithoutStaticNetwork
+import net.corda.membership.impl.registration.testCpiSignerSummaryHash
 import net.corda.membership.lib.EndpointInfoFactory
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
-import net.corda.membership.lib.MemberInfoExtension.Companion.cpiName
-import net.corda.membership.lib.MemberInfoExtension.Companion.cpiVersion
+import net.corda.membership.lib.MemberInfoExtension.Companion.cpiInfo
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.ledgerKeyHashes
@@ -303,8 +303,9 @@ class StaticMemberRegistrationServiceTest {
             assertEquals(DUMMY_GROUP_ID, memberPublished.groupId)
             assertEquals(TEST_SOFTWARE_VERSION, memberPublished.softwareVersion)
             assertEquals(TEST_PLATFORM_VERSION, memberPublished.platformVersion)
-            assertEquals(TEST_CPI_NAME, memberPublished.cpiName)
-            assertEquals(TEST_CPI_VERSION, memberPublished.cpiVersion)
+            assertEquals(TEST_CPI_NAME, memberPublished.cpiInfo.name)
+            assertEquals(TEST_CPI_VERSION, memberPublished.cpiInfo.version)
+            assertEquals(testCpiSignerSummaryHash, memberPublished.cpiInfo.signerSummaryHash)
             assertNotNull(memberPublished.serial)
             assertNotNull(memberPublished.modifiedTime)
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -19,6 +19,8 @@ import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.impl.registration.TEST_CPI_NAME
+import net.corda.membership.impl.registration.TEST_CPI_VERSION
 import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
 import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
 import net.corda.membership.impl.registration.buildMockPlatformInfoProvider
@@ -36,6 +38,8 @@ import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.
 import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithoutStaticNetwork
 import net.corda.membership.lib.EndpointInfoFactory
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.cpiName
+import net.corda.membership.lib.MemberInfoExtension.Companion.cpiVersion
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.ledgerKeyHashes
@@ -77,6 +81,7 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
 import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -263,308 +268,326 @@ class StaticMemberRegistrationServiceTest {
         )
     }
 
-    @Test
-    fun `starting and stopping the service succeeds`() {
-        registrationService.start()
-        assertTrue(registrationService.isRunning)
-        registrationService.stop()
-        assertFalse(registrationService.isRunning)
-    }
+    @Nested
+    inner class SuccessfulRegistrationTests {
+        @Test
+        fun `during registration, the registering static member inside the GroupPolicy file gets parsed and published`() {
+            setUpPublisher()
+            registrationService.start()
+            val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
+            val registrationResult = registrationService.register(registrationId, alice, mockContext)
+            Mockito.verify(mockPublisher, times(1)).publish(capturedPublishedList.capture())
+            CryptoConsts.Categories.all.forEach {
+                Mockito.verify(hsmRegistrationClient, times(1)).findHSM(aliceId.value, it)
+                Mockito.verify(hsmRegistrationClient, times(1))
+                    .assignSoftHSM(aliceId.value, it)
+            }
+            registrationService.stop()
 
-    @Test
-    fun `during registration, the registering static member inside the GroupPolicy file gets parsed and published`() {
-        setUpPublisher()
-        registrationService.start()
-        val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
-        val registrationResult = registrationService.register(registrationId, alice, mockContext)
-        Mockito.verify(mockPublisher, times(1)).publish(capturedPublishedList.capture())
-        CryptoConsts.Categories.all.forEach {
-            Mockito.verify(hsmRegistrationClient, times(1)).findHSM(aliceId.value, it)
-            Mockito.verify(hsmRegistrationClient, times(1))
-                .assignSoftHSM(aliceId.value, it)
-        }
-        registrationService.stop()
+            val publishedList = capturedPublishedList.firstValue
+            assertEquals(4, publishedList.size)
 
-        val publishedList = capturedPublishedList.firstValue
-        assertEquals(4, publishedList.size)
+            publishedList.take(3).forEach {
+                assertTrue(it.key.startsWith(aliceId.value) || it.key.startsWith(bobId.value)
+                        || it.key.startsWith(charlieId.value))
+                assertTrue(it.key.endsWith(aliceId.value))
+            }
 
-        publishedList.take(3).forEach {
-            assertTrue(it.key.startsWith(aliceId.value) || it.key.startsWith(bobId.value)
-                    || it.key.startsWith(charlieId.value))
-            assertTrue(it.key.endsWith(aliceId.value))
-        }
+            val publishedInfo = publishedList.first()
 
-        val publishedInfo = publishedList.first()
-
-        assertEquals(Schemas.Membership.MEMBER_LIST_TOPIC, publishedInfo.topic)
-        val persistentMemberPublished = publishedInfo.value as PersistentMemberInfo
-        val memberPublished = memberInfoFactory.create(
-            persistentMemberPublished.memberContext.toSortedMap(),
-            persistentMemberPublished.mgmContext.toSortedMap()
-        )
-        assertEquals(DUMMY_GROUP_ID, memberPublished.groupId)
-        assertEquals(TEST_SOFTWARE_VERSION, memberPublished.softwareVersion)
-        assertEquals(TEST_PLATFORM_VERSION, memberPublished.platformVersion)
-        assertNotNull(memberPublished.serial)
-        assertNotNull(memberPublished.modifiedTime)
-
-        assertEquals(aliceKey, memberPublished.sessionInitiationKey)
-        assertEquals(1, memberPublished.ledgerKeys.size)
-        assertEquals(1, memberPublished.ledgerKeyHashes.size)
-        assertEquals(aliceKey.calculateHash(), memberPublished.ledgerKeyHashes.first())
-        assertEquals(MEMBER_STATUS_ACTIVE, memberPublished.status)
-        assertEquals(1, memberPublished.endpoints.size)
-
-        // we publish the hosted identity as the last item
-        val publishedHostedIdentity = publishedList.last()
-
-        assertEquals(alice.shortHash.value, publishedHostedIdentity.key)
-        assertEquals(P2P_HOSTED_IDENTITIES_TOPIC, publishedHostedIdentity.topic)
-        val hostedIdentityPublished = publishedHostedIdentity.value as HostedIdentityEntry
-        assertEquals(alice.groupId, hostedIdentityPublished.holdingIdentity.groupId)
-        assertEquals(alice.x500Name.toString(), hostedIdentityPublished.holdingIdentity.x500Name)
-
-        assertEquals(MembershipRequestRegistrationResult(SUBMITTED), registrationResult)
-    }
-
-    @Test
-    fun `registration persist the status`() {
-        val status = argumentCaptor<RegistrationRequest>()
-        whenever(
-            persistenceClient.persistRegistrationRequest(
-                eq(alice),
-                status.capture()
+            assertEquals(Schemas.Membership.MEMBER_LIST_TOPIC, publishedInfo.topic)
+            val persistentMemberPublished = publishedInfo.value as PersistentMemberInfo
+            val memberPublished = memberInfoFactory.create(
+                persistentMemberPublished.memberContext.toSortedMap(),
+                persistentMemberPublished.mgmContext.toSortedMap()
             )
-        ).doReturn(MembershipPersistenceResult.success())
-        setUpPublisher()
-        registrationService.start()
+            assertEquals(DUMMY_GROUP_ID, memberPublished.groupId)
+            assertEquals(TEST_SOFTWARE_VERSION, memberPublished.softwareVersion)
+            assertEquals(TEST_PLATFORM_VERSION, memberPublished.platformVersion)
+            assertEquals(TEST_CPI_NAME, memberPublished.cpiName)
+            assertEquals(TEST_CPI_VERSION, memberPublished.cpiVersion)
+            assertNotNull(memberPublished.serial)
+            assertNotNull(memberPublished.modifiedTime)
 
-        registrationService.register(registrationId, alice, mockContext)
+            assertEquals(aliceKey, memberPublished.sessionInitiationKey)
+            assertEquals(1, memberPublished.ledgerKeys.size)
+            assertEquals(1, memberPublished.ledgerKeyHashes.size)
+            assertEquals(aliceKey.calculateHash(), memberPublished.ledgerKeyHashes.first())
+            assertEquals(MEMBER_STATUS_ACTIVE, memberPublished.status)
+            assertEquals(1, memberPublished.endpoints.size)
 
-        assertThat(status.firstValue.status).isEqualTo(RegistrationStatus.APPROVED)
-    }
+            // we publish the hosted identity as the last item
+            val publishedHostedIdentity = publishedList.last()
 
-    @Test
-    fun `registration fails when name field is empty in the GroupPolicy file`() {
-        setUpPublisher()
-        registrationService.start()
-        val registrationResult = registrationService.register(registrationId, bob, mockContext)
-        assertEquals(
-            MembershipRequestRegistrationResult(
-                NOT_SUBMITTED,
-                "Registration failed. Reason: Member's name is not provided in static member list."
-            ),
-            registrationResult
-        )
-        registrationService.stop()
-    }
+            assertEquals(alice.shortHash.value, publishedHostedIdentity.key)
+            assertEquals(P2P_HOSTED_IDENTITIES_TOPIC, publishedHostedIdentity.topic)
+            val hostedIdentityPublished = publishedHostedIdentity.value as HostedIdentityEntry
+            assertEquals(alice.groupId, hostedIdentityPublished.holdingIdentity.groupId)
+            assertEquals(alice.x500Name.toString(), hostedIdentityPublished.holdingIdentity.x500Name)
 
-    @Test
-    fun `registration fails when static network is missing`() {
-        setUpPublisher()
-        registrationService.start()
-        val registrationResult = registrationService.register(registrationId, charlie, mockContext)
-        assertEquals(
-            MembershipRequestRegistrationResult(
-                NOT_SUBMITTED,
-                "Registration failed. Reason: Could not find static member list in group policy file."
-            ),
-            registrationResult
-        )
-        registrationService.stop()
-    }
+            assertEquals(MembershipRequestRegistrationResult(SUBMITTED), registrationResult)
+        }
 
-    @Test
-    fun `registration fails when static network is empty`() {
-        setUpPublisher()
-        registrationService.start()
-        val registrationResult = registrationService.register(registrationId, eric, mockContext)
-        assertEquals(
-            MembershipRequestRegistrationResult(
-                NOT_SUBMITTED,
-                "Registration failed. Reason: Static member list inside the group policy file cannot be empty."
-            ),
-            registrationResult
-        )
-        registrationService.stop()
-    }
+        @Test
+        fun `registration persist the status`() {
+            val status = argumentCaptor<RegistrationRequest>()
+            whenever(
+                persistenceClient.persistRegistrationRequest(
+                    eq(alice),
+                    status.capture()
+                )
+            ).doReturn(MembershipPersistenceResult.success())
+            setUpPublisher()
+            registrationService.start()
 
-    @Test
-    fun `registration fails when coordinator is not running`() {
-        setUpPublisher()
-        val registrationResult = registrationService.register(registrationId, alice, mockContext)
-        assertEquals(
-            MembershipRequestRegistrationResult(
-                NOT_SUBMITTED,
-                "Registration failed. Reason: StaticMemberRegistrationService is not running/down."
-            ),
-            registrationResult
-        )
-    }
+            registrationService.register(registrationId, alice, mockContext)
 
-    @Test
-    fun `registration fails when registering member is not in the static member list`() {
-        setUpPublisher()
-        registrationService.start()
-        val registrationResult = registrationService.register(registrationId, daisy, mockContext)
-        assertEquals(
-            MembershipRequestRegistrationResult(
-                NOT_SUBMITTED,
-                "Registration failed. Reason: Our membership O=Daisy, L=London, C=GB is not listed in the static member list."
-            ),
-            registrationResult
-        )
-        registrationService.stop()
-    }
-
-    @Test
-    fun `registration fails when key scheme is not provided in context`() {
-        setUpPublisher()
-        registrationService.start()
-        val registrationResult = registrationService.register(registrationId, alice, mock())
-        assertEquals(
-            MembershipRequestRegistrationResult(
-                NOT_SUBMITTED,
-                "Registration failed. Reason: Key scheme must be specified."
-            ),
-            registrationResult
-        )
-        registrationService.stop()
-    }
-
-    @Test
-    fun `registration fails when notary role has missing information`() {
-        setUpPublisher()
-        registrationService.start()
-        val context = mapOf(
-            KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
-            "corda.roles.0" to "notary",
-        )
-
-        val registrationResult = registrationService.register(registrationId, alice, context)
-
-        assertThat(registrationResult.outcome).isEqualTo(NOT_SUBMITTED)
-    }
-
-    @Test
-    fun `registration submitted when context has notary role`() {
-        setUpPublisher()
-        registrationService.start()
-        val context = mapOf(
-            KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
-            "corda.roles.0" to "notary",
-            "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
-            "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
-        )
-
-        val registrationResult = registrationService.register(registrationId, alice, context)
-
-        assertThat(registrationResult.outcome).isEqualTo(SUBMITTED)
-    }
-
-    @Test
-    fun `registration not submitted when context has un known role`() {
-        setUpPublisher()
-        registrationService.start()
-        val context = mapOf(
-            KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
-            "corda.roles.0" to "nop",
-        )
-
-        val registrationResult = registrationService.register(registrationId, alice, context)
-
-        assertThat(registrationResult.outcome).isEqualTo(NOT_SUBMITTED)
-    }
-
-    @Test
-    fun `registration adds notary info to member info`() {
-        val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
-        whenever(mockPublisher.publish(capturedPublishedList.capture())).doReturn(emptyList())
-        setUpPublisher()
-        registrationService.start()
-        val context = mapOf(
-            KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
-            "corda.roles.0" to "notary",
-            "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
-            "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
-        )
-
-        registrationService.register(registrationId, alice, context)
-
-        val persistentMemberPublished = capturedPublishedList.firstValue.firstOrNull()?.value as PersistentMemberInfo
-        val memberInfo = memberInfoFactory.create(
-            persistentMemberPublished.memberContext.toSortedMap(),
-            persistentMemberPublished.mgmContext.toSortedMap()
-        )
-        val notaryDetails = memberInfo.notaryDetails
-        assertSoftly {
-            assertThat(notaryDetails).isNotNull
-            assertThat(notaryDetails?.serviceName).isEqualTo(MemberX500Name.parse("O=MyNotaryService, L=London, C=GB"))
-            assertThat(notaryDetails?.servicePlugin).isEqualTo("net.corda.notary.MyNotaryService")
-
-            assertThat(notaryDetails?.keys?.toList())
-                .hasSize(1)
-                .allMatch {
-                    it.publicKey == defaultKey
-                }
-                .allMatch {
-                    it.publicKeyHash == PublicKeyHash.calculate(defaultKey)
-                }
-                .allMatch {
-                    it.spec.signatureName == SignatureSpec.RSA_SHA512.signatureName
-                }
+            assertThat(status.firstValue.status).isEqualTo(RegistrationStatus.APPROVED)
         }
     }
 
-    @Test
-    fun `registration without notary will not add notary to member info`() {
-        val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
-        whenever(mockPublisher.publish(capturedPublishedList.capture())).doReturn(emptyList())
-        setUpPublisher()
-        registrationService.start()
-        val context = mapOf(
-            KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
-        )
+    @Nested
+    inner class FailedRegistrationTests {
+        @Test
+        fun `registration fails when name field is empty in the GroupPolicy file`() {
+            setUpPublisher()
+            registrationService.start()
+            val registrationResult = registrationService.register(registrationId, bob, mockContext)
+            assertEquals(
+                MembershipRequestRegistrationResult(
+                    NOT_SUBMITTED,
+                    "Registration failed. Reason: Member's name is not provided in static member list."
+                ),
+                registrationResult
+            )
+            registrationService.stop()
+        }
 
-        registrationService.register(registrationId, alice, context)
+        @Test
+        fun `registration fails when static network is missing`() {
+            setUpPublisher()
+            registrationService.start()
+            val registrationResult = registrationService.register(registrationId, charlie, mockContext)
+            assertEquals(
+                MembershipRequestRegistrationResult(
+                    NOT_SUBMITTED,
+                    "Registration failed. Reason: Could not find static member list in group policy file."
+                ),
+                registrationResult
+            )
+            registrationService.stop()
+        }
 
-        val persistentMemberPublished = capturedPublishedList.firstValue.firstOrNull()?.value as PersistentMemberInfo
-        val memberInfo = memberInfoFactory.create(
-            persistentMemberPublished.memberContext.toSortedMap(),
-            persistentMemberPublished.mgmContext.toSortedMap()
-        )
-        val notaryDetails = memberInfo.notaryDetails
-        assertThat(notaryDetails)
-            .isNull()
+        @Test
+        fun `registration fails when static network is empty`() {
+            setUpPublisher()
+            registrationService.start()
+            val registrationResult = registrationService.register(registrationId, eric, mockContext)
+            assertEquals(
+                MembershipRequestRegistrationResult(
+                    NOT_SUBMITTED,
+                    "Registration failed. Reason: Static member list inside the group policy file cannot be empty."
+                ),
+                registrationResult
+            )
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration fails when coordinator is not running`() {
+            setUpPublisher()
+            val registrationResult = registrationService.register(registrationId, alice, mockContext)
+            assertEquals(
+                MembershipRequestRegistrationResult(
+                    NOT_SUBMITTED,
+                    "Registration failed. Reason: StaticMemberRegistrationService is not running/down."
+                ),
+                registrationResult
+            )
+        }
+
+        @Test
+        fun `registration fails when registering member is not in the static member list`() {
+            setUpPublisher()
+            registrationService.start()
+            val registrationResult = registrationService.register(registrationId, daisy, mockContext)
+            assertEquals(
+                MembershipRequestRegistrationResult(
+                    NOT_SUBMITTED,
+                    "Registration failed. Reason: Our membership O=Daisy, L=London, C=GB " +
+                            "is not listed in the static member list."
+                ),
+                registrationResult
+            )
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration fails when key scheme is not provided in context`() {
+            setUpPublisher()
+            registrationService.start()
+            val registrationResult = registrationService.register(registrationId, alice, mock())
+            assertEquals(
+                MembershipRequestRegistrationResult(
+                    NOT_SUBMITTED,
+                    "Registration failed. Reason: Key scheme must be specified."
+                ),
+                registrationResult
+            )
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration fails when notary role has missing information`() {
+            setUpPublisher()
+            registrationService.start()
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+            )
+
+            val registrationResult = registrationService.register(registrationId, alice, context)
+
+            assertThat(registrationResult.outcome).isEqualTo(NOT_SUBMITTED)
+        }
+
+        @Test
+        fun `registration fails if the registration context doesn't match the schema`() {
+            setUpPublisher()
+            val err = "ERROR-MESSAGE"
+            val errReason = "ERROR-REASON"
+            whenever(
+                membershipSchemaValidator.validateRegistrationContext(
+                    eq(MembershipSchema.RegistrationContextSchema.StaticMember),
+                    any(),
+                    any()
+                )
+            ).doThrow(
+                MembershipSchemaValidationException(
+                    err,
+                    null,
+                    MembershipSchema.RegistrationContextSchema.DynamicMember,
+                    listOf(errReason)
+                )
+            )
+
+            registrationService.start()
+            val result = registrationService.register(registrationId, alice, mockContext)
+            assertSoftly {
+                it.assertThat(result.outcome).isEqualTo(NOT_SUBMITTED)
+                it.assertThat(result.message).contains(err)
+                it.assertThat(result.message).contains(errReason)
+            }
+            registrationService.stop()
+        }
     }
 
-    @Test
-    fun `registration fails if the registration context doesn't match the schema`() {
-        setUpPublisher()
-        val err = "ERROR-MESSAGE"
-        val errReason = "ERROR-REASON"
-        whenever(
-            membershipSchemaValidator.validateRegistrationContext(
-                eq(MembershipSchema.RegistrationContextSchema.StaticMember),
-                any(),
-                any()
+    @Nested
+    inner class NotaryRoleTests {
+        @Test
+        fun `registration submitted when context has notary role`() {
+            setUpPublisher()
+            registrationService.start()
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
             )
-        ).doThrow(
-            MembershipSchemaValidationException(
-                err,
-                null,
-                MembershipSchema.RegistrationContextSchema.DynamicMember,
-                listOf(errReason)
-            )
-        )
 
-        registrationService.start()
-        val result = registrationService.register(registrationId, alice, mockContext)
-        assertSoftly {
-            it.assertThat(result.outcome).isEqualTo(NOT_SUBMITTED)
-            it.assertThat(result.message).contains(err)
-            it.assertThat(result.message).contains(errReason)
+            val registrationResult = registrationService.register(registrationId, alice, context)
+
+            assertThat(registrationResult.outcome).isEqualTo(SUBMITTED)
         }
-        registrationService.stop()
+
+        @Test
+        fun `registration not submitted when context has un known role`() {
+            setUpPublisher()
+            registrationService.start()
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "nop",
+            )
+
+            val registrationResult = registrationService.register(registrationId, alice, context)
+
+            assertThat(registrationResult.outcome).isEqualTo(NOT_SUBMITTED)
+        }
+
+        @Test
+        fun `registration adds notary info to member info`() {
+            val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
+            whenever(mockPublisher.publish(capturedPublishedList.capture())).doReturn(emptyList())
+            setUpPublisher()
+            registrationService.start()
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
+            )
+
+            registrationService.register(registrationId, alice, context)
+
+            val persistentMemberPublished =
+                capturedPublishedList.firstValue.firstOrNull()?.value as PersistentMemberInfo
+            val memberInfo = memberInfoFactory.create(
+                persistentMemberPublished.memberContext.toSortedMap(),
+                persistentMemberPublished.mgmContext.toSortedMap()
+            )
+            val notaryDetails = memberInfo.notaryDetails
+            assertSoftly {
+                assertThat(notaryDetails).isNotNull
+                assertThat(notaryDetails?.serviceName)
+                    .isEqualTo(MemberX500Name.parse("O=MyNotaryService, L=London, C=GB"))
+                assertThat(notaryDetails?.servicePlugin).isEqualTo("net.corda.notary.MyNotaryService")
+
+                assertThat(notaryDetails?.keys?.toList())
+                    .hasSize(1)
+                    .allMatch {
+                        it.publicKey == defaultKey
+                    }
+                    .allMatch {
+                        it.publicKeyHash == PublicKeyHash.calculate(defaultKey)
+                    }
+                    .allMatch {
+                        it.spec.signatureName == SignatureSpec.RSA_SHA512.signatureName
+                    }
+            }
+        }
+
+        @Test
+        fun `registration without notary will not add notary to member info`() {
+            val capturedPublishedList = argumentCaptor<List<Record<String, Any>>>()
+            whenever(mockPublisher.publish(capturedPublishedList.capture())).doReturn(emptyList())
+            setUpPublisher()
+            registrationService.start()
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+            )
+
+            registrationService.register(registrationId, alice, context)
+
+            val persistentMemberPublished =
+                capturedPublishedList.firstValue.firstOrNull()?.value as PersistentMemberInfo
+            val memberInfo = memberInfoFactory.create(
+                persistentMemberPublished.memberContext.toSortedMap(),
+                persistentMemberPublished.mgmContext.toSortedMap()
+            )
+            val notaryDetails = memberInfo.notaryDetails
+            assertThat(notaryDetails)
+                .isNull()
+        }
+    }
+
+    @Nested
+    inner class LifecycleTests {
+        @Test
+        fun `starting and stopping the service succeeds`() {
+            registrationService.start()
+            assertTrue(registrationService.isRunning)
+            registrationService.stop()
+            assertFalse(registrationService.isRunning)
+        }
     }
 }

--- a/libs/membership/membership-common/build.gradle
+++ b/libs/membership/membership-common/build.gradle
@@ -17,4 +17,6 @@ dependencies {
     api project(":libs:membership:membership-datamodel")
     api project(":libs:virtual-node:virtual-node-info")
     implementation project(":libs:utilities")
+
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -131,10 +131,6 @@ class MemberInfoExtension {
         const val NOTARY_KEY_SPEC = "corda.notary.keys.%s.signature.spec"
 
         /** Identity certificate or null for non-PKI option. Certificate subject and key should match party */
-        // TODO we will need a CertPath converter somewhere
-        /*@JvmStatic
-        val MemberInfo.certificate: CertPath?
-            get() = memberProvidedContext.readAs(CERTIFICATE)*/
         @JvmStatic
         val MemberInfo.certificate: List<String>
             get() = memberProvidedContext.parseList(CERTIFICATE)
@@ -232,5 +228,15 @@ class MemberInfoExtension {
         @JvmStatic
         val MemberInfo.ecdhKey: PublicKey?
             get() = memberProvidedContext.parseOrNull(ECDH_KEY)
+
+        /** The CPI name included in the member's member info **/
+        @JvmStatic
+        val MemberInfo.cpiName: String
+            get() = memberProvidedContext.parse(MEMBER_CPI_NAME)
+
+        /** The CPI version included in the member's member info **/
+        @JvmStatic
+        val MemberInfo.cpiVersion: String
+            get() = memberProvidedContext.parse(MEMBER_CPI_VERSION)
     }
 }

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -28,6 +28,9 @@ class MemberInfoExtension {
         const val LEDGER_KEY_HASHES = "corda.ledger.keys"
         const val LEDGER_KEY_HASHES_KEY = "corda.ledger.keys.%s.hash"
 
+        /** Key name for ledger key signature spec property. */
+        const val LEDGER_KEY_SIGNATURE_SPEC = "corda.ledger.keys.%s.signature.spec"
+
         /** Key name for platform version property. */
         const val PLATFORM_VERSION = "corda.platformVersion"
 
@@ -37,6 +40,9 @@ class MemberInfoExtension {
 
         /** Key name for the session key hash **/
         const val SESSION_KEY_HASH = "corda.session.key.hash"
+
+        /** Key name for the session key signature spec **/
+        const val SESSION_KEY_SIGNATURE_SPEC = "corda.session.key.signature.spec"
 
         /** Key name for notary service property. */
         const val NOTARY_SERVICE_PARTY_NAME = "corda.notaryService.name"
@@ -80,6 +86,12 @@ class MemberInfoExtension {
 
         /** Key name for the ID of the registration in which the current member info was approved. */
         const val REGISTRATION_ID = "corda.registration.id"
+
+        /** Key name for the CPI name **/
+        const val MEMBER_CPI_NAME = "corda.cpi.name"
+
+        /** Key name for the CPI version **/
+        const val MEMBER_CPI_VERSION = "corda.cpi.version"
 
         /** Active nodes can transact in the Membership Group with the other nodes. **/
         const val MEMBER_STATUS_ACTIVE = "ACTIVE"

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.lib
 
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.lib.notary.MemberNotaryDetails
 import net.corda.utilities.NetworkHostAndPort
 import net.corda.v5.base.util.contextLogger
@@ -8,6 +9,7 @@ import net.corda.v5.base.util.parseList
 import net.corda.v5.base.util.parseOrNull
 import net.corda.v5.base.util.parseSet
 import net.corda.v5.crypto.PublicKeyHash
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.calculateHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
@@ -92,6 +94,9 @@ class MemberInfoExtension {
 
         /** Key name for the CPI version **/
         const val MEMBER_CPI_VERSION = "corda.cpi.version"
+
+        /** Key name for the CPI signer summary hash **/
+        const val MEMBER_CPI_SIGNER_HASH = "corda.cpi.signer.summary.hash"
 
         /** Active nodes can transact in the Membership Group with the other nodes. **/
         const val MEMBER_STATUS_ACTIVE = "ACTIVE"
@@ -229,14 +234,17 @@ class MemberInfoExtension {
         val MemberInfo.ecdhKey: PublicKey?
             get() = memberProvidedContext.parseOrNull(ECDH_KEY)
 
-        /** The CPI name included in the member's member info **/
+        /**
+         * Return the [CpiIdentifier] from the [MemberInfo]
+         */
         @JvmStatic
-        val MemberInfo.cpiName: String
-            get() = memberProvidedContext.parse(MEMBER_CPI_NAME)
-
-        /** The CPI version included in the member's member info **/
-        @JvmStatic
-        val MemberInfo.cpiVersion: String
-            get() = memberProvidedContext.parse(MEMBER_CPI_VERSION)
+        val MemberInfo.cpiInfo: CpiIdentifier
+            get() = CpiIdentifier(
+                memberProvidedContext.parse(MEMBER_CPI_NAME),
+                memberProvidedContext.parse(MEMBER_CPI_VERSION),
+                memberProvidedContext.parseOrNull<String>(MEMBER_CPI_SIGNER_HASH)?.let {
+                    SecureHash.parse(it)
+                }
+            )
     }
 }

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/MemberInfoExtensionTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/MemberInfoExtensionTest.kt
@@ -1,0 +1,76 @@
+package net.corda.membership.lib
+
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_HASH
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.cpiInfo
+import net.corda.membership.lib.MemberInfoExtension.Companion.softwareVersion
+import net.corda.v5.membership.MemberContext
+import net.corda.v5.membership.MemberInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class MemberInfoExtensionTest {
+    private val memberContext: MemberContext = mock()
+    private val memberInfo: MemberInfo = mock {
+        on { memberProvidedContext } doReturn memberContext
+    }
+
+    @Test
+    fun `CPI Info can be parsed from member context`() {
+        val cpiName = "cpi"
+        val cpiVersion = "1.3"
+        val cpiSignerHash = "ALG:A1B2C3D4"
+        whenever(
+            memberContext.parse(
+                eq(MEMBER_CPI_NAME),
+                eq(String::class.java)
+            )
+        ) doReturn cpiName
+
+        whenever(
+            memberContext.parse(
+                eq(MEMBER_CPI_VERSION),
+                eq(String::class.java)
+            )
+        ) doReturn cpiVersion
+
+        whenever(
+            memberContext.parseOrNull(
+                eq(MEMBER_CPI_SIGNER_HASH),
+                eq(String::class.java)
+            )
+        ) doReturn cpiSignerHash
+
+        val result = assertDoesNotThrow {
+            memberInfo.cpiInfo
+        }
+
+        assertThat(result.name).isEqualTo(cpiName)
+        assertThat(result.version).isEqualTo(cpiVersion)
+        assertThat(result.signerSummaryHash.toString()).isEqualTo(cpiSignerHash)
+    }
+
+    @Test
+    fun `Software version can be parsed from member context`() {
+        val softwareVersion = "software-version"
+        whenever(
+            memberContext.parse(
+                eq(SOFTWARE_VERSION),
+                eq(String::class.java)
+            )
+        ) doReturn softwareVersion
+
+        val result = assertDoesNotThrow {
+            memberInfo.softwareVersion
+        }
+
+        assertThat(result).isEqualTo(softwareVersion)
+    }
+}

--- a/libs/membership/schema-validation/src/main/kotlin/net/corda/membership/lib/schema/validation/MembershipSchemaValidationExceptions.kt
+++ b/libs/membership/schema-validation/src/main/kotlin/net/corda/membership/lib/schema/validation/MembershipSchemaValidationExceptions.kt
@@ -7,12 +7,12 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
  * Exception thrown when validation using a membership schema fails.
  */
 class MembershipSchemaValidationException(
-    val msg: String,
+    msg: String,
     cause: Throwable?,
-    private val schema: MembershipSchema,
-    private val errors: List<String>
+    schema: MembershipSchema,
+    errors: List<String>
 ) : CordaRuntimeException(msg, cause) {
-    fun getErrorSummary(): String = errors.joinToString(
+    override val message: String = errors.joinToString(
         prefix = "$msg. Failed to validate against schema \"${schema.schemaName}\" due to the following error(s): [",
         postfix = "]",
         separator = ",${System.lineSeparator()}"


### PR DESCRIPTION
Ensures that all `MemberInfo`'s generated by dynamic member registration, static member registration and mgm registration report their version information. This includes:
* Platform version (added in https://github.com/corda/corda-runtime-os/pull/2296)
* Software version
* CPI Name
* CPI Version
* CPI Signer Summary Hash

The changes in the test class can be difficult to see in the diff because I moved the unit tests to the nested class structure to make it easier to group and find tests. All tests are identical other than:

- `DynamicMemberRegistrationServiceTest`
    - `registration context is constructed as expected`: New test
    - `registration fails if virtual node info cannot be found`: New test
- `MGMRegistrationServiceTest`
    - `registration successfully builds MGM info and publishes it`: Added extra assertions for new properties
    - `registration fails when vnode info cannot be found`: New test
- `StaticMemberRegistrationServiceTest`
    - `during registration, the registering static member inside the GroupPolicy file gets parsed and published`: Added extra assertions for new properties
    - `registration fails when virtual node info is unavailable`: New test


The MGM registration became quite complex so I've refactored that in to smaller classes and added tests for each.