### PR TITLE
CORE-8042: Ensure RegistrationServiceLifecycleHandler closes resources in the right order

### DIFF
--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation "net.corda:corda-topic-schema"
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
+    testImplementation project(":libs:lifecycle:lifecycle-test-impl")
+
     integrationTestImplementation project(':testing:db-message-bus-testkit')
 
     integrationTestRuntimeOnly project(':components:configuration:configuration-read-service-impl')

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
@@ -37,9 +37,9 @@ class RegistrationServiceLifecycleHandler(
         // Keys for resources managed by this components lifecycle coordinator. Note that this class is reliant on a
         // coordinator created elsewhere. It is therefore important to ensure that these keys do not clash with any
         // resources created in any other place that uses the same coordinator.
-        internal const val SUBSCRIPTION_RESOURCE = "SUBSCRIPTION_RESOURCE"
-        internal const val CONFIG_HANDLE = "CONFIG_HANDLE"
-        internal const val COMPONENT_HANDLE = "COMPONENT_HANDLE"
+        private const val SUBSCRIPTION_RESOURCE = "RegistrationServiceLifecycleHandler.SUBSCRIPTION_RESOURCE"
+        private const val CONFIG_HANDLE = "RegistrationServiceLifecycleHandler.CONFIG_HANDLE"
+        private const val COMPONENT_HANDLE = "RegistrationServiceLifecycleHandler.COMPONENT_HANDLE"
     }
 
     private val publisherFactory = staticMemberRegistrationService.publisherFactory
@@ -68,7 +68,7 @@ class RegistrationServiceLifecycleHandler(
     override fun processEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
         when (event) {
             is StartEvent -> handleStartEvent(coordinator)
-            is StopEvent -> handleStopEvent(coordinator)
+            is StopEvent -> handleStopEvent()
             is RegistrationStatusChangeEvent -> handleRegistrationChangeEvent(event, coordinator)
             is ConfigChangedEvent -> handleConfigChange(event, coordinator)
         }
@@ -86,10 +86,9 @@ class RegistrationServiceLifecycleHandler(
         }
     }
 
