### PR TITLE
CORE-8385: Simulator ConsensualStates using matching keys

### DIFF
--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBase.kt
@@ -102,12 +102,12 @@ class ConsensualSignedTransactionBase(
         timestamp: Instant = config.clock.instant()
     ): ConsensualSignedTransactionBase {
         val signature = signWithMetadata(publicKey, timestamp)
-        return addSignature(signature)
+        return addSignatures(listOf(signature))
     }
 
-    internal fun addSignature(signature: DigitalSignatureAndMetadata): ConsensualSignedTransactionBase {
+    internal fun addSignatures(signatures: List<DigitalSignatureAndMetadata>): ConsensualSignedTransactionBase {
         return ConsensualSignedTransactionBase(
-            signatures = this.signatures.plus(signature),
+            signatures = this.signatures.plus(signatures),
             ledgerTransactionInfo,
             signingService,
             config

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBaseTest.kt
@@ -48,7 +48,7 @@ class ConsensualSignedTransactionBaseTest {
             config
         )
         val signedByTwoTx = signedByOneTx.addSignature(publicKeys[1])
-        val signedByAllTx = signedByTwoTx.addSignature(signatures[2])
+        val signedByAllTx = signedByTwoTx.addSignatures(listOf(signatures[2]))
         assertThat(signedByAllTx.signatures.map {it.by}, `is`(publicKeys))
     }
 


### PR DESCRIPTION
Previously ConsensualStatesLedger worked in Simulator using only the first ledger key in `receiveFinality`; now it looks to see which keys the member has that match the required signatories.