### PR TITLE
CORE-8985: Fix FlowStatusFeedSmokeTest Flakiness

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/Utils.kt
@@ -15,6 +15,9 @@ const val USERNAME = "admin"
 val PASSWORD = System.getenv("INITIAL_ADMIN_USER_PASSWORD") ?: "admin"
 const val GROUP_ID = "7c5d6948-e17b-44e7-9d1c-fa4a3f667cad"
 
+// Code signer certificate
+const val CODE_SIGNER_CERT = "/cordadevcodesign.pem"
+
 // The CPB and CPI used in smoke tests
 const val TEST_CPI_NAME = "test-cordapp"
 const val TEST_CPB_LOCATION = "/META-INF/test-cordapp.cpb"

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -9,6 +9,7 @@ import net.corda.applications.workers.smoketest.GROUP_ID
 import net.corda.applications.workers.smoketest.PASSWORD
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.USERNAME
+import net.corda.applications.workers.smoketest.CODE_SIGNER_CERT
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.startRpcFlow
@@ -26,8 +27,6 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.util.UUID
-
-const val CODESIGNER_CERT = "/cordadevcodesign.pem"
 
 /**
  * Any 'unordered' tests are run *last*
@@ -71,7 +70,7 @@ class VirtualNodeRpcTest {
                 // Certificate upload can be slow in the combined worker, especially after it has just started up.
                 timeout(Duration.ofSeconds(100))
                 interval(Duration.ofSeconds(1))
-                command { importCertificate(CODESIGNER_CERT, "code-signer", "cordadev") }
+                command { importCertificate(CODE_SIGNER_CERT, "code-signer", "cordadev") }
                 condition { it.code == 204 }
             }
         }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -6,12 +6,18 @@ import net.corda.applications.workers.smoketest.RpcSmokeTestInput
 import net.corda.applications.workers.smoketest.SMOKE_TEST_CLASS_NAME
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
+import net.corda.applications.workers.smoketest.CLUSTER_URI
+import net.corda.applications.workers.smoketest.USERNAME
+import net.corda.applications.workers.smoketest.PASSWORD
+import net.corda.applications.workers.smoketest.CODE_SIGNER_CERT
 import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
 import net.corda.applications.workers.smoketest.getFlowClasses
 import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
 import net.corda.applications.workers.smoketest.startRpcFlow
+import net.corda.applications.workers.smoketest.virtualnode.helpers.assertWithRetry
+import net.corda.applications.workers.smoketest.virtualnode.helpers.cluster
 import net.corda.applications.workers.smoketest.websocket.client.MessageQueueWebSocketHandler
 import net.corda.applications.workers.smoketest.websocket.client.SmokeTestWebsocketClient
 import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
@@ -19,7 +25,6 @@ import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
@@ -27,8 +32,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import java.time.Duration
 
-// This test relies on `VirtualNodeRpcTest` and `FlowTest` to run first which will create vNodes necessary to run this test
-@Order(30)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class FlowStatusFeedSmokeTest {
 
@@ -43,7 +46,18 @@ class FlowStatusFeedSmokeTest {
 
         @BeforeAll
         @JvmStatic
-        internal fun beforeAll() {
+        fun beforeAll() {
+            // Certificate upload can be slow in the combined worker, especially after it has just started up.
+            cluster {
+                endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+                assertWithRetry {
+                    timeout(Duration.ofSeconds(100))
+                    interval(Duration.ofSeconds(1))
+                    command { importCertificate(CODE_SIGNER_CERT, "code-signer", "cordadev") }
+                    condition { it.code == 204 }
+                }
+            }
+
             // Upload test flows if not already uploaded
             conditionallyUploadCordaPackage(cpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList)
 

--- a/testing/test-utilities/src/main/kotlin/net/corda/test/util/Consistently.kt
+++ b/testing/test-utilities/src/main/kotlin/net/corda/test/util/Consistently.kt
@@ -1,0 +1,38 @@
+package net.corda.test.util
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+/**
+ * Similar to "eventually" but the opposite: execute an assertion that must continuously succeed during a configurable
+ * period of time. This is meant for use from Kotlin code use only mainly due to its inline/reified nature
+ *
+ * @param duration How long to wait for, before returning the last test success. The default is 5 seconds.
+ * @param waitBetween How long to wait before retrying the test condition. The default is 1/10th of a second.
+ * @param waitBefore How long to wait before trying the test condition for the first time. It's assumed that [consistently]
+ * is being used because the condition is not _immediately_ fulfilled, so this defaults to the value of [waitBetween].
+ * @param block A test which should continuously pass during the given [duration].
+ *
+ * @throws AssertionError, if the test does not pass within the given [duration].
+ */
+fun <R> consistently(
+        duration: Duration = Duration.ofSeconds(5),
+        waitBetween: Duration = Duration.ofMillis(100),
+        waitBefore: Duration = waitBetween,
+        block: () -> R): R {
+    var lastSuccess: R? = null
+    val end = System.nanoTime() + duration.toNanos()
+    if (!waitBefore.isZero) Thread.sleep(waitBefore.toMillis())
+
+    while (System.nanoTime() < end) {
+        try {
+            lastSuccess = block()
+            if (!waitBetween.isZero) Thread.sleep(waitBetween.toMillis())
+        } catch (error: AssertionError) {
+            throw AssertionError("Test failed with \"${error.message}\" after " +
+                    "${TimeUnit.NANOSECONDS.toMillis(end - System.nanoTime())}ms", error)
+        }
+    }
+
+    return lastSuccess!!
+}


### PR DESCRIPTION
Wait for the vNode creation to be propagated through the system before
trying to execute tests that make use of it.

- Remove order and update setup so the test can be executed on its own
  without depending on other tests to be executed before.
- Update 'getOrCreateVirtualNodeFor' so it waits for the created
  'vNode' to be returned by the '/api/v1/virtualnode' REST endpoint.
- Add 'consistently' testing function, small utility to continuously
  assert that a certain condition remains 'true' for a configurable
  period of time.
- Update 'SmokeTestWebsocketClient' so it checks, not only that a web
  socket connection can be stablished, but also that it remains
  connected for a configurable period of time before proceeding with
  the tests.
