### PR TITLE
CORE-8743 Flows stuck in RUNNING

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -66,19 +66,14 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
             return
         }
 
-        val partitionsSynced = mutableSetOf<CordaTopicPartition>()
-        val states = stateConsumer.poll(STATE_POLL_TIMEOUT)
-        if (partitionsToSync.isNotEmpty()) {
-            log.info("State consumer in group ${config.group} is syncing partitions: $partitionsToSync")
-        }
-        for (state in states) {
+        stateConsumer.poll(STATE_POLL_TIMEOUT).forEach { state ->
             log.debug { "Updating state: $state" }
             updateInMemoryState(state)
-            partitionsSynced.addAll(getSyncedEventPartitions())
         }
 
-        if (syncPartitions && partitionsSynced.isNotEmpty()) {
-            resumeConsumerAndExecuteListener(partitionsSynced)
+        if (syncPartitions && partitionsToSync.isNotEmpty()) {
+            log.info("State consumer in group ${config.group} is syncing partitions: $partitionsToSync")
+            resumeConsumerAndExecuteListener(removeAndReturnSyncedPartitions())
         }
     }
 
@@ -88,7 +83,7 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
         executor.shutdown()
     }
 
-    private fun getSyncedEventPartitions(): Set<CordaTopicPartition> {
+    private fun removeAndReturnSyncedPartitions(): Set<CordaTopicPartition> {
         val partitionsSynced = mutableSetOf<CordaTopicPartition>()
         val statePartitionsToSync = partitionsToSync.toMap()
         for (partition in statePartitionsToSync) {
@@ -111,6 +106,10 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
     }
 
     private fun resumeConsumerAndExecuteListener(partitionsSynced: Set<CordaTopicPartition>) {
+        if (partitionsSynced.isEmpty()) {
+            return
+        }
+
         log.info("State consumer in group ${config.group} is up to date for $partitionsSynced.  Resuming event feed.")
         eventConsumer.resume(partitionsSynced)
 
@@ -198,14 +197,31 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
 
     override fun resetPollInterval() {
         if (System.currentTimeMillis() > pollIntervalCutoff) {
-            val assignment = eventConsumer.assignment() - eventConsumer.paused()
-            log.debug { "Resetting poll interval. Pausing assignment: $assignment"}
-            eventConsumer.pause(assignment)
-            eventConsumer.poll(PAUSED_POLL_TIMEOUT)
-            stateConsumer.poll(PAUSED_POLL_TIMEOUT)
+            // Here we pause each consumer in order to mark a poll to avoid a Kafka timeout without actually consuming
+            // any records.
+            val eventConsumerPausePartitions = eventConsumer.assignment() - eventConsumer.paused()
+            log.debug { "Resetting poll interval. Pausing event consumer partitions: $eventConsumerPausePartitions"}
+            eventConsumer.pause(eventConsumerPausePartitions)
+            val eventRecords = eventConsumer.poll(PAUSED_POLL_TIMEOUT)
+            eventRecords.forEach { event ->
+                log.warn("Resetting polling interval has lost event with key: ${event.key}, this will likely cause execution" +
+                        " problems with the Flow with this id")
+            }
+            eventConsumer.resume(eventConsumerPausePartitions)
+            log.debug { "Reset of event consumer poll interval complete. Resuming event assignment: $eventConsumerPausePartitions" }
+
+            val stateConsumerPausePartitions = stateConsumer.assignment() - stateConsumer.paused()
+            log.debug { "Resetting poll interval. Pausing state consumer partitions: $stateConsumerPausePartitions"}
+            stateConsumer.pause(stateConsumerPausePartitions)
+            val stateRecords = stateConsumer.poll(PAUSED_POLL_TIMEOUT)
+            stateRecords.forEach { state ->
+                log.warn("Resetting polling interval has lost state with key: ${state.key}, this will likely cause execution" +
+                        " problems with the Flow with this id")
+            }
+            stateConsumer.resume(stateConsumerPausePartitions)
+            log.debug { "Reset of state consumer poll interval complete. Resuming state assignment: $stateConsumerPausePartitions" }
+
             pollIntervalCutoff = getNextPollIntervalCutoff()
-            log.debug { "Reset of poll interval complete. Resuming assignment: $assignment"}
-            eventConsumer.resume(assignment)
         }
     }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
@@ -11,7 +11,9 @@ import net.corda.messaging.subscription.consumer.StateAndEventConsumerImpl
 import net.corda.messaging.subscription.consumer.StateAndEventPartitionState
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.inOrder
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
@@ -125,12 +127,18 @@ class StateAndEventConsumerImplTest {
                 stateAndEventListener
             )
 
+        val record = CordaConsumerRecord(TOPIC_PREFIX + TOPIC, partitionId, 0, "key1", "value1", 0)
+        whenever(stateConsumer.poll(any())).thenReturn(listOf(record))
+
         consumer.pollAndUpdateStates(true)
 
         verify(stateConsumer, times(1)).assignment()
         verify(stateConsumer, times(1)).poll(any())
         verify(stateConsumer, times(1)).poll(any())
-        verify(stateAndEventListener, times(1)).onPartitionSynced(any())
+        verify(stateAndEventListener, times(1)).onPartitionSynced(mapOf("key1" to "value1"))
+
+        // partitionsToSync should have had the synced partition removed
+        assertThat(partitionState.partitionsToSync.size).isEqualTo(0)
     }
 
     @Test
@@ -141,6 +149,10 @@ class StateAndEventConsumerImplTest {
             mutableMapOf(partitionId to mutableMapOf("key1" to Pair(Long.MIN_VALUE, "value1"))),
             mutableMapOf(partitionId to Long.MAX_VALUE)
         )
+
+        val record = CordaConsumerRecord(TOPIC_PREFIX + TOPIC, partitionId, 0, "key1", "value1", 0)
+        whenever(stateConsumer.poll(any())).thenReturn(listOf(record))
+
         val consumer = StateAndEventConsumerImpl(
             config,
             eventConsumer,
@@ -155,6 +167,12 @@ class StateAndEventConsumerImplTest {
         verify(stateConsumer, times(1)).poll(any())
         verify(stateConsumer, times(1)).poll(any())
         verify(stateAndEventListener, times(0)).onPartitionSynced(any())
+
+        // When false is passed to pollAndUpdateStates to indicate not to try and process whether partitions are synced
+        // or not, partitionsToSync should remain untouched, even though we return a record from the poll above which
+        // corresponds to a state which would otherwise have marked the partition as synced.
+        assertThat(partitionState.partitionsToSync.size).isEqualTo(1)
+        assertThat(partitionState.partitionsToSync[partitionId]).isEqualTo(Long.MAX_VALUE)
     }
 
     @Test
@@ -196,12 +214,33 @@ class StateAndEventConsumerImplTest {
                 (mutableMapOf(), mutableMapOf()), stateAndEventListener
         )
 
+        val assignedTopicPartitions = setOf(CordaTopicPartition(TOPIC, 0), CordaTopicPartition(TOPIC, 1))
+        val pausedTopicPartitions = setOf(CordaTopicPartition(TOPIC, 1))
+        whenever(eventConsumer.assignment()).thenReturn(assignedTopicPartitions)
+        whenever(eventConsumer.paused()).thenReturn(pausedTopicPartitions)
+
         consumer.resetPollInterval()
+
+        val eventConsumerOrder = inOrder(eventConsumer)
 
         verify(eventConsumer, times(1)).assignment()
         verify(eventConsumer, times(1)).paused()
-        verify(eventConsumer, times(1)).pause(any())
-        verify(eventConsumer, times(1)).resume(any())
+
+        eventConsumerOrder.verify(eventConsumer, times(1))
+            .pause(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
+        eventConsumerOrder.verify(eventConsumer, times(1)).poll(any())
+        eventConsumerOrder.verify(eventConsumer, times(1))
+            .resume(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
+
+        val stateConsumerOrder = inOrder(stateConsumer)
+
+        verify(stateConsumer, times(1)).assignment()
+        verify(stateConsumer, times(1)).paused()
+        stateConsumerOrder.verify(stateConsumer, times(1))
+            .pause(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
+        stateConsumerOrder.verify(stateConsumer, times(1)).poll(any())
+        stateConsumerOrder.verify(stateConsumer, times(1))
+            .resume(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
     }
 
     private fun setupMocks(): Mocks {


### PR DESCRIPTION
This doesn't fix all the problems with flows stuck in RUNNING, but two of the most prominent. At least the bug where duplicate start flow messages are processed still exists, and this leaves flows sometimes stuck in RUNNING as they are pushed to the DLQ. That almost certainly has the same root cause as CORE-7918 so will not be covered in CORE-8743.

It is recommended to retest this area after this PR and PR(s) for CORE-7918 are merged and everything we know about to date is resolved as a new baseline for testing.

* State consumer was not paused when attempting to reset the poll interval via a poll. This meant states could get lost as they were returned here and disregarded, instead of as a result of the state sync poll in `pollAndUpdateStates` where they are processed. Added logging so if any states are returned in `resetPollInterval` and lost in the future it will be clear from the log.
* Fixed a bug in `pollAndUpdateStates` when `false` is passed. In this case we are not syncing partitions, only forcing a poll towards the Kafka client. However the line of code which removed partitions being synced from the map if all the states had been polled was still called, meaning partitions considered themselves synced even though the code to resume was never called. The result of this was partitions were paused indefinitely.