### PR TITLE
CORE-7844 increase stability of the config update endpoint

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -1,6 +1,7 @@
 package net.corda.applications.workers.smoketest.flow
 
 import java.util.UUID
+import kotlin.text.Typography.quote
 import net.corda.applications.workers.smoketest.FlowStatus
 import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_FAILED
@@ -23,6 +24,7 @@ import net.corda.applications.workers.smoketest.updateConfig
 import net.corda.applications.workers.smoketest.waitForConfigurationChange
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
+import net.corda.v5.crypto.DigestAlgorithmName
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
@@ -32,8 +34,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.TestMethodOrder
-import kotlin.text.Typography.quote
-import net.corda.v5.crypto.DigestAlgorithmName
 
 @Suppress("Unused", "FunctionName")
 @Order(20)

--- a/components/configuration/configuration-rpcops-service-impl/src/main/kotlin/net/corda/configuration/rpcops/impl/v1/ConfigRPCOpsImpl.kt
+++ b/components/configuration/configuration-rpcops-service-impl/src/main/kotlin/net/corda/configuration/rpcops/impl/v1/ConfigRPCOpsImpl.kt
@@ -1,13 +1,14 @@
 package net.corda.configuration.rpcops.impl.v1
 
 import com.typesafe.config.ConfigFactory
+import java.time.Duration
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationGetService
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.configuration.rpcops.impl.exception.ConfigRPCOpsException
 import net.corda.configuration.rpcops.impl.CLIENT_NAME_HTTP
 import net.corda.configuration.rpcops.impl.GROUP_NAME
 import net.corda.configuration.rpcops.impl.exception.ConfigException
+import net.corda.configuration.rpcops.impl.exception.ConfigRPCOpsException
 import net.corda.configuration.rpcops.impl.exception.ConfigVersionConflictException
 import net.corda.data.config.ConfigurationManagementRequest
 import net.corda.data.config.ConfigurationManagementResponse
@@ -16,6 +17,7 @@ import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.BadRequestException
 import net.corda.httprpc.exception.InternalServerException
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
@@ -38,20 +40,20 @@ import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.schema.Schemas.Config.Companion.CONFIG_MGMT_REQUEST_TOPIC
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.utilities.concurrent.getOrThrow
 import net.corda.utilities.VisibleForTesting
+import net.corda.utilities.concurrent.getOrThrow
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.versioning.Version
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.time.Duration
 
 /** An implementation of [ConfigRPCOps]. */
 @Suppress("Unused")
@@ -161,7 +163,7 @@ internal class ConfigRPCOpsImpl @Activate constructor(
         this.requestTimeout = Duration.ofMillis(millis.toLong())
     }
 
