### PR TITLE
CORE-8126 - Fix helm command and typo in readme

### DIFF
--- a/tools/plugins/mgm/README.md
+++ b/tools/plugins/mgm/README.md
@@ -101,7 +101,7 @@ Running `setupCluster` with the name of the clusters to create. For example:
 ```shell
 ./corda-cli.sh mgm setupCluster demo-cluster-one demo-cluster-two
 ```
-By default, it will use the latest released tag. Change it using the `--baseImage` option. It will delete any
+By default, it will use the latest released tag. Change it using the `--base-image` option. It will delete any
 existing cluster with that name. Use the `--help` to view all the other options.
 
 # Onboard a member to an existing Corda cluster

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/SetupCordaCluster.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/SetupCordaCluster.kt
@@ -124,7 +124,7 @@ class SetupCordaCluster : Runnable {
                 "bootstrap.kafka.replicas=$kafkaReplicas," +
                 "kafka.sasl.enabled=false," +
                 "db.cluster.host=prereqs-postgresql," +
-                "db.cluster.existingSecret=prereqs-postgresql",
+                "db.cluster.password.valueFrom.secretKeyRef.name=prereqs-postgresql",
             "-n", clusterName, "--wait", "--timeout", "600s"
         )
         if (!cordaE2eType) {


### PR DESCRIPTION
Fix issue caused by changing the name of a param for helm install command. Fixed a typo in readme file.