### PR TITLE
CORE-8439 Add support bundle scripts

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -22,7 +22,7 @@ String dockerLabel = '11'
 String architectureTag = ''
 
 /*
- * architecture for Kuberenetes workers during E2E tests
+ * architecture for Kubernetes workers during E2E tests
  */
 String e2eArchitecture = 'amd64'
 
@@ -125,13 +125,10 @@ pipeline {
                 }
             }
             post {
-                always {
-                    sh '''\
-                        kubectl logs -lapp.kubernetes.io/instance=prereqs -n "${NAMESPACE}" --all-containers=true --prefix=true --tail=-1 > prereqsLogs.txt
-                        kubectl describe all -n "${NAMESPACE}" > prereqsDescribe.txt
-                    '''.stripIndent()
-                    archiveArtifacts artifacts: 'prereqsLogs.txt, prereqsDescribe.txt', allowEmptyArchive: true
-                    sh 'rm -f prereqsLogs.txt prereqsDescribe.txt'
+                unsuccessful {
+                    sh './support_bundle.sh ${NAMESPACE}'
+                    archiveArtifacts artifacts: '*-support-bundle-*.tgz', allowEmptyArchive: true
+                    sh 'rm -f *-support-bundle-*.tgz'
                 }
             }
         }
@@ -155,14 +152,9 @@ pipeline {
            }
             post {
                 unsuccessful {
-                    sh '''\
-                        kubectl logs -lapp.kubernetes.io/instance=corda-alice -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs-alice.txt
-                        kubectl logs -lapp.kubernetes.io/instance=corda-bob -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs-bob.txt
-                        kubectl logs -lapp.kubernetes.io/instance=corda-caroline -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs-caroline.txt
-                        kubectl describe all -n ${NAMESPACE} > describe.txt
-                    '''.stripIndent()
-                    archiveArtifacts artifacts: 'logs-alice.txt, logs-bob.txt, logs-caroline.txt, describe.txt', allowEmptyArchive: true
-                    sh 'rm -f logs-alice.txt logs-bob.txt logs-caroline.txt describe.txt'
+                    sh './support_bundle.sh ${NAMESPACE}'
+                    archiveArtifacts artifacts: '*-support-bundle-*.tgz', allowEmptyArchive: true
+                    sh 'rm -f *-support-bundle-*.tgz'
                 }
             }
         }
@@ -198,15 +190,9 @@ pipeline {
             post {
                 always {
                     junit allowEmptyResults: true, testResults: '**/test-results/**/TEST-*.xml'
-                    sh '''\
-                        kubectl logs -lapp.kubernetes.io/instance=corda-alice -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs-alice.txt
-                        kubectl logs -lapp.kubernetes.io/instance=corda-bob -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs-bob.txt
-                        kubectl logs -lapp.kubernetes.io/instance=corda-caroline -n ${NAMESPACE} --all-containers=true --prefix=true --tail=-1 > logs-caroline.txt
-                        kubectl describe all -n ${NAMESPACE} > describe.txt
-                        pgrep kubectl | xargs kill -9
-                    '''.stripIndent()
-                    archiveArtifacts artifacts: 'forward.txt, logs-alice.txt, logs-bob.txt, logs-caroline.txt, describe.txt', allowEmptyArchive: true
-                    sh 'rm -f forward.txt logs-alice.txt logs-bob.txt logs-caroline.txt describe.txt'
+                    sh './support_bundle.sh ${NAMESPACE}'
+                    archiveArtifacts artifacts: 'forward.txt, *-support-bundle-*.tgz', allowEmptyArchive: true
+                    sh 'rm -f forward.txt *-support-bundle-*.tgz'
                 }
             }
         }

