### PR TITLE
CORE-8180: Allow marking sandbox services as "uninjectable".

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.application.serialization
 
 import net.corda.flow.pipeline.exceptions.FlowFatalException
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.RequireSandboxAMQP.AMQP_SERIALIZATION_SERVICE
@@ -18,7 +19,7 @@ import java.io.NotSerializableException
 
 @Component(
     service = [ SerializationService::class, SerializationServiceInternal::class, UsedByFlow::class ],
-    property = [ "corda.system=true" ],
+    property = [ CORDA_SYSTEM_SERVICE ],
     scope = PROTOTYPE
 )
 class SerializationServiceImpl @Activate constructor(
@@ -32,7 +33,7 @@ class SerializationServiceImpl @Activate constructor(
 
     private val serializationService
         get(): SerializationService {
-            return currentSandboxGroupContext.get().getObjectByKey<SerializationService>(AMQP_SERIALIZATION_SERVICE)
+            return currentSandboxGroupContext.get().getObjectByKey(AMQP_SERIALIZATION_SERVICE)
                 ?: throw FlowFatalException(
                     "The flow sandbox has not been initialized with an AMQP serializer for " +
                             "identity ${currentSandboxGroupContext.get().virtualNodeContext.holdingIdentity}"

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/CheckpointSerializerProvider.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/CheckpointSerializerProvider.kt
@@ -2,6 +2,7 @@ package net.corda.flow.pipeline.sandbox.impl
 
 import net.corda.flow.pipeline.sandbox.impl.FlowSandboxGroupContextImpl.Companion.CHECKPOINT_SERIALIZER
 import net.corda.flow.pipeline.sandbox.impl.FlowSandboxGroupContextImpl.Companion.NON_INJECTABLE_SINGLETONS
+import net.corda.sandbox.type.SandboxConstants.CORDA_MARKER_ONLY_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CustomMetadataConsumer
 import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
@@ -26,7 +27,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 @Suppress("unused")
 @Component(
     service = [ UsedByFlow::class ],
-    property = [ "corda.marker.only:Boolean=true" ],
+    property = [ CORDA_MARKER_ONLY_SERVICE ],
     scope = PROTOTYPE
 )
 class CheckpointSerializerProvider @Activate constructor(

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.common.flow.impl.transaction
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.common.data.transaction.SignableData
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
@@ -28,7 +29,7 @@ const val SIGNATURE_METADATA_SIGNATURE_SPEC_KEY = "signatureSpec"
 @Component(
     service = [TransactionSignatureService::class, UsedByFlow::class],
     scope = ServiceScope.PROTOTYPE,
-    property = ["corda.system=true"]
+    property = [ CORDA_SYSTEM_SERVICE ]
 )
 class TransactionSignatureServiceImpl @Activate constructor(
     @Reference(service = SerializationService::class)

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImpl.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.common.flow.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.flow.transaction.filtered.FilteredTransaction
 import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
 import net.corda.ledger.common.flow.transaction.filtered.factory.FilteredTransactionFactory
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
@@ -19,9 +20,10 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 import java.util.function.Predicate
 
-@Component(service = [FilteredTransactionFactory::class, SingletonSerializeAsToken::class, UsedByFlow::class],
+@Component(
+    service = [ FilteredTransactionFactory::class, SingletonSerializeAsToken::class, UsedByFlow::class ],
+    property = [ CORDA_SYSTEM_SERVICE ],
     scope = PROTOTYPE,
-    property = ["corda.system=true"]
 )
 class FilteredTransactionFactoryImpl @Activate constructor(
     @Reference(service = JsonMarshallingService::class)

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.ledger.common.flow.impl.transaction.filtered.FilteredTransactionImpl
 import net.corda.ledger.common.flow.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.flow.transaction.filtered.FilteredTransaction
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.serialization.BaseProxySerializer
 import net.corda.serialization.InternalCustomSerializer
@@ -15,7 +16,11 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [InternalCustomSerializer::class, UsedByFlow::class], scope = PROTOTYPE)
+@Component(
+    service = [ InternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
 class FilteredTransactionSerializer @Activate constructor(
     @Reference(service = JsonMarshallingService::class)
     private val jsonMarshallingService: JsonMarshallingService,

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/serializer/kryo/WireTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/serializer/kryo/WireTransactionKryoSerializer.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.common.flow.impl.transaction.serializer.kryo
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.serialization.checkpoint.CheckpointInput
 import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
@@ -13,7 +14,11 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ], scope = PROTOTYPE)
+@Component(
+    service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
 class WireTransactionKryoSerializer @Activate constructor(
     @Reference(service = WireTransactionFactory::class) private val wireTransactionFactory: WireTransactionFactory
 ) : CheckpointInternalCustomSerializer<WireTransaction>, UsedByFlow {

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImpl.kt
@@ -10,6 +10,7 @@ import net.corda.ledger.consensual.flow.impl.persistence.external.events.Persist
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.PersistTransactionParameters
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
@@ -26,7 +27,7 @@ import java.nio.ByteBuffer
 
 @Component(
     service = [ ConsensualLedgerPersistenceService::class, UsedByFlow::class ],
-    property = [ "corda.system=true" ],
+    property = [ CORDA_SYSTEM_SERVICE ],
     scope = PROTOTYPE
 )
 class ConsensualLedgerPersistenceServiceImpl @Activate constructor(

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/amqp/ConsensualSignedTransactionSerializer.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/amqp/ConsensualSignedTransactionSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByVerification
 import net.corda.serialization.BaseProxySerializer
@@ -19,6 +20,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
     service = [InternalCustomSerializer::class, UsedByFlow::class, UsedByVerification::class],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
     scope = PROTOTYPE
 )
 class ConsensualSignedTransactionSerializer @Activate constructor(

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.serialization.checkpoint.CheckpointInput
 import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
@@ -16,7 +17,11 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ], scope = PROTOTYPE)
+@Component(
+    service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
 class ConsensualSignedTransactionKryoSerializer @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serialisationService: SerializationService,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRepositoryImpl.kt
@@ -6,6 +6,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.ledger.persistence.common.mapToComponentGroups
 import net.corda.ledger.persistence.consensual.ConsensualRepository
+import net.corda.sandbox.type.SandboxConstants.CORDA_MARKER_ONLY_SERVICE
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
@@ -32,7 +33,7 @@ import javax.persistence.Tuple
  */
 @Component(
     service = [ ConsensualRepository::class, UsedByPersistence::class ],
-    property = [ "corda.marker.only:Boolean=true" ],
+    property = [ CORDA_MARKER_ONLY_SERVICE ],
     scope = PROTOTYPE
 )
 class ConsensualRepositoryImpl @Activate constructor(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoLedgerTransactionVerifier
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
@@ -16,7 +17,11 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [TransactionBackchainVerifier::class, UsedByFlow::class], scope = PROTOTYPE, property = ["corda.system=true"])
+@Component(
+    service = [ TransactionBackchainVerifier::class, UsedByFlow::class ],
+    property = [ CORDA_SYSTEM_SERVICE ],
+    scope = PROTOTYPE
+)
 class TransactionBackchainVerifierImpl @Activate constructor(
     @Reference(service = UtxoLedgerPersistenceService::class)
     private val utxoLedgerPersistenceService: UtxoLedgerPersistenceService

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -13,6 +13,7 @@ import net.corda.ledger.utxo.flow.impl.persistence.external.events.UpdateTransac
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.UpdateTransactionStatusParameters
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
@@ -29,7 +30,7 @@ import java.nio.ByteBuffer
 
 @Component(
     service = [ UtxoLedgerPersistenceService::class, UsedByFlow::class ],
-    property = [ "corda.system=true" ],
+    property = [ CORDA_SYSTEM_SERVICE ],
     scope = PROTOTYPE
 )
 class UtxoLedgerPersistenceServiceImpl @Activate constructor(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionSerializer.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp
 
 import net.corda.ledger.common.flow.transaction.filtered.FilteredTransaction
 import net.corda.ledger.utxo.flow.impl.transaction.filtered.UtxoFilteredTransactionImpl
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.serialization.BaseProxySerializer
 import net.corda.serialization.InternalCustomSerializer
@@ -9,11 +10,12 @@ import net.corda.v5.application.serialization.SerializationService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ServiceScope
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
-    service = [InternalCustomSerializer::class, UsedByFlow::class],
-    scope = ServiceScope.PROTOTYPE
+    service = [ InternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
 )
 class UtxoFilteredTransactionSerializer @Activate constructor(
     @Reference(service = SerializationService::class)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByVerification
 import net.corda.serialization.BaseProxySerializer
@@ -15,12 +16,14 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ServiceScope
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
     service = [ InternalCustomSerializer::class, UsedByFlow::class, UsedByVerification::class ],
-    scope = ServiceScope.PROTOTYPE
-)class UtxoSignedTransactionSerializer @Activate constructor(
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
+class UtxoSignedTransactionSerializer @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService,
     @Reference(service = TransactionSignatureService::class)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.serialization.checkpoint.CheckpointInput
 import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
@@ -14,9 +15,13 @@ import net.corda.v5.base.util.uncheckedCast
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ServiceScope
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [CheckpointInternalCustomSerializer::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
+@Component(
+    service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
 class UtxoSignedTransactionKryoSerializer @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serialisationService: SerializationService,

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -8,6 +8,7 @@ import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
 import net.corda.internal.serialization.registerCustomSerializers
+import net.corda.sandbox.type.SandboxConstants.CORDA_MARKER_ONLY_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
@@ -35,7 +36,7 @@ import org.osgi.service.component.annotations.ServiceScope
 @Suppress("unused")
 @Component(
     service = [ UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
-    property = [ "corda.marker.only:Boolean=true" ],
+    property = [ CORDA_MARKER_ONLY_SERVICE ],
     scope = ServiceScope.PROTOTYPE
 )
 class AMQPSerializationProvider @Activate constructor(

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -13,9 +13,9 @@ import java.util.TreeMap
 import net.corda.cpk.read.CpkReadService
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.metrics.CordaMetrics
-import net.corda.sandbox.CORDA_SYSTEM
 import net.corda.sandbox.RequireSandboxHooks
 import net.corda.sandbox.RequireCordaSystem
+import net.corda.sandbox.RequireCordaSystem.CORDA_SYSTEM_NAMESPACE
 import net.corda.sandbox.SandboxCreationService
 import net.corda.sandbox.SandboxException
 import net.corda.sandboxgroupcontext.CORDA_SANDBOX
@@ -82,6 +82,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
 ) : SandboxGroupContextService, CacheConfiguration {
     private companion object {
         private const val SANDBOX_FACTORY_FILTER = "(&($SERVICE_SCOPE=$SCOPE_PROTOTYPE)($COMPONENT_NAME=*)(!$CORDA_SANDBOX_FILTER))"
+        private const val CORDA_UNINJECTABLE_FILTER = "(corda.uninjectable=*)"
         private const val CORDA_MARKER_ONLY_FILTER = "(corda.marker.only=*)"
 
         private val MARKER_INTERFACES: Set<String> = unmodifiableSet(
@@ -89,6 +90,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                 .mapTo(mutableSetOf(), SandboxGroupType::serviceMarkerType)
                 .mapTo(mutableSetOf(), Class<*>::getName)
         )
+        private val uninjectableFilter = FrameworkUtil.createFilter(CORDA_UNINJECTABLE_FILTER)
         private val markerOnlyFilter = FrameworkUtil.createFilter(CORDA_MARKER_ONLY_FILTER)
         private val systemFilter = FrameworkUtil.createFilter(CORDA_SYSTEM_FILTER)
         private val logger = loggerFor<SandboxGroupContextServiceImpl>()
@@ -212,8 +214,8 @@ class SandboxGroupContextServiceImpl @Activate constructor(
      * must all advertise a compatible "corda.system" capability.
      */
     private fun getCordaSystemBundles(sandboxGroupType: SandboxGroupType): Set<Bundle> {
-        return bundleContext.bundle.adapt(BundleWiring::class.java).getRequiredWires(CORDA_SYSTEM)
-            ?.filter { it.capability.attributes[CORDA_SYSTEM] == sandboxGroupType.toString() }
+        return bundleContext.bundle.adapt(BundleWiring::class.java).getRequiredWires(CORDA_SYSTEM_NAMESPACE)
+            ?.filter { it.capability.attributes[CORDA_SYSTEM_NAMESPACE] == sandboxGroupType.toString() }
             ?.mapTo(linkedSetOf()) { wire ->
                 wire.provider.bundle
             } ?: emptySet()
@@ -250,7 +252,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                         if (systemFilter.match(serviceRef)) {
                             // We always load interfaces for system services.
                             serviceRef.loadCommonService(serviceType)
-                        } else if (accessControlContext.checkServicePermission(serviceType)) {
+                        } else if (!uninjectableFilter.match(serviceRef) && accessControlContext.checkServicePermission(serviceType)) {
                             // Only accept those service types for which this sandbox also has a bundle wiring.
                             sandboxBundles.loadCommonService(serviceType)
                         } else {

--- a/components/virtual-node/sandbox-json/src/main/kotlin/net/corda/sandbox/serialization/json/JsonSerializerProvider.kt
+++ b/components/virtual-node/sandbox-json/src/main/kotlin/net/corda/sandbox/serialization/json/JsonSerializerProvider.kt
@@ -2,6 +2,7 @@ package net.corda.sandbox.serialization.json
 
 import net.corda.common.json.serializers.SerializationCustomizer
 import net.corda.common.json.serializers.serializableClassFromJsonSerializer
+import net.corda.sandbox.type.SandboxConstants.CORDA_MARKER_ONLY_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
@@ -25,7 +26,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 @Suppress("unused")
 @Component(
     service = [ UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
-    property = [ "corda.marker.only:Boolean=true" ],
+    property = [ CORDA_MARKER_ONLY_SERVICE ],
     scope = PROTOTYPE
 )
 class JsonSerializerProvider @Activate constructor(

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/serializer/amqp/WireTransactionSerializer.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/serializer/amqp/WireTransactionSerializer.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.common.data.transaction.serializer.amqp
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
@@ -17,6 +18,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
     service = [ InternalCustomSerializer::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
     scope = PROTOTYPE
 )
 class WireTransactionSerializer @Activate constructor(

--- a/libs/sandbox-types/src/main/java/net/corda/sandbox/type/SandboxConstants.java
+++ b/libs/sandbox-types/src/main/java/net/corda/sandbox/type/SandboxConstants.java
@@ -1,0 +1,11 @@
+package net.corda.sandbox.type;
+
+public final class SandboxConstants {
+    private SandboxConstants() {
+    }
+
+    public static final String CORDA_SYSTEM = "corda.system";
+    public static final String CORDA_SYSTEM_SERVICE = "corda.system:Boolean=true";
+    public static final String CORDA_MARKER_ONLY_SERVICE = "corda.marker.only:Boolean=true";
+    public static final String CORDA_UNINJECTABLE_SERVICE = "corda.uninjectable:Boolean=true";
+}

--- a/libs/sandbox/src/main/java/net/corda/sandbox/CordaSystemFlow.java
+++ b/libs/sandbox/src/main/java/net/corda/sandbox/CordaSystemFlow.java
@@ -6,11 +6,11 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
+import static net.corda.sandbox.RequireCordaSystem.CORDA_SYSTEM_NAMESPACE;
 import static net.corda.sandbox.RequireCordaSystem.VERSION;
-import static net.corda.sandbox.SandboxConstants.CORDA_SYSTEM;
 
 @Capability(
-    namespace = CORDA_SYSTEM,
+    namespace = CORDA_SYSTEM_NAMESPACE,
     name = "flow",
     version = VERSION
 )

--- a/libs/sandbox/src/main/java/net/corda/sandbox/RequireCordaSystem.java
+++ b/libs/sandbox/src/main/java/net/corda/sandbox/RequireCordaSystem.java
@@ -6,13 +6,12 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
-import static net.corda.sandbox.SandboxConstants.CORDA_SYSTEM;
 import static org.osgi.annotation.bundle.Requirement.Cardinality.MULTIPLE;
 import static org.osgi.framework.Constants.RESOLUTION_DIRECTIVE;
 import static org.osgi.framework.Constants.RESOLUTION_OPTIONAL;
 
 @Requirement(
-    namespace = CORDA_SYSTEM,
+    namespace = RequireCordaSystem.CORDA_SYSTEM_NAMESPACE,
     name = "*",
     version = RequireCordaSystem.VERSION,
     cardinality = MULTIPLE,
@@ -21,5 +20,6 @@ import static org.osgi.framework.Constants.RESOLUTION_OPTIONAL;
 @Retention(CLASS)
 @Target(TYPE)
 public @interface RequireCordaSystem {
+    String CORDA_SYSTEM_NAMESPACE = "corda.system";
     String VERSION = "1.0";
 }

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxConstants.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxConstants.kt
@@ -1,4 +1,0 @@
-@file:JvmName("SandboxConstants")
-package net.corda.sandbox
-
-const val CORDA_SYSTEM = "corda.system"

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/Constants.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/Constants.kt
@@ -1,7 +1,7 @@
 @file:JvmName("Constants")
 package net.corda.sandboxgroupcontext
 
-import net.corda.sandbox.CORDA_SYSTEM
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM
 
 const val CORDA_SANDBOX = "corda.sandbox"
 const val CORDA_SANDBOX_FILTER = "($CORDA_SANDBOX=*)"


### PR DESCRIPTION
We never intend to `@CordaInject` either AMQP or Kryo serializers, and the Security Manager will auotmatically exclude their service interfaces from consideration anyway. However, not all of our integration tests run with a Security Manager installed, and `SandboxDependencyInjectorFactory` is complaining whenever it is presented with services that do not also implement `SingletonSerializeAsToken`.

Solve the problem by adding a new `corda uninjectable` property to such services, so that they will be excluded regardless of whether we have installed a Security Manager or not.

Note that the `corda.system` property takes precedence over `corda.uninjectable`. I have also refactored `SandboxConstants` so that all of these property values are now available as part of the `sandbox-types` module.