### PR TITLE
CORE-7321: bump hsqldb version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -90,8 +90,7 @@ paxJdbcVersion=1.5.3
 assertjVersion=3.23.1
 dom4jOsgiVersion = 2.1.3_1
 hamcrestVersion=2.2
-# NOTE: 2.6.0 does not have OSGi exports
-hsqldbVersion=2.5.2
+hsqldbVersion=2.7.1
 jimfsVersion = 1.2
 junit5Version=5.9.1
 junitPlatformVersion=1.9.1


### PR DESCRIPTION
Regarding the code comment which was removed in this PR, 2.7.1 _does_ have OSGi exports in it's manifest, OSGi support was re added since 2.6.0 it seems