### PR TITLE
CORE-7042: Reduce the number of events post to coordinator after it had been closed

### DIFF
--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
@@ -167,7 +167,10 @@ class LifecycleCoordinatorImpl(
      */
     override fun cancelTimer(key: String) {
         logger.trace { "$name: Cancelling timer for key $key" }
-        postEvent(CancelTimer(key))
+        if (!isClosed) {
+            // No need to cancel any timer if the coordinator is closed
+            postEvent(CancelTimer(key))
+        }
     }
 
     /**
@@ -175,7 +178,9 @@ class LifecycleCoordinatorImpl(
      */
     override fun updateStatus(newStatus: LifecycleStatus, reason: String) {
         logger.trace { "$name: Updating status from ${lifecycleState.status} to $newStatus ($reason)" }
-        postEvent(StatusChange(newStatus, reason))
+        if (!isClosed) {
+            postEvent(StatusChange(newStatus, reason))
+        }
     }
 
     /**

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
@@ -204,8 +204,9 @@ internal class LifecycleProcessor(
     }
 
     private fun processClose(coordinator: LifecycleCoordinatorInternal): Boolean {
-        logger.debug  { "Closing coordinator ${coordinator.name}" }
+        logger.debug { "Closing coordinator ${coordinator.name}" }
         state.isRunning = false
+        state.cancelAllTimer()
         state.trackedRegistrations.forEach {
             logger.trace { "Closing $it on ${coordinator.name}." }
             it.close()

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleStateManager.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleStateManager.kt
@@ -109,6 +109,16 @@ internal class LifecycleStateManager(
     }
 
     /**
+     * Cancel al the timers own by the state manager.
+     */
+    fun cancelAllTimer() {
+        timerMap.values.forEach {
+            it.cancel(true)
+        }
+        timerMap.clear()
+    }
+
+    /**
      * Returns whether this coordinator has any open registrations, either on other coordinators or with other
      * coordinators on it.
      *

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
@@ -616,6 +616,18 @@ class LifecycleProcessorTest {
         verify(dependentComponents, never()).stopAll()
     }
 
+    @Test
+    fun `processClose will close all the timers`() {
+        val state = mock<LifecycleStateManager> {
+            on { nextBatch() } doReturn listOf(CloseCoordinator())
+        }
+        val processor = LifecycleProcessor(NAME, state, mock(), mock(), mock())
+
+        processor.processEvents(mock(), mock())
+
+        verify(state).cancelAllTimer()
+    }
+
     private object TestEvent1 : LifecycleEvent
     private object TestEvent2 : LifecycleEvent
     private object TestEvent3 : LifecycleEvent

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleStateManagerTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleStateManagerTest.kt
@@ -1,0 +1,37 @@
+package net.corda.lifecycle.impl
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import java.util.concurrent.ScheduledFuture
+
+class LifecycleStateManagerTest {
+    private val manager = LifecycleStateManager(10)
+
+    @Test
+    fun `cancelAllTimer will cancel all the timers`() {
+        val future1 = mock<ScheduledFuture<*>>()
+        val future2 = mock<ScheduledFuture<*>>()
+        manager.setTimer("one", future1)
+        manager.setTimer("two", future2)
+
+        manager.cancelAllTimer()
+
+        verify(future1).cancel(true)
+        verify(future2).cancel(true)
+    }
+
+    @Test
+    fun `cancelAllTimer will forget about the timers`() {
+        val future1 = mock<ScheduledFuture<*>>()
+        val future2 = mock<ScheduledFuture<*>>()
+        manager.setTimer("one", future1)
+        manager.setTimer("two", future2)
+
+        manager.cancelAllTimer()
+
+        manager.cancelTimer("one")
+        verify(future1, times(1)).cancel(true)
+    }
+}

--- a/libs/messaging/messaging-impl/build.gradle
+++ b/libs/messaging/messaging-impl/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
     testImplementation project(":testing:test-utilities")
 
     testRuntimeOnly 'org.osgi:osgi.core'

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/ThreadLooper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/ThreadLooper.kt
@@ -24,12 +24,23 @@ import kotlin.concurrent.withLock
  * drops out. That means you do not need to post explicit [LifecycleStatus.DOWN] events at the end of the loop function.
  * To raise UP or other lifecycle events at any time, the [updateLifecycleStatus] can be called.
  */
+@Suppress("LongParameterList")
 class ThreadLooper(
     private val log: Logger,
     private val config: ResolvedSubscriptionConfig,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     private val threadNamePrefix: String,
-    private val loopFunction: () -> Unit
+    private val loopFunction: () -> Unit,
+    private val threadFactory: (String, () -> Unit) -> Thread = { name, block ->
+        thread(
+            start = true,
+            isDaemon = true,
+            contextClassLoader = null,
+            name = name,
+            priority = -1,
+            block = block,
+        )
+    },
 ) : LifecycleStatusUpdater {
     @Volatile
     private var _stopped = false
@@ -67,13 +78,9 @@ class ThreadLooper(
             if (thread == null) {
                 _stopped = false
                 lifecycleCoordinator.start()
-                thread = thread(
-                    start = true,
-                    isDaemon = true,
-                    contextClassLoader = null,
-                    name = "$threadNamePrefix ${config.group}-${config.topic}",
-                    priority = -1,
-                    block = ::runConsumeLoop
+                thread = threadFactory(
+                    "$threadNamePrefix ${config.group}-${config.topic}",
+                    ::runConsumeLoop,
                 )
             }
         }
@@ -106,11 +113,15 @@ class ThreadLooper(
     }
 
     override fun updateLifecycleStatus(newStatus: LifecycleStatus) {
-        lifecycleCoordinator.updateStatus(newStatus)
+        if (isRunning) {
+            lifecycleCoordinator.updateStatus(newStatus)
+        }
     }
 
     override fun updateLifecycleStatus(newStatus: LifecycleStatus, reason: String) {
-        lifecycleCoordinator.updateStatus(newStatus, reason)
+        if (isRunning) {
+            lifecycleCoordinator.updateStatus(newStatus, reason)
+        }
     }
 
     private fun runConsumeLoop() {
@@ -119,8 +130,8 @@ class ThreadLooper(
         // by an apparent programming error at this point.
         try {
             loopFunction()
-            lifecycleCoordinator.close()
             _isRunning = false
+            lifecycleCoordinator.close()
         } catch (t: Throwable) {
             log.error("runConsumeLoop Throwable caught, subscription in an unrecoverable bad state:", t)
         }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/ThreadLooperTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/ThreadLooperTest.kt
@@ -1,0 +1,72 @@
+package net.corda.messaging.subscription
+
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.messaging.config.ResolvedSubscriptionConfig
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class ThreadLooperTest {
+    private val config = mock<ResolvedSubscriptionConfig> {
+        on { lifecycleCoordinatorName } doReturn LifecycleCoordinatorName("NAME")
+    }
+    private val coordinator = mock<LifecycleCoordinator>()
+    private val lifecycleCoordinatorFactory = mock<LifecycleCoordinatorFactory> {
+        on { createCoordinator(any(), any()) } doReturn coordinator
+    }
+    private val thread = mock<Thread>()
+
+    private val looper = ThreadLooper(
+        mock(),
+        config,
+        lifecycleCoordinatorFactory,
+        "",
+        { },
+    ) { _, block ->
+        block()
+        thread
+    }
+
+    @Test
+    fun `updateLifecycleStatus will update a running coordinate`() {
+        looper.updateLifecycleStatus(LifecycleStatus.UP)
+
+        verify(coordinator).updateStatus(LifecycleStatus.UP)
+    }
+
+    @Test
+    fun `updateLifecycleStatus will not update a closed coordinate`() {
+        looper.start()
+        looper.updateLifecycleStatus(LifecycleStatus.UP)
+
+        verify(coordinator, never()).updateStatus(LifecycleStatus.UP)
+    }
+
+    @Test
+    fun `updateLifecycleStatus with reason will update a running coordinate`() {
+        looper.updateLifecycleStatus(LifecycleStatus.UP, "reason")
+
+        verify(coordinator).updateStatus(LifecycleStatus.UP, "reason")
+    }
+
+    @Test
+    fun `updateLifecycleStatus with reason will not update a closed coordinate`() {
+        looper.start()
+        looper.updateLifecycleStatus(LifecycleStatus.UP, "reason")
+
+        verify(coordinator, never()).updateStatus(LifecycleStatus.UP, "reason")
+    }
+
+    @Test
+    fun `runConsumeLoop will close the coordinator`() {
+        looper.start()
+
+        verify(coordinator).close()
+    }
+}


### PR DESCRIPTION
This should remove (or reduce the occurrences) a few of the posting events to close coordinator messages:
* When we close the coordinator, posting something to cancel the timer is pointless. Instead, with this change closing, the coordinator will cancel all the timers and ignore any requests to cancel a timer.
* When we lose a partition, we change the RPC subscription to down, but this could also happen as part of the process of natural death; in that case, the coordinator is closed, and there is no point in updating its state to down.
* Changing the status of a coordinator after it has been closed should be ignored.

I'm not 100% sure that this warning is helpful at all. Maybe we should remove it.