### PR TITLE
CORE-7633 Notary plugin packaging refinements

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     smokeTestImplementation "net.corda:corda-config-schema:$cordaApiVersion"
 
     // But building a cpb for use in a test is ok.
+    cpis project(path: ':notary-plugins:notary-plugin-non-validating:notary-plugin-non-validating-server', configuration: 'cordaCPB')
     cpis project(path: ':testing:cpbs:test-cordapp', configuration: 'cordaCPB')
     cpis project(path: ':testing:cpbs:ledger-consensual-demo-app', configuration: 'cordaCPB')
     cpiForFlowCacheTest project(path: ':testing:cpbs:test-cordapp-for-cache-testing', configuration: 'cordaCPB')

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -159,12 +159,12 @@ fun getOrCreateVirtualNodeFor(x500: String, cpiName: String): String {
     }
 }
 
-fun registerMember(holdingIdentityShortHash: String) {
+fun registerMember(holdingIdentityShortHash: String, isNotary: Boolean = false) {
     return cluster {
         endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
         val membershipJson = assertWithRetry {
-            command { registerMember(holdingIdentityShortHash) }
+            command { registerMember(holdingIdentityShortHash, isNotary) }
             condition { it.code == 200 }
             failMessage("Failed to register the member to the network '$holdingIdentityShortHash'")
         }.toJson()
@@ -184,21 +184,6 @@ fun registerMember(holdingIdentityShortHash: String) {
             }
             failMessage("Registration was not completed for $holdingIdentityShortHash")
         }
-    }
-}
-
-fun registerNotary(holdingIdentityId: String) {
-    return cluster {
-        endpoint(CLUSTER_URI, USERNAME, PASSWORD)
-
-        val membershipJson = assertWithRetry {
-            command { registerNotary(holdingIdentityId) }
-            condition { it.code == 200 }
-            failMessage("Failed to register the notary to the network '$holdingIdentityId'")
-        }.toJson()
-
-        val registrationStatus = membershipJson["registrationStatus"].textValue()
-        assertThat(registrationStatus).isEqualTo("SUBMITTED")
     }
 }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
@@ -18,6 +18,8 @@ const val GROUP_ID = "7c5d6948-e17b-44e7-9d1c-fa4a3f667cad"
 // The CPB and CPI used in smoke tests
 const val TEST_CPI_NAME = "test-cordapp"
 const val TEST_CPB_LOCATION = "/META-INF/test-cordapp.cpb"
+const val TEST_NOTARY_CPI_NAME = "test-notary-server-cordapp"
+const val TEST_NOTARY_CPB_LOCATION = "/META-INF/notary-plugin-non-validating-server.cpb"
 const val CACHE_INVALIDATION_TEST_CPB = "/META-INF/cache-invalidation-testing/test-cordapp.cpb"
 
 val CLUSTER_URI = URI(System.getProperty("rpcHost"))

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -7,6 +7,8 @@ import net.corda.applications.workers.smoketest.RPC_FLOW_STATUS_SUCCESS
 import net.corda.applications.workers.smoketest.RpcSmokeTestInput
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
+import net.corda.applications.workers.smoketest.TEST_NOTARY_CPB_LOCATION
+import net.corda.applications.workers.smoketest.TEST_NOTARY_CPI_NAME
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
 import net.corda.applications.workers.smoketest.configWithDefaultsNode
@@ -16,7 +18,6 @@ import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
 import net.corda.applications.workers.smoketest.getRpcFlowResult
 import net.corda.applications.workers.smoketest.registerMember
-import net.corda.applications.workers.smoketest.registerNotary
 import net.corda.applications.workers.smoketest.startRpcFlow
 import net.corda.applications.workers.smoketest.toJsonString
 import net.corda.applications.workers.smoketest.updateConfig