-    private fun handleStopEvent(coordinator: LifecycleCoordinator) {
+    private fun handleStopEvent() {
         _publisher?.close()
         _publisher = null
-        coordinator.closeManagedResources(setOf(SUBSCRIPTION_RESOURCE, CONFIG_HANDLE, COMPONENT_HANDLE))
     }
 
     private fun handleRegistrationChangeEvent(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
@@ -199,8 +199,6 @@ class RegistrationServiceLifecycleHandler(
      *
      * This allows us to enforce the close order on these two resources, which prevents an accidental extra DOWN event
      * from propagating when we're recreating the subscription.
-     *
-     * By hanging on to the configuration used to build the subscription, it can be rebuilt in the event of an error.
      */
     private class MembershipSubscriptionAndRegistration(
         val subscription: Subscription<String, StaticGroupDefinition>,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -10,13 +10,9 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.Resource
-import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.lifecycle.test.impl.LifecycleTest
 import net.corda.membership.grouppolicy.GroupPolicyProvider
-import net.corda.membership.impl.registration.staticnetwork.RegistrationServiceLifecycleHandler.Companion.COMPONENT_HANDLE
-import net.corda.membership.impl.registration.staticnetwork.RegistrationServiceLifecycleHandler.Companion.CONFIG_HANDLE
-import net.corda.membership.impl.registration.staticnetwork.RegistrationServiceLifecycleHandler.Companion.SUBSCRIPTION_RESOURCE
 import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.configs
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
@@ -32,7 +28,6 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 
 class RegistrationServiceLifecycleHandlerTest {
     private val componentHandle: RegistrationHandle = mock()
@@ -249,12 +244,6 @@ class RegistrationServiceLifecycleHandlerTest {
             bringDependencyUp(subName)
             context.verifyIsUp<TestRegistrationComponent>()
         }
-    }
-
-    @Test
-    fun `stop event closes managed resources`() {
-        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
-        verify(coordinator).closeManagedResources(setOf(SUBSCRIPTION_RESOURCE, CONFIG_HANDLE, COMPONENT_HANDLE))
     }
 
     private class TestRegistrationComponent(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -1,20 +1,22 @@
 package net.corda.membership.impl.registration.staticnetwork
 
-import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.hsm.HSMRegistrationClient
 import net.corda.data.KeyValuePairList
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
-import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationHandle
-import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.Resource
-import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
+import net.corda.lifecycle.createCoordinator
+import net.corda.lifecycle.test.impl.LifecycleTest
 import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.impl.registration.staticnetwork.RegistrationServiceLifecycleHandler.Companion.COMPONENT_HANDLE
+import net.corda.membership.impl.registration.staticnetwork.RegistrationServiceLifecycleHandler.Companion.CONFIG_HANDLE
+import net.corda.membership.impl.registration.staticnetwork.RegistrationServiceLifecycleHandler.Companion.SUBSCRIPTION_RESOURCE
 import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.configs
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
@@ -23,17 +25,13 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.CompactedSubscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
-import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class RegistrationServiceLifecycleHandlerTest {
@@ -53,12 +51,20 @@ class RegistrationServiceLifecycleHandlerTest {
         on { createPublisher(any(), any()) } doReturn publisher
     }
 
+    private val subName = LifecycleCoordinatorName("COMPACTED_SUBSCRIPTION")
+
     private val mockSubscription: CompactedSubscription<String, KeyValuePairList> = mock {
-        on { subscriptionName } doReturn mock()
+        on { subscriptionName } doReturn subName
     }
 
     private val subscriptionFactory: SubscriptionFactory = mock {
-        on { createCompactedSubscription(any(), any<CompactedProcessor<String, KeyValuePairList>>(), any()) } doReturn mockSubscription
+        on {
+            createCompactedSubscription(
+                any(),
+                any<CompactedProcessor<String, KeyValuePairList>>(),
+                any()
+            )
+        } doReturn mockSubscription
     }
 
     private val coordinator: LifecycleCoordinator = mock {
@@ -101,110 +107,204 @@ class RegistrationServiceLifecycleHandlerTest {
     )
 
     @Test
-    fun `Start event starts following the statuses of the required dependencies`() {
-        registrationServiceLifecycleHandler.processEvent(StartEvent(), coordinator)
-        assertThrows<IllegalArgumentException> { registrationServiceLifecycleHandler.publisher }
+    fun `Start event does not immediately move to UP status`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
 
-        verify(coordinator).followStatusChangesByName(
-            eq(
-                setOf(
-                    LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
-                    LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
-                    LifecycleCoordinatorName.forComponent<HSMRegistrationClient>()
-                )
+            context.verifyIsDown<TestRegistrationComponent>()
+        }
+    }
+
+    @Test
+    fun `UP is posted once all dependencies are UP and configuration has been provided`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate(configs)
+
+            context.verifyIsUp<TestRegistrationComponent>()
+            assertNotNull(context.testClass.registrationServiceLifecycleHandler.publisher)
+            assertNotNull(context.testClass.registrationServiceLifecycleHandler.groupParametersCache)
+        }
+    }
+
+    @Test
+    fun `component remains UP if the config is changed`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate(configs)
+
+            context.verifyIsUp<TestRegistrationComponent>()
+
+            // A config update of any variety should not trigger the test component to go down. This can be verified by
+            // sending the same thing again, as the code will still respond to this event as if it were a change.
+            sendConfigUpdate(configs)
+            context.verifyIsUp<TestRegistrationComponent>()
+        }
+    }
+
+    @Test
+    fun `component is DOWN after a stop event and the publisher is closed`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate(configs)
+
+            context.verifyIsUp<TestRegistrationComponent>()
+            testClass.stop()
+            context.verifyIsDown<TestRegistrationComponent>()
+        }
+
+        assertThrows<IllegalArgumentException> { registrationServiceLifecycleHandler.publisher }
+    }
+
+    @Test
+    fun `component goes DOWN if one of its dependencies goes DOWN`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate(configs)
+
+            toggleDependency<GroupPolicyProvider>({
+                context.verifyIsDown<TestRegistrationComponent>()
+            }, {
+                context.verifyIsDown<TestRegistrationComponent>()
+            })
+            sendConfigUpdate(configs)
+            context.verifyIsUp<TestRegistrationComponent>()
+
+            toggleDependency<ConfigurationReadService>({
+                context.verifyIsDown<TestRegistrationComponent>()
+            }, {
+                context.verifyIsDown<TestRegistrationComponent>()
+            })
+            sendConfigUpdate(configs)
+            context.verifyIsUp<TestRegistrationComponent>()
+
+            toggleDependency<HSMRegistrationClient>({
+                context.verifyIsDown<TestRegistrationComponent>()
+            }, {
+                context.verifyIsDown<TestRegistrationComponent>()
+            })
+            sendConfigUpdate(configs)
+            context.verifyIsUp<TestRegistrationComponent>()
+        }
+    }
+
+    @Test
+    fun `component goes DOWN and comes back UP if subscription goes DOWN then UP`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate(configs)
+
+            context.verifyIsUp<TestRegistrationComponent>()
+
+            toggleDependency(subName, {
+                context.verifyIsDown<TestRegistrationComponent>()
+            }, {
+                context.verifyIsUp<TestRegistrationComponent>()
+            })
+        }
+    }
+
+    @Test
+    fun `component goes DOWN and comes back UP if a dependent component errors and comes back`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate(configs)
+            context.verifyIsUp<TestRegistrationComponent>()
+
+            setDependencyToError<HSMRegistrationClient>()
+            context.verifyIsDown<TestRegistrationComponent>()
+            bringDependencyUp<HSMRegistrationClient>()
+
+            // Model a config update coming back due to us re-registering with the config read service.
+            sendConfigUpdate(configs)
+            context.verifyIsUp<TestRegistrationComponent>()
+        }
+    }
+
+    @Test
+    fun `component handles a subscription error and restart`() {
+        val context = getTestContext()
+        context.run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate(configs)
+
+            context.verifyIsUp<TestRegistrationComponent>()
+
+            setDependencyToError(subName)
+            context.verifyIsDown<TestRegistrationComponent>()
+            bringDependencyUp(subName)
+            context.verifyIsUp<TestRegistrationComponent>()
+        }
+    }
+
+    @Test
+    fun `stop event closes managed resources`() {
+        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
+        verify(coordinator).closeManagedResources(setOf(SUBSCRIPTION_RESOURCE, CONFIG_HANDLE, COMPONENT_HANDLE))
+    }
+
+    private class TestRegistrationComponent(
+        coordinatorFactory: LifecycleCoordinatorFactory,
+        val registrationServiceLifecycleHandler: RegistrationServiceLifecycleHandler
+    ) : Lifecycle {
+
+        private val coordinator =
+            coordinatorFactory.createCoordinator<TestRegistrationComponent>(registrationServiceLifecycleHandler)
+        override val isRunning: Boolean
+            get() = coordinator.isRunning
+
+        override fun start() {
+            coordinator.start()
+        }
+
+        override fun stop() {
+            coordinator.stop()
+        }
+    }
+
+    private fun getTestContext(): LifecycleTest<TestRegistrationComponent> {
+        return LifecycleTest {
+            addDependency<GroupPolicyProvider>()
+            addDependency<ConfigurationReadService>()
+            addDependency<HSMRegistrationClient>()
+            addDependency(subName)
+
+            val staticMemberRegistrationService = StaticMemberRegistrationService(
+                groupPolicyProvider,
+                publisherFactory,
+                subscriptionFactory,
+                mock(),
+                mock(),
+                configReadService,
+                coordinatorFactory,
+                hsmRegistrationClient,
+                memberInfoFactory,
+                mock(),
+                mock(),
+                membershipSchemaValidatorFactory,
+                mock(),
+                platformInfoProvider,
+                mock(),
+                virtualNodeInfoReadService
             )
-        )
-    }
 
