### PR TITLE
CORE-8691: Delay Closing SandboxGroupContext

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -5,23 +5,88 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.cache.caffeine.CacheFactoryImpl
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
+import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.util.loggerFor
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
 
-internal class SandboxGroupContextCacheImpl(override val capacity: Long): SandboxGroupContextCache {
+internal class SandboxGroupContextCacheImpl(override val capacity: Long) : SandboxGroupContextCache {
     private companion object {
         private val logger = loggerFor<SandboxGroupContextCache>()
     }
 
-    private val contexts: Cache<VirtualNodeContext, CloseableSandboxGroupContext> = CacheFactoryImpl().build(
+    @VisibleForTesting
+    class ToBeClosed(
+        val cacheKey: VirtualNodeContext,
+        val sandboxGroupContextToClose: AutoCloseable,
+        sandboxGroupContext: SandboxGroupContextWrapper,
+        referenceQueue: ReferenceQueue<SandboxGroupContextWrapper>
+    ) : WeakReference<SandboxGroupContextWrapper>(sandboxGroupContext, referenceQueue)
+
+    @VisibleForTesting
+    val toBeClosed: ConcurrentHashMap.KeySetView<ToBeClosed, Boolean> = ConcurrentHashMap.newKeySet()
+
+    private val expiryQueue = ReferenceQueue<SandboxGroupContextWrapper>()
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun purgeExpiryQueue() {
+        // Close the wrapped [CloseableSandboxGroupContext] for every [SandboxGroupContextWrapper]
+        // that has already been garbage-collected.
+        while (true) {
+            val head = expiryQueue.poll() as? ToBeClosed ?: break
+
+            if (!toBeClosed.remove(head)) {
+                logger.warn("Reaped unexpected sandboxGroup context for ${head.cacheKey}")
+            }
+
+            try {
+                logger.info(
+                    "Closing ${head.cacheKey.sandboxGroupType} sandbox for " +
+                            "${head.cacheKey.holdingIdentity.x500Name} [UNUSED]"
+                )
+                head.sandboxGroupContextToClose.close()
+            } catch (e: Exception) {
+                logger.warn("Error closing ${head.cacheKey.sandboxGroupType} sandbox for " +
+                        "${head.cacheKey.holdingIdentity.x500Name}", e)
+            }
+        }
+    }
+
+    private val contexts: Cache<VirtualNodeContext, SandboxGroupContextWrapper> = CacheFactoryImpl().build(
         "Sandbox-Cache",
         Caffeine.newBuilder()
             .maximumSize(capacity)
-            .removalListener { key, value, cause ->
-                logger.info("Evicting {} sandbox for: {} [{}]", key!!.sandboxGroupType, key.holdingIdentity.x500Name, cause.name)
-                value?.close()
-            })
+            // If the entry was manually removed from the cache by the user, automatically close the wrapped
+            // [CloseableSandboxGroupContext]. If the entry was automatically removed due to eviction, however, add the
+            // wrapped [CloseableSandboxGroupContext] to the internal [expiryQueue], so it is only closed once it's safe
+            // to do so (wrapping [SandboxGroupContextWrapper] is not referenced anymore).
+            .removalListener { key, context, cause ->
+                if (cause.wasEvicted()) {
+                    (context?.wrappedSandboxGroupContext as? AutoCloseable)?.also { autoCloseable ->
+                        toBeClosed += ToBeClosed(key!!, autoCloseable, context, expiryQueue)
+                    }
+
+                    logger.info(
+                        "Evicting ${key!!.sandboxGroupType} sandbox for " +
+                                "${key.holdingIdentity.x500Name} [${cause.name}]"
+                    )
+
+                    purgeExpiryQueue()
+                } else {
+                    logger.info(
+                        "Closing ${key!!.sandboxGroupType} sandbox for " +
+                                "${key.holdingIdentity.x500Name} [${cause.name}]"
+                    )
+
+                    (context?.wrappedSandboxGroupContext as? AutoCloseable)?.close()
+                }
+            }
+    )
 
     override fun remove(virtualNodeContext: VirtualNodeContext) {
+        purgeExpiryQueue()
+
         contexts.invalidate(virtualNodeContext)
     }
 
@@ -29,10 +94,15 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long): Sandbo
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext {
+        purgeExpiryQueue()
+
         return contexts.get(virtualNodeContext) {
-            logger.info("Caching {} sandbox for: {} (cache size: {})",
-                virtualNodeContext.sandboxGroupType, virtualNodeContext.holdingIdentity.x500Name, contexts.estimatedSize())
-            createFunction(virtualNodeContext)
+            logger.info(
+                "Caching ${virtualNodeContext.sandboxGroupType} sandbox for " +
+                        "${virtualNodeContext.holdingIdentity.x500Name} (cache size: ${contexts.estimatedSize()})"
+            )
+
+            SandboxGroupContextWrapper(createFunction(virtualNodeContext))
         }
     }
 
@@ -40,5 +110,21 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long): Sandbo
         // close everything in cache
         contexts.invalidateAll()
         contexts.cleanUp()
