### PR TITLE
CORE-8972: bump api version prior to cutting release branch to avoid potential clash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.522-beta+
+cordaApiVersion=5.0.0.600-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24


### PR DESCRIPTION
corda-api PR -https://github.com/corda/corda-api/pull/746