### PR TITLE
CORE-6690 improved consistency

### DIFF
--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -384,53 +384,7 @@
                                     "enum": ["PEM","JKS"]
                                 },
                                 "password": {
-                                    "type": "object",
-                                    "default": {},
-                                    "title": "The password configuration",
-                                    "required": [
-                                        "value",
-                                        "valueFrom"
-                                    ],
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "value": {
-                                            "type": "string",
-                                            "default": "",
-                                            "title": "The password"
-                                        },
-                                        "valueFrom": {
-                                            "type": "object",
-                                            "default": {},
-                                            "title": "The password secret configuration",
-                                            "required": [
-                                                "secretKeyRef"
-                                            ],
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "secretKeyRef": {
-                                                    "type": "object",
-                                                    "default": {},
-                                                    "title": "The password key reference",
-                                                    "required": [
-                                                        "name",
-                                                        "key"
-                                                    ],
-                                                    "properties": {
-                                                        "name": {
-                                                            "type": "string",
-                                                            "default": "",
-                                                            "title": "The password secret name"
-                                                        },
-                                                        "key": {
-                                                            "type": "string",
-                                                            "default": "",
-                                                            "title": "The password secret key"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
+                                    "$ref": "#/$defs/config"
                                 } 
                             }
                         }

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -62,7 +62,7 @@ db:
     # the cluster database user configuration
     username:
       # -- the cluster database user
-      value: user
+      value: ""
       # the cluster database user secret configuration; used in preference to value if name is set
       valueFrom: 
         # the cluster database user secret key reference
@@ -130,7 +130,7 @@ kafka:
     # -- SASL username configuration for client connection to Kafka
     username: 
       # -- the SASL user
-      value: "user"
+      value: ""
       # -- the SASL user secret configuration; used in preference to value if name is set
       valueFrom:
         # -- the SASL user secret key reference

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -130,7 +130,7 @@ kafka:
     # -- SASL username configuration for client connection to Kafka
     username: 
       # -- the SASL user
-      value: ""
+      value: "user"
       # -- the SASL user secret configuration; used in preference to value if name is set
       valueFrom:
         # -- the SASL user secret key reference

--- a/values.yaml
+++ b/values.yaml
@@ -46,3 +46,5 @@ db:
         secretKeyRef:
           name: "prereqs-postgresql"
           key: "password"
+    username:
+      value: "user"


### PR DESCRIPTION
IntialAdminUSeer both have a default username.value however the sasl.username.value has been removed. I have added this default back for consistency.

turstore.password now refs the defs.config to reduce code duplication 

All changes have been tested with local deployment 