### PR TITLE
CORE-6958: Allow sandboxes to create instances of non-public classes.

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/ServiceDefinition.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/ServiceDefinition.kt
@@ -95,6 +95,9 @@ class ServiceDefinition(
             return serviceClass.constructors.firstOrNull { ctor ->
                 ctor.parameterCount == description.init && matchParameterTypes(ctor, parameterDTOs)
             }?.let { ctor ->
+                // Allow instantiation of classes which are non-public.
+                ctor.isAccessible = true
+
                 val properties = LinkedHashMap(description.properties ?: emptyMap()).let { props ->
                     props[COMPONENT_NAME] = description.name
                     unmodifiableMap(props)


### PR DESCRIPTION
OSGi requires that the component constructor is public,  but that doesn't guarantee anything about the class itself. Ensure that we can execute the constructor.