### PR TITLE
CORE-6126 remove skip task || so db job will now fail with SQL error

### DIFF
--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -141,12 +141,12 @@ spec:
           command: [ '/bin/sh', '-e', '-c' ]
           args:
             - |
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} -c "CREATE USER $RBAC_DB_USER_USERNAME WITH ENCRYPTED PASSWORD '$RBAC_DB_USER_PASSWORD';" || echo "User $RBAC_DB_USER_USERNAME already existed - skipping"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT USAGE ON SCHEMA RPC_RBAC to $RBAC_DB_USER_USERNAME;" || echo "Couldn't perform usage grant"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA RPC_RBAC to $RBAC_DB_USER_USERNAME;" || echo "Couldn't DML perform grant"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "CREATE USER $CRYPTO_DB_USER_USERNAME WITH ENCRYPTED PASSWORD '$CRYPTO_DB_USER_PASSWORD';" || echo "User $CRYPTO_DB_USER_USERNAME already existed - skipping"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT USAGE ON SCHEMA CRYPTO to $CRYPTO_DB_USER_USERNAME;" || echo "Couldn't perform usage grant"
-              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA CRYPTO to $CRYPTO_DB_USER_USERNAME;" || echo "Couldn't DML perform grant"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} -c "CREATE USER $RBAC_DB_USER_USERNAME WITH ENCRYPTED PASSWORD '$RBAC_DB_USER_PASSWORD';"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT USAGE ON SCHEMA RPC_RBAC to $RBAC_DB_USER_USERNAME;"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA RPC_RBAC to $RBAC_DB_USER_USERNAME;"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "CREATE USER $CRYPTO_DB_USER_USERNAME WITH ENCRYPTED PASSWORD '$CRYPTO_DB_USER_PASSWORD';"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT USAGE ON SCHEMA CRYPTO to $CRYPTO_DB_USER_USERNAME;"
+              psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }}  -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA CRYPTO to $CRYPTO_DB_USER_USERNAME;"
           volumeMounts:
             - mountPath: /tmp/working_dir
               name: working-volume


### PR DESCRIPTION
This change was tested by adding a syntax error inside the SQL command, which as a result the db-job would fail. 