-    @Test
-    fun `Stop event sets the publisher to null`() {
-        registrationServiceLifecycleHandler.processEvent(
-            ConfigChangedEvent(setOf(BOOT_CONFIG, MESSAGING_CONFIG), configs),
-            coordinator
-        )
-        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
-        assertThrows<IllegalArgumentException> { registrationServiceLifecycleHandler.publisher }
+            val handle = RegistrationServiceLifecycleHandler(staticMemberRegistrationService)
 
-        verify(componentHandle, never()).close()
-        verify(configHandle, never()).close()
-    }
-
-    @Test
-    fun `Component handle is created after starting and closed when stopping`() {
-        registrationServiceLifecycleHandler.processEvent(StartEvent(), coordinator)
-        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
-
-        verify(componentHandle).close()
-    }
-
-    @Test
-    fun `Config handle is created after registration status changes to UP and closed when stopping`() {
-        registrationServiceLifecycleHandler.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), coordinator
-        )
-        registrationServiceLifecycleHandler.processEvent(StopEvent(), coordinator)
-
-        verify(configHandle).close()
-    }
-
-    @Test
-    fun `Registration status UP registers for config updates`() {
-        registrationServiceLifecycleHandler.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), coordinator
-        )
-
-        verify(configurationReadService).registerComponentForUpdates(
-            any(), any()
-        )
-        verify(coordinator, never()).updateStatus(eq(LifecycleStatus.UP), any())
-    }
-
-    @Test
-    fun `Registration status DOWN sets component status to DOWN`() {
-        registrationServiceLifecycleHandler.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN), coordinator
-        )
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-    }
-
-    @Test
-    fun `Registration status ERROR sets component status to DOWN`() {
-        registrationServiceLifecycleHandler.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.ERROR), coordinator
-        )
-
-        verify(coordinator).updateStatus(eq(LifecycleStatus.DOWN), any())
-    }
-
-    @Test
-    fun `Registration status DOWN closes config handle if status was previously UP`() {
-        registrationServiceLifecycleHandler.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), coordinator
-        )
-
-        verify(configurationReadService).registerComponentForUpdates(
-            any(), any()
-        )
-
-        registrationServiceLifecycleHandler.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.DOWN), coordinator
-        )
-
-        verify(configHandle).close()
-    }
-
-    @Test
-    fun `After receiving the messaging configuration the publisher and group parameters cache are initialized`() {
-        registrationServiceLifecycleHandler.processEvent(
-            ConfigChangedEvent(setOf(BOOT_CONFIG, MESSAGING_CONFIG), configs),
-            coordinator
-        )
-        assertNotNull(registrationServiceLifecycleHandler.publisher)
-        assertNotNull(registrationServiceLifecycleHandler.groupParametersCache)
-        verify(coordinator).updateStatus(LifecycleStatus.UP)
-        verify(coordinator).followStatusChangesByName(
-            setOf(mockSubscription.subscriptionName)
-        )
+            TestRegistrationComponent(coordinatorFactory, handle)
+        }
     }
 }

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -189,6 +189,11 @@ class LifecycleTest<T : Lifecycle>(
     }
 
     /**
+     * Change the given dependency to the [LifecycleStatus.ERROR] state.
+     */
+    inline fun <reified D> setDependencyToError() = setDependencyToError(LifecycleCoordinatorName.forComponent<D>())
+
+    /**
      * Get the current coordinator by name
      */
     fun getCoordinatorFor(coordinatorName: LifecycleCoordinatorName): LifecycleCoordinator {


### PR DESCRIPTION
`RegistrationServiceLifecycleHandler` is responsible for the lifecycle of the membership registration service. The lifecycle handler creates a compacted subscription and then listens to it in order to respond to its lifecycle changes. However, when the subscription is created, previously no attempt was made to close the registration handle for that subscription. On closing the old subscription, a `RegistrationStatusChangeEvent` would be posted to coordinator indicating that the old subscription had gone down, which then resulted in the component shutting down completely. This situation cannot be recovered, as the dependency is circular - the component is waiting for the subscription to come up, but that can only happen if the component goes up and recreates it.

This PR ensures the registration handle is closed before closing the subscription on config change. The handler has also been migrated to use the managed resources API, which ensures objects are closed if they are ever recreated. This in turn reduces clutter in the class as a whole. Note that this is not appropriate for the publisher as this is exposed outside the class. Additionally the tests have been migrated to use the lifecycle testing API, to assist in readability.