### PR TITLE
NOTICK: Configure Quasar not to instrument more packages.

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -21,6 +21,7 @@ quasar {
     excludeLocations = [ 'PERSISTENCE/*', 'VERIFICATION/*' ]
     excludePackages.addAll([
             'org.eclipse.jetty**',
+            'org.hibernate.**',
             'net.corda.membership**'
     ])
 }

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -18,7 +18,6 @@ quasar {
         'io.micrometer.**',
         'kotlin**',
         'org.apache.**',
-        'org.hibernate.**',
         'org.objectweb.asm',
         'org.objenesis**',
         'org.osgi.**'

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -12,8 +12,13 @@ quasar {
     excludePackages = [
         'co.paralleluniverse**',
         'com.esotericsoftware.**',
+        'com.fasterxml.jackson.**',
+        'com.github.benmanes.caffeine**',
+        'com.typesafe.**',
+        'io.micrometer.**',
         'kotlin**',
         'org.apache.**',
+        'org.hibernate.**',
         'org.objectweb.asm',
         'org.objenesis**',
         'org.osgi.**'

--- a/components/virtual-node/sandbox-group-context-service/build.gradle
+++ b/components/virtual-node/sandbox-group-context-service/build.gradle
@@ -18,7 +18,7 @@ configurations {
 dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly "org.osgi:org.osgi.service.component.annotations"
+    compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -9,7 +9,8 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     compileOnly 'org.osgi:osgi.core'
-    compileOnly "org.osgi:osgi.annotation"
+    compileOnly 'org.osgi:osgi.annotation'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation 'org.slf4j:slf4j-api'

--- a/libs/metrics/src/main/java/net/corda/metrics/package-info.java
+++ b/libs/metrics/src/main/java/net/corda/metrics/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnorePackage
 package net.corda.metrics;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnorePackage;
 import org.osgi.annotation.bundle.Export;

--- a/libs/virtual-node/sandbox-group-context/build.gradle
+++ b/libs/virtual-node/sandbox-group-context/build.gradle
@@ -7,6 +7,7 @@ description "Sandbox Group Context Interfaces"
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 

--- a/libs/virtual-node/sandbox-group-context/src/main/java/net/corda/sandboxgroupcontext/package-info.java
+++ b/libs/virtual-node/sandbox-group-context/src/main/java/net/corda/sandboxgroupcontext/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.sandboxgroupcontext;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Configure Quasar not to instrument either Corda's metrics or its sandbox group context component. Also tell Quasar to ignore the following third-party dependencies:
- Micrometer
- Jackson
- Hibernate
- Caffeine
- Typesafe Config

This should reduce the Quasar-using workers' start-up times.

These Quasar annotations generate extra manifest attributes which tell Quasar not to instrument classes belonging to `${packageName}` and/or `${packageName}.**`, allowing Quasar to compute its configuration depending on which bundles exist in the OSGi framework. This approach obviously only works for Corda's own bundles.