### PR TITLE
CORE-8398: Remove `findFreePort()`

### DIFF
--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientAadIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientAadIntegrationTest.kt
@@ -8,7 +8,6 @@ import net.corda.httprpc.server.impl.HttpRpcServerImpl
 import net.corda.httprpc.test.TestHealthCheckAPI
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.AzureAdMock
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.utilities.NetworkHostAndPort
 import org.junit.jupiter.api.AfterEach
@@ -18,12 +17,10 @@ import kotlin.test.assertEquals
 
 class HttpRpcClientAadIntegrationTest : HttpRpcIntegrationTestBase() {
 
-    private lateinit var httpRpcSettings: HttpRpcSettings
-
     @BeforeEach
     fun setUp() {
-        httpRpcSettings = HttpRpcSettings(
-            NetworkHostAndPort("localhost", findFreePort()),
+        val httpRpcSettings = HttpRpcSettings(
+            NetworkHostAndPort("localhost", 0),
             context,
             null,
             SsoSettings(AzureAdSettings(AzureAdMock.clientId, null, AzureAdMock.tenantId, trustedIssuers = listOf(AzureAdMock.issuer))),
@@ -48,7 +45,7 @@ class HttpRpcClientAadIntegrationTest : HttpRpcIntegrationTestBase() {
     fun `azuread token accepted as authentication`() {
         AzureAdMock.create().use {
             val client = HttpRpcClient(
-                baseAddress = "http://localhost:${httpRpcSettings.address.port}/api/v1/",
+                baseAddress = "http://localhost:${server.port}/api/v1/",
                 TestHealthCheckAPI::class.java,
                 HttpRpcClientConfig()
                     .enableSSL(false)

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcClientIntegrationTest.kt
@@ -15,7 +15,6 @@ import net.corda.httprpc.test.TestEntityRpcOps
 import net.corda.httprpc.test.TestEntityRpcOpsImpl
 import net.corda.httprpc.test.TestHealthCheckAPI
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.test.util.eventually
 import net.corda.utilities.NetworkHostAndPort
 import net.corda.v5.base.util.seconds
@@ -42,15 +41,13 @@ import net.corda.httprpc.test.utils.multipartDir
 
 internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     companion object {
-        private var port: Int = -1
 
         @BeforeAll
         @JvmStatic
         @Suppress("Unused")
         fun setUpBeforeClass() {
-            port = findFreePort()
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", port),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 null,
                 null,
@@ -87,7 +84,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client against server with accepted protocol version succeeds`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -140,7 +137,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `return list of complex types`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -173,7 +170,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client against server with accepted protocol version and custom serializers succeeds`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             CustomSerializationAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -194,7 +191,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client against server with accepted protocol version and infinite durable streams call succeeds`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             NumberSequencesRPCOps::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -249,7 +246,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client against server with accepted protocol version and finite durable streams call succeeds`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             CalendarRPCOps::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -293,7 +290,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client against server with less than rpc version since but valid version for the resource fails only on the unsupported call`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -321,7 +318,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client against server with lower protocol version than minimum expected fails`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -337,7 +334,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `operations on TestEntity`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestEntityRpcOps::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -374,7 +371,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `operations on file upload using InputStream`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestFileUploadAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -417,7 +414,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `operations on file upload using HttpFileUpload`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestFileUploadAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -495,7 +492,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `name in annotation method call`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -518,7 +515,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `test api with nullable object return type that returns null`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -540,7 +537,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `test api with nullable String return type that returns null`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -563,7 +560,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `test api with object return type with nullable String inside returns that null string value`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)
@@ -587,7 +584,7 @@ internal class HttpRpcClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `optional query parameter call`() {
         val client = HttpRpcClient(
-            baseAddress = "http://localhost:$port/api/v1/",
+            baseAddress = "http://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(false)

--- a/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcSSLClientIntegrationTest.kt
+++ b/libs/http-rpc/http-rpc-client/src/integrationTest/kotlin/net/corda/httprpc/client/HttpRpcSSLClientIntegrationTest.kt
@@ -10,7 +10,6 @@ import net.corda.httprpc.test.CustomSerializationAPIImpl
 import net.corda.httprpc.test.CustomString
 import net.corda.httprpc.test.TestHealthCheckAPI
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.utilities.NetworkHostAndPort
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -23,7 +22,6 @@ import java.nio.file.Files
 
 internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
     companion object {
-        private val port = findFreePort()
 
         private val sslService = SslCertReadServiceStubImpl {
             Files.createTempDirectory("HttpRpcSSLClientIntegrationTest")
@@ -31,12 +29,13 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
 
         @BeforeAll
         @JvmStatic
+        @Suppress("unused")
         fun setUpBeforeClass() {
             //System.setProperty("javax.net.debug", "all")
             val keyStoreInfo = sslService.getOrCreateKeyStore()
             val sslConfig = HttpRpcSSLSettings(keyStoreInfo.path, keyStoreInfo.password)
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", port),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 sslConfig,
                 null,
@@ -54,6 +53,7 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
 
         @AfterAll
         @JvmStatic
+        @Suppress("unused")
         fun cleanUpAfterClass() {
             if (isServerInitialized()) {
                 server.close()
@@ -66,7 +66,7 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start connection-aware client against server with accepted protocol version and SSL enabled succeeds`() {
         val client = HttpRpcClient(
-            baseAddress = "https://localhost:$port/api/v1/",
+            baseAddress = "https://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(true)
@@ -91,7 +91,7 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client against server with accepted protocol version and SSL enabled and custom serializers succeeds`() {
         val client = HttpRpcClient(
-            baseAddress = "https://localhost:$port/api/v1/",
+            baseAddress = "https://localhost:${server.port}/api/v1/",
             CustomSerializationAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(true)
@@ -112,7 +112,7 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client with SSL enabled against server with less than rpc version since but valid version `() {
         val client = HttpRpcClient(
-            baseAddress = "https://localhost:$port/api/v1/",
+            baseAddress = "https://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(true)
@@ -138,7 +138,7 @@ internal class HttpRpcSSLClientIntegrationTest : HttpRpcIntegrationTestBase() {
     @Timeout(100)
     fun `start client with SSL enabled against server with lower protocol version than minimum expected fails`() {
         val client = HttpRpcClient(
-            baseAddress = "https://localhost:$port/api/v1/",
+            baseAddress = "https://localhost:${server.port}/api/v1/",
             TestHealthCheckAPI::class.java,
             HttpRpcClientConfig()
                 .enableSSL(true)

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/AbstractWebsocketTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/AbstractWebsocketTest.kt
@@ -37,6 +37,10 @@ abstract class AbstractWebsocketTest : HttpRpcServerTestBase() {
 
     protected abstract val httpRpcSettings: HttpRpcSettings
 
+    // We cannot use `httpRpcSettings.port` as when it is assigned to 0 a free port will be allocated during
+    // webserver start-up
+    protected abstract val port: Int
+
     @AfterEach
     fun reset() {
         securityManager.forgetChecks()
@@ -98,7 +102,7 @@ abstract class AbstractWebsocketTest : HttpRpcServerTestBase() {
         val range = 50
 
         val uri = URI(
-            "$wsProtocol://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/" +
+            "$wsProtocol://${httpRpcSettings.address.host}:$port/" +
                     "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/health/counterfeed/$start?range=$range"
         )
 
@@ -170,7 +174,7 @@ abstract class AbstractWebsocketTest : HttpRpcServerTestBase() {
         }
 
         val uri = URI(
-            "$wsProtocol://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/" +
+            "$wsProtocol://${httpRpcSettings.address.host}:$port/" +
                     "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/health/counterfeed/100"
         )
 

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerAzureAdTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerAzureAdTest.kt
@@ -13,7 +13,6 @@ import net.corda.httprpc.test.utils.FakeSecurityManager
 import net.corda.httprpc.test.utils.TestHttpClient
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb
 import net.corda.utilities.NetworkHostAndPort
@@ -24,7 +23,6 @@ import kotlin.test.assertEquals
 
 
 class HttpRpcServerAzureAdTest {
-    private lateinit var httpRpcSettings: HttpRpcSettings
     private lateinit var httpRpcServer: HttpRpcServer
     private lateinit var client: TestHttpClient
     private lateinit var securityManager: RPCSecurityManager
@@ -32,8 +30,8 @@ class HttpRpcServerAzureAdTest {
     @BeforeEach
     fun setUp() {
         securityManager = FakeSecurityManager()
-        httpRpcSettings = HttpRpcSettings(
-            NetworkHostAndPort("localhost", findFreePort()),
+        val httpRpcSettings = HttpRpcSettings(
+            NetworkHostAndPort("localhost", 0),
             HttpRpcContext("1", "api", "HttpRpcContext test title ", "HttpRpcContext test description"),
             null,
             SsoSettings(
@@ -49,7 +47,8 @@ class HttpRpcServerAzureAdTest {
             multipartDir,
             true
         ).apply { start() }
-        client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+        client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcServer.port}/" +
+                "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
     }
 
     @AfterEach

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveLoginTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveLoginTest.kt
@@ -4,7 +4,6 @@ import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.utilities.NetworkHostAndPort
 import org.apache.http.HttpStatus
@@ -20,7 +19,7 @@ class HttpRpcServerCaseSensitiveLoginTest: HttpRpcServerTestBase() {
         @JvmStatic
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", findFreePort()),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 null,
                 null,
@@ -36,7 +35,7 @@ class HttpRpcServerCaseSensitiveLoginTest: HttpRpcServerTestBase() {
             ).apply { start() }
             client =
                 TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:" +
-                        "${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+                        "${server.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveUrlTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerCaseSensitiveUrlTest.kt
@@ -4,7 +4,6 @@ import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb.GET
 import net.corda.httprpc.tools.HttpVerb.POST
@@ -22,7 +21,8 @@ class HttpRpcServerCaseSensitiveUrlTest: HttpRpcServerTestBase() {
         @JvmStatic
         @Suppress("Unused")
         fun setUpBeforeClass() {
-            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost", findFreePort()), context, null, null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE, 20000L)
+            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost", 0), context, null,
+                null, HttpRpcSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE, 20000L)
             server = HttpRpcServerImpl(
                 listOf(TestHealthCheckAPIImpl()),
                 ::securityManager,
@@ -30,7 +30,8 @@ class HttpRpcServerCaseSensitiveUrlTest: HttpRpcServerTestBase() {
                 multipartDir,
                 true
             ).apply { start() }
-            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                    "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerJsonObjectTest.kt
@@ -6,7 +6,6 @@ import net.corda.httprpc.test.CustomUnsafeString
 import net.corda.httprpc.test.ObjectsInJsonEndpointImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb.POST
 import net.corda.utilities.NetworkHostAndPort
@@ -23,7 +22,7 @@ class HttpRpcServerJsonObjectTest : HttpRpcServerTestBase() {
         @JvmStatic
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", findFreePort()),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 null,
                 null,
@@ -39,7 +38,8 @@ class HttpRpcServerJsonObjectTest : HttpRpcServerTestBase() {
                 multipartDir,
                 true
             ).apply { start() }
-            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                    "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerLifecycleTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerLifecycleTest.kt
@@ -4,7 +4,6 @@ import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.test.LifecycleRPCOpsImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb.GET
 import net.corda.test.util.lifecycle.usingLifecycle
@@ -25,7 +24,7 @@ class HttpRpcServerLifecycleTest : HttpRpcServerTestBase() {
         @JvmStatic
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", findFreePort()),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 null,
                 null,
@@ -40,7 +39,7 @@ class HttpRpcServerLifecycleTest : HttpRpcServerTestBase() {
                 true
             ).apply { start() }
             client =
-                TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/" +
+                TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
                         "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerMaxContentLengthTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerMaxContentLengthTest.kt
@@ -5,7 +5,6 @@ import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
 import net.corda.httprpc.test.utils.WebResponse
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb
 import net.corda.utilities.NetworkHostAndPort
@@ -23,7 +22,8 @@ class HttpRpcServerMaxContentLengthTest : HttpRpcServerTestBase() {
         @BeforeAll
         @JvmStatic
         fun setUpBeforeClass() {
-            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost",  findFreePort()), context, null, null, MAX_CONTENT_LENGTH, 20000L)
+            val httpRpcSettings = HttpRpcSettings(NetworkHostAndPort("localhost",  0), context, null,
+                null, MAX_CONTENT_LENGTH, 20000L)
             server = HttpRpcServerImpl(
                 listOf(TestHealthCheckAPIImpl()),
                 ::securityManager,
@@ -31,7 +31,8 @@ class HttpRpcServerMaxContentLengthTest : HttpRpcServerTestBase() {
                 multipartDir,
                 true
             ).apply { start() }
-            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                    "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
@@ -498,7 +498,7 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
 
     @Test
     fun `GET swagger UI dependencies should return non empty result`() {
-        val baseClient = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/")
+        val baseClient = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/")
         val swaggerUIversion = OptionalDependency.SWAGGERUI.version
         val swagger = baseClient.call(GET, WebRequest<Any>("api/v1/swagger"))
         val swaggerUIBundleJS = baseClient.call(GET, WebRequest<Any>("webjars/swagger-ui/$swaggerUIversion/swagger-ui-bundle.js"))

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerOpenApiTest.kt
@@ -35,13 +35,12 @@ import net.corda.httprpc.test.ObjectsInJsonEndpointImpl
 import net.corda.httprpc.test.TestFileUploadImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 
 class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
     companion object {
         private val httpRpcSettings = HttpRpcSettings(
-            NetworkHostAndPort("localhost", findFreePort()),
+            NetworkHostAndPort("localhost", 0),
             context,
             null,
             null,
@@ -66,7 +65,8 @@ class HttpRpcServerOpenApiTest : HttpRpcServerTestBase() {
                 multipartDir,
                 true
             ).apply { start() }
-            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                    "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
@@ -28,7 +28,6 @@ import net.corda.httprpc.test.utils.TestClientFileUpload
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
 import net.corda.httprpc.test.utils.WebResponse
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 
 class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
@@ -37,7 +36,7 @@ class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
         @JvmStatic
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", findFreePort()),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 null,
                 null,
@@ -57,7 +56,8 @@ class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
                 multipartDir,
                 true
             ).apply { start() }
-            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                    "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerResponseEntityTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerResponseEntityTest.kt
@@ -6,7 +6,6 @@ import net.corda.httprpc.test.CustomUnsafeString
 import net.corda.httprpc.test.ResponseEntityRpcOpsImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb.DELETE
 import net.corda.httprpc.tools.HttpVerb.POST
@@ -25,7 +24,7 @@ class HttpRpcServerResponseEntityTest : HttpRpcServerTestBase() {
         @JvmStatic
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", findFreePort()),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 null,
                 null,
@@ -42,7 +41,8 @@ class HttpRpcServerResponseEntityTest : HttpRpcServerTestBase() {
                 true
             ).apply { start() }
             client =
-                TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+                TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                        "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerWebsocketTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerWebsocketTest.kt
@@ -58,4 +58,7 @@ class HttpRpcServerWebsocketTest : AbstractWebsocketTest() {
     override val log = HttpRpcServerWebsocketTest.log
 
     override val httpRpcSettings = HttpRpcServerWebsocketTest.httpRpcSettings
+
+    override val port: Int
+        get() = server.port
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerWebsocketTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerWebsocketTest.kt
@@ -3,7 +3,6 @@ package net.corda.httprpc.server.impl
 import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.utilities.NetworkHostAndPort
 import net.corda.v5.base.util.contextLogger
@@ -17,7 +16,7 @@ class HttpRpcServerWebsocketTest : AbstractWebsocketTest() {
         val log = contextLogger()
 
         private val httpRpcSettings = HttpRpcSettings(
-            NetworkHostAndPort("localhost", findFreePort()),
+            NetworkHostAndPort("localhost", 0),
             context,
             null,
             null,
@@ -27,6 +26,7 @@ class HttpRpcServerWebsocketTest : AbstractWebsocketTest() {
 
         @BeforeAll
         @JvmStatic
+        @Suppress("unused")
         fun setUpBeforeClass() {
             server = HttpRpcServerImpl(
                 listOf(
@@ -37,11 +37,13 @@ class HttpRpcServerWebsocketTest : AbstractWebsocketTest() {
                 multipartDir,
                 true
             ).apply { start() }
-            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+            client = TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                    "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll
         @JvmStatic
+        @Suppress("unused")
         fun cleanUpAfterClass() {
             if (isServerInitialized()) {
                 server.close()

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpsRpcServerWebsocketTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpsRpcServerWebsocketTest.kt
@@ -5,7 +5,6 @@ import net.corda.httprpc.server.config.models.HttpRpcSettings
 import net.corda.httprpc.ssl.impl.SslCertReadServiceStubImpl
 import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.utilities.NetworkHostAndPort
 import net.corda.v5.base.util.contextLogger
@@ -29,13 +28,14 @@ class HttpsRpcServerWebsocketTest : AbstractWebsocketTest() {
 
         @BeforeAll
         @JvmStatic
+        @Suppress("unused")
         fun setUpBeforeClass() {
             //System.setProperty("javax.net.debug", "all")
             val keyStoreInfo = sslService.getOrCreateKeyStore()
             val sslConfig = HttpRpcSSLSettings(keyStoreInfo.path, keyStoreInfo.password)
 
             httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", findFreePort()),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 sslConfig,
                 null,
@@ -53,13 +53,14 @@ class HttpsRpcServerWebsocketTest : AbstractWebsocketTest() {
                 true
             ).apply { start() }
             client = TestHttpClientUnirestImpl(
-                "https://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/",
+                "https://${httpRpcSettings.address.host}:${server.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/",
                 true
             )
         }
 
         @AfterAll
         @JvmStatic
+        @Suppress("unused")
         fun cleanUpAfterClass() {
             if (isServerInitialized()) {
                 server.close()

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpsRpcServerWebsocketTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpsRpcServerWebsocketTest.kt
@@ -75,4 +75,7 @@ class HttpsRpcServerWebsocketTest : AbstractWebsocketTest() {
     override val log = LOG
 
     override val httpRpcSettings = HttpsRpcServerWebsocketTest.httpRpcSettings
+
+    override val port: Int
+        get() = server.port
 }

--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/InvalidRequestTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/InvalidRequestTest.kt
@@ -8,7 +8,6 @@ import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.WebRequest
 import net.corda.httprpc.test.utils.WebResponse
-import net.corda.httprpc.test.utils.findFreePort
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb
 import net.corda.utilities.NetworkHostAndPort
@@ -32,7 +31,7 @@ class InvalidRequestTest : HttpRpcServerTestBase() {
         @JvmStatic
         fun setUpBeforeClass() {
             val httpRpcSettings = HttpRpcSettings(
-                NetworkHostAndPort("localhost", findFreePort()),
+                NetworkHostAndPort("localhost", 0),
                 context,
                 null,
                 null,
@@ -47,7 +46,8 @@ class InvalidRequestTest : HttpRpcServerTestBase() {
                 true
             ).apply { start() }
             client =
-                TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${httpRpcSettings.address.port}/${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
+                TestHttpClientUnirestImpl("http://${httpRpcSettings.address.host}:${server.port}/" +
+                        "${httpRpcSettings.context.basePath}/v${httpRpcSettings.context.version}/")
         }
 
         @AfterAll

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/HttpRpcServerImpl.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/HttpRpcServerImpl.kt
@@ -57,6 +57,8 @@ class HttpRpcServerImpl(
         DeferredWebSocketCloserService()
     )
 
+    override val port: Int
+        get() = httpRpcServerInternal.port
 
     override fun start() {
         startStopLock.write {

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/HttpRpcServerInternal.kt
@@ -120,6 +120,8 @@ internal class HttpRpcServerInternal(
         }
     }
 
+    internal val port: Int get() = server.port()
+
     private fun getSwaggerUiBundle(): Bundle? {
         val rendererBundle = FrameworkUtil.getBundle(SwaggerUIRenderer::class.java) ?: return null
         return rendererBundle

--- a/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/HttpRpcServer.kt
+++ b/libs/http-rpc/http-rpc-server/src/main/kotlin/net/corda/httprpc/server/HttpRpcServer.kt
@@ -4,4 +4,6 @@ import net.corda.lifecycle.Resource
 
 interface HttpRpcServer : Resource {
     fun start()
+
+    val port: Int
 }

--- a/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/utils/TestUtils.kt
+++ b/libs/http-rpc/http-rpc-test-common/src/main/kotlin/net/corda/httprpc/test/utils/TestUtils.kt
@@ -1,8 +1,5 @@
 package net.corda.httprpc.test.utils
 
-import java.net.ServerSocket
 import java.nio.file.Path
-
-fun findFreePort() = ServerSocket(0).use { it.localPort }
 
 val multipartDir: Path = Path.of(System.getProperty("java.io.tmpdir"), "multipart")

--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
@@ -112,8 +112,7 @@ class OpenApiCompatibilityTest {
             "Corda HTTP RPC API",
             "All the endpoints for publicly visible Open API calls"
         )
-        val freePort = findFreePort()
-        val serverAddress = NetworkHostAndPort("localhost", freePort)
+        val serverAddress = NetworkHostAndPort("localhost", 0)
         val httpRpcSettings = HttpRpcSettings(
             serverAddress,
             context,
@@ -128,7 +127,7 @@ class OpenApiCompatibilityTest {
             { FakeSecurityManager() }, httpRpcSettings, multipartDir, devMode = true
         ).apply { start() }
 
-        val url = "http://${serverAddress.host}:${serverAddress.port}/${context.basePath}/v${context.version}/swagger.json"
+        val url = "http://${serverAddress.host}:${server.port}/${context.basePath}/v${context.version}/swagger.json"
         logger.info("Swagger should be accessible on: $url")
 
         return server.use {

--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/TestUtils.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/TestUtils.kt
@@ -1,10 +1,5 @@
 package net.corda.processors.rpc
 
-import java.net.ServerSocket
 import java.nio.file.Path
-
-// We cannot use implementations from `http-rpc-test-common` module as it is not OSGi module
-// And it cannot become OSGi module due to UniRest not being OSGi compliant
-fun findFreePort() = ServerSocket(0).use { it.localPort }
 
 val multipartDir: Path = Path.of(System.getProperty("java.io.tmpdir"), "multipart")


### PR DESCRIPTION
And its uses in HTTP RPC integration tests.