### PR TITLE
CORE-8417 Send the correct certificate during session negotation

### DIFF
--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -639,7 +639,7 @@ class SessionManagerTest {
         )
 
         val initiatorHandshakeMsg = mock<InitiatorHandshakeMessage>()
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(initiatorHandshakeMsg)
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(initiatorHandshakeMsg)
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(responderHello))
@@ -670,7 +670,7 @@ class SessionManagerTest {
         )
 
         val initiatorHandshakeMsg = mock<InitiatorHandshakeMessage>()
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(initiatorHandshakeMsg)
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(initiatorHandshakeMsg)
         whenever(linkManagerHostingMap.getInfo(OUR_PARTY)).thenReturn(null)
         whenever(members.getMemberInfo(OUR_PARTY, OUR_PARTY)).thenReturn(null)
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
@@ -690,7 +690,7 @@ class SessionManagerTest {
         )
 
         val initiatorHandshakeMsg = mock<InitiatorHandshakeMessage>()
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(initiatorHandshakeMsg)
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(initiatorHandshakeMsg)
         whenever(members.getMemberInfo(OUR_PARTY, PEER_PARTY)).thenReturn(null)
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)
@@ -708,7 +708,7 @@ class SessionManagerTest {
             OutboundSessionPool.SessionType.PendingSession(counterparties, protocolInitiator)
         )
 
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any()))
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any()))
             .thenThrow(CouldNotFindPrivateKey())
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)
@@ -727,7 +727,7 @@ class SessionManagerTest {
         )
 
         val initiatorHandshakeMsg = mock<InitiatorHandshakeMessage>()
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(initiatorHandshakeMsg)
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(initiatorHandshakeMsg)
         whenever(groups.getGroupInfo(OUR_PARTY)).thenReturn(null)
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)
@@ -763,7 +763,7 @@ class SessionManagerTest {
             )
         ).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         val responderHandshakeMsg = mock<ResponderHandshakeMessage>()
-        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), any())).thenReturn(responderHandshakeMsg)
+        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), eq(null), any())).thenReturn(responderHandshakeMsg)
         val session = mock<Session>()
         whenever(protocolResponder.getSession()).thenReturn(session)
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshakeMessage))
@@ -808,7 +808,7 @@ class SessionManagerTest {
             )
         ).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         val responderHandshakeMsg = mock<ResponderHandshakeMessage>()
-        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), any())).thenReturn(responderHandshakeMsg)
+        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), eq(null), any())).thenReturn(responderHandshakeMsg)
         val session = mock<Session>()
         whenever(protocolResponder.getSession()).thenReturn(session)
         sessionManager.processSessionMessage(LinkInMessage(initiatorHandshakeMessage))
@@ -844,7 +844,7 @@ class SessionManagerTest {
             )
         ).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         val responderHandshakeMsg = mock<ResponderHandshakeMessage>()
-        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), any())).thenReturn(responderHandshakeMsg)
+        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), eq(null), any())).thenReturn(responderHandshakeMsg)
         val session = mock<Session>()
         whenever(protocolResponder.getSession()).thenReturn(session)
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshakeMessage))
@@ -1100,7 +1100,7 @@ class SessionManagerTest {
             PEER_KEY.public,
             SignatureSpec.ECDSA_SHA256
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
-        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), any()))
+        whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), eq(null), any()))
             .thenThrow(UnsupportedAlgorithm(OUR_KEY.public))
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
 
@@ -1144,7 +1144,7 @@ class SessionManagerTest {
             OutboundSessionPool.SessionType.PendingSession(counterparties, protocolInitiator)
         )
 
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(mock())
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(mock())
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, someSessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)
         sessionManager.processSessionMessage(LinkInMessage(responderHello))
@@ -1306,7 +1306,7 @@ class SessionManagerTest {
         )
 
         val initiatorHandshakeMsg = mock<InitiatorHandshakeMessage>()
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(initiatorHandshakeMsg)
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(initiatorHandshakeMsg)
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)
         sessionManager.processSessionMessage(LinkInMessage(responderHello))
@@ -1712,7 +1712,7 @@ class SessionManagerTest {
             OutboundSessionPool.SessionType.PendingSession(counterparties, protocolInitiator)
         )
 
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(mock())
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(mock())
 
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, protocolInitiator.sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)
@@ -1846,7 +1846,7 @@ class SessionManagerTest {
             OutboundSessionPool.SessionType.PendingSession(counterparties, protocolInitiator)
         )
 
