### PR TITLE
CORE-7149 Reset default log level to info

### DIFF
--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -7,7 +7,6 @@ bootstrap:
 
 logging:
   format: "text"
-  level: "info"
 
 kafka:
   bootstrapServers: prereqs-kafka:9092

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -32,8 +32,8 @@ resources:
 logging:
   # -- log format; "json" or "text"
   format: "json"
-  # -- log level; one of "all", "trace", "debug", "info", "warn" (the default), "error", "fatal", or "off"
-  level: "warn"
+  # -- log level; one of "all", "trace", "debug", "info" (the default), "warn", "error", "fatal", or "off"
+  level: "info"
 
 # Metrics configuration
 metrics:


### PR DESCRIPTION
Setting the default log level for the Helm chart back to info and, as a consequence, the override in the E2E tests is no longer required. CORE-6905 has already reduced the noise from third-party libraries at info level.