### PR TITLE
CORE-7999 force flow tests to run last so they do not interfere with other tests. 

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -27,18 +27,22 @@ class ConfigTests {
 
     @Test
     fun `can update config`() {
-        val currentValue = getConfig(RECONCILIATION_CONFIG).configWithDefaultsNode()[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
+        var currentValue = getCurrentReconConfigValue()
         val newValue = (currentValue * 1.5).toInt()
         updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to newValue).toJsonString(), RECONCILIATION_CONFIG)
 
         try {
-            val currentConfig = getConfig(RECONCILIATION_CONFIG)
-            val currentConfigJSON = currentConfig.sourceConfigNode()
-            val updatedValue = currentConfigJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
-            assertThat(updatedValue).isEqualTo(newValue)
+            currentValue = getCurrentReconConfigValue()
+            assertThat(currentValue).isEqualTo(newValue)
         } finally {
             // Be a good neighbour and rollback the configuration change back to what it was
             updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to currentValue).toJsonString(), RECONCILIATION_CONFIG)
         }
+    }
+
+    private fun getCurrentReconConfigValue(): Int {
+        val currentConfig = getConfig(RECONCILIATION_CONFIG)
+        val currentConfigJSON = currentConfig.sourceConfigNode()
+        return currentConfigJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -27,7 +27,7 @@ class ConfigTests {
 
     @Test
     fun `can update config`() {
-        var currentValue = getCurrentReconConfigValue()
+        var currentValue = getCurrentReconConfigValue(false)
         val newValue = (currentValue * 2)
         updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to newValue).toJsonString(), RECONCILIATION_CONFIG)
 
@@ -40,10 +40,10 @@ class ConfigTests {
         }
     }
 
