### PR TITLE
CORE-9011 Only collect previous logs for main container

### DIFF
--- a/support_bundle.ps1
+++ b/support_bundle.ps1
@@ -38,7 +38,7 @@ foreach ($podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.
   if ($restartCount -gt 0)
   {
     Write-Output "Pod ${podName} has restarted - collecting previous logs"
-    kubectl --namespace "${namespace}" logs "${podName}" --all-containers=true --ignore-errors --prefix=true --previous > (Join-Path $podDir "previous-logs.txt")
+    kubectl --namespace "${namespace}" logs "${podName}" --ignore-errors --prefix=true --previous > (Join-Path $podDir "previous-logs.txt")
   }
   if ($podName -match '.*-worker-.*')
   {

--- a/support_bundle.sh
+++ b/support_bundle.sh
@@ -35,7 +35,7 @@ for podName in $(kubectl --namespace "$namespace" get pods -o jsonpath="{.items[
   restartCount=$(kubectl --namespace "$namespace" get pod "${podName}" -o jsonpath="{.status.containerStatuses[0].restartCount}")
   if [[ $restartCount -gt 0 ]]; then
     echo "Pod ${podName} has restarted - collecting previous logs"
-    kubectl --namespace "${namespace}" logs "${podName}" --all-containers=true --ignore-errors --prefix=true --previous > "${podDir}/previous-logs.txt"
+    kubectl --namespace "${namespace}" logs "${podName}" --ignore-errors --prefix=true --previous > "${podDir}/previous-logs.txt"
   fi
   if [[ "$podName" == *-worker-* ]]; then
     echo "Collecting status for pod ${podName}"


### PR DESCRIPTION
When a restart is detected, it is likely to be for the main container and attempting to collect previous logs for the init container results in a file containing an error.