### PR TITLE
CORE-8146: Lifecycle tweaks to prevent using closed publisher

### DIFF
--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -60,13 +60,12 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
     private fun onRegistrationStatusChangeEvent(event: RegistrationStatusChangeEvent, coordinator: LifecycleCoordinator) {
         if (event.status == LifecycleStatus.UP) {
             logger.info("Starting reconciliations")
-            reconcileAndScheduleNext(coordinator)
             coordinator.updateStatus(LifecycleStatus.UP)
+            reconcileAndScheduleNext(coordinator)
         } else {
             // TODO Revise below actions in case of an error from sub services (DOWN vs ERROR)
             coordinator.updateStatus(event.status)
             coordinator.cancelTimer(timerKey)
-            closeResources()
         }
     }
 
@@ -83,7 +82,6 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
             // on subsequent `RegistrationStatusChangeEvent` to see if it is going to be a `DOWN` or an `ERROR`.
             logger.warn("Reconciliation failed. Terminating reconciliations", e)
             coordinator.updateStatus(LifecycleStatus.DOWN)
-            closeResources()
         }
     }
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
@@ -134,6 +134,7 @@ class VirtualNodeInfoWriterComponentImpl @Activate constructor(
         } else {
             coordinator.updateStatus(event.status)
             configSubscription?.close()
+            configSubscription = null
         }
     }
 
@@ -143,6 +144,7 @@ class VirtualNodeInfoWriterComponentImpl @Activate constructor(
      */
     private fun onConfigChangedEventReceived(coordinator: LifecycleCoordinator, event: ConfigChangedEvent) {
         log.debug { "Creating resources" }
+        coordinator.updateStatus(LifecycleStatus.DOWN)
         createPublisher(event)
         coordinator.updateStatus(LifecycleStatus.UP)
     }


### PR DESCRIPTION
Explicitly sets writer components as down during states of config updates.

This should prevent attempted publishes while the publisher it requires is in the process of being recreated with a new messaging config.

This change additionally ensures that closed resources are set to null, and that the resources aren't cleaned up too aggressively in the case of a config update