-    override fun updateConfig(request: UpdateConfigParameters): UpdateConfigResponse {
+    override fun updateConfig(request: UpdateConfigParameters): ResponseEntity<UpdateConfigResponse> {
         validateRequestedConfig(request)
 
         val actor = CURRENT_RPC_CONTEXT.get().principal
@@ -177,12 +179,12 @@ internal class ConfigRPCOpsImpl @Activate constructor(
         val response = sendRequest(rpcRequest)
 
         return if (response.success) {
-            UpdateConfigResponse(
+            ResponseEntity.accepted(UpdateConfigResponse(
                 response.section, response.config, ConfigSchemaVersion(
                     response.schemaVersion.majorVersion,
                     response.schemaVersion.minorVersion
                 ), response.version
-            )
+            ))
         } else {
             val exception = response.exception
             if (exception == null) {
@@ -191,7 +193,7 @@ internal class ConfigRPCOpsImpl @Activate constructor(
             }
             logger.warn("Remote request to update config responded with exception: ${exception.errorType}: ${exception.errorMessage}")
 
-            when(exception.errorType) {
+            when (exception.errorType) {
                 WrongConfigVersionException::class.java.name -> throw ConfigVersionConflictException(
                     exception.errorType,
                     exception.errorMessage,
@@ -256,6 +258,10 @@ internal class ConfigRPCOpsImpl @Activate constructor(
         )
         return try {
             nonNullRPCSender.sendRequest(request).getOrThrow(nonNullRequestTimeout)
+        } catch (ex: CordaRPCAPIPartitionException) {
+            logger.warn("Partition event when getting response from db worker for update config message", ex)
+            //TODO - https://r3-cev.atlassian.net/browse/CORE-7930
+            ConfigurationManagementResponse(true, null, request.section, request.config, request.schemaVersion, request.version+1)
         } catch (e: Exception) {
             throw ConfigRPCOpsException("Could not publish updated configuration.", e)
         }

--- a/components/configuration/configuration-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/ConfigRPCOpsImplTests.kt
+++ b/components/configuration/configuration-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/ConfigRPCOpsImplTests.kt
@@ -1,7 +1,7 @@
 package net.corda.configuration.rpcops.impl
 
-import net.corda.configuration.read.ConfigurationGetService
 import java.util.concurrent.CompletableFuture
+import net.corda.configuration.read.ConfigurationGetService
 import net.corda.configuration.rpcops.impl.exception.ConfigRPCOpsException
 import net.corda.configuration.rpcops.impl.v1.ConfigRPCOpsImpl
 import net.corda.data.ExceptionEnvelope
@@ -12,6 +12,7 @@ import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.httprpc.JsonObject
 import net.corda.httprpc.ResponseCode
 import net.corda.httprpc.exception.HttpApiException
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.httprpc.security.RpcAuthContext
 import net.corda.libs.configuration.SmartConfigImpl
@@ -65,12 +66,12 @@ class ConfigRPCOpsImplTests {
             ), req.version
         )
     }
-    private val successResponse = UpdateConfigResponse(
+    private val successResponse = ResponseEntity.accepted(UpdateConfigResponse(
         req.section, req.config.escapedJson, ConfigSchemaVersion(
             req.schemaVersion.major,
             req.schemaVersion.minor
         ), req.version
-    )
+    ))
 
     private val configSection = "section"
     private val config = Configuration("CONFIG+DEFAULT", "CONFIG", 1, ConfigurationSchemaVersion(2,3))
@@ -124,7 +125,9 @@ class ConfigRPCOpsImplTests {
         configRPCOps.createAndStartRPCSender(mock())
         configRPCOps.setTimeout(1000)
 
-        assertEquals(successResponse, configRPCOps.updateConfig(req))
+        val result = configRPCOps.updateConfig(req)
+        assertEquals(successResponse.responseCode, result.responseCode)
+        assertEquals(successResponse.responseBody, result.responseBody)
     }
 
     @Test

--- a/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/ConfigRPCOps.kt
+++ b/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/ConfigRPCOps.kt
@@ -7,6 +7,7 @@ import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.libs.configuration.endpoints.v1.types.GetConfigResponse
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigResponse
@@ -48,7 +49,7 @@ interface ConfigRPCOps : RpcOps {
                 match the version stored in the database for the corresponding section or -1 if this is a new section 
                 for which no configuration has yet been stored.""")
         request: UpdateConfigParameters
-    ): UpdateConfigResponse
+    ): ResponseEntity<UpdateConfigResponse>
 
     /**
      * Get the configuration data the cluster is set with for a specific [section].

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/FutureTracker.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/FutureTracker.kt
@@ -1,9 +1,10 @@
 package net.corda.messaging.utils
 
-import net.corda.messagebus.api.CordaTopicPartition
-import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import net.corda.messagebus.api.CordaTopicPartition
+import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
+import net.corda.messaging.api.exception.CordaRPCAPISenderException
 
 /**
  * Data structure to keep track of active partitions and futures for a given sender and partition listener pair
@@ -46,7 +47,7 @@ class FutureTracker<RESPONSE> {
             val futures = futuresInPartitionMap[partition.partition]
             for (key in futures!!.keys) {
                 futures[key]?.completeExceptionally(
-                    CordaRPCAPISenderException(
+                    CordaRPCAPIPartitionException(
                         "Repartition event!! Results for this future can no longer be returned"
                     )
                 )

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaRPCAPIExceptions.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaRPCAPIExceptions.kt
@@ -9,6 +9,12 @@ class CordaRPCAPISenderException(message: String?, exception: Throwable? = null)
     CordaRuntimeException(message, exception)
 
 /**
+ * Exception that occurred when a repartition event occurred in that RPC messaging pattern
+ */
+class CordaRPCAPIPartitionException(message: String?, exception: Throwable? = null) :
+    CordaRuntimeException(message, exception)
+
+/**
  * Exception that occurred on the responder side of RPC messaging pattern
  */
 class CordaRPCAPIResponderException(val errorType: String, message: String?, exception: Throwable? = null) :

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/RPCSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/RPCSubscriptionIntegrationTest.kt
@@ -1,6 +1,10 @@
 package net.corda.messaging.integration.subscription
 
-import net.corda.utilities.concurrent.getOrThrow
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 import net.corda.data.messaging.RPCRequest
 import net.corda.data.messaging.RPCResponse
 import net.corda.data.messaging.ResponseStatus
@@ -13,6 +17,7 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleEvent
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import net.corda.messaging.api.publisher.factory.PublisherFactory
@@ -28,6 +33,7 @@ import net.corda.messaging.integration.processors.TestRPCErrorResponderProcessor
 import net.corda.messaging.integration.processors.TestRPCResponderProcessor
 import net.corda.messaging.integration.processors.TestRPCUnresponsiveResponderProcessor
 import net.corda.test.util.eventually
+import net.corda.utilities.concurrent.getOrThrow
 import net.corda.v5.base.util.millis
 import net.corda.v5.base.util.seconds
 import org.assertj.core.api.Assertions
@@ -41,11 +47,6 @@ import org.junit.jupiter.api.fail
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
-import java.nio.ByteBuffer
-import java.time.Instant
-import java.util.concurrent.CancellationException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
 
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class, DBSetup::class)
 class RPCSubscriptionIntegrationTest {
@@ -336,7 +337,7 @@ class RPCSubscriptionIntegrationTest {
             }
         }
         eventually(10.seconds, 1.seconds) {
-            assertThrows<CordaRPCAPISenderException> {
+            assertThrows<CordaRPCAPIPartitionException> {
                 future.getOrThrow()
             }
         }

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/RPCSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/RPCSubscriptionIntegrationTest.kt
@@ -17,7 +17,6 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleEvent
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationStatusChangeEvent
-import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import net.corda.messaging.api.publisher.factory.PublisherFactory
@@ -337,7 +336,7 @@ class RPCSubscriptionIntegrationTest {
             }
         }
         eventually(10.seconds, 1.seconds) {
-            assertThrows<CordaRPCAPIPartitionException> {
+            assertThrows<CordaRPCAPISenderException> {
                 future.getOrThrow()
             }
         }


### PR DESCRIPTION
When a config request is sent with the section set to "corda.messaging" nearly all components in the system will respond to this config change. This will cause the HttpGateway to go down bringing down the HttpServer. This will close all the connections open from http clients. this means a response is not received by the client for the request. To avoid this in tests we swallow the UniRestException thrown for put /config and does not retry the PUT, Previously the test would retry which caused multiple messaging config events to be sent to the RPC worker. 

Separately the RPC pattern when sending config to the db worker will also fail due to repartition exceptions thrown by the RPC messaging pattern as a result of the messaging config being updated. A tmp solution is added to return the config posted by the client aswell as a success response.

A better solution might be to not bother waiting for a response from the db worker for config updates and immediately return 202 Accepted to the client always https://r3-cev.atlassian.net/browse/CORE-7930