### PR TITLE
CORE-8966 Stop starting `CpkReadService` twice in DB worker

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -36,8 +36,6 @@ import java.util.Collections.unmodifiableList
 @Suppress("Unused", "LongParameterList")
 @Component(service = [ SandboxGroupContextComponent::class ])
 class SandboxGroupContextComponentImpl @Activate constructor(
-    @Reference(service = CpkReadService::class)
-    private val cpkReadService: CpkReadService,
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,
     @Reference(service = SandboxCreationService::class)
@@ -96,7 +94,6 @@ class SandboxGroupContextComponentImpl @Activate constructor(
         get() = coordinator.isRunning
 
     override fun start() {
-        cpkReadService.start()
         coordinator.start()
     }
 
@@ -105,7 +102,6 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     @Deactivate
     override fun close() {
         coordinator.close()
-        cpkReadService.stop()
     }
 
     private fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {

--- a/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
+++ b/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
@@ -2,6 +2,7 @@ package net.corda.processors.flow.internal
 
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
+import net.corda.cpk.read.CpkReadService
 import net.corda.flow.p2p.filter.FlowP2PFilterService
 import net.corda.flow.service.FlowService
 import net.corda.ledger.utxo.token.cache.factories.TokenCacheComponentFactory
@@ -53,6 +54,8 @@ class FlowProcessorImpl @Activate constructor(
     private val tokenCacheComponentFactory: TokenCacheComponentFactory,
     @Reference(service = GroupParametersReaderService::class)
     private val groupParametersReaderService: GroupParametersReaderService,
+    @Reference(service = CpkReadService::class)
+    private val cpkReadService: CpkReadService
 ) : FlowProcessor {
 
     private companion object {
@@ -68,7 +71,8 @@ class FlowProcessorImpl @Activate constructor(
         ::cpiInfoReadService,
         ::sandboxGroupContextComponent,
         ::membershipGroupReaderProvider,
-        ::groupParametersReaderService
+        ::groupParametersReaderService,
+        ::cpkReadService
     ).with(tokenCacheComponentFactory.create(), TokenCacheComponent::class.java)
 
     private val lifecycleCoordinator =


### PR DESCRIPTION
- Stops `CpkReadService` being started twice every time during DB worker start up for no reason (in `DBProcessorImpl` and in `SandboxGroupContextComponentImpl`). `CpkReadServiceImpl` cache holding CPKs state does not get reset, however the processor that populates it gets closed and a new one is created. Meaning the population of the CPKs cache could be delayed because `CpkReadServiceImpl` gets started twice.