### PR TITLE
NOTICK Fix wrong module name in composite build

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -432,7 +432,7 @@ if (compositeBuild.toBoolean() && file(cordaApiLocation).exists()) {
             substitute module('net.corda:corda-ledger-utxo') using project(':ledger:ledger-utxo')
             substitute module('net.corda:corda-membership') using project(':membership')
             substitute module('net.corda:corda-serialization') using project(':serialization')
-            substitute module('net.corda:notary-plugins') using project(':notary-plugins')
+            substitute module('net.corda:corda-notary-plugin') using project(':ledger:notary-plugin')
         }
     }
 }


### PR DESCRIPTION
The wrong module name was added to settings.gradle, thus making the composite build to fail