### PR TITLE
NOTICK: clean up workspace always

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -209,10 +209,7 @@ pipeline {
                 writeFile file: "e2eTestDataForSplunk.log", text: "${env.BUILD_URL}\n${NAMESPACE}"
                 archiveArtifacts artifacts: "e2eTestDataForSplunk.log", fingerprint: true
             }
-        }
-        success {
-            // Only delete namespace if we're successful (though it'll get pruned in 3 hours anyway)
-            sh 'kubectl delete ns "${NAMESPACE}"'
+             sh 'kubectl delete ns "${NAMESPACE}"'
         }
     }
 }


### PR DESCRIPTION
temp measure while increasing release brnach cron frequency during investigation of flakey tests by flow worker team expect to revert in a day or two.

Leaving this in place will overload our infra resource pool if increasing e2e test to run hourly. 