### PR TITLE
CORE-8399: Throw Bad Request 4 Invalid Short Hash

### DIFF
--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -69,6 +69,8 @@ class FlowRPCOpsImplTest {
     private companion object {
         val loginName = "${FlowRPCOpsImplTest::class.java.simpleName}-User"
         const val FLOW1 = "flow1"
+        const val VALID_SHORT_HASH = "1234567890ab"
+        val INVALID_SHORT_HASHES = listOf("invalid", "${VALID_SHORT_HASH}22")
     }
 
     private fun getMockCPIMeta(): CpiMetadata {
@@ -163,7 +165,7 @@ class FlowRPCOpsImplTest {
     fun `get flow status`() {
         whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(FlowStatus())
         val flowRPCOps = createFlowRpcOps()
-        flowRPCOps.getFlowStatus("1234567890ab", "")
+        flowRPCOps.getFlowStatus(VALID_SHORT_HASH, "")
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -178,7 +180,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps()
 
         assertThrows<ResourceNotFoundException> {
-            flowRPCOps.getFlowStatus("1234567890ab", "")
+            flowRPCOps.getFlowStatus(VALID_SHORT_HASH, "")
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -191,9 +193,10 @@ class FlowRPCOpsImplTest {
     fun `get flow status throws bad request if short hash is invalid`() {
         val flowRPCOps = createFlowRpcOps()
 
-        assertThrows<BadRequestException> {
-            flowRPCOps.getFlowStatus("invalid", "")
-            flowRPCOps.getFlowStatus("12345678901d22", "")
+        INVALID_SHORT_HASHES.forEach {
+            assertThrows<BadRequestException> {
+                flowRPCOps.getFlowStatus(it, "")
+            }
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -206,7 +209,7 @@ class FlowRPCOpsImplTest {
     fun `get multiple flow status`() {
         whenever(flowStatusCacheService.getStatusesPerIdentity(any())).thenReturn(listOf(FlowStatus(), FlowStatus()))
         val flowRPCOps = createFlowRpcOps()
-        flowRPCOps.getMultipleFlowStatus("1234567890ab")
+        flowRPCOps.getMultipleFlowStatus(VALID_SHORT_HASH)
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatusesPerIdentity(any())
@@ -221,7 +224,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps()
 
         assertThrows<ResourceNotFoundException> {
-            flowRPCOps.getMultipleFlowStatus("1234567890ab")
+            flowRPCOps.getMultipleFlowStatus(VALID_SHORT_HASH)
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -234,9 +237,10 @@ class FlowRPCOpsImplTest {
     fun `get multiple flow status throws bad request if short hash is invalid`() {
         val flowRPCOps = createFlowRpcOps()
 
-        assertThrows<BadRequestException> {
-            flowRPCOps.getMultipleFlowStatus("invalid")
-            flowRPCOps.getMultipleFlowStatus("12345678901d22")
+        INVALID_SHORT_HASHES.forEach {
+            assertThrows<BadRequestException> {
+                flowRPCOps.getMultipleFlowStatus(it)
+            }
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -253,7 +257,7 @@ class FlowRPCOpsImplTest {
 
         whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
 
-        flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+        flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, times(1)).get(any())
@@ -270,7 +274,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps(false)
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -287,9 +291,10 @@ class FlowRPCOpsImplTest {
     fun `start flow event throws bad request if short hash is invalid`() {
         val flowRPCOps = createFlowRpcOps()
 
-        assertThrows<BadRequestException> {
-            flowRPCOps.startFlow("invalid", StartFlowParameters("", "", TestJsonObject()))
-            flowRPCOps.startFlow("12345678901d22", StartFlowParameters("", "", TestJsonObject()))
+        INVALID_SHORT_HASHES.forEach {
+            assertThrows<BadRequestException> {
+                flowRPCOps.startFlow(it, StartFlowParameters("", "", TestJsonObject()))
+            }
         }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())
@@ -307,7 +312,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps()
 
         assertThrows<ResourceNotFoundException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", "", TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", "", TestJsonObject()))
         }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())
@@ -324,7 +329,7 @@ class FlowRPCOpsImplTest {
 
         whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(mock())
         assertThrows<ResourceAlreadyExistsException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -344,7 +349,7 @@ class FlowRPCOpsImplTest {
         whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
 
         assertThrows<InvalidInputDataException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("requetsId", "invalid", TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("requetsId", "invalid", TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -363,7 +368,7 @@ class FlowRPCOpsImplTest {
 
         doThrow(CordaMessageAPIIntermittentException("")).whenever(publisher).publish(any())
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -385,7 +390,7 @@ class FlowRPCOpsImplTest {
         }))
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -403,7 +408,7 @@ class FlowRPCOpsImplTest {
 
         doThrow(CordaMessageAPIFatalException("")).whenever(publisher).publish(any())
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -418,7 +423,7 @@ class FlowRPCOpsImplTest {
         // attempting to start the flow
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -440,7 +445,7 @@ class FlowRPCOpsImplTest {
         }))
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -455,7 +460,7 @@ class FlowRPCOpsImplTest {
         // attempting to start the flow
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -477,7 +482,7 @@ class FlowRPCOpsImplTest {
 
         val flowRPCOps = createFlowRpcOps()
 
-        flowRPCOps.registerFlowStatusUpdatesFeed(duplexChannel, "1234567890ab", "")
+        flowRPCOps.registerFlowStatusUpdatesFeed(duplexChannel, VALID_SHORT_HASH, "")
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(duplexChannel, times(1)).error(any())
@@ -514,7 +519,7 @@ class FlowRPCOpsImplTest {
         ).thenReturn(false)
 
         assertThrows<ForbiddenException> {
-            flowRPCOps.startFlow("1234567890ab", StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(fatalErrorFunction, never()).invoke()

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -193,6 +193,7 @@ class FlowRPCOpsImplTest {
 
         assertThrows<BadRequestException> {
             flowRPCOps.getFlowStatus("invalid", "")
+            flowRPCOps.getFlowStatus("12345678901d22", "")
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -235,6 +236,7 @@ class FlowRPCOpsImplTest {
 
         assertThrows<BadRequestException> {
             flowRPCOps.getMultipleFlowStatus("invalid")
+            flowRPCOps.getMultipleFlowStatus("12345678901d22")
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -287,6 +289,7 @@ class FlowRPCOpsImplTest {
 
         assertThrows<BadRequestException> {
             flowRPCOps.startFlow("invalid", StartFlowParameters("", "", TestJsonObject()))
+            flowRPCOps.startFlow("12345678901d22", StartFlowParameters("", "", TestJsonObject()))
         }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
@@ -70,7 +72,6 @@ class FlowRPCOpsImplTest {
         val loginName = "${FlowRPCOpsImplTest::class.java.simpleName}-User"
         const val FLOW1 = "flow1"
         const val VALID_SHORT_HASH = "1234567890ab"
-        val INVALID_SHORT_HASHES = listOf("invalid", "${VALID_SHORT_HASH}22")
     }
 
     private fun getMockCPIMeta(): CpiMetadata {
@@ -189,14 +190,13 @@ class FlowRPCOpsImplTest {
         verify(fatalErrorFunction, never()).invoke()
     }
 
-    @Test
-    fun `get flow status throws bad request if short hash is invalid`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["invalid", "${VALID_SHORT_HASH}AB"])
+    fun `get flow status throws bad request if short hash is invalid`(invalidShortHash: String) {
         val flowRPCOps = createFlowRpcOps()
 
-        INVALID_SHORT_HASHES.forEach {
-            assertThrows<BadRequestException> {
-                flowRPCOps.getFlowStatus(it, "")
-            }
+        assertThrows<BadRequestException> {
+            flowRPCOps.getFlowStatus(invalidShortHash, "")
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -233,14 +233,13 @@ class FlowRPCOpsImplTest {
         verify(fatalErrorFunction, never()).invoke()
     }
 
-    @Test
-    fun `get multiple flow status throws bad request if short hash is invalid`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["invalid", "${VALID_SHORT_HASH}AB"])
+    fun `get multiple flow status throws bad request if short hash is invalid`(invalidShortHash: String) {
         val flowRPCOps = createFlowRpcOps()
 
-        INVALID_SHORT_HASHES.forEach {
-            assertThrows<BadRequestException> {
-                flowRPCOps.getMultipleFlowStatus(it)
-            }
+        assertThrows<BadRequestException> {
+            flowRPCOps.getMultipleFlowStatus(invalidShortHash)
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -287,14 +286,13 @@ class FlowRPCOpsImplTest {
         verify(fatalErrorFunction, never()).invoke()
     }
 
-    @Test
-    fun `start flow event throws bad request if short hash is invalid`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["invalid", "${VALID_SHORT_HASH}AB"])
+    fun `start flow event throws bad request if short hash is invalid`(invalidShortHash: String) {
         val flowRPCOps = createFlowRpcOps()
 
-        INVALID_SHORT_HASHES.forEach {
-            assertThrows<BadRequestException> {
-                flowRPCOps.startFlow(it, StartFlowParameters("", "", TestJsonObject()))
-            }
+        assertThrows<BadRequestException> {
+            flowRPCOps.startFlow(invalidShortHash, StartFlowParameters("", "", TestJsonObject()))
         }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/ClientDtoConverters.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/ClientDtoConverters.kt
@@ -12,13 +12,13 @@ import net.corda.membership.httprpc.v1.types.response.RegistrationRequestProgres
 import net.corda.membership.httprpc.v1.types.response.RegistrationRequestStatus
 import net.corda.membership.httprpc.v1.types.response.RegistrationStatus
 import net.corda.virtualnode.ShortHash
-import net.corda.virtualnode.read.rpc.extensions.ofOrThrow
+import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 
 /**
  * Convert [MemberRegistrationRequest] from the HTTP API to the internal DTO [MemberRegistrationRequestDto].
  */
 fun MemberRegistrationRequest.toDto(holdingIdentityShortHash: String) = MemberRegistrationRequestDto(
-    ShortHash.ofOrThrow(holdingIdentityShortHash),
+    ShortHash.parseOrThrow(holdingIdentityShortHash),
     RegistrationActionDto.REQUEST_JOIN.getFromValue(action),
     context
 )

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MGMRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MGMRpcOpsImpl.kt
@@ -15,7 +15,7 @@ import net.corda.membership.httprpc.v1.MGMRpcOps
 import net.corda.membership.impl.httprpc.v1.lifecycle.RpcOpsLifecycleHandler
 import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
-import net.corda.virtualnode.read.rpc.extensions.ofOrThrow
+import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -88,7 +88,7 @@ class MGMRpcOpsImpl @Activate constructor(
     private inner class ActiveImpl : InnerMGMRpcOps {
         override fun generateGroupPolicy(holdingIdentityShortHash: String): String {
             return try {
-                mgmOpsClient.generateGroupPolicy(ShortHash.ofOrThrow(holdingIdentityShortHash))
+                mgmOpsClient.generateGroupPolicy(ShortHash.parseOrThrow(holdingIdentityShortHash))
             } catch (e: CouldNotFindMemberException) {
                 throw ResourceNotFoundException("Could not find member with holding identity $holdingIdentityShortHash.")
             } catch (e: MemberNotAnMgmException) {

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRpcOpsImpl.kt
@@ -15,7 +15,7 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.read.rpc.extensions.getByHoldingIdentityShortHashOrThrow
-import net.corda.virtualnode.read.rpc.extensions.ofOrThrow
+import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -90,7 +90,7 @@ class MemberLookupRpcOpsImpl @Activate constructor(
         state: String?,
         country: String?
     ) = impl.lookup(
-        ShortHash.ofOrThrow(holdingIdentityShortHash),
+        ShortHash.parseOrThrow(holdingIdentityShortHash),
         commonName,
         organization,
         organizationUnit,

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberRegistrationRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberRegistrationRpcOpsImpl.kt
@@ -16,7 +16,7 @@ import net.corda.membership.httprpc.v1.types.response.RegistrationRequestStatus
 import net.corda.membership.impl.httprpc.v1.lifecycle.RpcOpsLifecycleHandler
 import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
-import net.corda.virtualnode.read.rpc.extensions.ofOrThrow
+import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -135,7 +135,7 @@ class MemberRegistrationRpcOpsImpl @Activate constructor(
         override fun checkRegistrationProgress(holdingIdentityShortHash: String): List<RegistrationRequestStatus> {
             return try {
                 memberOpsClient.checkRegistrationProgress(
-                    ShortHash.ofOrThrow(holdingIdentityShortHash)
+                    ShortHash.parseOrThrow(holdingIdentityShortHash)
                 ).map { it.fromDto() }
             } catch (e: RegistrationProgressNotFoundException) {
                 throw ResourceNotFoundException(e.message!!)
@@ -148,7 +148,7 @@ class MemberRegistrationRpcOpsImpl @Activate constructor(
         ): RegistrationRequestStatus? {
             return try {
                 memberOpsClient.checkSpecificRegistrationProgress(
-                    ShortHash.ofOrThrow(holdingIdentityShortHash),
+                    ShortHash.parseOrThrow(holdingIdentityShortHash),
                     registrationRequestId
                 )?.fromDto()
             } catch (e: RegistrationProgressNotFoundException) {

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImpl.kt
@@ -15,7 +15,7 @@ import net.corda.membership.httprpc.v1.types.request.HostedIdentitySetupRequest
 import net.corda.membership.impl.httprpc.v1.lifecycle.RpcOpsLifecycleHandler
 import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
-import net.corda.virtualnode.read.rpc.extensions.ofOrThrow
+import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -38,7 +38,7 @@ class NetworkRpcOpsImpl @Activate constructor(
     ) {
         try {
             certificatesClient.setupLocallyHostedIdentity(
-                ShortHash.ofOrThrow(holdingIdentityShortHash),
+                ShortHash.parseOrThrow(holdingIdentityShortHash),
                 request.p2pTlsCertificateChainAlias,
                 request.useClusterLevelTlsCertificateAndKey != false,
                 request.useClusterLevelSessionCertificateAndKey == true,

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MGMRpcOpsTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MGMRpcOpsTest.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.impl.httprpc.v1
 
+import net.corda.httprpc.exception.BadRequestException
 import net.corda.httprpc.exception.InvalidInputDataException
 import net.corda.httprpc.exception.ResourceNotFoundException
 import net.corda.httprpc.exception.ServiceUnavailableException
@@ -26,7 +27,7 @@ import kotlin.test.assertFailsWith
 
 class MGMRpcOpsTest {
     companion object {
-        private const val HOLDING_IDENTITY_ID = "00111213141500"
+        private const val HOLDING_IDENTITY_ID = "111213141500"
     }
 
     private var coordinatorIsRunning = false
@@ -89,6 +90,16 @@ class MGMRpcOpsTest {
 
         assertThrows<InvalidInputDataException> {
             mgmRpcOps.generateGroupPolicy(HOLDING_IDENTITY_ID)
+        }
+    }
+
+    @Test
+    fun `generateGroupPolicy throws bad request if short hash is invalid`() {
+        mgmRpcOps.start()
+        mgmRpcOps.activate("")
+
+        assertThrows<BadRequestException> {
+            mgmRpcOps.generateGroupPolicy("ABS09234745D")
         }
     }
 

--- a/components/virtual-node/virtual-node-info-read-service-rpc-extensions/src/main/kotlin/net/corda/virtualnode/read/rpc/extensions/VirtualNodeInfoRPCExtensions.kt
+++ b/components/virtual-node/virtual-node-info-read-service-rpc-extensions/src/main/kotlin/net/corda/virtualnode/read/rpc/extensions/VirtualNodeInfoRPCExtensions.kt
@@ -69,7 +69,7 @@ fun VirtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(
  * @see VirtualNodeInfoReadService.getByHoldingIdentityShortHash
  */
 fun VirtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(holdingIdentityShortHash: String): VirtualNodeInfo {
-    val shortHash = ShortHash.ofOrThrow(holdingIdentityShortHash)
+    val shortHash = ShortHash.parseOrThrow(holdingIdentityShortHash)
     return getByHoldingIdentityShortHash(shortHash) ?: throw ResourceNotFoundException("Virtual Node", shortHash.value)
 }
 
@@ -95,7 +95,7 @@ fun VirtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(
     holdingIdentityShortHash: String,
     message: () -> String
 ): VirtualNodeInfo {
-    val shortHash = ShortHash.ofOrThrow(holdingIdentityShortHash)
+    val shortHash = ShortHash.parseOrThrow(holdingIdentityShortHash)
     return getByHoldingIdentityShortHash(shortHash) ?: throw ResourceNotFoundException(message())
 }
 
@@ -108,9 +108,28 @@ fun VirtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(
  *
  * @see ShortHash.of
  */
+@SuppressWarnings("SwallowedException")
 fun ShortHash.Companion.ofOrThrow(holdingIdentityShortHash: String): ShortHash {
     return try {
         of(holdingIdentityShortHash)
+    } catch (e: ShortHashException) {
+        throw BadRequestException("Invalid holding identity short hash${e.message?.let { ": $it" }}")
+    }
+}
+
+/**
+ * Creates a short hash parsing the given [holdingIdentityShortHash].
+ *
+ * For consistency with [SecureHash.toHexString], any lower case alpha characters are converted to uppercase.
+ *
+ * @throws [BadRequestException] If the string is not hexadecimal or has length different from [LENGTH].
+ *
+ * @see ShortHash.of
+ */
+@SuppressWarnings("SwallowedException")
+fun ShortHash.Companion.parseOrThrow(holdingIdentityShortHash: String): ShortHash {
+    return try {
+        parse(holdingIdentityShortHash)
     } catch (e: ShortHashException) {
         throw BadRequestException("Invalid holding identity short hash${e.message?.let { ": $it" }}")
     }

--- a/components/virtual-node/virtual-node-info-read-service-rpc-extensions/src/test/kotlin/net/corda/virtualnode/read/rpc/extensions/VirtualNodeInfoRPCExtensionsTest.kt
+++ b/components/virtual-node/virtual-node-info-read-service-rpc-extensions/src/test/kotlin/net/corda/virtualnode/read/rpc/extensions/VirtualNodeInfoRPCExtensionsTest.kt
@@ -90,4 +90,14 @@ class VirtualNodeInfoRPCExtensionsTest {
     fun `ShortHash ofOrThrow throws BadRequest if ShortHash is invalid`() {
         assertThrows<BadRequestException> { ShortHash.ofOrThrow(INVALID_SHORT_HASH) }
     }
+
+    @Test
+    fun `ShortHash parseOrThrow returns ShortHash if valid`() {
+        assertEquals(VALID_SHORT_HASH, ShortHash.parseOrThrow(VALID_SHORT_HASH.value))
+    }
+
+    @Test
+    fun `ShortHash parseOrThrow throws BadRequest if ShortHash is invalid`() {
+        assertThrows<BadRequestException> { ShortHash.parseOrThrow("${VALID_SHORT_HASH}AS3") }
+    }
 }

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/ShortHash.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/ShortHash.kt
@@ -35,6 +35,23 @@ class ShortHash private constructor(val value: String) {
         }
 
         /**
+         * Parses the given [hexString] and creates a short hash.
+         *
+         * For consistency with [SecureHash.toHexString], any lower case alpha characters are
+         * converted to uppercase.
+         *
+         * @throws [ShortHashException] if the string is not hexadecimal or has length different from [LENGTH].
+         */
+        fun parse(hexString: String) : ShortHash {
+            if (hexString.length != LENGTH) {
+                throw ShortHashException("Hex string has length of ${hexString.length} " +
+                        "but should be $LENGTH characters")
+            }
+
+            return of(hexString)
+        }
+
+        /**
          * Creates a short hash from the given secure hash.
          */
         fun of(secureHash: SecureHash) = of(secureHash.toHexString())

--- a/libs/virtual-node/virtual-node-info/src/test/kotlin/net/corda/virtualnode/ShortHashTest.kt
+++ b/libs/virtual-node/virtual-node-info/src/test/kotlin/net/corda/virtualnode/ShortHashTest.kt
@@ -52,6 +52,50 @@ class ShortHashTest {
     }
 
     @Test
+    fun `can parse short hash`() {
+        assertDoesNotThrow {
+            ShortHash.parse("123456789012")
+        }
+    }
+
+    @Test
+    fun `can parse short hash from hex string in lower case`() {
+        assertDoesNotThrow {
+            ShortHash.parse("567890abcdef")
+        }
+    }
+
+    @Test
+    fun `can parse short hash from hex string in caps`() {
+        assertDoesNotThrow {
+            ShortHash.parse("567890ABCDEF")
+        }
+    }
+
+    @Test
+    fun `cannot parse short hash if too short`() {
+        // 11 chars < 12 REQUIRED
+        assertThrows<ShortHashException> {
+            ShortHash.parse("12345678901")
+        }
+    }
+
+    @Test
+    fun `cannot parse short hash if too long`() {
+        // 14 chars > 12 REQUIRED
+        assertThrows<ShortHashException> {
+            ShortHash.parse("12345678901d22")
+        }
+    }
+
+    @Test
+    fun `cannot parse short hash if not a hex string`() {
+        assertThrows<ShortHashException> {
+            ShortHash.parse("finishfinish")
+        }
+    }
+
+    @Test
     fun `comparison`() {
         assertThat(ShortHash.of("1234567890ab")).isEqualTo(ShortHash.of("1234567890ab"))
         assertThat(ShortHash.of("1234567890ab")).isNotEqualTo(ShortHash.of("ab1234567890"))


### PR DESCRIPTION
Multiple user facing HTTP rest endpoints receive the holding identity
short hash as a parameter and silently truncate the input whenever is
longer than 12 characters. Instead of that, an error should be returned
to the users.

- Add 'ShortHash.parse' to throw an exception when the input length is
  invalid, and delegate to the existing implementation if it is not.
- Update user facing REST endpoints to return HTTP status code 400 (BAD
  REQUEST) whenever the holding identity short hash can not be parsed.
