### PR TITLE
CORE-8195 Use random group ids in uniqueness tests

### DIFF
--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
@@ -58,6 +58,7 @@ import java.time.LocalDateTime
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.Duration
+import java.util.*
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityExistsException
 import javax.persistence.RollbackException
@@ -83,7 +84,8 @@ class JPABackingStoreImplIntegrationTests {
     private val baseTime = Instant.EPOCH
     private val defaultTimeWindowUpperBound = LocalDate.of(2200, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC)
 
-    private val aliceIdentity = createTestHoldingIdentity("C=GB, L=London, O=Alice", "Test Group")
+    private val groupId = UUID.randomUUID().toString()
+    private val aliceIdentity = createTestHoldingIdentity("C=GB, L=London, O=Alice", groupId)
     private val aliceIdentityDbName = VirtualNodeDbType.UNIQUENESS.getSchemaName(aliceIdentity.shortHash)
     private val dbConfig = DbUtils.getEntityManagerConfiguration(aliceIdentityDbName)
     private val databaseInstaller = DatabaseInstaller(

--- a/components/uniqueness/backing-store-impl/src/test/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplTests.kt
+++ b/components/uniqueness/backing-store-impl/src/test/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplTests.kt
@@ -35,6 +35,7 @@ import org.mockito.kotlin.doReturn
 import java.sql.Connection
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.util.*
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -59,7 +60,8 @@ class JPABackingStoreImplTests {
     private lateinit var txnErrorQuery: TypedQuery<UniquenessRejectedTransactionEntity>
     private lateinit var dbConnectionManager: DbConnectionManager
 
-    private val aliceIdentity = createTestHoldingIdentity("C=GB, L=London, O=Alice", "Test Group")
+    private val groupId = UUID.randomUUID().toString()
+    private val aliceIdentity = createTestHoldingIdentity("C=GB, L=London, O=Alice", groupId)
 
     inner class DummyLifecycle : LifecycleEvent
 

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
@@ -160,8 +160,10 @@ class MessageBusIntegrationTests {
 
     private lateinit var backingStore: ThrowableBackingStoreImplFake
 
+    private val groupId = UUID.randomUUID().toString()
+
     private val defaultHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Alice", "Test Group").toAvro()
+        "C=GB, L=London, O=Alice", groupId).toAvro()
 
     // We don't use Instant.MAX because this appears to cause a long overflow in Avro
     private val defaultTimeWindowUpperBound: Instant =

--- a/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
@@ -66,29 +66,31 @@ class UniquenessCheckerImplDBIntegrationTests {
 
     private val baseTime: Instant = Instant.EPOCH
 
+    private val groupId = UUID.randomUUID().toString()
+
     // Default holding id used in most tests
     private val defaultHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Alice", "Test Group")
+        "C=GB, L=London, O=Alice", groupId)
     private val defaultHoldingIdentityDbName =
         VirtualNodeDbType.UNIQUENESS.getSchemaName(defaultHoldingIdentity.shortHash)
     private val defaultHoldingIdentityDb: EntityManagerFactory
 
     // Additional holding identites
     private val bobHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Bob", "Test Group")
+        "C=GB, L=London, O=Bob", groupId)
     private val bobHoldingIdentityDbName =
         VirtualNodeDbType.UNIQUENESS.getSchemaName(bobHoldingIdentity.shortHash)
     private val bobHoldingIdentityDb: EntityManagerFactory
 
     private val charlieHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Charlie", "Test Group")
+        "C=GB, L=London, O=Charlie", groupId)
     private val charlieHoldingIdentityDbName =
         VirtualNodeDbType.UNIQUENESS.getSchemaName(charlieHoldingIdentity.shortHash)
     private val charlieHoldingIdentityDb: EntityManagerFactory
 
     // Holding id that has no associated uniqueness DB
     private val noDbHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Nobody", "Test Group")
+        "C=GB, L=London, O=Nobody", groupId)
     private val noDbHoldingIdentityDbName =
         VirtualNodeDbType.UNIQUENESS.getSchemaName(noDbHoldingIdentity.shortHash)
 

--- a/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
@@ -56,9 +56,11 @@ class UniquenessCheckerImplTests {
 
     private val baseTime: Instant = Instant.EPOCH
 
+    private val groupId = UUID.randomUUID().toString()
+
     // Default holding id used in most tests
     private val defaultHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Alice", "Test Group").toAvro()
+        "C=GB, L=London, O=Alice", groupId).toAvro()
 
     // We don't use Instant.MAX because this appears to cause a long overflow in Avro
     private val defaultTimeWindowUpperBound: Instant =
@@ -1115,11 +1117,11 @@ class UniquenessCheckerImplTests {
     @Nested
     inner class MultiTenancy {
         private val bobHoldingIdentity = createTestHoldingIdentity(
-            "C=GB, L=London, O=Bob", "Test Group")
+            "C=GB, L=London, O=Bob", groupId)
         private val charlieHoldingIdentity = createTestHoldingIdentity(
-            "C=GB, L=London, O=Charlie", "Test Group")
+            "C=GB, L=London, O=Charlie", groupId)
         private val davidHoldingIdentity = createTestHoldingIdentity(
-            "C=GB, L=London, O=David", "Test Group")
+            "C=GB, L=London, O=David", groupId)
 
         @Test
         fun `Requests for different holding identities are processed independently`() {


### PR DESCRIPTION
### Summary
Previously, the tests for the uniqueness checker and backing store components used a hard coded "Test Group" group id. These tests also use the same X500 legal names for the tests - Alice, Bob, etc.

This means that multiple test classes are using the same holding identities, which have the same hashes. By extension, this means that the tests were trying to create the same uniqueness db schema, which can fail if two or more tests are executing in parallel and try to do this at the same time. It is suspected that this is the cause of a recent build failure in Jenkins.

This PR ensures that each test class uses a UUID for the group name to avoid this.

### Testing
Ensure that all modified test cases continue to pass.