### PR TITLE
NOTICK: bump timeout and combine gradle commands to reduce having to run configuration stage twice

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 35, unit: 'MINUTES')
         timestamps()
     }
 
@@ -191,8 +191,7 @@ pipeline {
                     }
                 }
                 sh '''\
-                    ./gradlew smokeTest ${GRADLE_PERFORMANCE_TUNING}
-                    ./gradlew e2eTest ${GRADLE_PERFORMANCE_TUNING}
+                    ./gradlew smokeTest e2eTest ${GRADLE_PERFORMANCE_TUNING}
                 '''.stripIndent()
             }
             post {


### PR DESCRIPTION
combine Gradle commands to ensure we don't run Gradles configuration stage twice which is time is needless duplication  