### PR TITLE
NOTICK: Upgrade version of Swagger tom complement Jackson upgrade

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -103,7 +103,7 @@ slingVersion=3.3.2
 
 # HTTP RPC dependency versions
 javalinVersion = 4.6.4
-swaggerVersion = 2.1.12
+swaggerVersion = 2.2.7
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.15.0
 nimbusVersion = 9.37.2


### PR DESCRIPTION
Swagger library uses Jackson library and older version of Swagger does not work with newer version of Jackson, outputting strings like: `"example": null,` into OpenAPI definition causing tests like `GET openapi should return the OpenApi spec json() – net.corda.httprpc.server.impl.HttpRpcServerOpenApiTest` to fail.