### PR TITLE
CORE-7304 Service to determine default signature spec

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -583,6 +583,7 @@ class FlowTests {
 
     @Test
     fun `Crypto - Get compatible signature specs`() {
+        // Input for get compatible signature specs api is public key only
         val requestBody = RpcSmokeTestInput()
         requestBody.command = "crypto_get_compatible_signature_specs"
         requestBody.data = mapOf("memberX500" to X500_BOB)
@@ -600,8 +601,24 @@ class FlowTests {
                 "SHA256withECDSA",
                 "SHA384withECDSA",
                 "SHA512withECDSA"
-            ),
+            )
         )
+
+        // Input for get compatible signature specs api is public key and digest algorithm name
+        requestBody.data = mapOf(
+            "memberX500" to X500_BOB,
+            "digestName" to DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name
+        )
+
+        val requestId1 = startRpcFlow(bobHoldingId, requestBody)
+        val result1 = awaitRpcFlowFinished(bobHoldingId, requestId1)
+        val flowResult1 = result1.getRpcFlowResult()
+        assertThat(result1.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result1.flowResult).isNotNull
+        assertThat(result1.flowError).isNull()
+        assertThat(flowResult1.command).isEqualTo("crypto_get_compatible_signature_specs")
+        val flowOutputs1 = requireNotNull(flowResult1.result).split("; ")
+        assertThat(flowOutputs1).containsAll(listOf("SHA256withECDSA"))
     }
 
     @Test

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -582,6 +582,29 @@ class FlowTests {
     }
 
     @Test
