### PR TITLE
CORE-6807 Separated the virtual node and sandbox testing services

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.persistence.consensual.tests
 
 import net.corda.common.json.validation.JsonValidator
+import net.corda.db.persistence.testkit.components.SandboxService
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.testkit.DbUtils
 import net.corda.ledger.common.data.transaction.CordaPackageSummary
@@ -80,8 +81,9 @@ class ConsensualLedgerRepositoryTest {
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
             val virtualNode = setup.fetchService<VirtualNodeService>(TIMEOUT_MILLIS)
+            val sandboxService = setup.fetchService<SandboxService>(TIMEOUT_MILLIS)
             val virtualNodeInfo = virtualNode.load(TESTING_DATAMODEL_CPB)
-            val ctx = virtualNode.entitySandboxService.get(virtualNodeInfo.holdingIdentity)
+            val ctx = sandboxService.entitySandboxService.get(virtualNodeInfo.holdingIdentity)
             wireTransactionFactory = ctx.getSandboxSingletonService()
             jsonMarshallingService = ctx.getSandboxSingletonService()
             jsonValidator = ctx.getSandboxSingletonService()

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -13,6 +13,7 @@ import net.corda.data.ledger.persistence.LedgerTypes
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.persistence.EntityResponse
 import net.corda.db.messagebus.testkit.DBSetup
+import net.corda.db.persistence.testkit.components.SandboxService
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
@@ -77,6 +78,7 @@ class UtxoLedgerMessageProcessorTests {
 
     // For sandboxing
     private lateinit var virtualNode: VirtualNodeService
+    private lateinit var sanboxService: SandboxService
     private lateinit var externalEventResponseFactory: ExternalEventResponseFactory
     private lateinit var deserializer: CordaAvroDeserializer<EntityResponse>
     private lateinit var delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector
@@ -104,7 +106,7 @@ class UtxoLedgerMessageProcessorTests {
     @Test
     fun `persistTransaction for utxo ledger deserialises the transaction and persists`() {
         val virtualNodeInfo = virtualNode.load(Resources.EXTENDABLE_CPB)
-        val ctx = virtualNode.entitySandboxService.get(virtualNodeInfo.holdingIdentity)
+        val ctx = sanboxService.entitySandboxService.get(virtualNodeInfo.holdingIdentity)
 
         val transaction = createTestTransaction(ctx)
 
@@ -116,7 +118,7 @@ class UtxoLedgerMessageProcessorTests {
 
         // Send request to message processor
         val processor = PersistenceRequestProcessor(
-            virtualNode.entitySandboxService,
+            sanboxService.entitySandboxService,
             delegatedRequestHandlerSelector,
             externalEventResponseFactory
         )

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.persistence.utxo.tests
 
 import net.corda.common.json.validation.JsonValidator
+import net.corda.db.persistence.testkit.components.SandboxService
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.testkit.DbUtils
 import net.corda.ledger.common.data.transaction.CordaPackageSummary
@@ -92,8 +93,9 @@ class UtxoPersistenceServiceImplTest {
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
             val virtualNode = setup.fetchService<VirtualNodeService>(TIMEOUT_MILLIS)
+            val sandboxService = setup.fetchService<SandboxService>(TIMEOUT_MILLIS)
             val virtualNodeInfo = virtualNode.load(TESTING_DATAMODEL_CPB)
-            val ctx = virtualNode.entitySandboxService.get(virtualNodeInfo.holdingIdentity)
+            val ctx = sandboxService.entitySandboxService.get(virtualNodeInfo.holdingIdentity)
             wireTransactionFactory = ctx.getSandboxSingletonService()
             jsonMarshallingService = ctx.getSandboxSingletonService()
             jsonValidator = ctx.getSandboxSingletonService()

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -10,6 +10,7 @@ import net.corda.data.flow.event.external.ExternalEventResponseErrorType
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.PersistEntities
 import net.corda.db.messagebus.testkit.DBSetup
+import net.corda.db.persistence.testkit.components.SandboxService
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.fake.FakeDbConnectionManager
 import net.corda.db.persistence.testkit.helpers.Resources
@@ -63,6 +64,7 @@ class PersistenceExceptionTests {
     private val lifecycle = EachTestLifecycle()
 
     private lateinit var virtualNode: VirtualNodeService
+    private lateinit var sanboxService: SandboxService
     private lateinit var cpiInfoReadService: CpiInfoReadService
     private lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
     private lateinit var responseFactory: ResponseFactory
@@ -80,6 +82,7 @@ class PersistenceExceptionTests {
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
             virtualNode = setup.fetchService(timeout = 5000)
+            sanboxService = setup.fetchService(timeout = 5000)
             cpiInfoReadService = setup.fetchService(timeout = 5000)
             virtualNodeInfoReadService = setup.fetchService(timeout = 5000)
             responseFactory = setup.fetchService(timeout = 5000)
@@ -100,7 +103,7 @@ class PersistenceExceptionTests {
 
         val brokenEntitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                sanboxService.sandboxGroupContextComponent,
                 brokenCpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager
@@ -136,7 +139,7 @@ class PersistenceExceptionTests {
 
         val brokenEntitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                sanboxService.sandboxGroupContextComponent,
                 brokenCpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager
@@ -171,7 +174,7 @@ class PersistenceExceptionTests {
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                sanboxService.sandboxGroupContextComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager
@@ -209,7 +212,7 @@ class PersistenceExceptionTests {
         // We need a 'working' service to set up the test
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                sanboxService.sandboxGroupContextComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 dbConnectionManager

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -21,6 +21,7 @@ import net.corda.db.admin.LiquibaseSchemaMigrator
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.messagebus.testkit.DBSetup
+import net.corda.db.persistence.testkit.components.SandboxService
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.fake.FakeDbConnectionManager
 import net.corda.db.persistence.testkit.helpers.BasicMocks
@@ -107,6 +108,7 @@ class PersistenceServiceInternalTests {
     private val lifecycle = EachTestLifecycle()
 
     private lateinit var virtualNode: VirtualNodeService
+    private lateinit var sanboxService: SandboxService
     private lateinit var cpiInfoReadService: CpiInfoReadService
     private lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
     private lateinit var responseFactory: ResponseFactory
@@ -133,6 +135,7 @@ class PersistenceServiceInternalTests {
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
             virtualNode = setup.fetchService(timeout = 10000)
+            sanboxService = setup.fetchService(timeout = 10000)
             cpiInfoReadService = setup.fetchService(timeout = 10000)
             virtualNodeInfoReadService = setup.fetchService(timeout = 10000)
             responseFactory = setup.fetchService(timeout = 10000)
@@ -720,7 +723,7 @@ class PersistenceServiceInternalTests {
 
     private fun createEntitySandbox(dbConnectionManager: DbConnectionManager = BasicMocks.dbConnectionManager()) =
         EntitySandboxServiceFactory().create(
-            virtualNode.sandboxGroupContextComponent,
+            sanboxService.sandboxGroupContextComponent,
             cpiInfoReadService,
             virtualNodeInfoReadService,
             dbConnectionManager

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/SerializationTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/SerializationTests.kt
@@ -2,6 +2,7 @@ package net.corda.entityprocessor.impl.tests
 
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.db.messagebus.testkit.DBSetup
+import net.corda.db.persistence.testkit.components.SandboxService
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.helpers.BasicMocks
 import net.corda.db.persistence.testkit.helpers.Resources
@@ -38,6 +39,7 @@ class SerializationTests {
     private val lifecycle = EachTestLifecycle()
 
     private lateinit var virtualNode: VirtualNodeService
+    private lateinit var sandboxService: SandboxService
     private lateinit var cpiInfoReadService: CpiInfoReadService
     private lateinit var virtualNodeInfoReadService: VirtualNodeInfoReadService
 
@@ -54,6 +56,7 @@ class SerializationTests {
         lifecycle.accept(sandboxSetup) { setup ->
             // TODO - look at using generic fake implementations for these.
             virtualNode = setup.fetchService(timeout = 5000)
+            sandboxService = setup.fetchService(timeout = 5000)
             cpiInfoReadService = setup.fetchService(timeout = 5000)
             virtualNodeInfoReadService = setup.fetchService(timeout = 5000)
         }
@@ -65,7 +68,7 @@ class SerializationTests {
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
+                sandboxService.sandboxGroupContextComponent,
                 cpiInfoReadService,
                 virtualNodeInfoReadService,
                 BasicMocks.dbConnectionManager()

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/SandboxService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/SandboxService.kt
@@ -1,0 +1,20 @@
+package net.corda.db.persistence.testkit.components
+
+import net.corda.persistence.common.EntitySandboxService
+import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+@Component(service = [ SandboxService::class ])
+class SandboxService  @Activate constructor(
+    @Reference
+    val entitySandboxService: EntitySandboxService,
+
+    @Reference
+    val sandboxGroupContextComponent: SandboxGroupContextComponent
+) {
+    init {
+        sandboxGroupContextComponent.initCache(2)
+    }
+}

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
@@ -3,8 +3,6 @@ package net.corda.db.persistence.testkit.components
 import net.corda.db.admin.LiquibaseSchemaMigrator
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.schema.DbSchema
-import net.corda.persistence.common.EntitySandboxService
-import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.virtualnode.VirtualNodeInfo
@@ -24,12 +22,6 @@ class VirtualNodeService @Activate constructor(
 
     @Reference
     private val liquibaseSchemaMigrator: LiquibaseSchemaMigrator,
-
-    @Reference
-    val entitySandboxService: EntitySandboxService,
-
-    @Reference
-    val sandboxGroupContextComponent: SandboxGroupContextComponent
 ) {
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
@@ -38,10 +30,6 @@ class VirtualNodeService @Activate constructor(
     }
 
     private var connectionCounter = AtomicInteger(0)
-
-    init {
-        sandboxGroupContextComponent.initCache(2)
-    }
 
     fun load(resourceName: String): VirtualNodeInfo {
         val virtualNodeInfo = virtualNodeLoader.loadVirtualNode(resourceName, generateHoldingIdentity())


### PR DESCRIPTION
Separated the virtual node and sandbox testing services to allow the virtual node to be used without the sandbox, this is needed for integration tests that require virtual node setup only.