### PR TITLE
NOTICK: Update the API for fetching sandbox singleton services.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/CheckpointSerializerProvider.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/CheckpointSerializerProvider.kt
@@ -47,8 +47,7 @@ class CheckpointSerializerProvider @Activate constructor(
 
         // Identify all the singleton services created for this sandbox (both injectable
         // and non-injectable ones) that should be passed to the checkpoint serializer.
-        val sandboxSingletons = context.getSandboxSingletonServices()
-            .filterIsInstanceTo(linkedSetOf<SingletonSerializeAsToken>())
+        val sandboxSingletons = context.getSandboxSingletonServices<SingletonSerializeAsToken>()
 
         // Create and configure the checkpoint serializer
         val checkpointSerializer = checkpointSerializerBuilderFactory.createCheckpointSerializerBuilder(sandboxGroup).let { builder ->

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -27,15 +27,12 @@ import net.corda.ledger.consensual.persistence.impl.processor.ConsensualLedgerMe
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.getSandboxSingletonServices
+import net.corda.sandboxgroupcontext.getSandboxSingletonService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
-import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.cipher.suite.DigestService
-import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
@@ -44,7 +41,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
-import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.test.common.annotation.InjectBundleContext
@@ -155,13 +151,10 @@ class ConsensualLedgerMessageProcessorTests {
             TransactionMetadata.CPI_METADATA_KEY to cpiPackgeSummaryExample,
             TransactionMetadata.CPK_METADATA_KEY to cpkPackageSummaryListExample
         ))
-        val singletonServices = ctx.getSandboxSingletonServices().ifEmpty {
-            fail("Sandbox has no singleton services")
-        }
         val wireTransaction = getWireTransactionExample(
-            singletonServices.filterIsInstance<DigestService>().single(),
-            singletonServices.filterIsInstance<MerkleTreeProvider>().single(),
-            singletonServices.filterIsInstance<JsonMarshallingService>().single(),
+            ctx.getSandboxSingletonService(),
+            ctx.getSandboxSingletonService(),
+            ctx.getSandboxSingletonService(),
             consensualTransactionMetadataExample
         )
         return ConsensualSignedTransactionContainer(

--- a/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerRepositoryTest.kt
+++ b/components/ledger/ledger-consensual-persistence-impl/src/integrationTest/kotlin/net/corda/ledger/consensual/persistence/impl/processor/tests/ConsensualLedgerRepositoryTest.kt
@@ -14,7 +14,7 @@ import net.corda.ledger.consensual.persistence.impl.repository.ConsensualLedgerR
 import net.corda.orm.utils.transaction
 import net.corda.persistence.common.getEntityManagerFactory
 import net.corda.persistence.common.getSerializationService
-import net.corda.sandboxgroupcontext.getSandboxSingletonServices
+import net.corda.sandboxgroupcontext.getSandboxSingletonService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
-import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.test.common.annotation.InjectBundleContext
@@ -90,10 +89,7 @@ class ConsensualLedgerRepositoryTest {
             val ctx = virtualNode.entitySandboxService.get(virtualNodeInfo.holdingIdentity)
             serializationService = ctx.getSerializationService()
             entityManagerFactory = ctx.getEntityManagerFactory()
-            repository = ctx.getSandboxSingletonServices()
-                .filterIsInstance<ConsensualLedgerRepository>()
-                .singleOrNull()
-                ?: fail("No ConsensualLedgerRepository found for sandbox")
+            repository = ctx.getSandboxSingletonService()
         }
     }
 

--- a/components/virtual-node/sandbox-json/src/main/kotlin/net/corda/sandbox/serialization/json/JsonSerializerProvider.kt
+++ b/components/virtual-node/sandbox-json/src/main/kotlin/net/corda/sandbox/serialization/json/JsonSerializerProvider.kt
@@ -39,14 +39,13 @@ class JsonSerializerProvider @Activate constructor(
     }
 
     override fun accept(context: MutableSandboxGroupContext) {
-        val customizers = context.getSandboxSingletonServices()
-            .filterIsInstance<SerializationCustomizer>()
+        val customizers = context.getSandboxSingletonServices<SerializationCustomizer>()
 
         registerJsonSerializers(customizers, context)
         registerJsonDeserializers(customizers, context)
     }
 
-    private fun registerJsonSerializers(customizers: List<SerializationCustomizer>, context: MutableSandboxGroupContext) {
+    private fun registerJsonSerializers(customizers: Set<SerializationCustomizer>, context: MutableSandboxGroupContext) {
         // Kotlin's Set.plus(Set) operator function preserves iteration order.
         // We add the platform's serializers first, and the users' second.
         val cordappJsonSerializers = context.getMetadataServices<JsonSerializer<*>>()
@@ -66,7 +65,7 @@ class JsonSerializerProvider @Activate constructor(
         }
     }
 
-    private fun registerJsonDeserializers(customizers: List<SerializationCustomizer>, context: MutableSandboxGroupContext) {
+    private fun registerJsonDeserializers(customizers: Set<SerializationCustomizer>, context: MutableSandboxGroupContext) {
         // Kotlin's Set.plus(Set) operator function preserves iteration order.
         // We add the platform's deserializers first, and the users' second.
         val cordappJsonDeserializers = context.getMetadataServices<JsonDeserializer<*>>()

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextExtensions.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContextExtensions.kt
@@ -18,15 +18,26 @@ fun <T : Any> SandboxGroupContext.getMetadataServices(type: Class<T>): Set<T> = 
 inline fun <reified T : Any> SandboxGroupContext.getMetadataServices(): Set<T> = getMetadataServices(T::class.java)
 
 /**
- * Fetch the set of singleton services created for use by this sandbox.
+ * Fetch the set of all singleton services created for use by this sandbox.
  */
-fun SandboxGroupContext.getSandboxSingletonServices(): Set<Any> = getObjectByKey(SANDBOX_SINGLETONS) ?: emptySet()
+fun SandboxGroupContext.getAllSandboxSingletonServices(): Set<Any> = getObjectByKey(SANDBOX_SINGLETONS) ?: emptySet()
 
 /**
- * Fetch the single service of the given type from the sandbox's set of singletons.
+ * Fetch the set of this sandbox's singleton services that are of type [T].
+ */
+fun <T : Any> SandboxGroupContext.getSandboxSingletonServices(type: Class<T>): Set<T> {
+    return getAllSandboxSingletonServices().filterIsInstanceTo(linkedSetOf(), type)
+}
+
+inline fun <reified T : Any> SandboxGroupContext.getSandboxSingletonServices(): Set<T> {
+    return getSandboxSingletonServices(T::class.java)
+}
+
+/**
+ * Fetch the single service of type [T] from the sandbox's set of singletons.
  */
 fun <T : Any> SandboxGroupContext.getSandboxSingletonService(type: Class<T>): T {
-    return getSandboxSingletonServices().filterIsInstance(type).singleOrNull()
+    return getSandboxSingletonServices(type).singleOrNull()
         ?: throw IllegalStateException("${type.name} service missing from sandbox")
 }
 


### PR DESCRIPTION
Provide three options for fetching sandbox services:
- Fetch them all.
- Fetch all the ones matching a given type.
- Fetch the unique one matching a given type.