+    fun `Crypto - Get compatible signature specs`() {
+        val requestBody = RpcSmokeTestInput()
+        requestBody.command = "crypto_get_compatible_signature_specs"
+        requestBody.data = mapOf("memberX500" to X500_BOB)
+
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
+        val flowResult = result.getRpcFlowResult()
+        assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result.flowResult).isNotNull
+        assertThat(result.flowError).isNull()
+        assertThat(flowResult.command).isEqualTo("crypto_get_compatible_signature_specs")
+        val flowOutputs = requireNotNull(flowResult.result).split("; ")
+        assertThat(flowOutputs).containsAll(
+            listOf(
+                "SHA256withECDSA",
+                "SHA384withECDSA",
+                "SHA512withECDSA"
+            ),
+        )
+    }
+
+    @Test
     fun `Context is propagated to initiated and sub flows`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "context_propagation"

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -568,7 +568,7 @@ class FlowTests {
         val requestBody = RpcSmokeTestInput()
         requestBody.command = "crypto_get_default_signature_spec"
         requestBody.data = mapOf(
-            "memberX500" to X500_BOB,
+            "memberX500" to bobX500,
             "digestName" to DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name
         )
 
@@ -583,7 +583,7 @@ class FlowTests {
 
         // Call get default signature spec api with public key only
         requestBody.data = mapOf(
-            "memberX500" to X500_BOB
+            "memberX500" to bobX500
         )
         val requestId1 = startRpcFlow(bobHoldingId, requestBody)
         val result1 = awaitRpcFlowFinished(bobHoldingId, requestId1)
@@ -600,7 +600,7 @@ class FlowTests {
         // Call get compatible signature specs api with public key only
         val requestBody = RpcSmokeTestInput()
         requestBody.command = "crypto_get_compatible_signature_specs"
-        requestBody.data = mapOf("memberX500" to X500_BOB)
+        requestBody.data = mapOf("memberX500" to bobX500)
 
         val requestId = startRpcFlow(bobHoldingId, requestBody)
         val result = awaitRpcFlowFinished(bobHoldingId, requestId)
@@ -620,7 +620,7 @@ class FlowTests {
 
         // Call get compatible signature specs api with public key and digest algorithm name
         requestBody.data = mapOf(
-            "memberX500" to X500_BOB,
+            "memberX500" to bobX500,
             "digestName" to DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name
         )
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.TestMethodOrder
 import kotlin.text.Typography.quote
+import net.corda.v5.crypto.DigestAlgorithmName
 
 @Suppress("Unused", "FunctionName")
 @Order(20)
@@ -559,6 +560,25 @@ class FlowTests {
         assertThat(result.flowError).isNull()
         assertThat(flowResult.command).isEqualTo("crypto_verify_invalid_signature")
         assertThat(flowResult.result).isEqualTo(true.toString())
+    }
+
+    @Test
+    fun `Crypto - Get default signature spec`() {
+        val requestBody = RpcSmokeTestInput()
+        requestBody.command = "crypto_get_default_signature_spec"
+        requestBody.data = mapOf(
+            "memberX500" to X500_BOB,
+            "digestName" to DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name
+        )
+
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
+        val flowResult = result.getRpcFlowResult()
+        assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result.flowResult).isNotNull
+        assertThat(result.flowError).isNull()
+        assertThat(flowResult.command).isEqualTo("crypto_get_default_signature_spec")
+        assertThat(flowResult.result).isEqualTo("SHA256withECDSA")
     }
 
     @Test

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -564,6 +564,7 @@ class FlowTests {
 
     @Test
     fun `Crypto - Get default signature spec`() {
+        // Call get default signature spec api with public key and digest algorithm name
         val requestBody = RpcSmokeTestInput()
         requestBody.command = "crypto_get_default_signature_spec"
         requestBody.data = mapOf(
@@ -579,11 +580,24 @@ class FlowTests {
         assertThat(result.flowError).isNull()
         assertThat(flowResult.command).isEqualTo("crypto_get_default_signature_spec")
         assertThat(flowResult.result).isEqualTo("SHA256withECDSA")
+
+        // Call get default signature spec api with public key only
+        requestBody.data = mapOf(
+            "memberX500" to X500_BOB
+        )
+        val requestId1 = startRpcFlow(bobHoldingId, requestBody)
+        val result1 = awaitRpcFlowFinished(bobHoldingId, requestId1)
+        val flowResult1 = result1.getRpcFlowResult()
+        assertThat(result1.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result1.flowResult).isNotNull
+        assertThat(result1.flowError).isNull()
+        assertThat(flowResult1.command).isEqualTo("crypto_get_default_signature_spec")
+        assertThat(flowResult1.result).isEqualTo("SHA256withECDSA")
     }
 
     @Test
     fun `Crypto - Get compatible signature specs`() {
-        // Input for get compatible signature specs api is public key only
+        // Call get compatible signature specs api with public key only
         val requestBody = RpcSmokeTestInput()
         requestBody.command = "crypto_get_compatible_signature_specs"
         requestBody.data = mapOf("memberX500" to X500_BOB)
@@ -604,7 +618,7 @@ class FlowTests {
             )
         )
 
-        // Input for get compatible signature specs api is public key and digest algorithm name
+        // Call get compatible signature specs api with public key and digest algorithm name
         requestBody.data = mapOf(
             "memberX500" to X500_BOB,
             "digestName" to DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
@@ -1,6 +1,9 @@
 package net.corda.flow.application.crypto
 
 import java.security.PublicKey
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByPersistence
+import net.corda.sandbox.type.UsedByVerification
 import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
@@ -13,13 +16,13 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
-    service = [SignatureSpecService::class, SingletonSerializeAsToken::class],
+    service = [SignatureSpecService::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
     scope = PROTOTYPE
 )
 class SignatureSpecServiceImpl @Activate constructor(
     @Reference(service = CipherSchemeMetadata::class)
     private val schemeMetadata: CipherSchemeMetadata
-) : SignatureSpecService, SingletonSerializeAsToken {
+) : SignatureSpecService, UsedByFlow, UsedByPersistence, UsedByVerification, SingletonSerializeAsToken {
 
     @Suspendable
     override fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec? =

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
@@ -26,7 +26,7 @@ class SignatureSpecServiceImpl @Activate constructor(
 
     @Suspendable
     override fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec? =
-        schemeMetadata.inferSignatureSpec(publicKey)
+        schemeMetadata.defaultSignatureSpec(publicKey)
 
     @Suspendable
     override fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): SignatureSpec? =

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
@@ -27,8 +27,8 @@ class SignatureSpecServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName): SignatureSpec? =
-        schemeMetadata.inferSignatureSpec(publicKey, digestAlgorithm)
+    override fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): SignatureSpec? =
+        schemeMetadata.inferSignatureSpec(publicKey, digestAlgorithmName)
 
     @Suspendable
     override fun compatibleSignatureSpecs(publicKey: PublicKey): List<SignatureSpec> {
@@ -37,7 +37,8 @@ class SignatureSpecServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun compatibleSignatureSpecs(publicKey: PublicKey, hash: DigestAlgorithmName): List<SignatureSpec> {
-        TODO()
+    override fun compatibleSignatureSpecs(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): List<SignatureSpec> {
+        val keyScheme = schemeMetadata.findKeyScheme(publicKey)
+        return schemeMetadata.supportedSignatureSpec(keyScheme, digestAlgorithmName)
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
@@ -1,0 +1,42 @@
+package net.corda.flow.application.crypto
+
+import java.security.PublicKey
+import net.corda.v5.application.crypto.SignatureSpecService
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.cipher.suite.CipherSchemeMetadata
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.serialization.SingletonSerializeAsToken
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+
+@Component(
+    service = [SignatureSpecService::class, SingletonSerializeAsToken::class],
+    scope = PROTOTYPE
+)
+class SignatureSpecServiceImpl @Activate constructor(
+    @Reference(service = CipherSchemeMetadata::class)
+    private val schemeMetadata: CipherSchemeMetadata
+) : SignatureSpecService, SingletonSerializeAsToken {
+
+    @Suspendable
+    override fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec {
+        TODO()
+    }
+
+    @Suspendable
+    override fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName): SignatureSpec? =
+        schemeMetadata.inferSignatureSpec(publicKey, digestAlgorithm)
+
+    @Suspendable
+    override fun compatibleSignatureSpecs(publicKey: PublicKey): List<SignatureSpec> {
+        TODO()
+    }
+
+    @Suspendable
+    override fun compatibleSignatureSpecs(publicKey: PublicKey, hash: DigestAlgorithmName): List<SignatureSpec> {
+        TODO()
+    }
+}

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
@@ -22,9 +22,8 @@ class SignatureSpecServiceImpl @Activate constructor(
 ) : SignatureSpecService, SingletonSerializeAsToken {
 
     @Suspendable
-    override fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec {
-        TODO()
-    }
+    override fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec? =
+        schemeMetadata.inferSignatureSpec(publicKey)
 
     @Suspendable
     override fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): SignatureSpec? =

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SignatureSpecServiceImpl.kt
@@ -32,7 +32,8 @@ class SignatureSpecServiceImpl @Activate constructor(
 
     @Suspendable
     override fun compatibleSignatureSpecs(publicKey: PublicKey): List<SignatureSpec> {
-        TODO()
+        val keyScheme = schemeMetadata.findKeyScheme(publicKey)
+        return schemeMetadata.supportedSignatureSpec(keyScheme)
     }
 
     @Suspendable

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.433-alpha-1667834528434
+cordaApiVersion=5.0.0.433-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.432-beta+
+cordaApiVersion=5.0.0.433-alpha-1667834528434
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataImpl.kt
@@ -98,9 +98,8 @@ class CipherSchemeMetadataImpl : CipherSchemeMetadata, SingletonSerializeAsToken
 
     override val secureRandom: SecureRandom get() = metadataProvider.secureRandom
 
-    override fun inferSignatureSpec(publicKey: PublicKey): SignatureSpec? {
-        TODO("Not yet implemented")
-    }
+    override fun inferSignatureSpec(publicKey: PublicKey): SignatureSpec? =
+        metadataProvider.keySchemeInfoMap[findKeyScheme(publicKey)]?.defaultSignatureSpec
 
     override fun inferSignatureSpec(publicKey: PublicKey, digest: DigestAlgorithmName): SignatureSpec? =
         metadataProvider.keySchemeInfoMap[findKeyScheme(publicKey)]?.getSignatureSpec(digest)
@@ -109,7 +108,7 @@ class CipherSchemeMetadataImpl : CipherSchemeMetadata, SingletonSerializeAsToken
         metadataProvider.keySchemeInfoMap[scheme]?.digestToSignatureSpecMap?.values?.toList() ?: emptyList()
 
     // TODO This can now only return one `SignatureSpec` for the specified key and digest due to underlying infrastructure/ apis.
-    //  This infrastructure should be modified to take into account more crypto parameters.
+    //  This infrastructure should be modified to take into account more crypto parameters (like RSA padding).
     //  `supportedSignatureSpec(scheme: KeyScheme, digest: DigestAlgorithmName)` should be able to return > 1 signature specs.
     override fun supportedSignatureSpec(scheme: KeyScheme, digest: DigestAlgorithmName): List<SignatureSpec> =
         metadataProvider.keySchemeInfoMap[scheme]?.getSignatureSpec(digest)?.let {

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataImpl.kt
@@ -98,11 +98,23 @@ class CipherSchemeMetadataImpl : CipherSchemeMetadata, SingletonSerializeAsToken
 
     override val secureRandom: SecureRandom get() = metadataProvider.secureRandom
 
+    override fun inferSignatureSpec(publicKey: PublicKey): SignatureSpec? {
+        TODO("Not yet implemented")
+    }
+
     override fun inferSignatureSpec(publicKey: PublicKey, digest: DigestAlgorithmName): SignatureSpec? =
         metadataProvider.keySchemeInfoMap[findKeyScheme(publicKey)]?.getSignatureSpec(digest)
 
     override fun supportedSignatureSpec(scheme: KeyScheme): List<SignatureSpec> =
         metadataProvider.keySchemeInfoMap[scheme]?.digestToSignatureSpecMap?.values?.toList() ?: emptyList()
+
+    // TODO This can now only return one `SignatureSpec` for the specified key and digest due to underlying infrastructure/ apis.
+    //  This infrastructure should be modified to take into account more crypto parameters.
+    //  `supportedSignatureSpec(scheme: KeyScheme, digest: DigestAlgorithmName)` should be able to return > 1 signature specs.
+    override fun supportedSignatureSpec(scheme: KeyScheme, digest: DigestAlgorithmName): List<SignatureSpec> =
+        metadataProvider.keySchemeInfoMap[scheme]?.getSignatureSpec(digest)?.let {
+            listOf(it)
+        } ?: emptyList()
 
     override fun inferableDigestNames(scheme: KeyScheme): List<DigestAlgorithmName> =
         metadataProvider.keySchemeInfoMap[scheme]?.digestToSignatureSpecMap?.keys?.toList() ?: emptyList()

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataImpl.kt
@@ -98,7 +98,7 @@ class CipherSchemeMetadataImpl : CipherSchemeMetadata, SingletonSerializeAsToken
 
     override val secureRandom: SecureRandom get() = metadataProvider.secureRandom
 
-    override fun inferSignatureSpec(publicKey: PublicKey): SignatureSpec? =
+    override fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec? =
         metadataProvider.keySchemeInfoMap[findKeyScheme(publicKey)]?.defaultSignatureSpec
 
     override fun inferSignatureSpec(publicKey: PublicKey, digest: DigestAlgorithmName): SignatureSpec? =

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/KeySchemeInfo.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/KeySchemeInfo.kt
@@ -22,11 +22,16 @@ import java.security.Provider
  * Scroll down to "Signature Algorithms" / "Schemes" (or search for "SHA256withECDDSA")
  */
 abstract class KeySchemeInfo private constructor(
-    val scheme: KeyScheme, val digestToSignatureSpecMap: Map<DigestAlgorithmName, SignatureSpec>
+    val scheme: KeyScheme,
+    val digestToSignatureSpecMap: Map<DigestAlgorithmName, SignatureSpec>,
+    val defaultSignatureSpec: SignatureSpec?
 ) {
     constructor(
-        provider: Provider, template: KeySchemeTemplate, signatureNameMap: Map<DigestAlgorithmName, SignatureSpec>
-    ) : this(template.makeScheme(provider.name), signatureNameMap)
+        provider: Provider,
+        template: KeySchemeTemplate,
+        signatureNameMap: Map<DigestAlgorithmName, SignatureSpec>,
+        defaultSignatureSpec: SignatureSpec?
+    ) : this(template.makeScheme(provider.name), signatureNameMap, defaultSignatureSpec)
 
     fun getSignatureSpec(digest: DigestAlgorithmName): SignatureSpec? = digestToSignatureSpecMap[digest]
 }
@@ -38,7 +43,8 @@ class RSAKeySchemeInfo(
         DigestAlgorithmName.SHA2_256 to SignatureSpec.RSA_SHA256,
         DigestAlgorithmName.SHA2_384 to SignatureSpec.RSA_SHA384,
         DigestAlgorithmName.SHA2_512 to SignatureSpec.RSA_SHA512
-    )
+    ),
+    SignatureSpec.RSA_SHA256
 )
 
 abstract class ECDSAKeySchemeInfo(
@@ -48,9 +54,11 @@ abstract class ECDSAKeySchemeInfo(
         DigestAlgorithmName.SHA2_256 to SignatureSpec.ECDSA_SHA256,
         DigestAlgorithmName.SHA2_384 to SignatureSpec.ECDSA_SHA384,
         DigestAlgorithmName.SHA2_512 to SignatureSpec.ECDSA_SHA512
-    )
+    ),
+    SignatureSpec.ECDSA_SHA256
 )
 
+// TODO How did this
 class ECDSAR1KeySchemeInfo(
     provider: Provider
 ) : ECDSAKeySchemeInfo(provider, ECDSA_SECP256R1_TEMPLATE)
@@ -64,13 +72,14 @@ class EDDSAKeySchemeInfo(
 ) : KeySchemeInfo(
     provider, EDDSA_ED25519_TEMPLATE, mapOf(
         DigestAlgorithmName("NONE") to SignatureSpec.EDDSA_ED25519
-    )
+    ),
+    SignatureSpec.EDDSA_ED25519
 )
 
 class X25519KeySchemeInfo(
     provider: Provider
 ) : KeySchemeInfo(
-    provider, X25519_TEMPLATE, emptyMap())
+    provider, X25519_TEMPLATE, emptyMap(), null)
 
 class SM2KeySchemeInfo(
     provider: Provider
@@ -78,7 +87,8 @@ class SM2KeySchemeInfo(
     provider, SM2_TEMPLATE, mapOf(
         DigestAlgorithmName("SM3") to SignatureSpec.SM2_SM3,
         DigestAlgorithmName.SHA2_256 to SignatureSpec.SM2_SHA256
-    )
+    ),
+    SignatureSpec.SM2_SM3
 )
 
 class GOST3410GOST3411KeySchemeInfo(
@@ -86,7 +96,8 @@ class GOST3410GOST3411KeySchemeInfo(
 ) : KeySchemeInfo(
     provider, GOST3410_GOST3411_TEMPLATE, mapOf(
         DigestAlgorithmName("GOST3411") to SignatureSpec.GOST3410_GOST3411
-    )
+    ),
+    SignatureSpec.GOST3410_GOST3411
 )
 
 class SPHINCS256KeySchemeInfo(
@@ -94,5 +105,6 @@ class SPHINCS256KeySchemeInfo(
 ) : KeySchemeInfo(
     provider, SPHINCS256_TEMPLATE, mapOf(
         DigestAlgorithmName.SHA2_512 to SignatureSpec.SPHINCS256_SHA512
-    )
+    ),
+    SignatureSpec.SPHINCS256_SHA512
 )

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -63,6 +63,7 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         "crypto_sign_and_verify" to this::signAndVerify,
         "crypto_verify_invalid_signature" to this::verifyInvalidSignature,
         "crypto_get_default_signature_spec" to this::getDefaultSignatureSpec,
+        "crypto_get_compatible_signature_specs" to this::getCompatibleSignatureSpecs,
         "context_propagation" to { contextPropagation() },
         "serialization" to this::serialization,
         "lookup_member_by_x500_name" to this::lookupMember,
@@ -377,6 +378,19 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         val digestName = DigestAlgorithmName(input.getValue("digestName"))
         val signatureSpec = signatureSpecService.defaultSignatureSpec(publicKey, digestName)
         return signatureSpec?.signatureName ?: "null"
+    }
+
+    @Suspendable
+    private fun getCompatibleSignatureSpecs(input: RpcSmokeTestInput): String {
+        val x500Name = input.getValue("memberX500")
+        val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
+        checkNotNull(member) { "Member $x500Name could not be looked up" }
+        val publicKey = member.ledgerKeys[0]
+        val signatureSpecs = signatureSpecService.compatibleSignatureSpecs(publicKey)
+        val outputs = signatureSpecs.map {
+            it.signatureName
+        }
+        return outputs.joinToString("; ")
     }
 
     @Suspendable

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -380,7 +380,7 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         } catch (e: IllegalStateException) {
             null
         }
-        log.info("Crypto - Getting default signature spec called with public key: $publicKey and digestName: $digestName ")
+        log.info("Crypto - Calling default signature spec with public key: $publicKey and digestName: $digestName ")
 
         val defaultSignatureSpec = if (digestName != null) {
             signatureSpecService.defaultSignatureSpec(publicKey, DigestAlgorithmName(digestName))
@@ -401,7 +401,7 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         } catch (e: IllegalStateException) {
             null
         }
-        log.info("Crypto - Getting compatible signature specs called with public key: $publicKey and digestName: $digestName ")
+        log.info("Crypto - Calling compatible signature specs with public key: $publicKey and digestName: $digestName ")
 
         val compatibleSignatureSpecs = if (digestName != null) {
             signatureSpecService.compatibleSignatureSpecs(publicKey, DigestAlgorithmName(digestName))

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -386,7 +386,20 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
         checkNotNull(member) { "Member $x500Name could not be looked up" }
         val publicKey = member.ledgerKeys[0]
-        val signatureSpecs = signatureSpecService.compatibleSignatureSpecs(publicKey)
+        val digestName = try {
+            input.getValue("digestName")
+        } catch (e: IllegalStateException) {
+            null
+        }
+        log.info(
+            "Crypto - Getting compatible signatures called with public key: $publicKey and digestName: $digestName "
+        )
+
+        val signatureSpecs = if (digestName != null) {
+            signatureSpecService.compatibleSignatureSpecs(publicKey, DigestAlgorithmName(digestName))
+        } else {
+            signatureSpecService.compatibleSignatureSpecs(publicKey)
+        }
         val outputs = signatureSpecs.map {
             it.signatureName
         }


### PR DESCRIPTION
- implementation of  `SignatureSpecService` as a `PROTOTYPE` service (sandbox singleton).
- adds default signature spec property in `KeySchemeInfo` (to hold default signature spec per key scheme) to support `defaultSignatureSpec(publicKey: PublicKey): SignatureSpec?` API.

complement api PR: [#668](https://github.com/corda/corda-api/pull/668)