### PR TITLE
NOTICK- Improve smoketests stability

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -123,9 +123,9 @@ fun getFlowClasses(holdingId: String): List<String> {
 fun getOrCreateVirtualNodeFor(x500: String, cpiName: String): String {
     return cluster {
         endpoint(CLUSTER_URI, USERNAME, PASSWORD)
-        val cpis = cpiList().toJson()["cpis"]
         // be a bit patient for the CPI info to get there in case it has just been uploaded
-        val json = eventually(duration = Duration.ofSeconds(5)) {
+        val json = eventually(duration = Duration.ofSeconds(30)) {
+            val cpis = cpiList().toJson()["cpis"]
             cpis.toList().first { it["id"]["cpiName"].textValue() == cpiName }
         }
         val hash = truncateLongHash(json["cpiFileChecksum"].textValue())

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -119,7 +119,7 @@ fun getFlowClasses(holdingId: String): List<String> {
     }
 }
 
-fun getOrCreateVirtualNodeFor(x500: String, cpiName: String = TEST_CPI_NAME): String {
+fun getOrCreateVirtualNodeFor(x500: String, cpiName: String): String {
     return cluster {
         endpoint(CLUSTER_URI, USERNAME, PASSWORD)
         val cpis = cpiList().toJson()["cpis"]

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 import net.corda.applications.workers.smoketest.virtualnode.helpers.assertWithRetry
 import net.corda.applications.workers.smoketest.virtualnode.helpers.cluster
 import net.corda.httprpc.ResponseCode.OK
+import net.corda.test.util.eventually
 import org.apache.commons.text.StringEscapeUtils.escapeJson
 import org.assertj.core.api.Assertions.assertThat
 
@@ -123,7 +124,10 @@ fun getOrCreateVirtualNodeFor(x500: String, cpiName: String): String {
     return cluster {
         endpoint(CLUSTER_URI, USERNAME, PASSWORD)
         val cpis = cpiList().toJson()["cpis"]
-        val json = cpis.toList().first { it["id"]["cpiName"].textValue() == cpiName }
+        // be a bit patient for the CPI info to get there in case it has just been uploaded
+        val json = eventually(duration = Duration.ofSeconds(5)) {
+            cpis.toList().first { it["id"]["cpiName"].textValue() == cpiName }
+        }
         val hash = truncateLongHash(json["cpiFileChecksum"].textValue())
 
         val vNodesJson = assertWithRetry {
@@ -224,6 +228,8 @@ fun conditionallyUploadCordaPackage(name: String, cpb: String, groupId: String, 
                 command { cpiStatus(responseStatusId) }
                 condition { it.code == OK.statusCode && it.toJson()["status"].textValue() == OK.toString() }
             }
+            // sleep a second to let the CPKs distribute
+            //Thread.sleep(1000)
         }
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
@@ -11,19 +11,6 @@ import java.util.concurrent.TimeoutException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-const val X500_BOB = "CN=Bob, OU=Application, O=R3, L=London, C=GB"
-const val X500_ALICE = "CN=Alice, OU=Application, O=R3, L=London, C=GB"
-//Charlie and David for use in multiple flow status endpoints. Number of flows they start is asserted. Do not start flows using these names
-const val X500_CHARLIE = "CN=Charlie, OU=Application, O=R3, L=Dublin, C=IE"
-const val X500_DAVID = "CN=David, OU=Application, O=R3, L=Dublin, C=IE"
-
-val TEST_STATIC_MEMBER_LIST: List<String> = listOf(
-    X500_ALICE,
-    X500_BOB,
-    X500_CHARLIE,
-    X500_DAVID
-)
-
 const val USERNAME = "admin"
 const val PASSWORD = "admin"
 const val GROUP_ID = "7c5d6948-e17b-44e7-9d1c-fa4a3f667cad"

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
+@Suppress("Unused")
 class AmqpSerializationTests {
 
     companion object {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
@@ -4,10 +4,9 @@ import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_SUCCESS
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
-import net.corda.applications.workers.smoketest.TEST_STATIC_MEMBER_LIST
-import net.corda.applications.workers.smoketest.X500_BOB
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
+import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
 import net.corda.applications.workers.smoketest.registerMember
 import net.corda.applications.workers.smoketest.startRpcFlow
@@ -15,34 +14,43 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class AmqpSerializationTests {
 
     companion object {
         private const val AmqpSerializationTestFlow = "net.cordapp.testing.smoketests.flow.AmqpSerializationTestFlow"
 
+        private val testRunUniqueId = UUID.randomUUID()
+        private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
+        private val bobX500 = "CN=Bob-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
+        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+        private val staticMemberList = listOf(
+            bobX500,
+        )
+
         @BeforeAll
         @JvmStatic
         internal fun beforeAll() {
             // Upload test flows if not already uploaded
-            conditionallyUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST)
+            conditionallyUploadCordaPackage(cpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList)
 
             // Make sure Virtual Nodes are created
-            val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
+            val bobActualHoldingId = getOrCreateVirtualNodeFor(bobX500, cpiName)
 
             // Just validate the function and actual vnode holding ID hash are in sync
             // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
-            assertThat(bobActualHoldingId).isEqualTo(FlowTests.bobHoldingId)
+            assertThat(bobActualHoldingId).isEqualTo(bobActualHoldingId)
 
-            registerMember(FlowTests.bobHoldingId)
+            registerMember(bobActualHoldingId)
         }
     }
 
     @Test
     fun `Serialize and deserialize a Pair`() {
 
-        val requestId = startRpcFlow(FlowTests.bobHoldingId, emptyMap(), AmqpSerializationTestFlow)
-        val result = awaitRpcFlowFinished(FlowTests.bobHoldingId, requestId)
+        val requestId = startRpcFlow(bobHoldingId, emptyMap(), AmqpSerializationTestFlow)
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
 
         val flowResult = result.flowResult
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -8,9 +8,6 @@ import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_SUCCESS
 import net.corda.applications.workers.smoketest.RpcSmokeTestInput
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
-import net.corda.applications.workers.smoketest.X500_BOB
-import net.corda.applications.workers.smoketest.X500_CHARLIE
-import net.corda.applications.workers.smoketest.X500_DAVID
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
 import net.corda.applications.workers.smoketest.configWithDefaultsNode
@@ -21,7 +18,6 @@ import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
 import net.corda.applications.workers.smoketest.getRpcFlowResult
 import net.corda.applications.workers.smoketest.registerMember
 import net.corda.applications.workers.smoketest.startRpcFlow
-import net.corda.applications.workers.smoketest.TEST_STATIC_MEMBER_LIST
 import net.corda.applications.workers.smoketest.toJsonString
 import net.corda.applications.workers.smoketest.updateConfig
 import net.corda.applications.workers.smoketest.waitForConfigurationChange
@@ -45,9 +41,22 @@ import kotlin.text.Typography.quote
 class FlowTests {
 
     companion object {
-        var bobHoldingId: String = getHoldingIdShortHash(X500_BOB, GROUP_ID)
-        var davidHoldingId: String = getHoldingIdShortHash(X500_DAVID, GROUP_ID)
-        var charlieHoldingId: String = getHoldingIdShortHash(X500_CHARLIE, GROUP_ID)
+        private val testRunUniqueId = UUID.randomUUID()
+        private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
+        private val aliceX500 = "CN=Alice-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
+        private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, GROUP_ID)
+        private val bobX500 = "CN=Bob-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
+        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+        private val davidX500 = "CN=David-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
+        private var davidHoldingId: String = getHoldingIdShortHash(davidX500, GROUP_ID)
+        private val charlyX500 = "CN=Charley-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
+        private var charlieHoldingId: String = getHoldingIdShortHash(charlyX500, GROUP_ID)
+        private val staticMemberList = listOf(
+            aliceX500,
+            bobX500,
+            charlyX500,
+            davidX500
+        )
 
         val invalidConstructorFlowNames = listOf(
             "net.cordapp.testing.smoketests.flow.errors.PrivateConstructorFlow",
@@ -78,12 +87,12 @@ class FlowTests {
         @JvmStatic
         internal fun beforeAll() {
             // Upload test flows if not already uploaded
-            conditionallyUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST)
+            conditionallyUploadCordaPackage(cpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList)
 
             // Make sure Virtual Nodes are created
-            val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
-            val charlieActualHoldingId = getOrCreateVirtualNodeFor(X500_CHARLIE)
-            val davidActualHoldingId = getOrCreateVirtualNodeFor(X500_DAVID)
+            val bobActualHoldingId = getOrCreateVirtualNodeFor(bobX500, cpiName)
+            val charlieActualHoldingId = getOrCreateVirtualNodeFor(charlyX500, cpiName)
+            val davidActualHoldingId = getOrCreateVirtualNodeFor(davidX500, cpiName)
 
             // Just validate the function and actual vnode holding ID hash are in sync
             // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
@@ -187,7 +196,7 @@ class FlowTests {
         val requestBody = RpcSmokeTestInput().apply {
             command = "start_sessions"
             data = mapOf(
-                "sessions" to "${X500_BOB};${X500_CHARLIE}",
+                "sessions" to "${bobX500};${charlyX500}",
                 "messages" to "m1;m2"
             )
         }
@@ -202,14 +211,14 @@ class FlowTests {
         assertThat(result.flowError).isNull()
         assertThat(flowResult.command).isEqualTo("start_sessions")
         assertThat(flowResult.result)
-            .isEqualTo("${X500_BOB}=echo:m1; ${X500_CHARLIE}=echo:m2")
+            .isEqualTo("${bobX500}=echo:m1; ${charlyX500}=echo:m2")
     }
 
     @Test
     fun `Platform Error - user code receives platform errors`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "throw_platform_error"
-            data = mapOf("x500" to X500_BOB)
+            data = mapOf("x500" to bobX500)
         }
 
         val requestId = startRpcFlow(bobHoldingId, requestBody)
@@ -451,7 +460,7 @@ class FlowTests {
         val requestBody = RpcSmokeTestInput().apply {
             command = "subflow_passed_in_initiated_session"
             data = mapOf(
-                "sessions" to "${X500_BOB};${X500_CHARLIE}",
+                "sessions" to "${bobX500};${charlyX500}",
                 "messages" to "m1;m2"
             )
         }
@@ -466,7 +475,7 @@ class FlowTests {
         assertThat(result.flowError).isNull()
         assertThat(flowResult.command).isEqualTo("subflow_passed_in_initiated_session")
         assertThat(flowResult.result)
-            .isEqualTo("${X500_BOB}=echo:m1; ${X500_CHARLIE}=echo:m2")
+            .isEqualTo("${bobX500}=echo:m1; ${charlyX500}=echo:m2")
     }
 
     @Test
@@ -475,7 +484,7 @@ class FlowTests {
         val requestBody = RpcSmokeTestInput().apply {
             command = "subflow_passed_in_non_initiated_session"
             data = mapOf(
-                "sessions" to "${X500_BOB};${X500_CHARLIE}",
+                "sessions" to "${bobX500};${charlyX500}",
                 "messages" to "m1;m2"
             )
         }
@@ -490,7 +499,7 @@ class FlowTests {
         assertThat(result.flowError).isNull()
         assertThat(flowResult.command).isEqualTo("subflow_passed_in_non_initiated_session")
         assertThat(flowResult.result)
-            .isEqualTo("${X500_BOB}=echo:m1; ${X500_CHARLIE}=echo:m2")
+            .isEqualTo("${bobX500}=echo:m1; ${charlyX500}=echo:m2")
     }
 
     @Test
@@ -498,7 +507,7 @@ class FlowTests {
 
         val requestBody = RpcSmokeTestInput().apply {
             command = "flow_messaging_apis"
-            data = mapOf("sessions" to X500_BOB)
+            data = mapOf("sessions" to bobX500)
         }
 
         val requestId = startRpcFlow(bobHoldingId, requestBody)
@@ -511,14 +520,14 @@ class FlowTests {
         assertThat(result.flowError).isNull()
         assertThat(flowResult.command).isEqualTo("flow_messaging_apis")
         assertThat(flowResult.result)
-            .isEqualTo("${X500_BOB}=Completed. Sum:18")
+            .isEqualTo("${bobX500}=Completed. Sum:18")
     }
 
     @Test
     fun `Crypto - Sign and verify bytes`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "crypto_sign_and_verify"
-            data = mapOf("memberX500" to X500_BOB)
+            data = mapOf("memberX500" to bobX500)
         }
 
         val requestId = startRpcFlow(bobHoldingId, requestBody)
@@ -537,7 +546,7 @@ class FlowTests {
     fun `Crypto - Verify invalid signature`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "crypto_verify_invalid_signature"
-            data = mapOf("memberX500" to X500_BOB)
+            data = mapOf("memberX500" to bobX500)
         }
 
         val requestId = startRpcFlow(bobHoldingId, requestBody)
@@ -610,12 +619,12 @@ class FlowTests {
     @Test
     fun `flows can use inheritance and platform dependencies are correctly injected`() {
         dependencyInjectionFlowNames.forEach {
-            val requestId = startRpcFlow(bobHoldingId, mapOf("id" to X500_CHARLIE), it)
+            val requestId = startRpcFlow(bobHoldingId, mapOf("id" to charlyX500), it)
             val result = awaitRpcFlowFinished(bobHoldingId, requestId)
 
             assertThat(result.flowError).isNull()
             assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
-            assertThat(result.flowResult).isEqualTo(X500_CHARLIE)
+            assertThat(result.flowResult).isEqualTo(charlyX500)
         }
     }
 
@@ -675,7 +684,7 @@ class FlowTests {
                     bobHoldingId,
                     RpcSmokeTestInput().apply {
                         command = "crypto_sign_and_verify"
-                        data = mapOf("memberX500" to X500_BOB)
+                        data = mapOf("memberX500" to bobX500)
                     }
                 ),
 
@@ -683,7 +692,7 @@ class FlowTests {
                     bobHoldingId,
                     RpcSmokeTestInput().apply {
                         command = "lookup_member_by_x500_name"
-                        data = mapOf("id" to X500_CHARLIE)
+                        data = mapOf("id" to charlyX500)
                     }
                 )
             )
@@ -704,7 +713,7 @@ class FlowTests {
     fun `Json serialisation`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "json_serialization"
-            data = mapOf("vnode" to X500_BOB)
+            data = mapOf("vnode" to bobX500)
         }
 
         val requestId = startRpcFlow(bobHoldingId, requestBody)
@@ -723,7 +732,7 @@ class FlowTests {
               "firstTest": {
                 "serialized-implicitly": "combined-test-stringtest-string"
               },
-              "secondTest": "CN=Bob, OU=Application, O=R3, L=London, C=GB"
+              "secondTest": "$bobX500"
             }
             """.trimJson()
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
@@ -4,20 +4,19 @@ import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_SUCCESS
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
-import net.corda.applications.workers.smoketest.X500_BOB
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
 import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
 import net.corda.applications.workers.smoketest.registerMember
 import net.corda.applications.workers.smoketest.startRpcFlow
-import net.corda.applications.workers.smoketest.TEST_STATIC_MEMBER_LIST
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import java.util.UUID
 
 /**
  * This file uses the flow tests' CPI, Group Id and X500 names.
@@ -26,16 +25,21 @@ import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 @TestInstance(PER_CLASS)
 @Disabled
 class ConsensualLedgerTests {
-
-    private val bobHoldingId: String = getHoldingIdShortHash(X500_BOB, GROUP_ID)
+    private val testRunUniqueId = UUID.randomUUID()
+    private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
+    private val bobX500 = "CN=Bob-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
+    private val bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+    private val staticMemberList = listOf(
+        bobX500,
+    )
 
     @BeforeAll
     fun beforeAll() {
         // Upload test flows if not already uploaded
-        conditionallyUploadCordaPackage(TEST_CPI_NAME, TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST)
+        conditionallyUploadCordaPackage(cpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList)
 
         // Make sure Virtual Nodes are created
-        val bobActualHoldingId = getOrCreateVirtualNodeFor(X500_BOB)
+        val bobActualHoldingId = getOrCreateVirtualNodeFor(bobX500, cpiName)
 
         // Just validate the function and actual vnode holding ID hash are in sync
         // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -10,11 +10,9 @@ import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.PASSWORD
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.USERNAME
-import net.corda.applications.workers.smoketest.X500_ALICE
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.startRpcFlow
-import net.corda.applications.workers.smoketest.TEST_STATIC_MEMBER_LIST
 import net.corda.applications.workers.smoketest.toJson
 import net.corda.applications.workers.smoketest.truncateLongHash
 import net.corda.applications.workers.smoketest.virtualnode.helpers.ClusterBuilder
@@ -29,6 +27,7 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.Instant
+import java.util.UUID
 
 const val CODESIGNER_CERT = "/cordadevcodesign.pem"
 
@@ -49,7 +48,15 @@ class VirtualNodeRpcTest {
         // Server side messages
         private const val EXPECTED_ERROR_NO_GROUP_POLICY = "CPI is missing a group policy file"
 
-        private val aliceHoldingId: String = getHoldingIdShortHash(X500_ALICE, GROUP_ID)
+        private val testRunUniqueId = UUID.randomUUID()
+        private val aliceX500 = "CN=Alice-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
+        private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, GROUP_ID)
+        private val staticMemberList = listOf(
+            aliceX500,
+        )
+
+        private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
+        private val otherCpiName = "${TEST_CPI_NAME}_OTHER_$testRunUniqueId"
     }
 
     /**
@@ -81,7 +88,7 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
-            val requestId = cpiUpload(TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST, TEST_CPI_NAME)
+            val requestId = cpiUpload(TEST_CPB_LOCATION, GROUP_ID, staticMemberList, cpiName)
                 .let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
@@ -112,7 +119,7 @@ class VirtualNodeRpcTest {
                 .withFailMessage("Short code length of wrong size - likely this test needs fixing")
                 .isEqualTo(12)
 
-            val actualChecksum = getCpiChecksum(TEST_CPI_NAME)
+            val actualChecksum = getCpiChecksum(cpiName)
 
             assertThat(actualChecksum).isNotNull.isNotEmpty
 
@@ -159,7 +166,7 @@ class VirtualNodeRpcTest {
     fun `cannot upload same CPI`() {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
-            val requestId = cpiUpload(TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST, TEST_CPI_NAME)
+            val requestId = cpiUpload(TEST_CPB_LOCATION, GROUP_ID, staticMemberList, cpiName)
                 .let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
@@ -172,15 +179,34 @@ class VirtualNodeRpcTest {
 
     @Test
     @Order(31)
-    fun `can upload same CPI with different groupId`() {
-        val cpiName = TEST_CPI_NAME + "_DIFFERENT_GROUP"
+    fun `cannot upload same CPI with different groupId`() {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
             val requestId = cpiUpload(
                 TEST_CPB_LOCATION,
                 "8c5d6948-e17b-44e7-9d1c-fa4a3f667cad",
-                TEST_STATIC_MEMBER_LIST,
+                staticMemberList,
                 cpiName
+            ).let { it.toJson()["id"].textValue() }
+            assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
+
+            assertWithRetry {
+                command { cpiStatus(requestId) }
+                condition { it.code == 409 }
+            }
+        }
+    }
+
+    @Test
+    @Order(32)
+    fun `can upload different CPI with same groupId`() {
+        cluster {
+            endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+            val requestId = cpiUpload(
+                TEST_CPB_LOCATION,
+                "8c5d6948-e17b-44e7-9d1c-fa4a3f667cad",
+                staticMemberList,
+                otherCpiName
             ).let { it.toJson()["id"].textValue() }
 
 
@@ -203,7 +229,7 @@ class VirtualNodeRpcTest {
 
             val cpiHash = json["cpiFileChecksum"].textValue()
             assertThat(cpiHash).isNotNull.isNotEmpty
-            val actualChecksum = getCpiChecksum(cpiName)
+            val actualChecksum = getCpiChecksum(otherCpiName)
             assertThat(actualChecksum).isNotNull.isNotEmpty
             assertThat(cpiHash).withFailMessage(ERROR_CPI_NOT_UPLOADED).isNotNull
             assertThat(actualChecksum).isEqualTo(cpiHash)
@@ -232,7 +258,7 @@ class VirtualNodeRpcTest {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
             val json = cpiList().toJson()
-            val cpiJson = json["cpis"].first { it["id"]["cpiName"].textValue() == TEST_CPI_NAME}
+            val cpiJson = json["cpis"].first { it["id"]["cpiName"].textValue() == cpiName}
 
             val groupPolicyJson = cpiJson["groupPolicy"].textValue().toJson()
             assertThat(groupPolicyJson["groupId"].textValue()).isEqualTo(GROUP_ID)
@@ -244,10 +270,10 @@ class VirtualNodeRpcTest {
     fun `can create virtual node with holding id and CPI`() {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
-            val hash = getCpiChecksum(TEST_CPI_NAME)
+            val hash = getCpiChecksum(cpiName)
 
             val vNodeJson = assertWithRetry {
-                command { vNodeCreate(hash, X500_ALICE) }
+                command { vNodeCreate(hash, aliceX500) }
                 condition { it.code == 200 }
                 failMessage(ERROR_HOLDING_ID)
             }.toJson()
@@ -261,10 +287,10 @@ class VirtualNodeRpcTest {
     fun `cannot create duplicate virtual node`() {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
-            val hash = getCpiChecksum(TEST_CPI_NAME)
+            val hash = getCpiChecksum(cpiName)
 
             assertWithRetry {
-                command { vNodeCreate(hash, X500_ALICE) }
+                command { vNodeCreate(hash, aliceX500) }
                 condition { it.code == 409 }
             }
         }
@@ -283,7 +309,7 @@ class VirtualNodeRpcTest {
                     val nodes = vNodeList().toJson()["virtualNodes"].map {
                         it["holdingIdentity"]["x500Name"].textValue()
                     }
-                    response.code == 200 && nodes.contains(X500_ALICE)
+                    response.code == 200 && nodes.contains(aliceX500)
                 }
             }
         }
@@ -348,10 +374,10 @@ class VirtualNodeRpcTest {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
             // Note CPI/CPK timestamp
-            val initialCpkTimeStamp = getCpkTimestamp()
+            val initialCpkTimeStamp = getCpkTimestamp(cpiName)
 
             // Perform force upload of the CPI
-            val requestId = forceCpiUpload(TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST, TEST_CPI_NAME).let { it.toJson()["id"].textValue() }
+            val requestId = forceCpiUpload(TEST_CPB_LOCATION, GROUP_ID, staticMemberList, cpiName).let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
             // BUG:  returning "OK" feels 'weakly' typed
@@ -364,7 +390,7 @@ class VirtualNodeRpcTest {
             // Cannot use `assertWithRetry` as there is a strict type `Instant`
             // Allow ample time for CPI upload to be propagated through the system
             eventually(Duration.ofSeconds(100)) {
-                assertThat(getCpkTimestamp()).isAfter(initialCpkTimeStamp)
+                assertThat(getCpkTimestamp(cpiName)).isAfter(initialCpkTimeStamp)
             }
         }
     }
@@ -395,9 +421,9 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
-            val initialCpkTimeStamp = getCpkTimestamp()
+            val initialCpkTimeStamp = getCpkTimestamp(cpiName)
 
-            val requestId = forceCpiUpload(CACHE_INVALIDATION_TEST_CPB, GROUP_ID, TEST_STATIC_MEMBER_LIST, TEST_CPI_NAME)
+            val requestId = forceCpiUpload(CACHE_INVALIDATION_TEST_CPB, GROUP_ID, staticMemberList, cpiName)
                 .let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
@@ -407,7 +433,7 @@ class VirtualNodeRpcTest {
             }
 
             eventually(Duration.ofSeconds(120)) {
-                assertThat(getCpkTimestamp()).isAfter(initialCpkTimeStamp)
+                assertThat(getCpkTimestamp(cpiName)).isAfter(initialCpkTimeStamp)
             }
         }
     }
@@ -440,9 +466,9 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
-            val initialCpkTimeStamp = getCpkTimestamp()
+            val initialCpkTimeStamp = getCpkTimestamp(cpiName)
 
-            val requestId = forceCpiUpload(TEST_CPB_LOCATION, GROUP_ID, TEST_STATIC_MEMBER_LIST, TEST_CPI_NAME)
+            val requestId = forceCpiUpload(TEST_CPB_LOCATION, GROUP_ID, staticMemberList, cpiName)
                 .let { it.toJson()["id"].textValue() }
             assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
@@ -452,7 +478,7 @@ class VirtualNodeRpcTest {
             }
 
             eventually(Duration.ofSeconds(100)) {
-                assertThat(getCpkTimestamp()).isAfter(initialCpkTimeStamp)
+                assertThat(getCpkTimestamp(cpiName)).isAfter(initialCpkTimeStamp)
             }
 
             runReturnAStringFlow("original-cpi")
@@ -490,9 +516,9 @@ class VirtualNodeRpcTest {
         assertThat(flowStatus.flowResult).isEqualTo(expectedResult)
     }
 
-    private fun ClusterBuilder.getCpkTimestamp(): Instant {
+    private fun ClusterBuilder.getCpkTimestamp(cpiName: String): Instant {
         val cpis = cpiList().toJson()["cpis"]
-        val cpiJson = cpis.toList().first { it["id"]["cpiName"].textValue() == TEST_CPI_NAME }
+        val cpiJson = cpis.toList().first { it["id"]["cpiName"].textValue() == cpiName }
         val cpksJson = cpiJson["cpks"].toList()
         return cpksJson.first()["timestamp"].toInstant()
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/CpiLoader.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/CpiLoader.kt
@@ -1,9 +1,5 @@
 package net.corda.applications.workers.smoketest.virtualnode.helpers
 
-import net.corda.applications.workers.smoketest.X500_ALICE
-import net.corda.applications.workers.smoketest.X500_BOB
-import net.corda.applications.workers.smoketest.X500_CHARLIE
-import net.corda.applications.workers.smoketest.X500_DAVID
 import net.corda.applications.workers.smoketest.virtualnode.helpers.GroupPolicyUtils.getDefaultStaticNetworkGroupPolicy
 import net.corda.cli.plugins.packaging.CreateCpiV2
 import net.corda.cli.plugins.packaging.signing.SigningOptions

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -1,17 +1,30 @@
 package net.corda.applications.workers.smoketest.websocket
 
-import net.corda.applications.workers.smoketest.*
-import net.corda.applications.workers.smoketest.flow.FlowTests
-import java.time.Duration
 import java.util.UUID
+import net.corda.applications.workers.smoketest.GROUP_ID
+import net.corda.applications.workers.smoketest.RpcSmokeTestInput
+import net.corda.applications.workers.smoketest.SMOKE_TEST_CLASS_NAME
+import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
+import net.corda.applications.workers.smoketest.TEST_CPI_NAME
+import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
+import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
+import net.corda.applications.workers.smoketest.getFlowClasses
+import net.corda.applications.workers.smoketest.getHoldingIdShortHash
+import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
+import net.corda.applications.workers.smoketest.startRpcFlow
 import net.corda.applications.workers.smoketest.websocket.client.MessageQueueWebSocketHandler
 import net.corda.applications.workers.smoketest.websocket.client.SmokeTestWebsocketClient
 import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import java.time.Duration
 
 // This test relies on `VirtualNodeRpcTest` and `FlowTest` to run first which will create vNodes necessary to run this test
 @Order(30)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -1,26 +1,17 @@
 package net.corda.applications.workers.smoketest.websocket
 
+import net.corda.applications.workers.smoketest.*
+import net.corda.applications.workers.smoketest.flow.FlowTests
 import java.time.Duration
 import java.util.UUID
-import net.corda.applications.workers.smoketest.GROUP_ID
-import net.corda.applications.workers.smoketest.RpcSmokeTestInput
-import net.corda.applications.workers.smoketest.SMOKE_TEST_CLASS_NAME
-import net.corda.applications.workers.smoketest.X500_BOB
-import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
-import net.corda.applications.workers.smoketest.getFlowClasses
-import net.corda.applications.workers.smoketest.getHoldingIdShortHash
-import net.corda.applications.workers.smoketest.startRpcFlow
 import net.corda.applications.workers.smoketest.websocket.client.MessageQueueWebSocketHandler
 import net.corda.applications.workers.smoketest.websocket.client.SmokeTestWebsocketClient
 import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
 
 // This test relies on `VirtualNodeRpcTest` and `FlowTest` to run first which will create vNodes necessary to run this test
 @Order(30)
@@ -28,7 +19,24 @@ import org.junit.jupiter.api.TestMethodOrder
 class FlowStatusFeedSmokeTest {
 
     private companion object {
-        val bobHoldingId: String = getHoldingIdShortHash(X500_BOB, GROUP_ID)
+        private val testRunUniqueId = UUID.randomUUID()
+        private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
+        private val bobX500 = "CN=Bob-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
+        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+        private val staticMemberList = listOf(
+            bobX500,
+        )
+
+        @BeforeAll
+        @JvmStatic
+        internal fun beforeAll() {
+            // Upload test flows if not already uploaded
+            conditionallyUploadCordaPackage(cpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList)
+
+            // Make sure Virtual Nodes are created
+            val bobActualHoldingId = getOrCreateVirtualNodeFor(bobX500, cpiName)
+            assertThat(bobActualHoldingId).isEqualTo(bobHoldingId)
+        }
     }
 
     private enum class FlowStates { START_REQUESTED, RUNNING, RETRYING, COMPLETED, FAILED }


### PR DESCRIPTION
Make CPI Name and X500s unique per test run and test class so that they don't clash.

This also means that tests can now be repeated against an existing environment.