### PR TITLE
CORE-8391 - Flaky force CPI upload test rely on CPI checksum rather than CPK upload timestamp

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -374,7 +374,7 @@ class VirtualNodeRpcTest {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
             // Note CPI/CPK timestamp
-            val initialCpkTimeStamp = getCpkTimestamp(cpiName)
+            val initialCpiFileChecksum = getCpiFileChecksum(cpiName)
 
             // Perform force upload of the CPI
             val requestId = forceCpiUpload(TEST_CPB_LOCATION, GROUP_ID, staticMemberList, cpiName).let { it.toJson()["id"].textValue() }
@@ -390,7 +390,7 @@ class VirtualNodeRpcTest {
             // Cannot use `assertWithRetry` as there is a strict type `Instant`
             // Allow ample time for CPI upload to be propagated through the system
             eventually(Duration.ofSeconds(100)) {
-                assertThat(getCpkTimestamp(cpiName)).isAfter(initialCpkTimeStamp)
+                assertThat(getCpiFileChecksum(cpiName)).isNotEqualTo(initialCpiFileChecksum)
             }
         }
     }
@@ -421,7 +421,7 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
-            val initialCpkTimeStamp = getCpkTimestamp(cpiName)
+            val initialCpiFileChecksum = getCpiFileChecksum(cpiName)
 
             val requestId = forceCpiUpload(CACHE_INVALIDATION_TEST_CPB, GROUP_ID, staticMemberList, cpiName)
                 .let { it.toJson()["id"].textValue() }
@@ -433,7 +433,7 @@ class VirtualNodeRpcTest {
             }
 
             eventually(Duration.ofSeconds(120)) {
-                assertThat(getCpkTimestamp(cpiName)).isAfter(initialCpkTimeStamp)
+                assertThat(getCpiFileChecksum(cpiName)).isNotEqualTo(initialCpiFileChecksum)
             }
         }
     }
@@ -466,7 +466,7 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
-            val initialCpkTimeStamp = getCpkTimestamp(cpiName)
+            val initialCpiFileChecksum = getCpiFileChecksum(cpiName)
 
             val requestId = forceCpiUpload(TEST_CPB_LOCATION, GROUP_ID, staticMemberList, cpiName)
                 .let { it.toJson()["id"].textValue() }
@@ -478,7 +478,7 @@ class VirtualNodeRpcTest {
             }
 
             eventually(Duration.ofSeconds(100)) {
-                assertThat(getCpkTimestamp(cpiName)).isAfter(initialCpkTimeStamp)
+                assertThat(getCpiFileChecksum(cpiName)).isNotEqualTo(initialCpiFileChecksum)
             }
 
             runReturnAStringFlow("original-cpi")
@@ -516,11 +516,10 @@ class VirtualNodeRpcTest {
         assertThat(flowStatus.flowResult).isEqualTo(expectedResult)
     }
 
-    private fun ClusterBuilder.getCpkTimestamp(cpiName: String): Instant {
+    private fun ClusterBuilder.getCpiFileChecksum(cpiName: String): String {
         val cpis = cpiList().toJson()["cpis"]
         val cpiJson = cpis.toList().first { it["id"]["cpiName"].textValue() == cpiName }
-        val cpksJson = cpiJson["cpks"].toList()
-        return cpksJson.first()["timestamp"].toInstant()
+        return cpiJson["cpiFileFullChecksum"].toString()
     }
 
     private fun JsonNode.toInstant(): Instant {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -382,6 +382,7 @@ class VirtualNodeRpcTest {
                 condition { it.code == 200 && it.toJson()["status"].textValue() == "OK" }
             }
 
+            // Force uploaded CPI may take some time to propagate through the system and arrive to REST worker's CpiInfoReadService
             eventually(Duration.ofSeconds(100)) {
                 assertThat(getCpiFileChecksum(cpiName)).isNotEqualTo(initialCpiFileChecksum)
             }

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -57,10 +57,7 @@ data class CpiMetadataEntity(
     var groupId: String,
     @Column(name = "file_upload_request_id", nullable = false)
     var fileUploadRequestId: String,
-    @OneToMany(
-        fetch = FetchType.EAGER,
-        cascade = [CascadeType.PERSIST, CascadeType.MERGE]
-    )
+    @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumns(
         JoinColumn(name = "cpi_name", referencedColumnName = "name", insertable = false, updatable = false),
         JoinColumn(name = "cpi_version", referencedColumnName = "version", insertable = false, updatable = false),

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiMetadataEntity.kt
@@ -57,7 +57,10 @@ data class CpiMetadataEntity(
     var groupId: String,
     @Column(name = "file_upload_request_id", nullable = false)
     var fileUploadRequestId: String,
-    @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToMany(
+        fetch = FetchType.EAGER,
+        cascade = [CascadeType.PERSIST, CascadeType.MERGE]
+    )
     @JoinColumns(
         JoinColumn(name = "cpi_name", referencedColumnName = "name", insertable = false, updatable = false),
         JoinColumn(name = "cpi_version", referencedColumnName = "version", insertable = false, updatable = false),


### PR DESCRIPTION
Rely on the checksum of the CPI being uploaded to verify the CPI was force uploaded rather than (potentially varying) timestamp of CPKs inserted.
