### PR TITLE
CORE-7268 Handle empty component groups

### DIFF
--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
@@ -97,11 +97,7 @@ class FilteredTransactionImpl(
                     componentGroupAuditProofProvider
                 }
                 MerkleProofType.SIZE -> {
-                    if (filteredComponentGroup.merkleProof.hasSingleEmptyLeaf()) { // todo???
-                        componentGroupAuditProofProvider
-                    } else {
-                        componentGroupSizeProofProvider
-                    }
+                    componentGroupSizeProofProvider
                 }
             }
             validate(filteredComponentGroup.merkleProof.verify(componentLeafHash, providerToVerifyWith)) {
@@ -155,10 +151,6 @@ class FilteredTransactionImpl(
             merkleTreeHashDigestProviderName = HASH_DIGEST_PROVIDER_NONCE_SIZE_ONLY_VERIFY_NAME,
             componentGroupDigestAlgorithmName
         )
-    }
-
-    private fun MerkleProof.hasSingleEmptyLeaf(): Boolean {
-        return treeSize == 1 && leaves.single().leafData.isEmpty()
     }
 
     private inline fun validate(condition: Boolean, message: () -> String) {

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.COMPONENT_MERKLE_TREE_DIGEST_ALG
 import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_ALGORITHM_NAME_KEY
 import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_OPTIONS_LEAF_PREFIX_B64_KEY
 import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_OPTIONS_NODE_PREFIX_B64_KEY
+import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_PROVIDER_NAME_KEY
 import net.corda.ledger.common.data.transaction.TransactionMetadata
 import net.corda.ledger.common.flow.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.flow.transaction.filtered.FilteredTransaction
@@ -127,7 +128,7 @@ class FilteredTransactionImpl(
     private fun createTopLevelAuditProofProvider(): MerkleTreeHashDigestProvider {
         val digestSettings = metadata.getDigestSettings()
         return merkleTreeProvider.createHashDigestProvider(
-            merkleTreeHashDigestProviderName = HASH_DIGEST_PROVIDER_TWEAKABLE_NAME, // TODO should come from meta eventually
+            merkleTreeHashDigestProviderName = digestSettings[ROOT_MERKLE_TREE_DIGEST_PROVIDER_NAME_KEY] as String,
             DigestAlgorithmName(digestSettings[ROOT_MERKLE_TREE_DIGEST_ALGORITHM_NAME_KEY] as String),
             options = mapOf(
                 HASH_DIGEST_PROVIDER_LEAF_PREFIX_OPTION to Base64.getDecoder()

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
@@ -121,7 +121,7 @@ class FilteredTransactionImpl(
             ?.merkleProof
             ?.leaves
             ?.filterIndexed{index, _ -> index > 0 }
-            ?.map { it.index to it.leafData }
+            ?.map { it.index - 1 to it.leafData }
     }
 
     private fun createTopLevelAuditProofProvider(): MerkleTreeHashDigestProvider {

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
@@ -20,17 +20,8 @@ import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_LEAF_PREFIX_OPTION
 import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_NODE_PREFIX_OPTION
 import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_NONCE_SIZE_ONLY_VERIFY_NAME
 import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_NONCE_VERIFY_NAME
-import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_TWEAKABLE_NAME
 import net.corda.v5.crypto.merkle.MerkleProof
 import java.util.Base64
-import kotlin.collections.filter
-import kotlin.collections.isEmpty
-import kotlin.collections.isNotEmpty
-import kotlin.collections.map
-import kotlin.collections.single
-import kotlin.collections.toSet
-import kotlin.text.decodeToString
-import kotlin.to
 
 class FilteredTransactionImpl(
     override val id: SecureHash,

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImpl.kt
@@ -120,7 +120,7 @@ class FilteredTransactionImpl(
         return filteredComponentGroups[componentGroupIndex]
             ?.merkleProof
             ?.leaves
-            ?.filterIndexed{index, _ -> index > 0 }
+            ?.filter { it.index > 0 }
             ?.map { it.index - 1 to it.leafData }
     }
 

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImpl.kt
@@ -92,25 +92,17 @@ class FilteredTransactionFactoryImpl @Activate constructor(
                     }
 
                 wireTransaction.componentMerkleTrees[componentGroupIndex]!!.let { merkleTree ->
-                    if (filteredComponents.isEmpty()) {
-                        merkleTree.createAuditProof(listOf(0))
-                    } else {
-                        merkleTree.createAuditProof(filteredComponents.map { (index, _) -> index })
-                    }
+                    merkleTree.createAuditProof(listOf(0) + filteredComponents.map { (index, _) -> index + 1 })
                 }
             }
             is ComponentGroupFilterParameters.SizeProof -> {
 
                 wireTransaction.componentMerkleTrees[componentGroupIndex]!!.let { merkleTree ->
-                    if (wireTransaction.getComponentGroupList(componentGroupIndex).isEmpty()) {
-                        merkleTree.createAuditProof(listOf(0))
-                    } else {
-                        val componentGroupMerkleTreeSizeProofProvider =
-                            checkNotNull(componentGroupMerkleTreeDigestProvider as? MerkleTreeHashDigestProviderWithSizeProofSupport) {
-                                "Expected to have digest provider with size proof support"
-                            }
-                        componentGroupMerkleTreeSizeProofProvider.getSizeProof(merkleTree.leaves)
-                    }
+                    val componentGroupMerkleTreeSizeProofProvider =
+                        checkNotNull(componentGroupMerkleTreeDigestProvider as? MerkleTreeHashDigestProviderWithSizeProofSupport) {
+                            "Expected to have digest provider with size proof support"
+                        }
+                    componentGroupMerkleTreeSizeProofProvider.getSizeProof(merkleTree.leaves)
                 }
             }
         }

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
@@ -9,6 +9,7 @@ import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_ALGORITH
 import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_OPTIONS_LEAF_PREFIX_B64_KEY
 import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_OPTIONS_NODE_PREFIX_B64_KEY
 import net.corda.ledger.common.data.transaction.TransactionMetadata
+import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
 import net.corda.ledger.common.flow.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.flow.transaction.filtered.FilteredTransaction
 import net.corda.ledger.common.flow.transaction.filtered.FilteredTransactionVerificationException
@@ -43,14 +44,7 @@ class FilteredTransactionImplTest {
         const val metadataJson = "{}"
         val metadata = TransactionMetadata(
             linkedMapOf(
-                TransactionMetadata.DIGEST_SETTINGS_KEY to linkedMapOf<String, Any>(
-                    ROOT_MERKLE_TREE_DIGEST_ALGORITHM_NAME_KEY to "algorithm",
-                    ROOT_MERKLE_TREE_DIGEST_OPTIONS_LEAF_PREFIX_B64_KEY to Base64.getEncoder()
-                        .encodeToString("leaf prefix".toByteArray(Charsets.UTF_8)),
-                    ROOT_MERKLE_TREE_DIGEST_OPTIONS_NODE_PREFIX_B64_KEY to Base64.getEncoder()
-                        .encodeToString("node prefix".toByteArray(Charsets.UTF_8)),
-                    COMPONENT_MERKLE_TREE_DIGEST_ALGORITHM_NAME_KEY to digestAlgorithmName
-                ),
+                TransactionMetadata.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues
             )
         )
     }

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
@@ -595,21 +595,22 @@ class FilteredTransactionImplTest {
         )
         val metadataBytes = metadataJson.encodeToByteArray()
         val indexedMerkleLeafs = listOf(
-            indexedMerkleLeaf(0, byteArrayOf(1)),
-            indexedMerkleLeaf(1, byteArrayOf(1, 2)),
-            indexedMerkleLeaf(2, byteArrayOf(3))
+            indexedMerkleLeaf(0),
+            indexedMerkleLeaf(1, byteArrayOf(1)),
+            indexedMerkleLeaf(2, byteArrayOf(1, 2)),
+            indexedMerkleLeaf(3, byteArrayOf(3))
         )
-        whenever(filteredComponentGroup0Proof.leaves).thenReturn(listOf(indexedMerkleLeaf(0, metadataBytes)))
+        whenever(filteredComponentGroup0Proof.leaves).thenReturn(listOf(indexedMerkleLeaf(0), indexedMerkleLeaf(1, metadataBytes)))
         whenever(filteredComponentGroup1Proof.leaves).thenReturn(indexedMerkleLeafs)
 
         assertArrayEquals(metadataBytes, filteredTransaction.getComponentGroupContent(0)!!.single().second)
         filteredTransaction.getComponentGroupContent(1)!!.let {
-            assertEquals(indexedMerkleLeafs[0].index, it[0].first)
-            assertEquals(indexedMerkleLeafs[1].index, it[1].first)
-            assertEquals(indexedMerkleLeafs[2].index, it[2].first)
-            assertArrayEquals(indexedMerkleLeafs[0].leafData, it[0].second)
-            assertArrayEquals(indexedMerkleLeafs[1].leafData, it[1].second)
-            assertArrayEquals(indexedMerkleLeafs[2].leafData, it[2].second)
+            assertEquals(indexedMerkleLeafs[1].index - 1, it[0].first)
+            assertEquals(indexedMerkleLeafs[2].index - 1, it[1].first)
+            assertEquals(indexedMerkleLeafs[3].index - 1, it[2].first)
+            assertArrayEquals(indexedMerkleLeafs[1].leafData, it[0].second)
+            assertArrayEquals(indexedMerkleLeafs[2].leafData, it[1].second)
+            assertArrayEquals(indexedMerkleLeafs[3].leafData, it[2].second)
         }
     }
 

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
@@ -4,10 +4,6 @@ import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.cipher.suite.impl.DigestServiceImpl
 import net.corda.crypto.merkle.impl.MerkleTreeProviderImpl
 import net.corda.crypto.merkle.impl.NonceHashDigestProvider
-import net.corda.ledger.common.data.transaction.COMPONENT_MERKLE_TREE_DIGEST_ALGORITHM_NAME_KEY
-import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_ALGORITHM_NAME_KEY
-import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_OPTIONS_LEAF_PREFIX_B64_KEY
-import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_OPTIONS_NODE_PREFIX_B64_KEY
 import net.corda.ledger.common.data.transaction.TransactionMetadata
 import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
 import net.corda.ledger.common.flow.transaction.filtered.FilteredComponentGroup
@@ -35,7 +31,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.Base64
 
 class FilteredTransactionImplTest {
 

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/FilteredTransactionImplTest.kt
@@ -309,7 +309,6 @@ class FilteredTransactionImplTest {
         assertDoesNotThrow { filteredTransaction.verify() }
         verify(filteredComponentGroup0Proof).verify(any(), any())
         verify(filteredComponentGroup1Proof).verify(any(), any())
-        verify(filteredComponentGroup1Proof).treeSize
         assertInstanceOf(NonceHashDigestProvider.Verify::class.java, merkleTreeHashDigestCaptor.firstValue)
         assertInstanceOf(NonceHashDigestProvider.SizeOnlyVerify::class.java, merkleTreeHashDigestCaptor.secondValue)
     }
@@ -339,7 +338,6 @@ class FilteredTransactionImplTest {
         assertDoesNotThrow { filteredTransaction.verify() }
         verify(filteredComponentGroup0Proof).verify(any(), any())
         verify(filteredComponentGroup1Proof).verify(any(), any())
-        verify(filteredComponentGroup1Proof).treeSize
         assertInstanceOf(NonceHashDigestProvider.Verify::class.java, merkleTreeHashDigestCaptor.firstValue)
         assertInstanceOf(NonceHashDigestProvider.SizeOnlyVerify::class.java, merkleTreeHashDigestCaptor.secondValue)
     }
@@ -369,9 +367,8 @@ class FilteredTransactionImplTest {
         assertDoesNotThrow { filteredTransaction.verify() }
         verify(filteredComponentGroup0Proof).verify(any(), any())
         verify(filteredComponentGroup1Proof).verify(any(), any())
-        verify(filteredComponentGroup1Proof).treeSize
         assertInstanceOf(NonceHashDigestProvider.Verify::class.java, merkleTreeHashDigestCaptor.firstValue)
-        assertInstanceOf(NonceHashDigestProvider.Verify::class.java, merkleTreeHashDigestCaptor.secondValue)
+        assertInstanceOf(NonceHashDigestProvider.SizeOnlyVerify::class.java, merkleTreeHashDigestCaptor.secondValue)
     }
 
     @Test
@@ -431,7 +428,6 @@ class FilteredTransactionImplTest {
             )
         verify(filteredComponentGroup0Proof).verify(any(), any())
         verify(filteredComponentGroup1Proof).verify(any(), any())
-        verify(filteredComponentGroup1Proof).treeSize
     }
 
     @Test
@@ -464,7 +460,6 @@ class FilteredTransactionImplTest {
             )
         verify(filteredComponentGroup0Proof).verify(any(), any())
         verify(filteredComponentGroup1Proof).verify(any(), any())
-        verify(filteredComponentGroup1Proof).treeSize
     }
 
     @Test
@@ -497,7 +492,6 @@ class FilteredTransactionImplTest {
             )
         verify(filteredComponentGroup0Proof).verify(any(), any())
         verify(filteredComponentGroup1Proof).verify(any(), any())
-        verify(filteredComponentGroup1Proof).treeSize
     }
 
     @Test

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImplTest.kt
@@ -139,7 +139,7 @@ class FilteredTransactionFactoryImplTest {
         assertThat(filteredTransaction.filteredComponentGroups[0]!!.componentGroupIndex).isEqualTo(0)
         assertThat(filteredTransaction.filteredComponentGroups[1]!!.componentGroupIndex).isEqualTo(1)
         assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProofType).isEqualTo(MerkleProofType.AUDIT)
-        assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProof.leaves).hasSize(2)
+        assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProof.leaves).hasSize(3)
     }
 
     @Test
