### PR TITLE
CORE-6624 - Review lifecycle handling for MemberOpsService

### DIFF
--- a/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/FlowMapperServiceTest.kt
+++ b/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/FlowMapperServiceTest.kt
@@ -42,7 +42,7 @@ internal class FlowMapperServiceTest {
             doAnswer { mock<StateAndEventSubscription<String, String, String>>() }
                 .whenever(it).createStateAndEventSubscription<String, String, String>(any(), any(), any(), any())
         }
-        LifecycleTest<FlowMapperService>{
+        LifecycleTest {
             addDependency<ConfigurationReadService>()
 
             FlowMapperService(
@@ -59,7 +59,7 @@ internal class FlowMapperServiceTest {
             bringDependenciesUp()
             verifyIsDown<FlowMapperService>()
 
-            sendConfigUpdate(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
+            sendConfigUpdate<FlowMapperService>(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
 
             verifyIsUp<FlowMapperService>()
 
@@ -89,7 +89,7 @@ internal class FlowMapperServiceTest {
                 .thenReturn(subscription)
         }
 
-        LifecycleTest<FlowMapperService> {
+        LifecycleTest {
             addDependency<ConfigurationReadService>()
             addDependency(subName)
 
@@ -106,7 +106,7 @@ internal class FlowMapperServiceTest {
             bringDependenciesUp()
             verifyIsDown<FlowMapperService>()
 
-            sendConfigUpdate(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
+            sendConfigUpdate<FlowMapperService>(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
 
             // Create and start the subscription (using the message config)
             verify(subscriptionFactory).createStateAndEventSubscription<String, FlowMapperState, FlowMapperEvent>(
@@ -118,7 +118,7 @@ internal class FlowMapperServiceTest {
             verify(subscription).start()
             verifyIsUp<FlowMapperService>()
 
-            sendConfigUpdate(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
+            sendConfigUpdate<FlowMapperService>(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
 
             // Close, recreate and start the subscription (using the message config)
             verify(subscription).close()
@@ -141,7 +141,7 @@ internal class FlowMapperServiceTest {
                 .thenThrow(CordaMessageAPIConfigException("Bad config!"))
         }
 
-        LifecycleTest<FlowMapperService> {
+        LifecycleTest {
             addDependency<ConfigurationReadService>()
             addDependency(subName)
 
@@ -158,7 +158,7 @@ internal class FlowMapperServiceTest {
             bringDependenciesUp()
             verifyIsDown<FlowMapperService>()
 
-            sendConfigUpdate(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
+            sendConfigUpdate<FlowMapperService>(mapOf(FLOW_CONFIG to flowConfig, MESSAGING_CONFIG to messagingConfig))
 
             // Create and start the subscription (using the message config)
             verify(subscriptionFactory).createStateAndEventSubscription<String, FlowMapperState, FlowMapperEvent>(

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
@@ -46,8 +46,7 @@ class FlowServiceTest {
 
     @Test
     fun `start event starts the flow executor`() {
-        val context = getFlowServiceTestContext()
-        context.run {
+        getFlowServiceTestContext().run {
             testClass.start()
 
             verify(flowExecutor).start()
@@ -56,9 +55,8 @@ class FlowServiceTest {
 
     @Test
     fun `configuration service event registration once all dependent components are up`() {
-        val context = getFlowServiceTestContext()
-        val flowServiceCoordinator = context.getCoordinatorFor<FlowService>()
-        context.run {
+        getFlowServiceTestContext().run {
+            val flowServiceCoordinator = getCoordinatorFor<FlowService>()
             testClass.start()
 
             verify(this.configReadService, times(0)).registerComponentForUpdates(any(), any())
@@ -74,9 +72,7 @@ class FlowServiceTest {
 
     @Test
     fun `on configuration event mark service up`() {
-        val context = getFlowServiceTestContext()
-
-        context.run {
+        getFlowServiceTestContext().run {
             testClass.start()
             bringDependenciesUp()
 
@@ -88,9 +84,7 @@ class FlowServiceTest {
 
     @Test
     fun `on configuration event configures services`() {
-        val context = getFlowServiceTestContext()
-
-        context.run {
+        getFlowServiceTestContext().run {
             testClass.start()
             bringDependenciesUp()
 
@@ -103,9 +97,7 @@ class FlowServiceTest {
 
     @Test
     fun `on all dependents up flow service should not be up`() {
-        val context = getFlowServiceTestContext()
-
-        context.run {
+        getFlowServiceTestContext().run {
             testClass.start()
             bringDependenciesUp()
 
@@ -116,9 +108,7 @@ class FlowServiceTest {
     @ParameterizedTest(name = "on component {0} going down the flow service should go down")
     @MethodSource("dependants")
     fun `on any dependent going down the flow service should go down`(name: LifecycleCoordinatorName) {
-        val context = getFlowServiceTestContext()
-
-        context.run {
+        getFlowServiceTestContext().run {
             testClass.start()
 
             bringDependenciesUp()
@@ -134,9 +124,7 @@ class FlowServiceTest {
     @ParameterizedTest(name = "on component {0} going down the flow service should go to error")
     @MethodSource("dependants")
     fun `on any dependent going to error the flow service should go down`(name: LifecycleCoordinatorName) {
-        val context = getFlowServiceTestContext()
-
-        context.run {
+        getFlowServiceTestContext().run {
             testClass.start()
 
             bringDependenciesUp()

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
@@ -80,7 +80,7 @@ class FlowServiceTest {
             testClass.start()
             bringDependenciesUp()
 
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<FlowService>(exampleConfig)
 
             verifyIsUp<FlowService>()
         }
@@ -94,7 +94,7 @@ class FlowServiceTest {
             testClass.start()
             bringDependenciesUp()
 
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<FlowService>(exampleConfig)
 
             verify(flowExecutor).onConfigChange(any())
             verify(flowWakeUpScheduler).onConfigChange(any())
@@ -122,7 +122,7 @@ class FlowServiceTest {
             testClass.start()
 
             bringDependenciesUp()
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<FlowService>(exampleConfig)
             verifyIsUp<FlowService>()
 
             bringDependencyDown(name)
@@ -140,7 +140,7 @@ class FlowServiceTest {
             testClass.start()
 
             bringDependenciesUp()
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<FlowService>(exampleConfig)
             verifyIsUp<FlowService>()
 
             setDependencyToError(name)

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/LedgerPersistenceServiceTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/LedgerPersistenceServiceTest.kt
@@ -49,12 +49,10 @@ class LedgerPersistenceServiceTest {
 
     @Test
     fun `on configuration event creates and starts subscription`() {
-        val context = getTokenCacheComponentTestContext()
-
         val subscription = mock<Subscription<String, LedgerPersistenceRequest>>()
         whenever(persistenceRequestSubscriptionFactory.create(MINIMUM_SMART_CONFIG)).thenReturn(subscription)
 
-        context.run {
+        getTokenCacheComponentTestContext().run {
             testClass.start()
             bringDependenciesUp()
 
@@ -67,9 +65,7 @@ class LedgerPersistenceServiceTest {
 
     @Test
     fun `on configuration event closes existing subscription`() {
-        val context = getTokenCacheComponentTestContext()
-
-        context.run {
+        getTokenCacheComponentTestContext().run {
             testClass.start()
             bringDependenciesUp()
 
@@ -86,9 +82,7 @@ class LedgerPersistenceServiceTest {
 
     @Test
     fun `on all dependents up persistence service should not be up`() {
-        val context = getTokenCacheComponentTestContext()
-
-        context.run {
+        getTokenCacheComponentTestContext().run {
             testClass.start()
             bringDependenciesUp()
 
@@ -99,9 +93,7 @@ class LedgerPersistenceServiceTest {
     @ParameterizedTest(name = "on component {0} going down the persistence service should go down")
     @MethodSource("dependants")
     fun `on any dependent going down the persistence service should go down`(name: LifecycleCoordinatorName) {
-        val context = getTokenCacheComponentTestContext()
-
-        context.run {
+        getTokenCacheComponentTestContext().run {
             testClass.start()
 
             bringDependenciesUp()
@@ -119,9 +111,7 @@ class LedgerPersistenceServiceTest {
     fun `on any dependent going to error the token persistence service should go to down`(
         name: LifecycleCoordinatorName
     ) {
-        val context = getTokenCacheComponentTestContext()
-
-        context.run {
+        getTokenCacheComponentTestContext().run {
             testClass.start()
 
             bringDependenciesUp()

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/LedgerPersistenceServiceTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/LedgerPersistenceServiceTest.kt
@@ -58,7 +58,7 @@ class LedgerPersistenceServiceTest {
             testClass.start()
             bringDependenciesUp()
 
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
 
             verify(persistenceRequestSubscriptionFactory).create(MINIMUM_SMART_CONFIG)
             verify(subscription).start()
@@ -73,12 +73,12 @@ class LedgerPersistenceServiceTest {
             testClass.start()
             bringDependenciesUp()
 
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
 
             verify(persistenceRequestSubscriptionFactory).create(MINIMUM_SMART_CONFIG)
             verify(subscription1).start()
 
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
             verify(subscription1).close()
             verify(subscription2).start()
         }
@@ -105,7 +105,7 @@ class LedgerPersistenceServiceTest {
             testClass.start()
 
             bringDependenciesUp()
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
             verifyIsUp<LedgerPersistenceService>()
 
             bringDependencyDown(name)
@@ -125,7 +125,7 @@ class LedgerPersistenceServiceTest {
             testClass.start()
 
             bringDependenciesUp()
-            sendConfigUpdate(exampleConfig)
+            sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
             verifyIsUp<LedgerPersistenceService>()
 
             setDependencyToError(name)

--- a/components/membership/membership-service-impl/build.gradle
+++ b/components/membership/membership-service-impl/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation project(":testing:test-utilities")
+    testImplementation project(':libs:lifecycle:lifecycle-test-impl')
     testImplementation project(":libs:membership:membership-impl")
     testImplementation project(":testing:layered-property-map-testkit")
     testImplementation ("net.corda:corda-serialization")

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
@@ -4,6 +4,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.membership.rpc.request.MembershipRpcRequest
 import net.corda.data.membership.rpc.response.MembershipRpcResponse
+import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -12,11 +13,11 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
-import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.membership.registration.RegistrationProxy
 import net.corda.membership.service.MemberOpsService
 import net.corda.libs.configuration.helper.getConfig
+import net.corda.lifecycle.Resource
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.subscription.RPCSubscription
@@ -53,18 +54,15 @@ class MemberOpsServiceImpl @Activate constructor(
         private val logger = contextLogger()
         const val GROUP_NAME = "membership.ops.rpc"
         const val CLIENT_NAME = "membership.ops.rpc"
+
+        const val SUBSCRIPTION_RESOURCE = "MemberOpsService.SUBSCRIPTION_RESOURCE"
+        const val CONFIG_HANDLE = "MemberOpsService.CONFIG_HANDLE"
+        const val COMPONENT_HANDLE = "MemberOpsService.COMPONENT_HANDLE"
     }
 
     private val lifecycleCoordinator =
         coordinatorFactory.createCoordinator<MemberOpsService>(::eventHandler)
 
-    @Volatile
-    private var configHandle: AutoCloseable? = null
-
-    @Volatile
-    private var registrationHandle: RegistrationHandle? = null
-
-    @Volatile
     private var subscription: RPCSubscription<MembershipRpcRequest, MembershipRpcResponse>? = null
 
     override val isRunning: Boolean get() = lifecycleCoordinator.isRunning
@@ -82,78 +80,120 @@ class MemberOpsServiceImpl @Activate constructor(
     private fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
         logger.info("Received event {}", event)
         when (event) {
-            is StartEvent -> {
-                logger.info("Received start event, starting wait for UP event from dependencies.")
-                registrationHandle?.close()
-                registrationHandle = coordinator.followStatusChangesByName(
-                    setOf(
-                        LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
-                        LifecycleCoordinatorName.forComponent<RegistrationProxy>(),
-                        LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
-                        LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),
-                        LifecycleCoordinatorName.forComponent<MembershipQueryClient>(),
-                    )
+            is StartEvent -> handleStartEvent(coordinator)
+            is RegistrationStatusChangeEvent -> handleRegistrationChangeEvent(event, coordinator)
+            is ConfigChangedEvent -> handleConfigChangeEvent(event, coordinator)
+            else -> { logger.warn("Unexpected event $event!") }
+        }
+    }
+
+    private fun handleStartEvent(coordinator: LifecycleCoordinator) {
+        logger.info("Received start event, waiting for dependencies.")
+        coordinator.createManagedResource(COMPONENT_HANDLE) {
+            coordinator.followStatusChangesByName(
+                setOf(
+                    LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+                    LifecycleCoordinatorName.forComponent<RegistrationProxy>(),
+                    LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
+                    LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),
+                    LifecycleCoordinatorName.forComponent<MembershipQueryClient>(),
                 )
-            }
-            is StopEvent -> {
-                registrationHandle?.close()
-                registrationHandle = null
-                configHandle?.close()
-                configHandle = null
-                deleteResources()
-            }
-            is RegistrationStatusChangeEvent -> {
-                if (event.status == LifecycleStatus.UP) {
+            )
+        }
+    }
+
+    private fun handleDependencyRegistrationChange(
+        event: RegistrationStatusChangeEvent,
+        coordinator: LifecycleCoordinator
+    ) {
+        when (event.status) {
+            LifecycleStatus.UP -> {
+                coordinator.createManagedResource(CONFIG_HANDLE) {
                     logger.info("Registering for configuration updates.")
-                    configHandle = configurationReadService.registerComponentForUpdates(
+                    configurationReadService.registerComponentForUpdates(
                         coordinator,
-                        setOf(MESSAGING_CONFIG, BOOT_CONFIG)
+                        setOf(BOOT_CONFIG, MESSAGING_CONFIG)
                     )
-                } else {
-                    configHandle?.close()
-                    configHandle = null
-                    deleteResources()
-                    logger.info("Setting status DOWN.")
-                    coordinator.updateStatus(LifecycleStatus.DOWN)
                 }
             }
-            is ConfigChangedEvent -> {
-                createResources(event)
-                logger.info("Setting status UP.")
-                coordinator.updateStatus(LifecycleStatus.UP)
-            }
             else -> {
-                logger.warn("Unexpected event $event!")
+                coordinator.updateStatus(LifecycleStatus.DOWN)
+                coordinator.closeManagedResources(setOf(SUBSCRIPTION_RESOURCE, CONFIG_HANDLE))
             }
         }
     }
 
-    private fun deleteResources() {
-        val current = subscription
-        subscription = null
-        current?.close()
+    private fun handleSubscriptionRegistrationChange(
+        event: RegistrationStatusChangeEvent,
+        coordinator: LifecycleCoordinator
+    ) {
+        logger.info("Handling subscription registration change.")
+        when (event.status) {
+            LifecycleStatus.UP -> coordinator.updateStatus(LifecycleStatus.UP)
+            else -> coordinator.updateStatus(LifecycleStatus.DOWN, "Subscription is DOWN.")
+        }
     }
 
-    private fun createResources(event: ConfigChangedEvent) {
-        logger.info("Creating RPC subscription for '{}' topic", Schemas.Membership.MEMBERSHIP_RPC_TOPIC)
-        val messagingConfig = event.config.getConfig(MESSAGING_CONFIG)
-        val processor = MemberOpsServiceProcessor(
-            registrationProxy,
-            virtualNodeInfoReadService,
-            membershipGroupReaderProvider,
-            membershipQueryClient
-        )
-        subscription?.close()
-        subscription = subscriptionFactory.createRPCSubscription(
-            rpcConfig = RPCConfig(
-                groupName = GROUP_NAME,
-                clientName = CLIENT_NAME,
-                requestTopic = Schemas.Membership.MEMBERSHIP_RPC_TOPIC,
-                requestType = MembershipRpcRequest::class.java,
-                responseType = MembershipRpcResponse::class.java
-            ),
-            responderProcessor = processor,
-            messagingConfig = messagingConfig
-        ).also { it.start() }
+    private fun handleRegistrationChangeEvent(
+        event: RegistrationStatusChangeEvent,
+        coordinator: LifecycleCoordinator
+    ) {
+        val subHandle = coordinator.getManagedResource<MembershipSubscriptionAndRegistration>(
+            SUBSCRIPTION_RESOURCE
+        )?.registrationHandle
+        if (event.registration == subHandle) {
+            handleSubscriptionRegistrationChange(event, coordinator)
+        } else {
+            handleDependencyRegistrationChange(event, coordinator)
+        }
+    }
+
+    private fun handleConfigChangeEvent(event: ConfigChangedEvent, coordinator: LifecycleCoordinator) {
+        recreateSubscription(coordinator, event.config.getConfig(MESSAGING_CONFIG))
+        if (coordinator.status != LifecycleStatus.UP) {
+            coordinator.updateStatus(LifecycleStatus.UP)
+        }
+    }
+
+    private fun recreateSubscription(coordinator: LifecycleCoordinator, messagingConfig: SmartConfig) {
+        coordinator.createManagedResource(SUBSCRIPTION_RESOURCE) {
+            logger.info("Creating RPC subscription for '{}' topic", Schemas.Membership.MEMBERSHIP_RPC_TOPIC)
+            subscription = subscriptionFactory.createRPCSubscription(
+                rpcConfig = RPCConfig(
+                    groupName = GROUP_NAME,
+                    clientName = CLIENT_NAME,
+                    requestTopic = Schemas.Membership.MEMBERSHIP_RPC_TOPIC,
+                    requestType = MembershipRpcRequest::class.java,
+                    responseType = MembershipRpcResponse::class.java
+                ),
+                responderProcessor = MemberOpsServiceProcessor(
+                    registrationProxy,
+                    virtualNodeInfoReadService,
+                    membershipGroupReaderProvider,
+                    membershipQueryClient
+                ),
+                messagingConfig = messagingConfig
+            ).also { it.start() }
+            val handle = coordinator.followStatusChangesByName(setOf(subscription!!.subscriptionName))
+            MembershipSubscriptionAndRegistration(subscription!!, handle)
+        }
+    }
+
+    /**
+     * Pair up the subscription and the registration handle to that subscription.
+     *
+     * This allows us to enforce the close order on these two resources, which prevents an accidental extra DOWN event
+     * from propagating when we're recreating the subscription.
+     */
+    private class MembershipSubscriptionAndRegistration(
+        val subscription: RPCSubscription<MembershipRpcRequest, MembershipRpcResponse>,
+        val registrationHandle: RegistrationHandle
+    ) : Resource {
+        override fun close() {
+            // The close order here is important - closing the subscription first can result in spurious lifecycle
+            // events being posted.
+            registrationHandle.close()
+            subscription.close()
+        }
     }
 }

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
@@ -63,6 +63,7 @@ class MemberOpsServiceImpl @Activate constructor(
     private val lifecycleCoordinator =
         coordinatorFactory.createCoordinator<MemberOpsService>(::eventHandler)
 
+    @Volatile
     private var subscription: RPCSubscription<MembershipRpcRequest, MembershipRpcResponse>? = null
 
     override val isRunning: Boolean get() = lifecycleCoordinator.isRunning

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
@@ -1,0 +1,163 @@
+package net.corda.membership.service.impl
+
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.data.membership.rpc.request.MembershipRpcRequest
+import net.corda.data.membership.rpc.response.MembershipRpcResponse
+import net.corda.libs.configuration.SmartConfig
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.test.impl.LifecycleTest
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.membership.registration.RegistrationProxy
+import net.corda.membership.service.MemberOpsService
+import net.corda.messaging.api.processor.RPCResponderProcessor
+import net.corda.messaging.api.subscription.RPCSubscription
+import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.schema.configuration.ConfigKeys
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class MemberOpsServiceTest {
+    private val subName = LifecycleCoordinatorName("RPC_SUBSCRIPTION")
+    private val subscription: RPCSubscription<MembershipRpcRequest, MembershipRpcResponse> = mock {
+        on { subscriptionName } doReturn subName
+    }
+    private val subscriptionFactory: SubscriptionFactory = mock {
+        on { createRPCSubscription(
+                any(), any(), any<RPCResponderProcessor<MembershipRpcRequest, MembershipRpcResponse>>()
+            )
+        } doReturn subscription
+    }
+
+    private val registrationProxy: RegistrationProxy = mock()
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock()
+    private val membershipGroupReaderProvider: MembershipGroupReaderProvider = mock()
+    private val membershipQueryClient: MembershipQueryClient = mock()
+
+    private val messagingConfig: SmartConfig = mock()
+    private val bootConfig: SmartConfig = mock {
+        on(it.withFallback(messagingConfig)).thenReturn(messagingConfig)
+    }
+
+    private val configs = mapOf(
+        ConfigKeys.BOOT_CONFIG to bootConfig,
+        ConfigKeys.MESSAGING_CONFIG to messagingConfig
+    )
+
+
+    @Test
+    fun `start event does not change status to UP`() {
+        getMemberOpsServiceTestContext().run {
+            testClass.start()
+            verifyIsDown<MemberOpsService>()
+        }
+    }
+
+    @Test
+    fun `status changes to UP and subscription gets created, once all dependencies are UP and config has been received`() {
+        getMemberOpsServiceTestContext().run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate<MemberOpsService>(configs)
+            verify(subscription).start()
+            verifyIsUp<MemberOpsService>()
+        }
+    }
+
+    @Test
+    fun `component remains UP when new config change is received`() {
+        getMemberOpsServiceTestContext().run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate<MemberOpsService>(configs)
+            verifyIsUp<MemberOpsService>()
+
+            sendConfigUpdate<MemberOpsService>(configs)
+            verifyIsUp<MemberOpsService>()
+        }
+    }
+
+    @Test
+    fun `stop event takes the component DOWN`() {
+        getMemberOpsServiceTestContext().run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate<MemberOpsService>(configs)
+
+            testClass.stop()
+            verifyIsDown<MemberOpsService>()
+        }
+    }
+
+    @Test
+    fun `component goes DOWN and comes back UP if subscription goes DOWN then UP`() {
+        getMemberOpsServiceTestContext().run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate<MemberOpsService>(configs)
+
+            verifyIsUp<MemberOpsService>()
+
+            toggleDependency(subName, {
+                verifyIsDown<MemberOpsService>()
+            }, {
+                verifyIsUp<MemberOpsService>()
+            })
+        }
+    }
+
+    @Test
+    fun `component goes DOWN and comes back UP if a dependent component has error state and comes back`() {
+        getMemberOpsServiceTestContext().run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate<MemberOpsService>(configs)
+
+            setDependencyToError<VirtualNodeInfoReadService>()
+            verifyIsDown<MemberOpsService>()
+            bringDependencyUp<VirtualNodeInfoReadService>()
+
+            sendConfigUpdate<MemberOpsService>(configs)
+            verifyIsUp<MemberOpsService>()
+        }
+    }
+
+    @Test
+    fun `component goes DOWN and comes back UP if subscription has error state and comes back`() {
+        getMemberOpsServiceTestContext().run {
+            testClass.start()
+            bringDependenciesUp()
+            sendConfigUpdate<MemberOpsService>(configs)
+
+            setDependencyToError(subName)
+            verifyIsDown<MemberOpsService>()
+            bringDependencyUp(subName)
+            verifyIsUp<MemberOpsService>()
+        }
+    }
+
+    private fun getMemberOpsServiceTestContext(): LifecycleTest<MemberOpsService> {
+        return LifecycleTest {
+            addDependency(subName)
+            addDependency<ConfigurationReadService>()
+            addDependency<RegistrationProxy>()
+            addDependency<VirtualNodeInfoReadService>()
+            addDependency<MembershipGroupReaderProvider>()
+            addDependency<MembershipQueryClient>()
+
+            MemberOpsServiceImpl(
+                coordinatorFactory,
+                subscriptionFactory,
+                configReadService,
+                registrationProxy,
+                virtualNodeInfoReadService,
+                membershipGroupReaderProvider,
+                membershipQueryClient
+            )
+        }
+    }
+}

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
@@ -40,7 +40,7 @@ class MemberOpsServiceTest {
 
     private val messagingConfig: SmartConfig = mock()
     private val bootConfig: SmartConfig = mock {
-        on(it.withFallback(messagingConfig)).thenReturn(messagingConfig)
+        on { withFallback(messagingConfig) } doReturn messagingConfig
     }
 
     private val configs = mapOf(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
@@ -146,10 +146,7 @@ class RegistrationServiceLifecycleHandler(
         _groupParametersCache = GroupParametersCache(platformInfoProvider, publisher, keyEncodingService)
 
         recreateSubscription(coordinator, event.config.getConfig(MESSAGING_CONFIG))
-
-        if (coordinator.status != LifecycleStatus.UP) {
-            coordinator.updateStatus(LifecycleStatus.UP)
-        }
+        coordinator.updateStatus(LifecycleStatus.UP)
     }
 
     /**

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -104,56 +104,52 @@ class RegistrationServiceLifecycleHandlerTest {
 
     @Test
     fun `Start event does not immediately move to UP status`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
 
-            context.verifyIsDown<TestRegistrationComponent>()
+            verifyIsDown<TestRegistrationComponent>()
         }
     }
 
     @Test
     fun `UP is posted once all dependencies are UP and configuration has been provided`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
             bringDependenciesUp()
             sendConfigUpdate<TestRegistrationComponent>(configs)
 
-            context.verifyIsUp<TestRegistrationComponent>()
-            assertNotNull(context.testClass.registrationServiceLifecycleHandler.publisher)
-            assertNotNull(context.testClass.registrationServiceLifecycleHandler.groupParametersCache)
+            verifyIsUp<TestRegistrationComponent>()
+            assertNotNull(testClass.registrationServiceLifecycleHandler.publisher)
+            assertNotNull(testClass.registrationServiceLifecycleHandler.groupParametersCache)
         }
     }
 
     @Test
     fun `component remains UP if the config is changed`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
             bringDependenciesUp()
             sendConfigUpdate<TestRegistrationComponent>(configs)
 
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
 
             // A config update of any variety should not trigger the test component to go down. This can be verified by
             // sending the same thing again, as the code will still respond to this event as if it were a change.
             sendConfigUpdate<TestRegistrationComponent>(configs)
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
         }
     }
 
     @Test
     fun `component is DOWN after a stop event and the publisher is closed`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
             bringDependenciesUp()
             sendConfigUpdate<TestRegistrationComponent>(configs)
 
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
             testClass.stop()
-            context.verifyIsDown<TestRegistrationComponent>()
+            verifyIsDown<TestRegistrationComponent>()
         }
 
         assertThrows<IllegalArgumentException> { registrationServiceLifecycleHandler.publisher }
@@ -161,89 +157,85 @@ class RegistrationServiceLifecycleHandlerTest {
 
     @Test
     fun `component goes DOWN if one of its dependencies goes DOWN`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
             bringDependenciesUp()
             sendConfigUpdate<TestRegistrationComponent>(configs)
 
             toggleDependency<GroupPolicyProvider>({
-                context.verifyIsDown<TestRegistrationComponent>()
+                verifyIsDown<TestRegistrationComponent>()
             }, {
-                context.verifyIsDown<TestRegistrationComponent>()
+                verifyIsDown<TestRegistrationComponent>()
             })
             sendConfigUpdate<TestRegistrationComponent>(configs)
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
 
             toggleDependency<ConfigurationReadService>({
-                context.verifyIsDown<TestRegistrationComponent>()
+                verifyIsDown<TestRegistrationComponent>()
             }, {
-                context.verifyIsDown<TestRegistrationComponent>()
+                verifyIsDown<TestRegistrationComponent>()
             })
             sendConfigUpdate<TestRegistrationComponent>(configs)
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
 
             toggleDependency<HSMRegistrationClient>({
-                context.verifyIsDown<TestRegistrationComponent>()
+                verifyIsDown<TestRegistrationComponent>()
             }, {
-                context.verifyIsDown<TestRegistrationComponent>()
+                verifyIsDown<TestRegistrationComponent>()
             })
             sendConfigUpdate<TestRegistrationComponent>(configs)
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
         }
     }
 
     @Test
     fun `component goes DOWN and comes back UP if subscription goes DOWN then UP`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
             bringDependenciesUp()
             sendConfigUpdate<TestRegistrationComponent>(configs)
 
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
 
             toggleDependency(subName, {
-                context.verifyIsDown<TestRegistrationComponent>()
+                verifyIsDown<TestRegistrationComponent>()
             }, {
-                context.verifyIsUp<TestRegistrationComponent>()
+                verifyIsUp<TestRegistrationComponent>()
             })
         }
     }
 
     @Test
     fun `component goes DOWN and comes back UP if a dependent component errors and comes back`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
             bringDependenciesUp()
             sendConfigUpdate<TestRegistrationComponent>(configs)
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
 
             setDependencyToError<HSMRegistrationClient>()
-            context.verifyIsDown<TestRegistrationComponent>()
+            verifyIsDown<TestRegistrationComponent>()
             bringDependencyUp<HSMRegistrationClient>()
 
             // Model a config update coming back due to us re-registering with the config read service.
             sendConfigUpdate<TestRegistrationComponent>(configs)
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
         }
     }
 
     @Test
     fun `component handles a subscription error and restart`() {
-        val context = getTestContext()
-        context.run {
+        getTestContext().run {
             testClass.start()
             bringDependenciesUp()
             sendConfigUpdate<TestRegistrationComponent>(configs)
 
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
 
             setDependencyToError(subName)
-            context.verifyIsDown<TestRegistrationComponent>()
+            verifyIsDown<TestRegistrationComponent>()
             bringDependencyUp(subName)
-            context.verifyIsUp<TestRegistrationComponent>()
+            verifyIsUp<TestRegistrationComponent>()
         }
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -118,7 +118,7 @@ class RegistrationServiceLifecycleHandlerTest {
         context.run {
             testClass.start()
             bringDependenciesUp()
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
 
             context.verifyIsUp<TestRegistrationComponent>()
             assertNotNull(context.testClass.registrationServiceLifecycleHandler.publisher)
@@ -132,13 +132,13 @@ class RegistrationServiceLifecycleHandlerTest {
         context.run {
             testClass.start()
             bringDependenciesUp()
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
 
             context.verifyIsUp<TestRegistrationComponent>()
 
             // A config update of any variety should not trigger the test component to go down. This can be verified by
             // sending the same thing again, as the code will still respond to this event as if it were a change.
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
             context.verifyIsUp<TestRegistrationComponent>()
         }
     }
@@ -149,7 +149,7 @@ class RegistrationServiceLifecycleHandlerTest {
         context.run {
             testClass.start()
             bringDependenciesUp()
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
 
             context.verifyIsUp<TestRegistrationComponent>()
             testClass.stop()
@@ -165,14 +165,14 @@ class RegistrationServiceLifecycleHandlerTest {
         context.run {
             testClass.start()
             bringDependenciesUp()
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
 
             toggleDependency<GroupPolicyProvider>({
                 context.verifyIsDown<TestRegistrationComponent>()
             }, {
                 context.verifyIsDown<TestRegistrationComponent>()
             })
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
             context.verifyIsUp<TestRegistrationComponent>()
 
             toggleDependency<ConfigurationReadService>({
@@ -180,7 +180,7 @@ class RegistrationServiceLifecycleHandlerTest {
             }, {
                 context.verifyIsDown<TestRegistrationComponent>()
             })
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
             context.verifyIsUp<TestRegistrationComponent>()
 
             toggleDependency<HSMRegistrationClient>({
@@ -188,7 +188,7 @@ class RegistrationServiceLifecycleHandlerTest {
             }, {
                 context.verifyIsDown<TestRegistrationComponent>()
             })
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
             context.verifyIsUp<TestRegistrationComponent>()
         }
     }
@@ -199,7 +199,7 @@ class RegistrationServiceLifecycleHandlerTest {
         context.run {
             testClass.start()
             bringDependenciesUp()
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
 
             context.verifyIsUp<TestRegistrationComponent>()
 
@@ -217,7 +217,7 @@ class RegistrationServiceLifecycleHandlerTest {
         context.run {
             testClass.start()
             bringDependenciesUp()
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
             context.verifyIsUp<TestRegistrationComponent>()
 
             setDependencyToError<HSMRegistrationClient>()
@@ -225,7 +225,7 @@ class RegistrationServiceLifecycleHandlerTest {
             bringDependencyUp<HSMRegistrationClient>()
 
             // Model a config update coming back due to us re-registering with the config read service.
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
             context.verifyIsUp<TestRegistrationComponent>()
         }
     }
@@ -236,7 +236,7 @@ class RegistrationServiceLifecycleHandlerTest {
         context.run {
             testClass.start()
             bringDependenciesUp()
-            sendConfigUpdate(configs)
+            sendConfigUpdate<TestRegistrationComponent>(configs)
 
             context.verifyIsUp<TestRegistrationComponent>()
 

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -19,7 +19,7 @@ class LifecycleTest<T : Lifecycle>(
 ) {
 
     private val dependencies = ConcurrentHashMap.newKeySet<LifecycleCoordinatorName>()
-    private val coordinatorToConfigKeys = mutableMapOf<LifecycleCoordinator, Set<String>>()
+    val coordinatorToConfigKeys = mutableMapOf<LifecycleCoordinator, Set<String>>()
     private val configCoordinator = argumentCaptor<LifecycleCoordinator>()
     private val configKeys = argumentCaptor<Set<String>>()
 
@@ -46,7 +46,7 @@ class LifecycleTest<T : Lifecycle>(
         }
     }
 
-    private val registry
+    val registry
         get() = coordinatorFactory.registry
 
     // Must go after all the initialization above as those classes may be used by the lambda
@@ -250,10 +250,10 @@ class LifecycleTest<T : Lifecycle>(
      * @throws IllegalArgumentException if the keys in [config] don't match what the coordinator registered
      * for [testClass].
      */
-    fun sendConfigUpdate(
+    inline fun <reified D> sendConfigUpdate(
         config: Map<String, SmartConfig>
     ) {
-        val coordinator = registry.getCoordinator(LifecycleCoordinatorName(testClass::class.java.name))
+        val coordinator = registry.getCoordinator(LifecycleCoordinatorName.forComponent<D>())
         // assert that the config contains exactly the keys from required keys set
         // during registration
         val configKeys = coordinatorToConfigKeys[coordinator]

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -19,7 +19,7 @@ class LifecycleTest<T : Lifecycle>(
 ) {
 
     private val dependencies = ConcurrentHashMap.newKeySet<LifecycleCoordinatorName>()
-    val coordinatorToConfigKeys = mutableMapOf<LifecycleCoordinator, Set<String>>()
+    private val coordinatorToConfigKeys = mutableMapOf<LifecycleCoordinator, Set<String>>()
     private val configCoordinator = argumentCaptor<LifecycleCoordinator>()
     private val configKeys = argumentCaptor<Set<String>>()
 
@@ -46,7 +46,7 @@ class LifecycleTest<T : Lifecycle>(
         }
     }
 
-    val registry
+    private val registry
         get() = coordinatorFactory.registry
 
     // Must go after all the initialization above as those classes may be used by the lambda
@@ -243,17 +243,34 @@ class LifecycleTest<T : Lifecycle>(
     }
 
     /**
-     * Send a configuration update to the [testClass].  This configuration update must _exactly_ match
+     * Send a configuration update to the component. This configuration update must _exactly_ match
      * what the coordinator for the class registers or an [IllegalArgumentException] will be thrown.
      *
      * @param config the new configuration update
      * @throws IllegalArgumentException if the keys in [config] don't match what the coordinator registered
-     * for [testClass].
+     * for the component.
      */
     inline fun <reified D> sendConfigUpdate(
         config: Map<String, SmartConfig>
     ) {
-        val coordinator = registry.getCoordinator(LifecycleCoordinatorName.forComponent<D>())
+        sendConfigUpdate(LifecycleCoordinatorName.forComponent<D>(), config)
+    }
+
+    /**
+     * Send a configuration update to the component. This configuration update must _exactly_ match
+     * what the coordinator for the class registers or an [IllegalArgumentException] will be thrown.
+     *
+     * @param coordinatorName the component's lifecycle coordinator name
+     * @param config the new configuration update
+     * @throws IllegalArgumentException if the keys in [config] don't match what the coordinator registered
+     * for the component.
+     */
+    fun sendConfigUpdate(
+        coordinatorName: LifecycleCoordinatorName,
+        config: Map<String, SmartConfig>
+    ) {
+
+        val coordinator = registry.getCoordinator(coordinatorName)
         // assert that the config contains exactly the keys from required keys set
         // during registration
         val configKeys = coordinatorToConfigKeys[coordinator]


### PR DESCRIPTION
Made changes to MemberOpsService's lifecycle handling to follow the recommended order for closing down and creating the resources.

Had to modify `LifecycleTest.kt`, because it was using the testClass's type as coordinator name which in our case would have required to rename the lifecycle coordinator to "MemberOpsServiceImpl" instead of being able to use the interface's name. I followed the protocol of the other functions that are using `reified D` as a type parameter. This way we can easily provide `MemberOpsService` as the type and it will not use the implementation class to retrieve it from the registry.