### PR TITLE
CORE-8110 add null safety check for config rpc call (#2539)

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTestUtils.kt
@@ -90,7 +90,10 @@ fun waitForConfigurationChange(section: String, key: String, value: String, expe
             timeout(timeout)
             command { getConfig(section) }
             condition {
-                it.code == OK.statusCode && it.body.toJson().sourceConfigNode()[key].asInt().toString() == value
+                val bodyJSON = it.body.toJson()
+                it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
+                        && bodyJSON.sourceConfigNode()[key] != null
+                        && bodyJSON.sourceConfigNode()[key].toString() == value
             }
         }
     }


### PR DESCRIPTION
rpc call to the config endpoint is returning sourceConfig field as null. This PR adds some null checking to the response condition check to avoid null pointers