### PR TITLE
NOTICK: Reduce the OSGi service ranking for sandbox testing services.

### DIFF
--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
@@ -3,6 +3,7 @@ package net.corda.testing.sandboxes.testkit.impl
 import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.sandboxgroupcontext.service.CacheConfiguration
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
+import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -11,7 +12,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking
 
 @Suppress("unused")
 @Component(service = [ SandboxGroupContextComponent::class ])
-@ServiceRanking(Int.MAX_VALUE)
+@ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class SandboxGroupContextComponentImpl @Activate constructor(
     @Reference
     private val sandboxGroupContextService: SandboxGroupContextService

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
@@ -4,10 +4,11 @@ import java.nio.file.Path
 import org.osgi.framework.BundleContext
 
 interface SandboxSetup {
-    fun configure(
-        bundleContext: BundleContext,
-        baseDirectory: Path
-    )
+    companion object {
+        const val SANDBOX_SERVICE_RANKING = Int.MAX_VALUE / 2
+    }
+
+    fun configure(bundleContext: BundleContext, baseDirectory: Path)
 
     fun start()
     fun shutdown()

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
@@ -6,14 +6,17 @@ import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.reconciliation.VersionedRecord
 import net.corda.testing.sandboxes.CpiLoader
+import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
 import java.util.stream.Stream
 
 @Suppress("unused")
 @Component
+@ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class CpiInfoServiceImpl @Activate constructor(
     @Reference
     private val loader: CpiLoader

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
@@ -8,6 +8,7 @@ import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.testutils.cpb.packaging.v2.TestCpbReaderV2
 import net.corda.testing.sandboxes.CpiLoader
+import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.SecureHash
 import org.osgi.framework.BundleContext
@@ -28,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap
     service = [ CpkReadService::class, CpiLoader::class ],
     configurationPolicy = REQUIRE
 )
-@ServiceRanking(Int.MAX_VALUE)
+@ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class CpkReadServiceImpl @Activate constructor(
     bundleContext: BundleContext,
     properties: Map<String, Any?>

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -3,6 +3,7 @@ package net.corda.testing.sandboxes.impl
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.read.NotaryVirtualNodeLookup
+import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.PublicKeyHash
@@ -14,7 +15,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking
 
 @Suppress("unused")
 @Component
-@ServiceRanking(Int.MAX_VALUE)
+@ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
     private val logger = loggerFor<MembershipGroupReaderProvider>()
 

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
@@ -6,6 +6,7 @@ import net.corda.libs.packaging.Cpi
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.reconciliation.VersionedRecord
 import net.corda.testing.sandboxes.CpiLoader
+import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.v5.base.util.loggerFor
 import net.corda.virtualnode.ShortHash
@@ -23,7 +24,7 @@ import java.util.stream.Stream
 
 @Suppress("unused")
 @Component(service = [ VirtualNodeLoader::class, VirtualNodeInfoReadService::class ])
-@ServiceRanking(Int.MAX_VALUE)
+@ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class VirtualNodeLoaderImpl @Activate constructor(
     @Reference
     private val cpiLoader: CpiLoader,


### PR DESCRIPTION
Not every testing service can have an OSGi service ranking of `Int.MAX_VALUE`! When choosing between two services with equal ranking, the OSGi framework will use the one that was registered first, which sounds racy to me.

Reduce the ranking for `:testing:sandboxes` and `:testing:sandboxes-testkit` services to `Int.MAX_VALUE / 2`, so that they can themselves be overridden as required.