+    }
+
+    /**
+     * Wrapper around [CloseableSandboxGroupContext], solely used to keep a [WeakReference] to every instance and only
+     * invoke [CloseableSandboxGroupContext.close] on cache eviction when all strong references are gone.
+     */
+    internal class SandboxGroupContextWrapper(
+        val wrappedSandboxGroupContext: CloseableSandboxGroupContext
+    ) : SandboxGroupContext {
+
+        override fun <T : Any> get(key: String, valueType: Class<out T>) =
+            wrappedSandboxGroupContext.get(key, valueType)
+
+        override val sandboxGroup = wrappedSandboxGroupContext.sandboxGroup
+
+        override val virtualNodeContext: VirtualNodeContext = wrappedSandboxGroupContext.virtualNodeContext
     }
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -130,12 +130,10 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long) : Sandb
      */
     internal class SandboxGroupContextWrapper(
         val wrappedSandboxGroupContext: CloseableSandboxGroupContext
-    ) : SandboxGroupContext, AutoCloseable {
+    ) : SandboxGroupContext {
 
         override fun <T : Any> get(key: String, valueType: Class<out T>) =
             wrappedSandboxGroupContext.get(key, valueType)
-
-        override fun close() = wrappedSandboxGroupContext.close()
 
         override val sandboxGroup = wrappedSandboxGroupContext.sandboxGroup
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -129,14 +129,6 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long) : Sandb
      * invoke [CloseableSandboxGroupContext.close] on cache eviction when all strong references are gone.
      */
     internal class SandboxGroupContextWrapper(
-        val wrappedSandboxGroupContext: CloseableSandboxGroupContext
-    ) : SandboxGroupContext {
-
-        override fun <T : Any> get(key: String, valueType: Class<out T>) =
-            wrappedSandboxGroupContext.get(key, valueType)
-
-        override val sandboxGroup = wrappedSandboxGroupContext.sandboxGroup
-
-        override val virtualNodeContext: VirtualNodeContext = wrappedSandboxGroupContext.virtualNodeContext
-    }
+        internal val wrappedSandboxGroupContext: CloseableSandboxGroupContext
+    ) : SandboxGroupContext by wrappedSandboxGroupContext
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -37,19 +37,23 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long) : Sandb
             val head = expiryQueue.poll() as? ToBeClosed ?: break
 
             if (!toBeClosed.remove(head)) {
-                logger.warn("Reaped unexpected sandboxGroup context for ${head.cacheKey}")
+                logger.warn("Reaped unexpected sandboxGroup context for {}", head.cacheKey)
             }
 
             try {
                 logger.info(
-                    "Closing ${head.cacheKey.sandboxGroupType} sandbox for " +
-                            "${head.cacheKey.holdingIdentity.x500Name} [UNUSED]"
+                    "Closing {} sandbox for {} [UNUSED]",
+                    head.cacheKey.sandboxGroupType,
+                    head.cacheKey.holdingIdentity.x500Name
                 )
+
                 head.sandboxGroupContextToClose.close()
-            } catch (e: Exception) {
+            } catch (exception: Exception) {
                 logger.warn(
-                    "Error closing ${head.cacheKey.sandboxGroupType} sandbox for " +
-                            "${head.cacheKey.holdingIdentity.x500Name}", e
+                    "Error closing {} sandbox for {}",
+                    head.cacheKey.sandboxGroupType,
+                    head.cacheKey.holdingIdentity.x500Name,
+                    exception
                 )
             }
         }
