### PR TITLE
CORE-5884: Simulator instances in interaction tests

### DIFF
--- a/simulator/api/src/main/kotlin/net/corda/simulator/RequestData.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/RequestData.kt
@@ -70,5 +70,12 @@ interface RequestData {
          */
         @JvmStatic
         fun create(jsonInput : String) = factory.create(jsonInput)
+
+        /**
+         * Creates a valid [RequestData] object that can be used for flows which ignore it. This can be useful for
+         * instance flows where the behaviour can be explicitly specified regardless of the input.
+         */
+        @JvmStatic
+        val IGNORED = create("r1", Flow::class.java, "")
     }
 }

--- a/simulator/example-app/src/integrationTest/kotlin/net/cordacon/example/utils/Members.kt
+++ b/simulator/example-app/src/integrationTest/kotlin/net/cordacon/example/utils/Members.kt
@@ -1,9 +1,0 @@
-package net.cordacon.example.utils
-
-import net.corda.v5.base.types.MemberX500Name
-
-/**
- * Creates a MemberX500 with the given common name
- */
-fun createMember(commonName: String) : MemberX500Name =
-    MemberX500Name.parse("CN=$commonName, OU=ExampleUnit, O=ExampleOrg, L=London, C=GB")

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/AbsenceCallResponderFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/AbsenceCallResponderFlowTest.kt
@@ -1,0 +1,9 @@
+package net.cordacon.example
+
+import net.corda.v5.application.flows.Flow
+import net.cordacon.example.rollcall.AbsenceCallResponderFlow
+
+class AbsenceCallResponderFlowTest : ResponderFlowDelegateTest() {
+    override val protocol: String = "absence-call"
+    override val flowClass: Class<out Flow> = AbsenceCallResponderFlow::class.java
+}

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/ResponderFlowDelegateTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/ResponderFlowDelegateTest.kt
@@ -1,0 +1,70 @@
+package net.cordacon.example
+
+import net.corda.simulator.RequestData
+import net.corda.simulator.Simulator
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.Flow
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.base.types.MemberX500Name
+import net.cordacon.example.rollcall.RollCallRequest
+import net.cordacon.example.rollcall.RollCallResponse
+import net.cordacon.example.utils.createMember
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Test
+
+abstract class ResponderFlowDelegateTest {
+
+    abstract val protocol: String
+    abstract val flowClass: Class<out Flow>
+
+    companion object {
+
+        private fun rollCallFlowFor(student: MemberX500Name) = object : RPCStartableFlow {
+            @CordaInject
+            private lateinit var flowMessaging: FlowMessaging
+
+            override fun call(requestBody: RPCRequestData): String {
+                val session = flowMessaging.initiateFlow(student)
+                session.send(RollCallRequest(student))
+                return session.receive(RollCallResponse::class.java).response
+            }
+        }
+    }
+
+    @Test
+    fun `should generally respond to roll call with Here`() {
+        val simulator = Simulator()
+
+        val student = createMember("Alice")
+        val teacher = createMember("Bob")
+
+        val teacherFlow = rollCallFlowFor(student)
+
+        val teacherNode = simulator.createInstanceNode(teacher, protocol, teacherFlow)
+        simulator.createVirtualNode(student, flowClass)
+
+        val result = teacherNode.callInstanceFlow(RequestData.IGNORED)
+
+        MatcherAssert.assertThat(result, Matchers.`is`("Here!"))
+    }
+
+    @Test
+    fun `should respond with an empty string if called Bueller`() {
+        val simulator = Simulator()
+
+        val student = createMember("Bueller")
+        val teacher = createMember("Ben Stein")
+
+        val teacherFlow = rollCallFlowFor(student)
+
+        val teacherNode = simulator.createInstanceNode(teacher, protocol, teacherFlow)
+        simulator.createVirtualNode(student, flowClass)
+
+        val result = teacherNode.callInstanceFlow(RequestData.IGNORED)
+
+        MatcherAssert.assertThat(result, Matchers.`is`(""))
+    }
+}

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/AbsenceSubFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/AbsenceSubFlowTest.kt
@@ -1,0 +1,52 @@
+package net.cordacon.example.rollcall
+
+import net.corda.simulator.RequestData
+import net.corda.simulator.Simulator
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.application.messaging.receive
+import net.cordacon.example.utils.createMember
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AbsenceSubFlowTest {
+
+    @Test
+    fun `should send a roll call request to the given student`() {
+        val alice = createMember("Alice")
+        val bob = createMember("Bob")
+
+        val simulator = Simulator()
+
+        val initiatingFlow = object: RPCStartableFlow {
+            @CordaInject
+            private lateinit var flowEngine: FlowEngine
+
+            override fun call(requestBody: RPCRequestData): String {
+                return flowEngine.subFlow(AbsenceSubFlow(bob))
+            }
+        }
+
+        val respondingFlow = mock<ResponderFlow>()
+        whenever(respondingFlow.call(any())).then {
+            val session = it.getArgument<FlowSession>(0)
+            session.receive<RollCallRequest>()
+            session.send(RollCallResponse("Here!"))
+        }
+
+        val aliceNode = simulator.createInstanceNode(alice, "roll-call", initiatingFlow)
+        simulator.createVirtualNode(bob, AbsenceCallResponderFlow::class.java)
+
+        val result = aliceNode.callInstanceFlow(RequestData.IGNORED)
+
+        assertThat(result, `is`("Here!"))
+    }
+}

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallFlowTest.kt
@@ -1,0 +1,106 @@
+package net.cordacon.example.rollcall
+
+import net.corda.simulator.RequestData
+import net.corda.simulator.Simulator
+import net.corda.simulator.crypto.HsmCategory
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.application.messaging.receive
+import net.cordacon.example.utils.createMember
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RollCallFlowTest {
+
+    companion object {
+        private fun receiveAndSendResponse(session: FlowSession, response: String) {
+            session.receive<Any>()
+            session.send(RollCallResponse(response))
+        }
+    }
+
+    @Test
+    fun `should initiate roll call with members in the same org`() {
+        val students = listOf("Alice", "Bob", "Charlie").map { createMember(it) }
+        val notAStudent = createMember("David", org="DifferentOrg")
+        val truancyOffice = createMember("TruancyOffice", org="AlsoDifferentOrg")
+
+        val simulator = Simulator()
+        val aliceNode = simulator.createVirtualNode(students[0], RollCallFlow::class.java)
+
+        val otherNodes = listOf(students[1], students[2], notAStudent).associateWith {
+            val flow = mock<ResponderFlow>()
+            whenever(flow.call(any())).then { f ->
+                receiveAndSendResponse(f.getArgument(0), "Here!")
+            }
+            simulator.createInstanceNode(it, "roll-call", flow)
+            flow
+        }
+
+        val truancyOfficeFlow = mock<ResponderFlow>()
+        whenever(truancyOfficeFlow.call(any())).then {
+            it.getArgument<FlowSession>(0).receive<TruancyRecord>()
+        }
+        simulator.createInstanceNode(truancyOffice, "truancy-record", truancyOfficeFlow)
+
+        aliceNode.callFlow(RequestData.create(
+            "r1",
+            RollCallFlow::class.java,
+            RollCallInitiationRequest(truancyOffice)
+        ))
+
+        listOf(students[1], students[2]).forEach { verify(otherNodes[it]!!, times(1)).call(any()) }
+        verify(otherNodes[notAStudent]!!, never()).call(any())
+    }
+
+    @Test
+    fun `should retry any empty responses as absences then send signed record to the truancy office`() {
+        val alice = createMember("Alice")
+        val bob = createMember("Bob")
+        val truancyOffice = createMember("TruancyOffice", org="DifferentOrg")
+
+        val simulator = Simulator()
+
+        val bobsAbsentFlow = object: ResponderFlow {
+            override fun call(session: FlowSession) {
+                receiveAndSendResponse(session, "")
+            }
+        }
+
+        val bobsStillAbsentFlow = mock<ResponderFlow>()
+        whenever(bobsStillAbsentFlow.call(any())).then {
+            receiveAndSendResponse(it.getArgument(0), "")
+        }
+
+        val truancyOfficeFlow = mock<ResponderFlow>()
+        lateinit var receivedRecord: TruancyRecord
+        whenever(truancyOfficeFlow.call(any())).then {
+            val flowSession = it.getArgument<FlowSession>(0)
+            receivedRecord = flowSession.receive()
+            receivedRecord
+        }
+
+        simulator.createInstanceNode(bob, "roll-call", bobsAbsentFlow)
+        simulator.createInstanceNode(bob, "absence-call", bobsStillAbsentFlow)
+        simulator.createInstanceNode(truancyOffice, "truancy-record", truancyOfficeFlow)
+
+        val aliceNode = simulator.createVirtualNode(alice, RollCallFlow::class.java)
+        aliceNode.generateKey("my-key", HsmCategory.LEDGER, "any-scheme")
+
+        aliceNode.callFlow(RequestData.create(
+            "r1",
+            RollCallFlow::class.java,
+            RollCallInitiationRequest(truancyOffice)
+        ))
+
+        verify(bobsStillAbsentFlow, times(2)).call(any())
+        assertThat(receivedRecord.absentees, `is`(listOf(bob)))
+    }
+}

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallResponderFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallResponderFlowTest.kt
@@ -1,0 +1,11 @@
+package net.cordacon.example.rollcall
+
+import net.corda.v5.application.flows.Flow
+import net.cordacon.example.ResponderFlowDelegateTest
+
+class RollCallResponderFlowTest : ResponderFlowDelegateTest() {
+
+    override val protocol: String = "roll-call"
+    override val flowClass: Class<out Flow> = RollCallResponderFlow::class.java
+
+}

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/TruancyResponderFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/TruancyResponderFlowTest.kt
@@ -1,0 +1,109 @@
+package net.cordacon.example.rollcall
+
+import net.corda.simulator.RequestData
+import net.corda.simulator.Simulator
+import net.corda.simulator.crypto.HsmCategory
+import net.corda.simulator.exceptions.ResponderFlowException
+import net.corda.simulator.factories.SerializationServiceFactory
+import net.corda.v5.application.crypto.SigningService
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.membership.MemberLookup
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.crypto.exceptions.CryptoSignatureException
+import net.cordacon.example.utils.createMember
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.isA
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class TruancyResponderFlowTest {
+
+    @Test
+    fun `should verify records sent against the key and persist them`() {
+        val alice = createMember("alice")
+        val bob = createMember("bob")
+        val charlie = createMember("charlie")
+
+        val simulator = Simulator()
+        val serializationService = SerializationServiceFactory.create()
+
+        val initiatingFlow = object: RPCStartableFlow {
+            @CordaInject
+            lateinit var flowMessaging: FlowMessaging
+
+            @CordaInject
+            lateinit var signingService: SigningService
+
+            @CordaInject
+            lateinit var memberLookup: MemberLookup
+
+            override fun call(requestBody: RPCRequestData): String {
+                val session = flowMessaging.initiateFlow(charlie)
+
+                val absentees = listOf(bob)
+                session.send(TruancyRecord(absentees, signingService.sign(
+                    serializationService.serialize(absentees).bytes,
+                    memberLookup.myInfo().ledgerKeys[0],
+                    SignatureSpec.ECDSA_SHA256
+                )))
+                return ""
+            }
+        }
+
+        val initiatingNode = simulator.createInstanceNode(alice, "truancy-record", initiatingFlow)
+        val truancyNode = simulator.createVirtualNode(charlie, TruancyResponderFlow::class.java)
+
+        initiatingNode.generateKey("my-key", HsmCategory.LEDGER, "any-scheme")
+        initiatingNode.callInstanceFlow(RequestData.IGNORED)
+
+        val truancyRecords = truancyNode.getPersistenceService().findAll(TruancyEntity::class.java).execute()
+        assertThat(truancyRecords.size, `is`(1))
+        assertThat(truancyRecords[0].name, `is`(bob.toString()))
+    }
+
+    @Test
+    fun `should throw an error if the record sent is not properly signed`() {
+        val alice = createMember("alice")
+        val bob = createMember("bob")
+        val charlie = createMember("charlie")
+
+        val simulator = Simulator()
+
+        val initiatingFlow = object: RPCStartableFlow {
+            @CordaInject
+            lateinit var flowMessaging: FlowMessaging
+
+            @CordaInject
+            lateinit var signingService: SigningService
+
+            @CordaInject
+            lateinit var memberLookup: MemberLookup
+
+            override fun call(requestBody: RPCRequestData): String {
+                val session = flowMessaging.initiateFlow(charlie)
+
+                session.send(TruancyRecord(listOf(bob), signingService.sign(
+                    "Not the right bytes!".toByteArray(),
+                    memberLookup.myInfo().ledgerKeys[0],
+                    SignatureSpec.ECDSA_SHA256
+                )))
+                return ""
+            }
+        }
+
+        val initiatingNode = simulator.createInstanceNode(alice, "truancy-record", initiatingFlow)
+        simulator.createVirtualNode(charlie, TruancyResponderFlow::class.java)
+
+        initiatingNode.generateKey("my-key", HsmCategory.LEDGER, "any-scheme")
+
+        assertThrows<ResponderFlowException> {
+            initiatingNode.callInstanceFlow(RequestData.IGNORED)
+        }.also {
+            assertThat(it.cause, isA(CryptoSignatureException::class.java))
+        }
+    }
+}

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/TruancySubFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/TruancySubFlowTest.kt
@@ -1,0 +1,56 @@
+package net.cordacon.example.rollcall
+
+import net.corda.simulator.RequestData
+import net.corda.simulator.Simulator
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.messaging.FlowSession
+import net.cordacon.example.utils.createMember
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class TruancySubFlowTest {
+
+    @Test
+    fun `should send on the truancy record with which it was constructed`() {
+        val alice = createMember("Alice")
+        val bob = createMember("Bob")
+        val charlie = createMember("Charlie")
+
+        val simulator = Simulator()
+        val truancyRecord = TruancyRecord(
+            listOf(bob),
+            mock()
+        )
+
+        val initiatingFlow = object: RPCStartableFlow {
+            @CordaInject
+            private lateinit var flowEngine: FlowEngine
+
+            override fun call(requestBody: RPCRequestData): String {
+                return flowEngine.subFlow(TruancySubFlow(charlie, truancyRecord))
+            }
+        }
+
+        val respondingFlow = mock<ResponderFlow>()
+        var receivedRecord: TruancyRecord? = null
+        whenever(respondingFlow.call(any())).then {
+            receivedRecord = it.getArgument<FlowSession>(0).receive(TruancyRecord::class.java)
+            receivedRecord
+        }
+
+        val aliceNode = simulator.createInstanceNode(alice, "truancy-record", initiatingFlow)
+        simulator.createInstanceNode(charlie, "truancy-record", respondingFlow)
+
+        aliceNode.callInstanceFlow(RequestData.IGNORED)
+
+        assertThat(receivedRecord, `is`(truancyRecord))
+    }
+}

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/utils/Members.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/utils/Members.kt
@@ -1,0 +1,9 @@
+package net.cordacon.example.utils
+
+import net.corda.v5.base.types.MemberX500Name
+
+/**
+ * Creates a MemberX500 with the given common name
+ */
+fun createMember(commonName: String, orgUnit: String = "ExampleUnit", org: String = "ExampleOrg") : MemberX500Name =
+    MemberX500Name.parse("CN=$commonName, OU=$orgUnit, O=$org, L=London, C=GB")

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/PersistenceTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/PersistenceTest.kt
@@ -1,6 +1,5 @@
 package net.corda.simulator
 