@@ -48,7 +49,8 @@ class FlowTests {
 
     companion object {
         private val testRunUniqueId = UUID.randomUUID()
-        private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
+        private val applicationCpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
+        private val notaryCpiName = "${TEST_NOTARY_CPI_NAME}_$testRunUniqueId"
         private val aliceX500 = "CN=Alice-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
         private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, GROUP_ID)
         private val bobX500 = "CN=Bob-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
@@ -96,13 +98,17 @@ class FlowTests {
         @JvmStatic
         internal fun beforeAll() {
             // Upload test flows if not already uploaded
-            conditionallyUploadCordaPackage(cpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList)
+            conditionallyUploadCordaPackage(
+                applicationCpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList)
+            // Upload notary server CPB
+            conditionallyUploadCordaPackage(
+                notaryCpiName, TEST_NOTARY_CPB_LOCATION, GROUP_ID, staticMemberList)
 
             // Make sure Virtual Nodes are created
-            val bobActualHoldingId = getOrCreateVirtualNodeFor(bobX500, cpiName)
-            val charlieActualHoldingId = getOrCreateVirtualNodeFor(charlyX500, cpiName)
-            val davidActualHoldingId = getOrCreateVirtualNodeFor(davidX500, cpiName)
-            val notaryActualHoldingId = getOrCreateVirtualNodeFor(notaryX500, cpiName)
+            val bobActualHoldingId = getOrCreateVirtualNodeFor(bobX500, applicationCpiName)
+            val charlieActualHoldingId = getOrCreateVirtualNodeFor(charlyX500, applicationCpiName)
+            val davidActualHoldingId = getOrCreateVirtualNodeFor(davidX500, applicationCpiName)
+            val notaryActualHoldingId = getOrCreateVirtualNodeFor(notaryX500, notaryCpiName)
 
             // Just validate the function and actual vnode holding ID hash are in sync
             // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
@@ -113,7 +119,7 @@ class FlowTests {
 
             registerMember(bobHoldingId)
             registerMember(charlieHoldingId)
-            registerNotary(notaryHoldingId)
+            registerMember(notaryHoldingId, isNotary = true)
         }
     }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
@@ -120,14 +120,14 @@ class ClusterBuilder {
     /**
      * Register a member to the network
      */
-    fun registerMember(holdingIdShortHash: String) =
-        post("/api/v1/membership/$holdingIdShortHash", registerMemberBody())
+    fun registerMember(holdingIdShortHash: String, isNotary: Boolean = false) =
+        post(
+            "/api/v1/membership/$holdingIdShortHash",
+            if (isNotary) registerNotaryBody() else registerMemberBody()
+        )
 
     fun getRegistrationStatus(holdingIdShortHash: String) =
         get("/api/v1/membership/$holdingIdShortHash")
-
-    fun registerNotary(holdingId: String) =
-        post("/api/v1/membership/$holdingId", registerNotaryBody())
 
     fun addSoftHsmToVNode(holdingIdentityShortHash: String, category: String) =
         post("/api/v1/hsm/soft/$holdingIdentityShortHash/$category", body = "")

--- a/notary-plugins/notary-plugin-common/build.gradle
+++ b/notary-plugins/notary-plugin-common/build.gradle
@@ -1,34 +1,27 @@
 plugins {
+    id 'org.jetbrains.kotlin.jvm'
     id 'corda.common-publishing'
     id 'net.corda.plugins.cordapp-cpk2'
 }
 
-description 'Corda Notary Plugins Common Functionality'
+description 'Corda Notary Plugin Common Library'
 
-group 'com.r3.corda.notary.plugin.nonvalidating'
+group 'com.r3.corda.notary.plugin.common'
 
-// TODO CORE-7945 This should not be a CorDapp, we need to find a way to properly include it.
-//  Potentially `cordaEmbedded`. However, that throws errors so needs further investigation.
 cordapp {
-    targetPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
-        name "Corda Non-Validating Notary - Common"
+        name "Corda Notary Plugin Common Library"
         versionId 1
         vendor "R3"
     }
 }
 
 dependencies {
-    compileOnly 'org.osgi:osgi.annotation'
-    compileOnly "org.osgi:org.osgi.service.component.annotations"
+    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 
     cordaProvided "net.corda:corda-application"
     cordaProvided "net.corda:corda-cipher-suite"
     cordaProvided "net.corda:corda-notary-plugin"
     cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
-
-    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 }
-
-
-

--- a/notary-plugins/notary-plugin-common/src/main/java/com/r3/corda/notary/plugin/common/package-info.java
+++ b/notary-plugins/notary-plugin-common/src/main/java/com/r3/corda/notary/plugin/common/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package com.r3.corda.notary.plugin.common;
-
-import org.osgi.annotation.bundle.Export;

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-api/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
+    id 'corda.common-publishing'
     id 'net.corda.plugins.cordapp-cpk2'
 }
 
@@ -8,7 +9,7 @@ description 'Corda Non-Validating Notary Plugin API'
 group 'com.r3.corda.notary.plugin.nonvalidating'
 
 cordapp {
-    targetPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
         name "Corda Non-Validating Notary - API"
         versionId 1
@@ -17,19 +18,13 @@ cordapp {
 }
 
 dependencies {
-    compileOnly "org.osgi:org.osgi.service.component.annotations"
+    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-cipher-suite'
     cordaProvided 'net.corda:corda-notary-plugin'
     cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
-
-    cordaProvided "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
-    cordaProvided "org.osgi:osgi.core"
     cordaProvided 'org.slf4j:slf4j-api'
 
-    // TODO CORE-7945 This should not be included as a CorDapp
     cordapp project(":notary-plugins:notary-plugin-common")
-
-    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-api/src/main/java/com/r3/corda/notary/plugin/nonvalidating/api/package-info.java
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-api/src/main/java/com/r3/corda/notary/plugin/nonvalidating/api/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package com.r3.corda.notary.plugin.nonvalidating.api;
-
-import org.osgi.annotation.bundle.Export;

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
+    id 'corda.common-publishing'
     id 'net.corda.plugins.cordapp-cpk2'
 }
 
@@ -8,7 +9,7 @@ description 'Corda Non-Validating Notary Plugin Client'
 group 'com.r3.corda.notary.plugin.nonvalidating'
 
 cordapp {
-    targetPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
         name "Corda Non-Validating Notary - Client"
         versionId 1
@@ -17,23 +18,16 @@ cordapp {
 }
 
 dependencies {
-    compileOnly "org.osgi:org.osgi.service.component.annotations"
+    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-cipher-suite'
     cordaProvided 'net.corda:corda-notary-plugin'
     cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
-
-    cordaProvided "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
-    cordaProvided "org.osgi:osgi.core"
     cordaProvided 'org.slf4j:slf4j-api'
 
-    // TODO CORE-7945 This should not be included as a CorDapp
-    cordapp project(":notary-plugins:notary-plugin-common")
+    // Common package pulled in as transitive dependency through API
     cordapp project(":notary-plugins:notary-plugin-non-validating:notary-plugin-non-validating-api")
-
-
-    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/java/com/r3/corda/notary/plugin/nonvalidating/client/package-info.java
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/java/com/r3/corda/notary/plugin/nonvalidating/client/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package com.r3.corda.notary.plugin.nonvalidating.client;
-
-import org.osgi.annotation.bundle.Export;

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'net.corda.plugins.cordapp-cpk2'
+    id 'corda.common-publishing'
+    id 'net.corda.plugins.cordapp-cpb2'
 }
 
 description 'Corda Non-Validating Notary Plugin Server'
@@ -8,7 +9,7 @@ description 'Corda Non-Validating Notary Plugin Server'
 group 'com.r3.corda.notary.plugin.nonvalidating'
 
 cordapp {
-    targetPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
         name "Corda Non-Validating Notary - Server"
         versionId 1
@@ -17,7 +18,7 @@ cordapp {
 }
 
 dependencies {
-    compileOnly "org.osgi:org.osgi.service.component.annotations"
+    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-cipher-suite'
@@ -28,10 +29,7 @@ dependencies {
     cordaProvided "org.osgi:osgi.core"
     cordaProvided 'org.slf4j:slf4j-api'
 
-    cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-
-    // TODO CORE-7945 This should not be included as a CorDapp
-    cordapp project(":notary-plugins:notary-plugin-common")
+    // Common package pulled in as transitive dependency through API
     cordapp project(":notary-plugins:notary-plugin-non-validating:notary-plugin-non-validating-api")
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/java/com/r3/corda/notary/plugin/nonvalidating/server/package-info.java
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/java/com/r3/corda/notary/plugin/nonvalidating/server/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package com.r3.corda.notary.plugin.nonvalidating.server;
-
-import org.osgi.annotation.bundle.Export;

--- a/testing/cpbs/test-cordapp/build.gradle
+++ b/testing/cpbs/test-cordapp/build.gradle
@@ -21,6 +21,6 @@ dependencies {
     cordaProvided 'net.corda:corda-notary-plugin'
 
     cordapp project(':testing:bundles:testing-dogs')
+    // Common and API packages pulled in as transitive dependencies through client
     cordapp project(':notary-plugins:notary-plugin-non-validating:notary-plugin-non-validating-client')
-    cordapp project(':notary-plugins:notary-plugin-non-validating:notary-plugin-non-validating-server')
 }

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -87,10 +87,10 @@ class NonValidatingNotaryTestFlow : RPCStartableFlow {
 
         val myInfo = memberLookup.myInfo()
 
-        // TODO CORE-6996 For now `NotaryLookup` is still work in progress, once it is finished, we need to find the
-        //  notary instead of a random member
+        // TODO CORE-6996 For now `NotaryLookup` is still work in progress, once it is finished, we
+        //  need to find the notary instead of the first whose common name contains "Notary".
         val notary = memberLookup.lookup().first {
-            it.name != myInfo.name
+            it.name.commonName?.contains("notary", ignoreCase = true) ?: false
         }
 
         val notaryParty = Party(notary.name, notary.sessionInitiationKey)
@@ -174,4 +174,3 @@ class NonValidatingNotaryTestFlow : RPCStartableFlow {
         )
     }
 }
-


### PR DESCRIPTION
### Summary
This PR makes several refinements to how the notary plugins are packaged:

- The non-validating notary server plugin build now produces a CPB. This is because this is intended to be a standalone installable application in its own right, and does not need to be bundled with any other CPKs to perform its function.
- Unnecessary includes and package info files have been removed; using the CPK / CPB plugins automatically ensures the correct OSGi packaging metadata is generated.
- Updated the flow smoke tests so that an additional notary server CPI is produced, and this is installed on the notary virtual node. This is a more realistic simulation of a real network.
- Refined the testing libraries to reduce code duplication.

### Testing
Ensured that the notary smoke tests continue to pass.

Successful publishing of CPKs / CPBs has not been verified as part of this PR. This will be done separately in [CORE-7634](https://r3-cev.atlassian.net/browse/CORE-7634), as build plugin changes are required to facilitate this.