@@ -70,15 +74,19 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long) : Sandb
                     }
 
                     logger.info(
-                        "Evicting ${key!!.sandboxGroupType} sandbox for " +
-                                "${key.holdingIdentity.x500Name} [${cause.name}]"
+                        "Evicting {} sandbox for {} [{}]",
+                        key!!.sandboxGroupType,
+                        key.holdingIdentity.x500Name,
+                        cause.name
                     )
 
                     purgeExpiryQueue()
                 } else {
                     logger.info(
-                        "Closing ${key!!.sandboxGroupType} sandbox for " +
-                                "${key.holdingIdentity.x500Name} [${cause.name}]"
+                        "Closing {} sandbox for {} [{}]",
+                        key!!.sandboxGroupType,
+                        key.holdingIdentity.x500Name,
+                        cause.name
                     )
 
                     (context?.wrappedSandboxGroupContext as? AutoCloseable)?.close()
@@ -100,8 +108,10 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long) : Sandb
 
         return contexts.get(virtualNodeContext) {
             logger.info(
-                "Caching ${virtualNodeContext.sandboxGroupType} sandbox for " +
-                        "${virtualNodeContext.holdingIdentity.x500Name} (cache size: ${contexts.estimatedSize()})"
+                "Caching {} sandbox for {} (cache size: {})",
+                virtualNodeContext.sandboxGroupType,
+                virtualNodeContext.holdingIdentity.x500Name,
+                contexts.estimatedSize()
             )
 
             SandboxGroupContextWrapper(createFunction(virtualNodeContext))

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -47,8 +47,10 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long) : Sandb
                 )
                 head.sandboxGroupContextToClose.close()
             } catch (e: Exception) {
-                logger.warn("Error closing ${head.cacheKey.sandboxGroupType} sandbox for " +
-                        "${head.cacheKey.holdingIdentity.x500Name}", e)
+                logger.warn(
+                    "Error closing ${head.cacheKey.sandboxGroupType} sandbox for " +
+                            "${head.cacheKey.holdingIdentity.x500Name}", e
+                )
             }
         }
     }
@@ -118,10 +120,12 @@ internal class SandboxGroupContextCacheImpl(override val capacity: Long) : Sandb
      */
     internal class SandboxGroupContextWrapper(
         val wrappedSandboxGroupContext: CloseableSandboxGroupContext
-    ) : SandboxGroupContext {
+    ) : SandboxGroupContext, AutoCloseable {
 
         override fun <T : Any> get(key: String, valueType: Class<out T>) =
             wrappedSandboxGroupContext.get(key, valueType)
+
+        override fun close() = wrappedSandboxGroupContext.close()
 
         override val sandboxGroup = wrappedSandboxGroupContext.sandboxGroup
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -84,8 +84,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
         //  when configuration default handling is complete (CORE-3780), this should be moved
         //  and changed to a sensible default, while keeping 2 as a default for our test environments.
         //  2 is good for a test environment as it is likely to validate both caching and eviction.
-        // TODO - revert this back to 2 once CORE-8691 is fixed.
-        const val SANDBOX_CACHE_SIZE_DEFAULT = 15L
+        const val SANDBOX_CACHE_SIZE_DEFAULT = 2L
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<SandboxGroupContextComponent>(::eventHandler)

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -170,6 +170,7 @@ class SandboxGroupContextCacheTest {
     }
 }
 
