### PR TITLE
CORE-7089 Distribute group parameters after registration approval

### DIFF
--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
@@ -11,6 +11,7 @@ import net.corda.data.membership.p2p.DistributionMetaData
 import net.corda.data.membership.p2p.DistributionType
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.SignedMemberships
+import net.corda.data.membership.p2p.WireGroupParameters
 import net.corda.layeredpropertymap.toAvro
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.utilities.time.Clock
@@ -19,6 +20,7 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.KeyEncodingService
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import java.nio.ByteBuffer
@@ -57,6 +59,7 @@ class MembershipPackageFactory(
         membersSignatures: Map<HoldingIdentity, CryptoSignatureWithKey>,
         membersToSend: Collection<MemberInfo>,
         hashCheck: SecureHash,
+        groupParameters: GroupParameters,
     ): MembershipPackage {
         val signedMembers = membersToSend.map {
             val memberTree = merkleTreeGenerator.generateTree(listOf(it))
@@ -70,6 +73,13 @@ class MembershipPackageFactory(
                 .setMgmSignature(mgmSignature)
                 .build()
         }
+        val wireGroupParameters = with(serializer.serialize(groupParameters.toAvro())) {
+            this ?: throw CordaRuntimeException("Failed to serialize group parameters.")
+            WireGroupParameters(
+                ByteBuffer.wrap(this),
+                mgmSigner.sign(this).toAvro()
+            )
+        }
         val membership = SignedMemberships.newBuilder()
             .setMemberships(signedMembers)
             .setHashCheck(hashCheck.toAvro())
@@ -79,7 +89,7 @@ class MembershipPackageFactory(
             .setCurrentPage(0)
             .setPageCount(1)
             .setCpiAllowList(null)
-            .setGroupParameters(null)
+            .setGroupParameters(wireGroupParameters)
             .setMemberships(
                 membership
             )

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
@@ -73,13 +73,12 @@ class MembershipPackageFactory(
                 .setMgmSignature(mgmSignature)
                 .build()
         }
-        val wireGroupParameters = with(serializer.serialize(groupParameters.toAvro())) {
-            this ?: throw CordaRuntimeException("Failed to serialize group parameters.")
+        val wireGroupParameters = serializer.serialize(groupParameters.toAvro())?.let {
             WireGroupParameters(
-                ByteBuffer.wrap(this),
-                mgmSigner.sign(this).toAvro()
+                ByteBuffer.wrap(it),
+                mgmSigner.sign(it).toAvro()
             )
-        }
+        } ?: throw CordaRuntimeException("Failed to serialize group parameters.")
         val membership = SignedMemberships.newBuilder()
             .setMemberships(signedMembers)
             .setHashCheck(hashCheck.toAvro())

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.persistence.client
 
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.data.KeyValuePairList
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
@@ -123,27 +124,27 @@ class MembershipPersistenceClientImpl(
     override fun persistGroupParameters(
         viewOwningIdentity: HoldingIdentity,
         groupParameters: GroupParameters
-    ): MembershipPersistenceResult<Int> {
+    ): MembershipPersistenceResult<KeyValuePairList> {
         logger.info("Persisting group parameters.")
         val result = MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
             PersistGroupParameters(groupParameters.toAvro())
         ).execute()
         return when (val response = result.payload) {
-            is PersistGroupParametersResponse -> MembershipPersistenceResult.Success(response.epoch)
+            is PersistGroupParametersResponse -> MembershipPersistenceResult.Success(response.groupParameters)
             is PersistenceFailedResponse -> MembershipPersistenceResult.Failure(response.errorMessage)
             else -> MembershipPersistenceResult.Failure("Unexpected response: $response")
         }
     }
 
-    override fun persistGroupParametersInitialSnapshot(viewOwningIdentity: HoldingIdentity): MembershipPersistenceResult<Unit> {
+    override fun persistGroupParametersInitialSnapshot(viewOwningIdentity: HoldingIdentity): MembershipPersistenceResult<KeyValuePairList> {
         logger.info("Persisting initial snapshot of group parameters.")
         val result = MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
             PersistGroupParametersInitialSnapshot()
         ).execute()
         return when (val response = result.payload) {
-            is PersistGroupParametersResponse -> MembershipPersistenceResult.success()
+            is PersistGroupParametersResponse -> MembershipPersistenceResult.Success(response.groupParameters)
             is PersistenceFailedResponse -> MembershipPersistenceResult.Failure(response.errorMessage)
             else -> MembershipPersistenceResult.Failure("Unexpected response: $response")
         }
@@ -152,7 +153,7 @@ class MembershipPersistenceClientImpl(
     override fun addNotaryToGroupParameters(
         viewOwningIdentity: HoldingIdentity,
         notary: MemberInfo
-    ): MembershipPersistenceResult<Int> {
+    ): MembershipPersistenceResult<KeyValuePairList> {
         logger.info("Adding notary to persisted group parameters.")
         val result = MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
@@ -165,7 +166,7 @@ class MembershipPersistenceClientImpl(
             )
         ).execute()
         return when (val response = result.payload) {
-            is PersistGroupParametersResponse -> MembershipPersistenceResult.Success(response.epoch)
+            is PersistGroupParametersResponse -> MembershipPersistenceResult.Success(response.groupParameters)
             is PersistenceFailedResponse -> MembershipPersistenceResult.Failure(response.errorMessage)
             else -> MembershipPersistenceResult.Failure("Unexpected response: $response")
         }

--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.persistence.client
 
+import net.corda.data.KeyValuePairList
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.lifecycle.Lifecycle
 import net.corda.membership.lib.registration.RegistrationRequest
@@ -49,12 +50,12 @@ interface MembershipPersistenceClient : Lifecycle {
      *
      * @param viewOwningIdentity The holding identity of the owner of the view of data.
      *
-     * @return Membership persistence result to indicate the result of the operation.
-     * No payload is returned in the case of success.
+     * @return Membership persistence result to indicate the result of the operation. In the case of success, the payload
+     * will include a [KeyValuePairList] of the newly persisted group parameters.
      */
     fun persistGroupParametersInitialSnapshot(
         viewOwningIdentity: HoldingIdentity
-    ): MembershipPersistenceResult<Unit>
+    ): MembershipPersistenceResult<KeyValuePairList>
 
     /**
      * Persists a set of group parameters. This method is expected to be used by members to persist group parameters
@@ -66,12 +67,12 @@ interface MembershipPersistenceClient : Lifecycle {
      * @param groupParameters The group parameters to persist.
      *
      * @return Membership persistence result to indicate the result of the operation. In the case of success, the payload
-     * will include the epoch of the newly persisted group parameters.
+     * will include a [KeyValuePairList] of the newly persisted group parameters.
      */
     fun persistGroupParameters(
         viewOwningIdentity: HoldingIdentity,
         groupParameters: GroupParameters
-    ): MembershipPersistenceResult<Int>
+    ): MembershipPersistenceResult<KeyValuePairList>
 
     /**
      * Adds notary information to an existing set of group parameters. This method is expected to be used by an MGM to
@@ -86,12 +87,12 @@ interface MembershipPersistenceClient : Lifecycle {
      * @param notary [MemberInfo] of the notary to be added.
      *
      * @return Membership persistence result to indicate the result of the operation. In the case of success, the payload
-     * will include the epoch of the newly persisted group parameters, which is the previous set's epoch incremented by 1.
+     * will include a [KeyValuePairList] of the newly persisted group parameters.
      */
     fun addNotaryToGroupParameters(
         viewOwningIdentity: HoldingIdentity,
         notary: MemberInfo
-    ): MembershipPersistenceResult<Int>
+    ): MembershipPersistenceResult<KeyValuePairList>
 
     /**
      * Persists a registration request record as viewed by a specific holding identity.

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -571,9 +571,21 @@ class MembershipPersistenceTest {
             )
         )
         val notary = memberInfoFactory.create(memberContext.toSortedMap(), mgmContext.toSortedMap())
-        val persisted2 = membershipPersistenceClientWrapper.addNotaryToGroupParameters(viewOwningHoldingIdentity, notary)
-        assertThat(persisted2).isInstanceOf(MembershipPersistenceResult.Success::class.java)
-        assertThat((persisted2 as? MembershipPersistenceResult.Success<Int>)?.payload).isEqualTo(51)
+        val expectedGroupParameters = listOf(
+            KeyValuePair(EPOCH_KEY, "51"),
+            KeyValuePair(MPV_KEY, "5000"),
+            KeyValuePair("corda.notary.service.0.name", notaryServiceName),
+            KeyValuePair("corda.notary.service.0.plugin", notaryServicePlugin),
+            KeyValuePair("corda.notary.service.0.keys.0", keyEncodingService.encodeAsString(notaryKey)),
+        )
+
+        val persisted = membershipPersistenceClientWrapper.addNotaryToGroupParameters(viewOwningHoldingIdentity, notary)
+
+        assertThat(persisted).isInstanceOf(MembershipPersistenceResult.Success::class.java)
+        with((persisted as? MembershipPersistenceResult.Success<KeyValuePairList>)!!.payload.items) {
+            assertThat(size).isEqualTo(6)
+            assertThat(containsAll(expectedGroupParameters))
+        }
 
         val persistedEntity = vnodeEmf.use {
             it.find(
@@ -583,14 +595,10 @@ class MembershipPersistenceTest {
         }
         assertThat(persistedEntity).isNotNull
         with(persistedEntity.parameters) {
-            val deserialized = cordaAvroDeserializer.deserialize(this)!!.toMap()
-            assertThat(deserialized.size).isEqualTo(6)
-            assertThat(deserialized[EPOCH_KEY]).isEqualTo("51")
-            assertDoesNotThrow { Instant.parse(deserialized[MODIFIED_TIME_KEY]) }
-            assertThat(deserialized[MPV_KEY]).isEqualTo("5000")
-            assertThat(deserialized["corda.notary.service.0.name"]).isEqualTo(notaryServiceName)
-            assertThat(deserialized["corda.notary.service.0.plugin"]).isEqualTo(notaryServicePlugin)
-            assertThat(deserialized["corda.notary.service.0.keys.0"]).isEqualTo(keyEncodingService.encodeAsString(notaryKey))
+            val deserialized = cordaAvroDeserializer.deserialize(this)!!
+            assertThat(deserialized.items.size).isEqualTo(6)
+            assertThat(deserialized.items.containsAll(expectedGroupParameters))
+            assertDoesNotThrow { Instant.parse(deserialized.toMap()[MODIFIED_TIME_KEY]) }
         }
     }
 
@@ -647,10 +655,21 @@ class MembershipPersistenceTest {
                 )
             it.persist(entity)
         }
+        val expectedGroupParameters = listOf(
+            KeyValuePair(EPOCH_KEY, "101"),
+            KeyValuePair(MPV_KEY, "5000"),
+            KeyValuePair("corda.notary.service.0.name", notaryServiceName),
+            KeyValuePair("corda.notary.service.0.plugin", notaryServicePlugin),
+            KeyValuePair("corda.notary.service.0.keys.0", notaryKeyAsString),
+        )
 
-        val persisted2 = membershipPersistenceClientWrapper.addNotaryToGroupParameters(viewOwningHoldingIdentity, notary)
-        assertThat(persisted2).isInstanceOf(MembershipPersistenceResult.Success::class.java)
-        assertThat((persisted2 as? MembershipPersistenceResult.Success<Int>)?.payload!!).isEqualTo(101)
+        val persisted = membershipPersistenceClientWrapper.addNotaryToGroupParameters(viewOwningHoldingIdentity, notary)
+
+        assertThat(persisted).isInstanceOf(MembershipPersistenceResult.Success::class.java)
+        with((persisted as? MembershipPersistenceResult.Success<KeyValuePairList>)!!.payload.items) {
+            assertThat(size).isEqualTo(6)
+            assertThat(containsAll(expectedGroupParameters))
+        }
 
         val persistedEntity = vnodeEmf.use {
             it.find(
@@ -660,14 +679,10 @@ class MembershipPersistenceTest {
         }
         assertThat(persistedEntity).isNotNull
         with(persistedEntity.parameters) {
-            val deserialized = cordaAvroDeserializer.deserialize(this)!!.toMap()
-            assertThat(deserialized.size).isEqualTo(6)
-            assertThat(deserialized[EPOCH_KEY]).isEqualTo("101")
-            assertDoesNotThrow { Instant.parse(deserialized[MODIFIED_TIME_KEY]) }
-            assertThat(deserialized[MPV_KEY]).isEqualTo("5000")
-            assertThat(deserialized["corda.notary.service.0.name"]).isEqualTo(notaryServiceName)
-            assertThat(deserialized["corda.notary.service.0.plugin"]).isEqualTo(notaryServicePlugin)
-            assertThat(deserialized["corda.notary.service.0.keys.0"]).isEqualTo(notaryKeyAsString)
+            val deserialized = cordaAvroDeserializer.deserialize(this)!!
+            assertThat(deserialized.items.size).isEqualTo(6)
+            assertThat(deserialized.items.containsAll(expectedGroupParameters))
+            assertDoesNotThrow { Instant.parse(deserialized.toMap()[MODIFIED_TIME_KEY]) }
         }
     }
 
@@ -729,10 +744,22 @@ class MembershipPersistenceTest {
             )
             it.persist(entity)
         }
+        val expectedGroupParameters = listOf(
+            KeyValuePair(EPOCH_KEY, "151"),
+            KeyValuePair(MPV_KEY, "5000"),
+            KeyValuePair("corda.notary.service.0.name", notaryServiceName),
+            KeyValuePair("corda.notary.service.0.plugin", notaryServicePlugin),
+            KeyValuePair("corda.notary.service.0.keys.0", oldNotaryKey),
+            KeyValuePair("corda.notary.service.0.keys.1", notaryKeyAsString),
+        )
 
-        val persisted2 = membershipPersistenceClientWrapper.addNotaryToGroupParameters(viewOwningHoldingIdentity, notary)
-        assertThat(persisted2).isInstanceOf(MembershipPersistenceResult.Success::class.java)
-        assertThat((persisted2 as? MembershipPersistenceResult.Success<Int>)?.payload!!).isEqualTo(151)
+        val persisted = membershipPersistenceClientWrapper.addNotaryToGroupParameters(viewOwningHoldingIdentity, notary)
+
+        assertThat(persisted).isInstanceOf(MembershipPersistenceResult.Success::class.java)
+        with((persisted as? MembershipPersistenceResult.Success<KeyValuePairList>)!!.payload.items) {
+            assertThat(size).isEqualTo(7)
+            assertThat(containsAll(expectedGroupParameters))
+        }
 
         val persistedEntity = vnodeEmf.use {
             it.find(
@@ -742,15 +769,10 @@ class MembershipPersistenceTest {
         }
         assertThat(persistedEntity).isNotNull
         with(persistedEntity.parameters) {
-            val deserialized = cordaAvroDeserializer.deserialize(this)!!.toMap()
-            assertThat(deserialized.size).isEqualTo(7)
-            assertThat(deserialized[EPOCH_KEY]).isEqualTo("151")
-            assertDoesNotThrow { Instant.parse(deserialized[MODIFIED_TIME_KEY]) }
-            assertThat(deserialized[MPV_KEY]).isEqualTo("5000")
-            assertThat(deserialized["corda.notary.service.0.name"]).isEqualTo(notaryServiceName)
-            assertThat(deserialized["corda.notary.service.0.plugin"]).isEqualTo(notaryServicePlugin)
-            assertThat(deserialized["corda.notary.service.0.keys.0"]).isEqualTo(oldNotaryKey)
-            assertThat(deserialized["corda.notary.service.0.keys.1"]).isEqualTo(notaryKeyAsString)
+            val deserialized = cordaAvroDeserializer.deserialize(this)!!
+            assertThat(deserialized.items.size).isEqualTo(7)
+            assertThat(deserialized.items.containsAll(expectedGroupParameters))
+            assertDoesNotThrow { Instant.parse(deserialized.toMap()[MODIFIED_TIME_KEY]) }
         }
     }
 

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandler.kt
@@ -29,8 +29,9 @@ internal class PersistGroupParametersHandler(
         context: MembershipRequestContext,
         request: PersistGroupParameters
     ): PersistGroupParametersResponse {
-        val epoch = transaction(context.holdingIdentity.toCorda().shortHash) { em ->
-            val epochFromRequest = request.groupParameters.toMap()[EPOCH_KEY]?.toInt()
+        val persistedGroupParameters = transaction(context.holdingIdentity.toCorda().shortHash) { em ->
+            val groupParameters = request.groupParameters
+            val epochFromRequest = groupParameters.toMap()[EPOCH_KEY]?.toInt()
                 ?: throw MembershipPersistenceException("Cannot persist group parameters - epoch not found.")
             val criteriaBuilder = em.criteriaBuilder
             val queryBuilder = criteriaBuilder.createQuery(GroupParametersEntity::class.java)
@@ -49,13 +50,13 @@ internal class PersistGroupParametersHandler(
             
             val entity = GroupParametersEntity(
                 epoch = epochFromRequest,
-                parameters = serializeProperties(request.groupParameters),
+                parameters = serializeProperties(groupParameters),
             )
             em.persist(entity)
 
-            entity.epoch
+            groupParameters
         }
 
-        return PersistGroupParametersResponse(epoch)
+        return PersistGroupParametersResponse(persistedGroupParameters)
     }
 }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
@@ -31,7 +31,7 @@ internal class PersistGroupParametersInitialSnapshotHandler(
         context: MembershipRequestContext,
         request: PersistGroupParametersInitialSnapshot
     ): PersistGroupParametersResponse {
-        val epoch = transaction(context.holdingIdentity.toCorda().shortHash) { em ->
+        val persistedGroupParameters = transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             // Create initial snapshot of group parameters.
             val groupParameters = KeyValuePairList(
                 listOf(
@@ -46,9 +46,9 @@ internal class PersistGroupParametersInitialSnapshotHandler(
             )
             em.persist(entity)
 
-            entity.epoch
+            groupParameters
         }
 
-        return PersistGroupParametersResponse(epoch)
+        return PersistGroupParametersResponse(persistedGroupParameters)
     }
 }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -197,8 +197,8 @@ class AddNotaryToGroupParametersHandlerTest {
                     KeyValuePair("corda.notary.service.0.keys.0", "test-key"),
                 )
             ))
+            assertThat(result).isEqualTo(PersistGroupParametersResponse(persistedParameters))
         }
-        assertThat(result).isEqualTo(PersistGroupParametersResponse(EPOCH + 1))
     }
 
     @Test
@@ -268,8 +268,8 @@ class AddNotaryToGroupParametersHandlerTest {
                     KeyValuePair("corda.notary.service.5.keys.1", "test-key"),
                 )
             ))
+            assertThat(result).isEqualTo(PersistGroupParametersResponse(persistedParameters))
         }
-        assertThat(result).isEqualTo(PersistGroupParametersResponse(EPOCH + 1))
     }
 
     @Test
@@ -308,14 +308,13 @@ class AddNotaryToGroupParametersHandlerTest {
         val request = mock<AddNotaryToGroupParameters> {
             on { notary } doReturn persistentNotary
         }
-        whenever(keyValuePairListDeserializer.deserialize(any())).doReturn(
-            KeyValuePairList(mutableListOf(
-                KeyValuePair(EPOCH_KEY, EPOCH.toString()),
-                KeyValuePair("corda.notary.service.5.name", KNOWN_NOTARY_SERVICE),
-                KeyValuePair("corda.notary.service.5.plugin", KNOWN_NOTARY_PLUGIN),
-                KeyValuePair("corda.notary.service.5.keys.0", "test-key")
-            ))
-        )
+        val mockGroupParameters = KeyValuePairList(mutableListOf(
+            KeyValuePair(EPOCH_KEY, EPOCH.toString()),
+            KeyValuePair("corda.notary.service.5.name", KNOWN_NOTARY_SERVICE),
+            KeyValuePair("corda.notary.service.5.plugin", KNOWN_NOTARY_PLUGIN),
+            KeyValuePair("corda.notary.service.5.keys.0", "test-key")
+        ))
+        whenever(keyValuePairListDeserializer.deserialize(any())).doReturn(mockGroupParameters)
 
         val result = handler.invoke(requestContext, request)
         verify(entityManagerFactory).createEntityManager()
@@ -323,7 +322,7 @@ class AddNotaryToGroupParametersHandlerTest {
         verify(entityManager).transaction
         verify(registry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(entityManager, times(0)).persist(any())
-        assertThat(result).isEqualTo(PersistGroupParametersResponse(EPOCH))
+        assertThat(result).isEqualTo(PersistGroupParametersResponse(mockGroupParameters))
     }
 
     @Test

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
@@ -110,17 +110,18 @@ class PersistGroupParametersHandlerTest {
         val context = mock<MembershipRequestContext> {
             on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
         }
-        val request = mock<PersistGroupParameters> {
-            on { groupParameters } doReturn KeyValuePairList(
-                listOf(
-                    KeyValuePair(EPOCH_KEY, "5")
-                )
+        val mockGroupParameters = KeyValuePairList(
+            listOf(
+                KeyValuePair(EPOCH_KEY, "5")
             )
+        )
+        val request = mock<PersistGroupParameters> {
+            on { groupParameters } doReturn mockGroupParameters
         }
 
         val result = handler.invoke(context, request)
 
-        assertThat(result).isEqualTo(PersistGroupParametersResponse(5))
+        assertThat(result).isEqualTo(PersistGroupParametersResponse(mockGroupParameters))
     }
 
     @Test

--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation project(":components:crypto:crypto-client")
     implementation project(":components:crypto:crypto-client-hsm")
     implementation project(':components:crypto:crypto-hes')
+    implementation project(":components:membership:group-params-writer-service")
     implementation project(":components:membership:group-policy")
     implementation project(":components:membership:membership-group-read")
     implementation project(":components:membership:membership-persistence-client")

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
@@ -17,6 +17,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipQueryClient
@@ -63,6 +64,8 @@ class RegistrationManagementServiceImpl @Activate constructor(
     private val cipherSchemeMetadata: CipherSchemeMetadata,
     @Reference(service = MerkleTreeProvider::class)
     private val merkleTreeProvider: MerkleTreeProvider,
+    @Reference(service = GroupParametersWriterService::class)
+    private val groupParametersWriterService: GroupParametersWriterService,
 ) : RegistrationManagementService {
 
     companion object {
@@ -165,6 +168,7 @@ class RegistrationManagementServiceImpl @Activate constructor(
                         cipherSchemeMetadata,
                         merkleTreeProvider,
                         membershipConfig,
+                        groupParametersWriterService,
                     ),
                     messagingConfig
                 ).also {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
@@ -18,6 +18,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipQueryClient
@@ -66,6 +67,8 @@ class RegistrationManagementServiceImpl @Activate constructor(
     private val merkleTreeProvider: MerkleTreeProvider,
     @Reference(service = GroupParametersWriterService::class)
     private val groupParametersWriterService: GroupParametersWriterService,
+    @Reference(service = GroupParametersFactory::class)
+    private val groupParametersFactory: GroupParametersFactory,
 ) : RegistrationManagementService {
 
     companion object {
@@ -169,6 +172,7 @@ class RegistrationManagementServiceImpl @Activate constructor(
                         merkleTreeProvider,
                         membershipConfig,
                         groupParametersWriterService,
+                        groupParametersFactory,
                     ),
                     messagingConfig
                 ).also {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -26,6 +26,7 @@ import net.corda.membership.impl.registration.dynamic.handler.mgm.DistributeMemb
 import net.corda.membership.impl.registration.dynamic.handler.mgm.ProcessMemberVerificationResponseHandler
 import net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.mgm.VerifyMemberHandler
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipQueryClient
@@ -50,6 +51,7 @@ class RegistrationProcessor(
     merkleTreeProvider: MerkleTreeProvider,
     membershipConfig: SmartConfig,
     groupParametersWriterService: GroupParametersWriterService,
+    groupParametersFactory: GroupParametersFactory,
 ) : StateAndEventProcessor<String, RegistrationState, RegistrationCommand> {
 
     override val keyClass = String::class.java
@@ -77,6 +79,8 @@ class RegistrationProcessor(
             cordaAvroSerializationFactory,
             memberTypeChecker,
             membershipGroupReaderProvider,
+            groupParametersWriterService,
+            groupParametersFactory,
         ),
         DistributeMembershipPackage::class.java to DistributeMembershipPackageHandler(
             membershipQueryClient,
@@ -87,7 +91,6 @@ class RegistrationProcessor(
             merkleTreeProvider,
             membershipConfig,
             membershipGroupReaderProvider,
-            groupParametersWriterService,
         ),
         DeclineRegistration::class.java to DeclineRegistrationHandler(
             membershipPersistenceClient,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -13,6 +13,7 @@ import net.corda.data.membership.command.registration.mgm.StartRegistration
 import net.corda.data.membership.command.registration.mgm.VerifyMember
 import net.corda.data.membership.state.RegistrationState
 import net.corda.libs.configuration.SmartConfig
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
@@ -48,6 +49,7 @@ class RegistrationProcessor(
     cipherSchemeMetadata: CipherSchemeMetadata,
     merkleTreeProvider: MerkleTreeProvider,
     membershipConfig: SmartConfig,
+    groupParametersWriterService: GroupParametersWriterService,
 ) : StateAndEventProcessor<String, RegistrationState, RegistrationCommand> {
 
     override val keyClass = String::class.java
@@ -85,6 +87,7 @@ class RegistrationProcessor(
             merkleTreeProvider,
             membershipConfig,
             membershipGroupReaderProvider,
+            groupParametersWriterService,
         ),
         DeclineRegistration::class.java to DeclineRegistrationHandler(
             membershipPersistenceClient,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -1,78 +1,45 @@
 package net.corda.membership.impl.registration.dynamic.handler.mgm
 
-import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.ApproveRegistration
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
+import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
 import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.p2p.DistributionType
-import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.layeredpropertymap.toAvro
-import net.corda.libs.configuration.SmartConfig
 import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
-import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
-import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
 import net.corda.membership.lib.MemberInfoExtension.Companion.notaryDetails
-import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
-import net.corda.membership.p2p.helpers.MembershipPackageFactory
-import net.corda.membership.p2p.helpers.MerkleTreeGenerator
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
-import net.corda.membership.p2p.helpers.P2pRecordsFactory.Companion.getTtlMinutes
-import net.corda.membership.p2p.helpers.SignerFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
-import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
-import net.corda.schema.configuration.MembershipConfig.TtlsConfig.MEMBERS_PACKAGE_UPDATE
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.cipher.suite.CipherSchemeMetadata
-import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
-import net.corda.v5.membership.MemberInfo
-import net.corda.virtualnode.HoldingIdentity
-import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
-import java.util.UUID
 
 @Suppress("LongParameterList")
 internal class ApproveRegistrationHandler(
     private val membershipPersistenceClient: MembershipPersistenceClient,
-    private val membershipQueryClient: MembershipQueryClient,
-    cipherSchemeMetadata: CipherSchemeMetadata,
     clock: Clock,
-    cryptoOpsClient: CryptoOpsClient,
     cordaAvroSerializationFactory: CordaAvroSerializationFactory,
-    merkleTreeProvider: MerkleTreeProvider,
     private val memberTypeChecker: MemberTypeChecker,
-    private val membershipConfig: SmartConfig,
-    private val signerFactory: SignerFactory = SignerFactory(cryptoOpsClient),
-    private val merkleTreeGenerator: MerkleTreeGenerator = MerkleTreeGenerator(
-        merkleTreeProvider,
-        cordaAvroSerializationFactory
-    ),
+    private val groupReaderProvider: MembershipGroupReaderProvider,
     private val p2pRecordsFactory: P2pRecordsFactory = P2pRecordsFactory(
         cordaAvroSerializationFactory,
         clock,
     ),
-    private val membershipPackageFactory: MembershipPackageFactory = MembershipPackageFactory(
-        clock,
-        cordaAvroSerializationFactory,
-        cipherSchemeMetadata,
-        DistributionType.STANDARD,
-        merkleTreeGenerator,
-    ) { UUID.randomUUID().toString() }
 ) : RegistrationHandler<ApproveRegistration> {
     private companion object {
         val logger = contextLogger()
@@ -104,11 +71,29 @@ internal class ApproveRegistrationHandler(
             )
             val memberInfo = persistState.getOrThrow()
 
-            val allMembers = getAllMembers(approvedBy.toCorda())
-            val members = allMembers.filter {
-                it.status == MEMBER_STATUS_ACTIVE && !it.isMgm
+            // If approved member has notary role set, add notary to MGM's view of the group parameters.
+            val newEpoch = memberInfo.notaryDetails
+                ?.let { membershipPersistenceClient.addNotaryToGroupParameters(mgm.holdingIdentity, memberInfo) }
+                ?.run {
+                    if (this is MembershipPersistenceResult.Failure) {
+                        throw MembershipPersistenceException("Failed to update group parameters with notary information of" +
+                                " '${memberInfo.name}', which has role set to 'notary'.")
+                    }
+                    getOrThrow()
+                }
+
+            // If approved member is not a notary, retrieve epoch of current group parameters from the group reader.
+            val epochForDistribution = if (newEpoch != null) {
+                newEpoch
+            } else {
+                val reader = groupReaderProvider.getGroupReader(approvedBy.toCorda())
+                reader.groupParameters.epoch
             }
-            val membershipPackageFactory = createMembershipPackageFactory(mgm, members)
+            val distributionCommand = Record(
+                REGISTRATION_COMMAND_TOPIC,
+                "$registrationId-${approvedBy.toCorda().shortHash}",
+                RegistrationCommand(DistributeMembershipPackage(epochForDistribution)),
+            )
 
             // Push member to member list kafka topic
             val persistentMemberInfo = PersistentMemberInfo.newBuilder()
@@ -122,27 +107,6 @@ internal class ApproveRegistrationHandler(
                 value = persistentMemberInfo,
             )
 
-            // Send all approved members from the same group to the newly approved member over P2P
-            val allMembersPackage = membershipPackageFactory.invoke(members)
-            val allMembersToNewMember = p2pRecordsFactory.createAuthenticatedMessageRecord(
-                source = approvedBy,
-                destination = approvedMember,
-                content = allMembersPackage,
-            )
-
-            // Send the newly approved member to all other members in the same group over P2P
-            val memberPackage = membershipPackageFactory.invoke(listOf(memberInfo))
-            val memberToAllMembers = members.filter {
-                it.holdingIdentity != approvedMember.toCorda()
-            }.map { memberToSendUpdateTo ->
-                p2pRecordsFactory.createAuthenticatedMessageRecord(
-                    source = approvedBy,
-                    destination = memberToSendUpdateTo.holdingIdentity.toAvro(),
-                    content = memberPackage,
-                    minutesToWait = membershipConfig.getTtlMinutes(MEMBERS_PACKAGE_UPDATE),
-                )
-            }
-
             val persistApproveMessage = p2pRecordsFactory.createAuthenticatedMessageRecord(
                 source = approvedBy,
                 destination = approvedMember,
@@ -152,17 +116,7 @@ internal class ApproveRegistrationHandler(
                 )
             )
 
-            // If approved member has notary role set, add notary to MGM's view of the group parameters.
-            memberInfo.notaryDetails
-                ?.let { membershipPersistenceClient.addNotaryToGroupParameters(mgm.holdingIdentity, memberInfo) }
-                ?.apply {
-                    if (this is MembershipPersistenceResult.Failure) {
-                        throw MembershipPersistenceException("Failed to update group parameters with notary information of" +
-                            " '${memberInfo.name}', which has role set to 'notary'.")
-                    }
-                }
-
-            memberToAllMembers + memberRecord + allMembersToNewMember + persistApproveMessage
+            listOf(memberRecord, persistApproveMessage, distributionCommand)
         } catch (e: Exception) {
             logger.warn("Could not approve registration request: '$registrationId'", e)
             listOf(
@@ -180,33 +134,5 @@ internal class ApproveRegistrationHandler(
             RegistrationState(registrationId, approvedMember, approvedBy),
             messages
         )
-    }
-
-    private fun createMembershipPackageFactory(
-        mgm: MemberInfo,
-        members: Collection<MemberInfo>
-    ): (Collection<MemberInfo>) -> MembershipPackage {
-        val mgmSigner = signerFactory.createSigner(mgm)
-        val signatures = membershipQueryClient
-            .queryMembersSignatures(
-                mgm.holdingIdentity,
-                members.map {
-                    it.holdingIdentity
-                }
-            ).getOrThrow()
-        val membersTree = merkleTreeGenerator.generateTree(members)
-
-        return {
-            membershipPackageFactory.createMembershipPackage(
-                mgmSigner,
-                signatures,
-                it,
-                membersTree.root,
-            )
-        }
-    }
-
-    private fun getAllMembers(owner: HoldingIdentity): Collection<MemberInfo> {
-        return membershipQueryClient.queryMemberInfo(owner).getOrThrow()
     }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -14,9 +14,11 @@ import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
+import net.corda.membership.lib.EPOCH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.membership.lib.MemberInfoExtension.Companion.notaryDetails
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
+import net.corda.membership.lib.toMap
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
@@ -81,7 +83,9 @@ internal class ApproveRegistrationHandler(
                                 " '${memberInfo.name}', which has role set to 'notary'."
                     )
                 }
-                result.getOrThrow()
+                val parametersMap = result.getOrThrow().toMap()
+                parametersMap[EPOCH_KEY]?.toInt()
+                    ?: throw CordaRuntimeException("Failed to get epoch of persisted group parameters.")
             } else {
                 val reader = groupReaderProvider.getGroupReader(approvedBy.toCorda())
                 reader.groupParameters.epoch

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -85,11 +85,10 @@ internal class ApproveRegistrationHandler(
                 }
                 val parametersMap = result.getOrThrow().toMap()
                 parametersMap[EPOCH_KEY]?.toInt()
-                    ?: throw CordaRuntimeException("Failed to get epoch of persisted group parameters.")
             } else {
                 val reader = groupReaderProvider.getGroupReader(approvedBy.toCorda())
-                reader.groupParameters.epoch
-            }
+                reader.groupParameters?.epoch
+            } ?: throw CordaRuntimeException("Failed to get epoch of persisted group parameters.")
 
             val distributionCommand = Record(
                 REGISTRATION_COMMAND_TOPIC,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
@@ -7,7 +7,6 @@ import net.corda.data.membership.p2p.DistributionType
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.state.RegistrationState
 import net.corda.libs.configuration.SmartConfig
-import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
@@ -45,7 +44,6 @@ class DistributeMembershipPackageHandler(
     merkleTreeProvider: MerkleTreeProvider,
     private val membershipConfig: SmartConfig,
     private val groupReaderProvider: MembershipGroupReaderProvider,
-    private val groupParametersWriterService: GroupParametersWriterService,
     private val signerFactory: SignerFactory = SignerFactory(cryptoOpsClient),
     private val merkleTreeGenerator: MerkleTreeGenerator = MerkleTreeGenerator(
         merkleTreeProvider,
@@ -119,11 +117,6 @@ class DistributeMembershipPackageHandler(
                     content = memberPackage,
                     minutesToWait = membershipConfig.getTtlMinutes(MembershipConfig.TtlsConfig.MEMBERS_PACKAGE_UPDATE),
                 )
-            }
-
-            // Publish group parameters to Kafka for the newly approved member and all other members
-            (members + approvedMemberInfo).forEach {
-                groupParametersWriterService.put(it.holdingIdentity, groupParameters)
             }
 
             memberToAllMembers + allMembersToNewMember

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
@@ -2,8 +2,6 @@ package net.corda.membership.impl.registration.dynamic.handler.mgm
 
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.CordaAvroSerializationFactory
-import net.corda.data.membership.command.registration.RegistrationCommand
-import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
 import net.corda.data.membership.p2p.DistributionType
 import net.corda.data.membership.p2p.MembershipPackage
@@ -123,16 +121,9 @@ class DistributeMembershipPackageHandler(
 
             memberToAllMembers + allMembersToNewMember
         } catch (e: Exception) {
-            logger.warn("Could not approve registration request: '$registrationId'", e)
-            listOf(
-                Record(
-                    REGISTRATION_COMMAND_TOPIC,
-                    key,
-                    RegistrationCommand(
-                        DeclineRegistration(e.message)
-                    )
-                ),
-            )
+            logger.warn("Could not distribute membership packages after registration request: '$registrationId' was approved. " +
+                        "Distribution will be reattempted.", e)
+            listOf(Record(REGISTRATION_COMMAND_TOPIC, key, command))
         }
 
         return RegistrationHandlerResult(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
@@ -1,0 +1,168 @@
+package net.corda.membership.impl.registration.dynamic.handler.mgm
+
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.membership.command.registration.RegistrationCommand
+import net.corda.data.membership.command.registration.mgm.DeclineRegistration
+import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
+import net.corda.data.membership.p2p.DistributionType
+import net.corda.data.membership.p2p.MembershipPackage
+import net.corda.data.membership.state.RegistrationState
+import net.corda.libs.configuration.SmartConfig
+import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
+import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
+import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
+import net.corda.membership.lib.MemberInfoExtension
+import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
+import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
+import net.corda.membership.lib.MemberInfoExtension.Companion.status
+import net.corda.membership.p2p.helpers.MembershipPackageFactory
+import net.corda.membership.p2p.helpers.MerkleTreeGenerator
+import net.corda.membership.p2p.helpers.P2pRecordsFactory
+import net.corda.membership.p2p.helpers.P2pRecordsFactory.Companion.getTtlMinutes
+import net.corda.membership.p2p.helpers.SignerFactory
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
+import net.corda.schema.configuration.MembershipConfig
+import net.corda.utilities.time.Clock
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.cipher.suite.CipherSchemeMetadata
+import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.v5.membership.GroupParameters
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.toAvro
+import net.corda.virtualnode.toCorda
+import java.util.UUID
+
+@Suppress("LongParameterList")
+class DistributeMembershipPackageHandler(
+    private val membershipQueryClient: MembershipQueryClient,
+    cipherSchemeMetadata: CipherSchemeMetadata,
+    clock: Clock,
+    cryptoOpsClient: CryptoOpsClient,
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    merkleTreeProvider: MerkleTreeProvider,
+    private val membershipConfig: SmartConfig,
+    private val groupReaderProvider: MembershipGroupReaderProvider,
+    private val signerFactory: SignerFactory = SignerFactory(cryptoOpsClient),
+    private val merkleTreeGenerator: MerkleTreeGenerator = MerkleTreeGenerator(
+        merkleTreeProvider,
+        cordaAvroSerializationFactory
+    ),
+    private val p2pRecordsFactory: P2pRecordsFactory = P2pRecordsFactory(
+        cordaAvroSerializationFactory,
+        clock,
+    ),
+    private val membershipPackageFactory: MembershipPackageFactory = MembershipPackageFactory(
+        clock,
+        cordaAvroSerializationFactory,
+        cipherSchemeMetadata,
+        DistributionType.STANDARD,
+        merkleTreeGenerator,
+    ) { UUID.randomUUID().toString() }
+) : RegistrationHandler<DistributeMembershipPackage> {
+    private companion object {
+        val logger = contextLogger()
+    }
+
+    override val commandType = DistributeMembershipPackage::class.java
+
+    override fun invoke(
+        state: RegistrationState?,
+        key: String,
+        command: DistributeMembershipPackage
+    ): RegistrationHandlerResult {
+        if (state == null) throw MissingRegistrationStateException
+        val approvedBy = state.mgm
+        val approvedMember = state.registeringMember
+        val registrationId = state.registrationId
+
+        val groupReader = groupReaderProvider.getGroupReader(approvedBy.toCorda())
+
+        // Verify that the group parameters from the reader are the ones persisted during registration approval.
+        // If not, republish the distribute command to be processed later when the updated set of group parameters
+        // is available.
+        val groupParameters = groupReader.groupParameters.apply {
+            if (epoch != command.groupParametersEpoch) {
+                return RegistrationHandlerResult(state, listOf(Record(REGISTRATION_COMMAND_TOPIC, key, command)))
+            }
+        }
+
+        val messages = try {
+            val allMembers = groupReader.lookup()
+            val members = allMembers.filter {
+                it.status == MemberInfoExtension.MEMBER_STATUS_ACTIVE && !it.isMgm
+            }
+            val approvedMemberInfo = members.first { it.name.toString() == approvedMember.x500Name }
+            val mgm = allMembers.first { it.isMgm }
+
+            val membershipPackageFactory = createMembershipPackageFactory(mgm, members)
+
+            // Send all approved members from the same group to the newly approved member over P2P
+            val allMembersPackage = membershipPackageFactory.invoke(members, groupParameters)
+            val allMembersToNewMember = p2pRecordsFactory.createAuthenticatedMessageRecord(
+                source = approvedBy,
+                destination = approvedMember,
+                content = allMembersPackage,
+            )
+
+            // Send the newly approved member to all other members in the same group over P2P
+            val memberPackage = membershipPackageFactory.invoke(listOf(approvedMemberInfo), groupParameters)
+            val memberToAllMembers = members.filter {
+                it.holdingIdentity != approvedMember.toCorda()
+            }.map { memberToSendUpdateTo ->
+                p2pRecordsFactory.createAuthenticatedMessageRecord(
+                    source = approvedBy,
+                    destination = memberToSendUpdateTo.holdingIdentity.toAvro(),
+                    content = memberPackage,
+                    minutesToWait = membershipConfig.getTtlMinutes(MembershipConfig.TtlsConfig.MEMBERS_PACKAGE_UPDATE),
+                )
+            }
+
+            memberToAllMembers + allMembersToNewMember
+        } catch (e: Exception) {
+            logger.warn("Could not approve registration request: '$registrationId'", e)
+            listOf(
+                Record(
+                    REGISTRATION_COMMAND_TOPIC,
+                    key,
+                    RegistrationCommand(
+                        DeclineRegistration(e.message)
+                    )
+                ),
+            )
+        }
+
+        return RegistrationHandlerResult(
+            RegistrationState(registrationId, approvedMember, approvedBy),
+            messages
+        )
+    }
+
+    private fun createMembershipPackageFactory(
+        mgm: MemberInfo,
+        members: Collection<MemberInfo>
+    ): (Collection<MemberInfo>, GroupParameters) -> MembershipPackage {
+        val mgmSigner = signerFactory.createSigner(mgm)
+        val signatures = membershipQueryClient
+            .queryMembersSignatures(
+                mgm.holdingIdentity,
+                members.map {
+                    it.holdingIdentity
+                }
+            ).getOrThrow()
+        val membersTree = merkleTreeGenerator.generateTree(members)
+
+        return { membersToSend, groupParameters ->
+            membershipPackageFactory.createMembershipPackage(
+                mgmSigner,
+                signatures,
+                membersToSend,
+                membersTree.root,
+                groupParameters,
+            )
+        }
+    }
+}

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandler.kt
@@ -1,8 +1,6 @@
 package net.corda.membership.impl.registration.dynamic.mgm
 
 import net.corda.layeredpropertymap.LayeredPropertyMapFactory
-import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
-import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.v5.base.exceptions.CordaRuntimeException
@@ -12,8 +10,6 @@ import net.corda.virtualnode.HoldingIdentity
 internal class MGMRegistrationGroupPolicyHandler(
     private val layeredPropertyMapFactory: LayeredPropertyMapFactory,
     private val membershipPersistenceClient: MembershipPersistenceClient,
-    private val groupParametersWriterService: GroupParametersWriterService,
-    private val groupParametersFactory: GroupParametersFactory,
 ) {
 
     fun buildAndPersist(
@@ -35,19 +31,6 @@ internal class MGMRegistrationGroupPolicyHandler(
                 "Registration failed, persistence error. Reason: ${groupPolicyPersistenceResult.errorMsg}"
             )
         }
-
-        // Persist group parameters snapshot
-        val groupParametersPersistenceResult =
-            membershipPersistenceClient.persistGroupParametersInitialSnapshot(holdingIdentity)
-        if (groupParametersPersistenceResult is MembershipPersistenceResult.Failure) {
-            throw MGMRegistrationGroupPolicyHandlingException(
-                "Registration failed, persistence error. Reason: ${groupParametersPersistenceResult.errorMsg}"
-            )
-        }
-
-        // Publish group parameters to Kafka
-        val groupParameters = groupParametersFactory.create(groupParametersPersistenceResult.getOrThrow())
-        groupParametersWriterService.put(holdingIdentity, groupParameters)
 
         return groupPolicy
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -17,6 +17,8 @@ import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
@@ -65,7 +67,11 @@ class MGMRegistrationService @Activate constructor(
     @Reference(service = PlatformInfoProvider::class)
     private val platformInfoProvider: PlatformInfoProvider,
     @Reference(service = VirtualNodeInfoReadService::class)
-    private val virtualNodeInfoReadService: VirtualNodeInfoReadService
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
+    @Reference(service = GroupParametersWriterService::class)
+    private val groupParametersWriterService: GroupParametersWriterService,
+    @Reference(service = GroupParametersFactory::class)
+    private val groupParametersFactory: GroupParametersFactory,
 ) : MemberRegistrationService {
     /**
      * Private interface used for implementation swapping in response to lifecycle events.
@@ -162,7 +168,9 @@ class MGMRegistrationService @Activate constructor(
         )
         private val mgmRegistrationGroupPolicyHandler = MGMRegistrationGroupPolicyHandler(
             layeredPropertyMapFactory,
-            membershipPersistenceClient
+            membershipPersistenceClient,
+            groupParametersWriterService,
+            groupParametersFactory,
         )
         private val mgmRegistrationOutputPublisher = MGMRegistrationOutputPublisher { publisher }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceTest.kt
@@ -108,6 +108,7 @@ class RegistrationManagementServiceTest {
             mock(),
             mock(),
             mock(),
+            mock(),
         )
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceTest.kt
@@ -107,6 +107,7 @@ class RegistrationManagementServiceTest {
             mock(),
             mock(),
             mock(),
+            mock(),
         )
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
@@ -193,6 +193,7 @@ class RegistrationProcessorTest {
             mock(),
             mock(),
             mock(),
+            mock(),
         )
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
@@ -192,6 +192,7 @@ class RegistrationProcessorTest {
             mock(),
             mock(),
             mock(),
+            mock(),
         )
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/TestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/TestUtils.kt
@@ -1,0 +1,60 @@
+package net.corda.membership.impl.registration.dynamic.handler
+
+import net.corda.membership.lib.MemberInfoExtension
+import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
+import net.corda.membership.lib.notary.MemberNotaryDetails
+import net.corda.test.util.identity.createTestHoldingIdentity
+import net.corda.v5.base.util.parse
+import net.corda.v5.membership.MGMContext
+import net.corda.v5.membership.MemberContext
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+object TestUtils {
+    private const val GROUP_ID = "group"
+
+    internal fun mockMemberInfo(
+        holdingIdentity: HoldingIdentity,
+        isMgm: Boolean = false,
+        status: String = MemberInfoExtension.MEMBER_STATUS_ACTIVE,
+        isNotary: Boolean = false,
+    ): MemberInfo {
+        val mgmContext = mock<MGMContext> {
+            on { parseOrNull(eq(MemberInfoExtension.IS_MGM), any<Class<Boolean>>()) } doReturn isMgm
+            on { parse(eq(MemberInfoExtension.STATUS), any<Class<String>>()) } doReturn status
+            on { entries } doReturn mapOf("mgm" to holdingIdentity.x500Name.toString()).entries
+        }
+        val memberContext = mock<MemberContext> {
+            on { parse(eq(MemberInfoExtension.GROUP_ID), any<Class<String>>()) } doReturn holdingIdentity.groupId
+            if (isNotary) {
+                on { entries } doReturn mapOf(
+                    "member" to holdingIdentity.x500Name.toString(),
+                    "${MemberInfoExtension.ROLES_PREFIX}.0" to "notary",
+                ).entries
+                val notaryDetails = MemberNotaryDetails(
+                    holdingIdentity.x500Name,
+                    "Notary Plugin A",
+                    listOf(mock())
+                )
+                whenever(mock.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+            } else {
+                on { entries } doReturn mapOf("member" to holdingIdentity.x500Name.toString()).entries
+            }
+        }
+        return mock {
+            on { mgmProvidedContext } doReturn mgmContext
+            on { memberProvidedContext } doReturn memberContext
+            on { name } doReturn holdingIdentity.x500Name
+            on { groupId } doReturn holdingIdentity.groupId
+        }
+    }
+
+    internal fun createHoldingIdentity(name: String): HoldingIdentity {
+        return createTestHoldingIdentity("C=GB,L=London,O=$name", GROUP_ID)
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
@@ -77,7 +77,12 @@ class ApproveRegistrationHandlerTest {
                 registrationId
             )
         } doReturn MembershipPersistenceResult.Success(notaryInfo)
-        on { addNotaryToGroupParameters(mgm.holdingIdentity, notaryInfo) } doReturn MembershipPersistenceResult.Success(mockGroupParametersList)
+        on {
+            addNotaryToGroupParameters(
+                mgm.holdingIdentity,
+                notaryInfo
+            )
+        } doReturn MembershipPersistenceResult.Success(mockGroupParametersList)
     }
     private val clock = TestClock(Instant.ofEpochMilli(0))
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
@@ -1,75 +1,43 @@
 package net.corda.membership.impl.registration.dynamic.handler.mgm
 
-import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
-import net.corda.data.KeyValuePairList
-import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.ApproveRegistration
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import net.corda.data.membership.state.RegistrationState
-import net.corda.libs.configuration.SmartConfig
 import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
-import net.corda.membership.lib.MemberInfoExtension
-import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
-import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
-import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
-import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
-import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
+import net.corda.membership.impl.registration.dynamic.handler.TestUtils.createHoldingIdentity
+import net.corda.membership.impl.registration.dynamic.handler.TestUtils.mockMemberInfo
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
-import net.corda.membership.lib.notary.MemberNotaryDetails
-import net.corda.membership.p2p.helpers.MembershipPackageFactory
-import net.corda.membership.p2p.helpers.MerkleTreeGenerator
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
-import net.corda.membership.p2p.helpers.Signer
-import net.corda.membership.p2p.helpers.SignerFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
-import net.corda.membership.persistence.client.MembershipQueryClient
-import net.corda.membership.persistence.client.MembershipQueryResult
+import net.corda.membership.read.MembershipGroupReader
+import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.records.Record
 import net.corda.p2p.app.AppMessage
 import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
-import net.corda.schema.configuration.MembershipConfig.TtlsConfig.MEMBERS_PACKAGE_UPDATE
-import net.corda.schema.configuration.MembershipConfig.TtlsConfig.TTLS
-import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
-import net.corda.v5.base.util.parse
-import net.corda.v5.cipher.suite.CipherSchemeMetadata
-import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
-import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.merkle.MerkleTree
-import net.corda.v5.membership.MGMContext
-import net.corda.v5.membership.MemberContext
-import net.corda.v5.membership.MemberInfo
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argThat
-import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.nio.ByteBuffer
 import java.time.Instant
 
 class ApproveRegistrationHandlerTest {
-    private companion object {
-        const val GROUP_ID = "group"
-    }
     private val owner = createHoldingIdentity("owner")
     private val member = createHoldingIdentity("member")
     private val notary = createHoldingIdentity("notary")
@@ -79,18 +47,10 @@ class ApproveRegistrationHandlerTest {
     private val key = "key"
     private val memberInfo = mockMemberInfo(member)
     private val notaryInfo = mockMemberInfo(notary, isNotary = true)
-    private val inactiveMember = mockMemberInfo(
-        createHoldingIdentity("inactive"),
-        status = MEMBER_STATUS_SUSPENDED
-    )
     private val mgm = mockMemberInfo(
         createHoldingIdentity("mgm"),
         isMgm = true,
     )
-    private val allActiveMembers = (1..3).map {
-        mockMemberInfo(createHoldingIdentity("member-$it"))
-    } + memberInfo + mgm
-    private val activeMembersWithoutMgm = allActiveMembers - mgm
     private val membershipPersistenceClient = mock<MembershipPersistenceClient> {
         on {
             setMemberAndRegistrationRequestAsApproved(
@@ -108,37 +68,8 @@ class ApproveRegistrationHandlerTest {
         } doReturn MembershipPersistenceResult.Success(notaryInfo)
         on { addNotaryToGroupParameters(mgm.holdingIdentity, notaryInfo) } doReturn mock()
     }
-    private val signatures = activeMembersWithoutMgm.associate {
-        val name = it.name.toString()
-        it.holdingIdentity to CryptoSignatureWithKey(
-            ByteBuffer.wrap("pk-$name".toByteArray()),
-            ByteBuffer.wrap("sig-$name".toByteArray()),
-            KeyValuePairList(
-                listOf(
-                    KeyValuePair("name", name)
-                )
-            )
-        )
-    }
-    private val membershipQueryClient = mock<MembershipQueryClient> {
-        on { queryMemberInfo(owner) } doReturn MembershipQueryResult.Success(allActiveMembers + inactiveMember)
-        on {
-            queryMembersSignatures(
-                mgm.holdingIdentity,
-                activeMembersWithoutMgm.map { it.holdingIdentity },
-            )
-        } doReturn MembershipQueryResult.Success(
-            signatures
-        )
-    }
-    private val cipherSchemeMetadata = mock<CipherSchemeMetadata>()
     private val clock = TestClock(Instant.ofEpochMilli(0))
-    private val cryptoOpsClient = mock<CryptoOpsClient>()
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>()
-    private val signer = mock<Signer>()
-    private val signerFactory = mock<SignerFactory> {
-        on { createSigner(mgm) } doReturn signer
-    }
     private val record = mock<Record<String, AppMessage>>()
     private val p2pRecordsFactory = mock<P2pRecordsFactory> {
         on {
@@ -151,45 +82,24 @@ class ApproveRegistrationHandlerTest {
             )
         } doReturn record
     }
-    private val checkHash = mock<SecureHash>()
-    private val merkleTree = mock<MerkleTree> {
-        on { root } doReturn checkHash
-    }
-    private val merkleTreeProvider = mock<MerkleTreeProvider>()
-    private val merkleTreeGenerator = mock<MerkleTreeGenerator> {
-        on { generateTree(any()) } doReturn merkleTree
-    }
-    private val membershipPackage = mock<MembershipPackage>()
-    private val membershipPackageFactory = mock<MembershipPackageFactory> {
-        on {
-            createMembershipPackage(
-                eq(signer),
-                eq(signatures),
-                any(),
-                any(),
-            )
-        } doReturn membershipPackage
-    }
-    private val config = mock<SmartConfig>()
     private val memberTypeChecker = mock<MemberTypeChecker> {
         on { isMgm(member.toAvro()) } doReturn false
         on { getMgmMemberInfo(owner) } doReturn mgm
     }
+    private val groupReader: MembershipGroupReader = mock {
+        on { groupParameters } doReturn mock()
+    }
+    private val groupReaderProvider: MembershipGroupReaderProvider = mock {
+        on { getGroupReader(any()) } doReturn groupReader
+    }
 
     private val handler = ApproveRegistrationHandler(
         membershipPersistenceClient,
-        membershipQueryClient,
-        cipherSchemeMetadata,
         clock,
-        cryptoOpsClient,
         cordaAvroSerializationFactory,
-        merkleTreeProvider,
         memberTypeChecker,
-        config,
-        signerFactory,
-        merkleTreeGenerator,
+        groupReaderProvider,
         p2pRecordsFactory,
-        membershipPackageFactory,
     )
 
     @Test
@@ -218,74 +128,6 @@ class ApproveRegistrationHandlerTest {
                     )
                 )
             }
-    }
-
-    @Test
-    fun `invoke return all approved members over P2P`() {
-        val allMembershipPackage = mock<MembershipPackage>()
-        whenever(
-            membershipPackageFactory.createMembershipPackage(
-                signer,
-                signatures,
-                activeMembersWithoutMgm,
-                checkHash,
-            )
-        ).doReturn(allMembershipPackage)
-        val allMemberPackage = mock<Record<String, AppMessage>>()
-        whenever(
-            p2pRecordsFactory.createAuthenticatedMessageRecord(
-                eq(owner.toAvro()),
-                eq(member.toAvro()),
-                eq(allMembershipPackage),
-                anyOrNull(),
-                any(),
-            )
-        ).doReturn(allMemberPackage)
-
-        val reply = handler.invoke(state, key, command)
-
-        assertThat(reply.outputStates).contains(allMemberPackage)
-    }
-
-    @Test
-    fun `invoke sends the newly approved member to all other members over P2P`() {
-        val memberPackage = mock<MembershipPackage>()
-        whenever(
-            membershipPackageFactory.createMembershipPackage(
-                eq(signer),
-                eq(signatures),
-                argThat {
-                    this.size == 1
-                },
-                eq(checkHash),
-            )
-        ).doReturn(memberPackage)
-        val membersRecord = (activeMembersWithoutMgm - memberInfo).map {
-            val record = mock<Record<String, AppMessage>>()
-            val ownerAvro = owner.toAvro()
-            val memberAvro = it.holdingIdentity.toAvro()
-            whenever(
-                p2pRecordsFactory.createAuthenticatedMessageRecord(
-                    eq(ownerAvro),
-                    eq(memberAvro),
-                    eq(memberPackage),
-                    anyOrNull(),
-                    any(),
-                )
-            ).doReturn(record)
-            record
-        }
-
-        val reply = handler.invoke(state, key, command)
-
-        assertThat(reply.outputStates).containsAll(membersRecord)
-    }
-
-    @Test
-    fun `invoke uses the correct TTL configuration`() {
-        handler.invoke(state, key, command)
-
-        verify(config, atLeastOnce()).getIsNull("$TTLS.$MEMBERS_PACKAGE_UPDATE")
     }
 
     @Test
@@ -379,45 +221,5 @@ class ApproveRegistrationHandlerTest {
         assertThrows<MissingRegistrationStateException> {
             handler.invoke(null, key, command)
         }
-    }
-
-    private fun mockMemberInfo(
-        holdingIdentity: HoldingIdentity,
-        isMgm: Boolean = false,
-        status: String = MemberInfoExtension.MEMBER_STATUS_ACTIVE,
-        isNotary: Boolean = false,
-    ): MemberInfo {
-        val mgmContext = mock<MGMContext> {
-            on { parseOrNull(eq(IS_MGM), any<Class<Boolean>>()) } doReturn isMgm
-            on { parse(eq(STATUS), any<Class<String>>()) } doReturn status
-            on { entries } doReturn mapOf("mgm" to holdingIdentity.x500Name.toString()).entries
-        }
-        val memberContext = mock<MemberContext> {
-            on { parse(eq(MemberInfoExtension.GROUP_ID), any<Class<String>>()) } doReturn holdingIdentity.groupId
-            if (isNotary) {
-                on { entries } doReturn mapOf(
-                    "member" to holdingIdentity.x500Name.toString(),
-                    "$ROLES_PREFIX.0" to "notary",
-                ).entries
-                val notaryDetails = MemberNotaryDetails(
-                    holdingIdentity.x500Name,
-                    "Notary Plugin A",
-                    listOf(mock())
-                )
-                whenever(mock.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
-            } else {
-                on { entries } doReturn mapOf("member" to holdingIdentity.x500Name.toString()).entries
-            }
-        }
-        return mock {
-            on { mgmProvidedContext } doReturn mgmContext
-            on { memberProvidedContext } doReturn memberContext
-            on { name } doReturn holdingIdentity.x500Name
-            on { groupId } doReturn holdingIdentity.groupId
-        }
-    }
-
-    private fun createHoldingIdentity(name: String): HoldingIdentity {
-        return createTestHoldingIdentity("C=GB,L=London,O=$name", GROUP_ID)
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
@@ -1,0 +1,258 @@
+package net.corda.membership.impl.registration.dynamic.handler.mgm
+
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.KeyValuePair
+import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureWithKey
+import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
+import net.corda.data.membership.p2p.MembershipPackage
+import net.corda.data.membership.state.RegistrationState
+import net.corda.libs.configuration.SmartConfig
+import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
+import net.corda.membership.impl.registration.dynamic.handler.TestUtils.createHoldingIdentity
+import net.corda.membership.impl.registration.dynamic.handler.TestUtils.mockMemberInfo
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
+import net.corda.membership.p2p.helpers.MembershipPackageFactory
+import net.corda.membership.p2p.helpers.MerkleTreeGenerator
+import net.corda.membership.p2p.helpers.P2pRecordsFactory
+import net.corda.membership.p2p.helpers.Signer
+import net.corda.membership.p2p.helpers.SignerFactory
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.persistence.client.MembershipQueryResult
+import net.corda.membership.read.MembershipGroupReader
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.messaging.api.records.Record
+import net.corda.p2p.app.AppMessage
+import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
+import net.corda.schema.configuration.MembershipConfig.TtlsConfig.MEMBERS_PACKAGE_UPDATE
+import net.corda.schema.configuration.MembershipConfig.TtlsConfig.TTLS
+import net.corda.test.util.time.TestClock
+import net.corda.v5.cipher.suite.CipherSchemeMetadata
+import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.merkle.MerkleTree
+import net.corda.v5.membership.GroupParameters
+import net.corda.virtualnode.toAvro
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.nio.ByteBuffer
+import java.time.Instant
+
+class DistributeMembershipPackageHandlerTest {
+    private companion object {
+        const val EPOCH = 5
+    }
+    private val owner = createHoldingIdentity("owner")
+    private val member = createHoldingIdentity("member")
+    private val registrationId = "registrationID"
+    private val command = DistributeMembershipPackage(EPOCH)
+    private val state = RegistrationState(registrationId, member.toAvro(), owner.toAvro())
+    private val key = "key"
+    private val memberInfo = mockMemberInfo(member)
+    private val inactiveMember = mockMemberInfo(
+        createHoldingIdentity("inactive"),
+        status = MEMBER_STATUS_SUSPENDED
+    )
+    private val mgm = mockMemberInfo(
+        createHoldingIdentity("mgm"),
+        isMgm = true,
+    )
+    private val allActiveMembers = (1..3).map {
+        mockMemberInfo(createHoldingIdentity("member-$it"))
+    } + memberInfo + mgm
+    private val activeMembersWithoutMgm = allActiveMembers - mgm
+    private val signatures = activeMembersWithoutMgm.associate {
+        val name = it.name.toString()
+        it.holdingIdentity to CryptoSignatureWithKey(
+            ByteBuffer.wrap("pk-$name".toByteArray()),
+            ByteBuffer.wrap("sig-$name".toByteArray()),
+            KeyValuePairList(
+                listOf(
+                    KeyValuePair("name", name)
+                )
+            )
+        )
+    }
+    private val membershipQueryClient = mock<MembershipQueryClient> {
+        on { queryMemberInfo(owner) } doReturn MembershipQueryResult.Success(allActiveMembers + inactiveMember)
+        on {
+            queryMembersSignatures(
+                mgm.holdingIdentity,
+                activeMembersWithoutMgm.map { it.holdingIdentity },
+            )
+        } doReturn MembershipQueryResult.Success(
+            signatures
+        )
+    }
+    private val cipherSchemeMetadata = mock<CipherSchemeMetadata>()
+    private val clock = TestClock(Instant.ofEpochMilli(0))
+    private val cryptoOpsClient = mock<CryptoOpsClient>()
+    private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>()
+    private val signer = mock<Signer>()
+    private val signerFactory = mock<SignerFactory> {
+        on { createSigner(mgm) } doReturn signer
+    }
+    private val record = mock<Record<String, AppMessage>>()
+    private val p2pRecordsFactory = mock<P2pRecordsFactory> {
+        on {
+            createAuthenticatedMessageRecord(
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                any(),
+            )
+        } doReturn record
+    }
+    private val checkHash = mock<SecureHash>()
+    private val merkleTree = mock<MerkleTree> {
+        on { root } doReturn checkHash
+    }
+    private val merkleTreeProvider = mock<MerkleTreeProvider>()
+    private val merkleTreeGenerator = mock<MerkleTreeGenerator> {
+        on { generateTree(any()) } doReturn merkleTree
+    }
+    private val membershipPackage = mock<MembershipPackage>()
+    private val membershipPackageFactory = mock<MembershipPackageFactory> {
+        on {
+            createMembershipPackage(
+                eq(signer),
+                eq(signatures),
+                any(),
+                any(),
+                any(),
+            )
+        } doReturn membershipPackage
+    }
+    private val config = mock<SmartConfig>()
+
+    private val groupParameters: GroupParameters = mock {
+        on { epoch } doReturn EPOCH
+    }
+    private val groupReader: MembershipGroupReader = mock {
+        on { groupParameters } doReturn groupParameters
+        on { lookup() } doReturn allActiveMembers
+    }
+    private val groupReaderProvider: MembershipGroupReaderProvider = mock {
+        on { getGroupReader(any()) } doReturn groupReader
+    }
+
+    private val handler = DistributeMembershipPackageHandler(
+        membershipQueryClient,
+        cipherSchemeMetadata,
+        clock,
+        cryptoOpsClient,
+        cordaAvroSerializationFactory,
+        merkleTreeProvider,
+        config,
+        groupReaderProvider,
+        signerFactory,
+        merkleTreeGenerator,
+        p2pRecordsFactory,
+        membershipPackageFactory,
+    )
+
+    @Test
+    fun `invoke returns all approved members over P2P`() {
+        val allMembershipPackage = mock<MembershipPackage>()
+        whenever(
+            membershipPackageFactory.createMembershipPackage(
+                signer,
+                signatures,
+                activeMembersWithoutMgm,
+                checkHash,
+                groupParameters,
+            )
+        ).doReturn(allMembershipPackage)
+        val allMemberPackage = mock<Record<String, AppMessage>>()
+        whenever(
+            p2pRecordsFactory.createAuthenticatedMessageRecord(
+                eq(owner.toAvro()),
+                eq(member.toAvro()),
+                eq(allMembershipPackage),
+                anyOrNull(),
+                any(),
+            )
+        ).doReturn(allMemberPackage)
+
+        val reply = handler.invoke(state, key, command)
+
+        assertThat(reply.outputStates).contains(allMemberPackage)
+    }
+
+    @Test
+    fun `invoke sends the newly approved member to all other members over P2P`() {
+        val memberPackage = mock<MembershipPackage>()
+        whenever(
+            membershipPackageFactory.createMembershipPackage(
+                eq(signer),
+                eq(signatures),
+                argThat {
+                    this.size == 1
+                },
+                eq(checkHash),
+                eq(groupParameters),
+            )
+        ).doReturn(memberPackage)
+        val membersRecord = (activeMembersWithoutMgm - memberInfo).map {
+            val record = mock<Record<String, AppMessage>>()
+            val ownerAvro = owner.toAvro()
+            val memberAvro = it.holdingIdentity.toAvro()
+            whenever(
+                p2pRecordsFactory.createAuthenticatedMessageRecord(
+                    eq(ownerAvro),
+                    eq(memberAvro),
+                    eq(memberPackage),
+                    anyOrNull(),
+                    any(),
+                )
+            ).doReturn(record)
+            record
+        }
+
+        val reply = handler.invoke(state, key, command)
+
+        assertThat(reply.outputStates).containsAll(membersRecord)
+    }
+
+    @Test
+    fun `invoke republishes the distribute command if expected group parameters are not available via the group reader`() {
+        whenever(groupParameters.epoch).thenReturn(EPOCH - 1)
+
+        val reply = handler.invoke(state, key, command)
+
+        assertThat(reply.outputStates)
+            .hasSize(1)
+            .allSatisfy {
+                assertThat(it.topic).isEqualTo(REGISTRATION_COMMAND_TOPIC)
+                val value = (it.value as? DistributeMembershipPackage)
+                assertThat(value).isNotNull
+            }
+    }
+
+    @Test
+    fun `invoke uses the correct TTL configuration`() {
+        handler.invoke(state, key, command)
+
+        verify(config, atLeastOnce()).getIsNull("$TTLS.$MEMBERS_PACKAGE_UPDATE")
+    }
+
+    @Test
+    fun `exception is thrown when RegistrationState is null`() {
+        assertThrows<MissingRegistrationStateException> {
+            handler.invoke(null, key, command)
+        }
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
@@ -9,7 +9,6 @@ import net.corda.data.membership.command.registration.mgm.DistributeMembershipPa
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.state.RegistrationState
 import net.corda.libs.configuration.SmartConfig
-import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.TestUtils.createHoldingIdentity
 import net.corda.membership.impl.registration.dynamic.handler.TestUtils.mockMemberInfo
@@ -36,7 +35,6 @@ import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.merkle.MerkleTree
 import net.corda.v5.membership.GroupParameters
-import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -44,12 +42,10 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
@@ -153,7 +149,6 @@ class DistributeMembershipPackageHandlerTest {
     private val groupReaderProvider: MembershipGroupReaderProvider = mock {
         on { getGroupReader(any()) } doReturn groupReader
     }
-    private val writerService: GroupParametersWriterService = mock()
 
     private val handler = DistributeMembershipPackageHandler(
         membershipQueryClient,
@@ -164,7 +159,6 @@ class DistributeMembershipPackageHandlerTest {
         merkleTreeProvider,
         config,
         groupReaderProvider,
-        writerService,
         signerFactory,
         merkleTreeGenerator,
         p2pRecordsFactory,
@@ -232,21 +226,6 @@ class DistributeMembershipPackageHandlerTest {
         val reply = handler.invoke(state, key, command)
 
         assertThat(reply.outputStates).containsAll(membersRecord)
-    }
-
-    @Test
-    fun `invoke publishes group parameters to kafka for all members`() {
-        val groupParametersCaptor = argumentCaptor<GroupParameters>()
-        val holdingIdentityCaptor = argumentCaptor<HoldingIdentity>()
-
-        handler.invoke(state, key, command)
-
-        val receivingMembers = activeMembersWithoutMgm + memberInfo
-        verify(writerService, times(receivingMembers.size)).put(holdingIdentityCaptor.capture(), groupParametersCaptor.capture())
-        groupParametersCaptor.allValues.forEach {
-            assertThat(it).isEqualTo(groupParameters)
-        }
-        assertThat(holdingIdentityCaptor.allValues).isEqualTo(receivingMembers.map { it.holdingIdentity })
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
@@ -51,8 +51,6 @@ class MGMRegistrationGroupPolicyHandlerTest {
     private val mgmRegistrationGroupPolicyHandler = MGMRegistrationGroupPolicyHandler(
         layeredPropertyMapFactory,
         membershipPersistenceClient,
-        mock(),
-        mock(),
     )
 
     @Test
@@ -71,7 +69,7 @@ class MGMRegistrationGroupPolicyHandlerTest {
     }
 
     @Test
-    fun `group parameters are persisted using the correct holding identity and map`() {
+    fun `group policy is persisted using the correct holding identity and map`() {
         mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
 
         verify(membershipPersistenceClient).persistGroupPolicy(
@@ -90,18 +88,6 @@ class MGMRegistrationGroupPolicyHandlerTest {
             mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
         }
         verify(membershipPersistenceClient).persistGroupPolicy(any(), any())
-    }
-
-    @Test
-    fun `Failed group parameters persistence is rethrown as group policy handling exception`() {
-        whenever (
-            membershipPersistenceClient.persistGroupParametersInitialSnapshot(any())
-        ) doReturn MembershipPersistenceResult.Failure("")
-
-        assertThrows<MGMRegistrationGroupPolicyHandlingException> {
-            mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
-        }
-        verify(membershipPersistenceClient).persistGroupParametersInitialSnapshot(any())
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
@@ -40,7 +40,7 @@ class MGMRegistrationGroupPolicyHandlerTest {
 
         on {
             persistGroupParametersInitialSnapshot(eq(testHoldingIdentity))
-        } doReturn MembershipPersistenceResult.Success(Unit)
+        } doReturn MembershipPersistenceResult.Success(mock())
     }
 
     private val testContext: Map<String, String> = mapOf(
@@ -50,7 +50,9 @@ class MGMRegistrationGroupPolicyHandlerTest {
 
     private val mgmRegistrationGroupPolicyHandler = MGMRegistrationGroupPolicyHandler(
         layeredPropertyMapFactory,
-        membershipPersistenceClient
+        membershipPersistenceClient,
+        mock(),
+        mock(),
     )
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -29,12 +29,14 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.impl.registration.TEST_CPI_NAME
 import net.corda.membership.impl.registration.TEST_CPI_VERSION
 import net.corda.membership.impl.registration.TEST_PLATFORM_VERSION
 import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
 import net.corda.membership.impl.registration.buildMockPlatformInfoProvider
 import net.corda.membership.impl.registration.buildTestVirtualNodeInfo
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
@@ -78,6 +80,7 @@ import net.corda.schema.membership.MembershipSchema
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -195,6 +198,7 @@ class MGMRegistrationServiceTest {
         )
     )
     private val memberInfoFactory: MemberInfoFactory = MemberInfoFactoryImpl(layeredPropertyMapFactory)
+    private val mockGroupParametersList: KeyValuePairList = mock()
     private val statusUpdate = argumentCaptor<RegistrationRequest>()
     private val membershipPersistenceClient = mock<MembershipPersistenceClient> {
         on { persistMemberInfo(any(), any()) } doReturn MembershipPersistenceResult.Success(Unit)
@@ -205,6 +209,7 @@ class MGMRegistrationServiceTest {
                 statusUpdate.capture()
             )
         } doReturn MembershipPersistenceResult.success()
+        on { persistGroupParametersInitialSnapshot(any()) } doReturn MembershipPersistenceResult.Success(mockGroupParametersList)
     }
     private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> = mock {
         on { serialize(any()) } doReturn byteArrayOf(1, 2, 3)
@@ -221,6 +226,11 @@ class MGMRegistrationServiceTest {
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
         on { get(eq(mgm)) } doReturn virtualNodeInfo
     }
+    private val writerService: GroupParametersWriterService = mock()
+    private val mockGroupParameters: GroupParameters = mock()
+    private val groupParametersFactory: GroupParametersFactory = mock {
+        on { create(mockGroupParametersList) } doReturn mockGroupParameters
+    }
     private val registrationService = MGMRegistrationService(
         publisherFactory,
         configurationReadService,
@@ -233,7 +243,9 @@ class MGMRegistrationServiceTest {
         cordaAvroSerializationFactory,
         membershipSchemaValidatorFactory,
         platformInfoProvider,
-        virtualNodeInfoReadService
+        virtualNodeInfoReadService,
+        writerService,
+        groupParametersFactory,
     )
 
     private val properties = mapOf(
@@ -433,6 +445,18 @@ class MGMRegistrationServiceTest {
             registrationService.register(registrationRequest, mgm, properties)
 
             verify(membershipPersistenceClient).persistGroupParametersInitialSnapshot(eq(mgm))
+        }
+
+        @Test
+        fun `registration publishes initial group parameters snapshot to Kafka`() {
+            val groupParametersCaptor = argumentCaptor<GroupParameters>()
+            postConfigChangedEvent()
+            registrationService.start()
+
+            registrationService.register(registrationRequest, mgm, properties)
+
+            verify(writerService, times(1)).put(eq(mgm), groupParametersCaptor.capture())
+            assertThat(groupParametersCaptor.firstValue).isEqualTo(mockGroupParameters)
         }
 
         @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -455,7 +455,7 @@ class MGMRegistrationServiceTest {
 
             registrationService.register(registrationRequest, mgm, properties)
 
-            verify(writerService, times(1)).put(eq(mgm), groupParametersCaptor.capture())
+            verify(writerService).put(eq(mgm), groupParametersCaptor.capture())
             assertThat(groupParametersCaptor.firstValue).isEqualTo(mockGroupParameters)
         }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -373,7 +373,7 @@ class StaticMemberRegistrationServiceTest {
                     any(),
                     status.capture()
                 )
-            ).doReturn(MembershipPersistenceResult.Success(1))
+            ).doReturn(MembershipPersistenceResult.Success(mock()))
             whenever(groupPolicyProvider.getGroupPolicy(knownIdentity)).thenReturn(groupPolicyWithStaticNetwork)
             whenever(virtualNodeInfoReadService.get(knownIdentity)).thenReturn(buildTestVirtualNodeInfo(knownIdentity))
             setUpPublisher()
@@ -643,7 +643,7 @@ class StaticMemberRegistrationServiceTest {
                     any(),
                     any()
                 )
-            ).doReturn(MembershipPersistenceResult.Success(1))
+            ).doReturn(MembershipPersistenceResult.Success(mock()))
             whenever(groupPolicyProvider.getGroupPolicy(bob)).thenReturn(groupPolicyWithStaticNetwork)
             whenever(virtualNodeInfoReadService.get(bob)).thenReturn(buildTestVirtualNodeInfo(bob))
             setUpPublisher()

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
@@ -440,6 +440,7 @@ class SynchronisationIntegrationTest {
                     assertThat(member.groupId).isEqualTo(groupId)
                     assertThat(member.status).isEqualTo(MEMBER_STATUS_ACTIVE)
                 }
+            it.assertThat(membershipPackage.groupParameters).isNotNull
         }
     }
 

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
@@ -1,9 +1,15 @@
 package net.corda.membership.impl.synchronisation.dummy
 
+import net.corda.data.KeyValuePair
+import net.corda.data.KeyValuePairList
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
+import net.corda.membership.lib.EPOCH_KEY
+import net.corda.membership.lib.GroupParametersFactory
+import net.corda.membership.lib.MODIFIED_TIME_KEY
+import net.corda.membership.lib.MPV_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
@@ -18,6 +24,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import java.time.Instant
 
 /**
  * Created for mocking and simplifying group reader functionalities used by the membership services.
@@ -30,7 +37,9 @@ interface TestGroupReaderProvider : MembershipGroupReaderProvider {
 @Component(service = [MembershipGroupReaderProvider::class, TestGroupReaderProvider::class])
 class TestGroupReaderProviderImpl @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
-    private val coordinatorFactory: LifecycleCoordinatorFactory
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = GroupParametersFactory::class)
+    private val groupParametersFactory: GroupParametersFactory
 ) : TestGroupReaderProvider {
     companion object {
         val logger = contextLogger()
@@ -44,7 +53,7 @@ class TestGroupReaderProviderImpl @Activate constructor(
         }
     }
 
-    private val groupReader = TestGroupReader()
+    private val groupReader = TestGroupReader(groupParametersFactory)
 
     override fun loadMembers(holdingIdentity: HoldingIdentity, memberList: List<MemberInfo>) {
         val reader = getGroupReader(holdingIdentity) as TestGroupReader
@@ -67,10 +76,11 @@ class TestGroupReaderProviderImpl @Activate constructor(
     }
 }
 
-class TestGroupReader : MembershipGroupReader {
+class TestGroupReader(private val groupParametersFactory: GroupParametersFactory) : MembershipGroupReader {
     companion object {
         val logger = contextLogger()
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
+        private const val PLATFORM_VERSION = "5000"
     }
 
     override val groupId: String
@@ -78,8 +88,15 @@ class TestGroupReader : MembershipGroupReader {
     override val owningMember: MemberX500Name
         get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
     override val groupParameters: GroupParameters
-        get() = throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
-
+        get() = groupParametersFactory.create(
+            KeyValuePairList(
+                listOf(
+                    KeyValuePair(EPOCH_KEY, "5"),
+                    KeyValuePair(MPV_KEY, PLATFORM_VERSION),
+                    KeyValuePair(MODIFIED_TIME_KEY, Instant.now().toString()),
+                )
+            )
+        )
     private var members = emptyList<MemberInfo>()
 
     fun loadMembers(memberList: List<MemberInfo>) {

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
@@ -80,6 +80,7 @@ class TestGroupReader(private val groupParametersFactory: GroupParametersFactory
     companion object {
         val logger = contextLogger()
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
+        private const val EPOCH = "5"
         private const val PLATFORM_VERSION = "5000"
     }
 
@@ -91,7 +92,7 @@ class TestGroupReader(private val groupParametersFactory: GroupParametersFactory
         get() = groupParametersFactory.create(
             KeyValuePairList(
                 listOf(
-                    KeyValuePair(EPOCH_KEY, "5"),
+                    KeyValuePair(EPOCH_KEY, EPOCH),
                     KeyValuePair(MPV_KEY, PLATFORM_VERSION),
                     KeyValuePair(MODIFIED_TIME_KEY, Instant.now().toString()),
                 )

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImpl.kt
@@ -216,6 +216,7 @@ class MgmSynchronisationServiceImpl internal constructor(
             // we don't want to include the MGM in the data package since MGM information comes from the group policy
             val allMembers = groupReader.lookup().filterNot { it.holdingIdentity == mgm.toCorda() }
             val groupParameters = groupReader.groupParameters
+                ?: throw CordaRuntimeException("Failed to retrieve group parameters for building membership packages.")
             if (compareHashes(memberHashFromTheReq.toCorda(), requesterInfo)) {
                 // member has the latest updates regarding its own membership
                 // will send all membership data from MGM

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImpl.kt
@@ -46,6 +46,7 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
@@ -214,14 +215,15 @@ class MgmSynchronisationServiceImpl internal constructor(
                 ?: throw CordaRuntimeException("Requester $requesterName $IDENTITY_EX_MESSAGE")
             // we don't want to include the MGM in the data package since MGM information comes from the group policy
             val allMembers = groupReader.lookup().filterNot { it.holdingIdentity == mgm.toCorda() }
+            val groupParameters = groupReader.groupParameters
             if (compareHashes(memberHashFromTheReq.toCorda(), requesterInfo)) {
                 // member has the latest updates regarding its own membership
                 // will send all membership data from MGM
-                sendPackage(mgm, requester, createMembershipPackage(mgmInfo, allMembers))
+                sendPackage(mgm, requester, createMembershipPackage(mgmInfo, allMembers, groupParameters))
             } else {
                 // member has not received the latest updates regarding its own membership
                 // will send its missing updates about themselves only
-                sendPackage(mgm, requester, createMembershipPackage(mgmInfo, listOf(requesterInfo)))
+                sendPackage(mgm, requester, createMembershipPackage(mgmInfo, listOf(requesterInfo), groupParameters))
             }
             logger.info("Sync package is sent to ${requester.x500Name}.")
         }
@@ -262,7 +264,8 @@ class MgmSynchronisationServiceImpl internal constructor(
 
         private fun createMembershipPackage(
             mgm: MemberInfo,
-            members: Collection<MemberInfo>
+            members: Collection<MemberInfo>,
+            groupParameters: GroupParameters,
         ): MembershipPackage {
             val mgmSigner = signerFactory.createSigner(mgm)
             val signatures = membershipQueryClient
@@ -278,7 +281,8 @@ class MgmSynchronisationServiceImpl internal constructor(
                 mgmSigner,
                 signatures,
                 members,
-                membersTree.root
+                membersTree.root,
+                groupParameters,
             )
         }
     }

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
@@ -62,6 +62,7 @@ import net.corda.test.util.time.TestClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.merkle.MerkleTree
+import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
@@ -162,13 +163,14 @@ class MgmSynchronisationServiceImplTest {
 
     private val memberInfos = listOf(mgmInfo, aliceInfo, bobInfo, daisyInfo)
     private val memberInfosWithoutMgm = listOf(aliceInfo, bobInfo, daisyInfo)
+    private val groupParameters: GroupParameters = mock()
     private val groupReader: MembershipGroupReader = mock {
         on { lookup() } doReturn memberInfos
         on { lookup(eq(MemberX500Name.parse(mgmName))) } doReturn mgmInfo
         on { lookup(eq(MemberX500Name.parse(aliceName))) } doReturn aliceInfo
         on { lookup(eq(MemberX500Name.parse(bobName))) } doReturn bobInfo
         on { lookup(eq(MemberX500Name.parse(daisyName))) } doReturn daisyInfo
-        on { groupParameters } doReturn mock()
+        on { groupParameters } doReturn groupParameters
     }
     private val groupReaderProvider: MembershipGroupReaderProvider = mock {
         on { getGroupReader(eq(mgm.toCorda())) } doReturn groupReader
@@ -473,7 +475,7 @@ class MgmSynchronisationServiceImplTest {
         val capturedList = argumentCaptor<List<MemberInfo>>()
         val request = createRequest(alice)
         synchronisationService.processSyncRequest(request)
-        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any(), any())
+        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any(), eq(groupParameters))
         verify(mockPublisher, times(1)).publish(eq(listOf(record1)))
         val membersPublished = capturedList.firstValue
         assertThat(membersPublished.size).isEqualTo(3)
@@ -488,7 +490,7 @@ class MgmSynchronisationServiceImplTest {
         val capturedList = argumentCaptor<List<MemberInfo>>()
         val request = createRequest(bob)
         synchronisationService.processSyncRequest(request)
-        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any(), any())
+        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any(), eq(groupParameters))
         verify(mockPublisher, times(1)).publish(eq(listOf(record2)))
         val membersPublished = capturedList.firstValue
         assertThat(membersPublished.size).isEqualTo(1)

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
@@ -168,6 +168,7 @@ class MgmSynchronisationServiceImplTest {
         on { lookup(eq(MemberX500Name.parse(aliceName))) } doReturn aliceInfo
         on { lookup(eq(MemberX500Name.parse(bobName))) } doReturn bobInfo
         on { lookup(eq(MemberX500Name.parse(daisyName))) } doReturn daisyInfo
+        on { groupParameters } doReturn mock()
     }
     private val groupReaderProvider: MembershipGroupReaderProvider = mock {
         on { getGroupReader(eq(mgm.toCorda())) } doReturn groupReader
@@ -224,6 +225,7 @@ class MgmSynchronisationServiceImplTest {
                 eq(signatures),
                 eq(memberInfosWithoutMgm),
                 any(),
+                any(),
             )
         } doReturn membershipPackage1
         on {
@@ -231,6 +233,7 @@ class MgmSynchronisationServiceImplTest {
                 eq(signer),
                 eq(signature),
                 eq(listOf(bobInfo)),
+                any(),
                 any(),
             )
         } doReturn membershipPackage2
@@ -470,7 +473,7 @@ class MgmSynchronisationServiceImplTest {
         val capturedList = argumentCaptor<List<MemberInfo>>()
         val request = createRequest(alice)
         synchronisationService.processSyncRequest(request)
-        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any())
+        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any(), any())
         verify(mockPublisher, times(1)).publish(eq(listOf(record1)))
         val membersPublished = capturedList.firstValue
         assertThat(membersPublished.size).isEqualTo(3)
@@ -485,7 +488,7 @@ class MgmSynchronisationServiceImplTest {
         val capturedList = argumentCaptor<List<MemberInfo>>()
         val request = createRequest(bob)
         synchronisationService.processSyncRequest(request)
-        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any())
+        verify(membershipPackageFactory, times(1)).createMembershipPackage(any(), any(), capturedList.capture(), any(), any())
         verify(mockPublisher, times(1)).publish(eq(listOf(record2)))
         val membersPublished = capturedList.firstValue
         assertThat(membersPublished.size).isEqualTo(1)

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.505-alpha-1669038095804
+cordaApiVersion=5.0.0.505-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.504-alpha-1668788618018
+cordaApiVersion=5.0.0.505-alpha-1669038095804
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.504-SNAPSHOT
+cordaApiVersion=5.0.0.504-alpha-1668788618018
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,8 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.504-beta+
-
+cordaApiVersion=5.0.0.504-SNAPSHOT
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24


### PR DESCRIPTION
The MGM now distributes updated membership packages in response to a new `DistributeMembershipPackage` command - this was previously done during registration approval. The new command is issued after registration approval, and the membership packages distributed by the MGM now include the signed group parameters. The group parameters are also published to Kafka whenever the MGM persists the initial group parameters snapshot or publishes the membership package.
Changes in response to the altered `PersistGroupParametersResponse` schema are also included.

corda-api change: https://github.com/corda/corda-api/pull/704
https://r3-cev.atlassian.net/browse/CORE-7089