### PR TITLE
CORE-7278 Fix broken backing store test for maximum field size

### DIFF
--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
@@ -17,6 +17,7 @@ import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.AutoTickTestClock
 import net.corda.uniqueness.backingstore.jpa.datamodel.JPABackingStoreEntities
 import net.corda.uniqueness.backingstore.jpa.datamodel.UniquenessTransactionDetailEntity
+import net.corda.uniqueness.datamodel.common.UniquenessConstants
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultSuccessImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultFailureImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckErrorMalformedRequestImpl
@@ -382,15 +383,17 @@ class JPABackingStoreImplIntegrationTests {
             )
         }
 
-        @Disabled("Review with CORE-7278. This test fails because it fails to persist an error message with " +
-                  "1024 bytes.")
         @Test
         fun `Persisting an error throws if the size is bigger than the maximum`() {
-            val txId = SecureHashUtils.randomSecureHash()
-            val internalRequest = generateRequestInternal(txId)
+            // We need to establish the object size without any message (i.e. a blank message) to
+            // see how much space we need to fill in order to hit our maximum valid  size.
+            val baseObjectSize = jpaBackingStoreObjectMapper()
+                .writeValueAsBytes(UniquenessCheckErrorMalformedRequestImpl("")).size
 
-            // 1024 is the expected maximum size of an error message.
-            val maxErrMsgLength = 1024
+            // Available characters that need filling is the hard-coded limit minus fixed size
+            val maxErrMsgLength =
+                UniquenessConstants.REJECTED_TRANSACTION_ERROR_DETAILS_LENGTH - baseObjectSize
+
             val validErrorMessage = "e".repeat(maxErrMsgLength)
             assertDoesNotThrow {
                 backingStoreImpl.session(aliceIdentity) { session ->
@@ -398,8 +401,10 @@ class JPABackingStoreImplIntegrationTests {
                         txnOps.commitTransactions(
                             listOf(
                                 Pair(
-                                    internalRequest, UniquenessCheckResultFailureImpl(
-                                        testClock.instant(), UniquenessCheckErrorMalformedRequestImpl(validErrorMessage)
+                                    generateRequestInternal(SecureHashUtils.randomSecureHash()),
+                                    UniquenessCheckResultFailureImpl(
+                                        testClock.instant(),
+                                        UniquenessCheckErrorMalformedRequestImpl(validErrorMessage)
                                     )
                                 )
                             )
@@ -410,14 +415,16 @@ class JPABackingStoreImplIntegrationTests {
 
             // Persisting this error should throw because its size if bigger than 1024.
             val invalidErrorMessage = "e".repeat(maxErrMsgLength + 1)
-            assertThrows<IllegalStateException> {
+            assertThrows<IllegalArgumentException> {
                 backingStoreImpl.session(aliceIdentity) { session ->
                     session.executeTransaction { _, txnOps ->
                         txnOps.commitTransactions(
                             listOf(
                                 Pair(
-                                    internalRequest, UniquenessCheckResultFailureImpl(
-                                        testClock.instant(), UniquenessCheckErrorMalformedRequestImpl(invalidErrorMessage)
+                                    generateRequestInternal(SecureHashUtils.randomSecureHash()),
+                                    UniquenessCheckResultFailureImpl(
+                                        testClock.instant(),
+                                        UniquenessCheckErrorMalformedRequestImpl(invalidErrorMessage)
                                     )
                                 )
                             )


### PR DESCRIPTION
### Summary
Our backing store test case to test behavior at the boundary of our maximum error details field size was broken. Investigation revealed this was due to setting an error message of length 1024 (equal to the maximum size of the field itself). This did not take into account the additional object data stored, which accounts for 42 bytes with the current error message being used,

This change fixes this by determining the overhead of the error object itself, by getting the size of the object with a blank message, and then creating a new message with a sufficiently sized error text as padding.

There were also a couple of other bugs in this test case that became apparent after fixing this issue, which has also been resolved as part of this PR.

### Testing
Ensured test case now passes with both HSQLDB and Postgres.