### PR TITLE
CORE-7842/Adding aborted block to Post

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -211,7 +211,11 @@ pipeline {
             }
         }
         success {
-            // Only delete namespace if we're successful (though it'll get pruned in 3 hours anyway)
+            // Delete namespace if we're successful (though it'll get pruned in 3 hours anyway)
+            sh 'kubectl delete ns "${NAMESPACE}"'
+        }
+        aborted {
+             // Delete nanmespace if the run has been aborted - assumption being aborted run - no need to look through namespace
             sh 'kubectl delete ns "${NAMESPACE}"'
         }
     }


### PR DESCRIPTION
Added ```aborted``` block to the ```post``` stage.
In this block the namespace will be deleted as the assumption is on an aborted run a developer doesn't need to look through the namespace.

Tested here: https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/PR-2482/1/
Run was aborted and namespace deleted accordingly.
