### PR TITLE
CORE-3013: Migrate bundle filtering logic into CustomSerializerPermission.

### DIFF
--- a/components/security-manager/src/main/resources/basic_security.policy
+++ b/components/security-manager/src/main/resources/basic_security.policy
@@ -26,7 +26,7 @@ ALLOW {
 
 (org.osgi.framework.PackagePermission "co.paralleluniverse.fibers.suspend" "import")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "FLOW")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=FLOW/*)")
 
 } "Allow public packages and services for FLOW Sandbox"
 
@@ -147,7 +147,7 @@ ALLOW {
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=PERSISTENCE/*)" "get")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "PERSISTENCE")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=PERSISTENCE/*)")
 
 } "Allow public packages and services for PERSISTENCE Sandbox"
 
@@ -278,7 +278,7 @@ ALLOW {
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=VERIFICATION/*)" "get")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "VERIFICATION")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=VERIFICATION/*)")
 
 } "Allow public packages and services for VERIFICATION Sandbox"
 

--- a/components/security-manager/src/main/resources/high_security.policy
+++ b/components/security-manager/src/main/resources/high_security.policy
@@ -27,7 +27,7 @@ ALLOW {
 
 (org.osgi.framework.PackagePermission "co.paralleluniverse.fibers.suspend" "import")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "FLOW")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=FLOW/*)")
 
 } "Allow public packages and services for FLOW Sandbox"
 
@@ -158,7 +158,7 @@ ALLOW {
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=PERSISTENCE/*)" "get")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "PERSISTENCE")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=PERSISTENCE/*)")
 
 } "Allow public packages and services for PERSISTENCE Sandbox"
 
@@ -289,7 +289,7 @@ ALLOW {
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=VERIFICATION/*)" "get")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "VERIFICATION")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=VERIFICATION/*)")
 
 } "Allow public packages and services for VERIFICATION Sandbox"
 

--- a/components/security-manager/src/main/resources/medium_security.policy
+++ b/components/security-manager/src/main/resources/medium_security.policy
@@ -27,7 +27,7 @@ ALLOW {
 
 (org.osgi.framework.PackagePermission "co.paralleluniverse.fibers.suspend" "import")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "FLOW")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=FLOW/*)")
 
 } "Allow public packages and services for FLOW Sandbox"
 
@@ -155,7 +155,7 @@ ALLOW {
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=PERSISTENCE/*)" "get")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "PERSISTENCE")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=PERSISTENCE/*)")
 
 } "Allow public packages and services for PERSISTENCE Sandbox"
 
@@ -286,7 +286,7 @@ ALLOW {
 (org.osgi.framework.ServicePermission "net.corda.v5.*" "get")
 (org.osgi.framework.ServicePermission "(location=VERIFICATION/*)" "get")
 
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "VERIFICATION")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=VERIFICATION/*)")
 
 } "Allow public packages and services for VERIFICATION Sandbox"
 

--- a/libs/serialization/serialization-amqp/src/integrationTest/resources/security-deny-platform-serializers.policy
+++ b/libs/serialization/serialization-amqp/src/integrationTest/resources/security-deny-platform-serializers.policy
@@ -1,6 +1,6 @@
 ALLOW {
 [org.osgi.service.condpermadmin.BundleLocationCondition "TEST/*"]
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "TEST")
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "(location=TEST/*)")
 } "allows custom serializers defined in test sandboxes for types also defined in test sandboxes"
 
 DENY {


### PR DESCRIPTION
Add an OSGi `Filter` to `CustomSerializerPermission` to make this permission behave similarly to `ServicePermission`.

Change security domain for tests to `TEST` to avoid overlap with the built-in policies.