### PR TITLE
CORE-8435: Cooperative Rebalace in RPC Pattern

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -23,6 +23,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.AuthenticationException
 import org.apache.kafka.common.errors.AuthorizationException
 import org.apache.kafka.common.errors.FencedInstanceIdException
+import org.apache.kafka.common.errors.InconsistentGroupProtocolException
 import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.errors.WakeupException
@@ -63,6 +64,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                 is IllegalStateException,
                 is ArithmeticException,
                 is FencedInstanceIdException,
+                is InconsistentGroupProtocolException,
                 is InvalidOffsetException -> {
                     logErrorAndThrowFatalException("Error attempting to poll.", ex)
                 }

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
@@ -73,15 +73,25 @@ roles {
     }
     rpcSender {
         consumer = ${consumer} {
+            # Extra suffix to prevent clashes within consumer groups with more than one member.
+            group.id = ${group}-sender
             # RPC pattern consumers can ignore old messages so choose to start at the end of the stream.
             auto.offset.reset = latest
+            # Identical to StickyAssignor but supports cooperative rebalances (consumers can continue consuming from
+            # the partitions that are not reassigned).
+            partition.assignment.strategy = org.apache.kafka.clients.consumer.CooperativeStickyAssignor
         }
         producer = ${producer}
     }
     rpcResponder {
         consumer = ${consumer} {
+            # Extra suffix to prevent clashes within consumer groups with more than one member.
+            group.id = ${group}-responder
             # RPC pattern consumers can ignore old messages so choose to start at the end of the stream.
             auto.offset.reset = latest
+            # More balanced than RoundRobinAssignor and leaves (during rebalances) as many assignments as possible in
+            # place, minimizing the overhead associated with moving partition assignments from one consumer to another.
+            partition.assignment.strategy = org.apache.kafka.clients.consumer.StickyAssignor
         }
         producer = ${producer}
     }
@@ -89,4 +99,3 @@ roles {
         producer = ${producer}
     }
 }
-

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
@@ -1,4 +1,4 @@
-package net.corda.messaging.kafka.subscription.net.corda.messagebus.kafka.config
+package net.corda.messagebus.kafka.config
 
 import com.typesafe.config.ConfigFactory
 import java.util.Properties
@@ -9,7 +9,6 @@ import net.corda.messagebus.api.configuration.ConsumerConfig
 import net.corda.messagebus.api.configuration.ProducerConfig
 import net.corda.messagebus.api.constants.ConsumerRoles
 import net.corda.messagebus.api.constants.ProducerRoles
