### PR TITLE
CORE-5396 Convert all worker and CLI arguments to kebab case

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -108,7 +108,7 @@ pipeline {
                 JDBC_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/drivers"
                 VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true"
                 LOG4J_PARAMETERS = "-Dlog4j2.debug=-false -Dlog4j.configurationFile=log4j2-console.xml"
-                PROGRAM_PARAMETERS = "--instanceId=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -ddatabase.user=u${postgresDb} -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://${postgresHost}:${postgresPort}/${postgresDb} -ddatabase.jdbc.directory=${JDBC_PATH}"
+                PROGRAM_PARAMETERS = "--instance-id=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -ddatabase.user=u${postgresDb} -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://${postgresHost}:${postgresPort}/${postgresDb} -ddatabase.jdbc.directory=${JDBC_PATH}"
                 WORKING_DIRECTORY = "${env.WORKSPACE}"
             }
             steps {

--- a/.run/Combined Worker Local.run.xml
+++ b/.run/Combined Worker Local.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Combined Worker Local" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
-    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster -ddatabase.jdbc.directory=$ProjectFileDir$/applications/workers/release/combined-worker/drivers" />
+    <option name="PROGRAM_PARAMETERS" value="--instance-id=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster -ddatabase.jdbc.directory=$ProjectFileDir$/applications/workers/release/combined-worker/drivers" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <method v="2">

--- a/.run/K8s - Flow Worker Local.run.xml
+++ b/.run/K8s - Flow Worker Local.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="K8s/telepresence - Flow Worker Local  (debug agent 5008)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/flow-worker/build/bin/corda-flow-worker-5.0.0.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5008" />
-    <option name="PROGRAM_PARAMETERS" value="--instanceId=1 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA" />
+    <option name="PROGRAM_PARAMETERS" value="--instance-id=1 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <method v="2">

--- a/.run/K8s - RPC Worker.run.xml
+++ b/.run/K8s - RPC Worker.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="K8s/telepresence - RPC Worker Local  (debug agent 5007)" type="JarApplication">
     <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/rpc-worker/build/bin/corda-rpc-worker-5.0.0.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5007" />
-    <option name="PROGRAM_PARAMETERS" value="--instanceId=0 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA" />
+    <option name="PROGRAM_PARAMETERS" value="--instance-id=0 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <method v="2">

--- a/.run/db-worker-local-debug.sh
+++ b/.run/db-worker-local-debug.sh
@@ -9,6 +9,6 @@ SALT=$(kubectl get secret corda-db-worker -o go-template='{{ .data.salt | base64
 PASSPHRASE=$(kubectl get secret corda-db-worker -o go-template='{{ .data.passphrase | base64decode }}')
 DATABASE_PASS=$(kubectl get secret prereqs-postgresql -o go-template='{{ .data.password | base64decode }}')
 
-PROGRAM_PARAMETERS="--instanceId=2 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA -spassphrase=$PASSPHRASE -ssalt=$SALT -ddatabase.user=user -ddatabase.pass=$DATABASE_PASS -ddatabase.jdbc.url=jdbc:postgresql://prereqs-postgresql.corda:5432/cordacluster"
+PROGRAM_PARAMETERS="--instance-id=2 -mbus.kafkaProperties.common.bootstrap.servers=prereqs-kafka.corda:9092 -mbus.busType=KAFKA -spassphrase=$PASSPHRASE -ssalt=$SALT -ddatabase.user=user -ddatabase.pass=$DATABASE_PASS -ddatabase.jdbc.url=jdbc:postgresql://prereqs-postgresql.corda:5432/cordacluster"
 
 java $VM_PARAMETERS -Dlog4j.configurationFile=log4j2-console.xml -jar $JAR_PATH $PROGRAM_PARAMETERS

--- a/applications/tools/p2p-test/app-simulator/README.md
+++ b/applications/tools/p2p-test/app-simulator/README.md
@@ -134,7 +134,7 @@ Below is a list of command line arguments you can use:
   -i, --instance-id=<instanceId>
                The instance ID. Defaults to the value of the env. variable
                  INSTANCE_ID or a random number, if that hasn't been set.
-  -m, --messagingParams=<String=String>
+  -m, --messaging-params=<String=String>
                Messaging parameters for the simulator.
       --receive-topic=<receiveTopic>
                Topic to receive messages from. Defaults to p2p.in, if not

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
@@ -169,25 +169,25 @@ class AppSimulator @Activate constructor(
 
 class CliParameters {
     @CommandLine.Option(
-        names = ["-m", "--messagingParams"],
+        names = ["-m", "--messaging-params"],
         description = ["Messaging parameters for the simulator."]
     )
     var messagingParams = emptyMap<String, String>()
 
     @CommandLine.Option(
-        names = ["-d", "--databaseParams"],
+        names = ["-d", "--database-params"],
         description = ["Database parameters for the simulator."]
     )
     var databaseParams = emptyMap<String, String>()
 
     @CommandLine.Option(
-        names = ["-l", "--loadGenerationParams"],
+        names = ["-l", "--load-generation-params"],
         description = ["Load generation parameters for the simulator."]
     )
     var loadGenerationParams = emptyMap<String, String>()
 
     @CommandLine.Option(
-        names = ["-t", "--topicCreationParams"],
+        names = ["-t", "--topic-creation-params"],
         description = ["Topic creation parameters for the simulator."]
     )
     var topicCreationParams = emptyMap<String, String>()

--- a/applications/tools/p2p-test/dump-topic/README.md
+++ b/applications/tools/p2p-test/dump-topic/README.md
@@ -27,7 +27,7 @@ java -jar \
 
 The command parameters are: 
 ```
--m, --messagingParams=<String=String>
+-m, --messaging-params=<String=String>
                         Messaging parameters for the topic dumper.
                           Default: {}
 -o, --output=<output>   The output file.

--- a/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/TopicDumper.kt
+++ b/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/TopicDumper.kt
@@ -41,7 +41,7 @@ internal class TopicDumper(
         private val logger = LoggerFactory.getLogger("Console")
     }
     @Option(
-        names = ["-m", "--messagingParams"],
+        names = ["-m", "--messaging-params"],
         description = ["Messaging parameters for the topic dumper."]
     )
     var messagingParams = emptyMap<String, String>()

--- a/applications/workers/release/combined-worker/README.md
+++ b/applications/workers/release/combined-worker/README.md
@@ -107,7 +107,7 @@ Run the worker using:
 ```bash
 java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
   ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
-  --instanceId=0 -mbus.busType=DATABASE  \
+  --instance-id=0 -mbus.busType=DATABASE  \
   -spassphrase=password -ssalt=salt \
   -ddatabase.user=user -ddatabase.pass=password \
   -ddatabase.jdbc.directory=applications/workers/release/combined-worker/drivers \
@@ -118,7 +118,7 @@ Or if you want to connect to "real" Kafka:
 ```bash
 java -jar -Dco.paralleluniverse.fibers.verifyInstrumentation=true \
   ./applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar \
-  --instanceId=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 \
+  --instance-id=0 -mbus.busType=KAFKA -mbootstrap.servers=localhost:9092 \
   -spassphrase=password -ssalt=salt \
   -ddatabase.user=user -ddatabase.pass=password \
   -ddatabase.jdbc.directory=applications/workers/release/combined-worker/drivers \

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -152,10 +152,10 @@ private class CombinedWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
 
-    @Option(names = ["-d", "--databaseParams"], description = ["Database parameters for the worker."])
+    @Option(names = ["-d", "--database-params"], description = ["Database parameters for the worker."])
     var databaseParams = emptyMap<String, String>()
 
-    @Option(names = ["-r", "--rpcParams"], description = ["RPC parameters for the worker."])
+    @Option(names = ["-r", "--rpc-params"], description = ["RPC parameters for the worker."])
     var rpcParams = emptyMap<String, String>()
 
     @Option(names = ["--hsm-id"], description = ["HSM ID which is handled by this worker instance."])

--- a/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
+++ b/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
@@ -86,7 +86,7 @@ class CryptoWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
 
-    @CommandLine.Option(names = ["-d", "--databaseParams"], description = ["Database parameters for the worker."])
+    @CommandLine.Option(names = ["-d", "--database-params"], description = ["Database parameters for the worker."])
     var databaseParams = emptyMap<String, String>()
 
     @CommandLine.Option(names = ["--hsm-id"], description = ["HSM ID which is handled by this worker instance."])

--- a/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
+++ b/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
@@ -79,6 +79,6 @@ private class DBWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
 
-    @Option(names = ["-d", "--databaseParams"], description = ["Database parameters for the worker."])
+    @Option(names = ["-d", "--database-params"], description = ["Database parameters for the worker."])
     var databaseParams = emptyMap<String, String>()
 }

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
@@ -15,31 +15,31 @@ class DefaultWorkerParams {
     var versionRequested = false
 
     @Option(
-        names = ["-i", "--instanceId"],
+        names = ["-i", "--instance-id"],
         description = ["The Kafka instance ID for this worker. Defaults to a random value."]
     )
     var instanceId = Random.nextInt().absoluteValue
 
     @Option(
-        names = ["-t", "--topicPrefix"],
+        names = ["-t", "--topic-prefix"],
         description = ["The prefix to use for Kafka topics. Defaults to the empty string."]
     )
     // This needs revision as arguably it belongs to the `messagingParams`
     var topicPrefix = ""
 
-    @Option(names = ["-n", "--noWorkerMonitor"], description = ["Disables the worker monitor."])
+    @Option(names = ["-n", "--no-worker-monitor"], description = ["Disables the worker monitor."])
     var disableWorkerMonitor = false
 
     @Option(
-        names = ["-p", "--workerMonitorPort"],
+        names = ["-p", "--worker-monitor-port"],
         description = ["The port the worker monitor should listen on. Defaults to $WORKER_MONITOR_PORT."]
     )
     var workerMonitorPort = WORKER_MONITOR_PORT
 
-    @Option(names = ["-m", "--messagingParams"], description = ["Messaging parameters for the worker."])
+    @Option(names = ["-m", "--messaging-params"], description = ["Messaging parameters for the worker."])
     var messagingParams = emptyMap<String, String>()
 
-    @Option(names = ["-s", "--secretsParams"], description = ["Secrets parameters for the worker."])
+    @Option(names = ["-s", "--secrets-params"], description = ["Secrets parameters for the worker."])
     var secretsParams = emptyMap<String, String>()
 
     @Option(names = ["--workspace-dir"], description = ["Corda workspace directory."])

--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -374,7 +374,7 @@ Worker Kafka arguments
 */}}
 {{- define "corda.workerKafkaArgs" -}}
 - "-mbootstrap.servers={{ include "corda.kafkaBootstrapServers" . }}"
-- "--topicPrefix={{ .Values.kafka.topicPrefix }}"
+- "--topic-prefix={{ .Values.kafka.topicPrefix }}"
 {{- if .Values.kafka.tls.enabled }}
 {{- if .Values.kafka.sasl.enabled }}
 - "-msecurity.protocol=SASL_SSL"

--- a/charts/corda/templates/db-job.yaml
+++ b/charts/corda/templates/db-job.yaml
@@ -64,7 +64,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: [ 'initial-config', 'create-db-config', '-u', '$(RBAC_DB_USER_USERNAME)', '-p', $(RBAC_DB_USER_PASSWORD), '--name', 'corda-rbac', '--jdbcURL', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}', '--jdbcPoolMaxSize', {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
+          args: [ 'initial-config', 'create-db-config', '-u', '$(RBAC_DB_USER_USERNAME)', '-p', $(RBAC_DB_USER_PASSWORD), '--name', 'corda-rbac', '--jdbc-url', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}', '--jdbc-pool-max-size', {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
           workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir
@@ -90,7 +90,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: [ 'initial-config', 'create-db-config', '-u', '$(CRYPTO_DB_USER_USERNAME)', '-p', '$(CRYPTO_DB_USER_PASSWORD)', '--name', 'corda-crypto', '--jdbcURL', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}?currentSchema=CRYPTO', '--jdbcPoolMaxSize', {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
+          args: [ 'initial-config', 'create-db-config', '-u', '$(CRYPTO_DB_USER_USERNAME)', '-p', '$(CRYPTO_DB_USER_PASSWORD)', '--name', 'corda-crypto', '--jdbc-url', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}?currentSchema=CRYPTO', '--jdbc-pool-max-size', {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
           workingDir: /tmp/working_dir
           volumeMounts:
             - mountPath: /tmp/working_dir

--- a/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Spec.kt
+++ b/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Spec.kt
@@ -23,7 +23,7 @@ class Spec(
     private val deleteFile: (Path) -> Unit = { path -> deleteIfExists(path) }
 ) : Runnable {
     @CommandLine.Option(
-        names = ["-c", "--clearChangeLog"],
+        names = ["-c", "--clear-change-log"],
         description = ["Automatically delete the changelogCSV in the PWD to force generation of the sql files"]
     )
     var clearChangeLog: Boolean? = false

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/DbConfigSubcommand.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/DbConfigSubcommand.kt
@@ -26,14 +26,14 @@ class DbConfigSubcommand : Runnable {
     var connectionName: String? = null
 
     @Option(
-        names = ["-j", "--jdbcURL"],
+        names = ["-j", "--jdbc-url"],
         required = true,
         description = ["The JDBC URL for the connection. Required."]
     )
     var jdbcUrl: String? = null
 
     @Option(
-        names = ["--jdbcPoolMaxSize"],
+        names = ["--jdbc-pool-max-size"],
         description = ["The maximum size for the JDBC connection pool. Defaults to 10"]
     )
     var jdbcPoolMaxSize: Int = 10
@@ -53,7 +53,7 @@ class DbConfigSubcommand : Runnable {
     var password: String? = null
 
     @Option(
-        names = ["-a", "--isAdmin"],
+        names = ["-a", "--is-admin"],
         description = ["Whether this is an admin (DDL) connection. Defaults to false"]
     )
     var isAdmin: Boolean = false

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
@@ -18,7 +18,7 @@ class TestInitialConfigPluginDb {
         }
         assertThat(outText).startsWith(
             "Missing required options: '--name=<connectionName>'," +
-                " '--jdbcURL=<jdbcUrl>', '--user=<username>', '--password=<password>'," +
+                " '--jdbc-url=<jdbcUrl>', '--user=<username>', '--password=<password>'," +
                 " '--salt=<salt>', '--passphrase=<passphrase>'"
         )
     }
@@ -35,7 +35,7 @@ class TestInitialConfigPluginDb {
                 "create-db-config",
                 "-n", "connection name",
                 "-j", "jdbd:postgres://testurl",
-                "--jdbcPoolMaxSize", "3",
+                "--jdbc-pool-max-size", "3",
                 "-u", "testuser",
                 "-p", "password",
                 "-s", "not so secure",

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/FlowExecutorSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/FlowExecutorSubcommand.kt
@@ -23,7 +23,7 @@ private const val FLOW_EXECUTOR_ROLE = "FlowExecutorRole"
 class FlowExecutorSubcommand : HttpRpcCommand(), Callable<Int> {
 
     @CommandLine.Option(
-        names = ["-v", "--vNodeId"],
+        names = ["-v", "--v-node-id"],
         description = ["vNode short hash identifier"],
         required = true
     )


### PR DESCRIPTION
Convert all worker and CLI arguments to kebab case. To conform to the GNU standard https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html).