### PR TITLE
CORE-8766: AMQP serializer should only load raw class names.

### DIFF
--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
@@ -116,7 +116,7 @@ class DefaultLocalSerializerFactory(
     : LocalSerializerFactory {
 
     companion object {
-        val logger = contextLogger()
+        private val logger = contextLogger()
     }
 
     override val customSerializerNames: List<String>
@@ -128,6 +128,15 @@ class DefaultLocalSerializerFactory(
     private val serializersByTypeId: MutableMap<TypeIdentifier, AMQPSerializer<Any>> = DefaultCacheProvider.createCache()
     private val typesByName = DefaultCacheProvider.createCache<String, Optional<LocalTypeInformation>>()
 
+    private fun rawTypeName(typeName: String): String {
+        val idx = typeName.indexOf('<')
+        return if (idx < 0) {
+            typeName
+        } else {
+            typeName.substring(0, idx)
+        }
+    }
+
     override fun createDescriptor(typeInformation: LocalTypeInformation): Symbol =
             Symbol.valueOf("$DESCRIPTOR_DOMAIN:${fingerPrinter.fingerprint(typeInformation)}")
 
@@ -136,11 +145,11 @@ class DefaultLocalSerializerFactory(
     override fun getTypeInformation(typeName: String): LocalTypeInformation? {
         return typesByName.getOrPut(typeName) {
             val localType = try {
-                sandboxGroup.loadClassFromMainBundles(typeName)
+                sandboxGroup.loadClassFromMainBundles(rawTypeName(typeName))
             } catch (e: Exception) {
                 null
             }
-            Optional.ofNullable(localType?.run { getTypeInformation(this) })
+            Optional.ofNullable(localType?.run(::getTypeInformation))
         }.orElse(null)
     }
 
@@ -148,12 +157,12 @@ class DefaultLocalSerializerFactory(
         return typesByName.getOrPut(typeName) {
             val localType = try {
                 val serializedClassTag = metadata.getValue(typeName) as String
-                sandboxGroup.getClass(typeName, serializedClassTag)
+                sandboxGroup.getClass(rawTypeName(typeName), serializedClassTag)
             } catch (_: SandboxException) {
                 logger.trace { "Failed to load class $typeName from any sandboxes" }
                 null
             }
-            Optional.ofNullable(localType?.run { getTypeInformation(this) })
+            Optional.ofNullable(localType?.run(::getTypeInformation))
         }.orElse(null)
     }
 


### PR DESCRIPTION
Java can only load classes by their raw class names, so remove any generic type parameters from type names.

This works, but I am concerned that I _may_ only be fixing a symptom of a deeper problem :worried:.