### PR TITLE
CORE-8135 Check the public key in the session certificate

### DIFF
--- a/libs/p2p-crypto/src/integrationTest/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
+++ b/libs/p2p-crypto/src/integrationTest/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
@@ -7,11 +7,21 @@ import net.corda.testing.p2p.certificates.Certificates
 import net.corda.v5.base.types.MemberX500Name
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.io.ByteArrayInputStream
+import java.security.cert.CertificateFactory
 
 class CertificateValidatorTest {
 
+    private companion object {
+        const val certificateFactoryType = "X.509"
+        val certificateFactory: CertificateFactory = CertificateFactory.getInstance(certificateFactoryType)
+    }
+
     private val aliceX500Name =  MemberX500Name.parse("CN=Alice, O=R3 Test, L=London, S=London, C=GB")
     private val aliceCert = Certificates.aliceKeyStorePem.readText()
+    private val alicePublicKey = certificateFactory.generateCertificate(
+        ByteArrayInputStream(Certificates.aliceKeyStorePem.readBytes())
+    ).publicKey
     private val trustStore = listOf(Certificates.truststoreCertificatePem.readText())
     private val wrongTrustStore = listOf(Certificates.c4TruststoreCertificatePem.readText())
     private val revokedResponse =  RevocationCheckResponse(Revoked("The certificate was revoked.", 0))
@@ -19,30 +29,30 @@ class CertificateValidatorTest {
     @Test
     fun `valid certificate passes validation`() {
         val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, trustStore, { RevocationCheckResponse(Active()) })
-        validator.validate(listOf(aliceCert), aliceX500Name)
+        validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey)
     }
 
     @Test
     fun `revoked certificate fails validation with HARD FAIL mode`() {
         val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, trustStore, { revokedResponse })
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey) }
     }
 
     @Test
     fun `revoked certificate fails validation with SOFT FAIL mode`() {
         val validator = CertificateValidator(RevocationCheckMode.SOFT_FAIL, trustStore, { revokedResponse })
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey) }
     }
 
     @Test
     fun `revoked certificate passes validation with revocation OFF`() {
         val validator = CertificateValidator(RevocationCheckMode.OFF, trustStore, { revokedResponse })
-        validator.validate(listOf(aliceCert), aliceX500Name)
+        validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey)
     }
 
     @Test
     fun `if truststore is wrong validation fails`() {
         val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, wrongTrustStore, { RevocationCheckResponse(Active()) })
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey) }
     }
 }

--- a/libs/p2p-crypto/src/integrationTest/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
+++ b/libs/p2p-crypto/src/integrationTest/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
@@ -22,6 +22,9 @@ class CertificateValidatorTest {
     private val alicePublicKey = certificateFactory.generateCertificate(
         ByteArrayInputStream(Certificates.aliceKeyStorePem.readBytes())
     ).publicKey
+    private val wrongPublicKey = certificateFactory.generateCertificate(
+        ByteArrayInputStream(Certificates.bobKeyStorePem.readBytes())
+    ).publicKey
     private val trustStore = listOf(Certificates.truststoreCertificatePem.readText())
     private val wrongTrustStore = listOf(Certificates.c4TruststoreCertificatePem.readText())
     private val revokedResponse =  RevocationCheckResponse(Revoked("The certificate was revoked.", 0))
@@ -54,5 +57,11 @@ class CertificateValidatorTest {
     fun `if truststore is wrong validation fails`() {
         val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, wrongTrustStore, { RevocationCheckResponse(Active()) })
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey) }
+    }
+
+    @Test
+    fun `if public key does not match validation fails`() {
+        val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, trustStore, { RevocationCheckResponse(Active()) })
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, wrongPublicKey) }
     }
 }

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolExceptions.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolExceptions.kt
@@ -14,6 +14,6 @@ class InvalidMaxMessageSizeProposedError(msg: String): CordaRuntimeException(msg
  */
 class InvalidPeerCertificate private constructor(msg: String?, certChain: String): CordaRuntimeException((msg ?: "") + certChain) {
     constructor(msg: String?, certChain: Array<X509Certificate?>?): this(msg, "\nCertificate chain: \n" + certPathToString(certChain) )
-    constructor(msg: String, cert: X509Certificate): this(msg, "\nCertificate: \n" + arrayOf(cert))
+    constructor(msg: String, cert: X509Certificate): this(msg, "\nCertificate: \n" + certPathToString(arrayOf(cert)))
     constructor(msg: String): this(msg, "")
 }

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiator.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiator.kt
@@ -227,16 +227,21 @@ class AuthenticationProtocolInitiator(val sessionId: String,
                 }
                 agreedMaxMessageSize = this
             }
