### PR TITLE
CORE-8743 Handling stray events

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/FlowEventContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/FlowEventContext.kt
@@ -25,8 +25,10 @@ data class FlowEventContext<T>(
     var inputEventPayload: T,
     val config: SmartConfig,
     val outputRecords: List<Record<*, *>>,
-    val sendToDlq: Boolean = false,
-    val mdcProperties: Map<String, String>
-)
-
-
+    val mdcProperties: Map<String, String>,
+    val processingStatus: ProcessingStatus = ProcessingStatus.SUCCESS
+) {
+    enum class ProcessingStatus {
+        SUCCESS, SEND_TO_DLQ, STRAY_EVENT
+    }
+}

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/FlowEventExceptionProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/FlowEventExceptionProcessor.kt
@@ -5,6 +5,7 @@ import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.flow.pipeline.exceptions.FlowEventException
 import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.exceptions.FlowPlatformException
+import net.corda.flow.pipeline.exceptions.FlowStrayEventException
 import net.corda.flow.pipeline.exceptions.FlowTransientException
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.processor.StateAndEventProcessor
@@ -60,13 +61,24 @@ interface FlowEventExceptionProcessor {
     /**
      * Processes a [FlowEventException] and provides the pipeline response.
      *
-     * Invoked if an event should be discarded, for example a spurious wakeup or a session event for a failed session.
+     * Invoked if event processing failed, for example a session event for a failed session.
      *
      * @param exception The [FlowEventException] thrown during processing
      *
      * @return The updated response.
      */
     fun process(exception: FlowEventException, context: FlowEventContext<*>): StateAndEventProcessor.Response<Checkpoint>
+
+    /**
+     * Processes a [FlowStrayEventException] and provides the pipeline response.
+     *
+     * Invoked if an event should be discarded, for example a spurious wakeup.
+     *
+     * @param exception The [FlowStrayEventException] thrown during processing
+     *
+     * @return The updated response.
+     */
+    fun process(exception: FlowStrayEventException, context: FlowEventContext<*>): StateAndEventProcessor.Response<Checkpoint>
 
     /**
      * Processes a [FlowPlatformException] and provides the pipeline response.

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/converters/impl/FlowEventContextConverterImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/converters/impl/FlowEventContextConverterImpl.kt
@@ -13,7 +13,11 @@ class FlowEventContextConverterImpl : FlowEventContextConverter {
         return StateAndEventProcessor.Response(
             flowContext.checkpoint.toAvro(),
             flowContext.outputRecords,
-            flowContext.sendToDlq
+            processingStatus = when(flowContext.processingStatus) {
+                FlowEventContext.ProcessingStatus.SUCCESS -> StateAndEventProcessor.Response.ProcessingStatus.SUCCESS
+                FlowEventContext.ProcessingStatus.SEND_TO_DLQ -> StateAndEventProcessor.Response.ProcessingStatus.SEND_TO_DLQ
+                FlowEventContext.ProcessingStatus.STRAY_EVENT -> StateAndEventProcessor.Response.ProcessingStatus.STRAY_EVENT
+            }
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/exceptions/FlowStrayEventException.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/exceptions/FlowStrayEventException.kt
@@ -1,0 +1,15 @@
+package net.corda.flow.pipeline.exceptions
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+/**
+ * The [FlowStrayEventException] is thrown when event processing needs to be aborted, and no state and output messages
+ * should be published. It indicates this event is malformed or operates on a state Corda doesn't currently have
+ * knowledge of and thus cannot interact with that state. This exception should be thrown in place of
+ * [FlowEventException] in these cases to avoid writing an erroneous null state. If [FlowEventException] was to be thrown
+ * instead Corda would write a null state for a Flow it thought was non-existent, effectively 'inventing' a Flow
+ * from nothing. If this flow actually existed in Kafka, but Corda was for some reason not yet aware of it, this stray
+ * event would have the effect of killing it.
+ */
+class FlowStrayEventException(override val message: String, cause: Throwable? = null) :
+    CordaRuntimeException(message, cause)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandler.kt
@@ -3,6 +3,7 @@ package net.corda.flow.pipeline.handlers.events
 import net.corda.data.flow.event.Wakeup
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowEventException
+import net.corda.flow.pipeline.exceptions.FlowStrayEventException
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Component
@@ -24,7 +25,7 @@ class WakeupEventHandler : FlowEventHandler<Wakeup> {
                 "Received a ${Wakeup::class.simpleName} for flow [${context.inputEvent.flowId}] that does not exist. " +
                         "The event will be discarded."
             }
-            throw FlowEventException(
+            throw FlowStrayEventException(
                 "WakeupEventHandler received a ${Wakeup::class.simpleName} for flow [${context.inputEvent.flowId}] that does not exist"
             )
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -51,7 +51,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
         return StateAndEventProcessor.Response(
             updatedState = null,
             responseEvents = listOf(),
-            markForDLQ = true
+            processingStatus = StateAndEventProcessor.Response.ProcessingStatus.SEND_TO_DLQ
         )
     }
 
@@ -110,7 +110,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
         StateAndEventProcessor.Response(
             updatedState = null,
             responseEvents = records,
-            markForDLQ = true
+            processingStatus = StateAndEventProcessor.Response.ProcessingStatus.SEND_TO_DLQ
         )
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -12,6 +12,7 @@ import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.exceptions.FlowPlatformException
 import net.corda.flow.pipeline.exceptions.FlowProcessingExceptionTypes.FLOW_FAILED
 import net.corda.flow.pipeline.exceptions.FlowProcessingExceptionTypes.PLATFORM_ERROR
+import net.corda.flow.pipeline.exceptions.FlowStrayEventException
 import net.corda.flow.pipeline.exceptions.FlowTransientException
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
@@ -137,6 +138,14 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
         context: FlowEventContext<*>
     ): StateAndEventProcessor.Response<Checkpoint> = withEscalation {
         log.warn("A non critical error was reported while processing the event: ${exception.message}")
+        flowEventContextConverter.convert(context)
+    }
+
+    override fun process(
+        exception: FlowStrayEventException,
+        context: FlowEventContext<*>
+    ): StateAndEventProcessor.Response<Checkpoint> = withEscalation {
+        log.warn("A stray event was discarded: ${exception.message}")
         flowEventContextConverter.convert(context)
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
@@ -8,6 +8,7 @@ import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.FlowEventPipeline
 import net.corda.flow.pipeline.FlowGlobalPostProcessor
 import net.corda.flow.pipeline.exceptions.FlowFatalException
+import net.corda.flow.pipeline.exceptions.FlowStrayEventException
 import net.corda.flow.pipeline.handlers.events.FlowEventHandler
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
 import net.corda.flow.pipeline.handlers.waiting.FlowWaitingForHandler
@@ -72,7 +73,12 @@ class FlowEventPipelineImpl(
         }
 
         val handler = getFlowEventHandler(updatedContext.inputEvent)
-        context = handler.preProcess(updatedContext)
+        try {
+            context = handler.preProcess(updatedContext)
+        } catch (ex: FlowStrayEventException) {
+            context = context.copy(processingStatus = FlowEventContext.ProcessingStatus.STRAY_EVENT)
+            throw ex
+        }
 
         return this
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
@@ -8,6 +8,7 @@ import net.corda.flow.pipeline.converters.FlowEventContextConverter
 import net.corda.flow.pipeline.exceptions.FlowEventException
 import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.exceptions.FlowPlatformException
+import net.corda.flow.pipeline.exceptions.FlowStrayEventException
 import net.corda.flow.pipeline.exceptions.FlowTransientException
 import net.corda.flow.pipeline.factory.FlowEventPipelineFactory
 import net.corda.libs.configuration.SmartConfig
@@ -88,6 +89,8 @@ class FlowEventProcessorImpl(
         } catch (e: FlowTransientException) {
             flowEventExceptionProcessor.process(e, pipeline.context)
         } catch (e: FlowEventException) {
+            flowEventExceptionProcessor.process(e, pipeline.context)
+        } catch (e: FlowStrayEventException) {
             flowEventExceptionProcessor.process(e, pipeline.context)
         } catch (e: FlowPlatformException) {
             flowEventExceptionProcessor.process(e, pipeline.context)

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
@@ -57,7 +57,7 @@ class TokenCacheEventProcessor constructor(
             )
         } catch (e: Exception) {
             log.error("Unexpected error while processing event '${event}'. The event will be sent to the DLQ.", e)
-            return StateAndEventProcessor.Response(state, listOf(), markForDLQ = true)
+            return StateAndEventProcessor.Response(state, listOf(), processingStatus = StateAndEventProcessor.Response.ProcessingStatus.SEND_TO_DLQ)
         }
     }
 }


### PR DESCRIPTION
This is a proof-of-concept for handling stray events. I had to add this code to debug CORE-8743, because without it, where states were incorrectly not picked up by Corda, wakeup events for those states would generate a new state in Kafka with null values. This was confusing as Kafka topics were full of null states for existing flows which didn't belong there and clouded the situation.

Note that the one place where events are flagged as stray events already had the following comment associated with it:
```
"The event will be discarded."
```
In the current state, this is not really true. The event actually leads to the creation of a new state!

There are two reasons why we wouldn't want to submit such a change that I can think of:
- This shouldn't happen. Events for flows should only be received when a partition is synced, and at this point all states should be known about.
- We might want to kill flows in Kafka where events are received by Corda before it knows about states. Producing a null state will effectively kill the flow. This is kind of a brute force approach to trying to recover when the software is in an invalid state by simply rejecting flows.

On the first point, one argument against that is that this has happened in the past (this is why I wrote this code in the first place, as a debugging aid). CORE-8743 represents bugs where this goes wrong. It's when something goes wrong that we need to inspect Kafka and worker logs, and this change leaves those in a state where determining what went wrong might be a little clearer.
