### PR TITLE
CORE-8702 Add virtualNodeInfoReadService to FlowSandboxServiceImpl's setup error msg

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
@@ -144,7 +144,7 @@ class StartFlowTest : FlowServiceTestBase() {
                 flowStatus(
                     state = FlowStates.FAILED,
                     errorType = FlowProcessingExceptionTypes.FLOW_FAILED,
-                    errorMessage = "Execution failed with \"Failed to create the sandbox: Failed to find the virtual node info for holder 'HoldingIdentity(x500Name=${BOB_HOLDING_IDENTITY.x500Name}, groupId=${BOB_HOLDING_IDENTITY.groupId})'\" after 1 retry attempts."
+                    errorMessage = "Execution failed with \"Failed to create the sandbox: Failed to find the virtual node info for holder 'HoldingIdentity(x500Name=${BOB_HOLDING_IDENTITY.x500Name}, groupId=${BOB_HOLDING_IDENTITY.groupId})' in class net.corda.virtualnode.read.fake.VirtualNodeInfoReadServiceFake\" after 1 retry attempts."
                 )
             }
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/FlowSandboxServiceImpl.kt
@@ -56,7 +56,9 @@ class FlowSandboxServiceImpl @Activate constructor(
 
     override fun get(holdingIdentity: HoldingIdentity): FlowSandboxGroupContext {
         val vNodeInfo = virtualNodeInfoReadService.get(holdingIdentity)
-        checkNotNull(vNodeInfo) { "Failed to find the virtual node info for holder '${holdingIdentity}'" }
+        checkNotNull(vNodeInfo) {
+            "Failed to find the virtual node info for holder '${holdingIdentity}' in ${virtualNodeInfoReadService::class.java}"
+        }
 
         val cpiMetadata = cpiInfoReadService.get(vNodeInfo.cpiIdentifier)
         checkNotNull(cpiMetadata) { "Failed to find the CPI meta data for '${vNodeInfo.cpiIdentifier}}'" }


### PR DESCRIPTION
CORE-8702 Add virtualNodeInfoReadService to the logs to be able to figure out which one is used (From @chrisr3)