### PR TITLE
CORE-8691: Temporarily Increase Sandbox CacheSize

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -84,7 +84,8 @@ class SandboxGroupContextComponentImpl @Activate constructor(
         //  when configuration default handling is complete (CORE-3780), this should be moved
         //  and changed to a sensible default, while keeping 2 as a default for our test environments.
         //  2 is good for a test environment as it is likely to validate both caching and eviction.
-        const val SANDBOX_CACHE_SIZE_DEFAULT = 2L
+        // TODO - revert this back to 2 once CORE-8691 is fixed.
+        const val SANDBOX_CACHE_SIZE_DEFAULT = 15L
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<SandboxGroupContextComponent>(::eventHandler)


### PR DESCRIPTION
Temporarily increase the Sandbox cache size to reduce the likelihood
of invoking "close()" on evicted entries that are still in use. This
will be reverted/removed once bug CORE-8691 is fixed.
