### PR TITLE
CORE-7090 Persist group parameters received from MGM

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
@@ -2,6 +2,7 @@ package net.corda.membership.impl.registration.dynamic.handler.mgm
 
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
 import net.corda.data.membership.p2p.DistributionType
 import net.corda.data.membership.p2p.MembershipPackage
@@ -123,7 +124,7 @@ class DistributeMembershipPackageHandler(
         } catch (e: Exception) {
             logger.warn("Could not distribute membership packages after registration request: '$registrationId' was approved. " +
                         "Distribution will be reattempted.", e)
-            listOf(Record(REGISTRATION_COMMAND_TOPIC, key, command))
+            listOf(Record(REGISTRATION_COMMAND_TOPIC, key, RegistrationCommand(command)))
         }
 
         return RegistrationHandlerResult(
@@ -139,7 +140,7 @@ class DistributeMembershipPackageHandler(
     ): RegistrationHandlerResult {
         logger.info("Retrieved group parameters are outdated or null. Republishing the distribute command to be processed" +
                 " later when the updated set of group parameters is available.")
-        return RegistrationHandlerResult(state, listOf(Record(REGISTRATION_COMMAND_TOPIC, key, command)))
+        return RegistrationHandlerResult(state, listOf(Record(REGISTRATION_COMMAND_TOPIC, key, RegistrationCommand(command))))
     }
 
     private fun createMembershipPackageFactory(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -222,12 +222,12 @@ class StaticMemberRegistrationService @Activate constructor(
         }
         val groupParameters = groupParametersFactory.create(groupParametersList)
 
-        // Persist group parameters for this member, and publish to Kafka for DB reconciliation.
+        // Persist group parameters for this member, and publish to Kafka.
         persistenceClient.persistGroupParameters(holdingIdentity, groupParameters)
         groupParametersWriterService.put(holdingIdentity, groupParameters)
 
         // If this member is a notary, persist updated group parameters for other members who have a vnode set up.
-        // Also publish to Kafka for DB reconciliation.
+        // Also publish to Kafka.
         memberInfo.notaryDetails?.let {
             val groupId = memberInfo.groupId
             staticMemberList

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -17,6 +17,7 @@ import net.corda.layeredpropertymap.toAvro
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.impl.registration.KeysFactory
 import net.corda.membership.impl.registration.MemberRole
@@ -112,6 +113,8 @@ class StaticMemberRegistrationService @Activate constructor(
     private val groupParametersFactory: GroupParametersFactory,
     @Reference(service = VirtualNodeInfoReadService::class)
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
+    @Reference(service = GroupParametersWriterService::class)
+    private val groupParametersWriterService: GroupParametersWriterService,
 ) : MemberRegistrationService {
     companion object {
         private val logger: Logger = contextLogger()
@@ -211,20 +214,20 @@ class StaticMemberRegistrationService @Activate constructor(
 
     private fun persistGroupParameters(memberInfo: MemberInfo, staticMemberList: List<StaticMember>) {
         val cache = lifecycleHandler.groupParametersCache
-        val groupParametersList = cache.getOrCreateGroupParameters(memberInfo.holdingIdentity).run {
+        val holdingIdentity = memberInfo.holdingIdentity
+        val groupParametersList = cache.getOrCreateGroupParameters(holdingIdentity).run {
             memberInfo.notaryDetails?.let {
                 cache.addNotary(memberInfo)
             } ?: this
         }
         val groupParameters = groupParametersFactory.create(groupParametersList)
 
-        // Persist group parameters for this member
-        persistenceClient.persistGroupParameters(
-            memberInfo.holdingIdentity,
-            groupParameters
-        )
+        // Persist group parameters for this member, and publish to Kafka for DB reconciliation.
+        persistenceClient.persistGroupParameters(holdingIdentity, groupParameters)
+        groupParametersWriterService.put(holdingIdentity, groupParameters)
 
-        // If this member is a notary, persist updated group parameters for other members who have a vnode set up
+        // If this member is a notary, persist updated group parameters for other members who have a vnode set up.
+        // Also publish to Kafka for DB reconciliation.
         memberInfo.notaryDetails?.let {
             val groupId = memberInfo.groupId
             staticMemberList
@@ -232,10 +235,9 @@ class StaticMemberRegistrationService @Activate constructor(
                 .forEach { staticMember ->
                 val name = MemberX500Name.parse(staticMember.name!!)
                 virtualNodeInfoReadService.get(HoldingIdentity(name, groupId))?.let {
-                    persistenceClient.persistGroupParameters(
-                        it.holdingIdentity,
-                        groupParameters
-                    )
+                    val peer = it.holdingIdentity
+                    persistenceClient.persistGroupParameters(peer, groupParameters)
+                    groupParametersWriterService.put(peer, groupParameters)
                 }
             }
         }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
@@ -5,6 +5,7 @@ import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
+import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.state.RegistrationState
@@ -238,8 +239,9 @@ class DistributeMembershipPackageHandlerTest {
             .hasSize(1)
             .allSatisfy {
                 assertThat(it.topic).isEqualTo(REGISTRATION_COMMAND_TOPIC)
-                val value = (it.value as? DistributeMembershipPackage)
-                assertThat(value).isNotNull
+                assertThat((it.value as? RegistrationCommand)?.command)
+                    .isNotNull
+                    .isInstanceOf(DistributeMembershipPackage::class.java)
             }
     }
 
@@ -253,8 +255,9 @@ class DistributeMembershipPackageHandlerTest {
             .hasSize(1)
             .allSatisfy {
                 assertThat(it.topic).isEqualTo(REGISTRATION_COMMAND_TOPIC)
-                val value = (it.value as? DistributeMembershipPackage)
-                assertThat(value).isNotNull
+                assertThat((it.value as? RegistrationCommand)?.command)
+                    .isNotNull
+                    .isInstanceOf(DistributeMembershipPackage::class.java)
             }
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -94,7 +94,8 @@ class RegistrationServiceLifecycleHandlerTest {
         mock(),
         platformInfoProvider,
         mock(),
-        virtualNodeInfoReadService
+        virtualNodeInfoReadService,
+        mock(),
     )
 
     private val registrationServiceLifecycleHandler = RegistrationServiceLifecycleHandler(
@@ -288,7 +289,8 @@ class RegistrationServiceLifecycleHandlerTest {
                 mock(),
                 platformInfoProvider,
                 mock(),
-                virtualNodeInfoReadService
+                virtualNodeInfoReadService,
+                mock(),
             )
 
             val handle = RegistrationServiceLifecycleHandler(staticMemberRegistrationService)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -18,6 +18,7 @@ import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.impl.registration.TEST_CPI_NAME
 import net.corda.membership.impl.registration.TEST_CPI_VERSION
@@ -91,6 +92,7 @@ import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
@@ -258,6 +260,7 @@ class StaticMemberRegistrationServiceTest {
     private val groupParametersFactory: GroupParametersFactory = mock {
         on { create(any()) } doReturn mockGroupParameters
     }
+    private val groupParametersWriterService: GroupParametersWriterService = mock()
 
     private val registrationService = StaticMemberRegistrationService(
         groupPolicyProvider,
@@ -276,6 +279,7 @@ class StaticMemberRegistrationServiceTest {
         platformInfoProvider,
         groupParametersFactory,
         virtualNodeInfoReadService,
+        groupParametersWriterService,
     )
 
     private fun setUpPublisher() {
@@ -374,6 +378,21 @@ class StaticMemberRegistrationServiceTest {
                     status.capture()
                 )
             ).doReturn(MembershipPersistenceResult.Success(mock()))
+            whenever(groupPolicyProvider.getGroupPolicy(knownIdentity)).thenReturn(groupPolicyWithStaticNetwork)
+            whenever(virtualNodeInfoReadService.get(knownIdentity)).thenReturn(buildTestVirtualNodeInfo(knownIdentity))
+            setUpPublisher()
+            registrationService.start()
+
+            registrationService.register(registrationId, knownIdentity, mockContext)
+
+            assertThat(status.firstValue).isEqualTo(mockGroupParameters)
+        }
+
+        @Test
+        fun `registration publishes group parameters to Kafka for registering member`() {
+            val knownIdentity = HoldingIdentity(aliceName, "test-group")
+            val status = argumentCaptor<GroupParameters>()
+            doNothing().whenever(groupParametersWriterService).put(any(), status.capture())
             whenever(groupPolicyProvider.getGroupPolicy(knownIdentity)).thenReturn(groupPolicyWithStaticNetwork)
             whenever(virtualNodeInfoReadService.get(knownIdentity)).thenReturn(buildTestVirtualNodeInfo(knownIdentity))
             setUpPublisher()
@@ -654,6 +673,26 @@ class StaticMemberRegistrationServiceTest {
             verify(persistenceClient, times(1)).persistGroupParameters(eq(bob), eq(mockGroupParameters))
             verify(persistenceClient, times(1)).persistGroupParameters(eq(alice), eq(mockGroupParameters))
             verify(persistenceClient, never()).persistGroupParameters(eq(charlie), eq(mockGroupParameters))
+        }
+
+        @Test
+        fun `registration with notary role publishes group parameters to Kafka for all members who have vnodes set up`() {
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
+            )
+            whenever(groupPolicyProvider.getGroupPolicy(bob)).thenReturn(groupPolicyWithStaticNetwork)
+            whenever(virtualNodeInfoReadService.get(bob)).thenReturn(buildTestVirtualNodeInfo(bob))
+            setUpPublisher()
+            registrationService.start()
+
+            registrationService.register(registrationId, bob, context)
+
+            verify(groupParametersWriterService).put(eq(bob), eq(mockGroupParameters))
+            verify(groupParametersWriterService).put(eq(alice), eq(mockGroupParameters))
+            verify(groupParametersWriterService, never()).put(eq(charlie), eq(mockGroupParameters))
         }
     }
 

--- a/components/membership/synchronisation-impl/build.gradle
+++ b/components/membership/synchronisation-impl/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     implementation project(":components:configuration:configuration-read-service")
     implementation project(':components:crypto:crypto-client')
+    implementation project(":components:membership:group-params-writer-service")
     implementation project(":components:membership:group-policy")
     implementation project(':components:membership:membership-group-read')
     implementation project(':components:membership:membership-p2p')
@@ -47,6 +48,7 @@ dependencies {
     integrationTestRuntimeOnly project(':components:crypto:crypto-client-impl')
     integrationTestRuntimeOnly project(':components:crypto:crypto-hes-impl')
     integrationTestRuntimeOnly project(':components:db:db-connection-manager-impl')
+    integrationTestRuntimeOnly project(":components:membership:group-params-writer-service-impl")
     integrationTestRuntimeOnly project(':components:membership:membership-group-read-impl')
     integrationTestRuntimeOnly project(':components:membership:membership-p2p-impl')
     integrationTestRuntimeOnly project(':components:membership:membership-persistence-client-impl')

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
@@ -10,12 +10,14 @@ import net.corda.crypto.hes.StableKeyPairDecryptor
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
+import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.config.Configuration
 import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.data.crypto.SecureHash
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.identity.HoldingIdentity
+import net.corda.data.membership.GroupParameters
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.SignedMemberInfo
 import net.corda.data.membership.p2p.DistributionMetaData
@@ -23,6 +25,7 @@ import net.corda.data.membership.p2p.DistributionType
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.MembershipSyncRequest
 import net.corda.data.membership.p2p.SignedMemberships
+import net.corda.data.membership.p2p.WireGroupParameters
 import net.corda.data.sync.BloomFilter
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.layeredpropertymap.toAvro
@@ -33,13 +36,18 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.impl.synchronisation.dummy.MemberTestGroupPolicy
 import net.corda.membership.impl.synchronisation.dummy.MgmTestGroupPolicy
 import net.corda.membership.impl.synchronisation.dummy.TestCryptoOpsClient
 import net.corda.membership.impl.synchronisation.dummy.TestGroupPolicyProvider
 import net.corda.membership.impl.synchronisation.dummy.TestGroupReaderProvider
+import net.corda.membership.impl.synchronisation.dummy.TestMembershipPersistenceClient
 import net.corda.membership.impl.synchronisation.dummy.TestMembershipQueryClient
+import net.corda.membership.lib.EPOCH_KEY
+import net.corda.membership.lib.MODIFIED_TIME_KEY
+import net.corda.membership.lib.MPV_KEY
 import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
@@ -51,6 +59,7 @@ import net.corda.membership.lib.toWire
 import net.corda.membership.p2p.MembershipP2PReadService
 import net.corda.membership.p2p.helpers.MerkleTreeGenerator
 import net.corda.membership.p2p.helpers.Verifier
+import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.synchronisation.SynchronisationProxy
 import net.corda.messaging.api.processor.PubSubProcessor
@@ -63,6 +72,7 @@ import net.corda.p2p.app.AppMessage
 import net.corda.p2p.app.AuthenticatedMessage
 import net.corda.p2p.app.AuthenticatedMessageHeader
 import net.corda.schema.Schemas.Config.Companion.CONFIG_TOPIC
+import net.corda.schema.Schemas.Membership.Companion.GROUP_PARAMETERS_TOPIC
 import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_IN_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_TOPIC
@@ -76,14 +86,14 @@ import net.corda.schema.configuration.MembershipConfig.TtlsConfig.TTLS
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.test.util.eventually
 import net.corda.test.util.time.TestClock
-import net.corda.utilities.time.Clock
 import net.corda.utilities.concurrent.getOrThrow
+import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.cipher.suite.KeyEncodingService
+import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
-import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
@@ -147,6 +157,9 @@ class SynchronisationIntegrationTest {
         lateinit var membershipQueryClient: TestMembershipQueryClient
 
         @InjectService(timeout = 5000)
+        lateinit var membershipPersistenceClient: TestMembershipPersistenceClient
+
+        @InjectService(timeout = 5000)
         lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
 
         @InjectService(timeout = 5000)
@@ -154,6 +167,9 @@ class SynchronisationIntegrationTest {
 
         @InjectService(timeout = 5000)
         lateinit var stableKeyPairDecryptor: StableKeyPairDecryptor
+
+        @InjectService(timeout = 5000)
+        lateinit var groupParametersWriterService: GroupParametersWriterService
 
         val merkleTreeGenerator: MerkleTreeGenerator by lazy {
             MerkleTreeGenerator(
@@ -219,6 +235,8 @@ class SynchronisationIntegrationTest {
         const val MEMBERSHIP_P2P_SUBSYSTEM = "membership"
         const val CATEGORY = "SESSION_INIT"
         const val SCHEME = ECDSA_SECP256R1_CODE_NAME
+        const val EPOCH = "5"
+        const val PLATFORM_VERSION = "5000"
         val schemaVersion = ConfigurationSchemaVersion(1, 0)
 
         val syncId = UUID.randomUUID().toString()
@@ -279,6 +297,8 @@ class SynchronisationIntegrationTest {
                                 LifecycleCoordinatorName.forComponent<MembershipP2PReadService>(),
                                 LifecycleCoordinatorName.forComponent<CryptoOpsClient>(),
                                 LifecycleCoordinatorName.forComponent<MembershipQueryClient>(),
+                                LifecycleCoordinatorName.forComponent<MembershipPersistenceClient>(),
+                                LifecycleCoordinatorName.forComponent<GroupParametersWriterService>(),
                             )
                         )
                     } else if (e is RegistrationStatusChangeEvent) {
@@ -295,7 +315,9 @@ class SynchronisationIntegrationTest {
             membershipP2PReadService.start()
             cryptoOpsClient.start()
             membershipQueryClient.start()
+            membershipPersistenceClient.start()
             virtualNodeInfoReadService.start()
+            groupParametersWriterService.start()
             configurationReadService.bootstrapConfig(bootConfig)
 
             eventually {
@@ -353,7 +375,7 @@ class SynchronisationIntegrationTest {
                 String.format(MemberInfoExtension.URL_KEY, 0) to "https://corda5.r3.com:10000",
                 String.format(MemberInfoExtension.PROTOCOL_VERSION, 0) to "1",
                 MemberInfoExtension.SOFTWARE_VERSION to "5.0.0",
-                MemberInfoExtension.PLATFORM_VERSION to "5000",
+                MemberInfoExtension.PLATFORM_VERSION to PLATFORM_VERSION,
                 MemberInfoExtension.SERIAL to "1",
             ),
             sortedMapOf(
@@ -496,12 +518,37 @@ class SynchronisationIntegrationTest {
             .setHashCheck(hash.toAvro())
             .build()
 
+        val groupParameters = KeyValuePairList(
+            listOf(
+                KeyValuePair(EPOCH_KEY, EPOCH),
+                KeyValuePair(MPV_KEY, PLATFORM_VERSION),
+                KeyValuePair(MODIFIED_TIME_KEY, Instant.now().toString()),
+            ).sorted()
+        )
+        val serializedGroupParameters = keyValueSerializer.serialize(groupParameters)!!
+        val mgmSignatureGroupParameters = cryptoOpsClient.sign(
+            mgm.toCorda().shortHash.value,
+            mgmSessionKey,
+            SignatureSpec.ECDSA_SHA256,
+            serializedGroupParameters,
+            mapOf(
+                Verifier.SIGNATURE_SPEC to SignatureSpec.ECDSA_SHA256.signatureName
+            )
+        ).let { withKey ->
+            CryptoSignatureWithKey(
+                ByteBuffer.wrap(keyEncodingService.encodeAsByteArray(withKey.by)),
+                ByteBuffer.wrap(withKey.bytes),
+                withKey.context.toWire()
+            )
+        }
+        val wireGroupParameters = WireGroupParameters(ByteBuffer.wrap(serializedGroupParameters), mgmSignatureGroupParameters)
+
         val membershipPackage = MembershipPackage.newBuilder()
             .setDistributionType(DistributionType.STANDARD)
             .setCurrentPage(0)
             .setPageCount(1)
             .setCpiAllowList(null)
-            .setGroupParameters(null)
+            .setGroupParameters(wireGroupParameters)
             .setMemberships(
                 membership
             )
@@ -519,6 +566,16 @@ class SynchronisationIntegrationTest {
             SubscriptionConfig("membership_updates_test_receiver", MEMBER_LIST_TOPIC),
             getTestProcessor { v ->
                 completableResult.complete(v as PersistentMemberInfo)
+            },
+            messagingConfig = bootConfig
+        ).also { it.start() }
+
+        // Start subscription to check published group parameters
+        val completableResult2 = CompletableFuture<GroupParameters>()
+        val groupParametersSubscription = subscriptionFactory.createPubSubSubscription(
+            SubscriptionConfig("group_parameters_test_receiver", GROUP_PARAMETERS_TOPIC),
+            getTestProcessor { v ->
+                completableResult2.complete(v as GroupParameters)
             },
             messagingConfig = bootConfig
         ).also { it.start() }
@@ -574,6 +631,25 @@ class SynchronisationIntegrationTest {
                 it.assertThat(memberPublished.ledgerKeys.size).isEqualTo(0)
                 it.assertThat(memberPublished.status).isEqualTo(MEMBER_STATUS_ACTIVE)
                 it.assertThat(memberPublished.modifiedTime).isEqualTo(clock.instant().toString())
+            }
+
+            it.assertThat(membershipPersistenceClient.getPersistedGroupParameters()!!.toAvro()).isEqualTo(groupParameters)
+        }
+
+        // Receive and assert on group parameters
+        val result2 = assertDoesNotThrow {
+            completableResult2.getOrThrow(Duration.ofSeconds(5))
+        }
+        groupParametersSubscription.close()
+
+        assertSoftly {
+            it.assertThat(result2).isNotNull
+            it.assertThat(result2)
+                .isNotNull
+                .isInstanceOf(GroupParameters::class.java)
+            with(result2) {
+                it.assertThat(this.groupParameters).isEqualTo(groupParameters)
+                it.assertThat(this.viewOwner).isEqualTo(requester)
             }
         }
     }

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestCryptoOpsClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestCryptoOpsClient.kt
@@ -212,12 +212,12 @@ class TestCryptoOpsClientImpl @Activate constructor(
         get() = coordinator.status == LifecycleStatus.UP
 
     override fun start() {
-        logger.info("TestCryptoOpsClient starting.")
+        logger.info("${this::class.java.simpleName} starting.")
         coordinator.start()
     }
 
     override fun stop() {
-        logger.info("TestCryptoOpsClient starting.")
+        logger.info("${this::class.java.simpleName} stopping.")
         coordinator.stop()
     }
 }

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupPolicyProvider.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupPolicyProvider.kt
@@ -57,12 +57,12 @@ class TestGroupPolicyProviderImpl @Activate constructor(
         get() = coordinator.status == LifecycleStatus.UP
 
     override fun start() {
-        logger.info("TestGroupPolicyProvider starting.")
+        logger.info("${this::class.java.simpleName} starting.")
         coordinator.start()
     }
 
     override fun stop() {
-        logger.info("TestGroupPolicyProvider stopping.")
+        logger.info("${this::class.java.simpleName} stopping.")
         coordinator.stop()
     }
 
@@ -91,7 +91,7 @@ class MemberTestGroupPolicy : GroupPolicy {
 
 }
 
-class MgmTestGroupPolicy : GroupPolicy{
+class MgmTestGroupPolicy : GroupPolicy {
     companion object {
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
     }

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
@@ -66,12 +66,12 @@ class TestGroupReaderProviderImpl @Activate constructor(
         get() = coordinator.status == LifecycleStatus.UP
 
     override fun start() {
-        logger.info("${TestGroupReaderProvider::class.java.simpleName} starting.")
+        logger.info("${this::class.java.simpleName} starting.")
         coordinator.start()
     }
 
     override fun stop() {
-        logger.info("TestGroupReaderProvider starting.")
+        logger.info("${this::class.java.simpleName} stopping.")
         coordinator.stop()
     }
 }

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
@@ -1,0 +1,152 @@
+package net.corda.membership.impl.synchronisation.dummy
+
+import net.corda.data.KeyValuePairList
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.layeredpropertymap.toAvro
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import net.corda.membership.lib.registration.RegistrationRequest
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.v5.base.types.LayeredPropertyMap
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.membership.GroupParameters
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+
+/**
+ * Created for mocking and simplifying membership persistence client functionalities used by the membership services.
+ */
+interface TestMembershipPersistenceClient : MembershipPersistenceClient {
+    fun getPersistedGroupParameters(): GroupParameters?
+}
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [MembershipPersistenceClient::class, TestMembershipPersistenceClient::class])
+class TestMembershipPersistenceClientImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+) : TestMembershipPersistenceClient {
+    companion object {
+        val logger = contextLogger()
+        private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
+    }
+
+    private var persistedGroupParameters: GroupParameters? = null
+
+    private val coordinator =
+        coordinatorFactory.createCoordinator(LifecycleCoordinatorName.forComponent<MembershipPersistenceClient>()) { event, coordinator ->
+            if (event is StartEvent) {
+                coordinator.updateStatus(LifecycleStatus.UP)
+            }
+        }
+
+    override fun getPersistedGroupParameters(): GroupParameters? = persistedGroupParameters
+
+    override fun persistMemberInfo(
+        viewOwningIdentity: HoldingIdentity,
+        memberInfos: Collection<MemberInfo>
+    ): MembershipPersistenceResult<Unit> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun persistGroupPolicy(
+        viewOwningIdentity: HoldingIdentity,
+        groupPolicy: LayeredPropertyMap
+    ): MembershipPersistenceResult<Int> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun persistGroupParametersInitialSnapshot(viewOwningIdentity: HoldingIdentity): MembershipPersistenceResult<KeyValuePairList> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun persistGroupParameters(
+        viewOwningIdentity: HoldingIdentity,
+        groupParameters: GroupParameters
+    ): MembershipPersistenceResult<KeyValuePairList> {
+        persistedGroupParameters = groupParameters
+        return MembershipPersistenceResult.Success(groupParameters.toAvro())
+    }
+
+    override fun addNotaryToGroupParameters(
+        viewOwningIdentity: HoldingIdentity,
+        notary: MemberInfo
+    ): MembershipPersistenceResult<KeyValuePairList> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun persistRegistrationRequest(
+        viewOwningIdentity: HoldingIdentity,
+        registrationRequest: RegistrationRequest
+    ): MembershipPersistenceResult<Unit> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun setMemberAndRegistrationRequestAsApproved(
+        viewOwningIdentity: HoldingIdentity,
+        approvedMember: HoldingIdentity,
+        registrationRequestId: String
+    ): MembershipPersistenceResult<MemberInfo> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun setMemberAndRegistrationRequestAsDeclined(
+        viewOwningIdentity: HoldingIdentity,
+        declinedMember: HoldingIdentity,
+        registrationRequestId: String
+    ): MembershipPersistenceResult<Unit> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun setRegistrationRequestStatus(
+        viewOwningIdentity: HoldingIdentity,
+        registrationId: String,
+        registrationRequestStatus: RegistrationStatus
+    ): MembershipPersistenceResult<Unit> {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override val isRunning: Boolean
+        get() = coordinator.status == LifecycleStatus.UP
+
+    override fun start() {
+        logger.info("${this::class.java.simpleName} starting.")
+        coordinator.start()
+    }
+
+    override fun stop() {
+        logger.info("${this::class.java.simpleName} stopping.")
+        coordinator.stop()
+    }
+}

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
@@ -108,12 +108,12 @@ class TestMembershipQueryClientImpl @Activate constructor(
         get() = coordinator.status == LifecycleStatus.UP
 
     override fun start() {
-        TestCryptoOpsClientImpl.logger.info("TestCryptoOpsClient starting.")
+        logger.info("${this::class.java.simpleName} starting.")
         coordinator.start()
     }
 
     override fun stop() {
-        TestCryptoOpsClientImpl.logger.info("TestCryptoOpsClient starting.")
+        logger.info("${this::class.java.simpleName} stopping.")
         coordinator.stop()
     }
 }

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -15,6 +15,7 @@ import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.command.synchronisation.member.ProcessMembershipUpdates
 import net.corda.data.membership.p2p.DistributionMetaData
 import net.corda.data.membership.p2p.MembershipSyncRequest
+import net.corda.data.membership.p2p.WireGroupParameters
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator
@@ -27,6 +28,8 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.TimerEvent
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoExtension.Companion.id
 import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
 import net.corda.membership.lib.MemberInfoFactory
@@ -35,6 +38,7 @@ import net.corda.membership.lib.toWire
 import net.corda.membership.p2p.helpers.MerkleTreeGenerator
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.p2p.helpers.Verifier
+import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.synchronisation.MemberSynchronisationService
@@ -57,6 +61,7 @@ import net.corda.v5.base.util.debug
 import net.corda.v5.cipher.suite.KeyEncodingService
 import net.corda.v5.cipher.suite.SignatureVerificationService
 import net.corda.v5.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -79,6 +84,9 @@ class MemberSynchronisationServiceImpl internal constructor(
     private val p2pRecordsFactory: P2pRecordsFactory,
     private val merkleTreeGenerator: MerkleTreeGenerator,
     private val clock: Clock,
+    private val membershipPersistenceClient: MembershipPersistenceClient,
+    private val groupParametersFactory: GroupParametersFactory,
+    private val groupParametersWriterService: GroupParametersWriterService,
 ) : MemberSynchronisationService {
     @Suppress("LongParameterList")
     @Activate
@@ -103,6 +111,12 @@ class MemberSynchronisationServiceImpl internal constructor(
         signatureVerificationService: SignatureVerificationService,
         @Reference(service = KeyEncodingService::class)
         keyEncodingService: KeyEncodingService,
+        @Reference(service = MembershipPersistenceClient::class)
+        membershipPersistenceClient: MembershipPersistenceClient,
+        @Reference(service = GroupParametersFactory::class)
+        groupParametersFactory: GroupParametersFactory,
+        @Reference(service = GroupParametersWriterService::class)
+        groupParametersWriterService: GroupParametersWriterService,
     ) : this(
         publisherFactory,
         configurationReadService,
@@ -127,6 +141,9 @@ class MemberSynchronisationServiceImpl internal constructor(
             cordaAvroSerializationFactory,
         ),
         UTCClock(),
+        membershipPersistenceClient,
+        groupParametersFactory,
+        groupParametersWriterService,
     )
 
     /**
@@ -236,6 +253,24 @@ class MemberSynchronisationServiceImpl internal constructor(
                 (random.nextDouble() * 0.1 * maxDelayBetweenRequestsInMillis).toLong()
         }
 
+        private fun persistGroupParameters(
+            viewOwningMember: HoldingIdentity,
+            parametersFromPackage: WireGroupParameters
+        ): GroupParameters {
+            val groupParameters = with(parametersFromPackage) {
+                val groupParametersBytes = groupParameters.array()
+                val parametersList = deserializer.deserialize(groupParametersBytes)
+                    ?: throw CordaRuntimeException("Failed to deserialize group parameters from received membership package.")
+                verifier.verify(
+                    mgmSignature,
+                    groupParametersBytes,
+                )
+                groupParametersFactory.create(parametersList)
+            }
+            membershipPersistenceClient.persistGroupParameters(viewOwningMember, groupParameters)
+            return groupParameters
+        }
+
         override fun cancelCurrentRequestAndScheduleNewOne(
             memberIdentity: HoldingIdentity,
             mgm: HoldingIdentity,
@@ -277,7 +312,6 @@ class MemberSynchronisationServiceImpl internal constructor(
                 }.associateBy { it.id }
 
                 val persistentMemberInfoRecords = updateMembersInfo.entries.map { (id, memberInfo) ->
-                    // TODO - CORE-5811 - verify signatures in signed member infos.
                     val persistentMemberInfo = PersistentMemberInfo(
                         viewOwningMember.toAvro(),
                         memberInfo.memberProvidedContext.toWire(),
@@ -312,6 +346,10 @@ class MemberSynchronisationServiceImpl internal constructor(
                         persistentMemberInfoRecords
                     }
                 }
+
+                val persistedGroupParameters = persistGroupParameters(viewOwningMember, updates.membershipPackage.groupParameters)
+
+                groupParametersWriterService.put(viewOwningMember, persistedGroupParameters)
 
                 publisher.publish(allRecords).first().get(PUBLICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             } catch (e: Exception) {

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
@@ -404,6 +404,17 @@ class MemberSynchronisationServiceImplTest {
     }
 
     @Test
+    fun `failed MGM signature verification will not publish the group parameters to Kafka`() {
+        whenever(verifier.verify(eq(mgmSignatureGroupParameters), any())).thenThrow(CordaRuntimeException("Mock failure"))
+        postConfigChangedEvent()
+        synchronisationService.start()
+
+        synchronisationService.processMembershipUpdates(updates)
+
+        verify(groupParametersWriterService, never()).put(any(), any())
+    }
+
+    @Test
     fun `verification is called with the correct data on receiving membership package from MGM`() {
         postConfigChangedEvent()
         synchronisationService.start()

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
@@ -17,6 +17,7 @@ import net.corda.data.membership.command.synchronisation.member.ProcessMembershi
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.MembershipSyncRequest
 import net.corda.data.membership.p2p.SignedMemberships
+import net.corda.data.membership.p2p.WireGroupParameters
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.lifecycle.LifecycleCoordinator
@@ -30,6 +31,8 @@ import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.TimerEvent
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
@@ -38,6 +41,8 @@ import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.p2p.helpers.MerkleTreeGenerator
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.p2p.helpers.Verifier
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.publisher.Publisher
@@ -53,6 +58,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.minutes
 import net.corda.v5.crypto.merkle.MerkleTree
+import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
@@ -89,6 +95,7 @@ class MemberSynchronisationServiceImplTest {
         const val PUBLISHER_CLIENT_ID = "member-synchronisation-service"
         val MEMBER_CONTEXT_BYTES = "2222".toByteArray()
         val MGM_CONTEXT_BYTES = "3333".toByteArray()
+        val GROUP_PARAMETERS_BYTES = "dummy-parameters".toByteArray()
     }
     private val mockPublisher = mock<Publisher>().apply {
         whenever(publish(any())).thenReturn(listOf(CompletableFuture.completedFuture(Unit)))
@@ -157,6 +164,7 @@ class MemberSynchronisationServiceImplTest {
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> = mock {
         on { deserialize(MEMBER_CONTEXT_BYTES) } doReturn memberContextList
         on { deserialize(MGM_CONTEXT_BYTES) } doReturn mgmContextList
+        on { deserialize(GROUP_PARAMETERS_BYTES) } doReturn mock()
     }
     private val serializationFactory: CordaAvroSerializationFactory = mock {
         on { createAvroDeserializer(any(), eq(KeyValuePairList::class.java)) } doReturn keyValuePairListDeserializer
@@ -180,8 +188,14 @@ class MemberSynchronisationServiceImplTest {
         on { memberships } doReturn listOf(signedMemberInfo)
         on { hashCheck } doReturn hash
     }
+    private val mgmSignatureGroupParameters = mock<CryptoSignatureWithKey>()
+    private val wireGroupParameters = mock<WireGroupParameters> {
+        on { mgmSignature } doReturn mgmSignatureGroupParameters
+        on { groupParameters } doReturn ByteBuffer.wrap(GROUP_PARAMETERS_BYTES)
+    }
     private val membershipPackage: MembershipPackage = mock {
         on { memberships } doReturn signedMemberships
+        on { groupParameters } doReturn wireGroupParameters
     }
     private val synchronisationMetadata = mock<SynchronisationMetaData> {
         on { member } doReturn member.toAvro()
@@ -224,6 +238,12 @@ class MemberSynchronisationServiceImplTest {
     }
     private val clock = TestClock(Instant.ofEpochSecond(100))
     private val verifier = mock<Verifier>()
+    private val persistenceClient = mock<MembershipPersistenceClient>()
+    private val groupParameters = mock<GroupParameters>()
+    private val groupParametersFactory = mock<GroupParametersFactory> {
+        on { create(any()) } doReturn groupParameters
+    }
+    private val groupParametersWriterService = mock<GroupParametersWriterService>()
     private val synchronisationService = MemberSynchronisationServiceImpl(
         publisherFactory,
         configurationReadService,
@@ -236,6 +256,9 @@ class MemberSynchronisationServiceImplTest {
         p2pRecordsFactory,
         merkleTreeGenerator,
         clock,
+        persistenceClient,
+        groupParametersFactory,
+        groupParametersWriterService,
     )
 
     private fun postStartEvent() {
@@ -313,8 +336,43 @@ class MemberSynchronisationServiceImplTest {
     }
 
     @Test
+    fun `group parameters are successfully persisted on receiving membership package from MGM`() {
+        postConfigChangedEvent()
+        synchronisationService.start()
+        val capturedPersistedGroupParameters = argumentCaptor<GroupParameters>()
+        whenever(
+            persistenceClient.persistGroupParameters(
+                any(),
+                capturedPersistedGroupParameters.capture()
+            )
+        ).thenReturn(MembershipPersistenceResult.Success(mock()))
+
+        synchronisationService.processMembershipUpdates(updates)
+
+        val persistedGroupParameters = capturedPersistedGroupParameters.firstValue
+        assertSoftly {
+            it.assertThat(persistedGroupParameters).isEqualTo(groupParameters)
+        }
+    }
+
+    @Test
+    fun `group parameters are successfully published to kafka on receiving membership package from MGM`() {
+        postConfigChangedEvent()
+        synchronisationService.start()
+        val capturedPersistedGroupParameters = argumentCaptor<GroupParameters>()
+        doNothing().whenever(groupParametersWriterService).put(any(), capturedPersistedGroupParameters.capture())
+
+        synchronisationService.processMembershipUpdates(updates)
+
+        val publishedGroupParameters = capturedPersistedGroupParameters.firstValue
+        assertSoftly {
+            it.assertThat(publishedGroupParameters).isEqualTo(groupParameters)
+        }
+    }
+
+    @Test
     fun `failed member signature verification will not persist the member`() {
-        whenever(verifier.verify(eq(memberSignature), any())).thenThrow(CordaRuntimeException("Nop"))
+        whenever(verifier.verify(eq(memberSignature), any())).thenThrow(CordaRuntimeException("Mock failure"))
         postConfigChangedEvent()
         synchronisationService.start()
 
@@ -325,13 +383,24 @@ class MemberSynchronisationServiceImplTest {
 
     @Test
     fun `failed MGM signature verification will not persist the member`() {
-        whenever(verifier.verify(eq(mgmSignature), any())).thenThrow(CordaRuntimeException("Nop"))
+        whenever(verifier.verify(eq(mgmSignature), any())).thenThrow(CordaRuntimeException("Mock failure"))
         postConfigChangedEvent()
         synchronisationService.start()
 
         synchronisationService.processMembershipUpdates(updates)
 
         verify(mockPublisher, never()).publish(any())
+    }
+
+    @Test
+    fun `failed MGM signature verification will not persist the group parameters`() {
+        whenever(verifier.verify(eq(mgmSignatureGroupParameters), any())).thenThrow(CordaRuntimeException("Mock failure"))
+        postConfigChangedEvent()
+        synchronisationService.start()
+
+        synchronisationService.processMembershipUpdates(updates)
+
+        verify(persistenceClient, never()).persistGroupParameters(any(), any())
     }
 
     @Test

--- a/components/membership/synchronisation-impl/test.bndrun
+++ b/components/membership/synchronisation-impl/test.bndrun
@@ -8,6 +8,7 @@
     sun.security.x509
 
 -runrequires: \
+    bnd.identity;id='net.corda.group-params-writer-service-impl',\
     bnd.identity;id='net.corda.synchronisation-impl',\
     bnd.identity;id='net.corda.membership-p2p-impl',\
     bnd.identity;id='net.corda.membership-persistence-client-impl',\


### PR DESCRIPTION
The membership package distributed by the MGM - after a member joins, or in response to a synchronisation request - contains the updated group parameters. A member processing such synchronisation updates now persists these group parameters received from the MGM to its vnode database (and also publishes them to Kafka), on successful verification of the MGM's signature. Static registration is also updated to publish the persisted group parameters to Kafka.
https://r3-cev.atlassian.net/browse/CORE-7090