### PR TITLE
CORE-8850: Upgrade Kafka Client Libraries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ jacksonVersion=2.14.0
 jaxbVersion = 2.3.1
 jbossTransactionApiSpecVersion=1.1.1.Final
 jetbrainsAnnotationsVersion=13.0
-kafkaClientVersion=2.8.1_1
+kafkaClientVersion=3.3.1_1
 # NOTE: Kryo cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.
 kryoVersion = 4.0.2

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -225,7 +225,9 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                 }
             }
         }
-            ?: logWarningAndThrowIntermittentException("Partitions for topic $topic are null. Kafka may not have completed startup.")
+            // Safeguard, should never happen in newer versions of Kafka
+            ?: logWarningAndThrowIntermittentException("Partitions for topic $topic are null. " +
+                    "Kafka may not have completed startup.")
 
         return listOfPartitions.map {
             CordaTopicPartition(it.topic().removePrefix(config.topicPrefix), it.partition())

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -271,14 +271,6 @@ class CordaKafkaConsumerImplTest {
         assertThat(positionAfterReset).isEqualTo(0L)
     }
 
-
-    @Test
-    fun testGetPartitionsNullPointerException() {
-        assertThatExceptionOfType(CordaMessageAPIIntermittentException::class.java).isThrownBy {
-            cordaKafkaConsumer.getPartitions("topic")
-        }.withMessageContaining("Partitions for topic topic are null. Kafka may not have completed startup.")
-    }
-
     @Test
     fun testAssignInvokedFatal() {
         consumer = mock()

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -272,6 +272,20 @@ class CordaKafkaConsumerImplTest {
     }
 
     @Test
+    fun testGetPartitionsNullPointerException() {
+        consumer = mock()
+        cordaKafkaConsumer = CordaKafkaConsumerImpl(
+            consumerConfig,
+            consumer,
+            listener
+        )
+        doReturn(null).`when`(consumer).partitionsFor(any())
+        assertThatExceptionOfType(CordaMessageAPIIntermittentException::class.java).isThrownBy {
+            cordaKafkaConsumer.getPartitions("topic")
+        }.withMessageContaining("Partitions for topic topic are null. Kafka may not have completed startup.")
+    }
+
+    @Test
     fun testAssignInvokedFatal() {
         consumer = mock()
         cordaKafkaConsumer = CordaKafkaConsumerImpl(


### PR DESCRIPTION
Bump Kafka Client libraries to the latest available version, 3.3.1_1.
