### PR TITLE
NOTICK: Add Jenkins build number as namespace label

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -110,6 +110,7 @@ pipeline {
                     kubectl label ns "${NAMESPACE}" namespace-type=corda-e2e --overwrite=true
                     kubectl label ns "${NAMESPACE}" branch="${E2E_BRANCH_LABEL}" --overwrite=true
                     kubectl label ns "${NAMESPACE}" arch="${E2E_WORKER_ARCH}" --overwrite=true
+                    kubectl label ns "${NAMESPACE}" JenkinsBuildNumber="${BUILD_NUMBER}" --overwrite=true
                 '''.stripIndent()
             }
         }


### PR DESCRIPTION
add the Jenkins build number as a namespace label to allow easier debugging when trying to trace a namespace back to a particular build which produced it.

Some times when investigating a issue and inspecting existing e2e namespaces, it is beneficial to be able to backtrack to Jenkins to find the PR or job responsible, this combined with the already existing branch name label allows for this. 




