### PR TITLE
CORE-7273: Fix issue serializing a map of SignableData

### DIFF
--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -59,10 +59,7 @@ dependencies {
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation "net.corda:corda-application"
-    integrationTestImplementation project(":libs:ledger:ledger-common-data")
     integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
-    integrationTestRuntimeOnly project(':libs:application:application-impl')
-    integrationTestRuntimeOnly project(':libs:crypto:merkle-impl')
     integrationTestRuntimeOnly project(':libs:crypto:crypto-core')
     integrationTestRuntimeOnly project(':libs:crypto:cipher-suite-impl')
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -59,7 +59,10 @@ dependencies {
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation "net.corda:corda-application"
+    integrationTestImplementation project(":libs:ledger:ledger-common-data")
     integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly project(':libs:application:application-impl')
+    integrationTestRuntimeOnly project(':libs:crypto:merkle-impl')
     integrationTestRuntimeOnly project(':libs:crypto:crypto-core')
     integrationTestRuntimeOnly project(':libs:crypto:cipher-suite-impl')
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -203,10 +203,10 @@ class AMQPwithOSGiSerializationTests {
     }
 
     @CordaSerializable
-    data class SignableData(val contents: String)
+    data class SignableDataAmqpTest(val contents: String)
 
     @CordaSerializable
-    data class TestMapOfSignableData(val signableData: Map<Int, SignableData>)
+    data class TestMapOfSignableData(val signableData: Map<Int, SignableDataAmqpTest>)
 
     @Test
     fun mapOfSignableData() {
@@ -216,7 +216,7 @@ class AMQPwithOSGiSerializationTests {
             registerCustomSerializers(factory)
             val context = testSerializationContext.withSandboxGroup(sandboxGroup)
 
-            val testObject = TestMapOfSignableData(mapOf(1 to SignableData("mapOfSignableData")))
+            val testObject = TestMapOfSignableData(mapOf(1 to SignableDataAmqpTest("mapOfSignableData")))
 
             val serializedBytes = SerializationOutput(factory).serialize(testObject, context)
             val deserialize = DeserializationInput(factory).deserialize(serializedBytes, context)
@@ -228,7 +228,7 @@ class AMQPwithOSGiSerializationTests {
     }
 
     @CordaSerializable
-    data class TestListOfSignableData(val signableData: List<SignableData>)
+    data class TestListOfSignableData(val signableData: List<SignableDataAmqpTest>)
 
     @Test
     fun listOfSignableData() {
@@ -238,7 +238,7 @@ class AMQPwithOSGiSerializationTests {
             registerCustomSerializers(factory)
             val context = testSerializationContext.withSandboxGroup(sandboxGroup)
 
-            val testObject = TestListOfSignableData(listOf(SignableData("listOfSignableData")))
+            val testObject = TestListOfSignableData(listOf(SignableDataAmqpTest("listOfSignableData")))
 
             val serializedBytes = SerializationOutput(factory).serialize(testObject, context)
             val deserialize = DeserializationInput(factory).deserialize(serializedBytes, context)

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -7,7 +7,6 @@ import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
 import net.corda.internal.serialization.registerCustomSerializers
-import net.corda.ledger.common.data.transaction.SignableData
 import net.corda.sandbox.SandboxException
 import net.corda.sandbox.SandboxGroup
 import net.corda.serialization.SerializationContext
@@ -18,10 +17,8 @@ import net.corda.utilities.copyTo
 import net.corda.utilities.div
 import net.corda.utilities.reflection.packageName_
 import net.corda.utilities.toByteSequence
-import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.types.OpaqueBytes
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SerializedBytes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -43,7 +40,6 @@ import java.io.File
 import java.io.NotSerializableException
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
-import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
@@ -207,6 +203,9 @@ class AMQPwithOSGiSerializationTests {
     }
 
     @CordaSerializable
+    class SignableData
+
+    @CordaSerializable
     data class TestMapOfSignableData(val signableData: Map<Int, SignableData>)
 
     @Test
@@ -217,9 +216,7 @@ class AMQPwithOSGiSerializationTests {
             registerCustomSerializers(factory)
             val context = testSerializationContext.withSandboxGroup(sandboxGroup)
 
-            val testObject = TestMapOfSignableData(
-                mapOf(1 to SignableData(SecureHash.parse("ALGO:1234"),
-                DigitalSignatureMetadata(Instant.EPOCH, emptyMap()))))
+            val testObject = TestMapOfSignableData(mapOf(1 to SignableData()))
 
             val serializedBytes = SerializationOutput(factory).serialize(testObject, context)
             val deserialize = DeserializationInput(factory).deserialize(serializedBytes, context)
@@ -241,12 +238,7 @@ class AMQPwithOSGiSerializationTests {
             registerCustomSerializers(factory)
             val context = testSerializationContext.withSandboxGroup(sandboxGroup)
 
-            val testObject = TestListOfSignableData(
-                listOf(SignableData(
-                    SecureHash.parse("ALGO:1234"),
-                    DigitalSignatureMetadata(Instant.EPOCH, emptyMap())
-                ))
-            )
+            val testObject = TestListOfSignableData(listOf(SignableData()))
 
             val serializedBytes = SerializationOutput(factory).serialize(testObject, context)
             val deserialize = DeserializationInput(factory).deserialize(serializedBytes, context)

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -203,7 +203,7 @@ class AMQPwithOSGiSerializationTests {
     }
 
     @CordaSerializable
-    class SignableData
+    data class SignableData(val contents: String)
 
     @CordaSerializable
     data class TestMapOfSignableData(val signableData: Map<Int, SignableData>)
@@ -216,7 +216,7 @@ class AMQPwithOSGiSerializationTests {
             registerCustomSerializers(factory)
             val context = testSerializationContext.withSandboxGroup(sandboxGroup)
 
-            val testObject = TestMapOfSignableData(mapOf(1 to SignableData()))
+            val testObject = TestMapOfSignableData(mapOf(1 to SignableData("mapOfSignableData")))
 
             val serializedBytes = SerializationOutput(factory).serialize(testObject, context)
             val deserialize = DeserializationInput(factory).deserialize(serializedBytes, context)
@@ -238,7 +238,7 @@ class AMQPwithOSGiSerializationTests {
             registerCustomSerializers(factory)
             val context = testSerializationContext.withSandboxGroup(sandboxGroup)
 
-            val testObject = TestListOfSignableData(listOf(SignableData()))
+            val testObject = TestListOfSignableData(listOf(SignableData("listOfSignableData")))
 
             val serializedBytes = SerializationOutput(factory).serialize(testObject, context)
             val deserialize = DeserializationInput(factory).deserialize(serializedBytes, context)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
@@ -217,8 +217,15 @@ class DefaultLocalSerializerFactory(
 
     private fun makeDeclaredCollection(localTypeInformation: LocalTypeInformation.ACollection): AMQPSerializer<Any> {
         val resolved = CollectionSerializer.resolveDeclared(localTypeInformation, sandboxGroup)
+
+        val declaredType = object : ParameterizedType {
+            override fun getActualTypeArguments(): Array<Type> = arrayOf(resolved.elementType.observedType)
+            override fun getRawType(): Type = resolved.observedType.asClass()
+            override fun getOwnerType(): Type? = (resolved.typeIdentifier as? ParameterizedType)?.ownerType
+        }
+
         return makeAndCache(resolved) {
-            CollectionSerializer(resolved.typeIdentifier.getLocalType(sandboxGroup) as ParameterizedType, this)
+            CollectionSerializer(declaredType, this)
         }
     }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
@@ -219,7 +219,7 @@ class DefaultLocalSerializerFactory(
         val resolved = CollectionSerializer.resolveDeclared(localTypeInformation, sandboxGroup)
 
         val declaredType = object : ParameterizedType {
-            override fun getActualTypeArguments(): Array<Type> = arrayOf(resolved.elementType.observedType)
+            override fun getActualTypeArguments(): Array<Type> = arrayOf(resolved.elementType.observedType.asClass())
             override fun getRawType(): Type = resolved.observedType.asClass()
             override fun getOwnerType(): Type? = (resolved.typeIdentifier as? ParameterizedType)?.ownerType
         }
@@ -234,8 +234,8 @@ class DefaultLocalSerializerFactory(
 
         val declaredType = object : ParameterizedType {
             override fun getActualTypeArguments(): Array<Type> = arrayOf(
-                resolved.keyType.observedType,
-                resolved.valueType.observedType
+                resolved.keyType.observedType.asClass(),
+                resolved.valueType.observedType.asClass()
             )
             override fun getRawType(): Type = resolved.observedType.asClass()
             override fun getOwnerType(): Type? = (resolved.typeIdentifier as? ParameterizedType)?.ownerType

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
@@ -1,13 +1,13 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.internal.serialization.amqp.standard.ArraySerializer
-import net.corda.internal.serialization.amqp.standard.CollectionSerializer
 import net.corda.internal.serialization.amqp.standard.EnumSerializer
+import net.corda.internal.serialization.amqp.standard.CollectionSerializer
 import net.corda.internal.serialization.amqp.standard.MapSerializer
-import net.corda.internal.serialization.amqp.standard.ObjectSerializer
-import net.corda.internal.serialization.amqp.standard.PrimArraySerializer
-import net.corda.internal.serialization.amqp.standard.SingletonSerializer
 import net.corda.internal.serialization.amqp.standard.checkSupportedMapType
+import net.corda.internal.serialization.amqp.standard.PrimArraySerializer
+import net.corda.internal.serialization.amqp.standard.ArraySerializer
+import net.corda.internal.serialization.amqp.standard.SingletonSerializer
+import net.corda.internal.serialization.amqp.standard.ObjectSerializer
 import net.corda.internal.serialization.model.DefaultCacheProvider
 import net.corda.internal.serialization.model.FingerPrinter
 import net.corda.internal.serialization.model.LocalTypeInformation


### PR DESCRIPTION
When the AMQP serializer stores a Map, it stores information about the type parameters for key and value. In the past, it would take the class names of those type parameters and search for them within the OSGi bundles. This PR uses already loaded type information instead.

PR includes:
- Test added, reproducing the issue
- Fix applied