### PR TITLE
CORE-8060 - Remove CPI Info callback feature.

### DIFF
--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoMap.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoMap.kt
@@ -7,7 +7,7 @@ import net.corda.data.packaging.CpiIdentifier as CpiIdentifierAvro
 import net.corda.data.packaging.CpiMetadata as CpiMetadataAvro
 
 /**
- * Map of [CpiIdentifierAvro] to [CpiMetadataAvro] AVRO data objects
+ * Map of [CpiIdentifier] to [CpiMetadata] AVRO data objects
  *
  * We use the [toCorda()] methods to convert the Avro objects to Corda ones.
  */
@@ -17,9 +17,9 @@ internal class CpiInfoMap {
     /** Clear all content */
     fun clear() = metadataById.clear()
 
-    /** Get the Avro objects as Corda objects */
-    fun getAllAsCordaObjects(): Map<CpiIdentifier, CpiMetadata> =
-        metadataById.toMap()
+    /** Get all CpiMetadata */
+    fun getAll(): Map<CpiIdentifier, CpiMetadata> =
+        metadataById
 
     /** Put (store/merge) the incoming map */
     fun putAll(incoming: Map<CpiIdentifierAvro, CpiMetadataAvro>) =
@@ -39,22 +39,17 @@ internal class CpiInfoMap {
     }
 
     /**
-     * Get all [CpiMetadataAvro]
-     */
-    fun getAll(): List<CpiMetadata> = metadataById.values.toList()
-
-    /**
-     * Get a [CpiMetadataAvro] by [CpiIdentifierAvro]
+     * Get a [CpiMetadata] by [CpiIdentifier]
      */
     fun get(id: CpiIdentifier): CpiMetadata? = metadataById[id]
 
     /**
-     * Remove the [CpiMetadataAvro] from this collection and return it.
+     * Remove the [CpiMetadata] from this collection and return it.
      */
     fun remove(key: CpiIdentifier): CpiMetadata? = metadataById.remove(key)
 
     /**
-     * Remove the [CpiMetadataAvro] from this collection and return it.
+     * Remove the [CpiMetadata] from this collection and return it.
      */
     fun remove(key: CpiIdentifierAvro): CpiMetadata? = metadataById.remove(CpiIdentifier.fromAvro(key))
 }

--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReadServiceImpl.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReadServiceImpl.kt
@@ -1,7 +1,6 @@
 package net.corda.cpiinfo.read.impl
 
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.cpiinfo.read.CpiInfoListener
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
@@ -77,10 +76,9 @@ class CpiInfoReadServiceImpl @Activate constructor(
     fun close() {
         log.debug { "Cpi Info Reader Service component closing" }
         coordinator.close()
-        cpiInfoProcessor.close()
     }
 
-    override fun getAll(): List<CpiMetadata> = cpiInfoProcessor.getAll()
+    override fun getAll(): Collection<CpiMetadata> = cpiInfoProcessor.getAll()
 
     override fun getAllVersionedRecords(): Stream<VersionedRecord<CpiIdentifier, CpiMetadata>> =
         getAll()
@@ -95,7 +93,4 @@ class CpiInfoReadServiceImpl @Activate constructor(
             }
 
     override fun get(identifier: CpiIdentifier): CpiMetadata? = cpiInfoProcessor.get(identifier)
-
-    override fun registerCallback(listener: CpiInfoListener): AutoCloseable =
-        cpiInfoProcessor.registerCallback(listener)
 }

--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderProcessor.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderProcessor.kt
@@ -1,6 +1,5 @@
 package net.corda.cpiinfo.read.impl
 
-import net.corda.cpiinfo.read.CpiInfoListener
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.messaging.api.processor.CompactedProcessor
@@ -8,8 +7,6 @@ import net.corda.messaging.api.records.Record
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import java.util.*
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 import net.corda.data.packaging.CpiIdentifier as CpiIdAvro
 import net.corda.data.packaging.CpiMetadata as CpiMetadataAvro
 
