### PR TITLE
CORE-8626: Fix query parameters encoding in permission strings

### DIFF
--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CheckClusterRolesE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CheckClusterRolesE2eTest.kt
@@ -3,6 +3,8 @@ package net.corda.applications.workers.rpc
 import net.corda.applications.workers.rpc.http.SkipWhenRpcEndpointUnavailable
 import net.corda.applications.workers.rpc.http.TestToolkitProperty
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
+import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionResponseType
+import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionType
 import net.corda.libs.permissions.endpoints.v1.role.RoleEndpoint
 import net.corda.libs.permissions.endpoints.v1.role.types.RoleResponseType
 import org.assertj.core.api.Assertions.assertThat
@@ -21,6 +23,11 @@ class CheckClusterRolesE2eTest {
 
     @Test
     fun `test UserAdminRole content`() {
+
+        fun wildcardMatch(permissionString: String, permissionRequested: String): Boolean {
+            return permissionRequested.matches(permissionString.toRegex(RegexOption.IGNORE_CASE))
+        }
+
         testToolkit.httpClientFor(RoleEndpoint::class.java).use { roleClient ->
             val roleProxy = roleClient.start().proxy
 
@@ -31,9 +38,16 @@ class CheckClusterRolesE2eTest {
 
             testToolkit.httpClientFor(PermissionEndpoint::class.java).use { permClient ->
                 val permProxy = permClient.start().proxy
-                val permissions = userAdminRole.permissions.map { permProxy.getPermission(it.id) }
+                val permissions: List<PermissionResponseType> =
+                    userAdminRole.permissions.map { permProxy.getPermission(it.id) }
                 assertThat(permissions.size).withFailMessage("Permissions: $permissions").isEqualTo(14)
                 assertThat(permissions.map { it.permissionString }).contains("POST:/api/v1/user")
+                assertThat(permissions.filter { it.permissionType == PermissionType.ALLOW }).anyMatch {
+                    wildcardMatch(
+                        it.permissionString,
+                        "GET:/api/v1/user?loginname=RandomUser"
+                    )
+                }
             }
         }
     }

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
@@ -23,7 +23,7 @@ class UserAdminSubcommand : HttpRpcCommand(), Callable<Int> {
     private val permissionsToCreate: Map<String, String> = listOf(
         // User manipulation permissions
         "CreateUsers" to "POST:/api/v1/user",
-        "GetUsers" to "GET:/api/v1/user?loginName=$USER_URL_REGEX",
+        "GetUsers" to "GET:/api/v1/user\\?loginName=$USER_URL_REGEX",
         "AddRoleToUser" to "PUT:/api/v1/user/$USER_URL_REGEX/role/$UUID_REGEX",
         "DeleteRoleFromUser" to "DELETE:/api/v1/user/$USER_URL_REGEX/role/$UUID_REGEX",
         "GetPermissionsSummary" to "GET:/api/v1/user/$USER_URL_REGEX/permissionSummary",
@@ -31,7 +31,7 @@ class UserAdminSubcommand : HttpRpcCommand(), Callable<Int> {
         // Permission manipulation permissions ;-)
         "CreatePermission" to "POST:/api/v1/permission",
         "BulkCreatePermissions" to "POST:/api/v1/permission/bulk",
-        "QueryPermissions" to "GET:/api/v1/permission?.*",
+        "QueryPermissions" to "GET:/api/v1/permission\\?.*",
         "GetPermission" to "GET:/api/v1/permission/$UUID_REGEX",
 
         // Role manipulation permissions


### PR DESCRIPTION
Also extended E2E test to prove that fix works.