+@Suppress("ExplicitGarbageCollectionCall")
 fun forceGarbageCollectionExecution() {
     var obj: String? = String()
     val ref = WeakReference(obj)

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -5,134 +5,193 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.impl.CloseableSandboxGroupContext
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCacheImpl
 import net.corda.test.util.identity.createTestHoldingIdentity
-import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
 
 class SandboxGroupContextCacheTest {
+    private val timeout = 10000L
+    private lateinit var idBob: HoldingIdentity
+    private lateinit var idAlice: HoldingIdentity
+    private lateinit var vNodeContext1: VirtualNodeContext
+
+    @BeforeEach
+    fun setUp() {
+        idBob = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
+        idAlice = createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group")
+
+        vNodeContext1 = VirtualNodeContext(
+            holdingIdentity = idBob,
+            serviceFilter = "filter",
+            sandboxGroupType = SandboxGroupType.FLOW,
+            cpkFileChecksums = setOf(SecureHash.parse("SHA-256:1234567890"))
+        )
+    }
 
     @Test
-    fun `when cache full, evict and close evicted`() {
+    fun `when cache is full, evict and do not close evicted sandbox if still in use`() {
         val cache = SandboxGroupContextCacheImpl(1)
-
-        val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
-        }
-        val vnodeContext1 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
-
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
-        for (i in 1..100) {
+        cache.get(vNodeContext1) { sandboxContext1 }
+
+        @Suppress("UnusedPrivateMember")
+        for (i in 1..50) {
             cache.get(mock {
+                on { holdingIdentity } doReturn idBob
                 on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-                on { holdingIdentity } doReturn id
             }) { mock() }
         }
 
+        assertThat(cache.toBeClosed).isNotEmpty
+        verify(sandboxContext1, never()).close()
+    }
 
-        verify(sandboxContext1, timeout(5000)).close()
+    @Test
+    fun `when cache is full, evict and close evicted sandbox if not in use anymore`() {
+        val cache = SandboxGroupContextCacheImpl(1)
+        val sandboxContext1 = spy<CloseableSandboxGroupContext>()
+
+        cache.get(vNodeContext1) { sandboxContext1 }
+
+        // Trigger some evictions, close should not be invoked (there's at least one reference)
+        @Suppress("UnusedPrivateMember")
+        for (i in 1..50) {
+            cache.get(mock {
+                on { holdingIdentity } doReturn idBob
+                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
+            }) { mock() }
+        }
+
+        // Simulate the reference enqueue done by the GC execution (it might take longer than one
+        // cycle for the GC to do this, and we can't rely on System.gc())
+        cache.toBeClosed.forEach {
+            it.enqueue()
+        }
+
+        // Trigger some more evictions, close should be invoked now
+        @Suppress("UnusedPrivateMember")
+        for (i in 1..50) {
+            cache.get(mock {
+                on { holdingIdentity } doReturn idBob
+                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
+            }) { mock() }
+        }
+
+        verify(sandboxContext1, timeout(timeout)).close()
     }
 
     @Test
     fun `when cache closed, close everything`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
-        val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
-        }
-        val vnodeContext1 = mock<VirtualNodeContext> {
+        val vNodeContext2 = mock<VirtualNodeContext> {
             on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
+            on { holdingIdentity } doReturn idBob
         }
-        val vnodeContext2 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
-
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
         val sandboxContext2 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
-        cache.get(vnodeContext2) { sandboxContext2 }
+        cache.get(vNodeContext1) { sandboxContext1 }
+        cache.get(vNodeContext2) { sandboxContext2 }
+        assertThat(cache.toBeClosed).isEmpty()
 
         cache.close()
 
-        verify(sandboxContext1, timeout(5000)).close()
-        verify(sandboxContext2, timeout(5000)).close()
+        verify(sandboxContext1, timeout(timeout)).close()
+        verify(sandboxContext2, timeout(timeout)).close()
     }
 
     @Test
     fun `when remove also close`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
-        val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
-        }
-        val vnodeContext1 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
-
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
-        cache.remove(vnodeContext1)
+        cache.get(vNodeContext1) { sandboxContext1 }
+        cache.remove(vNodeContext1)
+        assertThat(cache.toBeClosed).isEmpty()
 
-        verify(sandboxContext1, timeout(5000)).close()
+        verify(sandboxContext1, timeout(timeout)).close()
     }
 
     @Test
     fun `when in cache retrieve same`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
-        val id = mock<HoldingIdentity> {
-            on { x500Name } doReturn MemberX500Name.parse("CN=Bob, O=Bob Corp, L=LDN, C=GB")
-        }
-        val vnodeContext1 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn id
-        }
-
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
 
-        cache.get(vnodeContext1) { sandboxContext1 }
+        cache.get(vNodeContext1) { sandboxContext1 }
+        val retrievedContext =
+            cache.get(vNodeContext1) { mock() } as SandboxGroupContextCacheImpl.SandboxGroupContextWrapper
 
