### PR TITLE
CORE-8110 add null safety check for config rpc call

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -92,7 +92,7 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
             condition {
                 val bodyJSON = it.body.toJson()
                 it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
-                        && !bodyJSON["sourceConfig"][key].isNull
+                        && bodyJSON["sourceConfig"][key] != null
                         && bodyJSON.sourceConfigNode()[key].toString() == value
             }
         }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -93,7 +93,7 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
                 val bodyJSON = it.body.toJson()
                 it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
                         && bodyJSON["sourceConfig"][key] != null
-                        && bodyJSON.sourceConfigNode()[key].toString() == value
+                        && bodyJSON["sourceConfig"][key].toString() == value
             }
         }
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -71,7 +71,6 @@ fun updateConfig(config: String, section: String) {
  * Wait for the REST API on the rpc-worker to respond with an updated config value.
  * If [expectServiceToBeDown] is set to true it is expected the config endpoint will go down before coming back up with the new config.
  */
-@Suppress("UNNECESSARY_SAFE_CALL")
 fun waitForConfigurationChange(section: String, key: String, value: String, expectServiceToBeDown: Boolean = true, timeout: Duration = Duration
     .ofMinutes(1)) {
     cluster {
@@ -91,7 +90,9 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
             timeout(timeout)
             command { getConfig(section) }
             condition {
-                it.code == OK.statusCode && it.body.toJson().sourceConfigNode()?.get(key)?.asInt()?.toString() == value
+                val bodyJSON = it.body.toJson()
+                it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
+                        && bodyJSON.sourceConfigNode().get(key).asInt().toString() == value
             }
         }
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -92,7 +92,8 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
             condition {
                 val bodyJSON = it.body.toJson()
                 it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
-                        && bodyJSON.sourceConfigNode().get(key).asInt().toString() == value
+                        && !bodyJSON["sourceConfig"][key].isNull
+                        && bodyJSON.sourceConfigNode()[key].toString() == value
             }
         }
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -71,6 +71,7 @@ fun updateConfig(config: String, section: String) {
  * Wait for the REST API on the rpc-worker to respond with an updated config value.
  * If [expectServiceToBeDown] is set to true it is expected the config endpoint will go down before coming back up with the new config.
  */
+@Suppress("UNNECESSARY_SAFE_CALL")
 fun waitForConfigurationChange(section: String, key: String, value: String, expectServiceToBeDown: Boolean = true, timeout: Duration = Duration
     .ofMinutes(1)) {
     cluster {
@@ -90,7 +91,7 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
             timeout(timeout)
             command { getConfig(section) }
             condition {
-                it.code == OK.statusCode && it.body.toJson().sourceConfigNode()[key].asInt().toString() == value
+                it?.code == OK.statusCode && it.body?.toJson()?.sourceConfigNode()?.get(key)?.asInt()?.toString() == value
             }
         }
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -91,7 +91,7 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
             timeout(timeout)
             command { getConfig(section) }
             condition {
-                it?.code == OK.statusCode && it.body?.toJson()?.sourceConfigNode()?.get(key)?.asInt()?.toString() == value
+                it.code == OK.statusCode && it.body.toJson().sourceConfigNode()?.get(key)?.asInt()?.toString() == value
             }
         }
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -92,8 +92,8 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
             condition {
                 val bodyJSON = it.body.toJson()
                 it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
-                        && bodyJSON["sourceConfig"][key] != null
-                        && bodyJSON["sourceConfig"][key].toString() == value
+                        && bodyJSON.sourceConfigNode()[key] != null
+                        && bodyJSON.sourceConfigNode()[key].toString() == value
             }
         }
     }


### PR DESCRIPTION
rpc call to the config endpoint is returning sourceConfig field as null. This PR adds some null checking to the response condition check to avoid null pointers while the root cause is analysed