### PR TITLE
CORE-7295: Read the meta inf from the correct jar

### DIFF
--- a/libs/platform-info/build.gradle
+++ b/libs/platform-info/build.gradle
@@ -12,4 +12,10 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion") {
+        exclude group: 'mockito-core'
+    }
+    testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
 }

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -38,13 +38,19 @@ class PlatformInfoProviderTest {
             platformInfoProvider.localWorkerSoftwareVersion
         }
         val expectedValue = PlatformInfoProvider::class.java.classLoader
-            .getResource("META-INF/MANIFEST.MF")
-            ?.openStream()
-            ?.use {
-                Manifest(it)
-            }
-            ?.mainAttributes
-            ?.getValue("Bundle-Version")
+            .getResources("META-INF/MANIFEST.MF")
+            .asSequence()
+            .map {
+                it.openStream().use { input ->
+                    Manifest(input)
+                }
+            }.mapNotNull {
+                it.mainAttributes
+            }.filter {
+                it.getValue("Bundle-SymbolicName") == "net.corda.platform-info"
+            }.mapNotNull {
+                it.getValue("Bundle-Version")
+            }.firstOrNull()
 
         assertThat(expectedValue)
             .isNotNull


### PR DESCRIPTION
`.getResource(MANIFEST_FILE_NAME)` will not always return the correct manifest. In Windows, the manifest might not be there when running the tests.