### PR TITLE
NOTICK: reduce some excess logging noise

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -416,9 +416,9 @@ subprojects {
 // helper to log artifacts we will or will not publish during a release process
 def logArtifacts(Project project) {
     project.publishing.publications.each { publication ->
-        logger.quiet("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
+        logger.info("\n${publication.groupId}:${publication.artifactId}:${publication.version} [${project.path}]")
         publication.artifacts.each { artifact ->
-            logger.quiet(" * ${artifact.file.name}")
+            logger.info(" * ${artifact.file.name}")
         }
     }
 }


### PR DESCRIPTION
- only output this with -i:  `info` level logging, 
- existing cofig `quiet` logs output on every execution which is not needed