### PR TITLE
CORE-7954: Allow us to discover all bundles containing system flows.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/DigitalSignatureVerificationServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/DigitalSignatureVerificationServiceImpl.kt
@@ -16,8 +16,7 @@ import java.security.PublicKey
 
 @Component(
     service = [ DigitalSignatureVerificationService::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
-    scope = PROTOTYPE,
-    property = ["corda.system=true"]
+    scope = PROTOTYPE
 )
 class DigitalSignatureVerificationServiceImpl @Activate constructor(
     @Reference(service = SignatureVerificationService::class)

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.consensual.flow.impl.persistence.ConsensualLedgerPersistenceService
 import net.corda.ledger.consensual.flow.impl.persistence.TransactionStatus
+import net.corda.sandbox.CordaSystemFlow
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.SubFlow
@@ -18,6 +19,7 @@ import net.corda.v5.base.util.debug
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import java.security.PublicKey
 
+@CordaSystemFlow
 class ConsensualFinalityFlow(
     private val signedTransaction: ConsensualSignedTransaction,
     private val sessions: List<FlowSession>

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.consensual.flow.impl.flows.finality
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.consensual.flow.impl.persistence.ConsensualLedgerPersistenceService
 import net.corda.ledger.consensual.flow.impl.persistence.TransactionStatus
+import net.corda.sandbox.CordaSystemFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.membership.MemberLookup
@@ -17,6 +18,7 @@ import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransactionVerifier
 
+@CordaSystemFlow
 class ConsensualReceiveFinalityFlow(
     private val session: FlowSession,
     private val verifier: ConsensualSignedTransactionVerifier

--- a/libs/sandbox/src/main/java/net/corda/sandbox/CordaSystemFlow.java
+++ b/libs/sandbox/src/main/java/net/corda/sandbox/CordaSystemFlow.java
@@ -1,0 +1,20 @@
+package net.corda.sandbox;
+
+import org.osgi.annotation.bundle.Capability;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+import static net.corda.sandbox.RequireCordaSystem.VERSION;
+import static net.corda.sandbox.SandboxConstants.CORDA_SYSTEM;
+
+@Capability(
+    namespace = CORDA_SYSTEM,
+    name = "flow",
+    version = VERSION
+)
+@Retention(CLASS)
+@Target(TYPE)
+public @interface CordaSystemFlow {
+}

--- a/libs/sandbox/src/main/java/net/corda/sandbox/RequireCordaSystem.java
+++ b/libs/sandbox/src/main/java/net/corda/sandbox/RequireCordaSystem.java
@@ -1,0 +1,25 @@
+package net.corda.sandbox;
+
+import org.osgi.annotation.bundle.Requirement;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+import static net.corda.sandbox.SandboxConstants.CORDA_SYSTEM;
+import static org.osgi.annotation.bundle.Requirement.Cardinality.MULTIPLE;
+import static org.osgi.framework.Constants.RESOLUTION_DIRECTIVE;
+import static org.osgi.framework.Constants.RESOLUTION_OPTIONAL;
+
+@Requirement(
+    namespace = CORDA_SYSTEM,
+    name = "*",
+    version = RequireCordaSystem.VERSION,
+    cardinality = MULTIPLE,
+    attribute = { RESOLUTION_DIRECTIVE + ":=" + RESOLUTION_OPTIONAL }
+)
+@Retention(CLASS)
+@Target(TYPE)
+public @interface RequireCordaSystem {
+    String VERSION = "1.0";
+}

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxConstants.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxConstants.kt
@@ -1,3 +1,4 @@
+@file:JvmName("SandboxConstants")
 package net.corda.sandbox
 
 const val CORDA_SYSTEM = "corda.system"

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/factory/CheckpointSerializerBuilderFactoryImpl.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/factory/CheckpointSerializerBuilderFactoryImpl.kt
@@ -9,7 +9,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 
-@Component(immediate = true, service = [CheckpointSerializerBuilderFactory::class])
+@Component(service = [CheckpointSerializerBuilderFactory::class])
 class CheckpointSerializerBuilderFactoryImpl @Activate constructor(
     @Reference
     private val keyEncodingService: KeyEncodingService

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupType.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupType.kt
@@ -7,10 +7,12 @@ import net.corda.sandbox.type.UsedByVerification
 /**
  * Enumeration of various sandbox group types.
  */
-enum class SandboxGroupType(val serviceMarkerType: Class<*>) {
-    FLOW(UsedByFlow::class.java),
-    VERIFICATION(UsedByVerification::class.java),
-    PERSISTENCE(UsedByPersistence::class.java);
+enum class SandboxGroupType(private val typeName: String, val serviceMarkerType: Class<*>) {
+    FLOW("flow", UsedByFlow::class.java),
+    VERIFICATION("verification", UsedByVerification::class.java),
+    PERSISTENCE("persistence", UsedByPersistence::class.java);
+
+    override fun toString(): String = typeName
 
     init {
         require(serviceMarkerType.isInterface) {


### PR DESCRIPTION
Identify all bundles containing "system flows" so that we can reduce the number of components being declared as "system services".

While I've currently only implemented a new `corda.system=flow` capability, we could also create capabilities `corda.system=persistence` and `corda.system=verification` should the need arise.

The idea is that bundles containing classes which are recognised as being "system flows" are included along with a sandbox's "main" jars in its "bundle wiring" calculations. There's no realistic prospect of determining whether a particular CPK will use those system flows, though.