### PR TITLE
Lizr3/core 8641/simulator session management

### DIFF
--- a/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedCordaNetwork.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedCordaNetwork.kt
@@ -34,9 +34,9 @@ interface SimulatedCordaNetwork : Closeable {
      * @param instanceFlow An instance of an initiator/ responder flow.
      * @return A simulated virtual node which can run this instance of a initiator/responder flow.
      */
-    fun createVirtualNode(
+    fun createInstanceNode(
         holdingIdentity: HoldingIdentity,
         protocol: String,
-        instanceFlow: Flow
-    ): SimulatedVirtualNode
+        flow: Flow
+    ): SimulatedInstanceNode
 }

--- a/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedInstanceNode.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedInstanceNode.kt
@@ -1,0 +1,15 @@
+package net.corda.simulator
+
+interface SimulatedInstanceNode : SimulatedNode {
+
+    /**
+     * Calls the flow with the given request. Note that this call happens on the calling thread, which will wait until
+     * the flow has completed before returning the response.
+     *
+     * @param input The data to input to the flow.
+     * @param flow The flow to be called
+     *
+     * @return The response from the flow.
+     */
+    fun callInstanceFlow(input: RequestData): String
+}

--- a/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedInstanceNode.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedInstanceNode.kt
@@ -1,5 +1,8 @@
 package net.corda.simulator
 
+/**
+ * A simulated node in which the flow to be run has already been constructed.
+ */
 interface SimulatedInstanceNode : SimulatedNode {
 
     /**
@@ -7,9 +10,10 @@ interface SimulatedInstanceNode : SimulatedNode {
      * the flow has completed before returning the response.
      *
      * @param input The data to input to the flow.
-     * @param flow The flow to be called
      *
      * @return The response from the flow.
+     * @throws IllegalStateException if the flow with which this node was constructed was not a
+     * [net.corda.v5.application.flows.RPCStartableFlow].
      */
     fun callInstanceFlow(input: RequestData): String
 }

--- a/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedNode.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedNode.kt
@@ -1,0 +1,39 @@
+package net.corda.simulator
+
+import net.corda.simulator.crypto.HsmCategory
+import net.corda.v5.application.persistence.PersistenceService
+import net.corda.v5.base.types.MemberX500Name
+import java.security.PublicKey
+
+interface SimulatedNode {
+
+
+    /**
+     * The holding identity for which this node was created.
+     */
+    val holdingIdentity: HoldingIdentity
+
+    /**
+     * The member for which this node was created.
+     */
+    val member : MemberX500Name
+
+    /**
+     * @return The persistence service associated with this node.
+     */
+    fun getPersistenceService(): PersistenceService
+
+    /**
+     * Generates a key for this node which can then be accessed using the
+     * [net.corda.v5.application.membership.MemberLookup] service and used with the
+     * [net.corda.v5.application.crypto.SigningService] and
+     * [net.corda.v5.application.crypto.DigitalSignatureVerificationService]. Note that Simulator does not actually
+     * perform encryption, simulating it instead, and no private keys are held.
+     *
+     * @param alias An alias for the key.
+     * @param hsmCategory The HSM category for the key.
+     * @param scheme The scheme for the key. This is only used in verification. An ECDSA key will be returned.
+     * @return An ECDSA public key.
+     */
+    fun generateKey(alias: String, hsmCategory: HsmCategory, scheme: String) : PublicKey
+}