-            validateCertificate(responderHandshakePayload, theirX500Name)
+            validateCertificate(responderHandshakePayload, theirX500Name, theirPublicKey)
         }
     }
 
-    private fun validateCertificate(responderHandshakePayload: ResponderHandshakePayload, theirX500Name: MemberX500Name) {
+    private fun validateCertificate(
+        responderHandshakePayload: ResponderHandshakePayload,
+        theirX500Name: MemberX500Name,
+        theirPublicKey: PublicKey,
+    ) {
         if (certificateCheckMode != CertificateCheckMode.NoCertificate) {
             if (responderHandshakePayload.responderEncryptedExtensions.responderCertificate != null) {
                 certificateValidator!!.validate(
                     responderHandshakePayload.responderEncryptedExtensions.responderCertificate,
-                    theirX500Name
+                    theirX500Name,
+                    theirPublicKey
                 )
             } else {
                 throw InvalidPeerCertificate("No peer certificate was sent in the responder handshake message.")

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolResponder.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolResponder.kt
@@ -194,7 +194,7 @@ class AuthenticationProtocolResponder(val sessionId: String,
 
                 agreedMaxMessageSize = min(ourMaxMessageSize, this)
             }
-            validateCertificate(initiatorHandshakePayload, initiatorX500Name)
+            validateCertificate(initiatorHandshakePayload, initiatorX500Name, initiatorPublicKey)
 
             handshakeIdentityData =  HandshakeIdentityData(initiatorHandshakePayload.initiatorPublicKeyHash.array(),
                 initiatorHandshakePayload.initiatorEncryptedExtensions.responderPublicKeyHash.array(),
@@ -203,13 +203,18 @@ class AuthenticationProtocolResponder(val sessionId: String,
         }
     }
 
-    private fun validateCertificate(initiatorHandshakePayload: InitiatorHandshakePayload, initiatorX500Name: MemberX500Name) {
+    private fun validateCertificate(
+        initiatorHandshakePayload: InitiatorHandshakePayload,
+        initiatorX500Name: MemberX500Name,
+        initiatorPublicKey: PublicKey
+    ) {
         if (certificateCheckMode != CertificateCheckMode.NoCertificate) {
             if (initiatorHandshakePayload.initiatorEncryptedExtensions.initiatorCertificate != null) {
-            certificateValidator!!.validate(
-                initiatorHandshakePayload.initiatorEncryptedExtensions.initiatorCertificate,
-                initiatorX500Name
-            )
+                certificateValidator!!.validate(
+                    initiatorHandshakePayload.initiatorEncryptedExtensions.initiatorCertificate,
+                    initiatorX500Name,
+                    initiatorPublicKey
+                )
             } else {
                 throw InvalidPeerCertificate("No peer certificate was sent in the initiator handshake message.")
             }

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidator.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidator.kt
@@ -19,6 +19,7 @@ import java.security.cert.CertificateFactory
 import java.security.cert.PKIXBuilderParameters
 import java.security.cert.X509CertSelector
 import java.security.cert.X509Certificate
+import java.util.*
 
 class CertificateValidator(
     private val revocationCheckMode: RevocationCheckMode,
@@ -59,8 +60,11 @@ class CertificateValidator(
     }
 
     private fun validatePublicKey(certificate: X509Certificate, expectedPublicKey: PublicKey) {
-        if (certificate.publicKey != expectedPublicKey) {
-            throw InvalidPeerCertificate("The certificate does not contain the expected public key: $expectedPublicKey.", certificate)
+        if (!certificate.publicKey.encoded.contentEquals(expectedPublicKey.encoded)) {
+            throw InvalidPeerCertificate(
+                "The certificate does not contain the expected public key: ${expectedPublicKey.encoded.toBase64()}",
+                certificate
+            )
         }
     }
 
@@ -125,5 +129,9 @@ class CertificateValidator(
 
     private fun CertPath.toX509(): Array<X509Certificate?> {
         return this.certificates.map { it as? X509Certificate }.toTypedArray()
+    }
+
+    private fun ByteArray.toBase64(): String {
+        return Base64.getEncoder().encodeToString(this)
     }
 }

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
@@ -238,7 +238,7 @@ class AuthenticationProtocolFailureTest {
             sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, certCheckMode
         )
         val certificateValidatorResponder = certificateValidator.constructed()[1]!!
-        whenever(certificateValidatorResponder.validate(any(), any()))
+        whenever(certificateValidatorResponder.validate(any(), any(), any()))
             .thenThrow(InvalidPeerCertificate("Invalid peer certificate"))
 
         // Step 1: initiator sending hello message to responder.
@@ -287,7 +287,7 @@ class AuthenticationProtocolFailureTest {
             sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, certCheckMode
         )
         val certificateValidatorInitiator = certificateValidator.constructed()[0]!!
-        whenever(certificateValidatorInitiator.validate(any(), any())).thenThrow(InvalidPeerCertificate(""))
+        whenever(certificateValidatorInitiator.validate(any(), any(), any())).thenThrow(InvalidPeerCertificate(""))
 
         // Step 1: initiator sending hello message to responder.
         val initiatorHelloMsg = authenticationProtocolA.generateInitiatorHello()

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
@@ -73,8 +73,8 @@ class AuthenticationProtocolTest {
         )
         //One validator for AuthenticationProtocolInitiator and one for AuthenticationProtocolResponder
         assertThat(certificateValidator.constructed().size).isEqualTo(2)
-        verify(certificateValidator.constructed()[0]).validate(ourCertificate, aliceX500Name)
-        verify(certificateValidator.constructed()[1]).validate(ourCertificate, aliceX500Name)
+        verify(certificateValidator.constructed()[0]).validate(ourCertificate, aliceX500Name, partyBSessionKey.public)
+        verify(certificateValidator.constructed()[1]).validate(ourCertificate, aliceX500Name, partyASessionKey.public)
 
         certificateValidator.close()
     }

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
@@ -108,14 +108,4 @@ class CertificateValidatorTest {
         )
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
-
-    @Test
-    fun `if public key in certificate does not match the expected public key validation fails`() {
-        whenever(certificate.keyUsage).thenReturn(BooleanArray(10) { it == 0 }) //Set key usage bit
-        val validator = CertificateValidator(
-            RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
-        )
-        val differentPublicKey = mock<PublicKey>()
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, differentPublicKey) }
-    }
 }

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.security.PublicKey
 import java.security.cert.CertPath
 import java.security.cert.CertPathValidator
 import java.security.cert.Certificate
@@ -26,8 +27,10 @@ class CertificateValidatorTest {
     private val certX500Name =  MemberX500Name.parse("CN=cert, OU=MyUnit, O=MyOrg, L=London, S=London, C=GB")
     private val certPathValidator = mock<CertPathValidator>()
     private val certificatePemString = "certificate"
+    private val publicKey = mock<PublicKey>()
     private val certificate = mock<X509Certificate> {
         on {subjectX500Principal} doReturn certX500Name.x500Principal
+        on {publicKey} doReturn publicKey
     }
     private val certificateChain = mock<CertPath> {
         on { certificates } doReturn listOf(certificate)
@@ -51,7 +54,7 @@ class CertificateValidatorTest {
         val validator = CertificateValidator(
             RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
 
     @Test
@@ -59,7 +62,7 @@ class CertificateValidatorTest {
         val validator = CertificateValidator(
             RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), aliceX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), aliceX500Name, publicKey) }
     }
 
     @Test
@@ -69,7 +72,7 @@ class CertificateValidatorTest {
         val validator = CertificateValidator(
             RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
 
     @Test
@@ -82,7 +85,7 @@ class CertificateValidatorTest {
         val validator = CertificateValidator(
             RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
 
     @Test
@@ -91,7 +94,7 @@ class CertificateValidatorTest {
         val validator = CertificateValidator(
             RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
 
     @Test
@@ -103,6 +106,16 @@ class CertificateValidatorTest {
         val validator = CertificateValidator(
             RevocationCheckMode.HARD_FAIL, pemTruststore, { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name) }
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
+    }
+
+    @Test
+    fun `if public key in certificate does not match the expected public key validation fails`() {
+        whenever(certificate.keyUsage).thenReturn(BooleanArray(10) { it == 0 }) //Set key usage bit
+        val validator = CertificateValidator(
+            RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
+        )
+        val differentPublicKey = mock<PublicKey>()
+        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, differentPublicKey) }
     }
 }


### PR DESCRIPTION
Check that the session certificate’s public key matches the one used by the peer in the handshake of the authentication protocol. If these differ then the certificate validation.

I tested this following the instructions here: https://github.com/corda/corda-runtime-os/pull/2286#issue-1403608712. i.e. used the fake CA tool to create a session certificate when deploying a dynamic network. Sending 100 message between two peers using the app simulator.