-import net.corda.messagebus.kafka.config.MessageBusConfigResolver
 import net.corda.messaging.api.exception.CordaMessageAPIConfigException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -40,6 +39,7 @@ class MessageBusConfigResolverTest {
         private const val ACKS_PROP = "acks"
 
         @JvmStatic
+        @Suppress("unused", "LongMethod")
         private fun consumerConfigSource(): Stream<Arguments> {
             val arguments = mapOf(
                 ConsumerRoles.PUBSUB to getExpectedConsumerProperties(
@@ -83,6 +83,7 @@ class MessageBusConfigResolverTest {
                 ),
                 ConsumerRoles.RPC_SENDER to getExpectedConsumerProperties(
                     mapOf(
+                        GROUP_ID_PROP to "$GROUP_NAME-sender",
                         BOOTSTRAP_SERVERS_PROP to "kafka:1001",
                         SSL_KEYSTORE_PROP to "foo/bar",
                         AUTO_OFFSET_RESET_PROP to "latest"
@@ -90,6 +91,7 @@ class MessageBusConfigResolverTest {
                 ),
                 ConsumerRoles.RPC_RESPONDER to getExpectedConsumerProperties(
                     mapOf(
+                        GROUP_ID_PROP to "$GROUP_NAME-responder",
                         BOOTSTRAP_SERVERS_PROP to "kafka:1001",
                         SSL_KEYSTORE_PROP to "foo/bar",
                         AUTO_OFFSET_RESET_PROP to "latest"
@@ -100,6 +102,7 @@ class MessageBusConfigResolverTest {
         }
 
         @JvmStatic
+        @Suppress("unused", "LongMethod")
         private fun producerConfigSource(): Stream<Arguments> {
             val arguments = mapOf(
                 ProducerRoles.PUBLISHER to getExpectedProducerProperties(

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumerRebalanceListener.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumerRebalanceListener.kt
@@ -12,10 +12,6 @@ interface CordaConsumerRebalanceListener {
      * This method will be called during a rebalance operation when the consumer has to give up some partitions.
      * It can also be called when consumer is being closed or is unsubscribing.
      * It is recommended that offsets should be committed in this callback to prevent duplicate data.
-     * <p>
-     * In eager rebalancing, it will always be called at the start of a rebalance and after the consumer stops fetching
-     * data. In cooperative rebalancing, it will be called at the end of a rebalance on the set of partitions being
-     * revoked if the set is non-empty.
      *
      * @param partitions The list of partitions that were assigned to the consumer and now need to be revoked (may not
      *                   include all currently assigned partitions, i.e. there may still be some partitions left)

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumerRebalanceListener.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumerRebalanceListener.kt
@@ -10,18 +10,29 @@ interface CordaConsumerRebalanceListener {
 
     /**
      * This method will be called during a rebalance operation when the consumer has to give up some partitions.
+     * It can also be called when consumer is being closed or is unsubscribing.
      * It is recommended that offsets should be committed in this callback to prevent duplicate data.
+     * <p>
+     * In eager rebalancing, it will always be called at the start of a rebalance and after the consumer stops fetching
+     * data. In cooperative rebalancing, it will be called at the end of a rebalance on the set of partitions being
+     * revoked if the set is non-empty.
+     *
      * @param partitions The list of partitions that were assigned to the consumer and now need to be revoked (may not
      *                   include all currently assigned partitions, i.e. there may still be some partitions left)
+     *
      */
     fun onPartitionsRevoked(partitions: Collection<CordaTopicPartition>)
 
     /**
-     * This method will be called after the partition re-assignment completes and before the
-     * consumer starts fetching data, and only as the result of a poll call.
+     * This method will be called after the partition re-assignment completes and before the consumer
+     * starts fetching data, and only as the result of a poll(long) call.
      * <p>
      * It is guaranteed that under normal conditions all the processes in a consumer group will execute their
      * [onPartitionsRevoked] callback before any instance executes its [onPartitionsAssigned] callback.
+     * During exceptional scenarios, partitions may be migrated without the old owner being notified (i.e. their
+     * [onPartitionsRevoked] callback not triggered), and later when the old owner consumer realized this event,
+     * the [onPartitionsLost] callback will be triggered by the consumer then.
+     *
      * @param partitions The list of partitions that are now assigned to the consumer (previously owned partitions will
      *                   NOT be included, i.e. this list will only include newly added partitions)
      */
@@ -32,9 +43,10 @@ interface CordaConsumerRebalanceListener {
      * first be revoked by calling the [onPartitionsRevoked], before being reassigned
      * to other consumers during a rebalance event. However, during exceptional scenarios when the consumer realizes
      * that it does not own this partition any longer, i.e. not revoked via a normal rebalance event, then this method
-     * would be invoked.
+     * would be invoked. By default, it will just trigger [onPartitionsRevoked].
+     *
      * @param partitions The list of partitions that were assigned to the consumer and now have been reassigned
-     *                   to other consumers. With the current protocol this will always include all of the consumer's
+     *                   to other consumers. With the current protocol this will always include all the consumer's
      *                   previously assigned partitions, but this may change in future protocols (ie there would still
      *                   be some partitions left)
      */


### PR DESCRIPTION
Kafka executes a rebalance within a consumer group whenever a member
joins or leaves the group. The "eager rebalance" algorithm is used by
default, and it causes a stop the world effect by revoking and
re-assigning all partitions within the group (even those that don't
need to be moved), making consumers unavailable while rebalancing.
Changes in this commit aim to reduce the unavailability window during
rebalances within the RPC message pattern by forcing the usage of the 
"incremental cooperative rebalance" algorithm [1].

- Update javadocs and tests.
- Add 'InconsistentGroupProtocolException' to the list of unrecoverable
  (fatal) exceptions while polling from the topics.
- Configure the 'rpcSender.consumer' to use 'CooperativeStickyAssignor'
  as the partition strategy, this assignor acts as the 'StickyAssignor'
  but supports cooperative rebalances (consumers can continue consuming
  from the partitions that are not reassigned).
- Configure the 'rpcResponder.consumer' to use the 'StickyAssignor' as
  the partition strategy, works as the 'RoundRobinAssignor' but reduces
  the amount of partitions to move during rebalancing. Incremental
  cooperative rebalance is not used to prevent different consumers from
  handling a task that might not be idempotent (exceptional cases where
  the partitions are assigned to new consumers without first being
  revoked by the cooperative rebalance algorithm).

[1]: https://cwiki.apache.org/confluence/display/KAFKA/Incremental+Cooperative+Rebalancing:+Support+and+Policies