--- a/support_bundle.ps1
+++ b/support_bundle.ps1
@@ -45,6 +45,7 @@ foreach ($podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.
     Write-Output "Collecting status for pod ${podName}"
     $job=Start-Job -ScriptBlock {kubectl port-forward --namespace $args[0] $args[1] 7000:7000} -ArgumentList $namespace,$podName
     $ProgressPreference = 'SilentlyContinue'
+    # Retry needed as, at least on macOS, the forwarded port is not immediately available
     $count = 0
     do
     {

--- a/support_bundle.ps1
+++ b/support_bundle.ps1
@@ -43,15 +43,16 @@ foreach ($podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.
   if ($podName -match '.*-worker-.*')
   {
     Write-Output "Collecting status for pod ${podName}"
-    $job=Start-Job -ScriptBlock {kubectl port-forward "${podName}" 7000:7000}
+    $job=Start-Job -ScriptBlock {kubectl port-forward --namespace "${namespace}" "${podName}" 7000:7000}
     $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri http://localhost:7000/status -OutFile (Join-Path $podDir "status.json")
     Stop-Job $job
   }
 }
 
-$bundle="${namespace}-support-bundle-$(date +"%Y-%m-%dT%H_%M_%S").tgz"
+$date=Get-Date -UFormat "%Y-%m-%dT%H_%M_%S"
+$bundle="${namespace}-support-bundle-${date}.tgz"
 tar -C "${workDir}" -czvf "${bundle}" "${namespace}"
 Write-Output "Created support bundle ${bundle}"
 
-rm -rf "$workDir"
+Remove-Item -Recurse -Force -Path "$workDir"

--- a/support_bundle.ps1
+++ b/support_bundle.ps1
@@ -6,23 +6,23 @@ $parent = [System.IO.Path]::GetTempPath()
 [string] $name = [System.Guid]::NewGuid()
 $workDir = Join-Path $parent $name
 
-mkdir $workDir
+$null = New-Item -Path "${parent}" -Name "${name}" -ItemType "directory"
 $namespaceDir = Join-Path $workDir $namespace
-mkdir $namespaceDir
+$null = New-Item -Path "${workDir}" -Name "${namespace}" -ItemType "directory"
 
 Write-Output "Collecting events for namespace ${namespace}"
 kubectl --namespace "${namespace}" get events --sort-by=lastTimestamp > (Join-Path $namespaceDir "kubernetes_events.txt")
 
 Write-Output "Collecting Helm releases"
 $helmDir = Join-Path $namespaceDir "helm"
-mkdir $helmDir
+$null = New-Item -Path "${namespaceDir}" -Name "helm" -ItemType "directory"
 helm ls --namespace "${namespace}" > (Join-Path $helmDir "ls.txt")
 
 foreach ($release in $(helm ls -q --namespace "${namespace}").Split([System.Environment]::NewLine))
 {
   Write-Output "Collecting values and manifest for Helm release ${release}"
   $releaseDir = Join-Path $helmDir $release
-  mkdir $releaseDir
+  $null = New-Item -Path "${helmDir}" -Name "${release}" -ItemType "directory"
   helm get values "${release}" --namespace "${namespace}" > (Join-Path $releaseDir "values.txt")
   helm get manifest "${release}" --namespace "${namespace}" > (Join-Path $releaseDir "manifest.txt")
 }
@@ -31,7 +31,7 @@ foreach ($podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.
 {
   Write-Output "Collecting configuration and logs for pod ${podName}"
   $podDir = Join-Path $namespaceDir $podName
-  mkdir $podDir
+  $null = New-Item -Path "${namespaceDir}" -Name "${podName}" -ItemType "directory"
   kubectl --namespace "${namespace}" describe pod "${podName}" > (Join-Path $podDir "describe.txt")
   kubectl --namespace "${namespace}" logs "${podName}" --all-containers=true --ignore-errors --prefix=true > (Join-Path $podDir "logs.txt")
   $restartCount=$(kubectl --namespace "$namespace" get pod "${podName}" -o jsonpath="{.status.containerStatuses[0].restartCount}")
@@ -43,16 +43,36 @@ foreach ($podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.
   if ($podName -match '.*-worker-.*')
   {
     Write-Output "Collecting status for pod ${podName}"
-    $job=Start-Job -ScriptBlock {kubectl port-forward --namespace "${namespace}" "${podName}" 7000:7000}
+    $job=Start-Job -ScriptBlock {kubectl port-forward --namespace $args[0] $args[1] 7000:7000} -ArgumentList $namespace,$podName
     $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri http://localhost:7000/status -OutFile (Join-Path $podDir "status.json")
+    $count = 0
+    do
+    {
+      $count++
+      try
+      {
+        Invoke-RestMethod -Uri http://localhost:7000/status -OutFile (Join-Path $podDir "status.json")
+        break
+      }
+      catch
+      {
+        if ($count -eq 10)
+        {
+          Write-Error $_.Exception.InnerException.Message -ErrorAction Continue
+        }
+        else
+        {
+          Start-Sleep -Seconds 10
+        }
+      }
+    } while ($count -lt 5)
     Stop-Job $job
   }
 }
 
 $date=Get-Date -UFormat "%Y-%m-%dT%H_%M_%S"
-$bundle="${namespace}-support-bundle-${date}.tgz"
-tar -C "${workDir}" -czvf "${bundle}" "${namespace}"
+$bundle="${namespace}-support-bundle-${date}.zip"
+Compress-Archive -Path "${workDir}\${namespace}" -DestinationPath "${bundle}"
 Write-Output "Created support bundle ${bundle}"
 
-Remove-Item -Recurse -Force -Path "$workDir"
+$null = Remove-Item -Recurse -Force -Path "$workDir"

--- a/support_bundle.ps1
+++ b/support_bundle.ps1
@@ -1,0 +1,57 @@
+#!/usr/local/bin/pwsh
+
+param ($namespace=$(kubectl config view --minify -o jsonpath='{..namespace}'))
+
+$parent = [System.IO.Path]::GetTempPath()
+[string] $name = [System.Guid]::NewGuid()
+$workDir = Join-Path $parent $name
+
+mkdir $workDir
+$namespaceDir = Join-Path $workDir $namespace
+mkdir $namespaceDir
+
+Write-Output "Collecting events for namespace ${namespace}"
+kubectl --namespace "${namespace}" get events --sort-by=lastTimestamp > (Join-Path $namespaceDir "kubernetes_events.txt")
+
+Write-Output "Collecting Helm releases"
+$helmDir = Join-Path $namespaceDir "helm"
+mkdir $helmDir
+helm ls --namespace "${namespace}" > (Join-Path $helmDir "ls.txt")
+
+foreach ($release in $(helm ls -q --namespace "${namespace}").Split([System.Environment]::NewLine))
+{
+  Write-Output "Collecting values and manifest for Helm release ${release}"
+  $releaseDir = Join-Path $helmDir $release
+  mkdir $releaseDir
+  helm get values "${release}" --namespace "${namespace}" > (Join-Path $releaseDir "values.txt")
+  helm get manifest "${release}" --namespace "${namespace}" > (Join-Path $releaseDir "manifest.txt")
+}
+
+foreach ($podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.items[*].metadata.name}").Split(" "))
+{
+  Write-Output "Collecting configuration and logs for pod ${podName}"
+  $podDir = Join-Path $namespaceDir $podName
+  mkdir $podDir
+  kubectl --namespace "${namespace}" describe pod "${podName}" > (Join-Path $podDir "describe.txt")
+  kubectl --namespace "${namespace}" logs "${podName}" --all-containers=true --ignore-errors --prefix=true > (Join-Path $podDir "logs.txt")
+  $restartCount=$(kubectl --namespace "$namespace" get pod "${podName}" -o jsonpath="{.status.containerStatuses[0].restartCount}")
+  if ($restartCount -gt 0)
+  {
+    Write-Output "Pod ${podName} has restarted - collecting previous logs"
+    kubectl --namespace "${namespace}" logs "${podName}" --all-containers=true --ignore-errors --prefix=true --previous > (Join-Path $podDir "previous-logs.txt")
+  }
+  if ($podName -match '.*-worker-.*')
+  {
+    Write-Output "Collecting status for pod ${podName}"
+    $job=Start-Job -ScriptBlock {kubectl port-forward "${podName}" 7000:7000}
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri http://localhost:7000/status -OutFile (Join-Path $podDir "status.json")
+    Stop-Job $job
+  }
+}
+
+$bundle="${namespace}-support-bundle-$(date +"%Y-%m-%dT%H_%M_%S").tgz"
+tar -C "${workDir}" -czvf "${bundle}" "${namespace}"
+Write-Output "Created support bundle ${bundle}"
+
+rm -rf "$workDir"

--- a/support_bundle.sh
+++ b/support_bundle.sh
@@ -39,7 +39,7 @@ for podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.items[
   fi
   if [[ "$podName" == *-worker-* ]]; then
     echo "Collecting status for pod ${podName}"
-    kubectl port-forward "${podName}" 7000:7000  >/dev/null 2>&1 &
+    kubectl port-forward --namespace "${namespace}" "${podName}" 7000:7000  >/dev/null 2>&1 &
     pid=$!
     curl -s localhost:7000/status -o "${podDir}/status.json"
     disown $pid

--- a/support_bundle.sh
+++ b/support_bundle.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  namespace=$(kubectl config view --minify -o jsonpath='{..namespace}')
+else
+  namespace="$1"
+fi
+
+workDir=$(mktemp -d)
+namespaceDir="${workDir}/${namespace}"
+mkdir "${namespaceDir}"
+
+echo "Collecting events for namespace ${namespace}"
+kubectl --namespace "${namespace}" get events --sort-by=lastTimestamp > "${namespaceDir}/kubernetes_events.txt"
+
+echo "Collecting Helm releases"
+helmDir="${namespaceDir}/helm"
+mkdir "${helmDir}"
+helm ls --namespace "${namespace}" > "${helmDir}/ls.txt"
+
+for release in $(helm ls -q --namespace "${namespace}"); do
+  echo "Collecting values and manifest for Helm release ${release}"
+  releaseDir="${helmDir}/${release}"
+  mkdir "${releaseDir}"
+  helm get values "${release}" --namespace "${namespace}" > "${releaseDir}/values.txt"
+  helm get manifest "${release}" --namespace "${namespace}" > "${releaseDir}/manifest.txt"
+done
+
+for podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.items[*].metadata.name}"); do
+  echo "Collecting configuration and logs for pod ${podName}"
+  podDir="${namespaceDir}/${podName}"
+  mkdir -p "${podDir}"
+  kubectl --namespace "${namespace}" describe pod "${podName}" > "${podDir}/describe.txt"
+  kubectl --namespace "${namespace}" logs "${podName}" --all-containers=true --ignore-errors --prefix=true > "${podDir}/logs.txt"
+  restartCount=$(kubectl --namespace "$namespace" get pod "${podName}" -o jsonpath="{.status.containerStatuses[0].restartCount}")
+  if [[ $restartCount -gt 0 ]]; then
+    echo "Pod ${podName} has restarted - collecting previous logs"
+    kubectl --namespace "${namespace}" logs "${podName}" --all-containers=true --ignore-errors --prefix=true --previous > "${podDir}/previous-logs.txt"
+  fi
+  if [[ "$podName" == *-worker-* ]]; then
+    echo "Collecting status for pod ${podName}"
+    kubectl port-forward "${podName}" 7000:7000  >/dev/null 2>&1 &
+    pid=$!
+    curl -s localhost:7000/status -o "${podDir}/status.json"
+    disown $pid
+    kill $pid
+  fi
+done
+
+bundle="${namespace}-support-bundle-$(date +"%Y-%m-%dT%H_%M_%S").tgz"
+tar -C "${workDir}" -czvf "${bundle}" "${namespace}"
+echo "Created support bundle ${bundle}"
+
+rm -rf "$workDir"


### PR DESCRIPTION
Adds scripts (Bash and PowerShell) for generating a "support bundle" (tar file) containing:

- Kubernetes events
- Helm releases with values and manifests
- Logs (including those for previous instances) and output of `kubectl describe` for pods
- Results from `/status` for worker pods

Switches the E2E test pipeline to use the pipeline. The scripts are modelled on existing logic in the non-functional test pipeline and that should also be able to switch to use them as it is already checking out `corda-runtime-os`.