### PR TITLE
CORE-9066: CLI installer: Handle spaces in paths gracefully

### DIFF
--- a/tools/plugins/installScripts/install.ps1
+++ b/tools/plugins/installScripts/install.ps1
@@ -3,13 +3,13 @@ param ($addToPath)
 $cliHomeDir = "$ENV:UserProfile\.corda\cli"
 
 Write-Output "Creating corda-cli dir at $cliHomeDir"
-New-Item -Path "$cliHomeDir\plugins" -ItemType "directory" -Force
+New-Item -Path "$cliHomeDir" -ItemType "directory" -Force
 
 Write-Output "copying files and plugins"
 Copy-Item -Path ".\*" -Destination $cliHomeDir -Recurse
 
 Write-Output "Creating corda-cli Script"
-$cliCommand = "$ENV:JAVA_HOME\bin\java -Dpf4j.pluginsDir=$cliHomeDir\plugins -jar $cliHomeDir\corda-cli.jar %*"
+$cliCommand = "`"$ENV:JAVA_HOME\bin\java`" -Dpf4j.pluginsDir=`"$cliHomeDir\plugins`" -jar `"$cliHomeDir\corda-cli.jar`" %*"
 New-Item "$cliHomeDir\corda-cli.cmd" -ItemType File -Value $cliCommand
 
 if($addToPath) {
@@ -17,6 +17,6 @@ if($addToPath) {
 
     Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path
     $old = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path).path
-    $new  =  "$old;$cliHomeDir"
+    $new = "$old;$cliHomeDir"
     Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path -Value $new
 }


### PR DESCRIPTION
Also, few other minor changes:
- Eliminate warning when copying over `plugins` directory
- Tidy-up

Tested locally by running install script on Windows.