### PR TITLE
CORE-7629: CPI Query returns incomplete data

### DIFF
--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -165,7 +165,8 @@ fun EntityManager.findAllCpiMetadata(): Stream<CpiMetadataEntity> {
     return createQuery(
         "FROM ${CpiMetadataEntity::class.simpleName} cpi_ " +
                 "INNER JOIN FETCH cpi_.cpks cpk_ " +
-                "INNER JOIN FETCH cpk_.metadata cpk_meta_",
+                "INNER JOIN FETCH cpk_.metadata cpk_meta_ " +
+                "ORDER BY cpi_.name, cpi_.version, cpi_.signerSummaryHash",
         CpiMetadataEntity::class.java
     ).resultStream
 }


### PR DESCRIPTION
Sort the query results by the primary key so that results representing to-many relationships are grouped together.