--- a/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedVirtualNode.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedVirtualNode.kt
@@ -3,7 +3,7 @@ package net.corda.simulator
 import net.corda.v5.base.annotations.DoNotImplement
 
 /**
- * A simulated virtual node in which flows or instances of flows can be run.
+ * A simulated virtual node in which flows can be run.
  */
 @DoNotImplement
 interface SimulatedVirtualNode : SimulatedNode {

--- a/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedVirtualNode.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/SimulatedVirtualNode.kt
@@ -1,27 +1,12 @@
 package net.corda.simulator
 
-import net.corda.simulator.crypto.HsmCategory
-import net.corda.v5.application.flows.RPCStartableFlow
-import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.annotations.DoNotImplement
-import net.corda.v5.base.types.MemberX500Name
-import java.security.PublicKey
 
 /**
  * A simulated virtual node in which flows or instances of flows can be run.
  */
 @DoNotImplement
-interface SimulatedVirtualNode {
-
-    /**
-     * The holding identity for which this node was created.
-     */
-    val holdingIdentity: HoldingIdentity
-
-    /**
-     * The member for which this node was created.
-     */
-    val member : MemberX500Name
+interface SimulatedVirtualNode : SimulatedNode {
 
     /**
      * Calls the flow with the given request. Note that this call happens on the calling thread, which will wait until
@@ -32,34 +17,4 @@ interface SimulatedVirtualNode {
      * @param return The response from the flow.
      */
     fun callFlow(input: RequestData): String
-
-    /**
-     * Calls the flow with the given request. Note that this call happens on the calling thread, which will wait until
-     * the flow has completed before returning the response.
-     *
-     * @param input The data to input to the flow.
-     * @param flow The flow to be called
-     *
-     * @return The response from the flow.
-     */
-    fun callInstanceFlow(input: RequestData, flow: RPCStartableFlow): String
-
-    /**
-     * @return The persistence service associated with this node.
-     */
-    fun getPersistenceService(): PersistenceService
-
-    /**
-     * Generates a key for this node which can then be accessed using the
-     * [net.corda.v5.application.membership.MemberLookup] service and used with the
-     * [net.corda.v5.application.crypto.SigningService] and
-     * [net.corda.v5.application.crypto.DigitalSignatureVerificationService]. Note that Simulator does not actually
-     * perform encryption, simulating it instead, and no private keys are held.
-     *
-     * @param alias An alias for the key.
-     * @param hsmCategory The HSM category for the key.
-     * @param scheme The scheme for the key. This is only used in verification. An ECDSA key will be returned.
-     * @return An ECDSA public key.
-     */
-    fun generateKey(alias: String, hsmCategory: HsmCategory, scheme: String) : PublicKey
 }

--- a/simulator/api/src/main/kotlin/net/corda/simulator/Simulator.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/Simulator.kt
@@ -57,14 +57,13 @@ class Simulator(
      * @param instanceFlow An instance of a responder/initiator flow.
      * @return A simulated virtual node which can run this instance of a responder flow.
      */
-    override fun createVirtualNode(
+    override fun createInstanceNode(
         holdingIdentity: HoldingIdentity,
         protocol: String,
-        instanceFlow: Flow
-    ): SimulatedVirtualNode {
-        return delegate.createVirtualNode(holdingIdentity, protocol, instanceFlow)
+        flow: Flow
+    ): SimulatedInstanceNode {
+        return delegate.createInstanceNode(holdingIdentity, protocol, flow)
     }
-
 
     /**
      * Closes Simulator, releasing all resources including any database connections and in-memory databases.

--- a/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/SessionAlreadyClosedException.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/exceptions/SessionAlreadyClosedException.kt
@@ -1,0 +1,5 @@
+package net.corda.simulator.exceptions
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class SessionAlreadyClosedException : CordaRuntimeException("Session already closed")

--- a/simulator/example-app/src/integrationTest/java/net/cordacon/example/RollCallJavaTest.java
+++ b/simulator/example-app/src/integrationTest/java/net/cordacon/example/RollCallJavaTest.java
@@ -18,6 +18,7 @@ import net.cordacon.example.rollcall.TruancyResponderFlow;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
@@ -12,7 +12,6 @@ import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
-import net.corda.v5.application.messaging.receive
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
@@ -69,10 +68,6 @@ class DoorCodeChangeFlow : RPCStartableFlow {
             result.signatures.map { getMemberFromSignature(it) }.toSet()
         )
 
-        @Suppress("ForbiddenComment")
-        // TODO: This can be removed along with corresponding send once CORE-8641 is done
-        sessions.forEach { it.receive() }
-
         return jsonMarshallingService.format(output)
     }
 
@@ -118,7 +113,6 @@ class DoorCodeChangeResponderFlow : ResponderFlow {
             "and got:\n    " + actualSignatories.joinToString("\n    ")
         }
         log.info("Finished responder flow - $finalizedSignedTransaction")
-        session.send(Unit)
     }
 }
 

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
@@ -35,20 +35,19 @@ class TruancyResponderFlow : ResponderFlow {
 
     @Suspendable
     override fun call(session: FlowSession) {
-        log.info("Received request; persisting records")
+        log.info("Request to process truancy records received")
 
         val record = session.receive(TruancyRecord::class.java)
 
-        verificationService.verify(record.signature.by, SignatureSpec.ECDSA_SHA256, record.signature.bytes,
-            serializationService.serialize(record.absentees).bytes)
+        verificationService.verify(
+            record.signature.by, SignatureSpec.ECDSA_SHA256, record.signature.bytes,
+            serializationService.serialize(record.absentees).bytes
+        )
+        log.info("Records verified; persisting records")
 
         persistenceService.persist(record.absentees.map { TruancyEntity(name = it.toString()) })
-
-        session.send(Unit)
-
         log.info("Records persisted")
     }
-
 }
 
 @CordaSerializable

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
@@ -6,6 +6,7 @@ import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
 
 @InitiatingFlow("truancy-record")
 class TruancySubFlow(
@@ -13,14 +14,19 @@ class TruancySubFlow(
         private val truancyRecord: TruancyRecord
     ) : SubFlow<String> {
 
+    private companion object {
+        val log = contextLogger()
+    }
+
+
     @CordaInject
     lateinit var flowMessaging : FlowMessaging
 
     @Suspendable
     override fun call(): String {
+        log.info("Sending truancy record")
         val session = flowMessaging.initiateFlow(truancyOffice)
         session.send(truancyRecord)
-        session.receive(Unit::class.java)
         return ""
     }
 }

--- a/simulator/runtime/src/integrationTest/kotlin/SessionManagementTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/SessionManagementTest.kt
@@ -1,0 +1,102 @@
+import net.corda.simulator.HoldingIdentity
+import net.corda.simulator.RequestData
+import net.corda.simulator.Simulator
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.Suspendable
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SessionManagementTest {
+
+    companion object {
+
+        val alice = HoldingIdentity.create("Alice")
+        val bob = HoldingIdentity.create("Bob")
+        val charlie = HoldingIdentity.create("Charlie")
+
+        @InitiatingFlow("send-receive")
+        class InitiatingSendingFlow: RPCStartableFlow {
+            @CordaInject
+            private lateinit var flowMessaging: FlowMessaging
+
+            @Suspendable
+            override fun call(requestBody: RPCRequestData): String {
+                val session = flowMessaging.initiateFlow(bob.member)
+                session.send(Unit)
+                return ""
+            }
+        }
+
+        @InitiatedBy("send-receive")
+        class ReceivingAndSendingOnFlow: ResponderFlow {
+            @CordaInject
+            private lateinit var flowEngine: FlowEngine
+
+            @Suspendable
+            override fun call(session: FlowSession) {
+                session.receive(Any::class.java)
+                flowEngine.subFlow(SendingOnSubFlow())
+
+            }
+        }
+
+        @InitiatingFlow("receive-send")
+        class SendingOnSubFlow: SubFlow<String> {
+            @CordaInject
+            private lateinit var flowMessaging: FlowMessaging
+
+            @Suspendable
+            override fun call(): String {
+                val session = flowMessaging.initiateFlow(charlie.member)
+                session.receive(Any::class.java)
+                return ""
+            }
+        }
+
+        class SleepingEndFlow: ResponderFlow {
+            var finished = false
+
+            override fun call(session: FlowSession) {
+                Thread.sleep(200)
+                session.send(Any::class.java)
+                finished = true
+            }
+        }
+    }
+
+    @Test
+    fun `Simulator nodes should wait for all sessions to finish before returning`() {
+
+        // Given flow logic that look like:
+        //     Alice sends to Bob
+        //     Bob receives from Alice and starts a sub-flow that sends to Charlie
+        //     Charlie receives from Bob and waits for 200 ms before returning
+        // So we have a responder thread kicking off another responder thread in a subflow
+
+        val simulator = Simulator()
+        val charliesInstanceFlow = SleepingEndFlow()
+
+        val aliceNode = simulator.createVirtualNode(alice, InitiatingSendingFlow::class.java)
+        simulator.createVirtualNode(bob, ReceivingAndSendingOnFlow::class.java)
+        simulator.createInstanceNode(charlie, "receive-send", charliesInstanceFlow)
+
+        // When we call Alice's flow
+        aliceNode.callFlow(RequestData.Companion.create("r1", InitiatingSendingFlow::class.java, Unit))
+
+        // Then it shouldn't finish until Charlie's does
+        assertTrue(charliesInstanceFlow.finished)
+    }
+
+
+
+
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
@@ -1,0 +1,54 @@
+package net.corda.simulator.runtime
+
+import net.corda.simulator.HoldingIdentity
+import net.corda.simulator.RequestData
+import net.corda.simulator.SimulatedInstanceNode
+import net.corda.simulator.runtime.flows.BaseFlowManager
+import net.corda.simulator.runtime.flows.FlowFactory
+import net.corda.simulator.runtime.flows.FlowManager
+import net.corda.simulator.runtime.flows.FlowServicesInjector
+import net.corda.simulator.runtime.messaging.SimFiber
+import net.corda.v5.application.flows.Flow
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
+
+@Suppress("LongParameterList")
+class SimulatedInstanceNodeBase(
+    override val holdingIdentity: HoldingIdentity,
+    private val protocol: String,
+    private val flow: Flow,
+    override val fiber: SimFiber,
+    private val injector: FlowServicesInjector,
+    private val flowFactory: FlowFactory,
+    private val flowManager: FlowManager = BaseFlowManager()
+) : SimulatedNodeBase(), SimulatedInstanceNode {
+
+    override val member : MemberX500Name = holdingIdentity.member
+
+    init {
+        fiber.registerMember(member)
+        if (ResponderFlow::class.java.isInstance(flow)) {
+            fiber.registerFlowInstance(member, protocol, flow)
+        } else if (!RPCStartableFlow::class.java.isInstance(flow)) {
+            error("Member \"$member\" has already registered " +
+                    "flow instance for protocol \"$protocol\"")
+        }
+    }
+
+    companion object {
+        val log = contextLogger()
+    }
+
+    override fun callInstanceFlow(input: RequestData): String {
+
+        log.info("Calling flow instance for member \"$member\" and protocol \"$protocol\" " +
+                "with request: ${input.requestBody}")
+        injector.injectServices(flow, member, fiber, flowFactory)
+        val result = flowManager.call(input.toRPCRequestData(), flow as RPCStartableFlow)
+        SimulatedVirtualNodeBase.log.info("Finished flow instance for member \"$member\" and protocol \"$protocol\"")
+        return result
+    }
+
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedNodeBase.kt
@@ -1,0 +1,27 @@
+package net.corda.simulator.runtime
+
+import net.corda.simulator.SimulatedNode
+import net.corda.simulator.crypto.HsmCategory
+import net.corda.simulator.runtime.messaging.SimFiber
+import net.corda.v5.application.persistence.PersistenceService
+import net.corda.v5.base.util.contextLogger
+import java.security.PublicKey
+
+abstract class SimulatedNodeBase : SimulatedNode {
+
+    companion object {
+        val log = contextLogger()
+    }
+
+    protected abstract val fiber: SimFiber
+
+    override fun getPersistenceService(): PersistenceService =
+        fiber.getOrCreatePersistenceService(member)
+
+    override fun generateKey(alias: String, hsmCategory: HsmCategory, scheme: String) : PublicKey {
+        log.info("Generating key with alias \"$alias\", hsm category \"$hsmCategory\", scheme \"$scheme\" " +
+                "for member \"$member\""
+        )
+        return fiber.generateAndStoreKey(alias, hsmCategory, scheme, member)
+    }
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
@@ -3,15 +3,13 @@ package net.corda.simulator.runtime
 import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.RequestData
 import net.corda.simulator.SimulatedVirtualNode
-import net.corda.simulator.crypto.HsmCategory
+import net.corda.simulator.runtime.flows.BaseFlowManager
 import net.corda.simulator.runtime.flows.FlowFactory
+import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.messaging.SimFiber
-import net.corda.v5.application.flows.RPCStartableFlow
-import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
-import java.security.PublicKey
 
 /**
  * The base class for simulated virtual nodes.
@@ -24,43 +22,25 @@ import java.security.PublicKey
  */
 class SimulatedVirtualNodeBase(
     override val holdingIdentity: HoldingIdentity,
-    private val fiber: SimFiber,
+    override val fiber: SimFiber,
     private val injector: FlowServicesInjector,
-    private val flowFactory: FlowFactory
-) : SimulatedVirtualNode {
+    private val flowFactory: FlowFactory,
+    private val flowManager: FlowManager = BaseFlowManager()
+) : SimulatedNodeBase(), SimulatedVirtualNode {
 
     companion object {
         val log = contextLogger()
     }
 
     override val member : MemberX500Name = holdingIdentity.member
+
     override fun callFlow(input: RequestData): String {
         val flowClassName = input.flowClassName
         log.info("Calling flow $flowClassName for member \"$member\" with request: ${input.requestBody}")
         val flow = flowFactory.createInitiatingFlow(member, flowClassName)
         injector.injectServices(flow, member, fiber, flowFactory)
-        val result = flow.call(input.toRPCRequestData())
+        val result = flowManager.call(input.toRPCRequestData(), flow)
         log.info("Finished flow $flowClassName for member \"$member\"")
         return result
-    }
-
-    override fun callInstanceFlow(input: RequestData, flow: RPCStartableFlow): String {
-        val flowClassName = input.flowClassName
-        log.info("Calling flow instance $flowClassName for member \"$member\" with request: ${input.requestBody}")
-        injector.injectServices(flow, member, fiber, flowFactory)
-        val result = flow.call(input.toRPCRequestData())
-        log.info("Finished flow $flowClassName for member \"$member\"")
-        return result
-    }
-
-
-    override fun getPersistenceService(): PersistenceService =
-        fiber.getOrCreatePersistenceService(member)
-
-    override fun generateKey(alias: String, hsmCategory: HsmCategory, scheme: String) : PublicKey {
-        log.info("Generating key with alias \"$alias\", hsm category \"$hsmCategory\", scheme \"$scheme\" " +
-                "for member \"$member\""
-        )
-        return fiber.generateAndStoreKey(alias, hsmCategory, scheme, member)
     }
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
@@ -2,6 +2,7 @@ package net.corda.simulator.runtime
 
 import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.SimulatedCordaNetwork
+import net.corda.simulator.SimulatedInstanceNode
 import net.corda.simulator.SimulatedVirtualNode
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.runtime.flows.BaseFlowFactory
@@ -79,17 +80,15 @@ class SimulatorDelegateBase  (
         )
     }
 
-    override fun createVirtualNode(
+    override fun createInstanceNode(
         holdingIdentity: HoldingIdentity,
         protocol: String,
-        instanceFlow: Flow
-    ): SimulatedVirtualNode {
-        log.info("Creating virtual node for \"${holdingIdentity.member}\", flow instance provided for protocol $protocol")
-        fiber.registerMember(holdingIdentity.member)
-        fiber.registerFlowInstance(holdingIdentity.member, protocol, instanceFlow)
-        return SimulatedVirtualNodeBase(holdingIdentity, fiber, injector, flowFactory)
+        flow: Flow
+    ): SimulatedInstanceNode {
+        log.info("Creating virtual node for \"${holdingIdentity.member}\", " +
+                "flow instance provided for protocol $protocol")
+        return SimulatedInstanceNodeBase(holdingIdentity, protocol, flow, fiber, injector, flowFactory)
     }
-
 
     override fun close() {
         log.info("Closing Simulator")

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/BaseFlowManager.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/BaseFlowManager.kt
@@ -1,0 +1,40 @@
+package net.corda.simulator.runtime.flows
+
+import net.corda.simulator.runtime.utils.accessField
+import net.corda.v5.application.flows.Flow
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.base.util.contextLogger
+import java.io.Closeable
+
+class BaseFlowManager : FlowManager {
+
+    companion object {
+        val log = contextLogger()
+    }
+
+    override fun call(requestData: RPCRequestData, flow: RPCStartableFlow) : String {
+        val result = flow.call(requestData)
+        closeFlowMessaging(flow)
+        return result
+    }
+
+    private fun closeFlowMessaging(flow: Flow) {
+        val flowMessagingField = flow.accessField(FlowMessaging::class.java)
+        val flowMessaging = flowMessagingField?.get(flow) as Closeable?
+
+        if (flowMessaging != null) {
+            log.info("FlowMessaging found on flow ${flow.javaClass.simpleName} - closing down")
+            flowMessaging.close()
+            log.info("FlowMessaging on flow ${flow.javaClass.simpleName} closed")
+        }
+    }
+
+    override fun <R> call(subFlow: SubFlow<R>): R {
+        val result = subFlow.call()
+        closeFlowMessaging(subFlow)
+        return result
+    }
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/BaseFlowManager.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/BaseFlowManager.kt
@@ -9,6 +9,9 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.base.util.contextLogger
 import java.io.Closeable
 
+/**
+ * See [FlowManager].
+ */
 class BaseFlowManager : FlowManager {
 
     companion object {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowManager.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowManager.kt
@@ -4,8 +4,26 @@ import net.corda.v5.application.flows.RPCRequestData
 import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.SubFlow
 
+/**
+ * Calls the flow or subflow provided, waiting until all flows in this call have finished and closing down all sessions
+ * before returning.
+ */
 interface FlowManager {
 
+    /**
+     * Calls the provided flow with the given request.
+     *
+     * @param requestData The request to provide to the flow.
+     * @param flow The flow to call.
+     * @return The result of the flow.
+     */
     fun call(requestData: RPCRequestData, flow: RPCStartableFlow) : String
+
+    /**
+     * Calls the provided subflow.
+     *
+     * @param subFlow The subflow to call.
+     * @return The result of the subflow.
+     */
     fun <R> call(subFlow: SubFlow<R>): R
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowManager.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowManager.kt
@@ -1,0 +1,11 @@
+package net.corda.simulator.runtime.flows
+
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.SubFlow
+
+interface FlowManager {
+
+    fun call(requestData: RPCRequestData, flow: RPCStartableFlow) : String
+    fun <R> call(subFlow: SubFlow<R>): R
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
@@ -25,12 +25,14 @@ import java.util.UUID
  *
  * @return The value returned by the subflow when called.
  */
+@Suppress("LongParameterList")
 class InjectingFlowEngine(
     private val configuration: SimulatorConfiguration,
     override val virtualNodeName: MemberX500Name,
     private val fiber: SimFiber,
     private val injector: FlowServicesInjector = DefaultServicesInjector(configuration),
-    private val flowChecker: FlowChecker = CordaFlowChecker()
+    private val flowChecker: FlowChecker = CordaFlowChecker(),
+    private val flowManager: FlowManager = BaseFlowManager()
 ) : FlowEngine {
     companion object {
         val log = contextLogger()
@@ -46,7 +48,7 @@ class InjectingFlowEngine(
         log.info("Running subflow ${SubFlow::class.java} for \"$virtualNodeName\"")
         flowChecker.check(subFlow.javaClass)
         injector.injectServices(subFlow, virtualNodeName, fiber)
-        val result = subFlow.call()
+        val result = flowManager.call(subFlow)
         log.info("Finished subflow ${SubFlow::class.java} for \"$virtualNodeName\"")
         return result
     }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
@@ -1,12 +1,22 @@
 package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.exceptions.ResponderFlowException
+import net.corda.simulator.exceptions.SessionAlreadyClosedException
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
+import java.time.Instant
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+
+enum class SessionState {
+    AVAILABLE { override fun closedCheck() {} },
+    CLOSED { override fun closedCheck() { throw SessionAlreadyClosedException() } };
+
+    abstract fun closedCheck()
+}
+
 
 /**
  * Implementation of [FlowSession] that uses two [BlockingQueue]s to enable sender and receiver to communicate.
@@ -15,21 +25,18 @@ import java.util.concurrent.TimeoutException
  * @param from The queue on which to receive.
  * @param to The queue on which to send.
  */
-class BlockingQueueFlowSession(
+abstract class BlockingQueueFlowSession(
     private val flowDetails: FlowContext,
-    private val from: BlockingQueue<Any>,
-    private val to: BlockingQueue<Any>
+    protected val from: BlockingQueue<Any>,
+    protected val to: BlockingQueue<Any>
 ) : FlowSession {
 
-    private val configuration = flowDetails.configuration
-    private var caughtResponderError: Throwable? = null
 
-    /**
-     * Not implemented.
-     */
-    override fun close() {
-        TODO("Not yet implemented")
-    }
+    protected val configuration = flowDetails.configuration
+    protected var counterpartyError: Throwable? = null
+    protected abstract fun rethrowAnyResponderError()
+
+    protected var state = SessionState.AVAILABLE
 
     /**
      * Not implemented.
@@ -57,12 +64,11 @@ class BlockingQueueFlowSession(
      * @throws ResponderFlowException if an error was detected in the responding flow.
      */
     override fun <R : Any> receive(receiveType: Class<R>): R {
+        state.closedCheck()
         val start = configuration.clock.instant()
-        while (configuration.clock.instant().minus(configuration.timeout) < start) {
-            val immutableResponderError = caughtResponderError
-            if (immutableResponderError != null) {
-                throw ResponderFlowException(immutableResponderError)
-            }
+        while (true) {
+            checkTimeout(start)
+            rethrowAnyResponderError()
             val received = from.poll(configuration.pollInterval.toMillis(), TimeUnit.MILLISECONDS)
             if (received != null) {
                 try {
@@ -73,14 +79,15 @@ class BlockingQueueFlowSession(
                 }
             }
         }
-        throw TimeoutException("Session belonging to \"$counterparty\" timed out after ${configuration.timeout}")
     }
 
-    /**
-     * @param payload The payload to send to the counterparty.
-     */
-    override fun send(payload: Any) {
-        to.put(payload)
+    protected fun checkTimeout(start: Instant) {
+        val now = configuration.clock.instant()
+        val against = start.plus(configuration.timeout)
+        val timedOut = now > against
+        if(timedOut) {
+            throw TimeoutException("Session belonging to \"$counterparty\" timed out after ${configuration.timeout}")
+        }
     }
 
     /**
@@ -94,14 +101,5 @@ class BlockingQueueFlowSession(
         send(payload)
         return receive(receiveType)
     }
-
-    /**
-     * Used by [net.corda.v5.application.messaging.FlowMessaging] to indicate that an exception has been detected on
-     * the responding thread.
-     *
-     * @param t The error thrown by the responding thread.
-     */
-    fun responderErrorCaught(t: Throwable) {
-        caughtResponderError = t
-    }
 }
+

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
@@ -8,8 +8,10 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
-import java.util.concurrent.LinkedBlockingQueue
+import java.io.Closeable
 import kotlin.concurrent.thread
+
+interface CloseableFlowMessaging: FlowMessaging, Closeable
 
 /**
  * FlowMessaging is responsible for sending messages and from other "virtual nodes".
@@ -33,8 +35,11 @@ class ConcurrentFlowMessaging(
     private val flowContext: FlowContext,
     private val fiber: SimFiber,
     private val injector: FlowServicesInjector,
-    private val flowFactory: FlowFactory
-) : FlowMessaging {
+    private val flowFactory: FlowFactory,
+    private val sessionFactory: SessionFactory = BaseSessionFactory()
+) : CloseableFlowMessaging {
+
+    private val openedSessions = mutableListOf<SessionPair>()
 
     companion object {
         val log = contextLogger()
@@ -67,24 +72,20 @@ class ConcurrentFlowMessaging(
 
         injector.injectServices(responderFlow, x500Name, fiber, flowFactory)
 
-        val fromInitiatorToResponder = LinkedBlockingQueue<Any>()
-        val fromResponderToInitiator = LinkedBlockingQueue<Any>()
-        val initiatorSession = BlockingQueueFlowSession(
-            flowContext.copy(member = x500Name),
-            fromResponderToInitiator,
-            fromInitiatorToResponder
-        )
-        val recipientSession = BlockingQueueFlowSession(
-            flowContext,
-            fromInitiatorToResponder,
-            fromResponderToInitiator,
-        )
+        val sessions = sessionFactory.createSessions(x500Name, flowContext)
+        openedSessions.add(sessions)
+
+        val (initiatorSession, responderSession) = sessions
 
         log.info("Starting responder thread for protocol \"$protocol\" from \"${flowContext.member}\" to \"$x500Name\"")
         thread {
             try {
-                responderFlow.call(recipientSession)
+                responderFlow.call(responderSession)
+                responderSession.close()
+                initiatorSession.responderClosed()
+                log.info("Closed responder for protocol \"$protocol\" from \"${flowContext.member}\" to \"$x500Name\"")
             } catch (t: Throwable) {
+                log.info("Caught error in protocol \"$protocol\" from \"${flowContext.member}\" to \"$x500Name\"")
                 initiatorSession.responderErrorCaught(t)
             }
         }
@@ -115,6 +116,16 @@ class ConcurrentFlowMessaging(
 
     override fun sendAllMap(payloadsPerSession: Map<FlowSession, Any>) {
         TODO("Not yet implemented")
+    }
+
+    override fun close() {
+        openedSessions.forEach {
+            // Note that this order is important; the initiator waits for the responder to close anyway,
+            // which means that it has successfully been called.
+            // The second call to close the responder is in case it has errored.
+            it.initiatorSession.close()
+            it.responderSession.close()
+        }
     }
 
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/InitiatorFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/InitiatorFlowSession.kt
@@ -1,0 +1,95 @@
+package net.corda.simulator.runtime.messaging
+
+import net.corda.simulator.exceptions.ResponderFlowException
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.util.contextLogger
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+interface InitiatorFlowSession : FlowSession {
+    /**
+     * Used by [ConcurrentFlowMessaging] to indicate that an exception has been detected on
+     * the responding thread.
+     *
+     * @param t The error thrown by the responding thread.
+     */
+    fun responderErrorCaught(t: Throwable)
+    fun responderClosed()
+}
+
+class BaseInitiatorFlowSession(
+    private val flowDetails: FlowContext,
+    from: BlockingQueue<Any>,
+    to: BlockingQueue<Any>
+) : BlockingQueueFlowSession(flowDetails, from, to), InitiatorFlowSession {
+
+    companion object {
+        val log = contextLogger()
+    }
+
+    private var responderSessionClosed: Boolean = false
+    private val runningLock = ReentrantLock()
+    private val runningCondition = runningLock.newCondition()
+
+    /**
+     * @param payload The payload to send to the counterparty.
+     */
+    override fun send(payload: Any) {
+        rethrowAnyResponderError()
+        state.closedCheck()
+        to.put(payload)
+    }
+
+    override fun rethrowAnyResponderError() {
+        val immutableResponderError = counterpartyError
+        if (immutableResponderError != null) {
+            throw ResponderFlowException(immutableResponderError)
+        }
+    }
+
+    /**
+     * Used by [net.corda.v5.application.messaging.FlowMessaging] to indicate that an exception has been detected on
+     * the responding thread.
+     *
+     * @param t The error thrown by the responding thread.
+     */
+    override fun responderErrorCaught(t: Throwable) {
+        counterpartyError = t
+        runningLock.withLock {
+            runningCondition.signalAll()
+        }
+    }
+
+    override fun responderClosed() {
+        responderSessionClosed = true
+        log.info("Initiator session with protocol ${flowDetails.protocol}, " +
+                "counterparty \"${flowDetails.member}\"; responder signalled close")
+        runningLock.withLock {
+            runningCondition.signalAll()
+        }
+    }
+
+    override fun close() {
+        rethrowAnyResponderError()
+        log.info("Closing initiator session with protocol ${flowDetails.protocol}, " +
+                "counterparty \"${flowDetails.member}\"; responder is closed: $responderSessionClosed")
+
+        val start = configuration.clock.instant()
+        while(
+            !responderSessionClosed
+            && counterpartyError == null
+        ) {
+            checkTimeout(start)
+            runningLock.withLock {
+                println("Waiting for responder to close")
+                runningCondition.await(configuration.pollInterval.toMillis(), TimeUnit.MILLISECONDS)
+            }
+        }
+        rethrowAnyResponderError()
+        state = SessionState.CLOSED
+        log.info("Closed initiator session with protocol ${flowDetails.protocol}, " +
+                "counterparty \"${flowDetails.member}\"")
+    }
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ResponderFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ResponderFlowSession.kt
@@ -1,0 +1,23 @@
+package net.corda.simulator.runtime.messaging
+
+import net.corda.v5.application.messaging.FlowSession
+import java.util.concurrent.BlockingQueue
+
+interface ResponderFlowSession : FlowSession
+
+class BaseResponderFlowSession(
+    flowDetails: FlowContext,
+    from: BlockingQueue<Any>,
+    to: BlockingQueue<Any>
+): BlockingQueueFlowSession(flowDetails, from, to), ResponderFlowSession {
+    override fun rethrowAnyResponderError() {}
+
+    override fun close() {
+        state = SessionState.CLOSED
+    }
+
+    override fun send(payload: Any) {
+        state.closedCheck()
+        to.put(payload)
+    }
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SessionFactory.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SessionFactory.kt
@@ -1,0 +1,31 @@
+package net.corda.simulator.runtime.messaging
+
+import net.corda.v5.base.types.MemberX500Name
+import java.util.concurrent.LinkedBlockingQueue
+
+interface SessionFactory {
+    fun createSessions(counterparty: MemberX500Name, flowContext: FlowContext): SessionPair
+}
+
+class BaseSessionFactory : SessionFactory {
+    override fun createSessions(counterparty: MemberX500Name, flowContext: FlowContext): SessionPair {
+        val fromInitiatorToResponder = LinkedBlockingQueue<Any>()
+        val fromResponderToInitiator = LinkedBlockingQueue<Any>()
+        val initiatorSession = BaseInitiatorFlowSession(
+            flowContext.copy(member = counterparty),
+            fromResponderToInitiator,
+            fromInitiatorToResponder
+        )
+        val recipientSession = BaseResponderFlowSession(
+            flowContext,
+            fromInitiatorToResponder,
+            fromResponderToInitiator,
+        )
+        return SessionPair(initiatorSession, recipientSession)
+    }
+}
+
+data class SessionPair(
+    val initiatorSession: InitiatorFlowSession,
+    val responderSession: ResponderFlowSession
+    )

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SimFiber.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SimFiber.kt
@@ -5,7 +5,6 @@ import net.corda.simulator.crypto.HsmCategory
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.flows.Flow
-import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.persistence.PersistenceService
@@ -18,55 +17,12 @@ import java.security.PublicKey
  * Simulates the Quasar fiber and Kafka bus which sit at the centre of real Corda clusters. All state that is
  * shared between nodes, except for flow sessions, is stored on an instance of this class.
  */
-interface SimFiber : Closeable, HasMemberInfos {
+interface SimFiber : Closeable, HasMemberInfos, FlowRegistry {
 
     /**
      * Registers an initiating member for [MemberLookup].
      */
     fun registerMember(member: MemberX500Name)
-
-    /**
-     * Registers a responder class against the given member name and protocol.
-     *
-     * @param responder The member for whom to register the responder class.
-     * @param protocol The detected protocol of the responder class.
-     * @param flowClass The responder class to construct for the given protocol.
-     */
-    fun registerResponderClass(responder: MemberX500Name, protocol: String, flowClass: Class<out ResponderFlow>)
-
-    /**
-     * Registers an instance initiating flows for a given member and protocol
-     *
-     * @param member The member who initiates/ responds to the flow
-     * @param protocol The protocol of the initiating flow
-     * @param instanceFlow The instance flow class
-     */
-    fun registerFlowInstance(member: MemberX500Name, protocol: String, instanceFlow: Flow)
-
-    /**
-     * @param member The member for whom to look up the responder class.
-     * @param protocol The protocol to which the responder should respond.
-     *
-     * @return A [ResponderFlow] class previously registered against the given name and protocol, or null if
-     * no class has been registered.
-     */
-    fun lookUpResponderClass(member: MemberX500Name, protocol: String): Class<out ResponderFlow>?
-
-    /**
-     * @param member The member for whom to look up the initiator instance.
-     *
-     * @return A [Map] of previously registered instance initiating flows with protocols
-     */
-    fun lookupFlowInstance(member: MemberX500Name): Map<Flow, String>?
-
-    /**
-     * @param member The member for whom to look up the responder instance.
-     * @param protocol The protocol to which the responder should respond.
-     *
-     * @return A [ResponderFlow] instance previously registered against the given name and protocol, or null if
-     * no instance has been registered.
-     */
-    fun lookUpResponderInstance(member: MemberX500Name, protocol: String): ResponderFlow?
 
     /**
      * Gets the existing persistence service for the given member, or creates one if it does not exist.

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedCordaNetworkBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedCordaNetworkBaseTest.kt
@@ -67,7 +67,7 @@ class SimulatedCordaNetworkBaseTest {
 
         // When I upload the relevant flow and concrete responder
         corda.createVirtualNode(holdingId, PingAckFlow::class.java)
-        corda.createVirtualNode(holdingId, "ping-ack", responder)
+        corda.createInstanceNode(holdingId, "ping-ack", responder)
 
         // Then it should have registered the responder with the fiber
         verify(fiber, times(1)).registerFlowInstance(holdingId.member,"ping-ack", responder)

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeTest.kt
@@ -1,17 +1,12 @@
 package net.corda.simulator.runtime
 
 import net.corda.simulator.HoldingIdentity
-import net.corda.simulator.factories.RequestDataFactory
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.messaging.SimFiber
 import net.corda.simulator.runtime.signing.SimKeyStore
 import net.corda.v5.application.flows.RPCStartableFlow
-import net.corda.v5.application.persistence.PersistenceService
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
-import org.hamcrest.Matchers.isA
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -20,21 +15,14 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
-class SimulatedVirtualNodeBaseTest {
-
+class SimulatedInstanceNodeTest {
 
     private lateinit var fiber : SimFiber
     private lateinit var flowFactory : FlowFactory
     private lateinit var injector : FlowServicesInjector
     private lateinit var keyStore : SimKeyStore
     private val holdingId = HoldingIdentity.create("IRunCordapps")
-
-    @Test
-    fun `should be a RequestDataFactory`() {
-        assertThat(RPCRequestDataWrapperFactory(), isA(RequestDataFactory::class.java))
-    }
 
     @BeforeEach
     fun `setup mocks`() {
@@ -45,27 +33,28 @@ class SimulatedVirtualNodeBaseTest {
     }
 
     @Test
-    fun `should instantiate flow, inject services and call flow`() {
+    fun `should inject services into instance flow and call flow`() {
         // Given a virtual node with dependencies
         val flowManager = mock<FlowManager>()
         val flow = mock<RPCStartableFlow>()
-        whenever(flowFactory.createInitiatingFlow(any(), any())).thenReturn(flow)
 
-        val virtualNode = SimulatedVirtualNodeBase(
+        val virtualNode = SimulatedInstanceNodeBase(
             holdingId,
+            "a protocol",
+            flow,
             fiber,
             injector,
             flowFactory,
             flowManager
         )
 
-        // When a flow class is run on that node
-        // (NB: it doesn't actually matter if the flow class was created in that node or not)
+        // When we create a node for an instance flow
         val input = RPCRequestDataWrapperFactory().create("r1", "aClass", "someData")
-        virtualNode.callFlow(input)
+
+        virtualNode.callInstanceFlow(input)
 
         // Then it should have instantiated the node and injected the services into it
-        verify(injector, times(1)).injectServices(eq(flow), eq(holdingId.member), eq(fiber), eq(flowFactory))
+        verify(injector, times(1)).injectServices(eq(flow), eq(holdingId.member), eq(fiber), any())
 
         // And the flow should have been called
         verify(flowManager, times(1)).call(
@@ -73,28 +62,4 @@ class SimulatedVirtualNodeBaseTest {
             eq(flow)
         )
     }
-
-    @Test
-    fun `should return any persistence service registered for that member on the fiber`() {
-        // Given a virtual node with dependencies
-        val virtualNode = SimulatedVirtualNodeBase(
-            holdingId,
-            fiber,
-            injector,
-            flowFactory,
-            mock()
-        )
-
-        // And a persistence service registered on the fiber
-        val persistenceService = mock<PersistenceService>()
-        whenever(fiber.getOrCreatePersistenceService(holdingId.member)).thenReturn(persistenceService)
-
-        // When we get the persistence service
-        val result = virtualNode.getPersistenceService()
-
-        // Then it should be the one that was registered
-        assertThat(result, `is`(persistenceService))
-    }
-
-
 }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/BaseFlowManagerTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/BaseFlowManagerTest.kt
@@ -1,0 +1,99 @@
+package net.corda.simulator.runtime.flows
+
+import net.corda.simulator.runtime.messaging.CloseableFlowMessaging
+import net.corda.simulator.runtime.utils.accessField
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.application.messaging.FlowMessaging
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import java.io.Closeable
+import java.security.AccessController
+import java.security.PrivilegedExceptionAction
+
+class BaseFlowManagerTest {
+
+    companion object {
+
+        private class MyCloseableFlowMessagingFlow : RPCStartableFlow {
+            @CordaInject
+            private val flowMessaging: FlowMessaging = mock<CloseableFlowMessaging>()
+
+            override fun call(requestBody: RPCRequestData): String { return "result" }
+        }
+
+        private class MyStandaloneFlow : RPCStartableFlow {
+            override fun call(requestBody: RPCRequestData): String { return "result" }
+        }
+
+        private class MyCloseableSubFlow : SubFlow<String> {
+            @CordaInject
+            private val flowMessaging: FlowMessaging = mock<CloseableFlowMessaging>()
+            override fun call(): String { return "result" }
+
+
+        }
+    }
+
+    @Test
+    fun `should close any flow messaging service on flows`() {
+        // Given a flow with flow messaging that's also closeable
+        val flow = MyCloseableFlowMessagingFlow()
+
+        // When we call it through the flow manager
+        val flowManager = BaseFlowManager()
+        val result = flowManager.call(mock(), flow)
+
+        // Then we should get the result back
+        assertThat(result, `is`("result"))
+
+        // And all closeable services should have been closed
+        val field = flow.accessField(FlowMessaging::class.java) ?: fail("No flow messaging service found")
+        AccessController.doPrivileged(PrivilegedExceptionAction {
+            field.isAccessible = true
+        })
+        val flowMessaging = field.get(flow) as Closeable
+        verify(flowMessaging, times(1)).close()
+    }
+
+    @Test
+    fun `should close any flow messaging service on subFlows`() {
+        // Given a flow with flow messaging that's also closeable
+        val subFlow = MyCloseableSubFlow()
+
+        // When we call it through the flow manager
+        val flowManager = BaseFlowManager()
+        val result = flowManager.call(subFlow)
+
+        // Then we should get the result back
+        assertThat(result, `is`("result"))
+
+        // And all closeable services should have been closed
+        val field = subFlow.accessField(FlowMessaging::class.java) ?: fail("No flow messaging service found")
+        AccessController.doPrivileged(PrivilegedExceptionAction {
+            field.isAccessible = true
+        })
+        val flowMessaging = field.get(subFlow) as Closeable
+        verify(flowMessaging, times(1)).close()
+    }
+
+    @Test
+    fun `should not worry about any flow that does not have FlowMessaging`() {
+        // Given a flow with no flow messaging
+        val flow = MyStandaloneFlow()
+
+        // When we call it through the flow manager
+        val flowManager = BaseFlowManager()
+        val result = flowManager.call(mock(), flow)
+
+        // Then we should get the result back with no errors
+        assertThat(result, `is`("result"))
+    }
+}

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InitiatorFlowSessionTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InitiatorFlowSessionTest.kt
@@ -1,0 +1,57 @@
+package net.corda.simulator.runtime.flows
+
+import net.corda.simulator.exceptions.ResponderFlowException
+import net.corda.simulator.factories.SimulatorConfigurationBuilder
+import net.corda.simulator.runtime.messaging.BaseInitiatorFlowSession
+import net.corda.simulator.runtime.messaging.FlowContext
+import net.corda.v5.application.messaging.receive
+import net.corda.v5.base.types.MemberX500Name
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.LinkedBlockingQueue
+import kotlin.concurrent.thread
+
+class InitiatorFlowSessionTest {
+
+    private val sender = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")
+    private val flowCallConfiguration = SimulatorConfigurationBuilder.create().build()
+
+    @Test
+    fun `initiators should throw an exception if receivedException is set`() {
+        // Given a session constructed only on the sending side
+        val fromInitiatorToResponder = LinkedBlockingQueue<Any>()
+        val fromResponderToInitiator = LinkedBlockingQueue<Any>()
+
+        val sendingSession = BaseInitiatorFlowSession(
+            FlowContext(flowCallConfiguration, sender, "ping-ack"),
+            fromResponderToInitiator,
+            fromInitiatorToResponder
+        )
+
+        // When we send a message and then set a received exception
+        thread {
+            Thread.sleep(100)
+            sendingSession.responderErrorCaught(IllegalArgumentException("Just because"))
+        }
+
+        // Then it should throw in that receive
+        assertThrows<ResponderFlowException> {
+            sendingSession.receive<Any>()
+        }
+
+        // Or in any subsequent send
+        assertThrows<ResponderFlowException> {
+            sendingSession.send(Unit)
+        }
+
+        // Or any subsequent receive
+        assertThrows<ResponderFlowException> {
+            sendingSession.receive<Any>()
+        }
+
+        // Or when we try to close the session
+        assertThrows<ResponderFlowException> {
+            sendingSession.close()
+        }
+    }
+}

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngineTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngineTest.kt
@@ -22,17 +22,18 @@ class InjectingFlowEngineTest {
     private val member = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")
 
     @Test
-    fun `should inject subflow with provided services then call it`() {
+    fun `should inject subflow with provided services then call it through the flow manager`() {
         // Given some services and an injector
         val fiber = mock<SimFiber>()
         val injector = mock<FlowServicesInjector>()
+        val flowManager = mock<FlowManager>()
 
         // And a flow engine which uses them
-        val engine = InjectingFlowEngine(mock(), member, fiber, injector, CordaFlowChecker())
+        val engine = InjectingFlowEngine(mock(), member, fiber, injector, CordaFlowChecker(), flowManager)
 
         // When we pass a subflow to the flow engine
         val flow = mock<SubFlow<String>>()
-        whenever(flow.call()).thenReturn("Yo!")
+        whenever(flowManager.call(flow)).thenReturn("Yo!")
 
         val response = engine.subFlow(flow)
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningServiceTest.kt
@@ -29,7 +29,6 @@ class SimWithJsonSigningServiceTest {
             SignatureSpec.ECDSA_SHA256.signatureName,
             KeyParameters("my-alias", HsmCategory.LEDGER, "anyscheme"),
         )
-        println(signed.bytes.decodeToString())
         assertThat(result, `is`(expected))
     }
 


### PR DESCRIPTION
- Simulator's nodes are now separated into virtual and instance nodes
- Both types will close any flow messaging at the end of the call
- Flow messaging closes any opened responder sessions when their call has finished
- Flow messaging closes any initiator sessions when it is closed
- Errors detected on responder threads will be rethrown for any subsequent interaction in initiator or responder, including close
- Sessions can now be closed; any subsequent interaction except for another `close()` call will throw an exception