### PR TITLE
CORE-7032 Fix FlowMessagingImpl's batch sending with populating SessionInfo properly to not lose corda.account.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
@@ -114,8 +114,8 @@ class FlowSessionImpl(
         }
             ?: throw CordaRuntimeException("The session [${sourceSessionId}] did not receive a payload when trying to receive one")
     }
-    
-    private fun getSessionInfo(): FlowIORequest.SessionInfo {
+
+    override fun getSessionInfo(): FlowIORequest.SessionInfo {
         return FlowIORequest.SessionInfo(
             sourceSessionId,
             counterparty,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionInternal.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionInternal.kt
@@ -1,5 +1,6 @@
 package net.corda.flow.application.sessions
 
+import net.corda.flow.fiber.FlowIORequest
 import net.corda.v5.application.messaging.FlowSession
 
 /**
@@ -16,4 +17,9 @@ interface FlowSessionInternal : FlowSession {
      * Get the Id of a session
      */
     fun getSessionId(): String
+
+    /**
+     * Get the Session info of a session
+     */
+    fun getSessionInfo(): FlowIORequest.SessionInfo
 }


### PR DESCRIPTION
CORE-7032 Fix FlowMessagingImpl's batch sending with populating SessionInfo properly to not lose corda.account.
Split from: https://github.com/corda/corda-runtime-os/pull/2729