### PR TITLE
CORE-8691: Delay Closing SandboxGroupContext

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -5,23 +5,79 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.cache.caffeine.CacheFactoryImpl
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
+import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.util.loggerFor
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
 
-internal class SandboxGroupContextCacheImpl(override val capacity: Long): SandboxGroupContextCache {
+internal class SandboxGroupContextCacheImpl(override val capacity: Long) : SandboxGroupContextCache {
     private companion object {
         private val logger = loggerFor<SandboxGroupContextCache>()
+    }
+
+    @VisibleForTesting
+    class ToBeClosed(
+        val cacheKey: VirtualNodeContext,
+        val sandboxGroupContextToClose: AutoCloseable,
+        sandboxGroupContext: CloseableSandboxGroupContext,
+        referenceQueue: ReferenceQueue<CloseableSandboxGroupContext>
+    ) : WeakReference<CloseableSandboxGroupContext>(sandboxGroupContext, referenceQueue)
+
+    @VisibleForTesting
+    val toBeClosed: ConcurrentHashMap.KeySetView<ToBeClosed, Boolean> = ConcurrentHashMap.newKeySet()
+
+    private val expiryQueue = ReferenceQueue<CloseableSandboxGroupContext>()
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun purgeExpiryQueue() {
+        // Close contexts that have already been garbage-collected
+        while (true) {
+            val head = expiryQueue.poll() as? ToBeClosed ?: break
+            if (!toBeClosed.remove(head)) {
+                logger.warn("Reaped unexpected sandboxGroup context for ${head.cacheKey}")
+            }
+
+            try {
+                head.sandboxGroupContextToClose.close()
+            } catch (e: Exception) {
+                logger.warn("Error closing sandboxGroup context for ${head.cacheKey}", e)
+            }
+        }
     }
 
     private val contexts: Cache<VirtualNodeContext, CloseableSandboxGroupContext> = CacheFactoryImpl().build(
         "Sandbox-Cache",
         Caffeine.newBuilder()
             .maximumSize(capacity)
+            // If the entry was manually removed from the cache by the user, automatically close the relevant
+            // SandboxGroupContext. If the entry was automatically removed due to eviction, however, add the
+            // SandboxGroupContext to the internal expiryQueue, so it is only closed once it is not referenced anymore.
             .removalListener { key, value, cause ->
-                logger.info("Evicting {} sandbox for: {} [{}]", key!!.sandboxGroupType, key.holdingIdentity.x500Name, cause.name)
-                value?.close()
-            })
+                if (cause.wasEvicted()) {
+                    (value as? AutoCloseable)?.also { autoCloseable ->
+                        toBeClosed += ToBeClosed(key!!, autoCloseable, value , expiryQueue)
+                    }
+
+                    logger.info(
+                        "Evicting ${key!!.sandboxGroupType} sandbox for: " +
+                                "${key.holdingIdentity.x500Name} [${cause.name}]"
+                    )
+
+                    purgeExpiryQueue()
+                } else {
+                    logger.info(
+                        "Removing ${key!!.sandboxGroupType} sandbox for: " +
+                                "${key.holdingIdentity.x500Name} [${cause.name}]"
+                    )
+
+                    value?.close()
+                }
+            }
+    )
 
     override fun remove(virtualNodeContext: VirtualNodeContext) {
+        purgeExpiryQueue()
         contexts.invalidate(virtualNodeContext)
     }
 
