### PR TITLE
CORE-8691: Change sandbox cache to have a cache per sandbox type

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -9,27 +9,27 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.base.util.loggerFor
 import java.util.concurrent.ConcurrentHashMap
 
-internal class SandboxGroupContextCacheImpl(override val capacity: Long): SandboxGroupContextCache {
+internal class SandboxGroupContextCacheImpl(override val capacity: Long) : SandboxGroupContextCache {
     private companion object {
         private val logger = loggerFor<SandboxGroupContextCache>()
     }
 
     private val contexts = ConcurrentHashMap(SandboxGroupType.values().associate {
-            val cache: Cache<VirtualNodeContext, CloseableSandboxGroupContext> = CacheFactoryImpl().build(
-                "Sandbox-Cache-${it.name}",
-                Caffeine.newBuilder()
-                    .maximumSize(capacity)
-                    .removalListener { key, value, cause ->
-                        logger.info(
-                            "Evicting {} sandbox for: {} [{}]",
-                            key!!.sandboxGroupType,
-                            key.holdingIdentity.x500Name,
-                            cause.name
-                        )
-                        value?.close()
-                    })
-            Pair(it.name, cache)
-        })
+        val cache: Cache<VirtualNodeContext, CloseableSandboxGroupContext> = CacheFactoryImpl().build(
+            "Sandbox-Cache-${it.name}",
+            Caffeine.newBuilder()
+                .maximumSize(capacity)
+                .removalListener { key, value, cause ->
+                    logger.info(
+                        "Evicting {} sandbox for: {} [{}]",
+                        key!!.sandboxGroupType,
+                        key.holdingIdentity.x500Name,
+                        cause.name
+                    )
+                    value?.close()
+                })
+        Pair(it.name, cache)
+    })
 
     override fun remove(virtualNodeContext: VirtualNodeContext) {
         contexts.computeIfPresent(virtualNodeContext.sandboxGroupType.name) { _, cache ->
@@ -42,10 +42,13 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long): Sandbo
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext {
-        val cache = contexts[virtualNodeContext.sandboxGroupType.name] ?: throw IllegalArgumentException("Sandbox of type ${virtualNodeContext.sandboxGroupType.name} does not exist.")
+        val cache = contexts[virtualNodeContext.sandboxGroupType.name]
+            ?: throw IllegalArgumentException("Sandbox of type ${virtualNodeContext.sandboxGroupType.name} does not exist.")
         return cache.get(virtualNodeContext) {
-            logger.info("Caching {} sandbox for: {} (cache size: {})",
-                virtualNodeContext.sandboxGroupType, virtualNodeContext.holdingIdentity.x500Name, cache.estimatedSize())
+            logger.info(
+                "Caching {} sandbox for: {} (cache size: {})",
+                virtualNodeContext.sandboxGroupType, virtualNodeContext.holdingIdentity.x500Name, cache.estimatedSize()
+            )
             createFunction(virtualNodeContext)
         }
     }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -4,41 +4,57 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.cache.caffeine.CacheFactoryImpl
 import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.base.util.loggerFor
+import java.util.concurrent.ConcurrentHashMap
 
 internal class SandboxGroupContextCacheImpl(override val capacity: Long): SandboxGroupContextCache {
     private companion object {
         private val logger = loggerFor<SandboxGroupContextCache>()
     }
 
-    private val contexts: Cache<VirtualNodeContext, CloseableSandboxGroupContext> = CacheFactoryImpl().build(
-        "Sandbox-Cache",
-        Caffeine.newBuilder()
-            .maximumSize(capacity)
-            .removalListener { key, value, cause ->
-                logger.info("Evicting {} sandbox for: {} [{}]", key!!.sandboxGroupType, key.holdingIdentity.x500Name, cause.name)
-                value?.close()
-            })
+    private val contexts = ConcurrentHashMap(SandboxGroupType.values().associate {
+            val cache: Cache<VirtualNodeContext, CloseableSandboxGroupContext> = CacheFactoryImpl().build(
+                "Sandbox-Cache-${it.name}",
+                Caffeine.newBuilder()
+                    .maximumSize(capacity)
+                    .removalListener { key, value, cause ->
+                        logger.info(
+                            "Evicting {} sandbox for: {} [{}]",
+                            key!!.sandboxGroupType,
+                            key.holdingIdentity.x500Name,
+                            cause.name
+                        )
+                        value?.close()
+                    })
+            Pair(it.name, cache)
+        })
 
     override fun remove(virtualNodeContext: VirtualNodeContext) {
-        contexts.invalidate(virtualNodeContext)
+        contexts.computeIfPresent(virtualNodeContext.sandboxGroupType.name) { _, cache ->
+            cache.invalidate(virtualNodeContext)
+            cache
+        }
     }
 
     override fun get(
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext {
-        return contexts.get(virtualNodeContext) {
+        val cache = contexts[virtualNodeContext.sandboxGroupType.name] ?: throw IllegalArgumentException("Sandbox of type ${virtualNodeContext.sandboxGroupType.name} does not exist.")
+        return cache.get(virtualNodeContext) {
             logger.info("Caching {} sandbox for: {} (cache size: {})",
-                virtualNodeContext.sandboxGroupType, virtualNodeContext.holdingIdentity.x500Name, contexts.estimatedSize())
+                virtualNodeContext.sandboxGroupType, virtualNodeContext.holdingIdentity.x500Name, cache.estimatedSize())
             createFunction(virtualNodeContext)
         }
     }
 
     override fun close() {
-        // close everything in cache
-        contexts.invalidateAll()
-        contexts.cleanUp()
+        contexts.values.forEach {
+            // close everything in cache
+            it.invalidateAll()
+            it.cleanUp()
+        }
     }
 }

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -135,4 +135,34 @@ class SandboxGroupContextCacheTest {
 
         assertThat(retrievedContext).isSameAs(sandboxContext1)
     }
+
+    @Test
+    fun `sandboxes of different types do not trigger eviction of other sandbox types`() {
+        val cache = SandboxGroupContextCacheImpl(2)
+
+        val vncFlow = VirtualNodeContext(
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.FLOW,
+            "filter")
+        val vncPersistence = VirtualNodeContext(
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.PERSISTENCE,
+            "filter")
+        val vncVerification = VirtualNodeContext(
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.VERIFICATION,
+            "filter")
+        val sandboxContextFlow = mock<CloseableSandboxGroupContext>()
+        val sandboxContextPersistence = mock<CloseableSandboxGroupContext>()
+        val sandboxContextVerification = mock<CloseableSandboxGroupContext>()
+
+        cache.get(vncFlow) { sandboxContextFlow }
+        cache.get(vncPersistence) { sandboxContextPersistence }
+        cache.get(vncVerification) { sandboxContextVerification }
+        val retrievedContext = cache.get(vncFlow) { mock() }
+        assertThat(retrievedContext).isSameAs(sandboxContextFlow)
+    }
 }


### PR DESCRIPTION
The sandbox cache will evict sandboxes when the capacity is exceeded. This will in turn trigger the sandbox context to be closed, which cleans up the sandbox state and uninstalls the bundles. The sandbox cache was previously shared across all sandbox types however, so if two threads tried to use two different sandbox types at the same time a sandbox could be closed while still in use. This PR does not prevent that problem entirely. Instead it is made much less likely by creating a cache per sandbox type. The current processors will only use one sandbox of each type at a time, and so the condition of using two of the same type at once should vanish (this was previously possible in the combined worker).

A better fix would involve tracking in-use sandboxes and only closing on eviction if we were sure they weren't in use, but this change is likely non-trivial.