### PR TITLE
CORE-6010 add logging to identify if a subscription is assigned multiple partitions by the db message bus

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,9 +10,9 @@ cordaPipeline(
     publishPreTestImage: true,
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
-    runE2eTests: false,
-    combinedWorkere2eTests: false,
-    javadocJar: false,
+    runE2eTests: true,
+    combinedWorkere2eTests: true,
+    javadocJar: true,
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,
     // allow publishing an installer to a download site

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ cordaPipeline(
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: false,
     combinedWorkere2eTests: false,
-    javadocJar: true,
+    javadocJar: false,
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,
     // allow publishing an installer to a download site

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,8 +10,8 @@ cordaPipeline(
     publishPreTestImage: true,
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
-    runE2eTests: true,
-    combinedWorkere2eTests: true,
+    runE2eTests: false,
+    combinedWorkere2eTests: false,
     javadocJar: true,
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
@@ -16,7 +16,7 @@ class TestEventLogProcessor(
 
     override fun onNext(events: List<EventLogRecord<String, DemoRecord>>): List<Record<*, *>> {
         for (event in events) {
-            println("TestEventLogProcessor for topic $outputTopic processing event $event")
+            println("TestEventLogProcessor for output topic $outputTopic processing event $event")
             latch.countDown()
         }
 

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
@@ -5,18 +5,23 @@ import net.corda.data.demo.DemoRecord
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
+import net.corda.v5.base.util.contextLogger
 
 class TestEventLogProcessor(
-    private val latch: CountDownLatch, private val outputTopic: String? = null
+    private val latch: CountDownLatch, private val outputTopic: String? = null, private val id: String? = null
 ) : EventLogProcessor<String, DemoRecord> {
     override val keyClass: Class<String>
         get() = String::class.java
     override val valueClass: Class<DemoRecord>
         get() = DemoRecord::class.java
 
+    private companion object {
+        val logder = contextLogger()
+    }
+
     override fun onNext(events: List<EventLogRecord<String, DemoRecord>>): List<Record<*, *>> {
         for (event in events) {
-            println("TestEventLogProcessor for output topic $outputTopic processing event $event")
+            logder.info("TestEventLogProcessor $id for output topic $outputTopic processing event $event")
             latch.countDown()
         }
 

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
@@ -1,10 +1,11 @@
 package net.corda.messaging.integration.processors
 
+import java.util.concurrent.CountDownLatch
 import net.corda.data.demo.DemoRecord
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
-import java.util.concurrent.CountDownLatch
+import net.corda.v5.base.util.contextLogger
 
 class TestEventLogProcessor(
     private val latch: CountDownLatch, private val outputTopic: String? = null
@@ -14,8 +15,13 @@ class TestEventLogProcessor(
     override val valueClass: Class<DemoRecord>
         get() = DemoRecord::class.java
 
+    private companion object {
+        val logger = contextLogger()
+    }
+
     override fun onNext(events: List<EventLogRecord<String, DemoRecord>>): List<Record<*, *>> {
         for (event in events) {
+            logger.info("TestEventLogProcessor for topic $outputTopic processing event $event")
             latch.countDown()
         }
 

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
@@ -21,7 +21,7 @@ class TestEventLogProcessor(
 
     override fun onNext(events: List<EventLogRecord<String, DemoRecord>>): List<Record<*, *>> {
         for (event in events) {
-            logger.info("TestEventLogProcessor for topic $outputTopic processing event $event")
+            println("TestEventLogProcessor for topic $outputTopic processing event $event")
             latch.countDown()
         }
 

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
@@ -5,7 +5,6 @@ import net.corda.data.demo.DemoRecord
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 
 class TestEventLogProcessor(
     private val latch: CountDownLatch, private val outputTopic: String? = null
@@ -14,10 +13,6 @@ class TestEventLogProcessor(
         get() = String::class.java
     override val valueClass: Class<DemoRecord>
         get() = DemoRecord::class.java
-
-    private companion object {
-        val logger = contextLogger()
-    }
 
     override fun onNext(events: List<EventLogRecord<String, DemoRecord>>): List<Record<*, *>> {
         for (event in events) {

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/EventLogSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/EventLogSubscriptionIntegrationTest.kt
@@ -153,8 +153,8 @@ class EventLogSubscriptionIntegrationTest {
             ConfigValueFactory.fromAnyRef(2)
         )
 
-        val eventLogSub1 = createSub(TestEventLogProcessor(latch), TEST_CONFIG)
-        val eventLogSub2 = createSub(TestEventLogProcessor(latch), secondSubConfig)
+        val eventLogSub1 = createSub(TestEventLogProcessor(latch, null, "1"), TEST_CONFIG)
+        val eventLogSub2 = createSub(TestEventLogProcessor(latch, null, "2"), secondSubConfig)
 
         coordinator.followStatusChangesByName(setOf(eventLogSub1.subscriptionName, eventLogSub2.subscriptionName))
 
@@ -171,8 +171,8 @@ class EventLogSubscriptionIntegrationTest {
 
         publisher.publish(getDemoRecords(EVENT_LOG_TOPIC2, 10, 2)).forEach { it.get() }
 
-        val eventLogSub1part2 = createSub(TestEventLogProcessor(latch, null, "1"), TEST_CONFIG)
-        val eventLogSub2part2 = createSub(TestEventLogProcessor(latch, null, "2"), secondSubConfig)
+        val eventLogSub1part2 = createSub(TestEventLogProcessor(latch, null, "3"), TEST_CONFIG)
+        val eventLogSub2part2 = createSub(TestEventLogProcessor(latch, null, "4"), secondSubConfig)
 
         eventLogSub1part2.start()
         eventLogSub2part2.start()

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/EventLogSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/EventLogSubscriptionIntegrationTest.kt
@@ -1,6 +1,8 @@
 package net.corda.messaging.integration.subscription
 
 import com.typesafe.config.ConfigValueFactory
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import net.corda.data.demo.DemoRecord
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.libs.configuration.SmartConfig
@@ -20,6 +22,8 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.messaging.integration.IntegrationTestProperties.Companion.TEST_CONFIG
 import net.corda.messaging.integration.TopicTemplates
+import net.corda.messaging.integration.TopicTemplates.Companion.EVENT_LOG_TOPIC1
+import net.corda.messaging.integration.TopicTemplates.Companion.EVENT_LOG_TOPIC2
 import net.corda.messaging.integration.getDemoRecords
 import net.corda.messaging.integration.getKafkaProperties
 import net.corda.messaging.integration.getTopicConfig
@@ -38,8 +42,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class, DBSetup::class)
 class EventLogSubscriptionIntegrationTest {
@@ -49,10 +51,6 @@ class EventLogSubscriptionIntegrationTest {
 
     private companion object {
         const val CLIENT_ID = "eventLogTestPublisher"
-
-        //automatically created topics
-        const val TOPIC1 = "EventLogTopic1"
-        const val TOPIC2 = "EventLogTopic2"
     }
 
     @InjectService(timeout = 4000)
@@ -79,9 +77,9 @@ class EventLogSubscriptionIntegrationTest {
     fun `asynch publish records and then start durable subscription`() {
         topicUtils.createTopics(getTopicConfig(TopicTemplates.EVENT_LOG_TOPIC1_TEMPLATE))
 
-        publisherConfig = PublisherConfig(CLIENT_ID + TOPIC1, false)
+        publisherConfig = PublisherConfig(CLIENT_ID + EVENT_LOG_TOPIC1, false)
         publisher = publisherFactory.createPublisher(publisherConfig, TEST_CONFIG)
-        val futures = publisher.publish(getDemoRecords(TOPIC1, 5, 2))
+        val futures = publisher.publish(getDemoRecords(EVENT_LOG_TOPIC1, 5, 2))
         assertThat(futures.size).isEqualTo(10)
         futures.forEach { it.get(10, TimeUnit.SECONDS) }
         publisher.close()
@@ -103,7 +101,7 @@ class EventLogSubscriptionIntegrationTest {
 
         val latch = CountDownLatch(10)
         val eventLogSub = subscriptionFactory.createEventLogSubscription(
-            SubscriptionConfig("$TOPIC1-group", TOPIC1),
+            SubscriptionConfig("$EVENT_LOG_TOPIC1-group", EVENT_LOG_TOPIC1),
             TestEventLogProcessor(latch),
             TEST_CONFIG,
             null
@@ -128,6 +126,8 @@ class EventLogSubscriptionIntegrationTest {
     @Test
     @Timeout(value = 30, unit = TimeUnit.SECONDS)
     fun `transactional publish records, start two durable subscription, stop subs, publish again and start subs`() {
+        val records = getDemoRecords(EVENT_LOG_TOPIC2, 5, 2)
+        assertThat(records.size).isEqualTo(10)
         topicUtils.createTopics(getTopicConfig(TopicTemplates.EVENT_LOG_TOPIC2_TEMPLATE))
 
         val coordinator =
@@ -135,19 +135,15 @@ class EventLogSubscriptionIntegrationTest {
             { event: LifecycleEvent, coordinator: LifecycleCoordinator ->
                 when (event) {
                     is RegistrationStatusChangeEvent -> {
-                        if (event.status == LifecycleStatus.UP) {
-                            coordinator.updateStatus(LifecycleStatus.UP)
-                        } else {
-                            coordinator.updateStatus(LifecycleStatus.DOWN)
-                        }
+                            coordinator.updateStatus(event.status)
                     }
                 }
             }
         coordinator.start()
 
-        publisherConfig = PublisherConfig(CLIENT_ID + TOPIC2)
+        publisherConfig = PublisherConfig(CLIENT_ID + EVENT_LOG_TOPIC2)
         publisher = publisherFactory.createPublisher(publisherConfig, TEST_CONFIG)
-        val futures = publisher.publish(getDemoRecords(TOPIC2, 5, 2))
+        val futures = publisher.publish(getDemoRecords(EVENT_LOG_TOPIC2, 5, 2))
         assertThat(futures.size).isEqualTo(1)
         futures[0].get()
 
@@ -156,15 +152,6 @@ class EventLogSubscriptionIntegrationTest {
             INSTANCE_ID,
             ConfigValueFactory.fromAnyRef(2)
         )
-
-        fun createSub(processor: TestEventLogProcessor, config: SmartConfig): Subscription<String, DemoRecord> {
-            return subscriptionFactory.createEventLogSubscription(
-                SubscriptionConfig("$TOPIC2-group", TOPIC2),
-                processor,
-                config,
-                null
-            )
-        }
 
         val eventLogSub1 = createSub(TestEventLogProcessor(latch), TEST_CONFIG)
         val eventLogSub2 = createSub(TestEventLogProcessor(latch), secondSubConfig)
@@ -182,7 +169,7 @@ class EventLogSubscriptionIntegrationTest {
         eventLogSub1.close()
         eventLogSub2.close()
 
-        publisher.publish(getDemoRecords(TOPIC2, 10, 2)).forEach { it.get() }
+        publisher.publish(getDemoRecords(EVENT_LOG_TOPIC2, 10, 2)).forEach { it.get() }
 
         val eventLogSub1part2 = createSub(TestEventLogProcessor(latch), TEST_CONFIG)
         val eventLogSub2part2 = createSub(TestEventLogProcessor(latch), secondSubConfig)
@@ -195,4 +182,12 @@ class EventLogSubscriptionIntegrationTest {
         publisher.close()
     }
 
+    fun createSub(processor: TestEventLogProcessor, config: SmartConfig): Subscription<String, DemoRecord> {
+        return subscriptionFactory.createEventLogSubscription(
+            SubscriptionConfig("$EVENT_LOG_TOPIC2-group", EVENT_LOG_TOPIC2),
+            processor,
+            config,
+            null
+        )
+    }
 }

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/EventLogSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/EventLogSubscriptionIntegrationTest.kt
@@ -171,8 +171,8 @@ class EventLogSubscriptionIntegrationTest {
 
         publisher.publish(getDemoRecords(EVENT_LOG_TOPIC2, 10, 2)).forEach { it.get() }
 
-        val eventLogSub1part2 = createSub(TestEventLogProcessor(latch), TEST_CONFIG)
-        val eventLogSub2part2 = createSub(TestEventLogProcessor(latch), secondSubConfig)
+        val eventLogSub1part2 = createSub(TestEventLogProcessor(latch, null, "1"), TEST_CONFIG)
+        val eventLogSub2part2 = createSub(TestEventLogProcessor(latch, null, "2"), secondSubConfig)
 
         eventLogSub1part2.start()
         eventLogSub2part2.start()


### PR DESCRIPTION
Add some additional logging to the test processor to confirm that records are being read from 2 partitions from 1 of the subscriptions created in:
    fun `transactional publish records, start two durable subscription, stop subs, publish again and start subs`() 