-        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), any())).thenReturn(mock())
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(mock())
 
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, protocolInitiator.sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded), ProtocolMode.AUTHENTICATED_ENCRYPTION)

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateCheckMode.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateCheckMode.kt
@@ -20,7 +20,6 @@ sealed class CertificateCheckMode {
      */
     data class CheckCertificate(
         val truststore: List<PemCertificate>,
-        val ourCertificates: List<PemCertificate>,
         val revocationCheckMode: RevocationCheckMode,
         val revocationChecker: (request: RevocationCheckRequest) -> RevocationCheckResponse
     ): CertificateCheckMode()

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
@@ -65,7 +65,11 @@ class AuthenticatedEncryptionSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -80,7 +84,11 @@ class AuthenticatedEncryptionSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
@@ -146,7 +154,11 @@ class AuthenticatedEncryptionSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -161,7 +173,11 @@ class AuthenticatedEncryptionSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
@@ -233,7 +249,11 @@ class AuthenticatedEncryptionSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -248,7 +268,11 @@ class AuthenticatedEncryptionSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
@@ -64,7 +64,11 @@ class AuthenticatedSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -79,7 +83,11 @@ class AuthenticatedSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
@@ -138,7 +146,11 @@ class AuthenticatedSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -153,7 +165,11 @@ class AuthenticatedSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
@@ -203,7 +219,11 @@ class AuthenticatedSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -218,7 +238,11 @@ class AuthenticatedSessionTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
@@ -78,7 +78,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         val modifiedInitiatorHandshakeMessage = InitiatorHandshakeMessage(
             initiatorHandshakeMessage.header,
@@ -112,7 +116,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
@@ -144,7 +152,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage, aliceX500Name, wrongPublicKey, SignatureSpec.ECDSA_SHA256
@@ -173,7 +185,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -188,7 +204,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data + "0".toByteArray(Charsets.UTF_8))
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         assertThatThrownBy {
             authenticationProtocolA.validatePeerHandshakeMessage(
@@ -224,7 +244,7 @@ class AuthenticationProtocolFailureTest {
     @Test
     fun `session authentication fails if responder certificate validation fails`() {
         val ourCertificates = listOf<String>()
-        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), ourCertificates, mock(), mock())
+        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), mock(), mock())
 
         val authenticationProtocolA = AuthenticationProtocolInitiator(
             sessionId,
@@ -259,7 +279,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            ourCertificates,
+            signingCallbackForA
+        )
 
         assertThrows<InvalidPeerCertificate> { authenticationProtocolB.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage,
@@ -273,7 +297,7 @@ class AuthenticationProtocolFailureTest {
     @Test
     fun `session authentication fails if initiator certificate validation fails`() {
         val ourCertificates = listOf<String>()
-        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), ourCertificates, mock(), mock())
+        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), mock(), mock())
 
         val authenticationProtocolA = AuthenticationProtocolInitiator(
             sessionId,
@@ -307,7 +331,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            ourCertificates,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -322,7 +350,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            ourCertificates,
+            signingCallbackForB
+        )
 
         assertThrows<InvalidPeerCertificate> {
             authenticationProtocolA.validatePeerHandshakeMessage(
@@ -334,8 +366,7 @@ class AuthenticationProtocolFailureTest {
 
     @Test
     fun `session authentication fails for responder if initiator doesn't send a certificate`() {
-        val ourCertificates = listOf<String>()
-        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), ourCertificates, mock(), mock())
+        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), mock(), mock())
 
         val authenticationProtocolA = AuthenticationProtocolInitiator(
             sessionId,
@@ -367,7 +398,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForA
+        )
 
         assertThrows<InvalidPeerCertificate> { authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -381,7 +416,7 @@ class AuthenticationProtocolFailureTest {
     @Test
     fun `session authentication fails for initiator if responder doesn't send a certificate`() {
         val ourCertificates = listOf<String>()
-        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), ourCertificates, mock(), mock())
+        val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), mock(), mock())
 
         val authenticationProtocolA = AuthenticationProtocolInitiator(
             sessionId,
@@ -413,7 +448,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForA)
+        val initiatorHandshakeMessage = authenticationProtocolA.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            ourCertificates,
+            signingCallbackForA
+        )
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
@@ -428,7 +467,11 @@ class AuthenticationProtocolFailureTest {
             signature.update(data)
             signature.sign()
         }
-        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(partyBSessionKey.public, signingCallbackForB)
+        val responderHandshakeMessage = authenticationProtocolB.generateOurHandshakeMessage(
+            partyBSessionKey.public,
+            null,
+            signingCallbackForB
+        )
 
         assertThrows<InvalidPeerCertificate> {
             authenticationProtocolA.validatePeerHandshakeMessage(


### PR DESCRIPTION
When processing an initiator hello message the link manager looks up the first locally hosted identity that is in the same group as the sender of the initiator hello message. We then use this identity as a part of the responder handshake message. However this is not  necessarily the identity that the initiator intended to communicate with. The intended identity is sent as a part of the initiator handshake message. So use this instead to look up the correct certificate to send to the initiator.

I repeated the testing done here: https://github.com/corda/corda-runtime-os/pull/2286