### PR TITLE
CORE-8114 Increase timeouts on subscription tests

### DIFF
--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImplTest.kt
@@ -43,7 +43,7 @@ import kotlin.concurrent.withLock
 class CompactedSubscriptionImplTest {
 
     companion object {
-        private const val TEST_TIMEOUT_SECONDS = 2L
+        private const val TEST_TIMEOUT_SECONDS = 20L
     }
 
     private val mapFactory = object : MapFactory<String, String> {

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImplTest.kt
@@ -34,7 +34,7 @@ import kotlin.concurrent.withLock
 
 class EventLogSubscriptionImplTest {
     private companion object {
-        private const val TEST_TIMEOUT_SECONDS = 3L
+        private const val TEST_TIMEOUT_SECONDS = 30L
     }
 
     private var mockRecordCount = 5L


### PR DESCRIPTION
These two test groups have timeouts an order of magnitude lower than the others. One of them is timing out occasionally on CI. This only started happening after a timeout was introduced, if the test was failing previously it would have manifested itself as hanging. We never saw this, so most likely the new failure is only down to a very restrictive timeout. It's now aligned with the other tests of the same nature.