### PR TITLE
CORE-8457: Temp fix for Simulator test finishing before persistence

### DIFF
--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
@@ -44,6 +44,8 @@ class TruancyResponderFlow : ResponderFlow {
 
         persistenceService.persist(record.absentees.map { TruancyEntity(name = it.toString()) })
 
+        session.send(Unit)
+
         log.info("Records persisted")
     }
 

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
@@ -20,6 +20,7 @@ class TruancySubFlow(
     override fun call(): String {
         val session = flowMessaging.initiateFlow(truancyOffice)
         session.send(truancyRecord)
+        session.receive(Unit::class.java)
         return ""
     }
 }


### PR DESCRIPTION
Corda 5 waits until all sessions are closed before returning from a flow. This will be addressed in Simulator by CORE-8641. In the meantime this addition to the example code uses the send/receive approach from Corda 4, ensuring that persistence in the responder flow finishes before the initiating flow does, and preventing an intermittent failure.