### PR TITLE
CORE-8118: remove simulator related modules for alpha release

### DIFF
--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -4,13 +4,6 @@ plugins {
     id 'corda.javadoc-generation'
 }
 
-// Temporary measure for DP2, required as a transitive dependency by simulator modules 
-// This code marks this module as to be published externally. 
-// TODO To be revisited prior to beta program.
-ext {
-    releasable = true
-}
-
 description 'Database Admin Implementation'
 
 dependencies {

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -4,13 +4,6 @@ plugins {
     id 'corda.javadoc-generation'
 }
 
-// Temporary measure for DP2, required as a transitive dependency by simulator modules 
-// This code marks this module as to be published externally. 
-// TODO To be revisited prior to beta program.
-ext {
-    releasable = true
-}
-
 description 'Database Admin API'
 
 dependencies {

--- a/libs/serialization/json-serializers/build.gradle
+++ b/libs/serialization/json-serializers/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'corda.javadoc-generation'
 }
 
-ext {
-    releasable = true
-}
-
 description 'Corda Common JSON serializers'
 
 

--- a/simulator/api/build.gradle
+++ b/simulator/api/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'corda.javadoc-generation'
 }
 
-ext {
-    releasable = true
-}
-
 dependencies {
 
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'corda.javadoc-generation'
 }
 
-ext {
-    releasable = true
-}
-
 dependencies {
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     implementation "net.corda:corda-application:$cordaApiVersion"


### PR DESCRIPTION
Remove external publishing for simulator and its related runtime dependencies . This is out of scope for Alpha delivery.



 