### PR TITLE
 CORE-7629: Override equals/hashCode for cpi/cpk metadata entities so that stream to list conversions don't lose data on comparison.

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -1,7 +1,5 @@
 package net.corda.applications.workers.smoketest.flow
 
-import java.util.UUID
-import kotlin.text.Typography.quote
 import net.corda.applications.workers.smoketest.FlowStatus
 import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_FAILED
@@ -31,11 +29,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.TestMethodOrder
-import org.junit.jupiter.api.Disabled
+import java.util.*
+import kotlin.text.Typography.quote
 
 @Suppress("Unused", "FunctionName")
 //The flow tests must go last as one test updates the messaging config which is highly disruptive to subsequent test runs. The real
@@ -846,7 +846,7 @@ class FlowTests {
         assertThat(result.flowError?.message).contains("NotaryErrorReferenceStateUnknown")
     }
 
-    @Test
+    @RepeatedTest(10)
     fun `cluster configuration changes are picked up and workers continue to operate normally`() {
         val currentConfigValue = getConfig(MESSAGING_CONFIG).configWithDefaultsNode()[MAX_ALLOWED_MSG_SIZE].asInt()
         val newConfigurationValue = (currentConfigValue * 1.5).toInt()

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
@@ -846,7 +845,7 @@ class FlowTests {
         assertThat(result.flowError?.message).contains("NotaryErrorReferenceStateUnknown")
     }
 
-    @RepeatedTest(10)
+    @Test
     fun `cluster configuration changes are picked up and workers continue to operate normally`() {
         val currentConfigValue = getConfig(MESSAGING_CONFIG).configWithDefaultsNode()[MAX_ALLOWED_MSG_SIZE].asInt()
         val newConfigurationValue = (currentConfigValue * 1.5).toInt()

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -27,6 +27,7 @@ import net.corda.v5.crypto.DigestAlgorithmName
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/tests/CpiEntitiesTest.kt
@@ -144,7 +144,7 @@ class CpiEntitiesIntegrationTest {
             CpiEntities.classes.toList(),
             dbConfig
         ).use { em ->
-            val  loadedCpiEntity = em.find(
+            val loadedCpiEntity = em.find(
                 CpiMetadataEntity::class.java,
                 CpiMetadataEntityKey(cpi.name, cpi.version, cpi.signerSummaryHash)
             )
@@ -334,6 +334,7 @@ class CpiEntitiesIntegrationTest {
             dbConfig
         )
 
+        val cpiNames = mutableListOf<String>()
         // Create CPIs First
         for (i in 0..1) {
             val cpiId = UUID.randomUUID()
@@ -355,6 +356,7 @@ class CpiEntitiesIntegrationTest {
                 cpkMetadataEntity to cpkData
             }
             val cpi = TestObject.createCpi(cpiId, cpks.keys)
+            cpiNames.add(cpi.name)
 
             emFactory.use { em ->
                 em.transaction {
@@ -376,7 +378,9 @@ class CpiEntitiesIntegrationTest {
             // closing the EntityManager validates that we haven't returned proxies but instead eagerly loaded all data
         }
 
-        cpisEagerlyLoaded.forEach {
+        cpisEagerlyLoaded.filter {
+            it.name in cpiNames
+        }.forEach {
             assertThat(it.cpks.size).isEqualTo(2)
             it.cpks.forEach { cpkMetadataEntity ->
                 println("****       invoke metadata property ****")
@@ -391,7 +395,9 @@ class CpiEntitiesIntegrationTest {
             em.transaction {
                 val cpisLazyLoaded = em.findAllCpiMetadata()
 
-                cpisLazyLoaded.forEach {
+                cpisLazyLoaded.filter {
+                    it.name in cpiNames
+                }.forEach {
                     assertThat(it.cpks.size).isEqualTo(2)
                     it.cpks.forEach { cpkMetadataEntity ->
                         println("****       invoke metadata property ****")

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -18,6 +18,7 @@ import javax.persistence.OneToMany
 import javax.persistence.PreUpdate
 import javax.persistence.Table
 import javax.persistence.Version
+import kotlin.streams.asSequence
 
 /**
  * Cpi entity
@@ -143,5 +144,11 @@ fun EntityManager.findAllCpiMetadata(): Stream<CpiMetadataEntity> {
                 "INNER JOIN FETCH cpi_.cpks cpk_ " +
                 "INNER JOIN FETCH cpk_.metadata cpk_meta_",
         CpiMetadataEntity::class.java
-    ).resultStream
+    ).resultList.stream()
 }
+
+/**
+ * Extension to convert the stream to a list because Hibernate doesn't take all of the
+ * cpks for some reason.  But this seems to work.`
+ */
+fun Stream<CpiMetadataEntity>.toList(): List<CpiMetadataEntity> = asSequence().toList()

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -18,7 +18,6 @@ import javax.persistence.OneToMany
 import javax.persistence.PreUpdate
 import javax.persistence.Table
 import javax.persistence.Version
-import kotlin.streams.asSequence
 
 /**
  * Cpi entity
@@ -146,9 +145,3 @@ fun EntityManager.findAllCpiMetadata(): Stream<CpiMetadataEntity> {
         CpiMetadataEntity::class.java
     ).resultList.stream()
 }
-
-/**
- * Extension to convert the stream to a list because Hibernate doesn't take all of the
- * cpks for some reason.  But this seems to work.`
- */
-fun Stream<CpiMetadataEntity>.toList(): List<CpiMetadataEntity> = asSequence().toList()

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -126,6 +126,30 @@ data class CpiMetadataEntity(
             fileChecksum = fileChecksum,
             cpks = cpks,
         )
+
+    /**
+     * We'll override to only use the primary key as the default equals causes issues when converting a stream to a list
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CpiMetadataEntity) return false
+
+        if (name != other.name) return false
+        if (version != other.version) return false
+        if (signerSummaryHash != other.signerSummaryHash) return false
+
+        return true
+    }
+
+    /**
+     * We'll override to only use the primary key as the default equals causes issues when converting a stream to a list
+     */
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + version.hashCode()
+        result = 31 * result + signerSummaryHash.hashCode()
+        return result
+    }
 }
 
 /** The composite primary key for a CpiEntity. */
@@ -143,5 +167,5 @@ fun EntityManager.findAllCpiMetadata(): Stream<CpiMetadataEntity> {
                 "INNER JOIN FETCH cpi_.cpks cpk_ " +
                 "INNER JOIN FETCH cpk_.metadata cpk_meta_",
         CpiMetadataEntity::class.java
-    ).resultList.stream()
+    ).resultStream
 }

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpkMetadataEntity.kt
@@ -28,7 +28,27 @@ data class CpkMetadataEntity(
     @Version
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int = 0
-)
+) {
+    /**
+     * We'll override to only use the primary key as the default equals causes issues when converting a stream to a list
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CpkMetadataEntity) return false
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    /**
+     * We'll override to only use the primary key as the default equals causes issues when converting a stream to a list
+     */
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}
+
 /**
  * Composite primary key for a Cpk.
  */

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
@@ -23,6 +23,7 @@ import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
+import java.util.stream.Stream
 import javax.persistence.EntityManager
 import javax.persistence.TypedQuery
 import kotlin.streams.toList
@@ -105,7 +106,7 @@ class CpiInfoDbReconcilerReaderTest {
     @Test
     fun `doGetAllVersionedRecords converts db data to version records`() {
         val typeQuery = mock<TypedQuery<CpiMetadataEntity>>()
-        whenever(typeQuery.resultList).thenReturn(listOf(dummyCpiMetadataEntity))
+        whenever(typeQuery.resultStream).thenReturn(Stream.of(dummyCpiMetadataEntity))
         val em = mock<EntityManager>()
         whenever(em.transaction).thenReturn(mock())
         whenever(em.createQuery(any(), any<Class<CpiMetadataEntity>>())).thenReturn(typeQuery)

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
@@ -3,8 +3,10 @@ package net.corda.processors.db.internal.reconcile.db
 import net.corda.libs.cpi.datamodel.CpiCpkEntity
 import net.corda.libs.cpi.datamodel.CpiCpkKey
 import net.corda.libs.cpi.datamodel.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.CpkKey
 import net.corda.libs.cpi.datamodel.CpkMetadataEntity
 import net.corda.libs.packaging.core.CordappManifest
+import net.corda.libs.packaging.core.CordappType
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpkFormatVersion
 import net.corda.libs.packaging.core.CpkIdentifier
@@ -20,13 +22,10 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.util.Random
-import java.util.stream.Stream
+import java.util.*
 import javax.persistence.EntityManager
 import javax.persistence.TypedQuery
 import kotlin.streams.toList
-import net.corda.libs.cpi.datamodel.CpkKey
-import net.corda.libs.packaging.core.CordappType
 
 class CpiInfoDbReconcilerReaderTest {
     private val random = Random(0)
@@ -106,7 +105,7 @@ class CpiInfoDbReconcilerReaderTest {
     @Test
     fun `doGetAllVersionedRecords converts db data to version records`() {
         val typeQuery = mock<TypedQuery<CpiMetadataEntity>>()
-        whenever(typeQuery.resultStream).thenReturn(Stream.of(dummyCpiMetadataEntity))
+        whenever(typeQuery.resultList).thenReturn(listOf(dummyCpiMetadataEntity))
         val em = mock<EntityManager>()
         whenever(em.transaction).thenReturn(mock())
         whenever(em.createQuery(any(), any<Class<CpiMetadataEntity>>())).thenReturn(typeQuery)


### PR DESCRIPTION
This should ensure that conversion functions from Stream to List (for example) correctly grab all of the CPKs for a given CPI