### PR TITLE
NOTICK: Ensure LayeredPropertyMapFactory always finds all CustomPropertyConverters.

### DIFF
--- a/components/membership/membership-persistence-client-impl/build.gradle
+++ b/components/membership/membership-persistence-client-impl/build.gradle
@@ -26,5 +26,6 @@ dependencies {
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+    testImplementation project(':testing:layered-property-map-testkit')
     testImplementation project(':testing:test-utilities')
 }

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -20,8 +20,7 @@ import net.corda.data.membership.db.response.query.MemberSignatureQueryResponse
 import net.corda.data.membership.db.response.query.PersistenceFailedResponse
 import net.corda.data.membership.db.response.query.RegistrationRequestQueryResponse
 import net.corda.data.membership.db.response.query.RegistrationRequestsQueryResponse
-import net.corda.layeredpropertymap.LayeredPropertyMapFactory
-import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
+import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -102,7 +101,7 @@ class MembershipQueryClientImplTest {
     private val memberInfoFactory: MemberInfoFactory = mock {
         on { create(any()) } doReturn ourMemberInfo
     }
-    private val layeredPropertyMapFactory: LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(emptyList())
+    private val layeredPropertyMapFactory = LayeredPropertyMapMocks.createFactory(emptyList())
 
     private val testConfig =
         SmartConfigFactory.create(ConfigFactory.empty()).create(ConfigFactory.parseString("instanceId=1"))

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -16,8 +16,7 @@ import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.event.MembershipEvent
 import net.corda.data.membership.event.registration.MgmOnboarded
-import net.corda.layeredpropertymap.LayeredPropertyMapFactory
-import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
+import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -105,7 +104,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.security.PublicKey
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 class MGMRegistrationServiceTest {
@@ -189,7 +188,7 @@ class MGMRegistrationServiceTest {
     private val configurationReadService: ConfigurationReadService = mock {
         on { registerComponentForUpdates(eq(coordinator), any()) } doReturn configHandle
     }
-    private val layeredPropertyMapFactory: LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(
+    private val layeredPropertyMapFactory = LayeredPropertyMapMocks.createFactory(
         listOf(
             EndpointInfoConverter(),
             MemberNotaryDetailsConverter(keyEncodingService),

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -13,8 +13,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.common.RegistrationStatus
-import net.corda.layeredpropertymap.LayeredPropertyMapFactory
-import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
+import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
@@ -215,7 +214,7 @@ class StaticMemberRegistrationServiceTest {
         }
     }
 
-    private val layeredPropertyMapFactory: LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(
+    private val layeredPropertyMapFactory = LayeredPropertyMapMocks.createFactory(
         listOf(
             EndpointInfoConverter(),
             MemberNotaryDetailsConverter(keyEncodingService),

--- a/libs/layered-property-map/build.gradle
+++ b/libs/layered-property-map/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
+    api "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     implementation "net.corda:corda-avro-schema"

--- a/libs/layered-property-map/src/integrationTest/kotlin/net/corda/layeredpropertymap/tests/LayeredPropertyMapFactoryTests.kt
+++ b/libs/layered-property-map/src/integrationTest/kotlin/net/corda/layeredpropertymap/tests/LayeredPropertyMapFactoryTests.kt
@@ -30,7 +30,7 @@ class LayeredPropertyMapFactoryTests {
         )
 
     @Test
-    fun `Should be able to create instance of LayredPropertyMap with custom converters`() {
+    fun `Should be able to create instance of LayeredPropertyMap with custom converters`() {
         val layeredPropertyMap = facttory.createMap(createMap())
         assertEquals(42, layeredPropertyMap.parse("number"))
         val complexList = layeredPropertyMap.parseList<IntegrationDummyEndpointInfo>("corda.endpoints")

--- a/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapFactoryImpl.kt
+++ b/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapFactoryImpl.kt
@@ -4,37 +4,42 @@ import net.corda.layeredpropertymap.CustomPropertyConverter
 import net.corda.layeredpropertymap.LayeredPropertyMapFactory
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.util.contextLogger
+import org.osgi.service.component.ComponentContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality
-import org.osgi.service.component.annotations.ReferencePolicyOption
+import org.osgi.service.component.annotations.ReferencePolicy
 
-@Component(service = [LayeredPropertyMapFactory::class])
-class LayeredPropertyMapFactoryImpl @Activate constructor(
-    @Reference(
-        service = CustomPropertyConverter::class,
-        cardinality = ReferenceCardinality.MULTIPLE,
-        policyOption = ReferencePolicyOption.GREEDY
-    )
-    val customConverters: List<CustomPropertyConverter<out Any>>
-) : LayeredPropertyMapFactory {
-
-    private val converter = PropertyConverter(customConverters.associateBy { it.type })
-
-    companion object {
-        val logger = contextLogger()
-    }
-
-    init {
-        logger.info(
-            "{}", customConverters.joinToString(
-                prefix = "Loaded custom property converters: [",
-                postfix = "]",
-                transform = { it.javaClass.name }
-            )
+@Component(
+    service = [ LayeredPropertyMapFactory::class ],
+    reference = [
+        Reference(
+            name = LayeredPropertyMapFactoryImpl.CUSTOM_CONVERTERS_REFERENCE_NAME,
+            service = CustomPropertyConverter::class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC
         )
+    ]
+)
+class LayeredPropertyMapFactoryImpl @Activate constructor(
+    private val componentContext: ComponentContext
+) : LayeredPropertyMapFactory {
+    companion object {
+        const val CUSTOM_CONVERTERS_REFERENCE_NAME = "customConverters"
+        private val logger = contextLogger()
     }
+
+    @Suppress("unchecked_cast", "SameParameterValue")
+    private fun <T> fetchServices(name: String): List<T> {
+        return (componentContext.locateServices(name) as? Array<T>)?.toList() ?: emptyList()
+    }
+
+    private val customConverters: List<CustomPropertyConverter<out Any>>
+        get() = fetchServices(CUSTOM_CONVERTERS_REFERENCE_NAME)
+
+    private val converter
+        get() = PropertyConverter(customConverters.associateBy(CustomPropertyConverter<*>::type))
 
     override fun createMap(properties: Map<String, String?>): LayeredPropertyMap {
         logger.debug("Creating new instance of LayeredPropertyMapImpl")

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImplTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImplTest.kt
@@ -1,7 +1,6 @@
 package net.corda.membership.lib.impl.grouppolicy
 
-import net.corda.layeredpropertymap.LayeredPropertyMapFactory
-import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
+import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.ProtocolMode
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode
@@ -63,7 +62,7 @@ class GroupPolicyParserImplTest {
     private val keyEncodingService: KeyEncodingService = mock {
         on { decodePublicKey(any<String>()) } doReturn defaultKey
     }
-    private val layeredPropertyMapFactory: LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(
+    private val layeredPropertyMapFactory = LayeredPropertyMapMocks.createFactory(
         listOf(
             EndpointInfoConverter(),
             MemberNotaryDetailsConverter(keyEncodingService),

--- a/testing/layered-property-map-testkit/build.gradle
+++ b/testing/layered-property-map-testkit/build.gradle
@@ -6,9 +6,10 @@ plugins {
 description 'Layered property map testkit'
 
 dependencies {
-    compileOnly "org.osgi:osgi.annotation"
+    compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
+    implementation 'org.osgi:osgi.core'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     implementation "net.corda:corda-base"

--- a/testing/layered-property-map-testkit/src/main/kotlin/net/corda/layeredpropertymap/testkit/LayeredPropertyMapMocks.kt
+++ b/testing/layered-property-map-testkit/src/main/kotlin/net/corda/layeredpropertymap/testkit/LayeredPropertyMapMocks.kt
@@ -1,11 +1,13 @@
 package net.corda.layeredpropertymap.testkit
 
+import java.lang.reflect.Proxy
 import net.corda.layeredpropertymap.ConversionContext
 import net.corda.layeredpropertymap.CustomPropertyConverter
 import net.corda.layeredpropertymap.LayeredPropertyMapFactory
 import net.corda.layeredpropertymap.create
 import net.corda.layeredpropertymap.impl.LayeredPropertyMapFactoryImpl
 import net.corda.v5.base.types.LayeredPropertyMap
+import org.osgi.service.component.ComponentContext
 
 object LayeredPropertyMapMocks {
     /**
@@ -14,7 +16,14 @@ object LayeredPropertyMapMocks {
     @JvmStatic
     fun createFactory(
         customConverters: List<CustomPropertyConverter<out Any>> = emptyList()
-    ): LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(customConverters)
+    ): LayeredPropertyMapFactory = LayeredPropertyMapFactoryImpl(
+        Proxy.newProxyInstance(LayeredPropertyMapMocks::class.java.classLoader, arrayOf(ComponentContext::class.java)) { _, method, args ->
+            if (method.name == "locateServices" && args.size == 1 && args[0] == "customConverters") {
+                return@newProxyInstance customConverters.toTypedArray()
+            }
+            throw UnsupportedOperationException("Not implemented - $method")
+        } as ComponentContext
+    )
 
     /**
      * Creates a new instance of [ConversionContext] with a new instance of [T] for specified [map] and [key]
@@ -35,5 +44,5 @@ object LayeredPropertyMapMocks {
     inline fun <reified T: LayeredPropertyMap> create(
         map: Map<String, String?>,
         customConverters: List<CustomPropertyConverter<out Any>> = emptyList()
-    ): T = createFactory(customConverters).create<T>(map)
+    ): T = createFactory(customConverters).create(map)
 }


### PR DESCRIPTION
OSGi constructor injection can only find references for components which already exist when the SCR creates the new component. Consequently, it will not include any references from bundles which haven't been activated yet.

Note that `ComponentContext.locateServices()` returns a snapshot of the services which exist at that time, and you're not supposed to keep long-lived references to them in case they change. However, this caveat also applies to the original code.