### PR TITLE
NOTICK - CpiInfoMap improvements.

### DIFF
--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoMap.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoMap.kt
@@ -2,7 +2,7 @@ package net.corda.cpiinfo.read.impl
 
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
-import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import net.corda.data.packaging.CpiIdentifier as CpiIdentifierAvro
 import net.corda.data.packaging.CpiMetadata as CpiMetadataAvro
 
@@ -12,51 +12,49 @@ import net.corda.data.packaging.CpiMetadata as CpiMetadataAvro
  * We use the [toCorda()] methods to convert the Avro objects to Corda ones.
  */
 internal class CpiInfoMap {
-    private val metadataById: MutableMap<CpiIdentifierAvro, CpiMetadataAvro> =
-        Collections.synchronizedMap(mutableMapOf())
+    private val metadataById = ConcurrentHashMap<CpiIdentifier, CpiMetadata>()
 
     /** Clear all content */
     fun clear() = metadataById.clear()
 
     /** Get the Avro objects as Corda objects */
     fun getAllAsCordaObjects(): Map<CpiIdentifier, CpiMetadata> =
-        metadataById
-            .mapKeys { CpiIdentifier.fromAvro(it.key) }
-            .mapValues { CpiMetadata.fromAvro(it.value) }
+        metadataById.toMap()
 
     /** Put (store/merge) the incoming map */
     fun putAll(incoming: Map<CpiIdentifierAvro, CpiMetadataAvro>) =
         incoming.forEach { (key, value) -> put(key, value) }
 
-    /** Put [CpiMetadataAvro] into internal maps. */
-    private fun putValue(key: CpiIdentifierAvro, value: CpiMetadataAvro) {
-        metadataById[key] = value
-    }
-
     /** Putting a null value removes the [CpiMetadataAvro] from the maps. */
     fun put(key: CpiIdentifierAvro, value: CpiMetadataAvro?) {
+        val convertedKey = CpiIdentifier.fromAvro(key)
         if (value != null) {
             if (key != value.id) {
                 throw IllegalArgumentException("Trying to add a Cpi.Metadata for an incorrect Cpi.Identifier")
             }
-            putValue(key, value)
+            metadataById[convertedKey] = CpiMetadata.fromAvro(value)
         } else {
-            remove(key)
+            remove(convertedKey)
         }
     }
 
     /**
      * Get all [CpiMetadataAvro]
      */
-    fun getAll(): List<CpiMetadataAvro> = metadataById.values.toList()
+    fun getAll(): List<CpiMetadata> = metadataById.values.toList()
 
     /**
      * Get a [CpiMetadataAvro] by [CpiIdentifierAvro]
      */
-    fun get(id: CpiIdentifierAvro): CpiMetadataAvro? = metadataById[id]
+    fun get(id: CpiIdentifier): CpiMetadata? = metadataById[id]
 
     /**
      * Remove the [CpiMetadataAvro] from this collection and return it.
      */
-    fun remove(key: CpiIdentifierAvro): CpiMetadataAvro? = metadataById.remove(key)
+    fun remove(key: CpiIdentifier): CpiMetadata? = metadataById.remove(key)
+
+    /**
+     * Remove the [CpiMetadataAvro] from this collection and return it.
+     */
+    fun remove(key: CpiIdentifierAvro): CpiMetadata? = metadataById.remove(CpiIdentifier.fromAvro(key))
 }

--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderProcessor.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderProcessor.kt
@@ -104,14 +104,9 @@ class CpiInfoReaderProcessor(private val onStatusUpCallback: () -> Unit, private
         listeners.forEach { it.value.onUpdate(setOf(CpiIdentifier.fromAvro(newRecord.key)), currentSnapshot) }
     }
 
-    fun getAll(): List<CpiMetadata> {
-        return cpiInfoMap.getAll().map(CpiMetadata::fromAvro)
-    }
+    fun getAll(): List<CpiMetadata> = cpiInfoMap.getAll()
 
-    fun get(identifier: CpiIdentifier): CpiMetadata? {
-        val avroMsg = cpiInfoMap.get(identifier.toAvro()) ?: return null
-        return CpiMetadata.fromAvro(avroMsg)
-    }
+    fun get(identifier: CpiIdentifier): CpiMetadata? = cpiInfoMap.get(identifier)
 
     fun registerCallback(listener: CpiInfoListener): AutoCloseable {
         lock.withLock {


### PR DESCRIPTION
- Use a threadsafe map for CpiInfoMap
- Make the map more efficient by converting from Avro type on write rather than on read.