### PR TITLE
CORE-7414 - Add support for securityContext and serviceAccount to Helm chart

### DIFF
--- a/charts/corda/log4j2.xml
+++ b/charts/corda/log4j2.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO">
-    <Properties>
-        <Property name="layoutFile">log4j2-${env:CONSOLE_LOG_FORMAT:-json}-layout.xml</Property>
-    </Properties>
     <Appenders>
         <Console name="json" target="SYSTEM_OUT">
             <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" />

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -133,6 +133,16 @@ securityContext:
 {{- end }}
 
 {{/*
+Worker service account
+*/}}
+
+{{- define "corda.serviceAccount" }}
+{{- if .Values.serviceAccount  }}
+serviceAccountName: {{ default .Values.bootstrap.serviceAccount .Values.serviceAccount }}
+{{- end }}
+{{- end }}
+
+{{/*
 CLI image
 */}}
 {{- define "corda.bootstrapImage" -}}

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -115,8 +115,11 @@ Worker pod security context
 */}}
 {{- define "corda.workerPodSecurityContext" -}}
 {{- if and ( not .Values.dumpHostPath ) ( not ( get .Values.workers .worker ).profiling.enabled ) }}
-{{- with .Values.podSecurityContext }}
 securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+{{- with .Values.podSecurityContext }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
@@ -126,8 +129,9 @@ securityContext:
 Worker container security context
 */}}
 {{- define "corda.workerContainerSecurityContext" -}}
-{{- with .Values.securityContext }}
 securityContext:
+  allowPrivilegeEscalation: false
+{{- with .Values.securityContext }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
@@ -136,8 +140,8 @@ securityContext:
 Worker service account
 */}}
 {{- define "corda.serviceAccount" }}
-{{- if .Values.serviceAccount  }}
-serviceAccountName: {{ .Values.serviceAccount }}
+{{- if .Values.serviceAccount.name  }}
+serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 
@@ -192,8 +196,9 @@ nodeSelector:
 Security context for the bootstrapper
 */}}
 {{- define "corda.bootstrapSecurityContext" }}
-{{- with .Values.bootstrap.securityContext | default .Values.securityContext }}
 securityContext:
+  allowPrivilegeEscalation: false
+{{- with .Values.bootstrap.securityContext | default .Values.securityContext }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
@@ -202,8 +207,8 @@ securityContext:
 Service account for the bootstrapper
 */}}
 {{- define "corda.bootstrapServiceAccount" }}
-{{- if or .Values.bootstrap.serviceAccount .Values.serviceAccount }}
-serviceAccountName: {{ default .Values.serviceAccount .Values.bootstrap.serviceAccount }}
+{{- if or .Values.bootstrap.serviceAccount.name .Values.serviceAccount.name }}
+serviceAccountName: {{ default .Values.serviceAccount.name .Values.bootstrap.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -111,14 +111,24 @@ Worker image
 {{- end }}
 
 {{/*
-Worker security context
+Worker pod security context
 */}}
-{{- define "corda.workerSecurityContext" -}}
+{{- define "corda.workerPodSecurityContext" -}}
 {{- if and ( not .Values.dumpHostPath ) ( not ( get .Values.workers .worker ).profiling.enabled ) }}
+{{- with .Values.podSecurityContext | default .Values.podSecurityContext }}
 securityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Worker container security context
+*/}}
+{{- define "corda.workerConainterSecurityContext" -}}
+{{- with .Values.securityContext | default .Values.securityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -166,6 +176,27 @@ Node selector for the bootstrapper
 {{- with .Values.bootstrap.nodeSelector | default .Values.nodeSelector }}
 nodeSelector:
   {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Security context for the bootstrapper
+*/}}
+
+{{- define "corda.bootstrapSecurityContext" }}
+{{- with .Values.bootstrap.securityContext | default .Values.securityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Service account for the bootstrapper
+*/}}
+
+{{- define "corda.bootstrapServiceAccount" }}
+{{- if or .Values.bootstrap.serviceAccount .Values.serviceAccount }}
+serviceAccountName: {{ default .Values.bootstrap.serviceAccount .Values.serviceAccount }}
 {{- end }}
 {{- end }}
 

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -111,29 +111,23 @@ Worker image
 {{- end }}
 
 {{/*
-Worker pod security context
+Pod security context
 */}}
-{{- define "corda.workerPodSecurityContext" -}}
+{{- define "corda.podSecurityContext" -}}
 {{- if and ( not .Values.dumpHostPath ) ( not ( get .Values.workers .worker ).profiling.enabled ) }}
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
-{{- with .Values.podSecurityContext }}
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 {{- end }}
 {{- end }}
 
 {{/*
-Worker container security context
+Container security context
 */}}
-{{- define "corda.workerContainerSecurityContext" -}}
+{{- define "corda.containerSecurityContext" -}}
 securityContext:
   allowPrivilegeEscalation: false
-{{- with .Values.securityContext }}
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 {{- end }}
 
 {{/*
@@ -187,17 +181,6 @@ Node selector for the bootstrapper
 {{- define "corda.bootstrapNodeSelector" }}
 {{- with .Values.bootstrap.nodeSelector | default .Values.nodeSelector }}
 nodeSelector:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- end }}
-
-{{/*
-Security context for the bootstrapper
-*/}}
-{{- define "corda.bootstrapSecurityContext" }}
-securityContext:
-  allowPrivilegeEscalation: false
-{{- with .Values.bootstrap.securityContext | default .Values.securityContext }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}
@@ -563,6 +546,7 @@ Kafka SASL init container
   env:
   {{- include "corda.kafkaSaslPassword" . | nindent 2 }}
   {{- include "corda.kafkaSaslUsername" . | nindent 2 }}
+  {{- include "corda.containerSecurityContext" . | nindent 2 }}
   command:
   - /bin/bash
   - -c

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -115,7 +115,7 @@ Worker pod security context
 */}}
 {{- define "corda.workerPodSecurityContext" -}}
 {{- if and ( not .Values.dumpHostPath ) ( not ( get .Values.workers .worker ).profiling.enabled ) }}