-import net.corda.simulator.factories.JsonMarshallingServiceFactory
 import net.corda.simulator.runtime.persistence.GreetingEntity
 import net.corda.simulator.runtime.testutils.createMember
 import net.corda.v5.application.flows.CordaInject

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SessionManagementTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SessionManagementTest.kt
@@ -1,7 +1,5 @@
 package net.corda.simulator
 
-import net.corda.simulator.RequestData
-import net.corda.simulator.Simulator
 import net.corda.simulator.runtime.testutils.createMember
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SigningTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SigningTest.kt
@@ -1,7 +1,6 @@
 package net.corda.simulator
 
 import net.corda.simulator.crypto.HsmCategory
-import net.corda.simulator.exceptions.NoKeyGeneratedException
 import net.corda.simulator.runtime.testflows.HelloFlow
 import net.corda.simulator.runtime.testutils.createMember
 import net.corda.v5.application.crypto.SigningService

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesTest.kt
@@ -1,6 +1,5 @@
 package net.corda.simulator.runtime.flows
 
-import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.RequestData
 import net.corda.simulator.Simulator
 import net.corda.simulator.runtime.testutils.createMember

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithResponder.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithResponder.kt
@@ -1,15 +1,15 @@
 package net.corda.simulator.runtime.flows
 
