### PR TITLE
CORE-8870 Tidy up static registration to reduce the time taken to complete registration

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -135,7 +135,7 @@ pipeline {
         }
         stage('smoketests') {
                 options {
-                    timeout(time: 20, unit: 'MINUTES')
+                    timeout(time: 15, unit: 'MINUTES')
                 }
                 steps {
                    gradlew('smoketest -PisCombinedWorker=true')

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -135,7 +135,7 @@ pipeline {
         }
         stage('smoketests') {
                 options {
-                    timeout(time: 15, unit: 'MINUTES')
+                    timeout(time: 20, unit: 'MINUTES')
                 }
                 steps {
                    gradlew('smoketest -PisCombinedWorker=true')

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/FlowTestUtils.kt
@@ -7,6 +7,7 @@ import net.corda.applications.workers.smoketest.virtualnode.helpers.assertWithRe
 import net.corda.applications.workers.smoketest.virtualnode.helpers.cluster
 import net.corda.httprpc.ResponseCode.OK
 import net.corda.test.util.eventually
+import net.corda.v5.base.util.seconds
 import org.apache.commons.text.StringEscapeUtils.escapeJson
 import org.assertj.core.api.Assertions.assertThat
 import java.security.MessageDigest
@@ -173,11 +174,11 @@ fun registerMember(holdingIdentityShortHash: String, isNotary: Boolean = false) 
         assertThat(registrationStatus).isEqualTo("SUBMITTED")
 
         assertWithRetry {
-            // Use a fairly long interval and timeout here to give plenty of time for the other side to respond. Longer
+            // Use a fairly long timeout here to give plenty of time for the other side to respond. Longer
             // term this should be changed to not use the RPC message pattern and have the information available in a
             // cache on the RPC worker, but for now this will have to suffice.
-            timeout(Duration.ofSeconds(60))
-            interval(Duration.ofSeconds(15))
+            timeout(60.seconds)
+            interval(1.seconds)
             command { getRegistrationStatus(holdingIdentityShortHash) }
             condition {
                 it.toJson().firstOrNull()?.get("registrationStatus")?.textValue() == "APPROVED"

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/KeysFactory.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/KeysFactory.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts.SigningKeyFilters.ALIAS_FILTER
 import net.corda.crypto.core.CryptoConsts.SigningKeyFilters.CATEGORY_FILTER
+import net.corda.crypto.core.KeyAlreadyExistsException
 import net.corda.data.crypto.wire.ops.rpc.queries.CryptoKeyOrderBy
 import net.corda.membership.p2p.helpers.KeySpecExtractor
 import net.corda.v5.crypto.calculateHash
@@ -18,25 +19,30 @@ internal class KeysFactory(
     private val keySpecExtractor by lazy {
         KeySpecExtractor(tenantId, cryptoOpsClient)
     }
+
     fun getOrGenerateKeyPair(category: String): KeyDetails {
         val alias = "$tenantId-$category"
-        val key = cryptoOpsClient.lookup(
-            tenantId = tenantId,
-            skip = 0,
-            take = 10,
-            orderBy = CryptoKeyOrderBy.NONE,
-            filter = mapOf(
-                ALIAS_FILTER to alias,
-                CATEGORY_FILTER to category,
+        val key = try {
+            cryptoOpsClient.generateKeyPair(
+                tenantId = tenantId,
+                category = category,
+                alias = alias,
+                scheme = scheme
             )
-        ).firstOrNull()?.let {
-            keyEncodingService.decodePublicKey(it.publicKey.array())
-        } ?: cryptoOpsClient.generateKeyPair(
-            tenantId = tenantId,
-            category = category,
-            alias = alias,
-            scheme = scheme
-        )
+        } catch (e: KeyAlreadyExistsException) {
+            cryptoOpsClient.lookup(
+                tenantId = tenantId,
+                skip = 0,
+                take = 1,
+                orderBy = CryptoKeyOrderBy.NONE,
+                filter = mapOf(
+                    ALIAS_FILTER to alias,
+                    CATEGORY_FILTER to category,
+                )
+            ).first().let {
+                keyEncodingService.decodePublicKey(it.publicKey.array())
+            }
+        }
         return Key(key)
     }
 
@@ -49,7 +55,7 @@ internal class KeysFactory(
         override val hash by lazy {
             publicKey.calculateHash()
         }
-        override  val spec by lazy {
+        override val spec by lazy {
             keySpecExtractor.getSpec(publicKey)
         }
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -4,8 +4,9 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.client.hsm.HSMRegistrationClient
-import net.corda.crypto.core.CryptoConsts
+import net.corda.crypto.core.CryptoConsts.Categories.LEDGER
 import net.corda.crypto.core.CryptoConsts.Categories.NOTARY
+import net.corda.crypto.core.CryptoConsts.Categories.SESSION_INIT
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
@@ -18,6 +19,7 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.impl.registration.KeyDetails
 import net.corda.membership.impl.registration.KeysFactory
 import net.corda.membership.impl.registration.MemberRole
 import net.corda.membership.impl.registration.MemberRole.Companion.toMemberInfo
@@ -46,6 +48,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.membership.lib.MemberInfoExtension.Companion.notaryDetails
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.grouppolicy.GroupPolicy
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.ProtocolParameters.SessionKeyPolicy
 import net.corda.membership.lib.registration.RegistrationRequest
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidationException
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
@@ -65,7 +68,6 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.versioning.Version
-import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -228,18 +230,17 @@ class StaticMemberRegistrationService @Activate constructor(
 
         // If this member is a notary, persist updated group parameters for other members who have a vnode set up.
         // Also publish to Kafka.
-        memberInfo.notaryDetails?.let {
-            val groupId = memberInfo.groupId
+        if (memberInfo.notaryDetails != null) {
             staticMemberList
-                .filterNot { it.name == memberInfo.name.toString() }
-                .forEach { staticMember ->
-                val name = MemberX500Name.parse(staticMember.name!!)
-                virtualNodeInfoReadService.get(HoldingIdentity(name, groupId))?.let {
-                    val peer = it.holdingIdentity
-                    persistenceClient.persistGroupParameters(peer, groupParameters)
-                    groupParametersWriterService.put(peer, groupParameters)
+                .parallelStream()
+                .map { MemberX500Name.parse(it.name!!) }
+                .filter { it != memberInfo.name }
+                .map { HoldingIdentity(it, memberInfo.groupId) }
+                .filter { virtualNodeInfoReadService.get(it) != null }
+                .forEach {
+                    persistenceClient.persistGroupParameters(it, groupParameters)
+                    groupParametersWriterService.put(it, groupParameters)
                 }
-            }
         }
     }
 
@@ -274,28 +275,35 @@ class StaticMemberRegistrationService @Activate constructor(
         roles: Collection<MemberRole>,
         staticMemberList: List<StaticMember>,
     ): Pair<MemberInfo, List<Record<String, PersistentMemberInfo>>> {
-        val groupId = groupPolicy.groupId
-
         validateStaticMemberList(staticMemberList)
 
         val memberName = registeringMember.x500Name
         val memberId = registeringMember.shortHash.value
-
-        assignSoftHsm(memberId)
 
         val staticMemberInfo = staticMemberList.firstOrNull {
             MemberX500Name.parse(it.name!!) == memberName
         } ?: throw IllegalArgumentException("Our membership $memberName is not listed in the static member list.")
 
         validateStaticMemberDeclaration(staticMemberInfo)
-        // single key used as both session and ledger key
+        // single key scheme used for both session and ledger key
         val keysFactory = KeysFactory(
             cryptoOpsClient,
             keyEncodingService,
             keyScheme,
             memberId,
         )
-        val memberKey = keysFactory.getOrGenerateKeyPair(CryptoConsts.Categories.LEDGER)
+        hsmRegistrationClient.assignSoftHSM(memberId, LEDGER)
+        val ledgerKey = keysFactory.getOrGenerateKeyPair(LEDGER)
+
+        val sessionKey = when(groupPolicy.protocolParameters.sessionKeyPolicy) {
+            SessionKeyPolicy.DISTINCT -> {
+                hsmRegistrationClient.assignSoftHSM(memberId, SESSION_INIT)
+                keysFactory.getOrGenerateKeyPair(SESSION_INIT)
+            }
+            SessionKeyPolicy.COMBINED -> {
+                ledgerKey
+            }
+        }
 
         val cpi = virtualNodeInfoReadService.get(registeringMember)?.cpiIdentifier
             ?: throw CordaRuntimeException("Could not find virtual node info for member ${registeringMember.shortHash}")
@@ -303,18 +311,22 @@ class StaticMemberRegistrationService @Activate constructor(
         val optionalContext = cpi.signerSummaryHash?.let {
             mapOf(MEMBER_CPI_SIGNER_HASH to it.toString())
         } ?: emptyMap()
+
+        fun configureNotaryKey(): List<KeyDetails> {
+            hsmRegistrationClient.assignSoftHSM(memberId, NOTARY)
+            return listOf(keysFactory.getOrGenerateKeyPair(NOTARY))
+        }
+
         @Suppress("SpreadOperator")
         val memberContext = mapOf(
             PARTY_NAME to memberName.toString(),
-            PARTY_SESSION_KEY to memberKey.pem,
-            GROUP_ID to groupId,
-            *generateLedgerKeys(memberKey.pem).toTypedArray(),
-            *generateLedgerKeyHashes(memberKey.hash).toTypedArray(),
+            PARTY_SESSION_KEY to sessionKey.pem,
+            SESSION_KEY_HASH to sessionKey.hash.toString(),
+            GROUP_ID to groupPolicy.groupId,
+            LEDGER_KEYS_KEY.format(0) to ledgerKey.pem,
+            LEDGER_KEY_HASHES_KEY.format(0) to ledgerKey.hash.toString(),
             *convertEndpoints(staticMemberInfo).toTypedArray(),
-            *roles.toMemberInfo {
-                listOf(keysFactory.getOrGenerateKeyPair(NOTARY))
-            }.toTypedArray(),
-            SESSION_KEY_HASH to memberKey.hash.toString(),
+            *roles.toMemberInfo(::configureNotaryKey).toTypedArray(),
             SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
             PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
             MEMBER_CPI_NAME to cpi.name,
@@ -331,8 +343,7 @@ class StaticMemberRegistrationService @Activate constructor(
         )
 
         return memberInfo to staticMemberList.map {
-            val owningMemberName = MemberX500Name.parse(it.name!!).toString()
-            val owningMemberHoldingIdentity = HoldingIdentity(MemberX500Name.parse(owningMemberName), groupId)
+            val owningMemberHoldingIdentity = HoldingIdentity(MemberX500Name.parse(it.name!!), groupPolicy.groupId)
             Record(
                 MEMBER_LIST_TOPIC,
                 "${owningMemberHoldingIdentity.shortHash}-$memberId",
@@ -393,17 +404,6 @@ class StaticMemberRegistrationService @Activate constructor(
     }
 
     /**
-     * Assigns soft HSM to the registering member.
-     */
-    private fun assignSoftHsm(memberId: String) {
-        CryptoConsts.Categories.all.forEach {
-            if (hsmRegistrationClient.findHSM(memberId, it) == null) {
-                hsmRegistrationClient.assignSoftHSM(memberId, it)
-            }
-        }
-    }
-
-    /**
      * Mapping the keys from the json format to the keys expected in the [MemberInfo].
      */
     private fun convertEndpoints(member: StaticMember): List<Pair<String, String>> {
@@ -429,37 +429,5 @@ class StaticMemberRegistrationService @Activate constructor(
             )
         }
         return result
-    }
-
-    /**
-     * Only going to contain the common session and ledger key for passing the checks on the MemberInfo creation side.
-     * For the static network we don't need the rotated keys.
-     */
-    private fun generateLedgerKeys(
-        memberKey: String
-    ): List<Pair<String, String>> {
-        val ledgerKeys = listOf(memberKey)
-        return ledgerKeys.mapIndexed { index, ledgerKey ->
-            String.format(
-                LEDGER_KEYS_KEY,
-                index
-            ) to ledgerKey
-        }
-    }
-
-    /**
-     * Only going to contain hash of the common session and ledger key for passing the checks on the MemberInfo creation side.
-     * For the static network we don't need hashes of the rotated keys.
-     */
-    private fun generateLedgerKeyHashes(
-        memberKeyHash: PublicKeyHash
-    ): List<Pair<String, String>> {
-        val ledgerKeys = listOf(memberKeyHash)
-        return ledgerKeys.mapIndexed { index, ledgerKeyHash ->
-            String.format(
-                LEDGER_KEY_HASHES_KEY,
-                index
-            ) to ledgerKeyHash.toString()
-        }
     }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/cache/GroupParametersCache.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/cache/GroupParametersCache.kt
@@ -86,20 +86,16 @@ class GroupParametersCache(
     }
 
     private fun createGroupParametersSnapshot(holdingIdentity: HoldingIdentity): KeyValuePairList {
-        val groupParameters = KeyValuePairList(
+        return KeyValuePairList(
             listOf(
                 KeyValuePair(EPOCH_KEY, "1"),
                 KeyValuePair(MPV_KEY, platformInfoProvider.activePlatformVersion.toString()),
                 KeyValuePair(MODIFIED_TIME_KEY, clock.instant().toString())
             )
-        )
-        val groupId = holdingIdentity.groupId
-
-        set(groupId, groupParameters)
-
-        groupParameters.publish(groupId)
-
-        return groupParameters
+        ).apply {
+            set(holdingIdentity.groupId, this)
+            publish(holdingIdentity.groupId)
+        }
     }
 
     private fun KeyValuePairList.publish(groupId: String) {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts.SigningKeyFilters.ALIAS_FILTER
 import net.corda.crypto.core.CryptoConsts.SigningKeyFilters.CATEGORY_FILTER
+import net.corda.crypto.core.KeyAlreadyExistsException
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -24,8 +26,8 @@ import java.security.PublicKey
 class KeysFactoryTest {
     private val tenantId = "tenantId"
     private val scheme = "scheme"
-    private val exitedCategory = "category-one"
-    private val missingCategory = "category-two"
+    private val noExistingKeyCategory = "category-one"
+    private val existingKeyCategory = "category-two"
     private val encoded = byteArrayOf(33, 1)
     private val publicKey = mock<PublicKey> {
         on { encoded } doReturn encoded
@@ -46,34 +48,33 @@ class KeysFactoryTest {
                 any(),
                 any(),
                 argThat {
-                    this[CATEGORY_FILTER] == exitedCategory &&
+                    this[CATEGORY_FILTER] == existingKeyCategory &&
                         this.containsKey(ALIAS_FILTER)
                 },
             )
         } doReturn listOf(cryptoSigningKey)
         on {
-            lookup(
-                eq(tenantId),
-                eq(0),
-                any(),
-                any(),
-                argThat {
-                    this[CATEGORY_FILTER] == missingCategory &&
-                        this.containsKey(ALIAS_FILTER)
-                },
-            )
-        } doReturn emptyList()
-        on {
             generateKeyPair(
                 tenantId = eq(tenantId),
-                category = eq(missingCategory),
+                category = eq(noExistingKeyCategory),
                 alias = argThat {
-                    this.contains(missingCategory)
+                    this.contains(noExistingKeyCategory)
                 },
                 scheme = eq(scheme),
                 context = any(),
             )
         } doReturn publicKey
+        on {
+            generateKeyPair(
+                tenantId = eq(tenantId),
+                category = eq(existingKeyCategory),
+                alias = argThat {
+                    this.contains(existingKeyCategory)
+                },
+                scheme = eq(scheme),
+                context = any(),
+            )
+        } doThrow KeyAlreadyExistsException("")
         on {
             lookup(tenantId, listOf(publicKey.publicKeyId()))
         } doReturn listOf(cryptoSigningKey)
@@ -87,48 +88,62 @@ class KeysFactoryTest {
     )
 
     @Test
-    fun `if the key exists, new key will not be generated`() {
-        keysFactory.getOrGenerateKeyPair(exitedCategory)
+    fun `new key will be generated, and lookup is not performed if the key doesn't already exist for alias and category`() {
+        keysFactory.getOrGenerateKeyPair(noExistingKeyCategory)
 
-        verify(cryptoOpsClient, never()).generateKeyPair(
+        verify(cryptoOpsClient).generateKeyPair(
             any(),
             any(),
             any(),
             any(),
             any<Map<String, String>>(),
         )
+        verify(cryptoOpsClient, never()).lookup(
+            any(),
+            any(),
+            any(),
+            any(),
+            any()
+        )
     }
 
     @Test
-    fun `if the key is missing, new key will be generated`() {
-        keysFactory.getOrGenerateKeyPair(missingCategory)
+    fun `if the key is exists already, a lookup is performed to get that key`() {
+        keysFactory.getOrGenerateKeyPair(existingKeyCategory)
 
         verify(cryptoOpsClient).generateKeyPair(
             any(),
-            category = eq(missingCategory),
+            category = eq(existingKeyCategory),
             any(),
             any(),
             any<Map<String, String>>(),
+        )
+        verify(cryptoOpsClient).lookup(
+            any(),
+            any(),
+            any(),
+            any(),
+            any()
         )
     }
 
     @Test
     fun `pem returns the correct PEM`() {
-        val key = keysFactory.getOrGenerateKeyPair(exitedCategory)
+        val key = keysFactory.getOrGenerateKeyPair(noExistingKeyCategory)
 
         assertThat(key.pem).isEqualTo("PEM")
     }
 
     @Test
     fun `hash returns the correct hash`() {
-        val key = keysFactory.getOrGenerateKeyPair(missingCategory)
+        val key = keysFactory.getOrGenerateKeyPair(existingKeyCategory)
 
         assertThat(key.hash).isEqualTo(publicKey.calculateHash())
     }
 
     @Test
     fun `spec returns the correct signature spec`() {
-        val key = keysFactory.getOrGenerateKeyPair(exitedCategory)
+        val key = keysFactory.getOrGenerateKeyPair(noExistingKeyCategory)
 
         assertThat(key.spec).isEqualTo(SignatureSpec.ECDSA_SHA256)
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
@@ -129,22 +129,28 @@ class KeysFactoryTest {
 
     @Test
     fun `pem returns the correct PEM`() {
-        val key = keysFactory.getOrGenerateKeyPair(noExistingKeyCategory)
-
-        assertThat(key.pem).isEqualTo("PEM")
+        assertThat(
+            keysFactory
+                .getOrGenerateKeyPair(noExistingKeyCategory)
+                .pem
+        ).isEqualTo("PEM")
     }
 
     @Test
     fun `hash returns the correct hash`() {
-        val key = keysFactory.getOrGenerateKeyPair(existingKeyCategory)
-
-        assertThat(key.hash).isEqualTo(publicKey.calculateHash())
+        assertThat(
+            keysFactory
+                .getOrGenerateKeyPair(existingKeyCategory)
+                .hash
+        ).isEqualTo(publicKey.calculateHash())
     }
 
     @Test
     fun `spec returns the correct signature spec`() {
-        val key = keysFactory.getOrGenerateKeyPair(noExistingKeyCategory)
-
-        assertThat(key.spec).isEqualTo(SignatureSpec.ECDSA_SHA256)
+        assertThat(
+            keysFactory
+                .getOrGenerateKeyPair(noExistingKeyCategory)
+                .spec
+        ).isEqualTo(SignatureSpec.ECDSA_SHA256)
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -303,7 +303,7 @@ class StaticMemberRegistrationServiceTest {
             verify(hsmRegistrationClient).assignSoftHSM(aliceId.value, LEDGER)
             verify(cryptoOpsClient).generateKeyPair(any(), eq(LEDGER), any(), any(), any<Map<String, String>>())
 
-            (CryptoConsts.Categories.all - listOf(LEDGER)).forEach {
+            (CryptoConsts.Categories.all.minus(listOf(LEDGER))).forEach {
                 verify(hsmRegistrationClient, never()).assignSoftHSM(aliceId.value, it)
                 verify(cryptoOpsClient, never()).generateKeyPair(any(), eq(it), any(), any(), any<Map<String, String>>())
             }
@@ -366,7 +366,7 @@ class StaticMemberRegistrationServiceTest {
             verify(cryptoOpsClient).generateKeyPair(any(), eq(LEDGER), any(), any(), any<Map<String, String>>())
             verify(cryptoOpsClient).generateKeyPair(any(), eq(SESSION_INIT), any(), any(), any<Map<String, String>>())
 
-            (CryptoConsts.Categories.all - listOf(SESSION_INIT, LEDGER)).forEach {
+            (CryptoConsts.Categories.all.minus(listOf(SESSION_INIT, LEDGER))).forEach {
                 verify(hsmRegistrationClient, never()).assignSoftHSM(aliceId.value, it)
                 verify(cryptoOpsClient, never()).generateKeyPair(any(), eq(it), any(), any(), any<Map<String, String>>())
             }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/TestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/TestUtils.kt
@@ -28,6 +28,7 @@ import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.ProtocolParameters.SessionKeyPolicy.COMBINED
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.ProtocolParameters.SessionKeyPolicy.DISTINCT
 import net.corda.membership.lib.impl.grouppolicy.v1.MemberGroupPolicyImpl
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.base.types.MemberX500Name
@@ -100,6 +101,35 @@ class TestUtils {
                     "$SYNC_PROTOCOL": "com.foo.bar.SyncProtocol",
                     "$PROTOCOL_PARAMETERS": {
                         "$SESSION_KEY_POLICY": "$COMBINED",
+                        "$STATIC_NETWORK": {
+                            "$MEMBERS": $staticMemberTemplate
+                        }
+                    },
+                    "$P2P_PARAMETERS": {
+                        "$SESSION_PKI": "$NO_PKI",
+                        "$TLS_TRUST_ROOTS": [
+                            "$r3comCert"
+                        ],
+                        "$TLS_PKI": "$STANDARD",
+                        "$TLS_VERSION": "$VERSION_1_3",
+                        "$PROTOCOL_MODE": "$AUTH_ENCRYPT"
+                    },
+                    "$CIPHER_SUITE": {}
+                }
+            """.trimIndent()
+            )
+        )
+
+        val groupPolicyWithStaticNetworkAndDistinctKeys = MemberGroupPolicyImpl(
+            ObjectMapper().readTree(
+                """
+                {
+                    "$FILE_FORMAT_VERSION": 1,
+                    "$GROUP_ID": "$DUMMY_GROUP_ID",
+                    "$REGISTRATION_PROTOCOL": "com.foo.bar.RegistrationProtocol",
+                    "$SYNC_PROTOCOL": "com.foo.bar.SyncProtocol",
+                    "$PROTOCOL_PARAMETERS": {
+                        "$SESSION_KEY_POLICY": "$DISTINCT",
                         "$STATIC_NETWORK": {
                             "$MEMBERS": $staticMemberTemplate
                         }


### PR DESCRIPTION
A number of issues were found here which all added up to cause the slow processing of registrations:
* The utility function for registering in the smoke tests had a 15 second interval between checking for successful registration. If registration wasn’t complete within 15 seconds the test would pause until 30 seconds had passed (or 45 seconds if registration still hadn’t completed after 30).
* The static registration was assigning a HSM for every crypto category (8 categories) for every member registering. In reality we only need to assign one in most cases and occasionally 2 or 3 (depending on the vnode configuration)
* We were always checking if a key already exists before creating one. Almost always, the key is not already existing so this extra RPC call to the crypto processor is rarely required. When creating a key, the crypto processor will throw an exception to indicate the key already exists so I’ve flipped the logic to try create the key first, and then if it already exists, a lookup is done.
* When onboarding a notary it is slower than a regular member because of extra processing (persistence per existing vnode). This can be parallelised to cut down on processing time.
* The database reconciliation was happening every 30 seconds for three different reconcilers. As the number of members in the group grows, so does the processing time for the group parameters reconciliation. We don’t expect the group parameters to change often so I’ve increased the interval for this reconciler to two minutes. https://github.com/corda/corda-api/pull/725

In general the crypto operations are quite slow. It seems to take ~4-5 seconds to assign a soft HSM and generate a key in the HSM. I've tried to reduce our calls to the crypto worker where possible. 
