### PR TITLE
CORE-7856 Configure E2E test Kafka internal topics to have multiple replicas

### DIFF
--- a/.ci/e2eTests/prereqs.yaml
+++ b/.ci/e2eTests/prereqs.yaml
@@ -18,6 +18,8 @@ kafka:
       cpu: 1000m
   zookeeper:
     replicaCount: 3
+  offsetsTopicReplicationFactor: 3
+  transactionStateLogReplicationFactor: 3
 
 postgresql:
   primary:


### PR DESCRIPTION
The Bitnami Kafka helm chart defaults offset and transaction topics to having only 1 replica. The E2E tests are configured to have brokers scaled out to 7 instances which means the partitions are split amongst 7 instances. Because these topics have no replicas, when one of those 7 instances goes down, some of the transaction and offset partitions are not readable, because they only existed on that single broker. Upping the topic replicas to 3 (which mirrors user topic replica configuration for e2e tests) means 1 or 2 brokers can go down at the same time before partitions for these internal topics are unreadable.