### PR TITLE
CORE-8015 Lifecycle comment

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -106,6 +106,8 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
                         listOf(getRPCResponseTopic(config.topic)),
                         partitionListener
                     )
+                    // Note that Lifecycle UP and DOWN are handled by the RPCConsumerRebalanceListener based on whether
+                    // partitions are available to this sender or not.
                     pollAndProcessRecords(it)
                 }
                 attempts = 0


### PR DESCRIPTION
The RPC sender subscription differs from others in that Lifecycle status events are handled by the rebalance listener. Because this difference can be confusing on code inspection (it looks like an accidental omission in the subscription itself) this comment informs the user this is deliberate.