@@ -252,7 +252,7 @@ class FilteredTransactionFactoryImplTest {
         assertThat(filteredTransaction.filteredComponentGroups[0]!!.componentGroupIndex).isEqualTo(0)
         assertThat(filteredTransaction.filteredComponentGroups[1]!!.componentGroupIndex).isEqualTo(1)
         assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProofType).isEqualTo(MerkleProofType.SIZE)
-        assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProof.leaves).hasSize(3)
+        assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProof.leaves).hasSize(4)
     }
 
     private fun wireTransaction(componentGroupLists: List<List<ByteArray>>): WireTransaction {

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImplTest.kt
@@ -16,7 +16,6 @@ import net.corda.v5.base.annotations.CordaSerializable
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -196,8 +195,7 @@ class FilteredTransactionFactoryImplTest {
     }
 
     @Test
-    @Disabled("Empty component groups are not currently allowed. Enable this test when component groups can be empty.")
-    fun `creates an audit proof containing a default value instead of a size proof when the component group contains no components`() {
+    fun `creates a size proof normally when the component group contains no components`() {
         whenever(serializationService.deserialize(COMPONENT_1, Any::class.java)).thenReturn(MyClassA())
         whenever(serializationService.deserialize(COMPONENT_2, Any::class.java)).thenReturn(MyClassB())
         whenever(serializationService.deserialize(COMPONENT_3, Any::class.java)).thenReturn(MyClassC())
@@ -221,12 +219,7 @@ class FilteredTransactionFactoryImplTest {
         assertThat(filteredTransaction.filteredComponentGroups).hasSize(2)
         assertThat(filteredTransaction.filteredComponentGroups[0]!!.componentGroupIndex).isEqualTo(0)
         assertThat(filteredTransaction.filteredComponentGroups[1]!!.componentGroupIndex).isEqualTo(1)
-        assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProofType).isEqualTo(MerkleProofType.AUDIT)
-        assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProof).isEqualTo(
-            wireTransaction.componentMerkleTrees[1]!!.createAuditProof(
-                listOf(0)
-            )
-        )
+        assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProofType).isEqualTo(MerkleProofType.SIZE)
         assertThat(filteredTransaction.filteredComponentGroups[1]!!.merkleProof.leaves).hasSize(1)
     }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -29,6 +29,17 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
         assertIs<SecureHash>(tx.id)
     }
 