-import net.corda.v5.application.flows.InitiatingFlow
-import net.corda.v5.application.flows.InitiatedBy
-import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.flows.set
-import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithSubFlow.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithSubFlow.kt
@@ -1,15 +1,15 @@
 package net.corda.simulator.runtime.flows
 
-import net.corda.v5.application.flows.InitiatingFlow
-import net.corda.v5.application.flows.InitiatedBy
-import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.flows.set
-import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.messaging.receive

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
@@ -4,7 +4,6 @@ import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.RequestData
 import net.corda.simulator.SimulatedInstanceNode
 import net.corda.simulator.runtime.flows.BaseFlowManager
-import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.messaging.SimFiber
@@ -25,7 +24,6 @@ class SimulatedInstanceNodeBase(
     private val flow: Flow,
     override val fiber: SimFiber,
     private val injector: FlowServicesInjector,
-    private val flowFactory: FlowFactory,
     private val flowManager: FlowManager = BaseFlowManager()
 ) : SimulatedNodeBase(), SimulatedInstanceNode {
 
@@ -33,9 +31,9 @@ class SimulatedInstanceNodeBase(
 
     init {
         fiber.registerMember(member)
-        if (ResponderFlow::class.java.isInstance(flow)) {
+        if (ResponderFlow::class.java.isInstance(flow) || RPCStartableFlow::class.java.isInstance(flow)) {
             fiber.registerFlowInstance(member, protocol, flow)
-        } else if (!RPCStartableFlow::class.java.isInstance(flow)) {
+        } else {
             error("The flow provided to this node was neither a `ResponderFlow` nor an `RPCStartableFlow`.")
         }
     }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
@@ -91,7 +91,7 @@ class SimulatorDelegateBase  (
                 "flow instance provided for protocol $protocol")
 
         val holdingIdentity = HoldingIdentityBase(member, groupId)
-        return SimulatedInstanceNodeBase(holdingIdentity, protocol, flow, fiber, injector, flowFactory)
+        return SimulatedInstanceNodeBase(holdingIdentity, protocol, flow, fiber, injector)
     }
 
     override fun close() {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistry.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistry.kt
@@ -4,11 +4,16 @@ import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
 
 class BaseFlowRegistry: FlowRegistry {
     private val nodeFlowInstances = HashMap<MemberX500Name, HashMap<Flow, String>>()
     private val nodeResponderClasses = HashMap<MemberX500Name, HashMap<String, Class<out ResponderFlow>>>()
     private val nodeResponderInstances = HashMap<MemberX500Name, HashMap<String, ResponderFlow>>()
+
+    private companion object {
+        val log = contextLogger()
+    }
 
     override fun registerResponderClass(
         responder: MemberX500Name,
@@ -19,6 +24,8 @@ class BaseFlowRegistry: FlowRegistry {
             throw IllegalStateException("Member \"$responder\" has already registered " +
                     "flow instance for protocol \"$protocol\"")
         }
+
+        log.info("Registering class $flowClass against protocol $protocol")
 
         if(nodeResponderClasses[responder] == null) {
             nodeResponderClasses[responder] = hashMapOf(protocol to flowClass)
@@ -35,6 +42,7 @@ class BaseFlowRegistry: FlowRegistry {
         protocol: String,
         instanceFlow: Flow
     ) {
+        log.info("Registering instance $instanceFlow against protocol $protocol")
         if(!nodeFlowInstances.contains(initiator)) {
             nodeFlowInstances[initiator] = hashMapOf(instanceFlow to protocol)
         }else if(nodeFlowInstances[initiator]!![instanceFlow] == null){

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
@@ -73,9 +73,10 @@ class ConcurrentFlowMessaging(
 
         val responderClass = fiber.lookUpResponderClass(x500Name, protocol)
         val responderFlow = if (responderClass == null) {
-            log.info("Matched protocol with responder instance")
-            fiber.lookUpResponderInstance(x500Name, protocol)
+            val foundResponder = fiber.lookUpResponderInstance(x500Name, protocol)
                 ?: throw NoRegisteredResponderException(x500Name, protocol)
+            log.info("Matched protocol with responder instance $foundResponder")
+            foundResponder
         } else {
             log.info("Matched protocol with responder class $responderClass")
             flowFactory.createResponderFlow(x500Name, responderClass)

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeTest.kt
@@ -44,7 +44,6 @@ class SimulatedInstanceNodeTest {
             flow,
             fiber,
             injector,
-            flowFactory,
             flowManager
         )
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
@@ -13,13 +13,13 @@ import net.corda.v5.application.messaging.receive
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock


### PR DESCRIPTION
Showcasing how Simulator can help document flow interaction using instance uploads.

Note that these aren't unit tests, because we do use Simulator and its services; but the instance uploads allow us to focus on the interaction of the flow under test in a readable, easy-to-write way. These tests then provide living documentation for the flows, as well as allowing us to verify error conditions (like signing the wrong bytes) that would be impractical to test using real Corda.