### PR TITLE
CORE-8810: Allow Custom Annotations in Helm Chart

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -78,6 +78,12 @@ prometheus.io/scrape: "true"
 prometheus.io/path: /metrics
 prometheus.io/port: "7000"
 {{- end }}
+{{ if .Values.annotations -}}
+{{ .Values.annotations | toYaml }}
+{{- end }}
+{{ if ( get .Values.workers .worker ).annotations -}}
+{{ ( get .Values.workers .worker ).annotations | toYaml }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -213,6 +213,14 @@
             },
             "examples": [{}]
         },
+        "annotations": {
+            "type": "object",
+            "default": {},
+            "title": "custom annotations for all workers",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
         "db": {
             "type": "object",
             "default": {},
@@ -893,6 +901,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
                                 "logging": {},
@@ -930,6 +939,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
                                 "logging": {},
@@ -1005,6 +1015,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
                                 "logging": {},
@@ -1061,6 +1072,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
                                 "logging": {},
@@ -1083,6 +1095,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
                                 "logging": {},
@@ -1198,6 +1211,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
                                 "logging": {},
@@ -1259,6 +1273,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
                                 "logging": {},
@@ -1611,6 +1626,14 @@
                 },
                 "javaOptions": {
                     "type": "string"
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {},
+                    "title": "custom annotations for the worker",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
                 },
                 "replicaCount": {
                     "type": "integer",

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -53,6 +53,9 @@ nodeSelector: {}
 serviceAccount:
   name: ""
 
+# -- extra annotations for all workers
+annotations: {}
+
 # Database configuration
 db:
   # Cluster database configuration
@@ -155,8 +158,6 @@ kafka:
           name: ""
           # -- the SASL password secret key 
           key: ""
-
-
 
 # Configuration for cluster bootstrap
 bootstrap:
@@ -313,6 +314,8 @@ workers:
       tag: ""
     # -- crypto worker replica count
     replicaCount: 1
+    # -- crypto worker extra annotations; defaults to workers.annotations if not specified
+    annotations: {}
     # -- additional Java options for the crypto worker
     javaOptions: "-XX:MaxRAMPercentage=75"
     # crypto worker debug configuration
@@ -353,6 +356,8 @@ workers:
       tag: ""
     # -- DB worker replica count
     replicaCount: 1
+    # -- DB worker extra annotations; defaults to workers.annotations if not specified
+    annotations: {}
     # -- additional Java options for the DB worker
     javaOptions: "-XX:MaxRAMPercentage=75"
     # DB worker debug configuration
@@ -418,6 +423,8 @@ workers:
       tag: ""
     # -- flow worker replica count
     replicaCount: 1
+    # -- flow worker extra annotations; defaults to workers.annotations if not specified
+    annotations: {}
     # -- additional Java options for the flow worker
     javaOptions: "-XX:MaxRAMPercentage=75"
     # flow worker debug configuration
@@ -456,6 +463,8 @@ workers:
       tag: ""
     # -- membership worker replica count
     replicaCount: 1
+    # -- membership worker extra annotations; defaults to workers.annotations if not specified
+    annotations: {}
     # -- additional Java options for the membership worker
     javaOptions: "-XX:MaxRAMPercentage=75"
     # membership worker debug configuration
@@ -492,6 +501,8 @@ workers:
       tag: ""
     # -- RPC worker replica count
     replicaCount: 1
+    # -- RPC worker extra annotations; defaults to workers.annotations if not specified
+    annotations: {}
     # -- additional Java options for the rpc worker
     javaOptions: "-XX:MaxRAMPercentage=75"
     # RPC worker debug configuration
@@ -538,6 +549,8 @@ workers:
       tag: ""
     # -- p2p-link-manager worker replica count
     replicaCount: 1
+    # -- p2p-link-manager worker extra annotations; defaults to workers.annotations if not specified
+    annotations: {}
     # -- additional Java options for the p2p-link-manager worker
     javaOptions: "-XX:MaxRAMPercentage=75"
     # -- Use stubbed crypto processor, membership group reader and group policy provider
@@ -576,6 +589,8 @@ workers:
       tag: ""
     # -- p2p-gateway worker replica count
     replicaCount: 1
+    # -- p2p-gateway worker extra annotations; defaults to workers.annotations if not specified
+    annotations: {}
     # -- additional Java options for the p2p-gateway worker
     javaOptions: "-XX:MaxRAMPercentage=75"
     # -- Use stub crypto processor

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -53,7 +53,7 @@ nodeSelector: {}
 serviceAccount:
   name: ""
 
-# -- extra annotations for all workers
+# -- extra annotations (applied to all workers only)
 annotations: {}
 
 # Database configuration
@@ -314,7 +314,7 @@ workers:
       tag: ""
     # -- crypto worker replica count
     replicaCount: 1
-    # -- crypto worker extra annotations; defaults to workers.annotations if not specified
+    # -- crypto worker extra annotations
     annotations: {}
     # -- additional Java options for the crypto worker
     javaOptions: "-XX:MaxRAMPercentage=75"
@@ -356,7 +356,7 @@ workers:
       tag: ""
     # -- DB worker replica count
     replicaCount: 1
-    # -- DB worker extra annotations; defaults to workers.annotations if not specified
+    # -- DB worker extra annotations
     annotations: {}
     # -- additional Java options for the DB worker
     javaOptions: "-XX:MaxRAMPercentage=75"
@@ -423,7 +423,7 @@ workers:
       tag: ""
     # -- flow worker replica count
     replicaCount: 1
-    # -- flow worker extra annotations; defaults to workers.annotations if not specified
+    # -- flow worker extra annotations
     annotations: {}
     # -- additional Java options for the flow worker
     javaOptions: "-XX:MaxRAMPercentage=75"
@@ -463,7 +463,7 @@ workers:
       tag: ""
     # -- membership worker replica count
     replicaCount: 1
-    # -- membership worker extra annotations; defaults to workers.annotations if not specified
+    # -- membership worker extra annotations
     annotations: {}
     # -- additional Java options for the membership worker
     javaOptions: "-XX:MaxRAMPercentage=75"
@@ -501,7 +501,7 @@ workers:
       tag: ""
     # -- RPC worker replica count
     replicaCount: 1
-    # -- RPC worker extra annotations; defaults to workers.annotations if not specified
+    # -- RPC worker extra annotations
     annotations: {}
     # -- additional Java options for the rpc worker
     javaOptions: "-XX:MaxRAMPercentage=75"
@@ -549,7 +549,7 @@ workers:
       tag: ""
     # -- p2p-link-manager worker replica count
     replicaCount: 1
-    # -- p2p-link-manager worker extra annotations; defaults to workers.annotations if not specified
+    # -- p2p-link-manager worker extra annotations
     annotations: {}
     # -- additional Java options for the p2p-link-manager worker
     javaOptions: "-XX:MaxRAMPercentage=75"
@@ -589,7 +589,7 @@ workers:
       tag: ""
     # -- p2p-gateway worker replica count
     replicaCount: 1
-    # -- p2p-gateway worker extra annotations; defaults to workers.annotations if not specified
+    # -- p2p-gateway worker extra annotations
     annotations: {}
     # -- additional Java options for the p2p-gateway worker
     javaOptions: "-XX:MaxRAMPercentage=75"


### PR DESCRIPTION
Update helm chart so users can add extra annotations (both globally
and individually) to corda worker pods.