@@ -19,7 +16,6 @@ import net.corda.data.packaging.CpiMetadata as CpiMetadataAvro
  * Maintains a compacted queue of [CPIIdentifier] to [CPIMetadata] Avro objects
  */
 class CpiInfoReaderProcessor(private val onStatusUpCallback: () -> Unit, private val onErrorCallback: () -> Unit) :
-    AutoCloseable,
     CompactedProcessor<CpiIdAvro, CpiMetadataAvro> {
 
     companion object {
@@ -34,10 +30,6 @@ class CpiInfoReaderProcessor(private val onStatusUpCallback: () -> Unit, private
     @Volatile
     private var snapshotReceived = false
 
-    private val lock = ReentrantLock()
-
-    private val listeners = Collections.synchronizedMap(mutableMapOf<ListenerSubscription, CpiInfoListener>())
-
     override val keyClass: Class<CpiIdAvro>
         get() = CpiIdAvro::class.java
 
@@ -46,13 +38,8 @@ class CpiInfoReaderProcessor(private val onStatusUpCallback: () -> Unit, private
 
     fun clear() {
         snapshotReceived = false
-        val changeKeys = cpiInfoMap.getAllAsCordaObjects().keys
         cpiInfoMap.clear()
-        val newSnapshot = cpiInfoMap.getAllAsCordaObjects() // is now empty
-        listeners.forEach { it.value.onUpdate(changeKeys, newSnapshot) }
     }
-
-    override fun close() = listeners.clear()
 
     override fun onSnapshot(currentData: Map<CpiIdAvro, CpiMetadataAvro>) {
         log.trace { "Cpi Info Processor received snapshot" }
@@ -71,9 +58,6 @@ class CpiInfoReaderProcessor(private val onStatusUpCallback: () -> Unit, private
         }
 
         snapshotReceived = true
-
-        val currentSnapshot = cpiInfoMap.getAllAsCordaObjects()
-        listeners.forEach { it.value.onUpdate(currentSnapshot.keys, currentSnapshot) }
 
         onStatusUpCallback()
     }
@@ -99,39 +83,9 @@ class CpiInfoReaderProcessor(private val onStatusUpCallback: () -> Unit, private
         } else {
             cpiInfoMap.remove(newRecord.key)
         }
-
-        val currentSnapshot = cpiInfoMap.getAllAsCordaObjects()
-        listeners.forEach { it.value.onUpdate(setOf(CpiIdentifier.fromAvro(newRecord.key)), currentSnapshot) }
     }
 
-    fun getAll(): List<CpiMetadata> = cpiInfoMap.getAll()
+    fun getAll(): Collection<CpiMetadata> = cpiInfoMap.getAll().values
 
     fun get(identifier: CpiIdentifier): CpiMetadata? = cpiInfoMap.get(identifier)
-
-    fun registerCallback(listener: CpiInfoListener): AutoCloseable {
-        lock.withLock {
-            val subscription = ListenerSubscription(this)
-            listeners[subscription] = listener
-            if (snapshotReceived) {
-                val currentSnapshot = cpiInfoMap.getAllAsCordaObjects()
-                listener.onUpdate(currentSnapshot.keys, currentSnapshot)
-            }
-            return subscription
-        }
-    }
-
-    /** Unregister a caller's subscription when they close it. */
-    private fun unregisterCallback(subscription: ListenerSubscription) {
-        listeners.remove(subscription)
-    }
-
-    /**
-     * We return this handle to the subscription callback to the caller so that the can [close()]
-     * it and unregister if they wish.
-     */
-    private class ListenerSubscription(private val service: CpiInfoReaderProcessor) : AutoCloseable {
-        override fun close() {
-            service.unregisterCallback(this)
-        }
-    }
 }

--- a/components/virtual-node/cpi-info-read-service-impl/src/test/kotlin/net/corda/cpiinfo/read/CpiInfoMapTest.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/test/kotlin/net/corda/cpiinfo/read/CpiInfoMapTest.kt
@@ -86,7 +86,7 @@ class CpiInfoMapTest {
         var all = map.getAll()
         assertThat(all).isNotNull
         assertThat(all.size).isEqualTo(1)
-        assertThat(map.getAll()[0]).isEqualTo(metadata)
+        assertThat(map.getAll().values.first()).isEqualTo(metadata)
 
         val otherIdentifier = CpiIdentifier("abc", "def", secureHash)
         val otherMetadata = CpiMetadata(otherIdentifier, secureHash, emptyList(), "", -1, currentTimestamp)
@@ -95,8 +95,8 @@ class CpiInfoMapTest {
         all = map.getAll()
         assertThat(all).isNotNull
         assertThat(all.size).isEqualTo(2)
-        assertThat(map.getAll()).contains(metadata)
-        assertThat(map.getAll()).contains(otherMetadata)
+        assertThat(map.getAll().values).contains(metadata)
+        assertThat(map.getAll().values).contains(otherMetadata)
     }
 
     @Test
@@ -121,7 +121,7 @@ class CpiInfoMapTest {
         }
 
         // GET THE ENTIRE CONTENT OF THE MAP AS CORDA TYPES AND CHECK THAT TOO.
-        val allCpiInfos = map.getAllAsCordaObjects()
+        val allCpiInfos = map.getAll()
 
         allCpiInfos.forEach { (k: CpiIdentifier, v: CpiMetadata) ->
             assertThat(map.get(k)).isNotNull

--- a/components/virtual-node/cpi-info-read-service-impl/src/test/kotlin/net/corda/cpiinfo/read/CpiInfoProcessorTest.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/test/kotlin/net/corda/cpiinfo/read/CpiInfoProcessorTest.kt
@@ -5,212 +5,97 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.messaging.api.records.Record
 import net.corda.v5.crypto.SecureHash
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 class CpiInfoProcessorTest {
     private lateinit var processor: CpiInfoReaderProcessor
-    private lateinit var listener: ListenerForTest
 
     private val secureHash = SecureHash("algorithm", "1234".toByteArray())
 
-    private val currentTimestamp = Instant.now()
+    private val currentTimestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 
     @BeforeEach
     fun beforeEach() {
-        listener = ListenerForTest()
         processor = CpiInfoReaderProcessor({ /* don't care about the callback */ }, { /* don't care about callback */ })
     }
 
-    private fun sendOnNextRandomMessage(processor: CpiInfoReaderProcessor): CpiIdentifier {
-        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
-        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy",-1, currentTimestamp)
-        processor.onNext(Record("", cpiMetadata.cpiId.toAvro(), cpiMetadata.toAvro()), null, emptyMap())
-        return cpiIdentifier
-    }
-
     @Test
-    fun `register client listener callback before onSnapshot is called`() {
-        processor.registerCallback(listener)
-
-        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
-        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
-        processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
-
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertEquals(listener.lastSnapshot[cpiIdentifier]?.cpiId, cpiIdentifier)
-    }
-
-    @Test
-    fun `register client listener callback after onSnapshot is called`() {
-        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
-        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
-
-        processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
-
-        processor.registerCallback(listener)
-
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertEquals(listener.lastSnapshot[cpiIdentifier]?.cpiId, cpiIdentifier)
-    }
-
-    @Test
-    fun `client listener callback executed onNext`() {
-        processor.registerCallback(listener)
+    fun `can get messages`() {
         processor.onSnapshot(emptyMap())
 
-        assertTrue(listener.update)
-
+        // Send message
         val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
         val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
 
-        listener.update = false
+        assertNull(processor.get(cpiIdentifier))
+
         processor.onNext(Record("", cpiIdentifier.toAvro(), cpiMetadata.toAvro()), null, emptyMap())
 
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertEquals(listener.lastSnapshot[cpiIdentifier]?.cpiId, cpiIdentifier)
-
-        listener.update = false
-
-        val newHoldingIdentity = sendOnNextRandomMessage(processor)
-
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(newHoldingIdentity))
-        assertEquals(listener.lastSnapshot[newHoldingIdentity]?.cpiId, newHoldingIdentity)
-
-        val anotherHoldingIdentity = sendOnNextRandomMessage(processor)
-
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(anotherHoldingIdentity))
-        assertEquals(listener.lastSnapshot[anotherHoldingIdentity]?.cpiId, anotherHoldingIdentity)
-
-        assertEquals(3, listener.lastSnapshot.size, "Expected 3 updates")
+        assertNotNull(processor.get(cpiIdentifier))
     }
 
     @Test
-    fun `unregister client listener callback`() {
-        val closeable = processor.registerCallback(listener)
-
-        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
-        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
-
-        processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertEquals(listener.lastSnapshot[cpiIdentifier]?.cpiId, cpiIdentifier)
-
-        // unregister and reset the listener
-        closeable.close()
-        listener.update = false
-
-        val newHoldingIdentity = sendOnNextRandomMessage(processor)
-
-        assertFalse(listener.update, "Listener should not have updated")
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier), "Listener should still contain last snapshot")
-        assertEquals(
-            listener.lastSnapshot[cpiIdentifier]?.cpiId,
-            cpiIdentifier,
-            "Listener should still contain last snapshot"
-        )
-        assertFalse(listener.lastSnapshot.containsKey(newHoldingIdentity), "Listener should not have received update")
-        assertNull(listener.lastSnapshot[newHoldingIdentity], "Listener should not contain new value for new key")
-    }
-
-    @Test
-    fun `client listener callback persists between start and stop of service`() {
-        processor.registerCallback(listener)
+    fun `can get all messages`() {
         processor.onSnapshot(emptyMap())
 
-        assertTrue(listener.update)
-
-        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
-        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
-
-
-        listener.update = false
-        processor.onNext(Record("", cpiIdentifier.toAvro(), cpiMetadata.toAvro()), null, emptyMap())
-
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertEquals(listener.lastSnapshot[cpiIdentifier]?.cpiId, cpiIdentifier)
-
-        listener.update = false
-
-        val newHoldingIdentity = sendOnNextRandomMessage(processor)
-
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(newHoldingIdentity))
-        assertEquals(listener.lastSnapshot[newHoldingIdentity]?.cpiId, newHoldingIdentity)
-
-        assertEquals(2, listener.lastSnapshot.size, "Expected two updates")
-    }
-
-    @Test
-    fun `client listeners are unregistered when service closes`() {
-        processor.registerCallback(listener)
+        val processor = CpiInfoReaderProcessor({ /* don't care about callback */ }, { /* don't care about callback */ })
         val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
         val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
 
         processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
 
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertEquals(listener.lastSnapshot[cpiIdentifier]?.cpiId, cpiIdentifier)
+        assertEquals(processor.getAll().size, 1)
+        assertEquals(processor.getAll().single{ it.cpiId == cpiIdentifier }, cpiMetadata)
+    }
 
-        processor.close()
-        listener.update = false
+    @Test
+    fun `messages map is updated`() {
+        processor.onSnapshot(emptyMap())
 
-        // listener should not now receive this message
-        val newHoldingIdentity = sendOnNextRandomMessage(processor)
+        val processor = CpiInfoReaderProcessor({ /* don't care about callback */ }, { /* don't care about callback */ })
+        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
+        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
 
-        assertFalse(listener.update, "Listener should not have updated")
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier), "Listener should still contain last snapshot")
-        assertEquals(
-            listener.lastSnapshot[cpiIdentifier]?.cpiId,
-            cpiIdentifier,
-            "Listener should still contain last snapshot"
-        )
-        assertFalse(listener.lastSnapshot.containsKey(newHoldingIdentity), "Listener should not have received update")
-        assertNull(listener.lastSnapshot[newHoldingIdentity], "Listener should not contain new value for new key")
+        processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
+
+        assertEquals(processor.getAll().size, 1)
+
+        // Send message
+        val cpiIdentifier2 = CpiIdentifier("abc2", UUID.randomUUID().toString(), secureHash)
+        val cpiMetadata2 = CpiMetadata(cpiIdentifier2, secureHash, emptyList(), "group policy2", -1, currentTimestamp)
+
+        processor.onNext(Record("", cpiIdentifier2.toAvro(), cpiMetadata2.toAvro()), null, emptyMap())
+
+        assertEquals(processor.getAll().size, 2)
+        assertEquals(processor.get(cpiIdentifier2), cpiMetadata2)
     }
 
     @Test
     fun `can delete messages`() {
-        processor.registerCallback(listener)
         processor.onSnapshot(emptyMap())
-        assertTrue(listener.update)
 
         // Send message
-        listener.update = false
         val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
         val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
 
         processor.onNext(Record("", cpiIdentifier.toAvro(), cpiMetadata.toAvro()), null, emptyMap())
 
-        assertTrue(listener.update)
-        assertTrue(listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertEquals(listener.lastSnapshot[cpiIdentifier]?.cpiId, cpiIdentifier)
-        assertEquals(1, listener.lastSnapshot.size, "No messages in snapshot")
+        assertTrue(processor.getAll().any { it.cpiId == cpiIdentifier })
 
         // Delete message
-        listener.update = false
         processor.onNext(Record("", cpiIdentifier.toAvro(), null), cpiMetadata.toAvro(), emptyMap())
 
-        assertTrue(listener.update)
-        assertTrue(!listener.lastSnapshot.containsKey(cpiIdentifier))
-        assertNull(listener.lastSnapshot[cpiIdentifier]?.cpiId)
-
-        assertEquals(0, listener.lastSnapshot.size, "No messages in snapshot")
+        assertFalse(processor.getAll().any { it.cpiId == cpiIdentifier })
     }
 
     @Test
@@ -219,43 +104,52 @@ class CpiInfoProcessorTest {
         val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
         val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
 
-        processor.registerCallback(listener)
         processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
 
-        assertThat(listener.lastSnapshot.containsKey(cpiIdentifier)).isTrue
+        assertTrue(processor.getAll().any { it.cpiId == cpiIdentifier })
 
         processor.clear()
 
-        assertThat(listener.lastSnapshot.isEmpty()).isTrue
-        assertThat(listener.changedKeys.contains(cpiIdentifier)).isTrue
+        assertEquals(0, processor.getAll().size, "No messages in snapshot")
     }
 
     @Test
-    fun `internal onSnapshot callback is called`() {
-        var onSnapshot = false
-        val processor = CpiInfoReaderProcessor({ onSnapshot = true }, { /* don't care about callback */ })
-        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
-        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
-
-        processor.registerCallback(listener)
-
-        assertThat(onSnapshot).isFalse
-        processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
-        assertThat(onSnapshot).isTrue
-    }
-
-    @Test
-    fun `internal onError callback is called`() {
+    fun `onError callback is called from snapshot`() {
         var onError = false
         val processor = CpiInfoReaderProcessor({ /* don't care */ }, { onError = true })
         val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
         val cpiIdentifierOther = CpiIdentifier("def", UUID.randomUUID().toString(), secureHash)
         val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
 
-        processor.registerCallback(listener)
-
-        assertThat(onError).isFalse
+        Assertions.assertThat(onError).isFalse
         processor.onSnapshot(mapOf(cpiIdentifierOther.toAvro() to cpiMetadata.toAvro()))
-        assertThat(onError).isTrue
+        Assertions.assertThat(onError).isTrue
+    }
+
+    @Test
+    fun `onError callback is called from next`() {
+        var onError = false
+        val processor = CpiInfoReaderProcessor({ /* don't care */ }, { onError = true })
+        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
+        val cpiIdentifierOther = CpiIdentifier("def", UUID.randomUUID().toString(), secureHash)
+        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
+
+        Assertions.assertThat(onError).isFalse
+        processor.onNext(Record("", cpiIdentifierOther.toAvro(), cpiMetadata.toAvro()), null, emptyMap())
+        Assertions.assertThat(onError).isTrue
+    }
+
+    @Test
+    fun `onStatusUp callback is called from snapshot`() {
+        processor.onSnapshot(emptyMap())
+
+        var onStatusUp = false
+        val processor = CpiInfoReaderProcessor({ onStatusUp = true }, { /* don't care about callback */ })
+        val cpiIdentifier = CpiIdentifier("abc", UUID.randomUUID().toString(), secureHash)
+        val cpiMetadata = CpiMetadata(cpiIdentifier, secureHash, emptyList(), "group policy", -1, currentTimestamp)
+
+        Assertions.assertThat(onStatusUp).isFalse
+        processor.onSnapshot(mapOf(cpiIdentifier.toAvro() to cpiMetadata.toAvro()))
+        Assertions.assertThat(onStatusUp).isTrue
     }
 }

--- a/components/virtual-node/cpi-info-read-service/src/main/kotlin/net/corda/cpiinfo/read/CpiInfoReadService.kt
+++ b/components/virtual-node/cpi-info-read-service/src/main/kotlin/net/corda/cpiinfo/read/CpiInfoReadService.kt
@@ -9,15 +9,10 @@ interface CpiInfoReadService : ReconcilerReader<CpiIdentifier, CpiMetadata>, Lif
     /**
      * Returns a list of all CPI metadata, or empty list if no CPI metadata found.
      */
-    fun getAll(): List<CpiMetadata>
+    fun getAll(): Collection<CpiMetadata>
 
     /**
      * Returns a CPI metadata for a given identifier, or `null` if not found.
      */
     fun get(identifier: CpiIdentifier): CpiMetadata?
-
-    /**
-     * Register the [CpiInfoListener] callback to be notified on all [CpiMetadata] changes
-     */
-    fun registerCallback(listener: CpiInfoListener): AutoCloseable
 }

