### PR TITLE
NOTICK: Restore SandboxGroupContextComponentImpl to the sandbox testkit.

### DIFF
--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
@@ -1,0 +1,35 @@
+package net.corda.testing.sandboxes.testkit.impl
+
+import net.corda.sandboxgroupcontext.SandboxGroupContextService
+import net.corda.sandboxgroupcontext.service.CacheConfiguration
+import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.v5.base.util.loggerFor
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+
+@Suppress("unused")
+@Component(service = [ SandboxGroupContextComponent::class ])
+@ServiceRanking(Int.MAX_VALUE)
+class SandboxGroupContextComponentImpl @Activate constructor(
+    @Reference
+    private val sandboxGroupContextService: SandboxGroupContextService
+) : SandboxGroupContextComponent, SandboxGroupContextService by sandboxGroupContextService {
+    private val logger = loggerFor<SandboxGroupContextComponentImpl>()
+
+    override val isRunning: Boolean = true
+
+    override fun initCache(capacity: Long) {
+        (sandboxGroupContextService as? CacheConfiguration)?.initCache(capacity)
+            ?: throw IllegalStateException("Cannot initialize sandbox cache")
+    }
+
+    override fun start() {
+        logger.info("Started")
+    }
+
+    override fun stop() {
+        logger.info("Stopped")
+    }
+}

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/CpiLoader.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/CpiLoader.kt
@@ -6,6 +6,12 @@ import net.corda.libs.packaging.Cpi
 import java.util.concurrent.CompletableFuture
 
 interface CpiLoader {
+    companion object {
+        const val COMPONENT_NAME = "net.corda.testing.sandboxes.CpiLoader"
+        const val BASE_DIRECTORY_KEY = "baseDirectory"
+        const val TEST_BUNDLE_KEY = "testBundle"
+    }
+
     fun loadCPI(resourceName: String): Cpi
     fun unloadCPI(cpi: Cpi)
 

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -2,9 +2,8 @@ package net.corda.testing.sandboxes.impl
 
 import net.corda.cpk.read.CpkReadService
 import net.corda.sandbox.SandboxCreationService
+import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
-import net.corda.testing.sandboxes.impl.CpkReadServiceImpl.Companion.BASE_DIRECTORY_KEY
-import net.corda.testing.sandboxes.impl.CpkReadServiceImpl.Companion.TEST_BUNDLE_KEY
 import net.corda.testing.sandboxes.impl.SandboxSetupImpl.Companion.INSTALLER_NAME
 import net.corda.v5.base.util.loggerFor
 import org.osgi.framework.BundleContext
@@ -82,10 +81,10 @@ class SandboxSetupImpl @Activate constructor(
         val testBundle = bundleContext.bundle
         logger.info("Configuring sandboxes for [{}]", testBundle.symbolicName)
 
-        configAdmin.getConfiguration(CpkReadServiceImpl::class.java.name)?.also { config ->
+        configAdmin.getConfiguration(CpiLoader.COMPONENT_NAME)?.also { config ->
             val properties = Hashtable<String, Any?>()
-            properties[BASE_DIRECTORY_KEY] = baseDirectory.toString()
-            properties[TEST_BUNDLE_KEY] = testBundle.location
+            properties[CpiLoader.BASE_DIRECTORY_KEY] = baseDirectory.toString()
+            properties[CpiLoader.TEST_BUNDLE_KEY] = testBundle.location
             config.update(properties)
         }
 
@@ -100,7 +99,7 @@ class SandboxSetupImpl @Activate constructor(
      * the framework to create new instances of it.
      */
     override fun start() {
-        componentContext.enableComponent(CpkReadServiceImpl::class.java.name)
+        componentContext.enableComponent(CpiLoader.COMPONENT_NAME)
     }
 
     /**
@@ -120,7 +119,7 @@ class SandboxSetupImpl @Activate constructor(
          * for the framework to unregister it.
          */
         with(componentContext) {
-            disableComponent(CpkReadServiceImpl::class.java.name)
+            disableComponent(CpiLoader.COMPONENT_NAME)
             while (locateService<CpkReadService>(INSTALLER_NAME) != null) {
                 Thread.sleep(WAIT_MILLIS)
             }


### PR DESCRIPTION
The sandbox testkit provides a simpler `SandboxGroupContextComponent` so that we can create test sandboxes without using a lot of extra Corda machinery. I don't understand how this component was deleted, but it needs to be put back.

Also make some constants public so that they can be used by other bundles.