### PR TITLE
NOTICK: update cron to run job every 6 hours rather than 3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaPipeline(
-    dailyBuildCron: 'H H/3 * * *',
+    dailyBuildCron: 'H H/6 * * *',
     nexusAppId: 'flow-worker-5.0',
     runIntegrationTests: true,
     publishRepoPrefix: 'corda-ent-maven',


### PR DESCRIPTION
Now that we have achieved a level of increased stability dropping frequency of the release branch execution to every 6 hours. once stability over time is confirmed we will revert to running once per night ( and on PR merges) 