### PR TITLE
CORE-8946: Include algorithm parameters in error message for missing algorithm.

### DIFF
--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CipherSchemeMetadataProvider.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CipherSchemeMetadataProvider.kt
@@ -132,14 +132,13 @@ class CipherSchemeMetadataProvider : KeyEncodingService {
         COMPOSITE_KEY
     )
 
-    val algorithmMap: Map<AlgorithmIdentifier, KeyScheme> = schemes.flatMap { scheme ->
+    private val algorithmMap: Map<AlgorithmIdentifier, KeyScheme> = schemes.flatMap { scheme ->
         scheme.algorithmOIDs.map { identifier -> identifier to scheme }
     }.toMap()
 
-
     fun findKeyScheme(algorithm: AlgorithmIdentifier): KeyScheme =
         algorithmMap[normaliseAlgorithmIdentifier(algorithm)]
-            ?: throw IllegalArgumentException("Unrecognised algorithm: ${algorithm.algorithm.id}")
+            ?: throw IllegalArgumentException("Unrecognised algorithm: ${algorithm.algorithm.id}, with parameters=${algorithm.parameters}")
 
     override fun decodePublicKey(encodedKey: ByteArray): PublicKey = try {
         val subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(encodedKey)
@@ -173,8 +172,8 @@ class CipherSchemeMetadataProvider : KeyEncodingService {
     }
 
     override fun toSupportedPublicKey(key: PublicKey): PublicKey {
-        return when {
-            key is CompositeKey -> key
+        return when (key) {
+            is CompositeKey -> key
             else -> decodePublicKey(key.encoded)
         }
     }


### PR DESCRIPTION
The `algorithmMap` property should not be `public`, at any rate. And including the parameters in the error message may also help.