### PR TITLE
CORE-9014 token selection bug

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/impl/token/selection/impl/TokenSelectionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/impl/token/selection/impl/TokenSelectionImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.impl.token.selection.impl
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.ledger.utxo.impl.token.selection.factories.TokenClaimQueryExternalEventFactory
+import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.token.selection.TokenClaim
 import net.corda.v5.ledger.utxo.token.selection.TokenClaimCriteria
@@ -12,11 +13,11 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope
 
-@Component(service = [TokenSelection::class, SingletonSerializeAsToken::class], scope = ServiceScope.PROTOTYPE)
+@Component(service = [TokenSelection::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
 class TokenSelectionImpl @Activate constructor(
     @Reference(service = ExternalEventExecutor::class)
     private val externalEventExecutor: ExternalEventExecutor
-) : TokenSelection, SingletonSerializeAsToken {
+) : TokenSelection, UsedByFlow, SingletonSerializeAsToken {
 
     @Suspendable
     override fun tryClaim(criteria: TokenClaimCriteria): TokenClaim? {

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EntityConverterImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EntityConverterImpl.kt
@@ -46,6 +46,7 @@ class EntityConverterImpl : EntityConverter {
     override fun toClaimRelease(avroPoolKey: TokenPoolCacheKey, tokenClaimRelease: TokenClaimRelease): ClaimRelease {
         return ClaimRelease(
             tokenClaimRelease.claimId,
+            tokenClaimRelease.requestContext.requestId,
             tokenClaimRelease.requestContext.flowId,
             tokenClaimRelease.usedTokenStateRefs.toSet(),
             avroPoolKey

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimRelease.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimRelease.kt
@@ -4,6 +4,7 @@ import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 
 data class ClaimRelease(
     val claimId: String,
+    val externalEventRequestId: String,
     val flowId: String,
     val usedTokens: Set<String>,
     override val poolKey: TokenPoolCacheKey

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactory.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactory.kt
@@ -45,14 +45,14 @@ interface RecordFactory {
     /**
      * Creates a [Record] to acknowledge the release of a claim
      *
-     * @param flowId The unique identifier of the flow that requested the claim
-     * @param claimId The unique ID of the claim that was released
+     * @param flowId The unique identifier of the flow that requested the claim release
+     * @param externalEventRequestId The unique ID of the flow request event of the claim release
 
      * @return A [FlowEvent] response record for the release acknowledgement
      */
     fun getClaimReleaseAck(
         flowId: String,
-        claimId: String
+        externalEventRequestId: String
     ): Record<String, FlowEvent>
 }
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactoryImpl.kt
@@ -34,6 +34,7 @@ class RecordFactoryImpl(private val externalEventResponseFactory: ExternalEventR
     ): Record<String, FlowEvent> {
         val payload = TokenClaimQueryResult().apply {
             this.poolKey = poolKey
+            this.claimId = externalEventRequestId
             this.resultType = TokenClaimResultStatus.NONE_AVAILABLE
             this.claimedTokens = listOf()
         }
@@ -43,8 +44,8 @@ class RecordFactoryImpl(private val externalEventResponseFactory: ExternalEventR
 
     override fun getClaimReleaseAck(
         flowId: String,
-        claimId: String
+        externalEventRequestId: String
     ): Record<String, FlowEvent> {
-        return externalEventResponseFactory.success(claimId, flowId, TokenClaimReleaseAck())
+        return externalEventResponseFactory.success(externalEventRequestId, flowId, TokenClaimReleaseAck())
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheComponentFactory.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheComponentFactory.kt
@@ -43,7 +43,7 @@ class TokenCacheComponentFactory @Activate constructor(
         val eventHandlerMap = mapOf<Class<*>, TokenEventHandler<in TokenEvent>>(
             createHandler(TokenClaimQueryEventHandler(tokenFilterStrategy, recordFactory)),
             createHandler(TokenClaimReleaseEventHandler(recordFactory)),
-            createHandler(TokenLedgerChangeEventHandler(externalEventResponseFactory)),
+            createHandler(TokenLedgerChangeEventHandler()),
         )
 
         val tokenCacheEventHandlerFactory = TokenCacheEventProcessorFactoryImpl(

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenClaimReleaseEventHandler.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenClaimReleaseEventHandler.kt
@@ -26,11 +26,11 @@ class TokenClaimReleaseEventHandler(
 
         if (!state.claimExists(event.claimId)) {
             log.warn("Couldn't find existing claim for claimId='${event.claimId}'")
-        }else {
+        } else {
             tokenCache.removeAll(event.usedTokens)
             state.removeClaim(event.claimId)
         }
 
-        return recordFactory.getClaimReleaseAck(event.flowId, event.claimId)
+        return recordFactory.getClaimReleaseAck(event.flowId, event.externalEventRequestId)
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenLedgerChangeEventHandler.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenLedgerChangeEventHandler.kt
@@ -1,15 +1,12 @@
 package net.corda.ledger.utxo.token.cache.handlers
 
 import net.corda.data.flow.event.FlowEvent
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
-import net.corda.messaging.api.records.Record
 import net.corda.ledger.utxo.token.cache.entities.LedgerChange
 import net.corda.ledger.utxo.token.cache.entities.PoolCacheState
 import net.corda.ledger.utxo.token.cache.entities.TokenCache
+import net.corda.messaging.api.records.Record
 
-class TokenLedgerChangeEventHandler(
-    private val externalEventResponseFactory: ExternalEventResponseFactory,
-) : TokenEventHandler<LedgerChange> {
+class TokenLedgerChangeEventHandler : TokenEventHandler<LedgerChange> {
 
     override fun handle(
         tokenCache: TokenCache,
@@ -22,8 +19,6 @@ class TokenLedgerChangeEventHandler(
 
         tokenCache.removeAll(consumedStateRefs)
         state.tokensRemovedFromCache(consumedStateRefs)
-
-        // HACK: Added for testing will be removed by CORE-5722 (ledger integration)
-        return event.flowId?.let { externalEventResponseFactory.success(event.claimId!!, event.flowId, "HACK") }
+        return null
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EntityConverterImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EntityConverterImplTest.kt
@@ -65,6 +65,7 @@ class EntityConverterImplTest {
             .toClaimRelease(POOL_CACHE_KEY, tokenClaimRelease)
 
         assertThat(result.claimId).isEqualTo("c1")
+        assertThat(result.externalEventRequestId).isEqualTo("r1")
         assertThat(result.flowId).isEqualTo("f1")
         assertThat(result.usedTokens).containsOnly("s1", "s2")
         assertThat(result.poolKey).isEqualTo(POOL_CACHE_KEY)

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
@@ -23,7 +23,7 @@ class EventConverterImplTest {
 
     private val entityConverter = mock<EntityConverter>()
     private val claimQuery = ClaimQuery("","", BigDecimal(0), "", "", POOL_CACHE_KEY)
-    private val claimRelease = ClaimRelease("","", setOf(), POOL_CACHE_KEY)
+    private val claimRelease = ClaimRelease("","", "", setOf(), POOL_CACHE_KEY)
     private val ledgerChange = LedgerChange(POOL_CACHE_KEY,"","", listOf(), listOf())
 
     @BeforeEach

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/factories/RecordFactoryImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/factories/RecordFactoryImplTest.kt
@@ -54,6 +54,7 @@ class RecordFactoryImplTest {
     fun `create failure claim response`() {
         val expectedResponse = TokenClaimQueryResult().apply {
             this.poolKey = POOL_CACHE_KEY
+            this.claimId = externalEventRequestId
             this.resultType = TokenClaimResultStatus.NONE_AVAILABLE
             this.claimedTokens = listOf()
         }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenClaimReleaseEventHandlerTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenClaimReleaseEventHandlerTest.kt
@@ -24,12 +24,13 @@ class TokenClaimReleaseEventHandlerTest {
 
     private val tokenRef1 = "r1"
     private val claimId = "r1"
+    private val externalEventRequestId = "ext1"
     private val flowId = "f1"
 
     @Test
     fun `release returns an ack response event`() {
         val response = Record<String, FlowEvent>("", "", null)
-        whenever(recordFactory.getClaimReleaseAck(flowId, claimId)).thenReturn(response)
+        whenever(recordFactory.getClaimReleaseAck(flowId, externalEventRequestId)).thenReturn(response)
 
         val target = TokenClaimReleaseEventHandler(recordFactory)
         val claimRelease = createClaimRelease()
@@ -74,6 +75,6 @@ class TokenClaimReleaseEventHandlerTest {
     }
 
     private fun createClaimRelease(): ClaimRelease {
-        return ClaimRelease(claimId, flowId, setOf(tokenRef1), POOL_CACHE_KEY)
+        return ClaimRelease(claimId, externalEventRequestId,flowId, setOf(tokenRef1), POOL_CACHE_KEY)
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenLedgerChangeEventHandlerTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenLedgerChangeEventHandlerTest.kt
@@ -24,7 +24,7 @@ class TokenLedgerChangeEventHandlerTest {
 
         val ledgerChange = LedgerChange(POOL_CACHE_KEY,"","", listOf(), listOf(token1, token2))
 
-        val target = TokenLedgerChangeEventHandler(mock())
+        val target = TokenLedgerChangeEventHandler()
         val result = target.handle(tokenCache, poolCacheState, ledgerChange)
 
         assertThat(result).isNull()
@@ -39,7 +39,7 @@ class TokenLedgerChangeEventHandlerTest {
 
         val ledgerChange = LedgerChange(POOL_CACHE_KEY,"","", listOf(token1, token2), listOf())
 
-        val target = TokenLedgerChangeEventHandler(mock())
+        val target = TokenLedgerChangeEventHandler()
         val result = target.handle(tokenCache, poolCacheState, ledgerChange)
 
         assertThat(result).isNull()


### PR DESCRIPTION
- Fixed issue with incorrect flow external event ID not set correctly for token claim release acknowledgements
- Fixed issue preventing flow resuming after failed token query.
- Fixed issue preventing token selection API flow injection.
- Removed old unused test code