### PR TITLE
CORE-7096: Configurable Docker Target Platform

### DIFF
--- a/buildSrc/src/main/groovy/corda.docker-app.gradle
+++ b/buildSrc/src/main/groovy/corda.docker-app.gradle
@@ -65,6 +65,10 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
         multiArch = multiArchSupport.toBoolean()
     }
 
+    if (project.hasProperty('targetPlatform')) {
+        targetPlatform = project.property('targetPlatform').toString()
+    }
+
     if (project.hasProperty('workerBaseImageTag')) {
         baseImageTag = workerBaseImageTag
     }

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -143,6 +143,10 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('multiArchSupport')) {
         multiArch = multiArchSupport.toBoolean()
     }
+
+    if (project.hasProperty('targetPlatform')) {
+        targetPlatform = project.property('targetPlatform').toString()
+    }
 }
 
 def s3Script = null


### PR DESCRIPTION
Add 'targetPlatform' property to 'DeployableContainerBuilder' so
consumers can manually choose target platform for images built through
the 'publishOSGiImage' gradle task.
