### PR TITLE
CORE-9009 Improve entity manager factory handling for virtual node reconcilers

### DIFF
--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigDbReconcilerReader.kt
@@ -8,7 +8,7 @@ import net.corda.reconciliation.VersionedRecord
 
 val getAllConfigDBVersionedRecords
     : (ReconciliationContext) -> Stream<VersionedRecord<String, Configuration>> = { context ->
-    context.entityManager.findAllConfig().map { configEntity ->
+    context.getOrCreateEntityManager().findAllConfig().map { configEntity ->
         val config = Configuration(
             configEntity.config,
             configEntity.config,

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
@@ -29,7 +29,7 @@ class ConfigReconciler(
     private var reconciler: Reconciler? = null
 
     private val reconciliationContextFactory = {
-        Stream.of<ReconciliationContext>(ClusterReconciliationContext(dbConnectionManager))
+        Stream.of(ClusterReconciliationContext(dbConnectionManager))
     }
 
     override fun close() {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
@@ -9,6 +9,7 @@ import net.corda.reconciliation.ReconcilerFactory
 import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.ReconcilerWriter
 import net.corda.v5.base.util.contextLogger
+import java.util.stream.Stream
 
 class ConfigReconciler(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
@@ -28,7 +29,7 @@ class ConfigReconciler(
     private var reconciler: Reconciler? = null
 
     private val reconciliationContextFactory = {
-        listOf(ClusterReconciliationContext(dbConnectionManager))
+        Stream.of<ReconciliationContext>(ClusterReconciliationContext(dbConnectionManager))
     }
 
     override fun close() {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReader.kt
@@ -14,7 +14,7 @@ import java.util.stream.Stream
  */
 val getAllCpiInfoDBVersionedRecords
         : (ReconciliationContext) -> Stream<VersionedRecord<CpiIdentifier, CpiMetadata>> = { context ->
-    context.entityManager.findAllCpiMetadata().map { cpiMetadataEntity ->
+    context.getOrCreateEntityManager().findAllCpiMetadata().map { cpiMetadataEntity ->
         val cpiId = CpiIdentifier(
             cpiMetadataEntity.name,
             cpiMetadataEntity.version,

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
@@ -10,6 +10,7 @@ import net.corda.reconciliation.ReconcilerFactory
 import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.ReconcilerWriter
 import net.corda.v5.base.util.contextLogger
+import java.util.stream.Stream
 
 class CpiReconciler(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
@@ -29,7 +30,7 @@ class CpiReconciler(
     private var reconciler: Reconciler? = null
 
     private val reconciliationContextFactory = {
-        listOf(ClusterReconciliationContext(dbConnectionManager))
+        Stream.of<ReconciliationContext>(ClusterReconciliationContext(dbConnectionManager))
     }
 
     override fun close() {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
@@ -30,7 +30,7 @@ class CpiReconciler(
     private var reconciler: Reconciler? = null
 
     private val reconciliationContextFactory = {
-        Stream.of<ReconciliationContext>(ClusterReconciliationContext(dbConnectionManager))
+        Stream.of(ClusterReconciliationContext(dbConnectionManager))
     }
 
     override fun close() {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
@@ -30,7 +30,7 @@ class DbReconcilerReader<K : Any, V : Any>(
     keyClass: Class<K>,
     valueClass: Class<V>,
     private val dependencies: Set<LifecycleCoordinatorName>,
-    private val reconciliationContextFactory: () -> Stream<ReconciliationContext>,
+    private val reconciliationContextFactory: () -> Stream<out ReconciliationContext>,
     private val doGetAllVersionedRecords: (ReconciliationContext) -> Stream<VersionedRecord<K, V>>
 ) : ReconcilerReader<K, V>, Lifecycle {
 

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
@@ -97,7 +97,7 @@ class DbReconcilerReader<K : Any, V : Any>(
     override fun getAllVersionedRecords(): Stream<VersionedRecord<K, V>>? {
         return try {
             val streams = reconciliationContextFactory.invoke().map { context ->
-                val currentTransaction = context.entityManager.transaction
+                val currentTransaction = context.getOrCreateEntityManager().transaction
                 currentTransaction.begin()
                 doGetAllVersionedRecords(context).onClose {
                     // This class only have access to this em and transaction. This is a read only transaction,

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
@@ -121,7 +121,7 @@ class GroupParametersReconciler(
         require(context is VirtualNodeReconciliationContext) {
             "Reconciliation information must be virtual node level for group parameters reconciliation"
         }
-        return context.entityManager.getCurrentGroupParameters()?.let { entity ->
+        return context.getOrCreateEntityManager().getCurrentGroupParameters()?.let { entity ->
             val deserializedParams = cordaAvroDeserializer.deserialize(entity.parameters)
                 ?: throw CordaRuntimeException("Could not deserialize group parameters from the database entity.")
 

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
@@ -20,7 +20,6 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
-import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import java.util.concurrent.locks.ReentrantLock
 import java.util.stream.Stream
@@ -112,9 +111,9 @@ class GroupParametersReconciler(
     }
 
     private val reconciliationContextFactory = {
-        virtualNodeInfoReadService.getAll().map<VirtualNodeInfo, ReconciliationContext> {
+        virtualNodeInfoReadService.getAll().stream().map {
             VirtualNodeReconciliationContext(dbConnectionManager, entitiesSet, it)
-        }.stream()
+        }
     }
 
     private fun getAllGroupParametersDBVersionedRecords(context: ReconciliationContext):

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
@@ -20,6 +20,7 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import java.util.concurrent.locks.ReentrantLock
 import java.util.stream.Stream
@@ -111,9 +112,9 @@ class GroupParametersReconciler(
     }
 
     private val reconciliationContextFactory = {
-        virtualNodeInfoReadService.getAll().map {
+        virtualNodeInfoReadService.getAll().map<VirtualNodeInfo, ReconciliationContext> {
             VirtualNodeReconciliationContext(dbConnectionManager, entitiesSet, it)
-        }
+        }.stream()
     }
 
     private fun getAllGroupParametersDBVersionedRecords(context: ReconciliationContext):

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -24,21 +24,15 @@ interface ReconciliationContext : AutoCloseable {
 class ClusterReconciliationContext(
     private val dbConnectionManager: DbConnectionManager
 ) : ReconciliationContext {
-    private var entityManagerFactory: EntityManagerFactory? = null
     private var entityManager: EntityManager? = null
 
-    private fun getOrCreateEntityManagerFactory() = entityManagerFactory
-        ?: dbConnectionManager.getClusterEntityManagerFactory()
-            .also { entityManagerFactory = it }
-
     override fun getOrCreateEntityManager(): EntityManager = entityManager
-        ?: getOrCreateEntityManagerFactory().createEntityManager()
+        ?: dbConnectionManager.getClusterEntityManagerFactory().createEntityManager()
             .also { entityManager = it }
 
     override fun close() {
         entityManager?.close()
         entityManager = null
-        entityManagerFactory = null
     }
 }
 

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -38,6 +38,7 @@ class ClusterReconciliationContext(
     override fun close() {
         _entityManager?.close()
         _entityManager = null
+        _entityManagerFactory = null
     }
 }
 

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -24,21 +24,21 @@ interface ReconciliationContext : AutoCloseable {
 class ClusterReconciliationContext(
     private val dbConnectionManager: DbConnectionManager
 ) : ReconciliationContext {
-    private var _entityManagerFactory: EntityManagerFactory? = null
-    private var _entityManager: EntityManager? = null
+    private var entityManagerFactory: EntityManagerFactory? = null
+    private var entityManager: EntityManager? = null
 
-    private fun getOrCreateEntityManagerFactory() = _entityManagerFactory
+    private fun getOrCreateEntityManagerFactory() = entityManagerFactory
         ?: dbConnectionManager.getClusterEntityManagerFactory()
-            .also { _entityManagerFactory = it }
+            .also { entityManagerFactory = it }
 
-    override fun getOrCreateEntityManager(): EntityManager = _entityManager
+    override fun getOrCreateEntityManager(): EntityManager = entityManager
         ?: getOrCreateEntityManagerFactory().createEntityManager()
-            .also { _entityManager = it }
+            .also { entityManager = it }
 
     override fun close() {
-        _entityManager?.close()
-        _entityManager = null
-        _entityManagerFactory = null
+        entityManager?.close()
+        entityManager = null
+        entityManagerFactory = null
     }
 }
 
@@ -51,21 +51,21 @@ class VirtualNodeReconciliationContext(
     val virtualNodeInfo: VirtualNodeInfo
 ) : ReconciliationContext {
 
-    private var _entityManagerFactory: EntityManagerFactory? = null
-    private var _entityManager: EntityManager? = null
+    private var entityManagerFactory: EntityManagerFactory? = null
+    private var entityManager: EntityManager? = null
 
-    private fun getOrCreateEntityManagerFactory() = _entityManagerFactory
+    private fun getOrCreateEntityManagerFactory() = entityManagerFactory
         ?: dbConnectionManager.createEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
-            .also { _entityManagerFactory = it }
+            .also { entityManagerFactory = it }
 
-    override fun getOrCreateEntityManager(): EntityManager = _entityManager
+    override fun getOrCreateEntityManager(): EntityManager = entityManager
         ?: getOrCreateEntityManagerFactory().createEntityManager()
-            .also { _entityManager = it }
+            .also { entityManager = it }
 
     override fun close() {
-        _entityManager?.close()
-        _entityManagerFactory?.close()
-        _entityManager = null
-        _entityManagerFactory = null
+        entityManager?.close()
+        entityManagerFactory?.close()
+        entityManager = null
+        entityManagerFactory = null
     }
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -4,6 +4,7 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.orm.JpaEntitiesSet
 import net.corda.virtualnode.VirtualNodeInfo
 import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
 
 /**
  * Additional context to be included during reconciliation.
@@ -11,38 +12,59 @@ import javax.persistence.EntityManager
  * Context instances must be closed after use to close any created resources.
  */
 interface ReconciliationContext : AutoCloseable {
-    val entityManager: EntityManager
+    /**
+     * Return existing [EntityManager] or create one if one does not already exist.
+     */
+    fun getOrCreateEntityManager(): EntityManager
 }
 
 /**
  * Context required for reconciling cluster DBs
  */
 class ClusterReconciliationContext(
-    dbConnectionManager: DbConnectionManager
+    private val dbConnectionManager: DbConnectionManager
 ) : ReconciliationContext {
-    private val entityManagerFactory = dbConnectionManager.getClusterEntityManagerFactory()
-    override val entityManager: EntityManager = entityManagerFactory.createEntityManager()
+    private var _entityManagerFactory: EntityManagerFactory? = null
+    private var _entityManager: EntityManager? = null
 
-    override fun close() = entityManager.close()
+    private fun getOrCreateEntityManagerFactory() = _entityManagerFactory
+        ?: dbConnectionManager.getClusterEntityManagerFactory()
+            .also { _entityManagerFactory = it }
+
+    override fun getOrCreateEntityManager(): EntityManager = _entityManager
+        ?: getOrCreateEntityManagerFactory().createEntityManager()
+            .also { _entityManager = it }
+
+    override fun close() {
+        _entityManager?.close()
+        _entityManager = null
+    }
 }
 
 /**
  * Context required for reconciling virtual node DBs
  */
 class VirtualNodeReconciliationContext(
-    dbConnectionManager: DbConnectionManager,
-    jpaEntitiesSet: JpaEntitiesSet,
+    private val dbConnectionManager: DbConnectionManager,
+    private val jpaEntitiesSet: JpaEntitiesSet,
     val virtualNodeInfo: VirtualNodeInfo
 ) : ReconciliationContext {
 
-    private val entityManagerFactory = dbConnectionManager.createEntityManagerFactory(
-        virtualNodeInfo.vaultDmlConnectionId,
-        jpaEntitiesSet
-    )
-    override val entityManager: EntityManager = entityManagerFactory.createEntityManager()
+    private var _entityManagerFactory: EntityManagerFactory? = null
+    private var _entityManager: EntityManager? = null
+
+    private fun getOrCreateEntityManagerFactory() = _entityManagerFactory
+        ?: dbConnectionManager.createEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
+            .also { _entityManagerFactory = it }
+
+    override fun getOrCreateEntityManager(): EntityManager = _entityManager
+        ?: getOrCreateEntityManagerFactory().createEntityManager()
+            .also { _entityManager = it }
 
     override fun close() {
-        entityManager.close()
-        entityManagerFactory.close()
+        _entityManager?.close()
+        _entityManagerFactory?.close()
+        _entityManager = null
+        _entityManagerFactory = null
     }
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeInfoDbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeInfoDbReconcilerReader.kt
@@ -12,7 +12,7 @@ import java.util.stream.Stream
 val getAllVirtualNodesDBVersionedRecords
         : (ReconciliationContext) -> Stream<VersionedRecord<HoldingIdentity, VirtualNodeInfo>> =
     { context ->
-        virtualNodeEntitiesToVersionedRecords(VirtualNodeRepositoryImpl().findAll(context.entityManager))
+        virtualNodeEntitiesToVersionedRecords(VirtualNodeRepositoryImpl().findAll(context.getOrCreateEntityManager()))
     }
 
 fun virtualNodeEntitiesToVersionedRecords(virtualNodes: Stream<VirtualNodeInfo>)

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
@@ -10,6 +10,7 @@ import net.corda.reconciliation.ReconcilerWriter
 import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
+import java.util.stream.Stream
 
 class VirtualNodeReconciler(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
@@ -29,7 +30,7 @@ class VirtualNodeReconciler(
     private var reconciler: Reconciler? = null
 
     private val reconciliationContextFactory = {
-        listOf(ClusterReconciliationContext(dbConnectionManager))
+        Stream.of<ReconciliationContext>(ClusterReconciliationContext(dbConnectionManager))
     }
 
     override fun close() {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
@@ -30,7 +30,7 @@ class VirtualNodeReconciler(
     private var reconciler: Reconciler? = null
 
     private val reconciliationContextFactory = {
-        Stream.of<ReconciliationContext>(ClusterReconciliationContext(dbConnectionManager))
+        Stream.of(ClusterReconciliationContext(dbConnectionManager))
     }
 
     override fun close() {

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
@@ -111,7 +111,7 @@ class CpiInfoDbReconcilerReaderTest {
         whenever(em.transaction).thenReturn(mock())
         whenever(em.createQuery(any(), any<Class<CpiMetadataEntity>>())).thenReturn(typeQuery)
         val reconciliationContext = mock<ReconciliationContext>()
-        whenever(reconciliationContext.entityManager).thenReturn(em)
+        whenever(reconciliationContext.getOrCreateEntityManager()).thenReturn(em)
 
         val versionedRecords = getAllCpiInfoDBVersionedRecords(reconciliationContext).toList()
         val record = versionedRecords.single()

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
@@ -44,7 +44,7 @@ class DbReconcilerReaderTest {
         on { onClose(streamOnCloseCaptor.capture()) } doReturn mock
     }
     private val reconciliationContext: ReconciliationContext = mock {
-        on { entityManager } doReturn em
+        on { getOrCreateEntityManager() } doReturn em
     }
 
     private val dependencyMock: LifecycleCoordinatorName = LifecycleCoordinatorName("dependency")

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
@@ -28,36 +28,45 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.stream.Collectors
 import java.util.stream.Stream
 import javax.persistence.EntityManager
 import javax.persistence.EntityTransaction
 
 class DbReconcilerReaderTest {
 
-    private val transaction: EntityTransaction = mock()
-    private val em: EntityManager = mock {
-        on { transaction } doReturn transaction
+    private val transaction1: EntityTransaction = mock()
+    private val transaction2: EntityTransaction = mock()
+    private val em1: EntityManager = mock {
+        on { transaction } doReturn transaction1
+    }
+    private val em2: EntityManager = mock {
+        on { transaction } doReturn transaction2
     }
 
-    private val streamOnCloseCaptor = argumentCaptor<Runnable>()
-    private val versionedRecordsStream: Stream<VersionedRecord<String, Int>> = mock {
-        on { onClose(streamOnCloseCaptor.capture()) } doReturn mock
+    private val mockVersionedRecord1: VersionedRecord<String, Int> = mock()
+    private val mockVersionedRecord2: VersionedRecord<String, Int> = mock()
+    private val realStream1 = Stream.of(mockVersionedRecord1)
+    private val realStream2 = Stream.of(mockVersionedRecord2)
+    private val reconciliationContext1: ReconciliationContext = mock {
+        on { getOrCreateEntityManager() } doReturn em1
     }
-    private val reconciliationContext: ReconciliationContext = mock {
-        on { getOrCreateEntityManager() } doReturn em
+    private val reconciliationContext2: ReconciliationContext = mock {
+        on { getOrCreateEntityManager() } doReturn em2
     }
 
     private val dependencyMock: LifecycleCoordinatorName = LifecycleCoordinatorName("dependency")
     private val dependenciesMock: Set<LifecycleCoordinatorName> = setOf(dependencyMock)
-    private val reconciliationContexts = listOf(
-        reconciliationContext,
-        reconciliationContext
+    private val reconciliationContexts = Stream.of(
+        reconciliationContext1,
+        reconciliationContext2
     )
-    private val reconciliationContextFactory: () -> Collection<ReconciliationContext> = mock {
+    private val reconciliationContextFactory: () -> Stream<ReconciliationContext> = mock {
         on { invoke() } doReturn reconciliationContexts
     }
     private val getAllVersionRecordsMock: (ReconciliationContext) -> Stream<VersionedRecord<String, Int>> = mock {
-        on { invoke(any()) } doReturn versionedRecordsStream
+        on { invoke(eq(reconciliationContext1)) } doReturn realStream1
+        on { invoke(eq(reconciliationContext2)) } doReturn realStream2
     }
 
     private val coordinatorNameCaptor = argumentCaptor<LifecycleCoordinatorName>()
@@ -258,28 +267,41 @@ class DbReconcilerReaderTest {
 
         @Test
         fun `Expected services called when get versioned records executed successfully`() {
-            dbReconcilerReader.getAllVersionedRecords()
+            // call terminal operation to process stream
+            dbReconcilerReader.getAllVersionedRecords()?.count()
 
-            val numContexts = reconciliationContexts.size
             verify(reconciliationContextFactory).invoke()
-            verify(em, times(numContexts)).transaction
-            verify(transaction, times(numContexts)).begin()
-            verify(getAllVersionRecordsMock, times(numContexts)).invoke(any())
-            verify(versionedRecordsStream, times(numContexts)).onClose(any())
+
+            verify(em1).transaction
+            verify(transaction1).begin()
+            verify(em2).transaction
+            verify(transaction2).begin()
+
+            verify(getAllVersionRecordsMock, times(2)).invoke(any())
+
+            verify(transaction1).rollback()
+            verify(reconciliationContext1).close()
+            verify(transaction2).rollback()
+            verify(reconciliationContext2).close()
         }
 
         @Test
         fun `onClose callback closes the open transaction`() {
-            dbReconcilerReader.getAllVersionedRecords()
-            val onClose = streamOnCloseCaptor.firstValue
+            val versionedRecordsStream = dbReconcilerReader.getAllVersionedRecords()
 
-            verify(transaction, never()).rollback()
-            verify(reconciliationContext, never()).close()
 
-            onClose.run()
+            verify(transaction1, never()).rollback()
+            verify(transaction2, never()).rollback()
+            verify(reconciliationContext1, never()).close()
+            verify(reconciliationContext2, never()).close()
 
-            verify(transaction).rollback()
-            verify(reconciliationContext).close()
+            // run terminal operation on stream to process and close
+            versionedRecordsStream?.collect(Collectors.toList())
+
+            verify(transaction1).rollback()
+            verify(transaction2).rollback()
+            verify(reconciliationContext1).close()
+            verify(reconciliationContext2).close()
         }
     }
 
@@ -305,45 +327,48 @@ class DbReconcilerReaderTest {
 
         @Test
         fun `Failure to get entity transaction posts error event`() {
-            whenever(em.transaction) doThrow RuntimeException(errorMsg)
+            whenever(em1.transaction) doThrow RuntimeException(errorMsg)
 
-            val output = assertDoesNotThrow {
-                dbReconcilerReader.getAllVersionedRecords()
+            val numResults = assertDoesNotThrow {
+                // call terminal operation to process stream
+                dbReconcilerReader.getAllVersionedRecords()?.count()
             }
             val postedEvent = postEventCaptor.firstValue
 
-            verify(em).transaction
-            assertThat(output).isNull()
+            verify(em1).transaction
+            assertThat(numResults).isEqualTo(1)
             assertThat(postedEvent).isInstanceOf(GetRecordsErrorEvent::class.java)
             assertThat((postedEvent as GetRecordsErrorEvent).exception.message).isEqualTo(errorMsg)
         }
 
         @Test
         fun `Failure to start transaction posts error event`() {
-            whenever(transaction.begin()) doThrow RuntimeException(errorMsg)
+            whenever(transaction1.begin()) doThrow RuntimeException(errorMsg)
 
-            val output = assertDoesNotThrow {
-                dbReconcilerReader.getAllVersionedRecords()
+            val numResults = assertDoesNotThrow {
+                // call terminal operation to process stream
+                dbReconcilerReader.getAllVersionedRecords()?.count()
             }
             val postedEvent = postEventCaptor.firstValue
 
-            verify(transaction).begin()
-            assertThat(output).isNull()
+            verify(transaction1).begin()
+            assertThat(numResults).isEqualTo(1)
             assertThat(postedEvent).isInstanceOf(GetRecordsErrorEvent::class.java)
             assertThat((postedEvent as GetRecordsErrorEvent).exception.message).isEqualTo(errorMsg)
         }
 
         @Test
         fun `Failure to get all versioned records posts error event`() {
-            whenever(getAllVersionRecordsMock.invoke(any())) doThrow RuntimeException(errorMsg)
+            whenever(getAllVersionRecordsMock.invoke(eq(reconciliationContext2))) doThrow RuntimeException(errorMsg)
 
-            val output = assertDoesNotThrow {
-                dbReconcilerReader.getAllVersionedRecords()
+            val numResults = assertDoesNotThrow {
+                // call terminal operation to process stream
+                dbReconcilerReader.getAllVersionedRecords()?.count()
             }
             val postedEvent = postEventCaptor.firstValue
 
-            verify(getAllVersionRecordsMock).invoke(any())
-            assertThat(output).isNull()
+            verify(getAllVersionRecordsMock, times(2)).invoke(any())
+            assertThat(numResults).isEqualTo(1)
             assertThat(postedEvent).isInstanceOf(GetRecordsErrorEvent::class.java)
             assertThat((postedEvent as GetRecordsErrorEvent).exception.message).isEqualTo(errorMsg)
         }

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
@@ -205,7 +205,8 @@ class GroupParametersReconcilerTest {
         fun `processing versioned records stream calls expected functions`() {
             groupParametersReconciler.updateInterval(1000)
 
-            groupParametersReconciler.dbReconcilerReader?.getAllVersionedRecords()
+            // call terminal operation to process stream
+            groupParametersReconciler.dbReconcilerReader?.getAllVersionedRecords()?.count()
 
             verify(dbConnectionManager, times(2)).createEntityManagerFactory(any(), any())
             verify(em1).criteriaBuilder

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
@@ -174,7 +174,5 @@ class ReconciliationContextTest {
             context.close()
             verify(vnodeEmf).close()
         }
-
-
     }
 }


### PR DESCRIPTION
This change alters the behaviour of the reconciler context handling so that they are managed as streams of contexts which do not initialise their entity managers until necessary. This should ensure that we are only creating database connections when necessary instead of creating all up front which will reduce the number of concurrent connections when there is a large number of virtual nodes.