-    private fun getCurrentReconConfigValue(): Int {
+    private fun getCurrentReconConfigValue(defaults: Boolean = false): Int {
         val currentConfig = getConfig(RECONCILIATION_CONFIG)
-        val currentConfigJSON = currentConfig.sourceConfigNode()
-        println("currentConfig: ${currentConfigJSON.toPrettyString()}")
-        return currentConfigJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
+        val configJSON = if (defaults) { currentConfig.configWithDefaultsNode() } else { currentConfig.sourceConfigNode() }
+        println("configJSON (defaults: $defaults): ${configJSON.toPrettyString()}")
+        return configJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -27,7 +27,7 @@ class ConfigTests {
     @Test
     fun `can update config`() {
         var currentValue = getCurrentReconConfigValue()
-        val newValue = (currentValue * 1.5).toInt()
+        val newValue = (currentValue * 2)
         updateConfig(mapOf(MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES to newValue).toJsonString(), MEMBERSHIP_CONFIG)
 
         try {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -43,6 +43,7 @@ class ConfigTests {
     private fun getCurrentReconConfigValue(): Int {
         val currentConfig = getConfig(RECONCILIATION_CONFIG)
         val currentConfigJSON = currentConfig.sourceConfigNode()
+        println("currentConfig: ${currentConfigJSON.toPrettyString()}")
         return currentConfigJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -1,9 +1,8 @@
 package net.corda.applications.workers.smoketest
 
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
-import net.corda.schema.configuration.ReconciliationConfig
-import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CONFIG_INTERVAL_MS
+import net.corda.schema.configuration.ConfigKeys.MEMBERSHIP_CONFIG
+import net.corda.schema.configuration.MembershipConfig.MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -14,8 +13,8 @@ class ConfigTests {
 
     @Test
     fun `get config includes defaults`() {
-        val defaultedConfigValues = getConfig(RECONCILIATION_CONFIG).configWithDefaultsNode()
-        ReconciliationConfig::class.java.declaredFields
+        val defaultedConfigValues = getConfig(MEMBERSHIP_CONFIG).configWithDefaultsNode()
+        MEMBERSHIP_CONFIG::class.java.declaredFields
             .filter { it.name != "INSTANCE" }
             .map { it.get(ConfigKeys) as String }
             .forEach {
@@ -29,21 +28,21 @@ class ConfigTests {
     fun `can update config`() {
         var currentValue = getCurrentReconConfigValue()
         val newValue = (currentValue * 1.5).toInt()
-        updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to newValue).toJsonString(), RECONCILIATION_CONFIG)
+        updateConfig(mapOf(MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES to newValue).toJsonString(), MEMBERSHIP_CONFIG)
 
         try {
             currentValue = getCurrentReconConfigValue()
             assertThat(currentValue).isEqualTo(newValue)
         } finally {
             // Be a good neighbour and rollback the configuration change back to what it was
-            updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to currentValue).toJsonString(), RECONCILIATION_CONFIG)
+            updateConfig(mapOf(MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES to currentValue).toJsonString(), MEMBERSHIP_CONFIG)
         }
     }
 
     private fun getCurrentReconConfigValue(): Int {
-        val currentConfig = getConfig(RECONCILIATION_CONFIG)
+        val currentConfig = getConfig(MEMBERSHIP_CONFIG)
         val currentConfigJSON = currentConfig.sourceConfigNode()
         println("currentConfig: ${currentConfigJSON.toPrettyString()}")
-        return currentConfigJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
+        return currentConfigJSON[MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES].asInt()
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -2,8 +2,8 @@ package net.corda.applications.workers.smoketest
 
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
-import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CONFIG_INTERVAL_MS
 import net.corda.schema.configuration.ReconciliationConfig
+import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CONFIG_INTERVAL_MS
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -32,7 +32,9 @@ class ConfigTests {
         updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to newValue).toJsonString(), RECONCILIATION_CONFIG)
 
         try {
-            val updatedValue = getConfig(RECONCILIATION_CONFIG).sourceConfigNode()[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
+            val currentConfig = getConfig(RECONCILIATION_CONFIG)
+            val currentConfigJSON = currentConfig.sourceConfigNode()
+            val updatedValue = currentConfigJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
             assertThat(updatedValue).isEqualTo(newValue)
         } finally {
             // Be a good neighbour and rollback the configuration change back to what it was

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -1,8 +1,9 @@
 package net.corda.applications.workers.smoketest
 
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.schema.configuration.ConfigKeys.MEMBERSHIP_CONFIG
-import net.corda.schema.configuration.MembershipConfig.MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES
+import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
+import net.corda.schema.configuration.ReconciliationConfig
+import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CONFIG_INTERVAL_MS
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -13,8 +14,8 @@ class ConfigTests {
 
     @Test
     fun `get config includes defaults`() {
-        val defaultedConfigValues = getConfig(MEMBERSHIP_CONFIG).configWithDefaultsNode()
-        MEMBERSHIP_CONFIG::class.java.declaredFields
+        val defaultedConfigValues = getConfig(RECONCILIATION_CONFIG).configWithDefaultsNode()
+        ReconciliationConfig::class.java.declaredFields
             .filter { it.name != "INSTANCE" }
             .map { it.get(ConfigKeys) as String }
             .forEach {
@@ -28,21 +29,21 @@ class ConfigTests {
     fun `can update config`() {
         var currentValue = getCurrentReconConfigValue()
         val newValue = (currentValue * 2)
-        updateConfig(mapOf(MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES to newValue).toJsonString(), MEMBERSHIP_CONFIG)
+        updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to newValue).toJsonString(), RECONCILIATION_CONFIG)
 
         try {
             currentValue = getCurrentReconConfigValue()
             assertThat(currentValue).isEqualTo(newValue)
         } finally {
             // Be a good neighbour and rollback the configuration change back to what it was
-            updateConfig(mapOf(MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES to currentValue).toJsonString(), MEMBERSHIP_CONFIG)
+            updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to currentValue).toJsonString(), RECONCILIATION_CONFIG)
         }
     }
 
     private fun getCurrentReconConfigValue(): Int {
-        val currentConfig = getConfig(MEMBERSHIP_CONFIG)
+        val currentConfig = getConfig(RECONCILIATION_CONFIG)
         val currentConfigJSON = currentConfig.sourceConfigNode()
         println("currentConfig: ${currentConfigJSON.toPrettyString()}")
-        return currentConfigJSON[MAX_DURATION_BETWEEN_SYNC_REQUESTS_MINUTES].asInt()
+        return currentConfigJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -27,7 +27,7 @@ class ConfigTests {
 
     @Test
     fun `can update config`() {
-        var currentValue = getCurrentReconConfigValue(false)
+        var currentValue = getCurrentReconConfigValue(true)
         val newValue = (currentValue * 2)
         updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to newValue).toJsonString(), RECONCILIATION_CONFIG)
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -43,7 +43,6 @@ class ConfigTests {
     private fun getReconConfigValue(defaults: Boolean): Int {
         val currentConfig = getConfig(RECONCILIATION_CONFIG)
         val configJSON = if (defaults) { currentConfig.configWithDefaultsNode() } else { currentConfig.sourceConfigNode() }
-        println("configJSON (defaults: $defaults): ${configJSON.toPrettyString()}")
         return configJSON[RECONCILIATION_CONFIG_INTERVAL_MS].asInt()
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -27,12 +27,12 @@ class ConfigTests {
 
     @Test
     fun `can update config`() {
-        var currentValue = getCurrentReconConfigValue(true)
+        var currentValue = getReconConfigValue(defaults = true)
         val newValue = (currentValue * 2)
         updateConfig(mapOf(RECONCILIATION_CONFIG_INTERVAL_MS to newValue).toJsonString(), RECONCILIATION_CONFIG)
 
         try {
-            currentValue = getCurrentReconConfigValue()
+            currentValue = getReconConfigValue(defaults = false)
             assertThat(currentValue).isEqualTo(newValue)
         } finally {
             // Be a good neighbour and rollback the configuration change back to what it was
@@ -40,7 +40,7 @@ class ConfigTests {
         }
     }
 
-    private fun getCurrentReconConfigValue(defaults: Boolean = false): Int {
+    private fun getReconConfigValue(defaults: Boolean): Int {
         val currentConfig = getConfig(RECONCILIATION_CONFIG)
         val configJSON = if (defaults) { currentConfig.configWithDefaultsNode() } else { currentConfig.sourceConfigNode() }
         println("configJSON (defaults: $defaults): ${configJSON.toPrettyString()}")

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -36,7 +36,10 @@ import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.TestMethodOrder
 
 @Suppress("Unused", "FunctionName")
-@Order(20)
+//The flow tests must go last as one test updates the messaging config which is highly disruptive to subsequent test runs. The real
+// solution to this is a larger effort to have components listen to their messaging pattern lifecycle status and for them to go DOWN when
+// their patterns are DOWN - CORE-8015
+@Order(999)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @TestInstance(Lifecycle.PER_CLASS)
 class FlowTests {


### PR DESCRIPTION
The flow test `cluster configuration changes are picked up and workers continue to operate normally` updated the messaging config as a final step. This triggers a restart of many components such as RPC message pattern responders. Subsequent tests such the ConfigTests are reliant on these being UP and so they can fail due to the race condition. Ordering this test to be last to reduce impact.
