### PR TITLE
NOTICK: Further tuning of Quasar instrumentation.

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -21,7 +21,8 @@ quasar {
     excludeLocations = [ 'PERSISTENCE/*', 'VERIFICATION/*' ]
     excludePackages.addAll([
             'org.eclipse.jetty**',
-            'org.hibernate.**',
+            'org.hibernate**',
+            'org.jboss.logging',
             'net.corda.membership**'
     ])
 }

--- a/libs/cache/cache-caffeine/build.gradle
+++ b/libs/cache/cache-caffeine/build.gradle
@@ -8,6 +8,7 @@ description 'Caffeine cache utilities'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":libs:metrics")

--- a/libs/cache/cache-caffeine/src/main/java/net/corda/cache/caffeine/package-info.java
+++ b/libs/cache/cache-caffeine/src/main/java/net/corda/cache/caffeine/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnorePackage
 package net.corda.cache.caffeine;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnorePackage;
 import org.osgi.annotation.bundle.Export;

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -36,6 +36,7 @@ configurations {
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     api platform("net.corda:corda-api:$cordaApiVersion")
 

--- a/libs/packaging/packaging/src/main/java/net/corda/libs/packaging/package-info.java
+++ b/libs/packaging/packaging/src/main/java/net/corda/libs/packaging/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.libs.packaging;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Exclude more packages from Quasar instrumentation:
- Corda's packaging libraries
- Corda's cache library (which wraps caffeine)
- All Hibernate classes
- JBoss Logging, which is used by Hibernate