### PR TITLE
CORE-7270 Utxo Transaction signatories

### DIFF
--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -128,7 +128,7 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
                     ConsensualComponentGroup.TIMESTAMP ->
                         listOf(serializationService.serialize(Instant.now()).bytes)
 
-                    ConsensualComponentGroup.REQUIRED_SIGNING_KEYS ->
+                    ConsensualComponentGroup.SIGNATORIES ->
                         requiredSigningKeys.map { serializationService.serialize(it).bytes }
 
                     ConsensualComponentGroup.OUTPUT_STATES ->

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -24,7 +24,7 @@ data class UtxoTransactionBuilderImpl(
     override val timeWindow: TimeWindow? = null,
     override val attachments: List<SecureHash> = emptyList(),
     override val commands: List<Command> = emptyList(),
-    private val signatories: Set<PublicKey> = emptySet(),
+    override val signatories: List<PublicKey> = emptyList(),
     override val inputStateAndRefs: List<StateAndRef<*>> = emptyList(),
     override val referenceInputStateAndRefs: List<StateAndRef<*>> = emptyList(),
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -49,10 +49,6 @@ data class UtxoTransactionBuilderImpl(
         return copy(signatories = this.signatories + signatories)
     }
 
-    override fun addCommandAndSignatories(command: Command, signatories: Iterable<PublicKey>): UtxoTransactionBuilder {
-        return addCommand(command).addSignatories(signatories)
-    }
-
     override fun addInputState(stateAndRef: StateAndRef<*>): UtxoTransactionBuilder {
         return copy(inputStateAndRefs = inputStateAndRefs + stateAndRef)
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -6,12 +6,14 @@ import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.TimeWindow
+import java.security.PublicKey
 
 interface UtxoTransactionBuilderInternal {
     val notary: Party?
     val timeWindow: TimeWindow?
     val attachments: List<SecureHash>
     val commands: List<Command>
+    val signatories: List<PublicKey>
     val inputStateAndRefs: List<StateAndRef<*>>
     val referenceInputStateAndRefs: List<StateAndRef<*>>
     val outputStates: List<Pair<ContractState, Int?>>

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactoryImpl.kt
@@ -125,7 +125,6 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
         }
         val commandsInfo = utxoTransactionBuilder.commands.map {
             listOf(
-                "", // TODO signers
                 currentSandboxGroup.getEvolvableTag(it.javaClass),
             )
         }
@@ -140,6 +139,9 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
 
                     UtxoComponentGroup.NOTARY ->
                         notaryGroup.map { serializationService.serialize(it!!).bytes }
+
+                    UtxoComponentGroup.SIGNATORIES ->
+                        utxoTransactionBuilder.signatories.map { serializationService.serialize(it).bytes }
 
                     UtxoComponentGroup.OUTPUTS_INFO ->
                         outputsInfo.map { serializationService.serialize(it).bytes }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
@@ -14,6 +14,7 @@ import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.security.PublicKey
 import kotlin.test.assertIs
 
 @Suppress("DEPRECATION")
@@ -39,6 +40,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
             .addOutputState(utxoStateExample)
             .addInputState(inputStateAndRef)
             .addReferenceInputState(referenceStateAndRef)
+            .addSignatories(listOf(publicKeyExample))
             .addCommand(command)
             .addAttachment(attachment)
             .toSignedTransaction(publicKeyExample)
@@ -56,5 +58,10 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
         Assertions.assertEquals(1, ledgerTransaction.outputContractStates.size)
         Assertions.assertEquals(utxoStateExample, ledgerTransaction.outputContractStates.first())
         assertIs<UtxoStateClassExample>(ledgerTransaction.outputContractStates.first())
+
+        assertIs<List<PublicKey>>(ledgerTransaction.signatories)
+        Assertions.assertEquals(1, ledgerTransaction.signatories.size)
+        Assertions.assertEquals(publicKeyExample, ledgerTransaction.signatories.first())
+        assertIs<PublicKey>(ledgerTransaction.signatories.first())
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoLedgerTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoLedgerTransactionImplTest.kt
@@ -12,6 +12,7 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.ContractState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.security.PublicKey
 import kotlin.test.assertIs
 
 @Suppress("DEPRECATION")
@@ -32,6 +33,7 @@ internal class UtxoLedgerTransactionImplTest: UtxoLedgerTest() {
             .addOutputState(utxoStateExample)
             .addInputState(inputStateAndRef)
             .addReferenceInputState(referenceStateAndRef)
+            .addSignatories(listOf(publicKeyExample))
             .addCommand(command)
             .addAttachment(attachment)
             .toSignedTransaction(publicKeyExample)
@@ -45,6 +47,11 @@ internal class UtxoLedgerTransactionImplTest: UtxoLedgerTest() {
         assertEquals(1, ledgerTransaction.outputContractStates.size)
         assertEquals(utxoStateExample, ledgerTransaction.outputContractStates.first())
         assertIs<UtxoStateClassExample>(ledgerTransaction.outputContractStates.first())
+
+        assertIs<List<PublicKey>>(ledgerTransaction.signatories)
+        assertEquals(1, ledgerTransaction.signatories.size)
+        assertEquals(publicKeyExample, ledgerTransaction.signatories.first())
+        assertIs<PublicKey>(ledgerTransaction.signatories.first())
 
         /** TODO When inputStateAndRefs or referenceInputStateAndRefs will get available
         assertIs<List<StateAndRef<UtxoStateClassExample>>>(ledgerTransaction.inputStateAndRefs)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -29,11 +29,11 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
             .toSignedTransaction(publicKeyExample)
         assertIs<SecureHash>(tx.id)
-        assertEquals(tx.inputStateRefs.single(), getUtxoInvalidStateAndRef().ref)
-        assertEquals(tx.referenceStateRefs.single(), getUtxoInvalidStateAndRef().ref)
-        assertEquals(tx.outputStateAndRefs.single().state.contractState, utxoStateExample)
-        assertEquals(tx.notary, utxoNotaryExample)
-        assertEquals(tx.timeWindow, utxoTimeWindowExample)
+        assertEquals(getUtxoInvalidStateAndRef().ref, tx.inputStateRefs.single())
+        assertEquals(getUtxoInvalidStateAndRef().ref, tx.referenceStateRefs.single())
+        assertEquals(utxoStateExample, tx.outputStateAndRefs.single().state.contractState)
+        assertEquals(utxoNotaryExample, tx.notary)
+        assertEquals(utxoTimeWindowExample, tx.timeWindow)
     }
 
     @Test
@@ -47,9 +47,9 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
         assertIs<SecureHash>(tx.id)
         assertThat(tx.inputStateRefs).isEmpty()
         assertThat(tx.referenceStateRefs).isEmpty()
-        assertEquals(tx.outputStateAndRefs.single().state.contractState, utxoStateExample)
-        assertEquals(tx.notary, utxoNotaryExample)
-        assertEquals(tx.timeWindow, utxoTimeWindowExample)
+        assertEquals(utxoStateExample, tx.outputStateAndRefs.single().state.contractState)
+        assertEquals(utxoNotaryExample, tx.notary)
+        assertEquals(utxoTimeWindowExample, tx.timeWindow, )
     }
 
     // TODO Add tests for verification failures.

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -25,6 +25,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .addOutputState(utxoStateExample)
             .addInputState(getUtxoInvalidStateAndRef())
             .addReferenceInputState(getUtxoInvalidStateAndRef())
+            .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
             .toSignedTransaction(publicKeyExample)
@@ -34,6 +35,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
         assertEquals(utxoStateExample, tx.outputStateAndRefs.single().state.contractState)
         assertEquals(utxoNotaryExample, tx.notary)
         assertEquals(utxoTimeWindowExample, tx.timeWindow)
+        assertEquals(publicKeyExample, tx.signatories.first())
     }
 
     @Test
@@ -42,6 +44,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .setNotary(utxoNotaryExample)
             .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
             .addOutputState(utxoStateExample)
+            .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .toSignedTransaction(publicKeyExample)
         assertIs<SecureHash>(tx.id)
@@ -50,6 +53,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
         assertEquals(utxoStateExample, tx.outputStateAndRefs.single().state.contractState)
         assertEquals(utxoNotaryExample, tx.notary)
         assertEquals(utxoTimeWindowExample, tx.timeWindow, )
+        assertEquals(publicKeyExample, tx.signatories.first())
     }
 
     // TODO Add tests for verification failures.
@@ -62,6 +66,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .addOutputState(utxoStateExample)
             .addInputState(getUtxoInvalidStateAndRef())
             .addReferenceInputState(getUtxoInvalidStateAndRef())
+            .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
             .toSignedTransaction(publicKeyExample) as UtxoSignedTransactionImpl
@@ -103,6 +108,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
                 .addOutputState(utxoStateExample)
                 .addInputState(getUtxoInvalidStateAndRef())
                 .addReferenceInputState(getUtxoInvalidStateAndRef())
+                .addSignatories(listOf(publicKeyExample))
                 .addCommand(UtxoCommandExample())
                 .addAttachment(SecureHash("SHA-256", ByteArray(12)))
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,8 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-#cordaApiVersion=5.0.0.508-beta+
-cordaApiVersion=5.0.0.508-alpha-1670003631763
+cordaApiVersion=5.0.0.508-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,8 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.507-beta+
+#cordaApiVersion=5.0.0.508-beta+
+cordaApiVersion=5.0.0.508-alpha-1670003631763
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualComponentGroup.kt
+++ b/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualComponentGroup.kt
@@ -8,7 +8,7 @@ package net.corda.ledger.consensual.data.transaction
  *
  * @property METADATA The metadata parameters component group. Ordinal = 0. (It needs to be in the first position.)
  * @property TIMESTAMP The timestamp parameter component group. Ordinal = 1.
- * @property REQUIRED_SIGNING_KEYS The required signing keys component group. Ordinal = 2.
+ * @property SIGNATORIES The required signing keys component group. Ordinal = 2.
  * @property OUTPUT_STATES The output states component group. Ordinal = 3.
  * @property OUTPUT_STATE_TYPES The output state types component group. Ordinal = 4.
  */
@@ -17,7 +17,7 @@ enum class ConsensualComponentGroup {
     METADATA, // needs to be in sync with
               // [net.corda.ledger.common.impl.transaction.WireTransactionImplKt.ALL_LEDGER_METADATA_COMPONENT_GROUP_ID]
     TIMESTAMP,
-    REQUIRED_SIGNING_KEYS,
+    SIGNATORIES,
     OUTPUT_STATES,
     OUTPUT_STATE_TYPES
 }

--- a/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualLedgerTransactionImpl.kt
+++ b/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualLedgerTransactionImpl.kt
@@ -23,7 +23,7 @@ class ConsensualLedgerTransactionImpl(
     }
     override val requiredSignatories: Set<PublicKey> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         wireTransaction
-            .getComponentGroupList(ConsensualComponentGroup.REQUIRED_SIGNING_KEYS.ordinal)
+            .getComponentGroupList(ConsensualComponentGroup.SIGNATORIES.ordinal)
             .map { serializationService.deserialize(it, PublicKey::class.java) }.toSet()
     }
     private val consensualStateTypes: List<String> by lazy(LazyThreadSafetyMode.PUBLICATION) {

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoComponentGroup.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoComponentGroup.kt
@@ -6,6 +6,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 enum class UtxoComponentGroup {
     METADATA,
     NOTARY,
+    SIGNATORIES,
     OUTPUTS_INFO,
     COMMANDS_INFO,
     DATA_ATTACHMENTS,

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
@@ -54,8 +54,9 @@ class WrappedUtxoWireTransaction(
     }
 
     val signatories: List<PublicKey> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        //TODO("Not yet implemented.")
-        emptyList()
+        wireTransaction
+            .getComponentGroupList(UtxoComponentGroup.SIGNATORIES.ordinal)
+            .map { serializationService.deserialize(it) }
     }
 
     val inputStateRefs: List<StateRef> by lazy(LazyThreadSafetyMode.PUBLICATION) {


### PR DESCRIPTION
* CORE-7270 Remove UtxoTransactionBuilder.addCommandAndSignatories
* CORE-7270 Save signatories into wiretransaction and load it in signed/ledger tx
* CORE-7270 Use Signatories instead of Signing keys in the related Consensual Component Group name



API PR: https://github.com/corda/corda-api/pull/721