### PR TITLE
CORE-7245 Remove the lifecycle code from the message bus

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/build.gradle
+++ b/libs/messaging/kafka-message-bus-impl/build.gradle
@@ -8,8 +8,7 @@ description 'Kafka Message Bus Impl'
 dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-
-    implementation project(":libs:lifecycle:lifecycle")
+    
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:messaging:message-bus")
     implementation project(":libs:schema-registry:schema-registry")

--- a/libs/messaging/message-bus/build.gradle
+++ b/libs/messaging/message-bus/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "net.corda:corda-base"
-    implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:configuration:configuration-core")
 }
 


### PR DESCRIPTION
All that was left was unrequired dependency declarations.