### PR TITLE
NOTICK: Do not try to start a sandbox fragment bundle.

### DIFF
--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -225,7 +225,7 @@ internal class SandboxServiceImpl @Activate constructor(
 
         // Ensure that all of these bundles are resolved before we start them.
         if (!bundleUtils.resolveBundles(bundles)) {
-            val allFailed = bundles.filter { it.state < RESOLVED }
+            val allFailed = bundles.filter { !it.isFragment && it.state < RESOLVED }
             val ex = SandboxException("Failed to resolve bundles: ${allFailed.joinToString()}")
             for (failed in allFailed) {
                 try {


### PR DESCRIPTION
A sandbox may include a fragment bundle as a library, so allow for this when trying to resolve the sandbox bundles.