### PR TITLE
NOTICK: Set security policy once for all OSGi serialization tests.

### DIFF
--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -70,6 +70,7 @@ class AMQPwithOSGiSerializationTests {
         @TempDir
         testDirectory: Path
     ) {
+        applyPolicyFile("security-deny-platform-serializers.policy")
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
             sandboxFactory = setup.fetchService(timeout = 1500)
@@ -211,7 +212,6 @@ class AMQPwithOSGiSerializationTests {
 
     @Test
     fun `sandbox external custom serializers targeting platform types are denied`() {
-        applyPolicyFile("security-deny-platform-serializers.policy")
         val sandboxGroup = sandboxFactory.loadSandboxGroup("META-INF/TestSerializableCpk-platform-type-custom-serializer.cpb")
         try {
             // Corda platform type custom serializer
@@ -238,12 +238,10 @@ class AMQPwithOSGiSerializationTests {
         } finally {
             sandboxFactory.unloadSandboxGroup(sandboxGroup)
         }
-        System.setSecurityManager(null)
     }
 
     @Test
     fun `sandbox external custom serializers targeting sandbox types are allowed`() {
-        applyPolicyFile("security-deny-platform-serializers.policy")
         val sandboxGroup = sandboxFactory.loadSandboxGroup("META-INF/TestSerializableCpk-platform-type-custom-serializer.cpb")
         try {
             val factory = testDefaultFactory(sandboxGroup)
@@ -256,7 +254,6 @@ class AMQPwithOSGiSerializationTests {
         } finally {
             sandboxFactory.unloadSandboxGroup(sandboxGroup)
         }
-        System.setSecurityManager(null)
     }
 
     private fun applyPolicyFile(fileName: String) {

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/SandboxFactory.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/SandboxFactory.kt
@@ -16,7 +16,7 @@ class SandboxFactory @Activate constructor(
 ) {
     fun loadSandboxGroup(resourceName: String): SandboxGroup {
         return cpiLoader.loadCPI(resourceName).let { cpi ->
-            sandboxCreationService.createSandboxGroup(cpi.cpks, "FLOW")
+            sandboxCreationService.createSandboxGroup(cpi.cpks, "TEST")
         }
     }
 

--- a/libs/serialization/serialization-amqp/src/integrationTest/resources/security-deny-platform-serializers.policy
+++ b/libs/serialization/serialization-amqp/src/integrationTest/resources/security-deny-platform-serializers.policy
@@ -1,9 +1,9 @@
 ALLOW {
-[org.osgi.service.condpermadmin.BundleLocationCondition "FLOW/*"]
-(net.corda.internal.serialization.amqp.CustomSerializerPermission "FLOW")
-} "allows custom serializers defined in flow sandboxes for types also defined in flow sandboxes"
+[org.osgi.service.condpermadmin.BundleLocationCondition "TEST/*"]
+(net.corda.internal.serialization.amqp.CustomSerializerPermission "TEST")
+} "allows custom serializers defined in test sandboxes for types also defined in test sandboxes"
 
 DENY {
-[org.osgi.service.condpermadmin.BundleLocationCondition "FLOW/*"]
+[org.osgi.service.condpermadmin.BundleLocationCondition "TEST/*"]
 (net.corda.internal.serialization.amqp.CustomSerializerPermission "*")
-} "denies custom serializers defined in flow sandboxes for types defined outside flow sandboxes(e.g. platform types)"
+} "denies custom serializers defined in test sandboxes for types defined outside test sandboxes(e.g. platform types)"


### PR DESCRIPTION
Set a new policy for "TEST" sandboxes once during setup phase. And do not remove the SecurityManager after any test because resetting the sandboxes will not put it back.