-        val retrievedContext = cache.get(vnodeContext1) { mock() }
-
-        assertThat(retrievedContext).isSameAs(sandboxContext1)
+        assertThat(cache.toBeClosed).isEmpty()
+        assertThat(retrievedContext.wrappedSandboxGroupContext).isSameAs(sandboxContext1)
     }
 
     @Test
     fun `when key in cache equal, don't replace`() {
         val cache = SandboxGroupContextCacheImpl(10)
-
         val vnodeContext1 = VirtualNodeContext(
-            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            idAlice,
             setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
             SandboxGroupType.FLOW,
-            "filter")
-
+            "filter"
+        )
         val equalVnodeContext1 = VirtualNodeContext(
-            createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group"),
+            idAlice,
             setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
             SandboxGroupType.FLOW,
-            "filter")
+            "filter"
+        )
 
         val sandboxContext1 = mock<CloseableSandboxGroupContext>()
-
         cache.get(vnodeContext1) { sandboxContext1 }
-        val retrievedContext = cache.get(equalVnodeContext1) { mock() }
+        val retrievedContext =
+            cache.get(equalVnodeContext1) { mock() } as SandboxGroupContextCacheImpl.SandboxGroupContextWrapper
 
-        assertThat(retrievedContext).isSameAs(sandboxContext1)
+        assertThat(cache.toBeClosed).isEmpty()
+        assertThat(retrievedContext.wrappedSandboxGroupContext).isSameAs(sandboxContext1)
+    }
+
+    @Test
+    fun `sandboxes of different types do not trigger close on eviction of other sandbox types`() {
+        val cache = SandboxGroupContextCacheImpl(2)
+
+        val vncFlow = VirtualNodeContext(
+            idAlice,
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.FLOW,
+            "filter"
+        )
+        val vncPersistence = VirtualNodeContext(
+            idAlice,
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.PERSISTENCE,
+            "filter"
+        )
+        val vncVerification = VirtualNodeContext(
+            idAlice,
+            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            SandboxGroupType.VERIFICATION,
+            "filter"
+        )
+        val sandboxContextFlow = mock<CloseableSandboxGroupContext>()
+        val sandboxContextPersistence = mock<CloseableSandboxGroupContext>()
+        val sandboxContextVerification = mock<CloseableSandboxGroupContext>()
+
+        cache.get(vncFlow) { sandboxContextFlow }
+        cache.get(vncPersistence) { sandboxContextPersistence }
+        cache.get(vncVerification) { sandboxContextVerification }
+        cache.get(vncFlow) { mock() }
+
+        verify(sandboxContextFlow, never()).close()
+        verify(sandboxContextPersistence, never()).close()
+        verify(sandboxContextVerification, never()).close()
     }
 }

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -158,40 +158,4 @@ class SandboxGroupContextCacheTest {
         assertThat(cache.toBeClosed).isEmpty()
         assertThat(retrievedContext.wrappedSandboxGroupContext).isSameAs(sandboxContext1)
     }
-
-    @Test
-    fun `sandboxes of different types do not trigger close on eviction of other sandbox types`() {
-        val cache = SandboxGroupContextCacheImpl(2)
-
-        val vncFlow = VirtualNodeContext(
-            idAlice,
-            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
-            SandboxGroupType.FLOW,
-            "filter"
-        )
-        val vncPersistence = VirtualNodeContext(
-            idAlice,
-            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
-            SandboxGroupType.PERSISTENCE,
-            "filter"
-        )
-        val vncVerification = VirtualNodeContext(
-            idAlice,
-            setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
-            SandboxGroupType.VERIFICATION,
-            "filter"
-        )
-        val sandboxContextFlow = mock<CloseableSandboxGroupContext>()
-        val sandboxContextPersistence = mock<CloseableSandboxGroupContext>()
-        val sandboxContextVerification = mock<CloseableSandboxGroupContext>()
-
-        cache.get(vncFlow) { sandboxContextFlow }
-        cache.get(vncPersistence) { sandboxContextPersistence }
-        cache.get(vncVerification) { sandboxContextVerification }
-        cache.get(vncFlow) { mock() }
-
-        verify(sandboxContextFlow, never()).close()
-        verify(sandboxContextPersistence, never()).close()
-        verify(sandboxContextVerification, never()).close()
-    }
 }


### PR DESCRIPTION
Prevent automatically closing SandboxGroupContexts as soon as they are
evicted from the cache since they might still be in use. Instead, keep
a WeakReference to an internal wrapper and only close the evicted
SandboxGroupContext once all strong references to the wrapper are gone.

- Fix adapted from https://github.com/corda/corda/commit/4316838.
