### PR TITLE
CORE-9052 beta1 to 5.0 2022.12.22 merge

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -788,8 +788,6 @@ class FlowTests {
     }
 
     @Test
-    @Disabled
-    // TODO CORE-7939 For now it's impossible to test this scenario as there's no back-chain resolution
     fun `Notary - Non-validating plugin executes successfully and returns signatures when consuming a valid transaction`() {
         // 1. Issue 1 state
         val issuedStates = mutableListOf<String>()
@@ -837,9 +835,7 @@ class FlowTests {
     }
 
     @Test
-    @Disabled
-    // TODO CORE-7939 For now it's impossible to test this scenario as there's no back-chain resolution
-    fun `Notary - Non-validating plugin returns error when using reference state that is spent in same tx`() {
+    fun `Notary - Non-validating plugin returns error on double spend`() {
         // 1. Issue 1 state
         val issuedStates = mutableListOf<String>()
         issueStatesAndValidateResult(1) { issuanceResult ->
@@ -861,54 +857,182 @@ class FlowTests {
             })
         }
 
-        // 4. Include one of the issued states twice in the same TX (as input and as ref)
+        // 4. Spend the issued state
         val toConsume = issuedStates.first()
 
         consumeStatesAndValidateResult(
             inputStates = listOf(toConsume),
-            refStates = listOf(toConsume)
+            refStates = emptyList()
         ) { consumeResult ->
-            // 5. Make sure the request failed due to double spend error
             assertAll({
-                assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
-                assertThat(consumeResult.flowError?.message).contains("Unable to notarise transaction")
-                assertThat(consumeResult.flowError?.message).contains("NotaryErrorReferenceStateConflict")
+                assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
             })
         }
-    }
 
-    @Test
-    @Disabled
-    // TODO CORE-7939 For now it's impossible to test this scenario as there's no back-chain resolution
-    fun `Notary - Non-validating plugin returns error when trying to spend unknown input state`() {
+        // 5. Try to spend the state again, and expect the error
         consumeStatesAndValidateResult(
-            inputStates = listOf(
-                "SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903:0"
-            ),
+            inputStates = listOf(toConsume),
             refStates = emptyList()
         ) { consumeResult ->
             assertAll({
                 assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
                 assertThat(consumeResult.flowError?.message).contains("Unable to notarise transaction")
-                assertThat(consumeResult.flowError?.message).contains("NotaryErrorInputStateUnknown")
+                assertThat(consumeResult.flowError?.message).contains("NotaryErrorInputStateConflict")
             })
         }
     }
 
     @Test
-    @Disabled
-    // TODO CORE-7939 For now it's impossible to test this scenario as there's no back-chain resolution.
     fun `Notary - Non-validating plugin returns error when trying to spend unknown reference state`() {
+        // Random unknown state
+        val unknownTxId = "SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903:0"
+        // 1. Issue 1 state
+        val issuedStates = mutableListOf<String>()
+        issueStatesAndValidateResult(1) { issuanceResult ->
+            // 2. Make sure the states were issued
+            assertThat(issuanceResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+            val flowResultMap = issuanceResult.mapFlowJsonResult()
+
+            @Suppress("unchecked_cast")
+            val issuedStateRefs = flowResultMap["issuedStateRefs"] as List<String>
+
+            assertThat(issuedStateRefs).hasSize(1)
+
+            issuedStates.addAll(issuedStateRefs)
+
+            // 3. Make sure no states were consumed
+            assertAll({
+                assertThat(flowResultMap["consumedInputStateRefs"] as List<*>).hasSize(0)
+                assertThat(flowResultMap["consumedReferenceStateRefs"] as List<*>).hasSize(0)
+            })
+        }
+
+        // 4. Spend a valid state and reference an unknown state
         consumeStatesAndValidateResult(
-            inputStates = emptyList(),
+            inputStates = listOf(issuedStates.first()),
             refStates = listOf(
-                "SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903:0"
+                unknownTxId
             )
         ) { consumeResult ->
             assertAll({
                 assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+                // This will fail when building the transaction BEFORE reaching the plugin logic so we don't
+                // expect notarisation error here
+                assertThat(consumeResult.flowError?.message).contains(
+                    "Could not find transaction ${unknownTxId.substringBeforeLast(":")} " +
+                            "when fetching input states"
+                )
+            })
+        }
+    }
+
+    @Test
+    fun `Notary - Non-validating plugin executes successfully when using the same state for input and ref`() {
+        // 1. Issue 1 state
+        val issuedStates = mutableListOf<String>()
+        issueStatesAndValidateResult(1) { issuanceResult ->
+            // 2. Make sure the states were issued
+            assertThat(issuanceResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+            val flowResultMap = issuanceResult.mapFlowJsonResult()
+
+            @Suppress("unchecked_cast")
+            val issuedStateRefs = flowResultMap["issuedStateRefs"] as List<String>
+
+            assertThat(issuedStateRefs).hasSize(1)
+
+            issuedStates.addAll(issuedStateRefs)
+
+            // 3. Make sure no states were consumed
+            assertAll({
+                assertThat(flowResultMap["consumedInputStateRefs"] as List<*>).hasSize(0)
+                assertThat(flowResultMap["consumedReferenceStateRefs"] as List<*>).hasSize(0)
+            })
+        }
+
+        // 4. Make sure we consumed the state and managed to reference it
+        // Since the state we are trying to spend and reference is not spent yet (not persisted) we should be able
+        // to spend it and reference at the same time
+        consumeStatesAndValidateResult(
+            inputStates = listOf(issuedStates.first()),
+            refStates = listOf(issuedStates.first())
+        ) { consumeResult ->
+            val flowResultMap = consumeResult.mapFlowJsonResult()
+            assertAll({
+                assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+                assertAll({
+                    assertThat(flowResultMap["consumedInputStateRefs"] as List<*>).hasSize(1)
+                    assertThat(flowResultMap["consumedReferenceStateRefs"] as List<*>).hasSize(1)
+                })
+            })
+        }
+    }
+
+    @Test
+    fun `Notary - Non-validating plugin returns error when trying to spend unknown input state`() {
+        // Random unknown state
+        val unknownTxId = "SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903:0"
+        consumeStatesAndValidateResult(
+            inputStates = listOf(
+                unknownTxId
+            ),
+            refStates = emptyList()
+        ) { consumeResult ->
+            assertAll({
+                assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
+                // This will fail when building the transaction BEFORE reaching the plugin logic so we don't
+                // expect notarisation error here
+                assertThat(consumeResult.flowError?.message).contains(
+                    "Could not find transaction ${unknownTxId.substringBeforeLast(":")} " +
+                            "when fetching input states"
+                )
+            })
+        }
+    }
+
+    @Test
+    fun `Notary - Non-validating plugin returns error when referencing spent state`() {
+        // 1. Issue 2 states
+        val issuedStates = mutableListOf<String>()
+        issueStatesAndValidateResult(2) { issuanceResult ->
+            // 2. Make sure the states were issued
+            assertThat(issuanceResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+            val flowResultMap = issuanceResult.mapFlowJsonResult()
+
+            @Suppress("unchecked_cast")
+            val issuedStateRefs = flowResultMap["issuedStateRefs"] as List<String>
+
+            assertThat(issuedStateRefs).hasSize(2)
+
+            issuedStates.addAll(issuedStateRefs)
+
+            // 3. Make sure no states were consumed
+            assertAll({
+                assertThat(flowResultMap["consumedInputStateRefs"] as List<*>).hasSize(0)
+                assertThat(flowResultMap["consumedReferenceStateRefs"] as List<*>).hasSize(0)
+            })
+        }
+
+        // 4. Spend the issued state
+        consumeStatesAndValidateResult(
+            inputStates = listOf(issuedStates.first()),
+            refStates = emptyList()
+        ) { consumeResult ->
+            assertAll({
+                assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+            })
+        }
+
+        // 5. Try to reference the spent state.
+        // Note we MUST spend or issue a state otherwise it is not a valid transaction. In this case we choose to spend
+        // it because it's easier to do with `consumeStatesAndValidateResult`.
+        consumeStatesAndValidateResult(
+            inputStates = listOf(issuedStates[1]),
+            refStates = listOf(issuedStates.first())
+        ) { consumeResult ->
+            assertAll({
+                assertThat(consumeResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_FAILED)
                 assertThat(consumeResult.flowError?.message).contains("Unable to notarise transaction")
-                assertThat(consumeResult.flowError?.message).contains("NotaryErrorInputStateUnknown")
+                assertThat(consumeResult.flowError?.message).contains("NotaryErrorReferenceStateConflict")
             })
         }
     }
@@ -1035,8 +1159,8 @@ class FlowTests {
         val consumeRequestID = startRpcFlow(
             bobHoldingId,
             mapOf(
-                "inputStateRefs" to inputStates,
-                "referenceStateRefs" to refStates
+                "inputStateRefs" to jacksonObjectMapper.writeValueAsString(inputStates),
+                "referenceStateRefs" to jacksonObjectMapper.writeValueAsString(refStates)
             ),
             "net.cordapp.testing.testflows.NonValidatingNotaryTestFlow"
         )

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -119,7 +119,7 @@ class UtxoPersistenceServiceImplTest {
             entityManagerFactory = ctx.getEntityManagerFactory()
             val repository = UtxoRepositoryImpl(digestService, serializationService, wireTransactionFactory)
             persistenceService = UtxoPersistenceServiceImpl(
-                entityManagerFactory.createEntityManager(),
+                entityManagerFactory,
                 repository,
                 serializationService,
                 digestService,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -37,7 +37,7 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
             sandbox.getSandboxSingletonService()
         )
         val persistenceService = UtxoPersistenceServiceImpl(
-            sandbox.getEntityManagerFactory().createEntityManager(),
+            sandbox.getEntityManagerFactory(),
             repository,
             sandbox.getSandboxSingletonService(),
             sandbox.getSandboxSingletonService(),

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
@@ -35,7 +35,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
             .withTimeWindow()
             .withSignatories()
             .withInputStates()
-            .withReferenceInputStates()
+            .withReferenceStates()
             .withOutputStates()
             .withCommands()
             .build()
@@ -56,8 +56,8 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactlyElementsOf(utxoSignedTransaction.inputStateRefs)
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
-        assertThat((utxoFilteredTransaction.referenceInputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
+        assertThat((utxoFilteredTransaction.referenceStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactlyElementsOf(utxoSignedTransaction.referenceStateRefs)
 
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
@@ -82,7 +82,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat(utxoFilteredTransaction.timeWindow).isNull()
         assertThat(utxoFilteredTransaction.signatories).isInstanceOf(UtxoFilteredData.Removed::class.java)
         assertThat(utxoFilteredTransaction.inputStateRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
         assertThat(utxoFilteredTransaction.commands).isInstanceOf(UtxoFilteredData.Removed::class.java)
 
@@ -114,7 +114,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactlyElementsOf(utxoSignedTransaction.inputStateRefs)
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
 
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
         assertThat((utxoFilteredTransaction.outputStateAndRefs as UtxoFilteredData.Audit<StateAndRef<*>>).values.values)
@@ -162,7 +162,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
             .withTimeWindow()
             .withSignatoriesSize()
             .withInputStatesSize()
-            .withReferenceInputStatesSize()
+            .withReferenceStatesSize()
             .withOutputStatesSize()
             .withCommandsSize()
             .build()
@@ -183,8 +183,8 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.SizeOnly<StateRef>).size)
             .isEqualTo(utxoSignedTransaction.inputStateRefs.size)
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
-        assertThat((utxoFilteredTransaction.referenceInputStateRefs as UtxoFilteredData.SizeOnly<StateRef>).size)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
+        assertThat((utxoFilteredTransaction.referenceStateRefs as UtxoFilteredData.SizeOnly<StateRef>).size)
             .isEqualTo(utxoSignedTransaction.referenceStateRefs.size)
 
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
@@ -202,7 +202,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
     fun `create filtered transaction with the notary setup`() {
         val utxoFilteredTransaction = utxoLedgerService.filterSignedTransaction(utxoSignedTransaction)
             .withInputStates()
-            .withReferenceInputStates()
+            .withReferenceStates()
             .withOutputStatesSize()
             .withNotary()
             .withTimeWindow()
@@ -222,8 +222,8 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactlyElementsOf(utxoSignedTransaction.inputStateRefs)
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
-        assertThat((utxoFilteredTransaction.referenceInputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
+        assertThat((utxoFilteredTransaction.referenceStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactlyElementsOf(utxoSignedTransaction.referenceStateRefs)
 
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
@@ -240,7 +240,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         val utxoSignedTransaction = createSignedTransaction(numberOfOutputStates = 0)
         val utxoFilteredTransaction = utxoLedgerService.filterSignedTransaction(utxoSignedTransaction)
             .withInputStates()
-            .withReferenceInputStates()
+            .withReferenceStates()
             .withOutputStatesSize()
             .withNotary()
             .withTimeWindow()
@@ -258,7 +258,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         val utxoSignedTransaction = createSignedTransaction(numberOfInputStates = 0)
         val utxoFilteredTransaction = utxoLedgerService.filterSignedTransaction(utxoSignedTransaction)
             .withInputStates()
-            .withReferenceInputStates()
+            .withReferenceStates()
             .withOutputStatesSize()
             .withNotary()
             .withTimeWindow()
@@ -297,7 +297,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactlyElementsOf(utxoSignedTransaction.inputStateRefs)
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.Removed::class.java)
 
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
         assertThat((utxoFilteredTransaction.outputStateAndRefs as UtxoFilteredData.Audit<StateAndRef<*>>).values.values)
@@ -317,7 +317,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
             .withTimeWindow()
             .withSignatories { it == utxoSignedTransaction.signatories.single() }
             .withInputStates { it == utxoSignedTransaction.inputStateRefs[1] }
-            .withReferenceInputStates()
+            .withReferenceStates()
             .withOutputStates { it == utxoSignedTransaction.outputStateAndRefs.first().state.contractState }
             .withCommands { true }
             .build()
@@ -339,8 +339,8 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactly(utxoSignedTransaction.inputStateRefs[1])
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
-        assertThat((utxoFilteredTransaction.referenceInputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
+        assertThat((utxoFilteredTransaction.referenceStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
             .containsExactlyElementsOf(utxoSignedTransaction.referenceStateRefs)
 
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
@@ -361,7 +361,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
             .withTimeWindow()
             .withSignatories { false }
             .withInputStates { false }
-            .withReferenceInputStates { false }
+            .withReferenceStates { false }
             .withOutputStates { false }
             .withCommands { false }
             .build()
@@ -382,8 +382,8 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.SizeOnly<StateRef>).size)
             .isEqualTo(utxoSignedTransaction.inputStateRefs.size)
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
-        assertThat((utxoFilteredTransaction.referenceInputStateRefs as UtxoFilteredData.SizeOnly<StateRef>).size)
+        assertThat(utxoFilteredTransaction.referenceStateRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
+        assertThat((utxoFilteredTransaction.referenceStateRefs as UtxoFilteredData.SizeOnly<StateRef>).size)
             .isEqualTo(utxoSignedTransaction.referenceStateRefs.size)
 
         assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
@@ -410,6 +410,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
             jsonMarshallingService,
             jsonValidator,
             wireTransactionFactory,
+            utxoLedgerPersistenceService,
             componentGroups = listOf(
                 // Notary
                 listOf(

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
@@ -20,8 +20,9 @@ import org.junit.jupiter.api.Test
 import java.security.PublicKey
 import java.time.Instant
 
+@Suppress("FunctionName")
 class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
-    
+
     @BeforeEach
     fun beforeEach() {
         utxoSignedTransaction = createSignedTransaction()
@@ -198,6 +199,79 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
     }
 
     @Test
+    fun `create filtered transaction with the notary setup`() {
+        val utxoFilteredTransaction = utxoLedgerService.filterSignedTransaction(utxoSignedTransaction)
+            .withInputStates()
+            .withReferenceInputStates()
+            .withOutputStatesSize()
+            .withNotary()
+            .withTimeWindow()
+            .build()
+
+        assertThat(utxoFilteredTransaction.id).isEqualTo(utxoSignedTransaction.id)
+
+        assertThat(utxoFilteredTransaction.metadata).isEqualTo(utxoSignedTransaction.metadata)
+
+        assertThat(utxoFilteredTransaction.notary).isEqualTo(utxoSignedTransaction.notary)
+
+        assertThat(utxoFilteredTransaction.timeWindow).isEqualTo(utxoSignedTransaction.timeWindow)
+
+        assertThat(utxoFilteredTransaction.signatories).isInstanceOf(UtxoFilteredData.Removed::class.java)
+
+        assertThat(utxoFilteredTransaction.inputStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
+        assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
+            .containsExactlyElementsOf(utxoSignedTransaction.inputStateRefs)
+
+        assertThat(utxoFilteredTransaction.referenceInputStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
+        assertThat((utxoFilteredTransaction.referenceInputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
+            .containsExactlyElementsOf(utxoSignedTransaction.referenceStateRefs)
+
+        assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
+        assertThat((utxoFilteredTransaction.outputStateAndRefs as UtxoFilteredData.SizeOnly<StateAndRef<*>>).size)
+            .isEqualTo(utxoSignedTransaction.outputStateAndRefs.size)
+
+        assertThat(utxoFilteredTransaction.commands).isInstanceOf(UtxoFilteredData.Removed::class.java)
+
+        assertThatCode { utxoFilteredTransaction.verify() }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `create filtered transaction with the notary setup without outputs`() {
+        val utxoSignedTransaction = createSignedTransaction(numberOfOutputStates = 0)
+        val utxoFilteredTransaction = utxoLedgerService.filterSignedTransaction(utxoSignedTransaction)
+            .withInputStates()
+            .withReferenceInputStates()
+            .withOutputStatesSize()
+            .withNotary()
+            .withTimeWindow()
+            .build()
+
+        assertThat(utxoFilteredTransaction.outputStateAndRefs).isInstanceOf(UtxoFilteredData.SizeOnly::class.java)
+        assertThat((utxoFilteredTransaction.outputStateAndRefs as UtxoFilteredData.SizeOnly<StateAndRef<*>>).size)
+            .isEqualTo(utxoSignedTransaction.outputStateAndRefs.size)
+
+        assertThatCode { utxoFilteredTransaction.verify() }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `create filtered transaction with the notary setup without inputs`() {
+        val utxoSignedTransaction = createSignedTransaction(numberOfInputStates = 0)
+        val utxoFilteredTransaction = utxoLedgerService.filterSignedTransaction(utxoSignedTransaction)
+            .withInputStates()
+            .withReferenceInputStates()
+            .withOutputStatesSize()
+            .withNotary()
+            .withTimeWindow()
+            .build()
+
+        assertThat(utxoFilteredTransaction.inputStateRefs).isInstanceOf(UtxoFilteredData.Audit::class.java)
+        assertThat((utxoFilteredTransaction.inputStateRefs as UtxoFilteredData.Audit<StateRef>).values.values)
+            .containsExactlyElementsOf(utxoSignedTransaction.inputStateRefs)
+
+        assertThatCode { utxoFilteredTransaction.verify() }.doesNotThrowAnyException()
+    }
+
+    @Test
     fun `create filtered transaction with audit and size proofs and missing components`() {
         val utxoFilteredTransaction = utxoLedgerService.filterSignedTransaction(utxoSignedTransaction)
             .withNotary()
@@ -323,7 +397,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThatCode { utxoFilteredTransaction.verify() }.doesNotThrowAnyException()
     }
     
-    private fun createSignedTransaction(): UtxoSignedTransaction {
+    private fun createSignedTransaction(numberOfInputStates: Int = 2, numberOfOutputStates: Int = 2): UtxoSignedTransaction {
         val inputHash = SecureHash.parse("SHA256:1234567890abcdef")
         val outputInfo = UtxoOutputInfoComponent(
             encumbrance = null,
@@ -345,10 +419,9 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
                 // Signatories
                 listOf(serializationService.serialize(publicKeyExample).bytes),
                 // output infos
-                listOf(
-                    serializationService.serialize(outputInfo).bytes,
+                List(numberOfOutputStates) {
                     serializationService.serialize(outputInfo).bytes
-                ),
+                },
                 // command infos
                 listOf(
                     serializationService.serialize(listOf(MyCommand::class.java.name)).bytes,
@@ -357,20 +430,18 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
                 // attachments
                 emptyList(),
                 // inputs
-                listOf(
-                    serializationService.serialize(StateRef(inputHash, 0)).bytes,
-                    serializationService.serialize(StateRef(inputHash, 1)).bytes
-                ),
+                List(numberOfInputStates) {
+                    serializationService.serialize(StateRef(inputHash, it)).bytes
+                },
                 // references
                 listOf(
                     serializationService.serialize(StateRef(inputHash, 0)).bytes,
                     serializationService.serialize(StateRef(inputHash, 1)).bytes
                 ),
                 // outputs
-                listOf(
-                    serializationService.serialize(UtxoStateClassExample("1", emptyList())).bytes,
-                    serializationService.serialize(UtxoStateClassExample("2", emptyList())).bytes
-                ),
+                List(numberOfOutputStates) {
+                    serializationService.serialize(UtxoStateClassExample(it.toString(), emptyList())).bytes
+                },
                 // commands
                 listOf(
                     serializationService.serialize(MyCommand("1")).bytes,

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoFilteredTransactionAMQPSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoFilteredTransactionAMQPSerializationTest.kt
@@ -37,6 +37,7 @@ class UtxoFilteredTransactionAMQPSerializationTest : UtxoLedgerIntegrationTest()
             jsonMarshallingService,
             jsonValidator,
             wireTransactionFactory,
+            utxoLedgerPersistenceService,
             componentGroups = listOf(
                 emptyList(), // Notary
                 emptyList(), // Signatories
@@ -95,6 +96,7 @@ class UtxoFilteredTransactionAMQPSerializationTest : UtxoLedgerIntegrationTest()
             jsonMarshallingService,
             jsonValidator,
             wireTransactionFactory,
+            utxoLedgerPersistenceService,
             componentGroups = listOf(
                 emptyList(), // Notary
                 emptyList(), // Signatories
@@ -150,6 +152,7 @@ class UtxoFilteredTransactionAMQPSerializationTest : UtxoLedgerIntegrationTest()
             jsonMarshallingService,
             jsonValidator,
             wireTransactionFactory,
+            utxoLedgerPersistenceService,
             componentGroups = listOf(
                 emptyList(), // Notary
                 emptyList(), // Signatories

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/persistence/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/persistence/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.utxo.flow.impl.persistence;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.utxo.flow.impl.transaction.factory.impl;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -48,7 +48,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
 
     @Suspendable
     override fun getTransactionBuilder(): UtxoTransactionBuilder =
-        UtxoTransactionBuilderImpl(utxoSignedTransactionFactory)
+        UtxoTransactionBuilderImpl(utxoSignedTransactionFactory, utxoLedgerPersistenceService)
 
     override fun <T : ContractState> resolve(stateRefs: Iterable<StateRef>): List<StateAndRef<T>> {
         TODO("Not yet implemented")

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainExtensions.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainExtensions.kt
@@ -4,7 +4,7 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 
 val UtxoSignedTransaction.dependencies: Set<SecureHash>
-    get() = toLedgerTransaction()
-        .let { it.inputStateRefs.asSequence() + it.referenceInputStateRefs.asSequence() }
+    get() = this
+        .let { it.inputStateRefs.asSequence() + it.referenceStateRefs.asSequence() }
         .map { it.transactionHash }
         .toSet()

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
@@ -89,6 +89,7 @@ abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
         return transaction.addSignature(signature)
     }
 
+    @Suspendable
     protected fun verifyTransaction(signedTransaction: UtxoSignedTransaction) {
         UtxoTransactionMetadataVerifier(signedTransaction.metadata).verify()
         val ledgerTransactionToCheck = signedTransaction.toLedgerTransaction()

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -59,7 +59,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
                 FindTransactionParameters(id.toString(), transactionStatus)
             )
         }.firstOrNull()?.let {
-            serializationService.deserialize<SignedTransactionContainer>(it.array()).toSignedTransaction()
+            serializationService.deserialize<SignedTransactionContainer>(it.array()).toSignedTransaction(this)
         }
     }
 
@@ -128,8 +128,9 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
         }
     }
 
-    private fun SignedTransactionContainer.toSignedTransaction(): UtxoSignedTransaction {
-        return utxoSignedTransactionFactory.create(wireTransaction, signatures)
+    private fun SignedTransactionContainer.toSignedTransaction(utxoLedgerPersistenceService: UtxoLedgerPersistenceService)
+    : UtxoSignedTransaction {
+        return utxoSignedTransactionFactory.create(wireTransaction, signatures, utxoLedgerPersistenceService)
     }
 
     private fun UtxoSignedTransaction.toContainer() =

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -59,7 +59,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
                 FindTransactionParameters(id.toString(), transactionStatus)
             )
         }.firstOrNull()?.let {
-            serializationService.deserialize<SignedTransactionContainer>(it.array()).toSignedTransaction(this)
+            serializationService.deserialize<SignedTransactionContainer>(it.array()).toSignedTransaction()
         }
     }
 
@@ -128,9 +128,9 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
         }
     }
 
-    private fun SignedTransactionContainer.toSignedTransaction(utxoLedgerPersistenceService: UtxoLedgerPersistenceService)
+    private fun SignedTransactionContainer.toSignedTransaction()
     : UtxoSignedTransaction {
-        return utxoSignedTransactionFactory.create(wireTransaction, signatures, utxoLedgerPersistenceService)
+        return utxoSignedTransactionFactory.create(wireTransaction, signatures, this@UtxoLedgerPersistenceServiceImpl)
     }
 
     private fun UtxoSignedTransaction.toContainer() =

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -2,8 +2,8 @@ package net.corda.ledger.utxo.flow.impl.transaction
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
-import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
+import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
@@ -23,6 +23,7 @@ import java.util.Objects
 data class UtxoSignedTransactionImpl(
     private val serializationService: SerializationService,
     private val transactionSignatureService: TransactionSignatureService,
+    private val utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory,
     override val wireTransaction: WireTransaction,
     override val signatures: List<DigitalSignatureAndMetadata>
 ) : UtxoSignedTransactionInternal {
@@ -44,7 +45,7 @@ data class UtxoSignedTransactionImpl(
     override val outputStateAndRefs: List<StateAndRef<*>>
         get() = wrappedWireTransaction.outputStateAndRefs
     override val referenceStateRefs: List<StateRef>
-        get() = wrappedWireTransaction.referenceInputStateRefs
+        get() = wrappedWireTransaction.referenceStateRefs
     override val timeWindow: TimeWindow
         get() = wrappedWireTransaction.timeWindow
     override val signatories: List<PublicKey>
@@ -59,6 +60,7 @@ data class UtxoSignedTransactionImpl(
             UtxoSignedTransactionImpl(
                 serializationService,
                 transactionSignatureService,
+                utxoLedgerTransactionFactory,
                 wireTransaction,
                 signatures + newSignature
             ),
@@ -67,7 +69,7 @@ data class UtxoSignedTransactionImpl(
     }
 
     override fun addSignature(signature: DigitalSignatureAndMetadata): UtxoSignedTransactionInternal =
-        UtxoSignedTransactionImpl(serializationService, transactionSignatureService,
+        UtxoSignedTransactionImpl(serializationService, transactionSignatureService, utxoLedgerTransactionFactory,
             wireTransaction, signatures + signature)
 
     @Suspendable
@@ -84,8 +86,7 @@ data class UtxoSignedTransactionImpl(
                 false
             }
         }.map { it.by }.toSet()
-        val requiredSignatories = toLedgerTransaction().signatories
-        return requiredSignatories.filter {
+        return signatories.filter {
             !it.isFulfilledBy(appliedSignatories) // isFulfilledBy() helps to make this working with CompositeKeys.
         }.toSet()
     }
@@ -103,15 +104,15 @@ data class UtxoSignedTransactionImpl(
                 )
             }
         }.map { it.by }.toSet()
-        val requiredSignatories = this.toLedgerTransaction().signatories
-        if (requiredSignatories.any {
+        if (signatories.any {
                 !it.isFulfilledBy(appliedSignatories) // isFulfilledBy() helps to make this working with CompositeKeys.
-            }){
+            }) {
             throw TransactionVerificationException(id, "There are missing signatures", null)
         }
     }
+    @Suspendable
     override fun toLedgerTransaction(): UtxoLedgerTransaction {
-        return UtxoLedgerTransactionImpl(wireTransaction, serializationService)
+        return utxoLedgerTransactionFactory.create(wireTransaction)
     }
 
     override fun equals(other: Any?): Boolean {
@@ -130,6 +131,5 @@ data class UtxoSignedTransactionImpl(
     override fun toString(): String {
         return "UtxoSignedTransactionImpl(id=$id, signatures=$signatures, wireTransaction=$wireTransaction)"
     }
-
 
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -106,7 +106,8 @@ data class UtxoSignedTransactionImpl(
         }.map { it.by }.toSet()
         if (signatories.any {
                 !it.isFulfilledBy(appliedSignatories) // isFulfilledBy() helps to make this working with CompositeKeys.
-            }) {
+            })
+        {
             throw TransactionVerificationException(id, "There are missing signatures", null)
         }
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -14,6 +14,6 @@ interface UtxoTransactionBuilderInternal {
     val commands: List<Command>
     val signatories: List<PublicKey>
     val inputStateRefs: List<StateRef>
-    val referenceInputStateRefs: List<StateRef>
+    val referenceStateRefs: List<StateRef>
     val outputStates: List<ContractStateAndEncumbranceTag>
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
@@ -4,7 +4,17 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 
+/**
+ * Factory to create a [UtxoLedgerTransaction]s.
+ * This is required to resolve input and reference stateRefs to actual
+ * transaction states.
+ */
 interface UtxoLedgerTransactionFactory {
+    
+    /**
+     * Resolves the input and reference stateRefs to TransactionState objects
+     * and returns a fully resolved UtxoLedgerTransation
+     */
     @Suspendable
     fun create(
         wireTransaction: WireTransaction

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
@@ -1,0 +1,12 @@
+package net.corda.ledger.utxo.flow.impl.transaction.factory
+
+import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+
+interface UtxoLedgerTransactionFactory {
+    @Suspendable
+    fun create(
+        wireTransaction: WireTransaction
+    ): UtxoLedgerTransaction
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactory.kt
@@ -1,21 +1,27 @@
 package net.corda.ledger.utxo.flow.impl.transaction.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import java.security.PublicKey
 
+// TODO to avoid circular dependency between persistenceservice-signedTransactionFactory, we pass the persistence
+// service directly to the create()s instead of proper OSGi injection.
+
 interface UtxoSignedTransactionFactory {
     @Suspendable
     fun create(
         utxoTransactionBuilder: UtxoTransactionBuilderInternal,
-        signatories: Iterable<PublicKey>
+        signatories: Iterable<PublicKey>,
+        utxoLedgerPersistenceService: UtxoLedgerPersistenceService
     ): UtxoSignedTransaction
 
     fun create(
         wireTransaction: WireTransaction,
-        signaturesWithMetaData: List<DigitalSignatureAndMetadata>
+        signaturesWithMetaData: List<DigitalSignatureAndMetadata>,
+        utxoLedgerPersistenceService: UtxoLedgerPersistenceService
     ): UtxoSignedTransaction
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -1,0 +1,60 @@
+package net.corda.ledger.utxo.flow.impl.transaction.factory.impl
+
+import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
+import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
+import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
+import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+import net.corda.v5.serialization.SingletonSerializeAsToken
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope
+
+@Component(
+    service = [UtxoLedgerTransactionFactory::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE
+)
+class UtxoLedgerTransactionFactoryImpl @Activate constructor(
+    @Reference(service = SerializationService::class)
+    private val serializationService: SerializationService,
+    @Reference(service = UtxoLedgerPersistenceService::class)
+    private val utxoLedgerPersistenceService: UtxoLedgerPersistenceService
+) : UtxoLedgerTransactionFactory, UsedByFlow, SingletonSerializeAsToken {
+
+    @Suspendable
+    override fun create(
+        wireTransaction: WireTransaction
+    ): UtxoLedgerTransaction {
+        val wrappedUtxoWireTransaction = WrappedUtxoWireTransaction(wireTransaction, serializationService)
+        val sourceTransactions =
+            (wrappedUtxoWireTransaction.inputStateRefs + wrappedUtxoWireTransaction.referenceStateRefs)
+                .map { it.transactionHash }
+                .toSet()
+                .associateWith { it ->
+                    utxoLedgerPersistenceService.find(it)?.outputStateAndRefs
+                        ?: throw (CordaRuntimeException("Could not find transaction $it when fetching input states."))
+                }
+        val inputStateAndRefs =
+            wrappedUtxoWireTransaction.inputStateRefs.map { it ->
+                sourceTransactions[it.transactionHash]?.get(it.index)
+                    ?: throw (CordaRuntimeException("Input state not found ${it.transactionHash} ${it.index}"))
+            }
+
+        val referenceStateAndRefs =
+            wrappedUtxoWireTransaction.referenceStateRefs.map { it ->
+                sourceTransactions[it.transactionHash]?.get(it.index)
+                    ?: throw (CordaRuntimeException("Reference state not found ${it.transactionHash} ${it.index}"))
+            }
+
+        return UtxoLedgerTransactionImpl(
+            wrappedUtxoWireTransaction,
+            inputStateAndRefs,
+            referenceStateAndRefs
+        )
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -42,13 +42,13 @@ class UtxoLedgerTransactionFactoryImpl @Activate constructor(
         val inputStateAndRefs =
             wrappedUtxoWireTransaction.inputStateRefs.map { it ->
                 sourceTransactions[it.transactionHash]?.get(it.index)
-                    ?: throw (CordaRuntimeException("Input state not found ${it.transactionHash} ${it.index}"))
+                    ?: throw (CordaRuntimeException("Input state not found $it"))
             }
 
         val referenceStateAndRefs =
             wrappedUtxoWireTransaction.referenceStateRefs.map { it ->
                 sourceTransactions[it.transactionHash]?.get(it.index)
-                    ?: throw (CordaRuntimeException("Reference state not found ${it.transactionHash} ${it.index}"))
+                    ?: throw (CordaRuntimeException("Reference state not found $it"))
             }
 
         return UtxoLedgerTransactionImpl(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImpl.kt
@@ -21,7 +21,7 @@ data class UtxoFilteredTransactionBuilderImpl(
     override val timeWindow: Boolean = false,
     override val signatories: ComponentGroupFilterParameters? = null,
     override val inputStates: ComponentGroupFilterParameters? = null,
-    override val referenceInputStates: ComponentGroupFilterParameters? = null,
+    override val referenceStates: ComponentGroupFilterParameters? = null,
     override val outputStates: ComponentGroupFilterParameters? = null,
     override val commands: ComponentGroupFilterParameters? = null
 ) : UtxoFilteredTransactionBuilder, UtxoFilteredTransactionBuilderInternal {
@@ -79,19 +79,19 @@ data class UtxoFilteredTransactionBuilderImpl(
     }
 
     @Suspendable
-    override fun withReferenceInputStatesSize(): UtxoFilteredTransactionBuilderInternal {
-        return copy(referenceInputStates = ComponentGroupFilterParameters.SizeProof(UtxoComponentGroup.REFERENCES.ordinal))
+    override fun withReferenceStatesSize(): UtxoFilteredTransactionBuilderInternal {
+        return copy(referenceStates = ComponentGroupFilterParameters.SizeProof(UtxoComponentGroup.REFERENCES.ordinal))
     }
 
     @Suspendable
-    override fun withReferenceInputStates(): UtxoFilteredTransactionBuilderInternal {
-        return withReferenceInputStates { true }
+    override fun withReferenceStates(): UtxoFilteredTransactionBuilderInternal {
+        return withReferenceStates { true }
     }
 
     @Suspendable
-    override fun withReferenceInputStates(predicate: Predicate<StateRef>): UtxoFilteredTransactionBuilderInternal {
+    override fun withReferenceStates(predicate: Predicate<StateRef>): UtxoFilteredTransactionBuilderInternal {
         return copy(
-            referenceInputStates = ComponentGroupFilterParameters.AuditProof(
+            referenceStates = ComponentGroupFilterParameters.AuditProof(
                 UtxoComponentGroup.REFERENCES.ordinal,
                 StateRef::class.java,
                 predicate

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderInternal.kt
@@ -16,7 +16,7 @@ interface UtxoFilteredTransactionBuilderInternal : UtxoFilteredTransactionBuilde
 
     val inputStates: ComponentGroupFilterParameters?
 
-    val referenceInputStates: ComponentGroupFilterParameters?
+    val referenceStates: ComponentGroupFilterParameters?
 
     val outputStates: ComponentGroupFilterParameters?
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImpl.kt
@@ -80,7 +80,7 @@ class UtxoFilteredTransactionImpl(
             }
         }
 
-    override val referenceInputStateRefs: UtxoFilteredData<StateRef>
+    override val referenceStateRefs: UtxoFilteredData<StateRef>
         get() = getFilteredData(UtxoComponentGroup.REFERENCES.ordinal)
 
     override val signatories: UtxoFilteredData<PublicKey>

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImpl.kt
@@ -68,11 +68,14 @@ class UtxoFilteredTransactionImpl(
                             )
                             FilteredDataAuditImpl(filteredOutputStates.size, values)
                         }
-
-                        else -> throw FilteredDataInconsistencyException("Output infos have been removed. Cannot reconstruct outputs")
+                        else -> {
+                            if (filteredOutputStates.size == 0)
+                                FilteredDataSizeImpl(0)
+                            else
+                                throw FilteredDataInconsistencyException("Output infos have been removed. Cannot reconstruct outputs")
+                        }
                     }
                 }
-
                 else -> throw FilteredDataInconsistencyException("Unknown filtered data type.")
             }
         }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImpl.kt
@@ -53,7 +53,7 @@ class UtxoFilteredTransactionFactoryImpl @Activate constructor(
                     notaryAndTimeWindow,
                     filteredTransactionBuilder.signatories,
                     filteredTransactionBuilder.inputStates,
-                    filteredTransactionBuilder.referenceInputStates,
+                    filteredTransactionBuilder.referenceStates,
                     (filteredTransactionBuilder.outputStates as? ComponentGroupFilterParameters.AuditProof<*>)?.let { _ ->
                         ComponentGroupFilterParameters.AuditProof(
                             UtxoComponentGroup.OUTPUTS_INFO.ordinal,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByVerification
@@ -27,7 +28,9 @@ class UtxoSignedTransactionSerializer @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService,
     @Reference(service = TransactionSignatureService::class)
-    private val transactionSignatureService: TransactionSignatureService
+    private val transactionSignatureService: TransactionSignatureService,
+    @Reference(service = UtxoLedgerTransactionFactory::class)
+    private val utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory
 ) : BaseProxySerializer<UtxoSignedTransactionInternal, UtxoSignedTransactionProxy>(),
     UsedByFlow, UsedByVerification {
 
@@ -50,6 +53,7 @@ class UtxoSignedTransactionSerializer @Activate constructor(
             return UtxoSignedTransactionImpl(
                 serializationService,
                 transactionSignatureService,
+                utxoLedgerTransactionFactory,
                 proxy.wireTransaction,
                 proxy.signatures
             )

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.serialization.checkpoint.CheckpointInput
@@ -26,7 +27,9 @@ class UtxoSignedTransactionKryoSerializer @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serialisationService: SerializationService,
     @Reference(service = TransactionSignatureService::class)
-    private val transactionSignatureService: TransactionSignatureService
+    private val transactionSignatureService: TransactionSignatureService,
+    @Reference(service = UtxoLedgerTransactionFactory::class)
+    private val utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory
 ) : CheckpointInternalCustomSerializer<UtxoSignedTransactionInternal>, UsedByFlow {
     override val type: Class<UtxoSignedTransactionInternal> get() = UtxoSignedTransactionInternal::class.java
 
@@ -41,6 +44,7 @@ class UtxoSignedTransactionKryoSerializer @Activate constructor(
         return UtxoSignedTransactionImpl(
             serialisationService,
             transactionSignatureService,
+            utxoLedgerTransactionFactory,
             wireTransaction,
             signatures
         )

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/WrappedUtxoWireTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/WrappedUtxoWireTransactionKryoSerializer.kt
@@ -1,0 +1,38 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.kryo
+
+import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.serialization.checkpoint.CheckpointInput
+import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
+import net.corda.serialization.checkpoint.CheckpointOutput
+import net.corda.v5.application.serialization.SerializationService
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+
+@Component(
+    service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
+class WrappedUtxoWireTransactionKryoSerializer @Activate constructor(
+    @Reference(service = SerializationService::class)
+    private val serialisationService: SerializationService
+) : CheckpointInternalCustomSerializer<WrappedUtxoWireTransaction>, UsedByFlow {
+    override val type: Class<WrappedUtxoWireTransaction> get() = WrappedUtxoWireTransaction::class.java
+
+    override fun write(output: CheckpointOutput, obj: WrappedUtxoWireTransaction) {
+        output.writeClassAndObject(obj.wireTransaction)
+    }
+
+    override fun read(input: CheckpointInput, type: Class<WrappedUtxoWireTransaction>): WrappedUtxoWireTransaction {
+        val wireTransaction = input.readClassAndObject() as WireTransaction
+        return WrappedUtxoWireTransaction(
+            wireTransaction,
+            serialisationService,
+        )
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerifier.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerifier.kt
@@ -56,14 +56,14 @@ class UtxoLedgerTransactionVerifier(private val transaction: UtxoLedgerTransacti
 
 
     private fun verifyInputNotaries(notary: Party) {
-        val allInputs = transaction.inputTransactionStates + transaction.referenceInputTransactionStates
+        val allInputs = transaction.inputTransactionStates + transaction.referenceTransactionStates
         if(allInputs.isEmpty())
             return
         check(allInputs.map { it.notary }.distinct().size == 1) {
-            "Input and Reference input states' notaries need to be the same. ${allInputs.map { it.notary }.distinct().size}"
+            "Input and reference states' notaries need to be the same. ${allInputs.map { it.notary }.distinct().size}"
         }
         check(allInputs.first().notary == notary) {
-            "Input and Reference input states' notaries need to be the same as the $subjectClass's notary."
+            "Input and reference states' notaries need to be the same as the $subjectClass's notary."
         }
         // TODO CORE-8958 check rotated notaries
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/impl/token/selection/impl/TokenSelectionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/impl/token/selection/impl/TokenSelectionImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.impl.token.selection.impl
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.ledger.utxo.impl.token.selection.factories.TokenClaimQueryExternalEventFactory
+import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.token.selection.TokenClaim
 import net.corda.v5.ledger.utxo.token.selection.TokenClaimCriteria
@@ -12,11 +13,11 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope
 
-@Component(service = [TokenSelection::class, SingletonSerializeAsToken::class], scope = ServiceScope.PROTOTYPE)
+@Component(service = [TokenSelection::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
 class TokenSelectionImpl @Activate constructor(
     @Reference(service = ExternalEventExecutor::class)
     private val externalEventExecutor: ExternalEventExecutor
-) : TokenSelection, SingletonSerializeAsToken {
+) : TokenSelection, UsedByFlow, SingletonSerializeAsToken {
 
     @Suspendable
     override fun tryClaim(criteria: TokenClaimCriteria): TokenClaim? {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainReceiverFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainReceiverFlowTest.kt
@@ -7,11 +7,9 @@ import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.StateRef
-import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -44,17 +42,6 @@ class TransactionBackchainReceiverFlowTest {
     private val retrievedTransaction2 = mock<UtxoSignedTransaction>()
     private val retrievedTransaction3 = mock<UtxoSignedTransaction>()
 
-    private val ledgerTransaction1 = mock<UtxoLedgerTransaction>()
-    private val ledgerTransaction2 = mock<UtxoLedgerTransaction>()
-    private val ledgerTransaction3 = mock<UtxoLedgerTransaction>()
-
-    @BeforeEach
-    fun beforeEach() {
-        whenever(retrievedTransaction1.toLedgerTransaction()).thenReturn(ledgerTransaction1)
-        whenever(retrievedTransaction2.toLedgerTransaction()).thenReturn(ledgerTransaction2)
-        whenever(retrievedTransaction3.toLedgerTransaction()).thenReturn(ledgerTransaction3)
-    }
-
     @Test
     fun `a resolved transaction has its dependencies retrieved from its peer and persisted`() {
         whenever(utxoLedgerPersistenceService.find(any(), any())).thenReturn(null)
@@ -69,16 +56,16 @@ class TransactionBackchainReceiverFlowTest {
             .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
-        whenever(ledgerTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
-        whenever(ledgerTransaction1.referenceInputStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.referenceStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
 
         whenever(retrievedTransaction2.id).thenReturn(TX_ID_2)
-        whenever(ledgerTransaction2.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_2))
-        whenever(ledgerTransaction2.referenceInputStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2))
+        whenever(retrievedTransaction2.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_2))
+        whenever(retrievedTransaction2.referenceStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2))
 
         whenever(retrievedTransaction3.id).thenReturn(TX_ID_3)
-        whenever(ledgerTransaction3.inputStateRefs).thenReturn(emptyList())
-        whenever(ledgerTransaction3.referenceInputStateRefs).thenReturn(emptyList())
+        whenever(retrievedTransaction3.inputStateRefs).thenReturn(emptyList())
+        whenever(retrievedTransaction3.referenceStateRefs).thenReturn(emptyList())
 
         assertThat(callTransactionBackchainReceiverFlow(setOf(TX_ID_1, TX_ID_2)).complete()).isEqualTo(listOf(TX_ID_3, TX_ID_2, TX_ID_1))
 
@@ -113,16 +100,16 @@ class TransactionBackchainReceiverFlowTest {
             .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
-        whenever(ledgerTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
-        whenever(ledgerTransaction1.referenceInputStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.referenceStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
 
         whenever(retrievedTransaction2.id).thenReturn(TX_ID_2)
-        whenever(ledgerTransaction2.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_2))
-        whenever(ledgerTransaction2.referenceInputStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2))
+        whenever(retrievedTransaction2.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_2))
+        whenever(retrievedTransaction2.referenceStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2))
 
         whenever(retrievedTransaction3.id).thenReturn(TX_ID_3)
-        whenever(ledgerTransaction3.inputStateRefs).thenReturn(emptyList())
-        whenever(ledgerTransaction3.referenceInputStateRefs).thenReturn(emptyList())
+        whenever(retrievedTransaction3.inputStateRefs).thenReturn(emptyList())
+        whenever(retrievedTransaction3.referenceStateRefs).thenReturn(emptyList())
 
         assertThat(callTransactionBackchainReceiverFlow(setOf(TX_ID_1, TX_ID_2)).complete()).isEqualTo(listOf(TX_ID_3, TX_ID_2, TX_ID_1))
 
@@ -150,12 +137,12 @@ class TransactionBackchainReceiverFlowTest {
             .thenReturn(TransactionExistenceStatus.VERIFIED to listOf(PACKAGE_SUMMARY))
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
-        whenever(ledgerTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
-        whenever(ledgerTransaction1.referenceInputStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.referenceStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
 
         whenever(retrievedTransaction2.id).thenReturn(TX_ID_2)
-        whenever(ledgerTransaction2.inputStateRefs).thenReturn(emptyList())
-        whenever(ledgerTransaction2.referenceInputStateRefs).thenReturn(emptyList())
+        whenever(retrievedTransaction2.inputStateRefs).thenReturn(emptyList())
+        whenever(retrievedTransaction2.referenceStateRefs).thenReturn(emptyList())
 
         assertThat(callTransactionBackchainReceiverFlow(setOf(TX_ID_1, TX_ID_2)).complete()).isEqualTo(listOf(TX_ID_2))
 
@@ -180,8 +167,8 @@ class TransactionBackchainReceiverFlowTest {
             .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
-        whenever(ledgerTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
-        whenever(ledgerTransaction1.referenceInputStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.referenceStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
 
         whenever(retrievedTransaction2.id).thenReturn(TX_ID_2)
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowTest.kt
@@ -7,7 +7,6 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.StateRef
-import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -40,19 +39,17 @@ class TransactionBackchainResolutionFlowTest {
 
     private val session = mock<FlowSession>()
     private val transaction = mock<UtxoSignedTransaction>()
-    private val ledgerTransaction = mock<UtxoLedgerTransaction>()
 
     @BeforeEach
     fun beforeEach() {
         whenever(transaction.id).thenReturn(TX_ID_1)
-        whenever(transaction.toLedgerTransaction()).thenReturn(ledgerTransaction)
         whenever(transactionBackchainVerifier.verify(any(), any())).thenReturn(true)
     }
 
     @Test
     fun `does nothing when the transaction has no dependencies`() {
-        whenever(ledgerTransaction.inputStateRefs).thenReturn(emptyList())
-        whenever(ledgerTransaction.referenceInputStateRefs).thenReturn(emptyList())
+        whenever(transaction.inputStateRefs).thenReturn(emptyList())
+        whenever(transaction.referenceStateRefs).thenReturn(emptyList())
 
         callTransactionBackchainResolutionFlow()
 
@@ -63,14 +60,14 @@ class TransactionBackchainResolutionFlowTest {
 
     @Test
     fun `does nothing when the transactions dependencies are already verified`() {
-        whenever(ledgerTransaction.inputStateRefs).thenReturn(
+        whenever(transaction.inputStateRefs).thenReturn(
             listOf(
                 TX_2_INPUT_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_DEPENDENCY_STATE_REF_2
             )
         )
-        whenever(ledgerTransaction.referenceInputStateRefs).thenReturn(
+        whenever(transaction.referenceStateRefs).thenReturn(
             listOf(
                 TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2
@@ -87,14 +84,14 @@ class TransactionBackchainResolutionFlowTest {
 
     @Test
     fun `retrieves and verifies transactions dependencies that are not verified`() {
-        whenever(ledgerTransaction.inputStateRefs).thenReturn(
+        whenever(transaction.inputStateRefs).thenReturn(
             listOf(
                 TX_2_INPUT_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_DEPENDENCY_STATE_REF_2
             )
         )
-        whenever(ledgerTransaction.referenceInputStateRefs).thenReturn(
+        whenever(transaction.referenceStateRefs).thenReturn(
             listOf(
                 TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2
@@ -116,14 +113,14 @@ class TransactionBackchainResolutionFlowTest {
 
     @Test
     fun `throws exception when verification fails`() {
-        whenever(ledgerTransaction.inputStateRefs).thenReturn(
+        whenever(transaction.inputStateRefs).thenReturn(
             listOf(
                 TX_2_INPUT_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_DEPENDENCY_STATE_REF_2
             )
         )
-        whenever(ledgerTransaction.referenceInputStateRefs).thenReturn(
+        whenever(transaction.referenceStateRefs).thenReturn(
             listOf(
                 TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1,
                 TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowTest.kt
@@ -64,11 +64,11 @@ class TransactionBackchainSenderFlowTest {
             .thenReturn(TransactionBackchainRequest.Get(setOf(TX_ID_1, TX_ID_2, TX_ID_3)), TransactionBackchainRequest.Stop)
 
         whenever(ledgerTransaction1.inputStateRefs).thenReturn(emptyList())
-        whenever(ledgerTransaction1.referenceInputStateRefs).thenReturn(emptyList())
+        whenever(ledgerTransaction1.referenceStateRefs).thenReturn(emptyList())
         whenever(ledgerTransaction2.inputStateRefs).thenReturn(emptyList())
-        whenever(ledgerTransaction2.referenceInputStateRefs).thenReturn(emptyList())
+        whenever(ledgerTransaction2.referenceStateRefs).thenReturn(emptyList())
         whenever(ledgerTransaction3.inputStateRefs).thenReturn(emptyList())
-        whenever(ledgerTransaction3.referenceInputStateRefs).thenReturn(emptyList())
+        whenever(ledgerTransaction3.referenceStateRefs).thenReturn(emptyList())
 
         flow.call()
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -13,6 +13,7 @@ import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransa
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionIfDoesNotExistExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
@@ -141,6 +142,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         val expectedObj = UtxoSignedTransactionImpl(
             serializationService,
             transactionSignatureService,
+            mock<UtxoLedgerTransactionFactory>(),
             wireTransaction,
             signatures
         )
@@ -149,7 +151,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         whenever(serializationService.deserialize<SignedTransactionContainer>(any<ByteArray>(), any()))
             .thenReturn(SignedTransactionContainer(wireTransaction, signatures))
 
-        whenever(utxoSignedTransactionFactory.create(any<WireTransaction>(), any())).thenReturn(expectedObj)
+        whenever(utxoSignedTransactionFactory.create(any<WireTransaction>(), any(), any())).thenReturn(expectedObj)
 
         assertThat(utxoLedgerPersistenceService.find(testId)).isEqualTo(expectedObj)
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -10,29 +10,48 @@ import net.corda.ledger.utxo.testkit.utxoNotaryExample
 import net.corda.ledger.utxo.testkit.utxoStateExample
 import net.corda.ledger.utxo.testkit.utxoTimeWindowExample
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import kotlin.test.assertIs
 
 @Suppress("DEPRECATION")
 internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
     @Test
     fun `can build a simple Transaction`() {
+
+        val inputStateAndRef = getUtxoInvalidStateAndRef()
+        val inputStateRef = inputStateAndRef.ref
+        val referenceStateAndRef = getUtxoInvalidStateAndRef()
+        val referenceStateRef = referenceStateAndRef.ref
+
+        val mockSignedTxForInput = mock<UtxoSignedTransaction>()
+        val mockSignedTxForRef = mock<UtxoSignedTransaction>()
+
+        whenever(mockSignedTxForInput.outputStateAndRefs).thenReturn(listOf(inputStateAndRef))
+        whenever(mockSignedTxForRef.outputStateAndRefs).thenReturn(listOf(referenceStateAndRef))
+        whenever(mockUtxoLedgerPersistenceService.find(any(), any()))
+            .thenReturn(mockSignedTxForInput)
+            .thenReturn(mockSignedTxForRef)
+
         val tx = utxoTransactionBuilder
             .setNotary(utxoNotaryExample)
             .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
             .addOutputState(utxoStateExample)
-            .addInputState(getUtxoInvalidStateAndRef().ref)
-            .addReferenceInputState(getUtxoInvalidStateAndRef().ref)
+            .addInputState(inputStateRef)
+            .addReferenceState(referenceStateRef)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
             .toSignedTransaction(publicKeyExample)
         assertIs<SecureHash>(tx.id)
-        assertEquals(getUtxoInvalidStateAndRef().ref, tx.inputStateRefs.single())
-        assertEquals(getUtxoInvalidStateAndRef().ref, tx.referenceStateRefs.single())
+        assertEquals(inputStateRef, tx.inputStateRefs.single())
+        assertEquals(referenceStateRef, tx.referenceStateRefs.single())
         assertEquals(utxoStateExample, tx.outputStateAndRefs.single().state.contractState)
         assertEquals(utxoNotaryExample, tx.notary)
         assertEquals(utxoTimeWindowExample, tx.timeWindow)
@@ -65,8 +84,6 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .setNotary(utxoNotaryExample)
             .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
             .addOutputState(utxoStateExample)
-            .addInputState(getUtxoInvalidStateAndRef().ref)
-            .addReferenceInputState(getUtxoInvalidStateAndRef().ref)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
@@ -107,8 +124,6 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
                 .setNotary(utxoNotaryExample)
                 .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
                 .addOutputState(utxoStateExample)
-                .addInputState(getUtxoInvalidStateAndRef().ref)
-                .addReferenceInputState(getUtxoInvalidStateAndRef().ref)
                 .addSignatories(listOf(publicKeyExample))
                 .addCommand(UtxoCommandExample())
                 .addAttachment(SecureHash("SHA-256", ByteArray(12)))
@@ -120,6 +135,20 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
 
     @Test
     fun `Calculate encumbrance groups correctly`(){
+        val inputStateAndRef = getUtxoInvalidStateAndRef()
+        val inputStateRef = inputStateAndRef.ref
+        val referenceStateAndRef = getUtxoInvalidStateAndRef()
+        val referenceStateRef = referenceStateAndRef.ref
+
+        val mockSignedTxForInput = mock<UtxoSignedTransaction>()
+        val mockSignedTxForRef = mock<UtxoSignedTransaction>()
+
+        whenever(mockSignedTxForInput.outputStateAndRefs).thenReturn(listOf(inputStateAndRef))
+        whenever(mockSignedTxForRef.outputStateAndRefs).thenReturn(listOf(referenceStateAndRef))
+        whenever(mockUtxoLedgerPersistenceService.find(any(), any()))
+            .thenReturn(mockSignedTxForInput)
+            .thenReturn(mockSignedTxForRef)
+
         val tx = utxoTransactionBuilder
             .setNotary(utxoNotaryExample)
             .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
@@ -133,8 +162,8 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
                 UtxoStateClassExample("test 5", listOf(publicKeyExample)))
             .addEncumberedOutputStates("encumbrance 1",
                 UtxoStateClassExample("test 6", listOf(publicKeyExample)))
-            .addInputState(getUtxoInvalidStateAndRef().ref)
-            .addReferenceInputState(getUtxoInvalidStateAndRef().ref)
+            .addInputState(inputStateRef)
+            .addReferenceState(referenceStateRef)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImplTest.kt
@@ -76,15 +76,15 @@ class UtxoFilteredTransactionBuilderImplTest {
     }
 
     @Test
-    fun withReferenceInputStatesSize() {
-        val componentGroupFilterParameters = utxoFilteredTransactionBuilder.withReferenceInputStatesSize().referenceInputStates
+    fun withReferenceStatesSize() {
+        val componentGroupFilterParameters = utxoFilteredTransactionBuilder.withReferenceStatesSize().referenceStates
         assertThat(componentGroupFilterParameters).isInstanceOf(ComponentGroupFilterParameters.SizeProof::class.java)
         assertThat((componentGroupFilterParameters!!).componentGroupIndex).isEqualTo(UtxoComponentGroup.REFERENCES.ordinal)
     }
 
     @Test
-    fun withReferenceInputStates() {
-        val componentGroupFilterParameters = utxoFilteredTransactionBuilder.withReferenceInputStates().referenceInputStates
+    fun withReferenceStates() {
+        val componentGroupFilterParameters = utxoFilteredTransactionBuilder.withReferenceStates().referenceStates
         assertThat(componentGroupFilterParameters).isInstanceOf(ComponentGroupFilterParameters.AuditProof::class.java)
         assertThat((componentGroupFilterParameters!!).componentGroupIndex).isEqualTo(UtxoComponentGroup.REFERENCES.ordinal)
         assertThat((componentGroupFilterParameters as ComponentGroupFilterParameters.AuditProof<StateRef>).predicate.test(mock()))
@@ -92,8 +92,8 @@ class UtxoFilteredTransactionBuilderImplTest {
     }
 
     @Test
-    fun `withReferenceInputStates predicate`() {
-        val componentGroupFilterParameters = utxoFilteredTransactionBuilder.withReferenceInputStates { false }.referenceInputStates
+    fun `withReferenceStates predicate`() {
+        val componentGroupFilterParameters = utxoFilteredTransactionBuilder.withReferenceStates { false }.referenceStates
         assertThat(componentGroupFilterParameters).isInstanceOf(ComponentGroupFilterParameters.AuditProof::class.java)
         assertThat((componentGroupFilterParameters!!).componentGroupIndex).isEqualTo(UtxoComponentGroup.REFERENCES.ordinal)
         assertThat((componentGroupFilterParameters as ComponentGroupFilterParameters.AuditProof<StateRef>).predicate.test(mock()))
@@ -156,7 +156,7 @@ class UtxoFilteredTransactionBuilderImplTest {
         assertThat(utxoFilteredTransactionBuilder.timeWindow).isFalse
         assertThat(utxoFilteredTransactionBuilder.signatories).isNull()
         assertThat(utxoFilteredTransactionBuilder.inputStates).isNull()
-        assertThat(utxoFilteredTransactionBuilder.referenceInputStates).isNull()
+        assertThat(utxoFilteredTransactionBuilder.referenceStates).isNull()
         assertThat(utxoFilteredTransactionBuilder.outputStates).isNull()
         assertThat(utxoFilteredTransactionBuilder.commands).isNull()
     }
@@ -168,14 +168,14 @@ class UtxoFilteredTransactionBuilderImplTest {
             .withTimeWindow()
             .withSignatoriesSize()
             .withInputStates()
-            .withReferenceInputStatesSize()
+            .withReferenceStatesSize()
             .withOutputStatesSize()
             .withCommands() as UtxoFilteredTransactionBuilderInternal
         assertThat(builder.notary).isTrue
         assertThat(builder.timeWindow).isTrue
         assertThat(builder.signatories).isInstanceOf(ComponentGroupFilterParameters.SizeProof::class.java)
         assertThat(builder.inputStates).isInstanceOf(ComponentGroupFilterParameters.AuditProof::class.java)
-        assertThat(builder.referenceInputStates).isInstanceOf(ComponentGroupFilterParameters.SizeProof::class.java)
+        assertThat(builder.referenceStates).isInstanceOf(ComponentGroupFilterParameters.SizeProof::class.java)
         assertThat(builder.outputStates).isInstanceOf(ComponentGroupFilterParameters.SizeProof::class.java)
         assertThat(builder.commands).isInstanceOf(ComponentGroupFilterParameters.AuditProof::class.java)
     }
@@ -184,13 +184,13 @@ class UtxoFilteredTransactionBuilderImplTest {
     fun `miss some`() {
         val builder = utxoFilteredTransactionBuilder
             .withInputStates()
-            .withReferenceInputStatesSize()
+            .withReferenceStatesSize()
             .withCommands() as UtxoFilteredTransactionBuilderInternal
         assertThat(builder.notary).isFalse
         assertThat(builder.timeWindow).isFalse
         assertThat(builder.signatories).isNull()
         assertThat(builder.inputStates).isInstanceOf(ComponentGroupFilterParameters.AuditProof::class.java)
-        assertThat(builder.referenceInputStates).isInstanceOf(ComponentGroupFilterParameters.SizeProof::class.java)
+        assertThat(builder.referenceStates).isInstanceOf(ComponentGroupFilterParameters.SizeProof::class.java)
         assertThat(builder.outputStates).isNull()
         assertThat(builder.commands).isInstanceOf(ComponentGroupFilterParameters.AuditProof::class.java)
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImplTest.kt
@@ -204,7 +204,7 @@ class UtxoFilteredTransactionImplTest : UtxoFilteredTransactionTestBase() {
         val utxoFilteredTransaction: UtxoFilteredTransaction =
             UtxoFilteredTransactionImpl(serializationService, filteredTransaction)
 
-        assertThat(utxoFilteredTransaction.referenceInputStateRefs)
+        assertThat(utxoFilteredTransaction.referenceStateRefs)
             .isInstanceOf(UtxoFilteredData.Removed::class.java)
 
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializerTest.kt
@@ -11,9 +11,13 @@ import net.corda.ledger.utxo.testkit.utxoStateExample
 import net.corda.ledger.utxo.testkit.utxoTimeWindowExample
 import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 
 class UtxoSignedTransactionSerializerTest : UtxoLedgerTest() {
@@ -36,6 +40,20 @@ class UtxoSignedTransactionSerializerTest : UtxoLedgerTest() {
     @Suppress("DEPRECATION")
     @Test
     fun `serialize and deserialize with encumbrance`() {
+        val inputStateAndRef = getUtxoInvalidStateAndRef()
+        val inputStateRef = inputStateAndRef.ref
+        val referenceStateAndRef = getUtxoInvalidStateAndRef()
+        val referenceStateRef = referenceStateAndRef.ref
+
+        val mockSignedTxForInput = mock<UtxoSignedTransaction>()
+        val mockSignedTxForRef = mock<UtxoSignedTransaction>()
+
+        whenever(mockSignedTxForInput.outputStateAndRefs).thenReturn(listOf(inputStateAndRef))
+        whenever(mockSignedTxForRef.outputStateAndRefs).thenReturn(listOf(referenceStateAndRef))
+        whenever(mockUtxoLedgerPersistenceService.find(any(), any()))
+            .thenReturn(mockSignedTxForInput)
+            .thenReturn(mockSignedTxForRef)
+
         val signedTx = utxoTransactionBuilder
             .setNotary(utxoNotaryExample)
             .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
@@ -45,8 +63,8 @@ class UtxoSignedTransactionSerializerTest : UtxoLedgerTest() {
                 UtxoStateClassExample("test 2", listOf(publicKeyExample))
             )
             .addOutputState(utxoStateExample)
-            .addInputState(getUtxoInvalidStateAndRef().ref)
-            .addReferenceInputState(getUtxoInvalidStateAndRef().ref)
+            .addInputState(inputStateRef)
+            .addReferenceState(referenceStateRef)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EntityConverterImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EntityConverterImpl.kt
@@ -46,6 +46,7 @@ class EntityConverterImpl : EntityConverter {
     override fun toClaimRelease(avroPoolKey: TokenPoolCacheKey, tokenClaimRelease: TokenClaimRelease): ClaimRelease {
         return ClaimRelease(
             tokenClaimRelease.claimId,
+            tokenClaimRelease.requestContext.requestId,
             tokenClaimRelease.requestContext.flowId,
             tokenClaimRelease.usedTokenStateRefs.toSet(),
             avroPoolKey

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimRelease.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimRelease.kt
@@ -4,6 +4,7 @@ import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 
 data class ClaimRelease(
     val claimId: String,
+    val externalEventRequestId: String,
     val flowId: String,
     val usedTokens: Set<String>,
     override val poolKey: TokenPoolCacheKey

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactory.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactory.kt
@@ -45,14 +45,14 @@ interface RecordFactory {
     /**
      * Creates a [Record] to acknowledge the release of a claim
      *
-     * @param flowId The unique identifier of the flow that requested the claim
-     * @param claimId The unique ID of the claim that was released
+     * @param flowId The unique identifier of the flow that requested the claim release
+     * @param externalEventRequestId The unique ID of the flow request event of the claim release
 
      * @return A [FlowEvent] response record for the release acknowledgement
      */
     fun getClaimReleaseAck(
         flowId: String,
-        claimId: String
+        externalEventRequestId: String
     ): Record<String, FlowEvent>
 }
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/RecordFactoryImpl.kt
@@ -34,6 +34,7 @@ class RecordFactoryImpl(private val externalEventResponseFactory: ExternalEventR
     ): Record<String, FlowEvent> {
         val payload = TokenClaimQueryResult().apply {
             this.poolKey = poolKey
+            this.claimId = externalEventRequestId
             this.resultType = TokenClaimResultStatus.NONE_AVAILABLE
             this.claimedTokens = listOf()
         }
@@ -43,8 +44,8 @@ class RecordFactoryImpl(private val externalEventResponseFactory: ExternalEventR
 
     override fun getClaimReleaseAck(
         flowId: String,
-        claimId: String
+        externalEventRequestId: String
     ): Record<String, FlowEvent> {
-        return externalEventResponseFactory.success(claimId, flowId, TokenClaimReleaseAck())
+        return externalEventResponseFactory.success(externalEventRequestId, flowId, TokenClaimReleaseAck())
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheComponentFactory.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheComponentFactory.kt
@@ -43,7 +43,7 @@ class TokenCacheComponentFactory @Activate constructor(
         val eventHandlerMap = mapOf<Class<*>, TokenEventHandler<in TokenEvent>>(
             createHandler(TokenClaimQueryEventHandler(tokenFilterStrategy, recordFactory)),
             createHandler(TokenClaimReleaseEventHandler(recordFactory)),
-            createHandler(TokenLedgerChangeEventHandler(externalEventResponseFactory)),
+            createHandler(TokenLedgerChangeEventHandler()),
         )
 
         val tokenCacheEventHandlerFactory = TokenCacheEventProcessorFactoryImpl(

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenClaimReleaseEventHandler.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenClaimReleaseEventHandler.kt
@@ -26,11 +26,11 @@ class TokenClaimReleaseEventHandler(
 
         if (!state.claimExists(event.claimId)) {
             log.warn("Couldn't find existing claim for claimId='${event.claimId}'")
-        }else {
+        } else {
             tokenCache.removeAll(event.usedTokens)
             state.removeClaim(event.claimId)
         }
 
-        return recordFactory.getClaimReleaseAck(event.flowId, event.claimId)
+        return recordFactory.getClaimReleaseAck(event.flowId, event.externalEventRequestId)
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenLedgerChangeEventHandler.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenLedgerChangeEventHandler.kt
@@ -1,15 +1,12 @@
 package net.corda.ledger.utxo.token.cache.handlers
 
 import net.corda.data.flow.event.FlowEvent
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
-import net.corda.messaging.api.records.Record
 import net.corda.ledger.utxo.token.cache.entities.LedgerChange
 import net.corda.ledger.utxo.token.cache.entities.PoolCacheState
 import net.corda.ledger.utxo.token.cache.entities.TokenCache
+import net.corda.messaging.api.records.Record
 
-class TokenLedgerChangeEventHandler(
-    private val externalEventResponseFactory: ExternalEventResponseFactory,
-) : TokenEventHandler<LedgerChange> {
+class TokenLedgerChangeEventHandler : TokenEventHandler<LedgerChange> {
 
     override fun handle(
         tokenCache: TokenCache,
@@ -22,8 +19,6 @@ class TokenLedgerChangeEventHandler(
 
         tokenCache.removeAll(consumedStateRefs)
         state.tokensRemovedFromCache(consumedStateRefs)
-
-        // HACK: Added for testing will be removed by CORE-5722 (ledger integration)
-        return event.flowId?.let { externalEventResponseFactory.success(event.claimId!!, event.flowId, "HACK") }
+        return null
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EntityConverterImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EntityConverterImplTest.kt
@@ -65,6 +65,7 @@ class EntityConverterImplTest {
             .toClaimRelease(POOL_CACHE_KEY, tokenClaimRelease)
 
         assertThat(result.claimId).isEqualTo("c1")
+        assertThat(result.externalEventRequestId).isEqualTo("r1")
         assertThat(result.flowId).isEqualTo("f1")
         assertThat(result.usedTokens).containsOnly("s1", "s2")
         assertThat(result.poolKey).isEqualTo(POOL_CACHE_KEY)

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
@@ -23,7 +23,7 @@ class EventConverterImplTest {
 
     private val entityConverter = mock<EntityConverter>()
     private val claimQuery = ClaimQuery("","", BigDecimal(0), "", "", POOL_CACHE_KEY)
-    private val claimRelease = ClaimRelease("","", setOf(), POOL_CACHE_KEY)
+    private val claimRelease = ClaimRelease("","", "", setOf(), POOL_CACHE_KEY)
     private val ledgerChange = LedgerChange(POOL_CACHE_KEY,"","", listOf(), listOf())
 
     @BeforeEach

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/factories/RecordFactoryImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/factories/RecordFactoryImplTest.kt
@@ -54,6 +54,7 @@ class RecordFactoryImplTest {
     fun `create failure claim response`() {
         val expectedResponse = TokenClaimQueryResult().apply {
             this.poolKey = POOL_CACHE_KEY
+            this.claimId = externalEventRequestId
             this.resultType = TokenClaimResultStatus.NONE_AVAILABLE
             this.claimedTokens = listOf()
         }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenClaimReleaseEventHandlerTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenClaimReleaseEventHandlerTest.kt
@@ -24,12 +24,13 @@ class TokenClaimReleaseEventHandlerTest {
 
     private val tokenRef1 = "r1"
     private val claimId = "r1"
+    private val externalEventRequestId = "ext1"
     private val flowId = "f1"
 
     @Test
     fun `release returns an ack response event`() {
         val response = Record<String, FlowEvent>("", "", null)
-        whenever(recordFactory.getClaimReleaseAck(flowId, claimId)).thenReturn(response)
+        whenever(recordFactory.getClaimReleaseAck(flowId, externalEventRequestId)).thenReturn(response)
 
         val target = TokenClaimReleaseEventHandler(recordFactory)
         val claimRelease = createClaimRelease()
@@ -74,6 +75,6 @@ class TokenClaimReleaseEventHandlerTest {
     }
 
     private fun createClaimRelease(): ClaimRelease {
-        return ClaimRelease(claimId, flowId, setOf(tokenRef1), POOL_CACHE_KEY)
+        return ClaimRelease(claimId, externalEventRequestId,flowId, setOf(tokenRef1), POOL_CACHE_KEY)
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenLedgerChangeEventHandlerTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenLedgerChangeEventHandlerTest.kt
@@ -24,7 +24,7 @@ class TokenLedgerChangeEventHandlerTest {
 
         val ledgerChange = LedgerChange(POOL_CACHE_KEY,"","", listOf(), listOf(token1, token2))
 
-        val target = TokenLedgerChangeEventHandler(mock())
+        val target = TokenLedgerChangeEventHandler()
         val result = target.handle(tokenCache, poolCacheState, ledgerChange)
 
         assertThat(result).isNull()
@@ -39,7 +39,7 @@ class TokenLedgerChangeEventHandlerTest {
 
         val ledgerChange = LedgerChange(POOL_CACHE_KEY,"","", listOf(token1, token2), listOf())
 
-        val target = TokenLedgerChangeEventHandler(mock())
+        val target = TokenLedgerChangeEventHandler()
         val result = target.handle(tokenCache, poolCacheState, ledgerChange)
 
         assertThat(result).isNull()

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
@@ -160,7 +160,7 @@ class BatchedUniquenessCheckerImpl(
         // the tx id)
         var numMalformed = 0
 
-        // TODO CORE-7250 We have no way to pre-check the number of reference input states in the plugin
+        // TODO CORE-7250 We have no way to pre-check the number of reference states in the plugin
         //  server anymore, so we need to make sure that not having the 10k limit for reference states is,
         //  okay, if not, we need to re-add the check in this class.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -99,7 +99,7 @@ mockitoInlineVersion=4.8.0
 mockitoKotlinVersion=4.0.0
 mockitoVersion=4.8.0
 osgiTestJunit5Version=1.2.1
-postgresDriverVersion=42.4.1
+postgresDriverVersion=42.4.3
 slingVersion=3.3.2
 
 # HTTP RPC dependency versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.522-Fox-beta+
+cordaApiVersion=5.0.0.523-Fox-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,8 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-#cordaApiVersion=5.0.0.602-beta+
-cordaApiVersion=5.0.0.602-alpha-1671808301071
+cordaApiVersion=5.0.0.602-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ bouncycastleVersion=1.70
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
 #cordaApiVersion=5.0.0.602-beta+
-cordaApiVersion=5.0.0.602-alpha-1671734636795
+cordaApiVersion=5.0.0.602-alpha-1671808301071
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoLedgerTransactionImpl.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoLedgerTransactionImpl.kt
@@ -1,8 +1,6 @@
 package net.corda.ledger.utxo.data.transaction
 
-import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.utxo.data.state.filterIsContractStateInstance
-import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.Attachment
 import net.corda.v5.ledger.utxo.Command
@@ -14,11 +12,11 @@ import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import java.security.PublicKey
 
 class UtxoLedgerTransactionImpl(
-    wireTransaction: WireTransaction,
-    serializationService: SerializationService
+    private val wrappedWireTransaction: WrappedUtxoWireTransaction,
+    override val inputStateAndRefs: List<StateAndRef<*>>,
+    override val referenceStateAndRefs: List<StateAndRef<*>>
 ) : UtxoLedgerTransaction {
 
-    private val wrappedWireTransaction = WrappedUtxoWireTransaction(wireTransaction, serializationService)
     override val id: SecureHash
         get() = wrappedWireTransaction.id
 
@@ -40,18 +38,8 @@ class UtxoLedgerTransactionImpl(
     override val inputStateRefs: List<StateRef>
         get() = wrappedWireTransaction.inputStateRefs
 
-    override val inputStateAndRefs: List<StateAndRef<*>> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        //TODO("Not yet implemented.")
-        emptyList()
-    }
-
-    override val referenceInputStateRefs: List<StateRef>
-        get() = wrappedWireTransaction.referenceInputStateRefs
-
-    override val referenceInputStateAndRefs: List<StateAndRef<*>> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        //TODO("Not yet implemented.")
-        emptyList()
-    }
+    override val referenceStateRefs: List<StateRef>
+        get() = wrappedWireTransaction.referenceStateRefs
 
     override val outputStateAndRefs: List<StateAndRef<*>>
         get() = wrappedWireTransaction.outputStateAndRefs
@@ -73,12 +61,12 @@ class UtxoLedgerTransactionImpl(
         return inputContractStates.filterIsInstance(type)
     }
 
-    override fun <T : ContractState> getReferenceInputStateAndRefs(type: Class<T>): List<StateAndRef<T>> {
-        return referenceInputStateAndRefs.filterIsContractStateInstance(type)
+    override fun <T : ContractState> getReferenceStateAndRefs(type: Class<T>): List<StateAndRef<T>> {
+        return referenceStateAndRefs.filterIsContractStateInstance(type)
     }
 
-    override fun <T : ContractState> getReferenceInputStates(type: Class<T>): List<T> {
-        return referenceInputContractStates.filterIsInstance(type)
+    override fun <T : ContractState> getReferenceStates(type: Class<T>): List<T> {
+        return referenceContractStates.filterIsInstance(type)
     }
 
     override fun <T : ContractState> getOutputStateAndRefs(type: Class<T>): List<StateAndRef<T>> {

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
@@ -17,7 +17,7 @@ import net.corda.v5.ledger.utxo.TimeWindow
 import java.security.PublicKey
 
 class WrappedUtxoWireTransaction(
-    private val wireTransaction: WireTransaction,
+    val wireTransaction: WireTransaction,
     private val serializationService: SerializationService
 ) {
 
@@ -65,7 +65,7 @@ class WrappedUtxoWireTransaction(
         deserialize(UtxoComponentGroup.INPUTS)
     }
 
-    val referenceInputStateRefs: List<StateRef> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    val referenceStateRefs: List<StateRef> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         deserialize(UtxoComponentGroup.REFERENCES)
     }
 

--- a/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/NotarisationRequest.kt
+++ b/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/NotarisationRequest.kt
@@ -11,6 +11,6 @@ import net.corda.v5.ledger.utxo.StateRef
  */
 @CordaSerializable
 data class NotarisationRequest(
-    val statesToConsume: Collection<StateRef>,
+    val statesToConsume: List<StateRef>,
     val transactionId: SecureHash
 )

--- a/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
+++ b/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
@@ -61,9 +61,7 @@ fun validateRequestSignature(notarisationRequest: NotarisationRequest,
             expectedSignedBytes
         )
     } catch (e: Exception) {
-        throw IllegalStateException(
-            "Error while verifying request signature. Cause: $e"
-        )
+        throw IllegalStateException("Error while verifying request signature.", e)
     }
 }
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
@@ -98,14 +98,14 @@ class NonValidatingNotaryClientFlowImpl(
     internal fun generatePayload(stx: UtxoSignedTransaction): NonValidatingNotarisationPayload {
         val filteredTx = utxoLedgerService.filterSignedTransaction(stx)
             .withInputStates()
-            .withReferenceInputStates()
+            .withReferenceStates()
             .withOutputStatesSize()
             .withNotary()
             .withTimeWindow()
             .build()
 
         val notarisationRequest = NotarisationRequest(
-            stx.toLedgerTransaction().inputStateAndRefs.map { it.ref },
+            stx.inputStateRefs,
             stx.id
         )
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
@@ -129,7 +129,7 @@ class NonValidatingNotaryClientFlowImplTest {
 
         val mockBuilder = mock<UtxoFilteredTransactionBuilder> {
             on { withInputStates() } doReturn this.mock
-            on { withReferenceInputStates() } doReturn this.mock
+            on { withReferenceStates() } doReturn this.mock
             on { withOutputStatesSize() } doReturn this.mock
             on { withNotary() } doReturn this.mock
             on { withTimeWindow() } doReturn this.mock

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -176,8 +176,8 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
             filteredTx.id,
             outputStates.size,
             filteredTx.timeWindow!!,
-            inputStates.values.values,
-            refStates.values.values,
+            inputStates.values.values.toList(),
+            refStates.values.values.toList(),
             filteredTx.notary!!
         )
     }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -164,8 +164,8 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
             "Could not fetch input states from the filtered transaction"
         }
 
-        val refStates = filteredTx.referenceInputStateRefs.castOrThrow<UtxoFilteredData.Audit<StateRef>> {
-            "Could not fetch reference input states from the filtered transaction"
+        val refStates = filteredTx.referenceStateRefs.castOrThrow<UtxoFilteredData.Audit<StateRef>> {
+            "Could not fetch reference states from the filtered transaction"
         }
 
         val outputStates = filteredTx.outputStateAndRefs.castOrThrow<UtxoFilteredData.SizeOnly<StateAndRef<*>>> {

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryTransactionDetails.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryTransactionDetails.kt
@@ -13,8 +13,8 @@ data class NonValidatingNotaryTransactionDetails(
     val id: SecureHash,
     val numOutputs: Int,
     val timeWindow: TimeWindow,
-    val inputs: Collection<StateRef>,
-    val references: Collection<StateRef>,
+    val inputs: List<StateRef>,
+    val references: List<StateRef>,
     // TODO CORE-8976 This is not used for now but will be needed when the notary check is added
     val notary: Party
 )

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -302,9 +302,9 @@ class NonValidatingNotaryServerFlowImplTest {
                     ?: mockStateRefUtxoFilteredData
             }
 
-            on { referenceInputStateRefs } doAnswer {
+            on { referenceStateRefs } doAnswer {
                 @Suppress("unchecked_cast")
-                filteredTxContents["referenceInputStateRefs"] as? UtxoFilteredData<StateRef>
+                filteredTxContents["referenceStateRefs"] as? UtxoFilteredData<StateRef>
                     ?: mockStateAndRefUtxoFilteredData
             }
             on { outputStateAndRefs } doAnswer {

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
@@ -84,8 +84,8 @@ class UtxoDemoFlow : RPCStartableFlow {
                 members.map { it.ledgerKeys.first() } + myInfo.ledgerKeys.first()
             )
 
-            val notary = notaryLookup.notaryServices.first()
-            val notaryKey = memberLookup.lookup().first {
+            val notary = notaryLookup.notaryServices.single()
+            val notaryKey = memberLookup.lookup().single {
                 it.memberProvidedContext["corda.notary.service.name"] == notary.name.toString()
             }.ledgerKeys.first()
             // TODO CORE-6173 use proper notary key

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -87,9 +87,9 @@ class NonValidatingNotaryTestFlow : RPCStartableFlow {
         flowEngine.subFlow(pluginClient)
 
         return jsonMarshallingService.format(NonValidatingNotaryTestFlowResult(
-            stx.toLedgerTransaction().outputStateAndRefs.map { it.ref.toString() },
-            stx.toLedgerTransaction().inputStateAndRefs.map { it.ref.toString() },
-            stx.toLedgerTransaction().referenceInputStateAndRefs.map { it.toString() }
+            stx.outputStateAndRefs.map { it.ref.toString() },
+            stx.inputStateRefs.map { it.toString() },
+            stx.referenceStateRefs.map { it.toString() }
         ))
     }
 
@@ -187,7 +187,7 @@ class NonValidatingNotaryTestFlow : RPCStartableFlow {
                 }
 
                 referenceStateRefs.forEach {
-                    builder = builder.addReferenceInputState(StateRef.parse(it))
+                    builder = builder.addReferenceState(StateRef.parse(it))
                 }
                 builder = builder.addSignatories(listOf(myKey))
                 builder

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -4,21 +4,28 @@ import net.corda.ledger.common.flow.impl.transaction.filtered.factory.FilteredTr
 import net.corda.ledger.common.test.CommonLedgerTest
 import net.corda.ledger.common.testkit.mockTransactionSignatureService
 import net.corda.ledger.utxo.flow.impl.UtxoLedgerServiceImpl
+import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderImpl
+import net.corda.ledger.utxo.flow.impl.transaction.factory.impl.UtxoLedgerTransactionFactoryImpl
 import net.corda.ledger.utxo.flow.impl.transaction.filtered.factory.UtxoFilteredTransactionFactoryImpl
-import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactoryImpl
+import net.corda.ledger.utxo.flow.impl.transaction.factory.impl.UtxoSignedTransactionFactoryImpl
 import net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp.UtxoSignedTransactionSerializer
 import net.corda.ledger.utxo.flow.impl.transaction.serializer.kryo.UtxoSignedTransactionKryoSerializer
 import net.corda.ledger.utxo.testkit.getUtxoSignedTransactionExample
 import org.mockito.kotlin.mock
 
 abstract class UtxoLedgerTest : CommonLedgerTest() {
+    val mockUtxoLedgerPersistenceService = mock<UtxoLedgerPersistenceService>()
     private val utxoFilteredTransactionFactory = UtxoFilteredTransactionFactoryImpl(
         FilteredTransactionFactoryImpl(
             jsonMarshallingService,
             merkleTreeProvider,
             serializationServiceWithWireTx
         ), serializationServiceWithWireTx
+    )
+    private val utxoLedgerTransactionFactory = UtxoLedgerTransactionFactoryImpl(
+        serializationServiceWithWireTx,
+        mockUtxoLedgerPersistenceService
     )
     val utxoSignedTransactionFactory = UtxoSignedTransactionFactoryImpl(
         currentSandboxGroupContext,
@@ -29,22 +36,33 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
         transactionMetadataFactory,
         wireTransactionFactory
     )
-    val utxoLedgerService = UtxoLedgerServiceImpl(utxoFilteredTransactionFactory, utxoSignedTransactionFactory, flowEngine, mock())
+    val utxoLedgerService = UtxoLedgerServiceImpl(
+        utxoFilteredTransactionFactory,
+        utxoSignedTransactionFactory,
+        flowEngine,
+        mockUtxoLedgerPersistenceService
+    )
     val utxoSignedTransactionKryoSerializer = UtxoSignedTransactionKryoSerializer(
         serializationServiceWithWireTx,
-        mockTransactionSignatureService()
+        mockTransactionSignatureService(),
+        utxoLedgerTransactionFactory
     )
     val utxoSignedTransactionAMQPSerializer =
-        UtxoSignedTransactionSerializer(serializationServiceNullCfg, mockTransactionSignatureService())
+        UtxoSignedTransactionSerializer(
+            serializationServiceNullCfg,
+            mockTransactionSignatureService(),
+            utxoLedgerTransactionFactory
+        )
     val utxoSignedTransactionExample = getUtxoSignedTransactionExample(
         digestService,
         merkleTreeProvider,
         serializationServiceWithWireTx,
         jsonMarshallingService,
         jsonValidator,
-        mockTransactionSignatureService()
+        mockTransactionSignatureService(),
+        mockUtxoLedgerPersistenceService
     )
     
     // This is the only not stateless.
-    val utxoTransactionBuilder = UtxoTransactionBuilderImpl(utxoSignedTransactionFactory)
+    val utxoTransactionBuilder = UtxoTransactionBuilderImpl(utxoSignedTransactionFactory, mockUtxoLedgerPersistenceService)
 }

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoLedgerIntegrationTest.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoLedgerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.testkit
 
 import net.corda.ledger.common.integration.test.CommonLedgerIntegrationTest
+import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.sandboxgroupcontext.getSandboxSingletonService
 import net.corda.testing.sandboxes.SandboxSetup
@@ -12,6 +13,7 @@ abstract class UtxoLedgerIntegrationTest: CommonLedgerIntegrationTest() {
 
     lateinit var utxoSignedTransactionFactory: UtxoSignedTransactionFactory
     lateinit var utxoLedgerService: UtxoLedgerService
+    lateinit var utxoLedgerPersistenceService: UtxoLedgerPersistenceService
     lateinit var utxoSignedTransaction: UtxoSignedTransaction
 
     override fun initialize(setup: SandboxSetup){
@@ -19,10 +21,12 @@ abstract class UtxoLedgerIntegrationTest: CommonLedgerIntegrationTest() {
 
         utxoSignedTransactionFactory = sandboxGroupContext.getSandboxSingletonService()
         utxoLedgerService = sandboxGroupContext.getSandboxSingletonService()
+        utxoLedgerPersistenceService = sandboxGroupContext.getSandboxSingletonService()
         utxoSignedTransaction = utxoSignedTransactionFactory.createExample(
             jsonMarshallingService,
             jsonValidator,
-            wireTransactionFactory
+            wireTransactionFactory,
+            utxoLedgerPersistenceService
         )
     }
 }

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
@@ -9,7 +9,9 @@ import net.corda.ledger.common.testkit.defaultComponentGroups
 import net.corda.ledger.common.testkit.getWireTransactionExample
 import net.corda.ledger.common.testkit.signatureWithMetadataExample
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
+import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
+import net.corda.ledger.utxo.flow.impl.transaction.factory.impl.UtxoLedgerTransactionFactoryImpl
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.marshalling.JsonMarshallingService
@@ -20,11 +22,12 @@ fun UtxoSignedTransactionFactory.createExample(
     jsonMarshallingService: JsonMarshallingService,
     jsonValidator: JsonValidator,
     wireTransactionFactory: WireTransactionFactory,
+    utxoLedgerPersistenceService: UtxoLedgerPersistenceService,
     componentGroups: List<List<ByteArray>> = defaultComponentGroups +
             List(UtxoComponentGroup.values().size - defaultComponentGroups.size) { emptyList() }
 ):UtxoSignedTransaction {
     val wireTransaction = wireTransactionFactory.createExample(jsonMarshallingService, jsonValidator, componentGroups)
-    return create(wireTransaction, listOf(signatureWithMetadataExample))
+    return create(wireTransaction, listOf(signatureWithMetadataExample), utxoLedgerPersistenceService)
 }
 
 @Suppress("LongParameterList")
@@ -34,7 +37,8 @@ fun getUtxoSignedTransactionExample(
     serializationService: SerializationService,
     jsonMarshallingService: JsonMarshallingService,
     jsonValidator: JsonValidator,
-    transactionSignatureService: TransactionSignatureService
+    transactionSignatureService: TransactionSignatureService,
+    utxoLedgerPersistenceService: UtxoLedgerPersistenceService
 ): UtxoSignedTransaction {
     val wireTransaction = getWireTransactionExample(
         digestService,
@@ -46,6 +50,7 @@ fun getUtxoSignedTransactionExample(
     return UtxoSignedTransactionImpl(
         serializationService,
         transactionSignatureService,
+        UtxoLedgerTransactionFactoryImpl(serializationService, utxoLedgerPersistenceService),
         wireTransaction,
         listOf(signatureWithMetadataExample)
     )


### PR DESCRIPTION
CORE-9052
* Resolve input and reference input states in UtxoLedgerTransactionFactory.
* Which requires the UtxoLedgerPersistenceService. To avoid creating a circular dependency between SignedTxFactory and LedgerPersistenceService, we made the persistence service accessible via non-osgi. This needs to improved later.
* Removed some toLedgerTransaction() calls where the already available signed transaction has all the required information in the given context. (To spare the database lookups and adding @Suspendable)
* WrappedUtxoWireTransactionKryoSerializer
* ReferenceInputState -> ReferenceState

CORE-9014 
* Fixed issue with incorrect flow external event ID not set correctly for token claim release acknowledgements
* Fixed issue preventing flow resuming after failed token query.
* Fixed issue preventing token selection API flow injection.
* Removed old unused test code

CORE-9021
* Enable notary smoke test scenarios

CORE-9050
* Fix bug with Kryo serialization

API: https://github.com/corda/corda-api/pull/763