--- a/testing/cpi-info-read-service-fake/src/main/kotlin/net/corda/cpiinfo/read/fake/CpiInfoReadServiceFake.kt
+++ b/testing/cpi-info-read-service-fake/src/main/kotlin/net/corda/cpiinfo/read/fake/CpiInfoReadServiceFake.kt
@@ -16,7 +16,6 @@ import net.corda.reconciliation.VersionedRecord
 import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
 import java.util.stream.Stream
@@ -87,13 +86,6 @@ class CpiInfoReadServiceFake internal constructor(
         return cpiData[identifier]
     }
 
-    override fun registerCallback(listener: CpiInfoListener): AutoCloseable {
-        throwIfNotRunning()
-        callbacks += listener
-        listener.onUpdate(cpiData.keys, cpiData)
-        return AutoCloseable { callbacks.remove(listener) }
-    }
-
     override fun getAllVersionedRecords(): Stream<VersionedRecord<CpiIdentifier, CpiMetadata>>? {
         TODO("Not yet implemented")
     }
@@ -118,11 +110,6 @@ class CpiInfoReadServiceFake internal constructor(
 
     override fun stop() {
         coordinator.stop()
-    }
-
-    @Deactivate
-    fun close() {
-        coordinator.close()
     }
 
     private fun throwIfNotRunning() {

--- a/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/CpiInfoReadServiceFakeTest.kt
+++ b/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/CpiInfoReadServiceFakeTest.kt
@@ -28,15 +28,6 @@ internal class CpiInfoReadServiceFakeTest {
     }
 
     @Test
-    fun `callback is called immediately when registered`() {
-        val listener = Mockito.mock(CpiInfoListener::class.java)
-        val service = createService(cpi1)
-
-        service.registerCallback(listener)
-        Mockito.verify(listener).onUpdate(changedKeys(cpi1), snapshot(cpi1))
-    }
-
-    @Test
     fun `add a cpi info`() {
         val listener = Mockito.mock(CpiInfoListener::class.java)
         val service = createService(cpi1, callbacks = listOf(listener))

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.testing.sandboxes.impl
 
-import net.corda.cpiinfo.read.CpiInfoListener
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
@@ -44,10 +43,6 @@ class CpiInfoServiceImpl @Activate constructor(
     override fun get(identifier: CpiIdentifier): CpiMetadata? {
         val cpiFile = loader.getCpiMetadata(identifier)
         return cpiFile.get()
-    }
-
-    override fun registerCallback(listener: CpiInfoListener): AutoCloseable {
-        return AutoCloseable {}
     }
 
     override fun start() {


### PR DESCRIPTION
The callback feature was not used by any component and is introducing unnecessary complexity.

There is a similar feature for the VirtualNodeInfo, but this is used by the MGM/P2P components, so left in for now.