### PR TITLE
NOTICK: Ensure VirtualNodeSrvice exists before fetching FlowSandboxService.

### DIFF
--- a/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
+++ b/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
@@ -67,10 +67,12 @@ abstract class CommonLedgerIntegrationTest {
     }
 
     open fun initialize(setup: SandboxSetup) {
-        flowSandboxService = setup.fetchService(TIMEOUT_MILLIS)
-
+        // Load VirtualNodeService before FlowSandboxService so that
+        // FlowSandboxService can use the correct VirtualNodeInfoReadService.
         val virtualNode = setup.fetchService<VirtualNodeService>(TIMEOUT_MILLIS)
         val virtualNodeInfo = virtualNode.loadVirtualNode(testingCpb)
+
+        flowSandboxService = setup.fetchService(TIMEOUT_MILLIS)
         sandboxGroupContext = flowSandboxService.get(virtualNodeInfo.holdingIdentity)
         setup.withCleanup { virtualNode.unloadSandbox(sandboxGroupContext) }
 


### PR DESCRIPTION
The `FlowSandboxService` needs to use the `VirtualNodeInfoReadService` provided by the `:testing:sandboxes` module when running integration tests, as otherwise it will fail to find any `VirtualNodeInfo` objects.

Fetching `VirtualNodeService` before `FlowSandboxService` ensures that the testing versions of the services are available for use.