### PR TITLE
CORE-8184: Remove hardcoded "admin" user password from E2E/Smoke tests

### DIFF
--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/FlowExecutorE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/FlowExecutorE2eTest.kt
@@ -5,6 +5,8 @@ import net.corda.applications.workers.rpc.http.SkipWhenRpcEndpointUnavailable
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.applications.workers.rpc.http.TestToolkitProperty.Companion.DEFAULT_HTTP_HOST
 import net.corda.applications.workers.rpc.http.TestToolkitProperty.Companion.DEFAULT_HTTP_PORT
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminPassword
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminUser
 import net.corda.libs.permissions.endpoints.v1.role.RoleEndpoint
 import net.corda.test.util.eventually
 import net.corda.v5.base.util.seconds
@@ -29,7 +31,7 @@ class FlowExecutorE2eTest {
     fun `check FlowExecutor role creation`() {
         val randomVNodeHash = UUID.randomUUID().toString().replace("-", "").take(12)
 
-        val result = CliTask.execute(listOf("initial-rbac", "flow-executor", "-u", "admin", "-p", "admin",
+        val result = CliTask.execute(listOf("initial-rbac", "flow-executor", "-u", adminUser, "-p", adminPassword,
             "-t", "https://$DEFAULT_HTTP_HOST:$DEFAULT_HTTP_PORT", "-v", randomVNodeHash))
         assertThat(result.exitCode).withFailMessage(result.stdErr).isEqualTo(0)
         val roleName = "FlowExecutorRole-$randomVNodeHash"

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/LimitedUserAuthorizationE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/LimitedUserAuthorizationE2eTest.kt
@@ -4,6 +4,8 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit.DAYS
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.applications.workers.rpc.http.SkipWhenRpcEndpointUnavailable
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminPassword
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminUser
 import net.corda.httprpc.client.exceptions.PermissionException
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionType
 import org.assertj.core.api.Assertions
@@ -24,7 +26,7 @@ class LimitedUserAuthorizationE2eTest {
 
     companion object {
         private val testToolkit by TestToolkitProperty()
-        private val adminTestHelper = RbacE2eClientRequestHelper(testToolkit, "admin", "admin")
+        private val adminTestHelper = RbacE2eClientRequestHelper(testToolkit, adminUser, adminPassword)
         private lateinit var limitedUserTestHelper: RbacE2eClientRequestHelper
         private var limitedUserLogin: String = testToolkit.uniqueName
         private var limitedUserPassword: String = testToolkit.uniqueName

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/PermissionSummaryConcurrentE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/PermissionSummaryConcurrentE2eTest.kt
@@ -5,6 +5,8 @@ import java.time.temporal.ChronoUnit.DAYS
 import java.util.concurrent.Executors
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.applications.workers.rpc.http.SkipWhenRpcEndpointUnavailable
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminPassword
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminUser
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionType
 import net.corda.test.util.eventually
@@ -21,8 +23,8 @@ class PermissionSummaryConcurrentE2eTest {
     companion object {
         private val testToolkit by TestToolkitProperty()
         private val concurrentTestToolkit by TestToolkitProperty()
-        private val adminTestHelper = RbacE2eClientRequestHelper(testToolkit, "admin", "admin")
-        private val concurrentAdminTestHelper = RbacE2eClientRequestHelper(concurrentTestToolkit, "admin", "admin")
+        private val adminTestHelper = RbacE2eClientRequestHelper(testToolkit, adminUser, adminPassword)
+        private val concurrentAdminTestHelper = RbacE2eClientRequestHelper(concurrentTestToolkit, adminUser, adminPassword)
     }
 
     @Test
@@ -51,7 +53,7 @@ class PermissionSummaryConcurrentE2eTest {
         }
 
         val permissionsCount = 50
-        val client = testToolkit.httpClientFor(PermissionEndpoint::class.java, "admin", "admin")
+        val client = testToolkit.httpClientFor(PermissionEndpoint::class.java, adminUser, adminPassword)
         val proxy = client.start().proxy
         val permissionIdsAllow = (1..permissionsCount).map {
             proxy.createPermission(PermissionType.ALLOW, "$it-allow-${testToolkit.uniqueName}", false)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/PermissionSummaryE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/PermissionSummaryE2eTest.kt
@@ -4,6 +4,8 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit.DAYS
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.applications.workers.rpc.http.SkipWhenRpcEndpointUnavailable
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminPassword
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminUser
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionType
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
@@ -19,7 +21,7 @@ class PermissionSummaryE2eTest {
 
     companion object {
         private val testToolkit by TestToolkitProperty()
-        private val adminTestHelper = RbacE2eClientRequestHelper(testToolkit, "admin", "admin")
+        private val adminTestHelper = RbacE2eClientRequestHelper(testToolkit, adminUser, adminPassword)
         private val passwordExpiry = Instant.now().plus(1, DAYS).truncatedTo(DAYS)
     }
 

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/http/TestToolkit.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/http/TestToolkit.kt
@@ -1,5 +1,7 @@
 package net.corda.applications.workers.rpc.http
 
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminPassword
+import net.corda.applications.workers.rpc.utils.AdminPasswordUtil.adminUser
 import net.corda.httprpc.RpcOps
 import net.corda.httprpc.client.HttpRpcClient
 
@@ -16,6 +18,9 @@ interface TestToolkit {
     /**
      * Creates the [HttpRpcClient] for a given [RpcOps] class.
      */
-    fun <I : RpcOps> httpClientFor(rpcOpsClass: Class<I>, userName: String = "admin", password: String = "admin"):
-            HttpRpcClient<I>
+    fun <I : RpcOps> httpClientFor(
+        rpcOpsClass: Class<I>,
+        userName: String = adminUser,
+        password: String = adminPassword
+    ): HttpRpcClient<I>
 }

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/AdminPasswordUtil.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/AdminPasswordUtil.kt
@@ -1,0 +1,6 @@
+package net.corda.applications.workers.rpc.utils
+
+object AdminPasswordUtil {
+    const val adminUser = "admin"
+    val adminPassword = System.getenv("INITIAL_ADMIN_USER_PASSWORD") ?: "admin"
+}

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
@@ -12,7 +12,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 const val USERNAME = "admin"
-const val PASSWORD = "admin"
+val PASSWORD = System.getenv("INITIAL_ADMIN_USER_PASSWORD") ?: "admin"
 const val GROUP_ID = "7c5d6948-e17b-44e7-9d1c-fa4a3f667cad"
 
 // The CPB and CPI used in smoke tests

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
@@ -1,5 +1,7 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
+import net.corda.applications.workers.smoketest.PASSWORD
+import net.corda.applications.workers.smoketest.USERNAME
 import java.net.URI
 import java.time.Duration
 import java.util.LinkedList
@@ -39,8 +41,8 @@ fun useWebsocketConnection(
 }
 
 class SmokeTestWebsocketClient(
-    private val username: String = "admin",
-    private val password: String = "admin",
+    private val username: String = USERNAME,
+    private val password: String = PASSWORD,
     private val connectTimeout: Duration = Duration.ofSeconds(10),
 ) : AutoCloseable {
 

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcIntegrationTestBase.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcIntegrationTestBase.kt
@@ -8,8 +8,7 @@ abstract class HttpRpcIntegrationTestBase {
     internal companion object {
         lateinit var server: HttpRpcServer
         fun isServerInitialized() = ::server.isInitialized
-        const val password = "admin"
-        val userAlice = User("admin", password, setOf())
+        val userAlice = User(FakeSecurityManager.USERNAME, FakeSecurityManager.PASSWORD, setOf())
         val securityManager = FakeSecurityManager()
         val context = HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description")
     }

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerTestBase.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerTestBase.kt
@@ -10,8 +10,8 @@ abstract class HttpRpcServerTestBase {
         lateinit var server: HttpRpcServer
         fun isServerInitialized() = ::server.isInitialized
         lateinit var client: TestHttpClient
-        val userName = "admin"
-        val password = "admin"
+        const val userName = FakeSecurityManager.USERNAME
+        const val password = FakeSecurityManager.PASSWORD
         val securityManager = FakeSecurityManager()
         val context = HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description")
     }

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/utils/FakeSecurityManager.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/utils/FakeSecurityManager.kt
@@ -9,6 +9,8 @@ import javax.security.auth.login.FailedLoginException
 class FakeSecurityManager : RPCSecurityManager {
 
     companion object {
+        const val USERNAME = "admin"
+        const val PASSWORD = "admin"
         data class SecurityCheck(val action: String, val arguments: List<String>)
     }
 
@@ -39,12 +41,10 @@ class FakeSecurityManager : RPCSecurityManager {
     }
 
     override fun authenticate(principal: String, password: Password): AuthorizingSubject {
-        return "admin".let {
-            if (it.equals(principal, true) && password == Password(it)) {
-                RecordKeepingSubject(principal)
-            } else {
-                throw FailedLoginException("No provisions for: $principal")
-            }
+        return if (USERNAME.equals(principal, true) && password == Password(PASSWORD)) {
+            RecordKeepingSubject(principal)
+        } else {
+            throw FailedLoginException("No provisions for: $principal")
         }
     }
 

--- a/libs/permissions/permission-management-cache-impl/src/test/kotlin/net/corda/libs/permissions/cache/impl/PermissionManagementCacheImplTest.kt
+++ b/libs/permissions/permission-management-cache-impl/src/test/kotlin/net/corda/libs/permissions/cache/impl/PermissionManagementCacheImplTest.kt
@@ -44,9 +44,9 @@ internal class PermissionManagementCacheImplTest {
     private val permission2 = Permission("perm2", 0, ChangeDetails(Instant.now()), "virtNode2",
         PermissionType.DENY, "*", group1.id)
 
-    private val role1 = Role("role1", 0, ChangeDetails(Instant.now()), "admin", group1.id,
+    private val role1 = Role("role1", 0, ChangeDetails(Instant.now()), "role1Name", group1.id,
         listOf(PermissionAssociation(ChangeDetails(Instant.now()), permission1.id)))
-    private val role2 = Role("role2", 0, ChangeDetails(Instant.now()), "admin", group1.id,
+    private val role2 = Role("role2", 0, ChangeDetails(Instant.now()), "role2Name", group1.id,
         listOf(PermissionAssociation(ChangeDetails(Instant.now()), permission2.id)))
 
     private val permissionSummary1 = UserPermissionSummary(

--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/FakeSecurityManager.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/FakeSecurityManager.kt
@@ -7,9 +7,15 @@ import net.corda.httprpc.security.read.Password
 import net.corda.httprpc.security.read.RPCSecurityManager
 import javax.security.auth.login.FailedLoginException
 
+/**
+ * Note: We cannot use `FakeSecurityManager` from "net.corda.httprpc.test.utils" as this is non-OSGi module.
+ * It cannot be made OSGi module easily as it has a dependency on non-OSGi Unirest library.
+ */
 internal class FakeSecurityManager : RPCSecurityManager {
 
     companion object {
+        const val USERNAME = "admin"
+        const val PASSWORD = "admin"
         data class SecurityCheck(val action: String, val arguments: List<String>)
     }
 
@@ -40,12 +46,10 @@ internal class FakeSecurityManager : RPCSecurityManager {
     }
 
     override fun authenticate(principal: String, password: Password): AuthorizingSubject {
-        return "admin".let {
-            if (it.equals(principal, true) && password == Password(it)) {
-                RecordKeepingSubject(principal)
-            } else {
-                throw FailedLoginException("No provisions for: $principal")
-            }
+        return if (USERNAME.equals(principal, true) && password == Password(PASSWORD)) {
+            RecordKeepingSubject(principal)
+        } else {
+            throw FailedLoginException("No provisions for: $principal")
         }
     }
 


### PR DESCRIPTION
Make use of `INITIAL_ADMIN_USER_PASSWORD` environment variable in E2E and Smoke tests to derive the value for `admin` user when making Rest calls.

**Note:** The value of this environment variable is yet populated and will be separately along with changes to CI Helm chart.