### PR TITLE
NOTICK: Update Jackson dependency to 2.14.0

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
     implementation "io.javalin:javalin-osgi:$javalinVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation ("io.micrometer:micrometer-core:0.1.0-SNAPSHOT") {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'

--- a/components/chunking/chunk-db-write-impl/build.gradle
+++ b/components/chunking/chunk-db-write-impl/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation project(':components:chunking:chunk-db-write')
     implementation project(':components:membership:certificates-service')
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
 
     implementation project(":libs:lifecycle:lifecycle")

--- a/components/crypto/crypto-service-impl/build.gradle
+++ b/components/crypto/crypto-service-impl/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -52,11 +52,7 @@ felixSecurityVersion=2.8.3
 guavaVersion=30.1.1-jre
 hibernateVersion=5.6.12.Final
 hikariCpVersion=5.0.1
-
-# jacksonVersion and jacksonDatabindVersion can be collapsed back together when 2.13.5 is released
-jacksonVersion=2.13.4
-jacksonDatabindVersion=2.13.4.2
-
+jacksonVersion=2.14.0
 jaxbVersion = 2.3.1
 jbossTransactionApiSpecVersion=1.1.1.Final
 jetbrainsAnnotationsVersion=13.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ slingVersion=3.3.2
 
 # HTTP RPC dependency versions
 javalinVersion = 4.6.4
-swaggerVersion = 2.1.12
+swaggerVersion = 2.2.7
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.15.0
 nimbusVersion = 9.37.2

--- a/libs/configuration/configuration-validation/build.gradle
+++ b/libs/configuration/configuration-validation/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation project(":libs:configuration:configuration-core")
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
 

--- a/libs/http-rpc/http-rpc-server-impl/build.gradle
+++ b/libs/http-rpc/http-rpc-server-impl/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     runtimeOnly "org.webjars:swagger-ui:$swaggeruiVersion"
-    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
 

--- a/libs/membership/schema-validation/build.gradle
+++ b/libs/membership/schema-validation/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation "net.corda:corda-base"
     api "net.corda:corda-membership-schema"
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     testRuntimeOnly 'org.osgi:osgi.core'

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     // Jackson dependencies for JSON formatted logs
     runtimeOnly "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     runtimeOnly "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -11,7 +11,7 @@ ext {
 dependencies {
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     implementation "net.corda:corda-application:$cordaApiVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/tools/crypto-tck/build.gradle
+++ b/tools/crypto-tck/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     api project(':libs:crypto:cipher-suite-impl')
     api project(':libs:crypto:crypto-serialization-impl')
 
-    api "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     api "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     api "org.assertj:assertj-core:$assertjVersion"


### PR DESCRIPTION
Updates the Jackson version to the latest, and folds the Jackson databind property back into the main Jackson property as per previous comments.

Upgrades:
jackson: 2.13.4.0 -> 2.14.0