### PR TITLE
CORE-8018 Fix dropped registration ID from RPC worker

### DIFF
--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
@@ -63,7 +63,6 @@ class MemberOpsServiceProcessor(
     private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
     private val membershipQueryClient: MembershipQueryClient,
     private val clock: Clock = UTCClock(),
-    private val idFactory: () -> UUID = { UUID.randomUUID() }
 ) : RPCResponderProcessor<MembershipRpcRequest, MembershipRpcResponse> {
 
     interface RpcHandler<REQUEST> {
@@ -133,7 +132,7 @@ class MemberOpsServiceProcessor(
                     ?: throw MembershipRegistrationException(
                         "Could not find holding identity associated with ${request.holdingIdentityId}"
                     )
-            val registrationId = idFactory()
+            val registrationId = UUID.fromString(context.requestId)
             val result = try {
                 registrationProxy.register(registrationId, holdingIdentity, request.context.toMap())
             } catch (e: RegistrationProtocolSelectionException) {

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -154,8 +154,8 @@ class MemberOpsServiceProcessorTest {
         virtualNodeInfoReadService,
         membershipGroupReaderProvider,
         membershipQueryClient,
-        clock
-    ) { UUID(3, 5) }
+        clock,
+    )
 
     private fun assertResponseContext(expected: MembershipRpcRequestContext, actual: MembershipRpcResponseContext) {
         assertEquals(expected.requestId, actual.requestId)
@@ -167,8 +167,9 @@ class MemberOpsServiceProcessorTest {
     @Test
     fun `should successfully submit registration request`() {
         val requestTimestamp = now
+        val requestId = UUID(0, 1).toString()
         val requestContext = MembershipRpcRequestContext(
-            UUID(0, 1).toString(),
+            requestId,
             requestTimestamp
         )
         val request = MembershipRpcRequest(
@@ -183,7 +184,7 @@ class MemberOpsServiceProcessorTest {
         processor.onNext(request, future)
         val result = future.get()
         val expectedResponse = RegistrationRpcResponse(
-            UUID(3, 5).toString(),
+            requestId,
             requestTimestamp,
             RegistrationRpcStatus.SUBMITTED,
             null,


### PR DESCRIPTION
When a registration request is submitted, the RPC worker generates an ID for the request. When the membership worker processes that request, it generates a new ID. In error scenarios, the RPC worker cannot return the registration ID since it has changed.
This change addresses the issue so that the ID is generated once in the RPC worker, and used by the membership worker.
https://r3-cev.atlassian.net/browse/CORE-8018