### PR TITLE
CORE-8701 Remove duplicate MemberInfo extension property

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -8,7 +8,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.libs.platform.PlatformInfoProvider
-import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
@@ -148,7 +148,7 @@ internal class MGMRegistrationMemberInfoHandler(
         return memberInfoFactory.create(
             memberContext = memberContext.toSortedMap(),
             mgmContext = sortedMapOf(
-                CREATED_TIME to now,
+                CREATION_TIME to now,
                 MODIFIED_TIME to now,
                 STATUS to MEMBER_STATUS_ACTIVE,
                 IS_MGM to "true"

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
@@ -11,7 +11,7 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.impl.registration.TEST_CPI_NAME
 import net.corda.membership.impl.registration.TEST_CPI_VERSION
-import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
@@ -292,7 +292,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         }
 
         assertThat(mgmContext)
-            .containsOnlyKeys(CREATED_TIME, MODIFIED_TIME, STATUS, IS_MGM)
+            .containsOnlyKeys(CREATION_TIME, MODIFIED_TIME, STATUS, IS_MGM)
             .containsEntry(STATUS, MEMBER_STATUS_ACTIVE)
             .containsEntry(IS_MGM, true.toString())
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -37,7 +37,7 @@ import net.corda.membership.impl.registration.TEST_SOFTWARE_VERSION
 import net.corda.membership.impl.registration.buildMockPlatformInfoProvider
 import net.corda.membership.impl.registration.buildTestVirtualNodeInfo
 import net.corda.membership.lib.GroupParametersFactory
-import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
@@ -349,7 +349,7 @@ class MGMRegistrationServiceTest {
                 it.assertThat(persistedMgm.mgmContext.items.map { item -> item.key })
                     .containsExactlyInAnyOrderElementsOf(
                         listOf(
-                            CREATED_TIME,
+                            CREATION_TIME,
                             MODIFIED_TIME,
                             STATUS,
                             IS_MGM

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -77,9 +77,6 @@ class MemberInfoExtension {
         /** Key name for certificate property. */
         const val CERTIFICATE = "corda.session.certificate"
 
-        /** Key name for created time property. */
-        const val CREATED_TIME = "corda.createdTime"
-
         /** Key name for modified time property. */
         const val MODIFIED_TIME = "corda.modifiedTime"
 

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImpl.kt
@@ -2,7 +2,7 @@ package net.corda.membership.lib.impl.grouppolicy
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import net.corda.membership.lib.MemberInfoExtension.Companion.CREATED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
@@ -111,7 +111,7 @@ class GroupPolicyParserImpl @Activate constructor(
         }
     } ?: throw BadGroupPolicyException("Could not find $GROUP_ID at the root level of the group policy file.")
 
-    @Suppress("UNCHECKED_CAST", "SpreadOperator")
+    @Suppress("SpreadOperator")
     override fun getMgmInfo(
         holdingIdentity: HoldingIdentity,
         groupPolicy: String
@@ -130,7 +130,7 @@ class GroupPolicyParserImpl @Activate constructor(
             memberInfoFactory.create(
                 it.toSortedMap(),
                 sortedMapOf(
-                    CREATED_TIME to now,
+                    CREATION_TIME to now,
                     MODIFIED_TIME to now,
                     STATUS to MEMBER_STATUS_ACTIVE,
                     IS_MGM to "true"


### PR DESCRIPTION
Removes MemberInfo extension property `CREATED_TIME`, and updates all usages to existing `CREATION_TIME` property.
https://r3-cev.atlassian.net/browse/CORE-8701