### PR TITLE
CORE-7246: do not report and trigger updateStatus on setting status to down if a crypto component is already down

### DIFF
--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractConfigurableComponent.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractConfigurableComponent.kt
@@ -236,7 +236,7 @@ abstract class AbstractConfigurableComponent<IMPL : AbstractConfigurableComponen
             logger.info("Setting the status of {} UP", myName)
             coordinator.updateStatus(LifecycleStatus.UP)
         } else {
-            if(coordinator.status != LifecycleStatus.ERROR) {
+            if (coordinator.status != LifecycleStatus.ERROR && coordinator.status != LifecycleStatus.DOWN) {
                 logger.info("Setting the status of {} DOWN", myName)
                 coordinator.updateStatus(LifecycleStatus.DOWN)
             }


### PR DESCRIPTION
There are scenarios where a crypto component is not ready to be run yet, so it's _impl reference is null, and will stay that way until it is ready. That might involve for instance waiting for its boot config to arrive. In that time, its status is DOWN, and  will remain DOWN as for instance upstreams go up one by one. In such cases, there's no point in logging at INFO level each time something like that happens which could have caused it to start but won't since there's not enough. There's also no point in calling updateStatus(DOWN) repeatedly, so let's stop doing that.