### PR TITLE
CORE-7209 Use pod name in dumps path

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -370,6 +370,7 @@ Volume mounts for corda workers
 {{- if .Values.dumpHostPath }}
 - mountPath: /dumps
   name: dumps
+  subPathExpr: $(K8S_POD_NAME)
 {{- end }}
 {{ include "corda.log4jVolumeMount" . }}
 {{- end }}
@@ -393,7 +394,7 @@ Volumes for corda workers
 {{- if .Values.dumpHostPath }}
 - name: dumps
   hostPath:
-    path: {{ .Values.dumpHostPath }}/{{ .Release.Namespace }}/{{ (include "corda.workerName" .) }}/
+    path: {{ .Values.dumpHostPath }}/{{ .Release.Namespace }}/
     type: DirectoryOrCreate
 {{- end }}
 {{ include "corda.log4jVolume" . }}


### PR DESCRIPTION
Use the pod name rather than the worker name as the last part of the dump path so that dumps from different replicas end up in different folders.