-{{- with .Values.podSecurityContext | default .Values.podSecurityContext }}
+{{- with .Values.podSecurityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
@@ -125,8 +125,8 @@ securityContext:
 {{/*
 Worker container security context
 */}}
-{{- define "corda.workerConainterSecurityContext" -}}
-{{- with .Values.securityContext | default .Values.securityContext }}
+{{- define "corda.workerContainerSecurityContext" -}}
+{{- with .Values.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}
 {{- end }}
@@ -135,7 +135,6 @@ securityContext:
 {{/*
 Worker service account
 */}}
-
 {{- define "corda.serviceAccount" }}
 {{- if .Values.serviceAccount  }}
 serviceAccountName: {{ .Values.serviceAccount }}
@@ -192,7 +191,6 @@ nodeSelector:
 {{/*
 Security context for the bootstrapper
 */}}
-
 {{- define "corda.bootstrapSecurityContext" }}
 {{- with .Values.bootstrap.securityContext | default .Values.securityContext }}
 securityContext:
@@ -203,7 +201,6 @@ securityContext:
 {{/*
 Service account for the bootstrapper
 */}}
-
 {{- define "corda.bootstrapServiceAccount" }}
 {{- if or .Values.bootstrap.serviceAccount .Values.serviceAccount }}
 serviceAccountName: {{ default .Values.serviceAccount .Values.bootstrap.serviceAccount }}

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -138,7 +138,7 @@ Worker service account
 
 {{- define "corda.serviceAccount" }}
 {{- if .Values.serviceAccount  }}
-serviceAccountName: {{ default .Values.bootstrap.serviceAccount .Values.serviceAccount }}
+serviceAccountName: {{ .Values.serviceAccount }}
 {{- end }}
 {{- end }}
 
@@ -206,7 +206,7 @@ Service account for the bootstrapper
 
 {{- define "corda.bootstrapServiceAccount" }}
 {{- if or .Values.bootstrap.serviceAccount .Values.serviceAccount }}
-serviceAccountName: {{ default .Values.bootstrap.serviceAccount .Values.serviceAccount }}
+serviceAccountName: {{ default .Values.serviceAccount .Values.bootstrap.serviceAccount }}
 {{- end }}
 {{- end }}
 

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -163,7 +163,6 @@ DB client image
 Resources for the bootstrapper
 */}}
 {{- define "corda.bootstrapResources" }}
-
 resources:
   requests:
   {{- if or .Values.resources.requests.cpu .Values.bootstrap.resources.requests.cpu }}
@@ -294,6 +293,8 @@ Corda CLI environment variables
   value: {{ .Values.logging.format }}
 - name: CONSOLE_LOG_LEVEL
   value: {{ .Values.logging.level }}
+- name: CORDA_CLI_HOME_DIR
+  value: "/tmp"
 {{- end }}
 
 {{/*

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -36,7 +36,8 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
+        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
+
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
+      {{- include "corda.podSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
@@ -36,9 +36,8 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
-
         {{- include "corda.workerResources" . | nindent 8 }}
+        {{- include "corda.containerSecurityContext" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}
         {{- include "corda.clusterDbEnv" . | nindent 10 }}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerSecurityContext" . | nindent 6 }}
+      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
@@ -35,8 +35,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        securityContext:
-          allowPrivilegeEscalation: false
+        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -15,10 +15,16 @@ spec:
     spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: fin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           command:
@@ -26,6 +32,7 @@ spec:
             - -e
             - -c
           args: ["echo", "'DB Bootstrapped'"]
+          workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
@@ -33,9 +40,12 @@ spec:
         - name: create-db-schemas
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'database', 'spec', '-c', '-l', '/tmp/working_dir' ]
+          workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
@@ -53,8 +63,11 @@ spec:
         - name: create-initial-rbac-db-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           args: [ 'initial-config', 'create-db-config', '-u', 'rbac_user', '-p', 'rbac_password', '--name', 'corda-rbac', '--jdbcURL', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}', '--jdbcPoolMaxSize', {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
+          workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
@@ -74,6 +87,8 @@ spec:
         - name: apply-initial-rbac-db-config
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
@@ -84,9 +99,12 @@ spec:
         - name: create-initial-crypto-db-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-db-config', '-u', 'crypto_user', '-p', 'crypto_password', '--name', 'corda-crypto', '--jdbcURL', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}?currentSchema=CRYPTO', '--jdbcPoolMaxSize', {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
+          workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
@@ -106,6 +124,8 @@ spec:
         - name: apply-initial-crypto-db-config
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
@@ -116,9 +136,12 @@ spec:
         - name: create-initial-rpc-admin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-user-config', '-u', '$(INITIAL_ADMIN_USER_USERNAME)', '-p', '$(INITIAL_ADMIN_USER_PASSWORD)', '-l', '/tmp/working_dir']
+          workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
@@ -138,6 +161,8 @@ spec:
         - name: apply-initial-rpc-admin
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/rbac-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
@@ -148,6 +173,8 @@ spec:
         - name: create-db-users-and-grant
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           command: [ '/bin/sh', '-e', '-c' ]
           args:
@@ -166,9 +193,12 @@ spec:
         - name: create-initial-crypto-worker-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-crypto-config', '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
+          workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume
@@ -188,6 +218,8 @@ spec:
         - name: apply-initial-crypto-worker-config
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/crypto-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -23,10 +23,8 @@ spec:
         - name: fin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           command:
             - /bin/sh
             - -e
@@ -40,10 +38,8 @@ spec:
         - name: create-db-schemas
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: [ 'database', 'spec', '-c', '-l', '/tmp/working_dir' ]
           workingDir: /tmp/working_dir
           volumeMounts:
@@ -63,9 +59,8 @@ spec:
         - name: create-initial-rbac-db-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-db-config', '-u', 'rbac_user', '-p', 'rbac_password', '--name', 'corda-rbac', '--jdbcURL', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}', '--jdbcPoolMaxSize', {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
           workingDir: /tmp/working_dir
           volumeMounts:
@@ -87,9 +82,8 @@ spec:
         - name: apply-initial-rbac-db-config
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -99,10 +93,8 @@ spec:
         - name: create-initial-crypto-db-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-db-config', '-u', 'crypto_user', '-p', 'crypto_password', '--name', 'corda-crypto', '--jdbcURL', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}?currentSchema=CRYPTO', '--jdbcPoolMaxSize', {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
           workingDir: /tmp/working_dir
           volumeMounts:
@@ -124,9 +116,8 @@ spec:
         - name: apply-initial-crypto-db-config
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/db-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -136,10 +127,8 @@ spec:
         - name: create-initial-rpc-admin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-user-config', '-u', '$(INITIAL_ADMIN_USER_USERNAME)', '-p', '$(INITIAL_ADMIN_USER_PASSWORD)', '-l', '/tmp/working_dir']
           workingDir: /tmp/working_dir
           volumeMounts:
@@ -161,9 +150,8 @@ spec:
         - name: apply-initial-rpc-admin
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/rbac-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -173,9 +161,8 @@ spec:
         - name: create-db-users-and-grant
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           command: [ '/bin/sh', '-e', '-c' ]
           args:
             - |
@@ -193,10 +180,8 @@ spec:
         - name: create-initial-crypto-worker-config
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-crypto-config', '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
           workingDir: /tmp/working_dir
           volumeMounts:
@@ -218,9 +203,8 @@ spec:
         - name: apply-initial-crypto-worker-config
           image: {{ include "corda.dbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/crypto-config.sql --dbname {{ include "corda.clusterDbName" . }}' ]
           volumeMounts:
             - mountPath: /tmp/working_dir

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -14,11 +14,13 @@ spec:
         {{- include "corda.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       containers:
         - name: fin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           command:
             - /bin/sh
             - -e
@@ -32,6 +34,7 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'database', 'spec', '-c', '-l', '/tmp/working_dir' ]
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -82,6 +85,7 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-db-config', '-u', 'crypto_user', '-p', 'crypto_password', '--name', 'corda-crypto', '--jdbcURL', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}?currentSchema=CRYPTO', '--jdbcPoolMaxSize', {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -113,6 +117,7 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-user-config', '-u', '$(INITIAL_ADMIN_USER_USERNAME)', '-p', '$(INITIAL_ADMIN_USER_PASSWORD)', '-l', '/tmp/working_dir']
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -162,6 +167,7 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [ 'initial-config', 'create-crypto-config', '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
           volumeMounts:
             - mountPath: /tmp/working_dir

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
+      {{- include "corda.podSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
@@ -36,7 +36,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
+        {{- include "corda.containerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }} 
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerSecurityContext" . | nindent 6 }}
+      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
@@ -35,8 +35,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        securityContext:
-          allowPrivilegeEscalation: false
+        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }} 
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -36,7 +36,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
+        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }} 
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
+      {{- include "corda.podSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
@@ -36,7 +36,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
+        {{- include "corda.containerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -36,7 +36,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
+        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerSecurityContext" . | nindent 6 }}
+      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
@@ -35,8 +35,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        securityContext:
-          allowPrivilegeEscalation: false
+        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.serviceAccount" . | nindent 6 }}
       containers:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -17,14 +17,13 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerSecurityContext" . | nindent 6 }}
+      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        securityContext:
-          allowPrivilegeEscalation: false
+        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -17,14 +17,14 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
+      {{- include "corda.podSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.serviceAccount" . | nindent 6 }}
       containers:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
+        {{- include "corda.containerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -24,7 +24,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
+        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       containers:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -51,7 +51,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
+        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -32,7 +32,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
+      {{- include "corda.podSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
@@ -51,7 +51,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
+        {{- include "corda.containerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -32,7 +32,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerSecurityContext" . | nindent 6 }}
+      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
@@ -50,8 +50,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        securityContext:
-         allowPrivilegeEscalation: false
+        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerSecurityContext" . | nindent 6 }}
+      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
@@ -35,8 +35,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        securityContext:
-         allowPrivilegeEscalation: false
+        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
+      {{- include "corda.podSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
@@ -36,7 +36,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
+        {{- include "corda.containerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -36,7 +36,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy:  {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
+        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/rbac-job.yaml
+++ b/charts/corda/templates/rbac-job.yaml
@@ -15,10 +15,16 @@ spec:
     spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: create-rbac-role-user-admin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'user-admin', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
@@ -41,6 +47,8 @@ spec:
         - name: create-rbac-role-vnode-creator
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'vnode-creator', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
@@ -63,6 +71,8 @@ spec:
         - name: create-rbac-role-corda-dev
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'corda-developer', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",

--- a/charts/corda/templates/rbac-job.yaml
+++ b/charts/corda/templates/rbac-job.yaml
@@ -23,10 +23,8 @@ spec:
         - name: create-rbac-role-user-admin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'user-admin', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
             '--target', "https://{{ include "corda.fullname" . }}-rpc-worker:443"]
@@ -47,10 +45,8 @@ spec:
         - name: create-rbac-role-vnode-creator
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'vnode-creator', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
             '--target', "https://{{ include "corda.fullname" . }}-rpc-worker:443"]
@@ -71,10 +67,8 @@ spec:
         - name: create-rbac-role-corda-dev
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'corda-developer', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
             '--target', "https://{{ include "corda.fullname" . }}-rpc-worker:443"]

--- a/charts/corda/templates/rbac-job.yaml
+++ b/charts/corda/templates/rbac-job.yaml
@@ -14,11 +14,13 @@ spec:
         {{- include "corda.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       containers:
         - name: create-rbac-role-user-admin
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'user-admin', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
             '--target', "https://{{ include "corda.fullname" . }}-rpc-worker:443"]
@@ -40,6 +42,7 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'vnode-creator', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
             '--target', "https://{{ include "corda.fullname" . }}-rpc-worker:443"]
@@ -61,6 +64,7 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'corda-developer', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
             '--target', "https://{{ include "corda.fullname" . }}-rpc-worker:443"]

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -43,7 +43,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
+      {{- include "corda.podSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
@@ -62,7 +62,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
+        {{- include "corda.containerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -62,7 +62,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
+        {{- include "corda.workerContainerSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -45,7 +45,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.serviceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -43,7 +43,7 @@ spec:
       labels:
         {{- include "corda.workerSelectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.workerSecurityContext" . | nindent 6 }}
+      {{- include "corda.workerPodSecurityContext" . | nindent 6 }}
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       affinity:
         podAntiAffinity:
@@ -61,8 +61,7 @@ spec:
       - name: {{ include "corda.workerName" . | quote }}
         image: {{ include "corda.workerImage" . }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        securityContext:
-          allowPrivilegeEscalation: false
+        {{- include "corda.workerConainterSecurityContext" . | nindent 8 }}
         {{- include "corda.workerResources" . | nindent 8 }}
         env:
         {{- include "corda.workerEnv" . | nindent 10 }}

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -15,10 +15,16 @@ spec:
     spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: create-topics
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [
@@ -50,6 +56,8 @@ spec:
         - name: create-trust-store
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           env:

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -14,11 +14,13 @@ spec:
         {{- include "corda.selectorLabels" . | nindent 8 }}
     spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       containers:
         - name: create-topics
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [
             'topic',
             '-b', '{{ include "corda.kafkaBootstrapServers" . }}',
@@ -49,6 +51,7 @@ spec:
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           env:
           {{- include "corda.kafkaSaslPassword" . | nindent 12 }}
           {{- include "corda.kafkaSaslUsername" . | nindent 12 }}

--- a/charts/corda/templates/topic-job.yaml
+++ b/charts/corda/templates/topic-job.yaml
@@ -23,10 +23,8 @@ spec:
         - name: create-topics
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
           args: [
             'topic',
             '-b', '{{ include "corda.kafkaBootstrapServers" . }}',
@@ -56,10 +54,8 @@ spec:
         - name: create-trust-store
           image: {{ include "corda.bootstrapImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
           {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.bootstrapSecurityContext" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
           env:
           {{- include "corda.kafkaSaslPassword" . | nindent 12 }}
           {{- include "corda.kafkaSaslUsername" . | nindent 12 }}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -186,7 +186,6 @@
                 false,
                 true
             ]
-            
         },
         "nodeSelector": {
             "type": "object",
@@ -195,6 +194,28 @@
             "required": [],
             "properties": {},
             "examples": [{}]
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "default": {},
+            "title": "security context for pod assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "securityContext": {
+            "type": "object",
+            "default": {},
+            "title": "security context for container assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "serviceAccount": {
+            "type": "string",
+            "default": "",
+            "title": "service account for pod assignment, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+            "examples": [""]
         },
         "db": {
             "type": "object",
@@ -780,6 +801,20 @@
                     "required": [],
                     "properties": {},
                     "examples": [{}]
+                },
+                "securityContext": {
+                    "type": "object",
+                    "default": {},
+                    "title": "security context for the bootstrap containers",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                },
+                "serviceAccount": {
+                    "type": "string",
+                    "default": "",
+                    "title": "service account for the bootstrap containers",
+                    "examples": [""]
                 },
                 "rbac": {
                     "type": "object",

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -195,22 +195,6 @@
             "properties": {},
             "examples": [{}]
         },
-        "podSecurityContext": {
-            "type": "object",
-            "default": {},
-            "title": "security context for pod assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-            "required": [],
-            "properties": {},
-            "examples": [{}]
-        },
-        "securityContext": {
-            "type": "object",
-            "default": {},
-            "title": "security context for container assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/",
-            "required": [],
-            "properties": {},
-            "examples": [{}]
-        },
         "serviceAccount": {
             "type": "object",
             "default": {},
@@ -810,14 +794,6 @@
                     "type": "object",
                     "default": {},
                     "title": "node selector for the bootstrap containers",
-                    "required": [],
-                    "properties": {},
-                    "examples": [{}]
-                },
-                "securityContext": {
-                    "type": "object",
-                    "default": {},
-                    "title": "security context for the bootstrap containers",
                     "required": [],
                     "properties": {},
                     "examples": [{}]

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -212,10 +212,22 @@
             "examples": [{}]
         },
         "serviceAccount": {
-            "type": "string",
-            "default": "",
+            "type": "object",
+            "default": {},
             "title": "service account for pod assignment, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-            "examples": [""]
+            "additionalProperties": false,
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "default": "",
+                    "title": "name of the service account",
+                    "examples": [""]
+                }
+            },
+            "examples": [{}]
         },
         "db": {
             "type": "object",
@@ -811,10 +823,22 @@
                     "examples": [{}]
                 },
                 "serviceAccount": {
-                    "type": "string",
+                    "type": "object",
                     "default": "",
                     "title": "service account for the bootstrap containers",
-                    "examples": [""]
+                    "additionalProperties": false,
+                    "required": [
+                        "name"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "default": "",
+                            "title": "name of the service account",
+                            "examples": [""]
+                        }
+                    },
+                    "examples": [{}]
                 },
                 "rbac": {
                     "type": "object",

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -49,12 +49,6 @@ heapDumpOnOutOfMemoryError: false
 # -- node labels for pod assignment, see https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
-# -- security context for pod assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/
-podSecurityContext: {}
-
-# -- security context for container assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/
-securityContext: {}
-
 # -- service account for pod assignment, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 serviceAccount:
   name: ""
@@ -251,9 +245,6 @@ bootstrap:
 
   # node selector for the bootstrap containers
   nodeSelector: { }
-
-  # security context for the bootstrap containers
-  securityContext: { }
 
   # service account for the bootstrap containers
   serviceAccount:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -50,17 +50,14 @@ heapDumpOnOutOfMemoryError: false
 nodeSelector: {}
 
 # -- security context for pod assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/
-podSecurityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+podSecurityContext: {}
 
 # -- security context for container assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/
-securityContext:
-  allowPrivilegeEscalation: false
+securityContext: {}
 
 # -- service account for pod assignment, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-serviceAccount: "" 
+serviceAccount:
+  name: ""
 
 # Database configuration
 db:
@@ -259,7 +256,8 @@ bootstrap:
   securityContext: { }
 
   # service account for the bootstrap containers
-  serviceAccount: "" 
+  serviceAccount:
+    name: ""
 
 # worker configuration
 workers:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -49,6 +49,19 @@ heapDumpOnOutOfMemoryError: false
 # -- node labels for pod assignment, see https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
+# -- security context for pod assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+# -- security context for container assignment, see https://kubernetes.io/docs/concepts/security/pod-security-standards/
+securityContext:
+  allowPrivilegeEscalation: false
+
+# -- service account for pod assignment, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+serviceAccount: "" 
+
 # Database configuration
 db:
   # Cluster database configuration
@@ -241,6 +254,12 @@ bootstrap:
 
   # node selector for the bootstrap containers
   nodeSelector: { }
+
+  # security context for the bootstrap containers
+  securityContext: { }
+
+  # service account for the bootstrap containers
+  serviceAccount: "" 
 
 # worker configuration
 workers:


### PR DESCRIPTION
When deploying Corda in OCP, found out that a `serviceAccount` and some `securityContext` flags are required for the bootstrap jobs and worker deployments to work. More info can be found here: https://r3-cev.atlassian.net/browse/CORE-7414

This PR adds the option to use a `serviceAccount` for both bootstrap jobs and worker deployments and it enforces securityContext usage on all pods and containers.
 