+    @Test
+    fun `can build a simple Transaction with empty component groups`() {
+        val tx = utxoTransactionBuilder
+            .setNotary(utxoNotaryExample)
+            .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
+            .addOutputState(utxoStateExample)
+            .addCommand(UtxoCommandExample())
+            .sign(publicKeyExample)
+        assertIs<SecureHash>(tx.id)
+    }
+
     // TODO Add tests for verification failures.
 
     @Test

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/WireTransaction.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/WireTransaction.kt
@@ -115,7 +115,9 @@ class WireTransaction(
     val rootMerkleTree: MerkleTree by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val componentGroupRoots: List<ByteArray> = componentGroupLists.mapIndexed { index, group ->
             val componentMerkleTree = merkleTreeProvider.createTree(
-                group,
+                    // We prepend the component groups with the their index to have something in the
+                    // Merkle trees for the otherwise empty component groups too.
+                listOf(index.toByteArray()) + group,
                 getComponentGroupMerkleTreeDigestProvider(privacySalt, index)
             )
             _componentMerkleTrees[index] = componentMerkleTree

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/WireTransaction.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/WireTransaction.kt
@@ -109,13 +109,14 @@ class WireTransaction(
             )
         )
 
+    // These are prepended by the component group index to have at least 1 element in each.
     val componentMerkleTrees: Map<Int, MerkleTree> get() = _componentMerkleTrees
     private val _componentMerkleTrees: MutableMap<Int, MerkleTree> = ConcurrentHashMap()
 
     val rootMerkleTree: MerkleTree by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val componentGroupRoots: List<ByteArray> = componentGroupLists.mapIndexed { index, group ->
             val componentMerkleTree = merkleTreeProvider.createTree(
-                    // We prepend the component groups with the their index to have something in the
+                    // We prepend the component groups with their index to have something in the
                     // Merkle trees for the otherwise empty component groups too.
                 listOf(index.toByteArray()) + group,
                 getComponentGroupMerkleTreeDigestProvider(privacySalt, index)

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImpl.kt
@@ -74,7 +74,7 @@ class WireTransactionFactoryImpl @Activate constructor(
     }
 
     private fun checkComponentGroups(componentGroupLists: List<List<ByteArray>>) {
-        check(componentGroupLists.isNotEmpty()) { "todo text" }
+        check(componentGroupLists.isNotEmpty()) { "Wire transactions cannot be created without at least one component group!" }
     }
 
     private fun parseMetadata(metadataBytes: ByteArray): TransactionMetadata {


### PR DESCRIPTION
CORE-7268 Handle empty component groups
All component groups gets prefixed with an extra item to avoid empty lists.