### PR TITLE
CORE-8440: Change parameter name for `/permission/bulk` endpoint

### DIFF
--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
@@ -112,20 +112,20 @@ class PermissionEndpointImpl @Activate constructor(
         return permissions.map { it.convertToEndpointType() }
     }
 
-    override fun createAndAssignPermissions(permissionsToCreate: BulkCreatePermissionsRequestType):
+    override fun createAndAssignPermissions(request: BulkCreatePermissionsRequestType):
             ResponseEntity<BulkCreatePermissionsResponseType> {
 
         // Validate non-empty set of permissions requested
-        if(permissionsToCreate.permissionsToCreate.isEmpty()) {
+        if(request.permissionsToCreate.isEmpty()) {
             throw InvalidInputDataException("No permissions requested to be created")
         }
 
         // Validate RoleIds passed in
-        if (permissionsToCreate.roleIds.isNotEmpty()) {
+        if (request.roleIds.isNotEmpty()) {
             val allRoleIds = permissionManagementService.permissionManager.getRoles().map { it.id }
-            val intersection = allRoleIds.intersect(permissionsToCreate.roleIds)
-            if (intersection != permissionsToCreate.roleIds) {
-                val notFoundRoles = permissionsToCreate.roleIds.subtract(intersection)
+            val intersection = allRoleIds.intersect(request.roleIds)
+            if (intersection != request.roleIds) {
+                val notFoundRoles = request.roleIds.subtract(intersection)
                 throw InvalidInputDataException("Roles with the following ids cannot be found: $notFoundRoles")
             }
         }
@@ -135,7 +135,7 @@ class PermissionEndpointImpl @Activate constructor(
 
         // Construct and send Kafka message and wait for the response
         val createPermissionsResult = withPermissionManager(permissionManagementService.permissionManager, logger) {
-            createPermissions(permissionsToCreate.convertToDto(principal))
+            createPermissions(request.convertToDto(principal))
         }
 
         return ResponseEntity.created(createPermissionsResult.convertToEndpointType())

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
@@ -99,6 +99,6 @@ interface PermissionEndpoint : RpcOps {
     fun createAndAssignPermissions(
         @HttpRpcRequestBodyParameter(description = "The details of the permissions to be created along with existing role " +
                 "identifiers newly created permissions should be associated with.")
-        permissionsToCreate: BulkCreatePermissionsRequestType
+        request: BulkCreatePermissionsRequestType
     ): ResponseEntity<BulkCreatePermissionsResponseType>
 }


### PR DESCRIPTION
Due to the fact that we collapse OpenAPI in case of single argument, with nested `permissionsToCreate` parameter name we have a corner case in OpenAPI generation which leads to confusion when manually invoking this endpoint.