### PR TITLE
CORE-7240: Simplify helper functions for fetching sandbox singletons.

### DIFF
--- a/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/processor/ConsensualLedgerMessageProcessor.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/main/kotlin/net/corda/ledger/consensual/persistence/impl/processor/ConsensualLedgerMessageProcessor.kt
@@ -17,7 +17,7 @@ import net.corda.persistence.common.exceptions.NullParameterException
 import net.corda.persistence.common.getEntityManagerFactory
 import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.getSandboxSingletonServices
+import net.corda.sandboxgroupcontext.getSandboxSingletonService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.exceptions.CordaRuntimeException
@@ -78,9 +78,7 @@ class ConsensualLedgerMessageProcessor(
         // get the per-sandbox entity manager and serialization services
         val entityManagerFactory = sandbox.getEntityManagerFactory()
         val serializationService = sandbox.getSerializationService()
-        val sandboxSingletons = sandbox.getSandboxSingletonServices()
-        val repository = sandboxSingletons.filterIsInstance<ConsensualLedgerRepository>().singleOrNull()
-            ?: throw IllegalStateException("ConsensualLedgerRepository service missing from sandbox")
+        val repository = sandbox.getSandboxSingletonService<ConsensualLedgerRepository>()
 
         return entityManagerFactory.createEntityManager().transaction { em ->
             when (val req = request.request) {

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -255,6 +255,16 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                 logger.warn("Failed to identify injectable services from $serviceRef", e)
             }
         }
+
+        // Include the service marker interfaces in our "universe" of sandbox services,
+        // but without any ServiceReference<*> objects. This effectively prevents the
+        // sandbox from injecting anything against any marker interface reference,
+        // which sandbox components are not supposed to have anyway.
+        val emptyImmutableSet = java.util.Collections.emptySet<ServiceReference<*>>()
+        MARKER_INTERFACES.forEach { markerName ->
+            serviceIndex[markerName] = emptyImmutableSet
+        }
+
         return SandboxServiceContext(bundleContext, serviceComponentRuntime, serviceIndex, injectables)
     }
 

--- a/libs/crypto/cipher-suite-impl/build.gradle
+++ b/libs/crypto/cipher-suite-impl/build.gradle
@@ -8,6 +8,7 @@ description 'Cipher suite default implementation'
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
+    compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     implementation platform("net.corda:corda-api:$cordaApiVersion")

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
@@ -18,6 +18,7 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL
 import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.osgi.service.component.propertytypes.ServiceRanking
 import java.io.InputStream
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
@@ -112,3 +113,13 @@ class DigestServiceImpl @Activate constructor(
         }
     }
 }
+
+/**
+ * A [DigestService] singleton for everyone not inside a sandbox to share.
+ */
+@Component
+@ServiceRanking(1)
+class SingletonDigestServiceImpl @Activate constructor(
+    @Reference(scope = PROTOTYPE_REQUIRED)
+    private val digestService: DigestService
+) : DigestService by digestService

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextExtensions.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextExtensions.kt
@@ -13,9 +13,21 @@ inline fun <reified T : Any> SandboxGroupContext.getObjectByKey(key: String) = g
  * Fetch service instances previously created using [SandboxGroupContextComponent.registerMetadataServices].
  */
 @Suppress("KDocUnresolvedReference")
-inline fun <reified T : Any> SandboxGroupContext.getMetadataServices(): Set<T> = getObjectByKey(T::class.java.name) ?: emptySet()
+fun <T : Any> SandboxGroupContext.getMetadataServices(type: Class<T>): Set<T> = getObjectByKey(type.name) ?: emptySet()
+
+inline fun <reified T : Any> SandboxGroupContext.getMetadataServices(): Set<T> = getMetadataServices(T::class.java)
 
 /**
  * Fetch the set of singleton services created for use by this sandbox.
  */
 fun SandboxGroupContext.getSandboxSingletonServices(): Set<Any> = getObjectByKey(SANDBOX_SINGLETONS) ?: emptySet()
+
+/**
+ * Fetch the single service of the given type from the sandbox's set of singletons.
+ */
+fun <T : Any> SandboxGroupContext.getSandboxSingletonService(type: Class<T>): T {
+    return getSandboxSingletonServices().filterIsInstance(type).singleOrNull()
+        ?: throw IllegalStateException("${type.name} service missing from sandbox")
+}
+
+inline fun <reified T : Any> SandboxGroupContext.getSandboxSingletonService(): T = getSandboxSingletonService(T::class.java)


### PR DESCRIPTION
Update the sandbox handling:
- Add more helper functions to obtain sandbox service references.
- Ensure sandboxes cannot obtain any services references via their marker interfaces.
- Provide a `DigestService` singleton for use outside sandboxes.