### PR TITLE
NOTICK Try cut down `CryptoProcessorTests` time

### DIFF
--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -182,15 +182,11 @@ class CryptoProcessorTests {
 
         private val cryptoConfig = makeCryptoConfig()
 
-        private var startTime: Long? = null
-        private var endTime: Long? = null
-
         private lateinit var tracker: TestDependenciesTracker
 
         @JvmStatic
         @BeforeAll
         fun setup() {
-            startTime = System.nanoTime()
             setupPrerequisites()
             setupDatabases()
             setupVirtualNodeInfo()
@@ -206,10 +202,7 @@ class CryptoProcessorTests {
                 flowOpsResponsesSub.close()
             }
             cryptoProcessor.stop()
-            tracker.waitUntilStopped(Duration.ofSeconds(10))
-            endTime = System.nanoTime()
-            val endTimeSeconds = Duration.ofNanos(endTime!! - startTime!!).toSeconds()
-            logger.info(">>>>>>>>>>>>>>>> CryptoProcessorTests took $endTimeSeconds seconds to run")
+            tracker.waitUntilStopped(Duration.ofSeconds(5))
         }
 
         private fun setupPrerequisites() {
@@ -393,7 +386,7 @@ class CryptoProcessorTests {
         )
     }
 
-//    @ParameterizedTest
+    @ParameterizedTest
     @MethodSource("testCategories")
     fun `Should be able to get supported schemes`(
         category: String,
@@ -403,7 +396,7 @@ class CryptoProcessorTests {
         assertTrue(supportedSchemes.isNotEmpty())
     }
 
-//    @ParameterizedTest
+    @ParameterizedTest
     @MethodSource("testTenants")
     fun `Should not find unknown public key by its id`(
         tenantId: String
@@ -415,7 +408,7 @@ class CryptoProcessorTests {
         assertEquals(0, found.size)
     }
 
-//    @ParameterizedTest
+    @ParameterizedTest
     @MethodSource("testTenants")
     fun `Should return empty collection when lookp filter does not match`(
         tenantId: String
@@ -432,7 +425,7 @@ class CryptoProcessorTests {
         assertEquals(0, found.size)
     }
 
-//    @ParameterizedTest
+    @ParameterizedTest
     @MethodSource("testTenants")
     fun `Should generate a new key pair using alias then find it and use for hybrid encryption`(
         tenantId: String
@@ -455,7 +448,7 @@ class CryptoProcessorTests {
         `Should be able to derive secret and encrypt`(tenantId, original)
     }
 
-//    @ParameterizedTest
+    @ParameterizedTest
     @MethodSource("testTenants")
     fun `Should generate a new a new fresh key pair then find it and use for hybrid encryption`(
         tenantId: String
@@ -538,7 +531,7 @@ class CryptoProcessorTests {
         `Should be able to sign by flow ops and verify bu inferring signature spec`(tenantId, original)
     }
 
-//    @ParameterizedTest
+    @ParameterizedTest
     @MethodSource("testTenants")
     fun `Should generate a new fresh key pair without external id then find it and use for signing`(
         tenantId: String

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -340,7 +340,6 @@ class CryptoProcessorTests {
             hsmRegistrationClient.start()
             stableDecryptor.start()
             tracker = TestDependenciesTracker(
-                    LifecycleCoordinatorName.forComponent<CryptoProcessorTests>(),
             coordinatorFactory,
             lifecycleRegistry,
             setOf(

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -363,7 +363,13 @@ class CryptoProcessorTests {
         }
 
         private fun assignHSMs() {
-            CryptoConsts.Categories.all.forEach {
+            val cryptoCategories = setOf(
+                CryptoConsts.Categories.LEDGER,
+                CryptoConsts.Categories.TLS,
+                CryptoConsts.Categories.SESSION_INIT,
+            )
+
+            cryptoCategories.forEach {
                 // cluster is assigned in the crypto processor
                 if (hsmRegistrationClient.findHSM(vnodeId, it) == null) {
                     hsmRegistrationClient.assignSoftHSM(vnodeId, it)

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -356,6 +356,7 @@ class CryptoProcessorTests {
 
         private fun assignHSMs() {
             val cryptoCategories = setOf(
+                CryptoConsts.Categories.CI,
                 CryptoConsts.Categories.LEDGER,
                 CryptoConsts.Categories.TLS,
                 CryptoConsts.Categories.SESSION_INIT,

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -206,7 +206,7 @@ class CryptoProcessorTests {
                 flowOpsResponsesSub.close()
             }
             cryptoProcessor.stop()
-            tracker.waitUntilAllStopped(Duration.ofSeconds(10))
+            tracker.waitUntilStopped(Duration.ofSeconds(10))
             endTime = System.nanoTime()
             val endTimeSeconds = Duration.ofNanos(endTime!! - startTime!!).toSeconds()
             logger.info(">>>>>>>>>>>>>>>> CryptoProcessorTests took $endTimeSeconds seconds to run")

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
@@ -11,10 +11,11 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.registry.LifecycleRegistry
-import net.corda.test.util.eventually
+import net.corda.utilities.concurrent.getOrThrow
 import net.corda.v5.base.util.contextLogger
 import org.junit.jupiter.api.Assertions
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
 
 class TestDependenciesTracker(
     coordinatorName: LifecycleCoordinatorName,
@@ -26,10 +27,12 @@ class TestDependenciesTracker(
         private val logger = contextLogger()
     }
 
-    @Volatile
     private var registrationHandle: RegistrationHandle? = null
 
     private val coordinator = coordinatorFactory.createCoordinator(coordinatorName, ::eventHandler)
+
+    private val allDependenciesUp = CompletableFuture<LifecycleStatus>()
+    private val stopped = CompletableFuture<Unit>()
 
     override val isRunning: Boolean
         get() = coordinator.isRunning
@@ -40,17 +43,20 @@ class TestDependenciesTracker(
     }
 
     override fun stop() {
-        logger.info("Stopping...")
-        coordinator.stop()
+        throw UnsupportedOperationException(
+            "TestDependenciesTracker is meant to be closed through underlying components"
+        )
+    }
+
+    private fun closeResourcesAndNotify() {
         registrationHandle?.close()
-        coordinator.close()
+        registrationHandle = null
+        stopped.complete(Unit)
     }
 
     fun waitUntilAllUp(duration: Duration) {
         try {
-            eventually(duration = duration) {
-                Assertions.assertTrue(coordinator.status == LifecycleStatus.UP)
-            }
+            Assertions.assertTrue(allDependenciesUp.getOrThrow(duration) == LifecycleStatus.UP)
         } catch (e: Throwable) {
             val downReport = lifecycleRegistry.componentStatus().values.filter {
                 it.status == LifecycleStatus.DOWN
@@ -67,6 +73,10 @@ class TestDependenciesTracker(
         logger.info("ALL DEPENDENCIES ARE UP!!!")
     }
 
+    fun waitUntilAllStopped(duration: Duration) {
+        stopped.getOrThrow(duration)
+    }
+
     private fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
         logger.info("Received event $event.")
         when (event) {
@@ -75,15 +85,23 @@ class TestDependenciesTracker(
                 logger.info("Registered to follow $registrationHandle")
             }
             is StopEvent -> {
-                registrationHandle?.close()
-                registrationHandle = null
+                closeResourcesAndNotify()
             }
             is RegistrationStatusChangeEvent -> {
                 coordinator.updateStatus(event.status)
-                if(event.status == LifecycleStatus.UP) {
-                    logger.info("All required dependencies are UP...")
-                } else {
-                    logger.info("Some or all required dependencies are DOWN...")
+                when (event.status) {
+                    LifecycleStatus.UP -> {
+                        logger.info("All required dependencies are UP...")
+                        // This will only work the very first time this block gets executed
+                        allDependenciesUp.complete(LifecycleStatus.UP)
+                    }
+                    LifecycleStatus.DOWN -> {
+                        logger.info("Some or all required dependencies are DOWN...")
+                        closeResourcesAndNotify()
+                    }
+                    else -> {
+                        logger.info("Some or all required dependencies are ERROR...")
+                    }
                 }
             }
         }

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
@@ -73,7 +73,8 @@ class TestDependenciesTracker(
         logger.info("ALL DEPENDENCIES ARE UP!!!")
     }
 
-    fun waitUntilAllStopped(duration: Duration) {
+    // This will actually get called when any of the sub components has stopped
+    fun waitUntilStopped(duration: Duration) {
         stopped.getOrThrow(duration)
     }
 

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
@@ -18,7 +18,6 @@ import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
 class TestDependenciesTracker(
-    coordinatorName: LifecycleCoordinatorName,
     coordinatorFactory: LifecycleCoordinatorFactory,
     private val lifecycleRegistry: LifecycleRegistry,
     private val dependencies: Set<LifecycleCoordinatorName>
@@ -29,6 +28,7 @@ class TestDependenciesTracker(
 
     private var registrationHandle: RegistrationHandle? = null
 
+    private val coordinatorName = LifecycleCoordinatorName.forComponent<TestDependenciesTracker>()
     private val coordinator = coordinatorFactory.createCoordinator(coordinatorName, ::eventHandler)
 
     private val allDependenciesUp = CompletableFuture<LifecycleStatus>()

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestUtils.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestUtils.kt
@@ -7,17 +7,13 @@ import net.corda.crypto.core.CryptoConsts.SOFT_HSM_ID
 import net.corda.crypto.core.aes.KeyCredentials
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
-import net.corda.lifecycle.Lifecycle
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
-import net.corda.processors.crypto.CryptoProcessor
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
-import net.corda.test.util.eventually
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.toAvro
-import org.junit.jupiter.api.Assertions.assertTrue
 import java.time.Instant
 import kotlin.random.Random
 
@@ -57,22 +53,6 @@ private val smartConfigFactory: SmartConfigFactory = SmartConfigFactory.create(
 
 inline fun <reified T> makeClientId(): String =
     "${T::class.java}-integration-test"
-
-fun Lifecycle.startAndWait() {
-    start()
-    isStarted()
-}
-
-fun CryptoProcessor.startAndWait(bootConfig: SmartConfig) {
-    start(bootConfig)
-    eventually {
-        assertTrue(isRunning, "Failed waiting to start for ${this::class.java.name}")
-    }
-}
-
-fun Lifecycle.isStarted() = eventually {
-    assertTrue(isRunning, "Failed waiting to start for ${this::class.java.name}")
-}
 
 fun makeMessagingConfig(): SmartConfig =
     smartConfigFactory.create(


### PR DESCRIPTION
- replace test thread retries with futures.
- cut down crypto categories to ones needed/ used by the test.
- further monitor `UP` and `DOWN` of test dependencies using `TestDependenciesTracker`.