### PR TITLE
NOTICK: add javadoc generation to assemble task

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ cordaPipeline(
     e2eTestName: 'corda-runtime-os-e2e-tests',
     runE2eTests: true,
     combinedWorkere2eTests: true,
-    javadocJar: true,
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,
     // allow publishing an installer to a download site

--- a/build.gradle
+++ b/build.gradle
@@ -101,8 +101,10 @@ allprojects {
         }
     }
     
-    pluginManager.withPlugin('corda.javadoc-generation') {
-        assemble.dependsOn javadocJar
+    if(project.hasProperty('generateJavaDocWithBuild')) {
+        pluginManager.withPlugin('corda.javadoc-generation') {
+            assemble.dependsOn javadocJar
+        }
     }
 
     tasks.register('compileAll') { task ->

--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,10 @@ allprojects {
             }
         }
     }
+    
+    pluginManager.withPlugin('corda.javadoc-generation') {
+        assemble.dependsOn javadocJar
+    }
 
     tasks.register('compileAll') { task ->
         description = "Compiles all the Kotlin and Java classes, including all of the test classes."

--- a/build.gradle
+++ b/build.gradle
@@ -101,9 +101,11 @@ allprojects {
         }
     }
     
-    if(project.hasProperty('generateJavaDocWithBuild')) {
+    if (project.hasProperty('generateJavaDocWithBuild')) {
         pluginManager.withPlugin('corda.javadoc-generation') {
-            assemble.dependsOn javadocJar
+            artifacts {
+                archives javadocJar
+            }
         }
     }
 


### PR DESCRIPTION
add javadoc generation to assemble task to prevent the need for a separate dedicated target to be called in the CI in a effort to reduce build times (less gradle stages = less configuration overhead if we can do the work in one stage) , `./gradlew build` or `assemble` will now produce this java doc. 

Associated Shared-library PR https://github.com/corda/corda-shared-build-pipeline-steps/pull/457 