### PR TITLE
CORE-3698 Remove TODO that are no longer valid

### DIFF
--- a/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
+++ b/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
@@ -47,10 +47,6 @@ fun validateRequestSignature(notarisationRequest: NotarisationRequest,
         )
     }
 
-    // TODO CORE-3698: Review if this TODO is still valid
-    //  if requestSignature was generated over an old version of NotarisationRequest, we need to be able to
-    //  reserialize it in that version to get the exact same bytes. Modify the serialization logic once that's
-    //  available.
     val expectedSignedBytes = serializationService.serialize(notarisationRequest).bytes
 
     try {


### PR DESCRIPTION
## Overview

This TODO was added back in the C4 world (4 years ago) and is no longer valid. The main concern of this TODO was that if the NotarisationRequest's signature changes it will no longer be backwards compatible. However, backwards compatibility with C4 is no longer an issue for us. Also, having time windows further limits the duration these requests can be used anyway.