### PR TITLE
CORE-8413 Fix intermittently failing group parameters cache test

### DIFF
--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/cache/GroupParametersCacheTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/cache/GroupParametersCacheTest.kt
@@ -80,7 +80,7 @@ class GroupParametersCacheTest {
                 val params = this.groupParameters.toMap()
                 assertThat(params[EPOCH_KEY]).isEqualTo("1")
                 assertThat(params[MPV_KEY]).isEqualTo("5000")
-                assertThat(Instant.parse(params[MODIFIED_TIME_KEY])).isBefore(Instant.now())
+                assertThat(Instant.parse(params[MODIFIED_TIME_KEY])).isBeforeOrEqualTo(Instant.now())
             }
         }
     }

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/GroupParametersFactoryTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/GroupParametersFactoryTest.kt
@@ -59,7 +59,7 @@ class GroupParametersFactoryTest {
         with(groupParameters) {
             assertThat(epoch).isEqualTo(EPOCH.toInt())
             assertThat(minimumPlatformVersion).isEqualTo(MPV.toInt())
-            assertThat(modifiedTime).isBefore(Instant.now())
+            assertThat(modifiedTime).isBeforeOrEqualTo(Instant.now())
         }
     }
 }


### PR DESCRIPTION
`GroupParametersCacheTest` was failing intermittently on Windows builds, as it expected the modified time group parameter to be strictly before a time instant specified in the test - and did not take into account the two time instants being equal. This change fixes the above, and also applies the same update to `GroupParametersFactoryTest`.
https://r3-cev.atlassian.net/browse/CORE-8413