### PR TITLE
CORE-8375 Handle signature errors with code 400 in Network API

### DIFF
--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRpcOpsImpl.kt
@@ -19,6 +19,7 @@ import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.security.SignatureException
 
 @Component(service = [PluggableRPCOps::class])
 class NetworkRpcOpsImpl @Activate constructor(
@@ -50,6 +51,9 @@ class NetworkRpcOpsImpl @Activate constructor(
         } catch (e: BadRequestException) {
             logger.warn(e.message)
             throw e
+        } catch (e: SignatureException) {
+            logger.warn("Could not set up locally hosted identities", e)
+            throw BadRequestException("The certificate was not signed by the correct certificate authority. ${e.message}")
         } catch (e: Throwable) {
             logger.warn("Could not publish to locally hosted identities", e)
             throw InternalServerException("Could not import certificate: ${e.message}")


### PR DESCRIPTION
While setting up locally hosted identities `SignatureException`s were reported back as internal server errors (error code 500). This is now updated to report bad request errors (error code 400) instead.
https://r3-cev.atlassian.net/browse/CORE-8375