### PR TITLE
CORE-8907 Transient errors in ledger persistence

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -16,7 +16,6 @@ import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.testkit.DbUtils
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.testkit.getWireTransactionExample
@@ -26,6 +25,7 @@ import net.corda.ledger.consensual.data.transaction.ConsensualComponentGroup
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
 import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
 import net.corda.messaging.api.records.Record
+import net.corda.persistence.common.ResponseFactory
 import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.getSandboxSingletonService
@@ -82,7 +82,7 @@ class ConsensualLedgerMessageProcessorTests {
 
     // For sandboxing
     private lateinit var virtualNode: VirtualNodeService
-    private lateinit var externalEventResponseFactory: ExternalEventResponseFactory
+    private lateinit var responseFactory: ResponseFactory
     private lateinit var deserializer: CordaAvroDeserializer<EntityResponse>
     private lateinit var delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector
 
@@ -98,7 +98,7 @@ class ConsensualLedgerMessageProcessorTests {
         logger.info("Setup test (test directory: {})", testDirectory)
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
-            externalEventResponseFactory = setup.fetchService(TIMEOUT_MILLIS)
+            responseFactory = setup.fetchService(TIMEOUT_MILLIS)
             virtualNode = setup.fetchService(TIMEOUT_MILLIS)
             deserializer = setup.fetchService<CordaAvroSerializationFactory>(TIMEOUT_MILLIS)
                 .createAvroDeserializer({}, EntityResponse::class.java)
@@ -124,7 +124,7 @@ class ConsensualLedgerMessageProcessorTests {
         val processor = PersistenceRequestProcessor(
             virtualNode.entitySandboxService,
             delegatedRequestHandlerSelector,
-            externalEventResponseFactory
+            responseFactory
         )
 
         val requestId = UUID.randomUUID().toString()

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -16,7 +16,6 @@ import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.testkit.DbUtils
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.testkit.getWireTransactionExample
@@ -26,6 +25,7 @@ import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
 import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.messaging.api.records.Record
+import net.corda.persistence.common.ResponseFactory
 import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.getSandboxSingletonService
@@ -82,7 +82,7 @@ class UtxoLedgerMessageProcessorTests {
 
     // For sandboxing
     private lateinit var virtualNode: VirtualNodeService
-    private lateinit var externalEventResponseFactory: ExternalEventResponseFactory
+    private lateinit var responseFactory: ResponseFactory
     private lateinit var deserializer: CordaAvroDeserializer<EntityResponse>
     private lateinit var delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector
 
@@ -98,7 +98,7 @@ class UtxoLedgerMessageProcessorTests {
         logger.info("Setup test (test directory: {})", testDirectory)
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
-            externalEventResponseFactory = setup.fetchService(TIMEOUT_MILLIS)
+            responseFactory = setup.fetchService(TIMEOUT_MILLIS)
             virtualNode = setup.fetchService(TIMEOUT_MILLIS)
             deserializer = setup.fetchService<CordaAvroSerializationFactory>(TIMEOUT_MILLIS)
                 .createAvroDeserializer({}, EntityResponse::class.java)
@@ -125,7 +125,7 @@ class UtxoLedgerMessageProcessorTests {
         val processor = PersistenceRequestProcessor(
             virtualNode.entitySandboxService,
             delegatedRequestHandlerSelector,
-            externalEventResponseFactory
+            responseFactory
         )
 
         val requestId = UUID.randomUUID().toString()

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/common/UnsupportedLedgerTypeException.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/common/UnsupportedLedgerTypeException.kt
@@ -1,0 +1,5 @@
+package net.corda.ledger.persistence.common
+
+import net.corda.data.ledger.persistence.LedgerTypes
+
+class UnsupportedLedgerTypeException(type: LedgerTypes) : IllegalArgumentException("Unsupported ledger type '$type'")

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/common/UnsupportedRequestTypeException.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/common/UnsupportedRequestTypeException.kt
@@ -1,0 +1,6 @@
+package net.corda.ledger.persistence.common
+
+import net.corda.data.ledger.persistence.LedgerTypes
+
+class UnsupportedRequestTypeException(type: LedgerTypes, requestType: Class<*>) :
+    IllegalArgumentException("$type request type '${requestType.name} is unsupported")

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRequestHandlerSelectorImpl.kt
@@ -2,8 +2,10 @@ package net.corda.ledger.persistence.consensual.impl
 
 import net.corda.data.ledger.persistence.FindTransaction
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
+import net.corda.data.ledger.persistence.LedgerTypes
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.common.UnsupportedRequestTypeException
 import net.corda.ledger.persistence.consensual.ConsensualRepository
 import net.corda.ledger.persistence.consensual.ConsensualRequestHandlerSelector
 import net.corda.persistence.common.ResponseFactory
@@ -50,7 +52,7 @@ class ConsensualRequestHandlerSelectorImpl @Activate constructor(
                 )
             }
             else -> {
-                throw IllegalStateException("The Consensual request type '${request.request.javaClass}' is not supported.")
+                throw UnsupportedRequestTypeException(LedgerTypes.CONSENSUAL, request.request.javaClass)
             }
         }
     }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
@@ -1,12 +1,15 @@
 package net.corda.ledger.persistence.processor
 
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
+import net.corda.ledger.persistence.common.UnsupportedLedgerTypeException
+import net.corda.ledger.persistence.common.UnsupportedRequestTypeException
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.EntitySandboxService
+import net.corda.persistence.common.ResponseFactory
+import net.corda.utilities.withMDC
 import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.util.debug
+import net.corda.v5.base.util.trace
 import net.corda.virtualnode.toCorda
 
 /**
@@ -16,11 +19,12 @@ import net.corda.virtualnode.toCorda
 class PersistenceRequestProcessor(
     private val entitySandboxService: EntitySandboxService,
     private val delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector,
-    private val externalEventResponseFactory: ExternalEventResponseFactory,
+    private val responseFactory: ResponseFactory
 ) : DurableProcessor<String, LedgerPersistenceRequest> {
 
     private companion object {
         val log = contextLogger()
+        const val MDC_EXTERNAL_EVENT_ID = "external_event_id"
     }
 
     override val keyClass = String::class.java
@@ -28,21 +32,31 @@ class PersistenceRequestProcessor(
     override val valueClass = LedgerPersistenceRequest::class.java
 
     override fun onNext(events: List<Record<String, LedgerPersistenceRequest>>): List<Record<*, *>> {
-        log.debug { "onNext processing messages ${events.joinToString(",") { it.key }}" }
+        log.trace { "onNext processing messages ${events.joinToString(",") { it.key }}" }
 
-        return events.mapNotNull { it.value }.flatMap { request ->
-            try {
-                val holdingIdentity = request.holdingIdentity.toCorda()
-                // TODOs calling get on the sandbox could throw a transient exception,
-                // we should handle this with the appropriate response type.
-                val sandbox = entitySandboxService.get(holdingIdentity)
-                delegatedRequestHandlerSelector.selectHandler(sandbox, request).execute()
-            } catch (e: Exception) {
-                // need to re-add database error handling of transient errors
-                log.warn("Unexpected error", e)
-                listOf<Record<*, *>>(externalEventResponseFactory.fatalError(request.flowExternalEventContext, e))
+        return events
+            .mapNotNull { it.value }
+            .flatMap { request ->
+                withMDC(mapOf(MDC_EXTERNAL_EVENT_ID to request.flowExternalEventContext.requestId)) {
+                    try {
+                        val holdingIdentity = request.holdingIdentity.toCorda()
+                        val sandbox = entitySandboxService.get(holdingIdentity)
+                        delegatedRequestHandlerSelector.selectHandler(sandbox, request).execute()
+                    } catch (e: Exception) {
+                        listOf(
+                            when (e) {
+                                is UnsupportedLedgerTypeException, is UnsupportedRequestTypeException -> {
+                                    responseFactory.fatalErrorResponse(request.flowExternalEventContext, e)
+                                }
+
+                                else -> {
+                                    responseFactory.errorResponse(request.flowExternalEventContext, e)
+                                }
+                            }
+                        )
+                    }
+                }
             }
-        }
     }
 }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/DelegatedRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/DelegatedRequestHandlerSelectorImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.persistence.processor.impl
 
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.data.ledger.persistence.LedgerTypes
+import net.corda.ledger.persistence.common.UnsupportedLedgerTypeException
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.consensual.ConsensualRequestHandlerSelector
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
@@ -40,7 +41,7 @@ class DelegatedRequestHandlerSelectorImpl @Activate constructor(
                 )
             }
             else -> {
-                val error = IllegalStateException("unsupported ledger type '${request.ledgerType}'")
+                val error = UnsupportedLedgerTypeException(request.ledgerType)
                 log.error(error.message)
                 throw error
             }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImpl.kt
@@ -1,7 +1,6 @@
 package net.corda.ledger.persistence.processor.impl
 
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
 import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
 import net.corda.ledger.persistence.processor.PersistenceRequestSubscriptionFactory
@@ -10,6 +9,7 @@ import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.persistence.common.EntitySandboxService
+import net.corda.persistence.common.ResponseFactory
 import net.corda.schema.Schemas
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -24,8 +24,8 @@ class PersistenceRequestSubscriptionFactoryImpl @Activate constructor(
     private val entitySandboxService: EntitySandboxService,
     @Reference(service = DelegatedRequestHandlerSelector::class)
     private val delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector,
-    @Reference(service = ExternalEventResponseFactory::class)
-    private val externalEventResponseFactory: ExternalEventResponseFactory
+    @Reference(service = ResponseFactory::class)
+    private val responseFactory: ResponseFactory
 ) : PersistenceRequestSubscriptionFactory {
     companion object {
         internal const val GROUP_NAME = "persistence.ledger.processor"
@@ -37,7 +37,7 @@ class PersistenceRequestSubscriptionFactoryImpl @Activate constructor(
         val processor = PersistenceRequestProcessor(
             entitySandboxService,
             delegatedRequestHandlerSelector,
-            externalEventResponseFactory
+            responseFactory
         )
 
         return subscriptionFactory.createDurableSubscription(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -2,11 +2,13 @@ package net.corda.ledger.persistence.utxo.impl
 
 import net.corda.data.ledger.persistence.FindTransaction
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
+import net.corda.data.ledger.persistence.LedgerTypes
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.ledger.persistence.PersistTransactionIfDoesNotExist
 import net.corda.data.ledger.persistence.UpdateTransactionStatus
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.common.UnsupportedRequestTypeException
 import net.corda.ledger.persistence.utxo.UtxoRequestHandlerSelector
 import net.corda.persistence.common.ResponseFactory
 import net.corda.persistence.common.getEntityManagerFactory
@@ -76,7 +78,7 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
                 )
             }
             else -> {
-                throw IllegalStateException("The UTXO request type '${request.request.javaClass}' is not supported.")
+                throw UnsupportedRequestTypeException(LedgerTypes.UTXO, request.request.javaClass)
             }
         }
     }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestProcessorTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestProcessorTest.kt
@@ -5,13 +5,13 @@ import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.data.ledger.persistence.LedgerTypes
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.persistence.ALICE_X500_HOLDING_ID
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
 import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.EntitySandboxService
+import net.corda.persistence.common.ResponseFactory
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
@@ -25,14 +25,14 @@ class PersistenceRequestProcessorTest {
 
     private val entitySandboxService = mock<EntitySandboxService>()
     private val delegatedRequestHandlerSelector = mock<DelegatedRequestHandlerSelector>()
-    private val externalEventResponseFactory = mock<ExternalEventResponseFactory>()
+    private val responseFactory = mock<ResponseFactory>()
     private val cordaHoldingIdentity = ALICE_X500_HOLDING_ID.toCorda()
     private val sandbox = mock<SandboxGroupContext>()
 
     private val target = PersistenceRequestProcessor(
         entitySandboxService,
         delegatedRequestHandlerSelector,
-        externalEventResponseFactory
+        responseFactory
     )
 
     @BeforeEach
@@ -88,7 +88,7 @@ class PersistenceRequestProcessorTest {
         val failureResponseRecord = Record("", "3", FlowEvent())
         val request2Response = IllegalStateException()
         val handler2 = mock<RequestHandler>().apply { whenever(this.execute()).thenThrow(request2Response) }
-        whenever(externalEventResponseFactory.fatalError(request2.flowExternalEventContext, request2Response))
+        whenever(responseFactory.errorResponse(request2.flowExternalEventContext, request2Response))
             .thenReturn(failureResponseRecord)
         whenever(delegatedRequestHandlerSelector.selectHandler(sandbox, request2)).thenReturn(handler2)
 


### PR DESCRIPTION
The ledger persistence code was not returning transient errors to the flow engine and was instead treating everything as fatal.

The correct error handling has now been added.