### PR TITLE
CORE-6319 - excessive logging for HTTP exceptions 

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ContextUtils.kt
@@ -113,7 +113,7 @@ internal object ContextUtils {
                     ctx.header(Header.CACHE_CONTROL, "no-cache")
                     log.debug { "Invoke method \"${this.method.method.name}\" for route info completed." }
                 } catch (e: Exception) {
-                    log.warn("Error invoking path '${this.fullPath}'.", e)
+                    log.info("Error invoking path '${this.fullPath}' - ${e.message}")
                     throw HttpExceptionMapper.mapToResponse(e)
                 } finally {
                     MDC.remove("http.method")


### PR DESCRIPTION
Log level reduced from warn to info.

Log message only includes the exception message not the stack trace.

New:
```
2022-11-08 20:58:48.129 [qtp2107680220-229] INFO  net.corda.httprpc.server.impl.context.ContextUtils {http.method=POST, http.path=/api/v1/flow/E3B2E915CA0F, http.user=admin} - Error invoking path '/api/v1/flow/{holdingidentityshorthash}' - Virtual Node 'E3B2E915CA0F' not found.
```

Previous:

```
2022-11-08 21:08:55.608 [qtp1608484946-238] WARN  net.corda.httprpc.server.impl.context.ContextUtils {http.method=POST, http.path=/api/v1/flow/E3B2E915CA0F, http.user=admin} - Error invoking path '/api/v1/flow/{holdingidentityshorthash}'.
net.corda.httprpc.exception.ResourceNotFoundException: Virtual Node 'E3B2E915CA0F' not found.
	at net.corda.virtualnode.read.rpc.extensions.VirtualNodeInfoRPCExtensionsKt.getByHoldingIdentityShortHashOrThrow(VirtualNodeInfoRPCExtensions.kt:73) ~[?:?]
	at net.corda.flow.rpcops.impl.v1.FlowRPCOpsImpl.getVirtualNode(FlowRPCOpsImpl.kt:211) ~[?:?]
	at net.corda.flow.rpcops.impl.v1.FlowRPCOpsImpl.startFlow(FlowRPCOpsImpl.kt:89) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at net.corda.httprpc.server.impl.apigen.processing.DefaultMethodInvoker.invoke(MethodInvoker.kt:47) ~[?:?]
	at net.corda.httprpc.server.impl.apigen.processing.RouteInfo.invokeDelegatedMethod(RouteProvider.kt:117) ~[?:?]
	at net.corda.httprpc.server.impl.context.ContextUtils$invokeHttpMethod$1.invoke$lambda$4(ContextUtils.kt:109) ~[?:?]
	at io.micrometer.core.instrument.composite.CompositeTimer.recordCallable(CompositeTimer.java:129) ~[?:?]
	at net.corda.httprpc.server.impl.context.ContextUtils$invokeHttpMethod$1.invoke(ContextUtils.kt:99) ~[?:?]
	at net.corda.httprpc.server.impl.context.ContextUtils$invokeHttpMethod$1.invoke(ContextUtils.kt:85) ~[?:?]
	at net.corda.httprpc.server.impl.internal.HttpRpcServerInternal.registerHandlerForRoute$lambda$14(HttpRpcServerInternal.kt:179) ~[?:?]
	at io.javalin.core.security.SecurityUtil.noopAccessManager(SecurityUtil.kt:20) ~[?:?]
	at io.javalin.http.JavalinServlet.addHandler$lambda-0(JavalinServlet.kt:96) ~[?:?]
	at io.javalin.http.JavalinServlet$lifecycle$2$1$1.invoke(JavalinServlet.kt:43) ~[?:?]
	at io.javalin.http.JavalinServlet$lifecycle$2$1$1.invoke(JavalinServlet.kt:43) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask(JavalinServletHandler.kt:99) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$lambda-1(JavalinServletHandler.kt:85) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$javalin(JavalinServletHandler.kt:85) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask$lambda-11$lambda-10(JavalinServletHandler.kt:119) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask(JavalinServletHandler.kt:119) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$lambda-1(JavalinServletHandler.kt:85) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$javalin(JavalinServletHandler.kt:85) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask$lambda-11$lambda-10(JavalinServletHandler.kt:119) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask(JavalinServletHandler.kt:119) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$lambda-1(JavalinServletHandler.kt:85) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$javalin(JavalinServletHandler.kt:85) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask$lambda-11$lambda-10(JavalinServletHandler.kt:119) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask(JavalinServletHandler.kt:119) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$lambda-1(JavalinServletHandler.kt:85) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$javalin(JavalinServletHandler.kt:85) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask$lambda-11$lambda-10(JavalinServletHandler.kt:119) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094) ~[?:?]
	at io.javalin.http.JavalinServletHandler.executeNextTask(JavalinServletHandler.kt:119) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$lambda-1(JavalinServletHandler.kt:85) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at io.javalin.http.JavalinServletHandler.queueNextTaskOrFinish$javalin(JavalinServletHandler.kt:85) ~[?:?]
	at io.javalin.http.JavalinServlet.service(JavalinServlet.kt:89) ~[?:?]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[javax.servlet-api-3.1.0.jar:3.1.0]
	at io.javalin.jetty.JavalinJettyServlet.service(JavalinJettyServlet.kt:58) ~[?:?]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[javax.servlet-api-3.1.0.jar:3.1.0]
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799) ~[?:?]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:554) ~[?:?]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[?:?]
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624) ~[?:?]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[?:?]
	at io.javalin.jetty.JettyServer$start$wsAndHttpHandler$1.doHandle(JettyServer.kt:52) ~[?:?]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) ~[?:?]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505) ~[?:?]
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594) ~[?:?]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) ~[?:?]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355) ~[?:?]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[?:?]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[?:?]
	at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[?:?]
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487) ~[?:?]
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732) ~[?:?]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479) ~[?:?]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) ~[?:?]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) ~[?:?]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) ~[?:?]
	at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:555) ~[?:?]
	at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:410) ~[?:?]
	at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:164) ~[?:?]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) ~[?:?]
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) ~[?:?]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034) ~[jetty-util-9.4.48.v20220622.jar:9.4.48.v20220622]
	at java.lang.Thread.run(Thread.java:834) ~[?:?]
```
