### PR TITLE
CORE-9071: Simulator flow registry changes

### DIFF
--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallFlowTest.kt
@@ -68,14 +68,8 @@ class RollCallFlowTest {
 
         val simulator = Simulator()
 
-        val bobsAbsentFlow = object: ResponderFlow {
-            override fun call(session: FlowSession) {
-                receiveAndSendResponse(session, "")
-            }
-        }
-
-        val bobsStillAbsentFlow = mock<ResponderFlow>()
-        whenever(bobsStillAbsentFlow.call(any())).then {
+        val bobsAbsentFlow = mock<ResponderFlow>()
+        whenever(bobsAbsentFlow.call(any())).then {
             receiveAndSendResponse(it.getArgument(0), "")
         }
 
@@ -88,7 +82,7 @@ class RollCallFlowTest {
         }
 
         simulator.createInstanceNode(bob, "roll-call", bobsAbsentFlow)
-        simulator.createInstanceNode(bob, "absence-call", bobsStillAbsentFlow)
+        simulator.createInstanceNode(bob, "absence-call", bobsAbsentFlow)
         simulator.createInstanceNode(truancyOffice, "truancy-record", truancyOfficeFlow)
 
         val aliceNode = simulator.createVirtualNode(alice, RollCallFlow::class.java)
@@ -100,7 +94,7 @@ class RollCallFlowTest {
             RollCallInitiationRequest(truancyOffice)
         ))
 
-        verify(bobsStillAbsentFlow, times(2)).call(any())
+        verify(bobsAbsentFlow, times(3)).call(any())
         assertThat(receivedRecord.absentees, `is`(listOf(bob)))
     }
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
@@ -4,6 +4,7 @@ import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.RequestData
 import net.corda.simulator.SimulatedInstanceNode
 import net.corda.simulator.runtime.flows.BaseFlowManager
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.messaging.SimFiber
@@ -31,9 +32,9 @@ class SimulatedInstanceNodeBase(
 
     init {
         fiber.registerMember(member)
-        if (ResponderFlow::class.java.isInstance(flow) || RPCStartableFlow::class.java.isInstance(flow)) {
-            fiber.registerFlowInstance(member, protocol, flow)
-        } else {
+        if (ResponderFlow::class.java.isInstance(flow)) {
+            fiber.registerResponderInstance(member, protocol, flow as ResponderFlow)
+        } else if (!RPCStartableFlow::class.java.isInstance(flow)){
             error("The flow provided to this node was neither a `ResponderFlow` nor an `RPCStartableFlow`.")
         }
     }
@@ -43,21 +44,26 @@ class SimulatedInstanceNodeBase(
     }
 
     override fun callInstanceFlow(input: RequestData): String {
-        return doCallFlow(input, emptyMap())
+        return callInstanceFlow(input, emptyMap())
     }
 
     override fun callInstanceFlow(input: RequestData, contextPropertiesMap: Map<String, String>): String {
-        return doCallFlow(input, contextPropertiesMap)
-    }
-
-    private fun doCallFlow(input: RequestData, contextPropertiesMap: Map<String, String>): String{
         if (flow !is RPCStartableFlow) {
-            error("The flow provided to the instance node for member \"$member\" and protocol $protocol " +
-                    "was not an RPCStartableFlow")
+            error(
+                "The flow provided to the instance node for member \"$member\" and protocol $protocol " +
+                        "was not an RPCStartableFlow"
+            )
         }
-        log.info("Calling flow instance for member \"$member\" and protocol \"$protocol\" " +
-                "with request: ${input.requestBody}")
-        injector.injectServices(flow, member, fiber, SimFlowContextProperties(contextPropertiesMap))
+        log.info(
+            "Calling flow instance for member \"$member\" and protocol \"$protocol\" " +
+                    "with request: ${input.requestBody}"
+        )
+        injector.injectServices(
+            FlowAndProtocol(flow, protocol),
+            member,
+            fiber,
+            SimFlowContextProperties(contextPropertiesMap)
+        )
         val result = flowManager.call(input.toRPCRequestData(), flow)
         SimulatedVirtualNodeBase.log.info("Finished flow instance for member \"$member\" and protocol \"$protocol\"")
         return result

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
@@ -4,6 +4,7 @@ import net.corda.simulator.HoldingIdentity
 import net.corda.simulator.RequestData
 import net.corda.simulator.SimulatedVirtualNode
 import net.corda.simulator.runtime.flows.BaseFlowManager
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
@@ -45,7 +46,12 @@ class SimulatedVirtualNodeBase(
         val flowClassName = input.flowClassName
         log.info("Calling flow $flowClassName for member \"$member\" with request: ${input.requestBody}")
         val flow = flowFactory.createInitiatingFlow(member, flowClassName)
-        injector.injectServices(flow, member, fiber, SimFlowContextProperties(contextPropertiesMap))
+        injector.injectServices(
+            FlowAndProtocol(flow),
+            member,
+            fiber,
+            SimFlowContextProperties(contextPropertiesMap)
+        )
         val result = flowManager.call(input.toRPCRequestData(), flow)
         log.info("Finished flow $flowClassName for member \"$member\"")
         return result

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjector.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjector.kt
@@ -50,11 +50,13 @@ class DefaultServicesInjector(private val configuration: SimulatorConfiguration)
      * @param flowFactory A factory for constructing flows.
      */
     override fun injectServices(
-        flow: Flow,
+        flowAndProtocol: FlowAndProtocol,
         member: MemberX500Name,
         fiber: SimFiber,
         contextProperties: FlowContextProperties
     ) {
+        val flow = flowAndProtocol.flow
+
         log.info("Injecting services into ${flow.javaClass} for \"$member\"")
         checkAPIAvailability(flow, configuration)
         
@@ -68,7 +70,7 @@ class DefaultServicesInjector(private val configuration: SimulatorConfiguration)
             userContextProperties = flowEngine.flowContextProperties
         }
         doInject(member, flow, FlowMessaging::class.java) {
-            createFlowMessaging(configuration, flow, member, fiber, userContextProperties)
+            createFlowMessaging(configuration, flowAndProtocol, member, fiber, userContextProperties)
         }
         doInject(member, flow, MemberLookup::class.java) { getOrCreateMemberLookup(member, fiber) }
         doInject(member, flow, SigningService::class.java) {
@@ -174,7 +176,7 @@ class DefaultServicesInjector(private val configuration: SimulatorConfiguration)
 
     private fun createFlowMessaging(
         configuration: SimulatorConfiguration,
-        flow: Flow,
+        flow: FlowAndProtocol,
         member: MemberX500Name,
         fiber: SimFiber,
         contextProperties: FlowContextProperties

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowAndProtocol.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowAndProtocol.kt
@@ -1,0 +1,6 @@
+package net.corda.simulator.runtime.flows
+
+import net.corda.simulator.runtime.utils.getProtocolOrNull
+import net.corda.v5.application.flows.Flow
+
+data class FlowAndProtocol(val flow: Flow, val protocol: String? = flow.getProtocolOrNull())

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowServicesInjector.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/FlowServicesInjector.kt
@@ -1,7 +1,6 @@
 package net.corda.simulator.runtime.flows
 
 import net.corda.simulator.runtime.messaging.SimFiber
-import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.base.types.MemberX500Name
 
@@ -16,7 +15,7 @@ interface FlowServicesInjector {
      * @param contextProperties The [FlowContextProperties] for the flow.
      */
     fun injectServices(
-        flow: Flow,
+        flowAndProtocol: FlowAndProtocol,
         member: MemberX500Name,
         fiber: SimFiber,
         contextProperties: FlowContextProperties

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
@@ -52,7 +52,12 @@ class InjectingFlowEngine(
     override fun <R> subFlow(subFlow: SubFlow<R>): R {
         log.info("Running subflow ${SubFlow::class.java} for \"$virtualNodeName\"")
         flowChecker.check(subFlow.javaClass)
-        injector.injectServices(subFlow, virtualNodeName, fiber, copyFlowContextProperties(userContextProperties))
+        injector.injectServices(
+            FlowAndProtocol(subFlow),
+            virtualNodeName,
+            fiber,
+            copyFlowContextProperties(userContextProperties)
+        )
         val result = flowManager.call(subFlow)
         log.info("Finished subflow ${SubFlow::class.java} for \"$virtualNodeName\"")
         return result

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowMessagingFactory.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowMessagingFactory.kt
@@ -1,10 +1,10 @@
 package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.SimulatorConfiguration
+import net.corda.simulator.exceptions.NoProtocolAnnotationException
 import net.corda.simulator.runtime.flows.BaseFlowFactory
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowServicesInjector
-import net.corda.simulator.runtime.utils.getProtocol
-import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.base.types.MemberX500Name
@@ -16,20 +16,13 @@ class BaseFlowMessagingFactory: FlowMessagingFactory {
         member: MemberX500Name,
         fiber: SimFiber,
         injector: FlowServicesInjector,
-        flow: Flow,
+        flow: FlowAndProtocol,
         contextProperties: FlowContextProperties
     ): FlowMessaging {
-
-        val instanceFlowMap = fiber.lookupFlowInstance(member)
-
-        val protocol: String = if(instanceFlowMap ==null || instanceFlowMap[flow] == null) {
-            flow.getProtocol()
-        }else{
-            instanceFlowMap[flow]!!
-        }
+        if(flow.protocol == null) throw NoProtocolAnnotationException(flow::class.java)
 
         return ConcurrentFlowMessaging(
-            FlowContext(configuration, member, protocol),
+            FlowContext(configuration, member, flow.protocol),
             fiber,
             injector,
             BaseFlowFactory(),

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistry.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistry.kt
@@ -1,15 +1,16 @@
 package net.corda.simulator.runtime.messaging
 
 import net.corda.v5.application.flows.Flow
-import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
+import java.util.concurrent.ConcurrentHashMap
 
 class BaseFlowRegistry: FlowRegistry {
-    private val nodeFlowInstances = HashMap<MemberX500Name, HashMap<Flow, String>>()
-    private val nodeResponderClasses = HashMap<MemberX500Name, HashMap<String, Class<out ResponderFlow>>>()
-    private val nodeResponderInstances = HashMap<MemberX500Name, HashMap<String, ResponderFlow>>()
+    private val nodeFlowInstances = ConcurrentHashMap<MemberX500Name, ConcurrentHashMap<Flow, String>>()
+    private val nodeResponderClasses = ConcurrentHashMap<MemberX500Name,
+            ConcurrentHashMap<String, Class<out ResponderFlow>>>()
+    private val nodeResponderInstances = ConcurrentHashMap<MemberX500Name, ConcurrentHashMap<String, ResponderFlow>>()
 
     private companion object {
         val log = contextLogger()
@@ -27,71 +28,32 @@ class BaseFlowRegistry: FlowRegistry {
 
         log.info("Registering class $flowClass against protocol $protocol")
 
-        if(nodeResponderClasses[responder] == null) {
-            nodeResponderClasses[responder] = hashMapOf(protocol to flowClass)
-        } else if (nodeResponderClasses[responder]!![protocol] == null) {
-            nodeResponderClasses[responder]!![protocol] = flowClass
-        } else {
-            throw IllegalStateException("Member \"$responder\" has already registered " +
-                    "flow class for protocol \"$protocol\"")
+        nodeResponderClasses.putIfAbsent(responder, ConcurrentHashMap())
+        val alreadyRegistered = nodeResponderClasses[responder]!!.putIfAbsent(protocol, flowClass)
+
+        if(alreadyRegistered != null) {
+            error("Member \"$responder\" has already registered flow class for protocol \"$protocol\"")
         }
     }
 
-    private fun doRegisterFlowInstance(
-        initiator: MemberX500Name,
-        protocol: String,
-        instanceFlow: Flow
-    ) {
-        log.info("Registering instance $instanceFlow against protocol $protocol")
-        if(!nodeFlowInstances.contains(initiator)) {
-            nodeFlowInstances[initiator] = hashMapOf(instanceFlow to protocol)
-        }else if(nodeFlowInstances[initiator]!![instanceFlow] == null){
-            nodeFlowInstances[initiator]!![instanceFlow] = protocol
-        }else{
-            throw IllegalStateException("Member \"$initiator\" has already registered " +
-                    "flow instance for protocol \"$protocol\"")
-        }
-    }
-
-
-    override fun registerFlowInstance(member: MemberX500Name, protocol: String, instanceFlow: Flow) {
-
-        if(!(instanceFlow is ResponderFlow) && !(instanceFlow is RPCStartableFlow)){
-            throw IllegalArgumentException("$instanceFlow is neither a  ${RPCStartableFlow::class.java}" +
-                    "nor a ${ResponderFlow::class.java}")
-        }
-
-        doRegisterFlowInstance(member, protocol, instanceFlow)
-
-        if(instanceFlow is ResponderFlow)
-            registerResponderInstance(member, protocol, instanceFlow)
-
-    }
-
-
-    private fun registerResponderInstance(responder: MemberX500Name, protocol: String, responderFlow: ResponderFlow) {
+    override fun registerResponderInstance(responder: MemberX500Name, protocol: String, responderFlow: ResponderFlow) {
 
         if(nodeResponderClasses[responder]?.get(protocol) != null) {
-            throw IllegalStateException("Member \"$responder\" has already registered " +
-                    "flow class for protocol \"$protocol\"")
+            error("Member \"$responder\" has already registered flow class for protocol \"$protocol\"")
         }
 
-        if(nodeResponderInstances[responder] == null) {
-            nodeResponderInstances[responder] = hashMapOf(protocol to responderFlow)
-        } else if (nodeResponderInstances[responder]!![protocol] == null) {
-            nodeResponderInstances[responder]!![protocol] = responderFlow
-        } else {
-            throw IllegalStateException("Member \"$responder\" has already registered " +
-                    "flow instance for protocol \"$protocol\"")
+        log.info("Registering instance $responderFlow against protocol $protocol")
+
+        nodeResponderInstances.putIfAbsent(responder, ConcurrentHashMap())
+        val alreadyRegistered = nodeResponderInstances[responder]!!.putIfAbsent(protocol, responderFlow)
+
+        if(alreadyRegistered != null) {
+            error("Member \"$responder\" has already registered flow instance for protocol \"$protocol\"")
         }
     }
 
     override fun lookUpResponderClass(member: MemberX500Name, protocol: String): Class<out ResponderFlow>? {
         return nodeResponderClasses[member]?.get(protocol)
-    }
-
-    override fun lookupFlowInstance(member: MemberX500Name): Map<Flow, String>? {
-        return nodeFlowInstances[member]
     }
 
     override fun lookUpResponderInstance(member: MemberX500Name, protocol: String): ResponderFlow? {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
@@ -1,6 +1,7 @@
 package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.exceptions.NoRegisteredResponderException
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.v5.application.flows.FlowContextProperties
@@ -90,7 +91,12 @@ class ConcurrentFlowMessaging(
             }?:
             copyFlowContextProperties(contextProperties)
 
-        injector.injectServices(responderFlow, x500Name, fiber, updatedContextProperties)
+        injector.injectServices(
+            FlowAndProtocol(responderFlow, protocol),
+            x500Name,
+            fiber,
+            updatedContextProperties
+        )
 
         val sessions = sessionFactory.createSessions(x500Name, flowContext,
             flowContextProperties = updatedContextProperties as SimFlowContextProperties)

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/FlowMessagingFactory.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/FlowMessagingFactory.kt
@@ -1,8 +1,8 @@
 package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.SimulatorConfiguration
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowServicesInjector
-import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.base.types.MemberX500Name
@@ -25,6 +25,6 @@ interface FlowMessagingFactory {
                             member: MemberX500Name,
                             fiber: SimFiber,
                             injector: FlowServicesInjector,
-                            flow: Flow,
+                            flow: FlowAndProtocol,
                             contextProperties: FlowContextProperties): FlowMessaging
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/FlowRegistry.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/FlowRegistry.kt
@@ -1,6 +1,5 @@
 package net.corda.simulator.runtime.messaging
 
-import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.base.types.MemberX500Name
 
@@ -16,13 +15,13 @@ interface FlowRegistry{
     fun registerResponderClass(responder: MemberX500Name, protocol: String, flowClass: Class<out ResponderFlow>)
 
     /**
-     * Registers an instance initiating flows for a given member and protocol
+     * Registers an instance of a responder flow for a given member and protocol
      *
      * @param member The member who initiates/ responds to the flow
-     * @param protocol The protocol of the initiating flow
-     * @param instanceFlow The instance flow class
+     * @param protocol The protocol of the responding flow
+     * @param responderFlow The instance flow class
      */
-    fun registerFlowInstance(member: MemberX500Name, protocol: String, instanceFlow: Flow)
+    fun registerResponderInstance(responder: MemberX500Name, protocol: String, responderFlow: ResponderFlow)
 
 
     /**
@@ -35,13 +34,6 @@ interface FlowRegistry{
     fun lookUpResponderClass(member: MemberX500Name, protocol: String): Class<out ResponderFlow>?
 
     /**
-     * @param member The member for whom to look up the initiator instance.
-     *
-     * @return A [Map] of previously registered instance initiating flows with protocols
-     */
-    fun lookupFlowInstance(member: MemberX500Name): Map<Flow, String>?
-
-    /**
      * @param member The member for whom to look up the responder instance.
      * @param protocol The protocol to which the responder should respond.
      *
@@ -49,5 +41,4 @@ interface FlowRegistry{
      * no instance has been registered.
      */
     fun lookUpResponderInstance(member: MemberX500Name, protocol: String): ResponderFlow?
-
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SimFiber.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SimFiber.kt
@@ -2,9 +2,9 @@ package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.crypto.HsmCategory
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.v5.application.crypto.SigningService
-import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
@@ -59,7 +59,7 @@ interface SimFiber : Closeable, HasMemberInfos, FlowRegistry {
      * @param contextProperties The [FlowContextProperties] for the flow.
      * @return A [FlowMessaging] services responsible for sending and receiving messages
      */
-    fun createFlowMessaging(configuration: SimulatorConfiguration, flow: Flow, member: MemberX500Name,
+    fun createFlowMessaging(configuration: SimulatorConfiguration, flow: FlowAndProtocol, member: MemberX500Name,
                             injector: FlowServicesInjector, contextProperties: FlowContextProperties)
     : FlowMessaging
 

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SimFiberBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/SimFiberBase.kt
@@ -2,6 +2,7 @@ package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.crypto.HsmCategory
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.persistence.CloseablePersistenceService
 import net.corda.simulator.runtime.persistence.DbPersistenceServiceFactory
@@ -12,7 +13,6 @@ import net.corda.simulator.runtime.signing.SimKeyStore
 import net.corda.simulator.runtime.signing.keystoreFactoryBase
 import net.corda.simulator.runtime.signing.signingServiceFactoryBase
 import net.corda.v5.application.crypto.SigningService
-import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
@@ -85,7 +85,7 @@ class SimFiberBase(
 
     override fun createFlowMessaging(
         configuration: SimulatorConfiguration,
-        flow: Flow,
+        flow: FlowAndProtocol,
         member: MemberX500Name,
         injector: FlowServicesInjector,
         contextProperties: FlowContextProperties

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/utils/Utilities.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/utils/Utilities.kt
@@ -1,7 +1,6 @@
 package net.corda.simulator.runtime.utils
 
 import net.corda.simulator.SimulatorConfiguration
-import net.corda.simulator.exceptions.NoProtocolAnnotationException
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
 import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.crypto.SigningService
@@ -92,12 +91,11 @@ fun checkAPIAvailability(flow: Flow, configuration: SimulatorConfiguration){
 }
 
 /**
- * Return the protocol of the flow
+ * Return the protocol of the flow, if any
  */
-fun Flow.getProtocol() : String =
-    this.javaClass.getAnnotation(InitiatingFlow::class.java)?.protocol
-        ?: this.javaClass.getAnnotation(InitiatedBy::class.java)?.protocol
-        ?: throw NoProtocolAnnotationException(this.javaClass)
+fun Flow.getProtocolOrNull() =
+    (this.javaClass.getAnnotation(InitiatingFlow::class.java)?.protocol
+        ?: this.javaClass.getAnnotation(InitiatedBy::class.java)?.protocol)
 
 
 val availableAPIs = setOf(

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedCordaNetworkBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedCordaNetworkBaseTest.kt
@@ -70,7 +70,7 @@ class SimulatedCordaNetworkBaseTest {
         corda.createInstanceNode(member, "ping-ack", responder)
 
         // Then it should have registered the responder with the fiber
-        verify(fiber, times(1)).registerFlowInstance(member,"ping-ack", responder)
+        verify(fiber, times(1)).registerResponderInstance(member,"ping-ack", responder)
     }
 
     @Test

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeTest.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime
 
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
@@ -53,7 +54,12 @@ class SimulatedInstanceNodeTest {
         virtualNode.callInstanceFlow(input)
 
         // Then it should have instantiated the node and injected the services into it
-        verify(injector, times(1)).injectServices(eq(flow), eq(holdingId.member), eq(fiber), any())
+        verify(injector, times(1)).injectServices(
+            eq(FlowAndProtocol(flow, "a protocol")),
+            eq(holdingId.member),
+            eq(fiber),
+            any()
+        )
 
         // And the flow should have been called
         verify(flowManager, times(1)).call(

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBaseTest.kt
@@ -1,6 +1,7 @@
 package net.corda.simulator.runtime
 
 import net.corda.simulator.factories.RequestDataFactory
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
@@ -67,8 +68,12 @@ class SimulatedVirtualNodeBaseTest {
         virtualNode.callFlow(input)
 
         // Then it should have instantiated the node and injected the services into it
-        verify(injector, times(1)).injectServices(eq(flow), eq(holdingId.member), eq(fiber),
-            eq(contextProperties))
+        verify(injector, times(1)).injectServices(
+            eq(FlowAndProtocol(flow, null)),
+            eq(holdingId.member),
+            eq(fiber),
+            eq(contextProperties)
+        )
 
         // And the flow should have been called
         verify(flowManager, times(1)).call(

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjectorTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjectorTest.kt
@@ -51,7 +51,7 @@ class DefaultServicesInjectorTest {
 
         fiber.use {
             // When we inject services into it
-            DefaultServicesInjector(mock()).injectServices(flow, member, it, contextProperties)
+            DefaultServicesInjector(mock()).injectServices(FlowAndProtocol(flow), member, it, contextProperties)
 
             // Then it should have constructed useful things for us
             assertNotNull(flow.flowEngine)
@@ -77,7 +77,7 @@ class DefaultServicesInjectorTest {
             // When we inject services into it
             // Then it should throw an exception
             assertThrows<NotImplementedError> {
-                DefaultServicesInjector(mock()).injectServices(flow, member, it, mock())
+                DefaultServicesInjector(mock()).injectServices(FlowAndProtocol(flow), member, it, mock())
             }
         }
     }
@@ -114,7 +114,7 @@ class DefaultServicesInjectorTest {
 
         fiber.use {
             // When we inject services into it
-            DefaultServicesInjector(config).injectServices(flow, member, it, mock())
+            DefaultServicesInjector(config).injectServices(FlowAndProtocol(flow), member, it, mock())
         }
 
         // Then the flow should have the overridden services
@@ -177,11 +177,15 @@ class DefaultServicesInjectorTest {
         val fiber = SimFiberBase()
         val contextProperties = SimFlowContextProperties(emptyMap())
         fiber.registerMember(member)
-        fiber.registerFlowInstance(member, "protocol", responder)
+        fiber.registerResponderInstance(member, "protocol", responder)
 
         fiber.use {
             // When we inject services into it
-            DefaultServicesInjector(mock()).injectServices(responder, member, it, contextProperties)
+            DefaultServicesInjector(mock()).injectServices(
+                FlowAndProtocol(responder, "protocol"),
+                member,
+                it,
+                contextProperties)
 
             // Then it should have constructed useful things for us
             assertNotNull(responder.flowMessaging)
@@ -231,11 +235,15 @@ class DefaultServicesInjectorTest {
         val fiber = SimFiberBase()
         val contextProperties = SimFlowContextProperties(emptyMap())
         fiber.registerMember(member)
-        fiber.registerFlowInstance(member, "protocol", flow)
 
         fiber.use {
             // When we inject services into it
-            DefaultServicesInjector(mock()).injectServices(flow, member, it, contextProperties)
+            DefaultServicesInjector(mock()).injectServices(
+                FlowAndProtocol(flow, "a protocol"),
+                member,
+                it,
+                contextProperties
+            )
 
             // Then it should have constructed useful things for us
             assertNotNull(flow.flowEngine)
@@ -271,7 +279,7 @@ class DefaultServicesInjectorTest {
 
         fiber.use {
             injector.injectServices(
-                flow,
+                FlowAndProtocol(flow),
                 MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB"),
                 it,
                 contextProperties

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngineTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngineTest.kt
@@ -33,7 +33,15 @@ class InjectingFlowEngineTest {
         val contextProperties = SimFlowContextProperties(emptyMap())
 
         // And a flow engine which uses them
-        val engine = InjectingFlowEngine(mock(), member, fiber,contextProperties, injector, CordaFlowChecker(), flowManager)
+        val engine = InjectingFlowEngine(
+            mock(),
+            member,
+            fiber,
+            contextProperties,
+            injector,
+            CordaFlowChecker(),
+            flowManager
+        )
 
         // When we pass a subflow to the flow engine
         val flow = mock<SubFlow<String>>()
@@ -43,7 +51,7 @@ class InjectingFlowEngineTest {
 
         // Then it should inject those
         verify(injector, times(1))
-            .injectServices(eq(flow), eq(member), eq(fiber), any())
+            .injectServices(eq(FlowAndProtocol(flow, null)), eq(member), eq(fiber), any())
 
         // And it should call the subFlow
         assertThat(response, `is`("Yo!"))

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BaseFlowMessagingFactoryTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BaseFlowMessagingFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.runtime.config.DefaultConfigurationBuilder
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.testflows.PingAckFlow
 import net.corda.simulator.runtime.testflows.PingAckResponderFlow
@@ -23,15 +24,26 @@ class BaseFlowMessagingFactoryTest {
         val injector = mock<FlowServicesInjector>()
         val fiber = SimFiberBase()
 
-        fiber.registerFlowInstance(memberA, "protocol", initiator)
-        fiber.registerFlowInstance(memberA, "protocol", responder)
+        fiber.registerResponderInstance(memberA, "protocol", responder)
 
         // When we call the factory create method for the flow
         val flowMessagingA =  BaseFlowMessagingFactory().createFlowMessaging(
-            DefaultConfigurationBuilder().build(), memberA, fiber, injector, initiator, mock())
+            DefaultConfigurationBuilder().build(),
+            memberA,
+            fiber,
+            injector,
+            FlowAndProtocol(initiator, "protocol"),
+            mock()
+        )
 
         val flowMessagingB =  BaseFlowMessagingFactory().createFlowMessaging(
-            DefaultConfigurationBuilder().build(), memberA, fiber, injector, responder, mock())
+            DefaultConfigurationBuilder().build(),
+            memberA,
+            fiber,
+            injector,
+            FlowAndProtocol(responder, "protocol"),
+            mock()
+        )
 
         // Then the factory should return a flow messaging object
         assertThat(flowMessagingA is ConcurrentFlowMessaging)
@@ -49,9 +61,22 @@ class BaseFlowMessagingFactoryTest {
 
         // When we call the factory create method for the flow
         val flowMessagingA =  BaseFlowMessagingFactory().createFlowMessaging(
-            DefaultConfigurationBuilder().build(), memberA, fiber, injector, initiator, mock())
+            DefaultConfigurationBuilder().build(),
+            memberA,
+            fiber,
+            injector,
+            FlowAndProtocol(initiator),
+            mock()
+        )
+
         val flowMessagingB =  BaseFlowMessagingFactory().createFlowMessaging(
-            DefaultConfigurationBuilder().build(), memberA, fiber, injector, responder, mock())
+            DefaultConfigurationBuilder().build(),
+            memberA,
+            fiber,
+            injector,
+            FlowAndProtocol(responder),
+            mock()
+        )
 
         // Then the factory should return a flow messaging object
         assertThat(flowMessagingA is ConcurrentFlowMessaging)

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistryTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistryTest.kt
@@ -1,50 +1,24 @@
 package net.corda.simulator.runtime.messaging
 
-import net.corda.v5.application.flows.Flow
-import net.corda.v5.application.flows.RPCStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.kotlin.mock
 
 class BaseFlowRegistryTest {
     private val memberA = MemberX500Name.parse("CN=CorDapperA, OU=Application, O=R3, L=London, C=GB")
     private val memberB = MemberX500Name.parse("CN=CorDapperB, OU=Application, O=R3, L=London, C=GB")
 
-    @Test
-    fun `should look up instance flows for a given member`() {
-        // Given a fiber with a concrete implementation registered for a protocol
-        val flowRegistry = BaseFlowRegistry()
-        val flow = mock<RPCStartableFlow>()
-        val responder = mock<ResponderFlow>()
-        val nonFlow = DummyFlow()
-        val protocol = "protocol-1"
-        flowRegistry.registerFlowInstance(memberA, protocol, flow)
-        flowRegistry.registerFlowInstance(memberB, protocol, responder)
-
-        assertThrows<IllegalArgumentException>{
-            flowRegistry.registerFlowInstance(memberA, protocol, nonFlow)
-        }
-
-        // When we look up an instance of a flow
-        val result = flowRegistry.lookupFlowInstance(memberA)
-        val result1 = flowRegistry.lookupFlowInstance(memberB)
-
-        // Then it should successfully return it
-        MatcherAssert.assertThat(result, Matchers.`is`(hashMapOf(flow to protocol)))
-        MatcherAssert.assertThat(result1, Matchers.`is`(hashMapOf(responder to protocol)))
-    }
 
     @Test
     fun `should tell us if it cant find a flow for a given party and protocol`() {
         // Given a fiber and a node with a flow and protocol already
         val flowRegistry = BaseFlowRegistry()
-        flowRegistry.registerResponderClass(memberA, "protocol-1", SimFiberBaseTest.Flow1::class.java)
-        flowRegistry.registerFlowInstance(memberB, "protocol-2", SimFiberBaseTest.Flow2())
+        flowRegistry.registerResponderClass(memberA, "protocol-1", Flow1::class.java)
 
         // When we try to look up a member or protocol that doesn't exist
         // Then it should throw an error
@@ -59,8 +33,8 @@ class BaseFlowRegistryTest {
     fun `should look up concrete implementations for a given protocol and a given party`() {
         // Given a fiber with a concrete implementation registered for a protocol
         val flowRegistry = BaseFlowRegistry()
-        val flow = SimFiberBaseTest.Flow1()
-        flowRegistry.registerFlowInstance(memberA, "protocol-1", flow)
+        val flow = Flow1()
+        flowRegistry.registerResponderInstance(memberA, "protocol-1", flow)
 
         // When we look up an instance of a flow
         val result = flowRegistry.lookUpResponderInstance(memberA, "protocol-1")
@@ -73,41 +47,44 @@ class BaseFlowRegistryTest {
     fun `should look up the matching flow class for a given protocol and a given party`() {
         // Given a fiber and two nodes with some shared flow protocol
         val flowRegistry = BaseFlowRegistry()
-        flowRegistry.registerResponderClass(memberA, "protocol-1", SimFiberBaseTest.Flow1::class.java)
-        flowRegistry.registerResponderClass(memberA, "protocol-2", SimFiberBaseTest.Flow2::class.java)
-        flowRegistry.registerResponderClass(memberB, "protocol-1", SimFiberBaseTest.Flow3InitBy1::class.java)
-        flowRegistry.registerResponderClass(memberB, "protocol-2", SimFiberBaseTest.Flow4InitBy2::class.java)
+        flowRegistry.registerResponderClass(memberA, "protocol-1", Flow1::class.java)
+        flowRegistry.registerResponderClass(memberA, "protocol-2", Flow2::class.java)
+        flowRegistry.registerResponderClass(memberB, "protocol-1", Flow3InitBy1::class.java)
+        flowRegistry.registerResponderClass(memberB, "protocol-2", Flow4InitBy2::class.java)
 
         // When we look up a given protocol for a given party
         val flowClass = flowRegistry.lookUpResponderClass(memberB, "protocol-2")
 
         // Then we should get the flow that matches both the protocol and the party
-        MatcherAssert.assertThat(flowClass, Matchers.`is`(SimFiberBaseTest.Flow4InitBy2::class.java))
+        MatcherAssert.assertThat(flowClass, Matchers.`is`(Flow4InitBy2::class.java))
     }
 
     @Test
     fun `should prevent us from uploading a responder twice for a given party and protocol`() {
         // Given a fiber and a node with a flow and protocol already
         val flowRegistry = BaseFlowRegistry()
-        flowRegistry.registerResponderClass(memberA, "protocol-1", SimFiberBaseTest.Flow1::class.java)
-        flowRegistry.registerFlowInstance(memberB, "protocol-1", SimFiberBaseTest.Flow2())
+        flowRegistry.registerResponderClass(memberA, "protocol-1", Flow1::class.java)
+        flowRegistry.registerResponderInstance(memberB, "protocol-1", Flow2())
 
         // When we try to register a node and flow with the same protocol
         // regardless of whether it is, or was, a class or instance
         // Then it should throw an error
         assertThrows<IllegalStateException> { // class, then class
-            flowRegistry.registerResponderClass(memberA, "protocol-1", SimFiberBaseTest.Flow2::class.java)
+            flowRegistry.registerResponderClass(memberA, "protocol-1", Flow2::class.java)
         }
         assertThrows<IllegalStateException> { // instance, then class
-            flowRegistry.registerResponderClass(memberB, "protocol-1", SimFiberBaseTest.Flow2::class.java)
+            flowRegistry.registerResponderClass(memberB, "protocol-1", Flow2::class.java)
         }
         assertThrows<IllegalStateException> { // instance, then instance
-            flowRegistry.registerFlowInstance(memberA, "protocol-1", SimFiberBaseTest.Flow1())
+            flowRegistry.registerResponderInstance(memberA, "protocol-1", Flow1())
         }
         assertThrows<IllegalStateException> { // class, then instance
-            flowRegistry.registerFlowInstance(memberA, "protocol-1", SimFiberBaseTest.Flow1())
+            flowRegistry.registerResponderInstance(memberA, "protocol-1", Flow1())
         }
     }
 }
 
-class DummyFlow: Flow
+class Flow1 : ResponderFlow { override fun call(session: FlowSession) = Unit }
+class Flow2 : ResponderFlow { override fun call(session: FlowSession) = Unit }
+class Flow3InitBy1 : ResponderFlow { override fun call(session: FlowSession) = Unit }
+class Flow4InitBy2 : ResponderFlow { override fun call(session: FlowSession) = Unit }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
@@ -3,6 +3,7 @@ package net.corda.simulator.runtime.messaging
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.exceptions.ResponderFlowException
 import net.corda.simulator.exceptions.SessionAlreadyClosedException
+import net.corda.simulator.runtime.flows.FlowAndProtocol
 import net.corda.simulator.runtime.flows.FlowFactory
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.testflows.PingAckMessage
@@ -83,7 +84,7 @@ class ConcurrentFlowMessagingTest {
 
         // Then it should have injected the services into the responder
         verify(injector, times(1)).injectServices(
-            eq(responderFlow),
+            eq(FlowAndProtocol(responderFlow, "ping-ack")),
             eq(receiverX500),
             eq(fiber),
             eq(contextProperties)
@@ -131,7 +132,7 @@ class ConcurrentFlowMessagingTest {
 
         // Then it should have injected the services into the responder
         verify(injector, times(1)).injectServices(
-            eq(responderFlow),
+            eq(FlowAndProtocol(responderFlow, "ping-ack")),
             eq(receiverX500),
             eq(flowAndServiceLookUp),
             eq(contextProperties)

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/SimFiberBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/SimFiberBaseTest.kt
@@ -7,9 +7,7 @@ import net.corda.simulator.runtime.signing.KeyStoreFactory
 import net.corda.simulator.runtime.signing.SigningServiceFactory
 import net.corda.simulator.runtime.signing.SimKeyStore
 import net.corda.v5.application.crypto.SigningService
-import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.membership.MemberLookup
-import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
@@ -123,8 +121,5 @@ class SimFiberBaseTest {
     }
 
 
-    class Flow1 : ResponderFlow { override fun call(session: FlowSession) = Unit }
-    class Flow2 : ResponderFlow { override fun call(session: FlowSession) = Unit }
-    class Flow3InitBy1 : ResponderFlow { override fun call(session: FlowSession) = Unit }
-    class Flow4InitBy2 : ResponderFlow { override fun call(session: FlowSession) = Unit }
+
 }


### PR DESCRIPTION
Rather than storing protocols by flow in the flow registry, we store responder flows by their protocol and otherwise pass flow and protocol around as a pair. This better matches the way that Corda handles flows. It also allows us to mock out responder flows in instance upload for two different protocols, avoiding a problem whereby Mockito overrides one mock's stub with the stub of a second mock of the same type.