### PR TITLE
CORE-8400: add external publishing for missing direct and transitive dependencies brought in by simulator

### DIFF
--- a/libs/configuration/configuration-core/build.gradle
+++ b/libs/configuration/configuration-core/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Configuration Library'
 
 dependencies {

--- a/libs/crypto/cipher-suite-impl/build.gradle
+++ b/libs/crypto/cipher-suite-impl/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Cipher suite default implementation'
 
 dependencies {

--- a/libs/crypto/crypto-core/build.gradle
+++ b/libs/crypto/crypto-core/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Crypto core'
 
 dependencies {

--- a/libs/crypto/crypto-impl/build.gradle
+++ b/libs/crypto/crypto-impl/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Common crypto implementation'
 
 dependencies {

--- a/libs/crypto/crypto-serialization-impl/build.gradle
+++ b/libs/crypto/crypto-serialization-impl/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Crypto serialization'
 
 dependencies {

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -9,6 +9,10 @@ plugins {
     id 'biz.aQute.bnd.builder'
 }
 
+ext {
+    releasable = true
+}
+
 description "Bare bones Kotlin reflection within an OSGi framework."
 
 configurations {

--- a/libs/layered-property-map/build.gradle
+++ b/libs/layered-property-map/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'corda.osgi-test-conventions'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Layered property map internal API and implementation'
 
 dependencies {

--- a/libs/packaging/packaging-core/build.gradle
+++ b/libs/packaging/packaging-core/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Packaging Interfaces and Data Classes'
 
 dependencies {

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Corda Packaging'
 
 allprojects {

--- a/libs/sandbox-types/build.gradle
+++ b/libs/sandbox-types/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Corda Sandbox Types'
 
 dependencies {

--- a/libs/sandbox/build.gradle
+++ b/libs/sandbox/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Corda Sandbox'
 
 dependencies {

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -6,6 +6,11 @@ plugins {
     id 'corda.common-library'
 }
 
+
+ext {
+    releasable = true
+}
+
 description 'Corda AMQP serialization library'
 
 configurations {

--- a/libs/serialization/serialization-encoding/build.gradle
+++ b/libs/serialization/serialization-encoding/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'biz.aQute.bnd.builder'
     id 'corda.common-publishing'
 }
+
+ext {
+    releasable = true
+}
+
 description 'Corda Serialization encoding'
 
 configurations {

--- a/libs/serialization/serialization-internal/build.gradle
+++ b/libs/serialization/serialization-internal/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-publishing'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Corda Serialization Internal API'
 
 dependencies {

--- a/libs/utilities/build.gradle
+++ b/libs/utilities/build.gradle
@@ -4,6 +4,9 @@ plugins {
 }
 description 'Utilities'
 
+ext {
+    releasable = true
+}
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'


### PR DESCRIPTION
CSDE Sample project which brings in the dependencies of the modules altered in this PR either directly or transitively ,  These do not get published to our isolated staging env and therefore will not ultimatly be published to maven central with out this change.

As a result CSDE fails to compile against the latest corda-runtime-os code base.

Note, logic elsewhere in our internal gradle plugins looks for the setting of this `releasable` property for a module to mark it as something we will release externally. We need this as we do not currently blanket publish all runtime-os modules externally (internally yes to Artifactory but this is not currently the plan for external releases) 


Modules altered to ensure their Jars are published and available

```
libs:sandbox-types
libs:layered-property-map
libs:configuration:configuration-core
libs:crypto:crypto-core
libs:crypto:cipher-suite-impl
libs:crypto:crypto-impl
libs:crypto:crypto-serialization-impl
libs:utilities
libs:serialization
libs:serialization-encoding
libs:kotlin-reflection
libs:packaging:packaging-core
libs:packaging:packaging
libs:serialization
libs:sandbox
libs:serialization:serialization-amqp 
```
