### PR TITLE
CORE-7934: Make the import certificate API clearer

### DIFF
--- a/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
@@ -65,7 +65,7 @@ sign_certificate() {
 }
 
 upload_certificate() {
-    curl --fail-with-body -s -S -k -u admin:admin -X PUT  -F certificate=@$2 -F alias=cluster-tls "https://$1/api/v1/certificates/p2p"
+    curl --fail-with-body -s -S -k -u admin:admin -X PUT  -F certificate=@$2 -F alias=cluster-tls "https://$1/api/v1/certificates/cluster/p2p"
 }
 
 register_node() {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
@@ -60,7 +60,7 @@ class ClusterBuilder {
             ?: throw FileNotFoundException("No such resource: '$resourceName'")
 
     fun importCertificate(resourceName: String, usage: String, alias: String) =
-        uploadCertificateResource("/api/v1/certificates/$usage/cluster", resourceName, alias)
+        uploadCertificateResource("/api/v1/certificates/cluster/$usage", resourceName, alias)
 
     /** Assumes the resource *is* a CPB */
     fun cpbUpload(resourceName: String) = uploadUnmodifiedResource("/api/v1/cpi/", resourceName)

--- a/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/CertificatesRpcOps.kt
+++ b/components/membership/membership-http-rpc/src/main/kotlin/net/corda/membership/httprpc/v1/CertificatesRpcOps.kt
@@ -45,7 +45,7 @@ interface CertificatesRpcOps : RpcOps {
      * @param certificates A valid certificate chain in PEM format obtained from a certificate authority.
      */
     @HttpRpcPUT(
-        path = "{usage}/cluster",
+        path = "cluster/{usage}",
         description = "This method imports a certificate chain for a cluster."
     )
     fun importCertificateChain(
@@ -96,7 +96,7 @@ interface CertificatesRpcOps : RpcOps {
      * @param certificates A valid certificate chain in PEM format obtained from a certificate authority.
      */
     @HttpRpcPUT(
-        path = "{usage}/{holdingIdentityId}",
+        path = "vnode/{holdingIdentityId}/{usage}",
         description = "This method imports a certificate chain for a virtual node."
     )
     fun importCertificateChain(

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -64,6 +64,66 @@
     "description" : "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management.Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them."
   } ],
   "paths" : {
+    "/certificates/cluster/{usage}" : {
+      "put" : {
+        "tags" : [ "Certificates API" ],
+        "description" : "This method imports a certificate chain for a cluster.",
+        "operationId" : "put_certificates_cluster__usage_",
+        "parameters" : [ {
+          "name" : "usage",
+          "in" : "path",
+          "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "requestBody",
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "alias" : {
+                    "type" : "string",
+                    "description" : "The unique alias under which the certificate chain will be stored",
+                    "nullable" : false,
+                    "example" : "string"
+                  },
+                  "certificate" : {
+                    "uniqueItems" : false,
+                    "type" : "array",
+                    "nullable" : false,
+                    "items" : {
+                      "type" : "string",
+                      "description" : "A content of the file to upload.",
+                      "format" : "binary",
+                      "example" : "No example available for this type"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Success"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
     "/certificates/getprotocolversion" : {
       "get" : {
         "tags" : [ "Certificates API" ],
@@ -83,6 +143,77 @@
                 }
               }
             }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
+    "/certificates/vnode/{holdingidentityid}/{usage}" : {
+      "put" : {
+        "tags" : [ "Certificates API" ],
+        "description" : "This method imports a certificate chain for a virtual node.",
+        "operationId" : "put_certificates_vnode__holdingidentityid___usage_",
+        "parameters" : [ {
+          "name" : "usage",
+          "in" : "path",
+          "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        }, {
+          "name" : "holdingidentityid",
+          "in" : "path",
+          "description" : "The certificate holding identity ID",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The certificate holding identity ID",
+            "nullable" : true,
+            "example" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "requestBody",
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "alias" : {
+                    "type" : "string",
+                    "description" : "The unique alias under which the certificate chain will be stored",
+                    "nullable" : false,
+                    "example" : "string"
+                  },
+                  "certificate" : {
+                    "uniqueItems" : false,
+                    "type" : "array",
+                    "nullable" : false,
+                    "items" : {
+                      "type" : "string",
+                      "description" : "A content of the file to upload.",
+                      "format" : "binary",
+                      "example" : "No example available for this type"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Success"
           },
           "401" : {
             "description" : "Unauthorized"
@@ -144,137 +275,6 @@
                 }
               }
             }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/certificates/{usage}/cluster" : {
-      "put" : {
-        "tags" : [ "Certificates API" ],
-        "description" : "This method imports a certificate chain for a cluster.",
-        "operationId" : "put_certificates__usage__cluster",
-        "parameters" : [ {
-          "name" : "usage",
-          "in" : "path",
-          "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "description" : "requestBody",
-          "content" : {
-            "multipart/form-data" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "alias" : {
-                    "type" : "string",
-                    "description" : "The unique alias under which the certificate chain will be stored",
-                    "nullable" : false,
-                    "example" : "string"
-                  },
-                  "certificate" : {
-                    "uniqueItems" : false,
-                    "type" : "array",
-                    "nullable" : false,
-                    "items" : {
-                      "type" : "string",
-                      "description" : "A content of the file to upload.",
-                      "format" : "binary",
-                      "example" : "No example available for this type"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Success"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/certificates/{usage}/{holdingidentityid}" : {
-      "put" : {
-        "tags" : [ "Certificates API" ],
-        "description" : "This method imports a certificate chain for a virtual node.",
-        "operationId" : "put_certificates__usage___holdingidentityid_",
-        "parameters" : [ {
-          "name" : "usage",
-          "in" : "path",
-          "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The certificate usage. Can be either 'p2p-tls' for a TLS certificate to be used in P2P communication, 'p2p-session' for a session certificate to be used in P2P communication, 'rpc-api-tls' for a TLS certificate to be used in RPC API communication, or 'code-signer' for a certificate of the code signing service.",
-            "nullable" : false,
-            "example" : "string"
-          }
-        }, {
-          "name" : "holdingidentityid",
-          "in" : "path",
-          "description" : "The certificate holding identity ID",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The certificate holding identity ID",
-            "nullable" : true,
-            "example" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "description" : "requestBody",
-          "content" : {
-            "multipart/form-data" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "alias" : {
-                    "type" : "string",
-                    "description" : "The unique alias under which the certificate chain will be stored",
-                    "nullable" : false,
-                    "example" : "string"
-                  },
-                  "certificate" : {
-                    "uniqueItems" : false,
-                    "type" : "array",
-                    "nullable" : false,
-                    "items" : {
-                      "type" : "string",
-                      "description" : "A content of the file to upload.",
-                      "format" : "binary",
-                      "example" : "No example available for this type"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "Success"
           },
           "401" : {
             "description" : "Unauthorized"

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
@@ -206,7 +206,7 @@ abstract class BaseOnboard : Runnable {
             }
         } as? PKCS10CertificationRequest ?: throw OnboardException("CSR is not a valid CSR: ${generateCsrResponse.body}")
         ca.signCsr(csr).toPem().byteInputStream().use { certificate ->
-            Unirest.put("/certificates/p2p-tls/cluster")
+            Unirest.put("/certificates/cluster/p2p-tls")
                 .field("certificate", certificate, "certificate.pem")
                 .field("alias", P2P_TLS_CERTIFICATE_ALIAS)
                 .asJson()


### PR DESCRIPTION
Change the path of the import certificate requests to explicitly differentiate between a cluster certificate and a node certificate.