### PR TITLE
NOTICK: Allow SandboxGroupContext cache to be flushed.

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -16,6 +16,7 @@ interface VNodeService {
     fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo
     fun getOrCreateSandbox(holdingIdentity: HoldingIdentity): SandboxGroupContext
     fun unloadVirtualNode(virtualNodeInfo: VirtualNodeInfo)
+    fun flushSandboxCache()
 }
 
 @Suppress("unused")
@@ -36,7 +37,7 @@ class VNodeServiceImpl @Activate constructor(
     private val logger = loggerFor<VNodeService>()
 
     init {
-        setupSandboxCache()
+        sandboxGroupContextComponent.initCache(1)
     }
 
     override fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo {
@@ -49,14 +50,14 @@ class VNodeServiceImpl @Activate constructor(
         virtualNodeLoader.unloadVirtualNode(virtualNodeInfo)
         virtualNodeLoader.forgetCPI(cpiMetadata.cpiId)
         cpiLoader.removeCpiMetadata(cpiMetadata.cpiId)
-        setupSandboxCache()
+        flushSandboxCache()
     }
 
     override fun getOrCreateSandbox(holdingIdentity: HoldingIdentity): SandboxGroupContext {
         return flowSandboxService.get(holdingIdentity)
     }
 
-    private fun setupSandboxCache() {
-        sandboxGroupContextComponent.initCache(1)
+    override fun flushSandboxCache() {
+        sandboxGroupContextComponent.flushCache()
     }
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
@@ -69,6 +69,10 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
         TODO("Not yet implemented")
     }
 
+    override fun flushCache() {
+        TODO("Not yet implemented")
+    }
+
     override val isRunning: Boolean
         get() = true
 

--- a/components/virtual-node/sandbox-group-context-service/build.gradle
+++ b/components/virtual-node/sandbox-group-context-service/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     testRuntimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     testRuntimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     integrationTestImplementation project('test-impl-one')
     integrationTestImplementation project('test-impl-two')

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheConfiguration.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheConfiguration.kt
@@ -1,8 +1,9 @@
 package net.corda.sandboxgroupcontext.service
 
-// NOTE: this interface is a bit a hack and only here so we can configure the cache from the sandbox
+// NOTE: this interface is a bit a hack and is only here so that we can configure the cache from the sandbox
 //  OSGi integration tests.
 //  Once we have a good way of faking/stubbing the lifecycle coordinator, then I think we can remove this.
 interface CacheConfiguration {
     fun initCache(capacity: Long)
+    fun flushCache()
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
@@ -10,5 +10,7 @@ interface SandboxGroupContextCache : AutoCloseable {
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext
-}
 
+    fun resize(newCapacity: Long): SandboxGroupContextCache
+    fun flush()
+}

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -174,6 +174,11 @@ class SandboxGroupContextComponentImpl @Activate constructor(
         sandboxCreationService.createPublicSandbox(publicBundles, privateBundles)
     }
 
+    override fun flushCache() {
+        (sandboxGroupContextService as? CacheConfiguration)?.flushCache()
+            ?: throw IllegalStateException("Sandbox cache could not be flushed")
+    }
+
     override fun initCache(capacity: Long) {
         logger.info("Initialising Sandbox cache with capacity: $capacity")
         resizeCache(capacity)

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
@@ -26,6 +26,11 @@ class SandboxGroupContextComponentImpl @Activate constructor(
             ?: throw IllegalStateException("Cannot initialize sandbox cache")
     }
 
+    override fun flushCache() {
+        (sandboxGroupContextService as? CacheConfiguration)?.flushCache()
+            ?: throw IllegalStateException("Cannot flush sandbox cache")
+    }
+
     override fun start() {
         logger.info("Started")
     }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
@@ -80,7 +80,7 @@ class VirtualNodeLoaderImpl @Activate constructor(
     }
 
     override fun getByHoldingIdentityShortHash(holdingIdentityShortHash: ShortHash): VirtualNodeInfo? {
-        TODO("Not yet implemented - getById")
+        TODO("Not yet implemented - getByHoldingIdentityShortHash")
     }
 
     private fun put(virtualNodeInfo: VirtualNodeInfo) {
@@ -94,7 +94,7 @@ class VirtualNodeLoaderImpl @Activate constructor(
     }
 
     override fun getAllVersionedRecords(): Stream<VersionedRecord<HoldingIdentity, VirtualNodeInfo>>? {
-        TODO("Not yet implemented")
+        TODO("Not yet implemented - getAllVersionedRecords")
     }
 
     override val lifecycleCoordinatorName: LifecycleCoordinatorName


### PR DESCRIPTION
Allow flushing of the `SandboxGroupContextCache`. This cache is managed asynchronously and so we cannot guarantee when any of its contents are actually evicted and destroyed. We also need to preserve the cache's `expiryQueue` property when we resize it so that expired entries from the old cache continue to be reaped.

All old `SandboxGroupContext` entries are now expired as `WeakReference`s, which means they _cannot_ be closed accidentally while still in use.