@@ -29,9 +85,12 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long): Sandbo
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext {
+        purgeExpiryQueue()
+
         return contexts.get(virtualNodeContext) {
-            logger.info("Caching {} sandbox for: {} (cache size: {})",
-                virtualNodeContext.sandboxGroupType, virtualNodeContext.holdingIdentity.x500Name, contexts.estimatedSize())
+            logger.info("Caching ${virtualNodeContext.sandboxGroupType} sandbox for: " +
+                    "${virtualNodeContext.holdingIdentity.x500Name} (cache size: ${contexts.estimatedSize()})")
+
             createFunction(virtualNodeContext)
         }
     }

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -9,36 +9,77 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 
 class SandboxGroupContextCacheTest {
+    private lateinit var id : HoldingIdentity
+    private lateinit var vNodeContext1: VirtualNodeContext
 
-    @Test
-    fun `when cache full, evict and close evicted`() {
-        val cache = SandboxGroupContextCacheImpl(1)
-
-        val id = mock<HoldingIdentity> {
+    @BeforeEach
+    fun setUp() {
+        id = mock {
             on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
         }
-        val vnodeContext1 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
 
+        vNodeContext1 = mock {
+            on { holdingIdentity } doReturn id
+            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
+        }
+    }
+
+    @Test
+    fun `when cache full, evict and do not close evicted if in use`() {
+        val cache = SandboxGroupContextCacheImpl(1)
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
+        cache.get(vNodeContext1) { sandboxContext1 }
+
+        @Suppress("UnusedPrivateMember")
         for (i in 1..100) {
             cache.get(mock {
-                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
                 on { holdingIdentity } doReturn id
+                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
             }) { mock() }
         }
 
+        assertThat(cache.toBeClosed).isNotEmpty
+        verify(sandboxContext1, never()).close()
+    }
+
+    @Test
+    fun `when cache full and not in use anymore, evict and close evicted`() {
+        val cache = SandboxGroupContextCacheImpl(1)
+        val sandboxContext1 = mock<CloseableSandboxGroupContext>()
+
+        cache.get(vNodeContext1) { sandboxContext1 }
+
+        // First eviction, close should not be invoked (there's at least one reference)
+        cache.get(mock {
+            on { holdingIdentity } doReturn id
+            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
+        }) { mock() }
+        verify(sandboxContext1, never()).close()
+
+        // Simulate the reference enqueue done by the GC execution (it might take longer than one
+        // cycle for the GC to do this, and we can't rely on System.gc())
+        cache.toBeClosed.forEach {
+            it.enqueue()
+        }
+
+        @Suppress("UnusedPrivateMember")
+        // Trigger some evictions, close should be invoked now
+        for (i in 1..50) {
+            cache.get(mock {
+                on { holdingIdentity } doReturn id
+                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
+            }) { mock() }
+        }
 
         verify(sandboxContext1, timeout(5000)).close()
     }
@@ -46,24 +87,16 @@ class SandboxGroupContextCacheTest {
     @Test
     fun `when cache closed, close everything`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
-        val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
-        }
-        val vnodeContext1 = mock<VirtualNodeContext> {
+        val vNodeContext2 = mock<VirtualNodeContext> {
             on { sandboxGroupType } doReturn SandboxGroupType.FLOW
             on { holdingIdentity } doReturn id
         }
-        val vnodeContext2 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
-
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
         val sandboxContext2 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
-        cache.get(vnodeContext2) { sandboxContext2 }
+        cache.get(vNodeContext1) { sandboxContext1 }
+        cache.get(vNodeContext2) { sandboxContext2 }
+        assertThat(cache.toBeClosed).isEmpty()
 
         cache.close()
 
@@ -74,19 +107,11 @@ class SandboxGroupContextCacheTest {
     @Test
     fun `when remove also close`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
-        val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
-        }
-        val vnodeContext1 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
-
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
-        cache.remove(vnodeContext1)
+        cache.get(vNodeContext1) { sandboxContext1 }
+        cache.remove(vNodeContext1)
+        assertThat(cache.toBeClosed).isEmpty()
 
         verify(sandboxContext1, timeout(5000)).close()
     }
@@ -94,34 +119,23 @@ class SandboxGroupContextCacheTest {
     @Test
     fun `when in cache retrieve same`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
-        val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
-        }
-        val vnodeContext1 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
-
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
+        cache.get(vNodeContext1) { sandboxContext1 }
+        val retrievedContext = cache.get(vNodeContext1) { mock() }
 
-        val retrievedContext = cache.get(vnodeContext1) { mock() }
-
+        assertThat(cache.toBeClosed).isEmpty()
         assertThat(retrievedContext).isSameAs(sandboxContext1)
     }
 
     @Test
     fun `when key in cache equal, don't replace`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
         val vnodeContext1 = VirtualNodeContext(
             createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
             setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
             SandboxGroupType.FLOW,
             "filter")
-
         val equalVnodeContext1 = VirtualNodeContext(
             createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
             setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
@@ -129,10 +143,43 @@ class SandboxGroupContextCacheTest {
             "filter")
 
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
-
         cache.get(vnodeContext1) { sandboxContext1 }
         val retrievedContext = cache.get(equalVnodeContext1) { mock() }
 
+        assertThat(cache.toBeClosed).isEmpty()
         assertThat(retrievedContext).isSameAs(sandboxContext1)
+    }
+
+    @Test
+    fun `sandboxes of different types do not trigger close on eviction of other sandbox types`() {
+        val cache = SandboxGroupContextCacheImpl(2)
+
+        val vncFlow = VirtualNodeContext(
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.FLOW,
+            "filter")
+        val vncPersistence = VirtualNodeContext(
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.PERSISTENCE,
+            "filter")
+        val vncVerification = VirtualNodeContext(
+            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.VERIFICATION,
+            "filter")
+        val sandboxContextFlow = mock<CloseableSandboxGroupContext>()
+        val sandboxContextPersistence = mock<CloseableSandboxGroupContext>()
+        val sandboxContextVerification = mock<CloseableSandboxGroupContext>()
+
+        cache.get(vncFlow) { sandboxContextFlow }
+        cache.get(vncPersistence) { sandboxContextPersistence }
+        cache.get(vncVerification) { sandboxContextVerification }
+        cache.get(vncFlow) { mock() }
+
+        verify(sandboxContextFlow, never()).close()
+        verify(sandboxContextPersistence, never()).close()
+        verify(sandboxContextVerification, never()).close()
     }
 }


### PR DESCRIPTION
Do not automatically close sandboxes when evicted from the cache if
there are still references in use. Ported from commit 4316838 [1].

[1]: https://github.com/corda/corda/commit/4316838
