### PR TITLE
NOTICK: Allow flushing SandboxGroupContextCache to be synchronous.

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
@@ -1,5 +1,7 @@
 package net.corda.flow.testing.fakes
 
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.sandbox.SandboxDependencyInjector
 import net.corda.flow.pipeline.sandbox.impl.FlowSandboxGroupContextImpl
@@ -69,7 +71,15 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
         TODO("Not yet implemented")
     }
 
-    override fun flushCache() {
+    override fun flushCache(): CompletableFuture<*> {
+        TODO("Not yet implemented")
+    }
+
+    override fun waitFor(completion: CompletableFuture<*>, duration: Duration): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>? {
         TODO("Not yet implemented")
     }
 
@@ -96,6 +106,8 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
             RequireSandboxAMQP.AMQP_SERIALIZATION_SERVICE to FakeSerializationService(),
             FlowSandboxGroupContextImpl.FLOW_PROTOCOL_STORE to makeProtocolStore()
         )
+
+        override val completion: CompletableFuture<Boolean> = CompletableFuture()
 
         override fun <T : Any> get(key: String, valueType: Class<out T>): T? {
             return cache[key]?.let(valueType::cast)

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/CustomCryptoDigestTests.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/CustomCryptoDigestTests.kt
@@ -1,7 +1,7 @@
 package net.corda.sandboxgroupcontext.test
 
 import java.nio.file.Path
-import net.corda.sandbox.SandboxException
+import java.util.concurrent.TimeUnit.SECONDS
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
@@ -12,9 +12,11 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.fail
 import org.junit.jupiter.api.io.TempDir
 import org.osgi.framework.BundleContext
 import org.osgi.test.common.annotation.InjectBundleContext
@@ -124,76 +126,65 @@ class CustomCryptoDigestTests {
         }
     }
 
+    @Timeout(30, unit = SECONDS)
     @Test
     fun `load cpi and then unload cpi`() {
-        val sandboxGroupContext = virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW)
+        val sandboxGroupContext = mutableListOf(virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW))
 
-        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContext)
+        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContext.single())
 
-        virtualNode.unloadSandbox(sandboxGroupContext)
-
-        assertThrows<SandboxException> {
-            virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContext)
-        }
+        val completion = virtualNode.releaseSandbox(sandboxGroupContext.single())?: fail("Sandbox missing")
+        sandboxGroupContext.clear()
+        virtualNode.unloadSandbox(completion)
     }
 
+    @Timeout(30, unit = SECONDS)
     @Test
     fun `load two cpis then unload both`() {
-        val sandboxGroupContextOne = virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW)
-        val sandboxGroupContextTwo = virtualNode.loadSandbox(DIGEST_CPB_TWO, SandboxGroupType.FLOW)
+        val sandboxGroupContextOne = mutableListOf(virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW))
+        val sandboxGroupContextTwo = mutableListOf(virtualNode.loadSandbox(DIGEST_CPB_TWO, SandboxGroupType.FLOW))
 
         // We can use the two different custom cryptos
-        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextOne)
-        virtualNode.runFlow<SecureHash>(DIGEST_TWO_CLASSNAME, sandboxGroupContextTwo)
+        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextOne.single())
+        virtualNode.runFlow<SecureHash>(DIGEST_TWO_CLASSNAME, sandboxGroupContextTwo.single())
 
         // explicitly unload sandboxGroupOne
-        virtualNode.unloadSandbox(sandboxGroupContextOne)
+        val completion1 = virtualNode.releaseSandbox(sandboxGroupContextOne.single()) ?: fail("Sandbox1 missing")
+        sandboxGroupContextOne.clear()
+        virtualNode.unloadSandbox(completion1)
 
         // we can still run "two"
-        virtualNode.runFlow<SecureHash>(DIGEST_TWO_CLASSNAME, sandboxGroupContextTwo)
-
-        // but not sandboxGroupOne
-        assertThrows<SandboxException> {
-            virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextOne)
-        }
+        virtualNode.runFlow<SecureHash>(DIGEST_TWO_CLASSNAME, sandboxGroupContextTwo.single())
 
         // explicitly unload sandboxGroupTwo
-        virtualNode.unloadSandbox(sandboxGroupContextTwo)
-
-        // and now we cannot run that.
-        assertThrows<SandboxException> {
-            virtualNode.runFlow<SecureHash>(DIGEST_TWO_CLASSNAME, sandboxGroupContextTwo)
-        }
+        val completion2 = virtualNode.releaseSandbox(sandboxGroupContextTwo.single()) ?: fail("Sandbox2 missing")
+        sandboxGroupContextTwo.clear()
+        virtualNode.unloadSandbox(completion2)
     }
 
     /**
      * This test uses the SAME cpi, twice.  This tests some of the sandbox code.
      */
+    @Timeout(30, unit = SECONDS)
     @Test
     fun `load same cpis twice with different sandboxes then unload both`() {
-        val sandboxGroupContextOne = virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW)
-        val sandboxGroupContextTwo = virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW)
+        val sandboxGroupContextOne = mutableListOf(virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW))
+        val sandboxGroupContextTwo = mutableListOf(virtualNode.loadSandbox(DIGEST_CPB_ONE, SandboxGroupType.FLOW))
 
-        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextOne)
-        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextTwo)
+        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextOne.single())
+        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextTwo.single())
 
         // explicitly unwire *and* unload the first sandbox group
-        virtualNode.unloadSandbox(sandboxGroupContextOne)
+        val completion1 = virtualNode.releaseSandbox(sandboxGroupContextOne.single()) ?: fail("Sandbox1 missing")
+        sandboxGroupContextOne.clear()
+        virtualNode.unloadSandbox(completion1)
 
         // But we can still run the same identical custom crypto code in the second sandbox group
-        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextTwo)
-
-        // But not in the first, because it's been removed.
-        assertThrows<SandboxException> {
-            virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextOne)
-        }
+        virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextTwo.single())
 
         // Explicitly unwire *and* unload the second sandbox group
-        virtualNode.unloadSandbox(sandboxGroupContextTwo)
-
-        // And now we cannot run anything in the second group.
-        assertThrows<SandboxException> {
-            virtualNode.runFlow<SecureHash>(DIGEST_ONE_CLASSNAME, sandboxGroupContextTwo)
-        }
+        val completion2 = virtualNode.releaseSandbox(sandboxGroupContextTwo.single()) ?: fail("Sandbox2 missing")
+        sandboxGroupContextTwo.clear()
+        virtualNode.unloadSandbox(completion2)
     }
 }

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SandboxSingletonsTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SandboxSingletonsTest.kt
@@ -28,7 +28,7 @@ import java.nio.file.Path
 @TestInstance(PER_CLASS)
 class SandboxSingletonsTest {
     companion object {
-        private const val TIMEOUT_MILLIS = 1000L
+        private const val TIMEOUT_MILLIS = 10000L
         private const val CPB = "META-INF/sandbox-singletons-cpk.cpb"
         private const val MAP_PROVIDER_FLOW = "com.example.singletons.TestDataProvider"
     }

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SecurityManagerTests.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SecurityManagerTests.kt
@@ -33,7 +33,7 @@ import java.security.AccessControlException
 @Suppress("FunctionName")
 class SecurityManagerTests {
     companion object {
-        private const val TIMEOUT_MILLIS = 1000L
+        private const val TIMEOUT_MILLIS = 10000L
         private const val CPB1 = "META-INF/sandbox-security-manager-one.cpb"
         private const val CPK1_FLOWS_PACKAGE = "com.example.securitymanager.one.flows"
         private const val CPK2_FLOWS_PACKAGE = "com.example.securitymanager.two.flows"
@@ -57,7 +57,7 @@ class SecurityManagerTests {
 
     @BeforeAll
     fun setup(
-        @InjectService(timeout = 1000)
+        @InjectService(timeout = TIMEOUT_MILLIS)
         sandboxSetup: SandboxSetup,
         @InjectBundleContext
         bundleContext: BundleContext,
@@ -66,7 +66,7 @@ class SecurityManagerTests {
     ) {
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
-            virtualNode = setup.fetchService(timeout = 1000)
+            virtualNode = setup.fetchService(TIMEOUT_MILLIS)
         }
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VerificationSandboxTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VerificationSandboxTest.kt
@@ -30,7 +30,7 @@ import java.security.AccessControlException
 @Suppress("FunctionName")
 class VerificationSandboxTest {
     companion object {
-        private const val TIMEOUT_MILLIS = 1000L
+        private const val TIMEOUT_MILLIS = 10000L
         private const val CPB1 = "META-INF/sandbox-security-manager-one.cpb"
         private const val CPK1_FLOWS_PACKAGE = "com.example.securitymanager.one.flows"
         private const val CPK1_ENVIRONMENT_FLOW = "$CPK1_FLOWS_PACKAGE.EnvironmentFlow"
@@ -46,7 +46,7 @@ class VerificationSandboxTest {
 
     @BeforeAll
     fun setup(
-        @InjectService(timeout = 1000)
+        @InjectService(timeout = TIMEOUT_MILLIS)
         sandboxSetup: SandboxSetup,
         @InjectBundleContext
         bundleContext: BundleContext,
@@ -55,7 +55,7 @@ class VerificationSandboxTest {
     ) {
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
-            virtualNode = setup.fetchService(timeout = 1000)
+            virtualNode = setup.fetchService(TIMEOUT_MILLIS)
         }
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheConfiguration.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheConfiguration.kt
@@ -1,9 +1,0 @@
-package net.corda.sandboxgroupcontext.service
-
-// NOTE: this interface is a bit a hack and is only here so that we can configure the cache from the sandbox
-//  OSGi integration tests.
-//  Once we have a good way of faking/stubbing the lifecycle coordinator, then I think we can remove this.
-interface CacheConfiguration {
-    fun initCache(capacity: Long)
-    fun flushCache()
-}

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheControl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheControl.kt
@@ -1,0 +1,14 @@
+package net.corda.sandboxgroupcontext.service
+
+import net.corda.sandboxgroupcontext.VirtualNodeContext
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+
+interface CacheControl {
+    fun initCache(capacity: Long)
+    fun flushCache(): CompletableFuture<*>
+    fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
+
+    @Throws(InterruptedException::class)
+    fun waitFor(completion: CompletableFuture<*>, duration: Duration): Boolean
+}

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupContextComponent.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/SandboxGroupContextComponent.kt
@@ -10,7 +10,7 @@ import net.corda.v5.crypto.extensions.DigestAlgorithmFactory
 import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlowProvider
 import net.corda.v5.serialization.SerializationCustomSerializer
 
-interface SandboxGroupContextComponent : SandboxGroupContextService, CacheConfiguration, Lifecycle
+interface SandboxGroupContextComponent : SandboxGroupContextService, CacheControl, Lifecycle
 
 /**
  * This function registers any [DigestAlgorithmFactory][net.corda.v5.crypto.extensions.DigestAlgorithmFactory]

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CloseableSandboxGroupContext.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CloseableSandboxGroupContext.kt
@@ -4,6 +4,7 @@ import net.corda.sandbox.SandboxGroup
 import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.base.util.loggerFor
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -34,6 +35,9 @@ internal class CloseableSandboxGroupContextImpl(
 
     override val sandboxGroup: SandboxGroup
         get() = sandboxGroupContext.sandboxGroup
+
+    override val completion: CompletableFuture<Boolean>
+        get() = sandboxGroupContext.completion
 
     override fun <T : Any> get(key: String, valueType: Class<out T>): T? = sandboxGroupContext.get(key, valueType)
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
@@ -1,16 +1,21 @@
 package net.corda.sandboxgroupcontext.service.impl
 
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 
 interface SandboxGroupContextCache : AutoCloseable {
     val capacity: Long
-    fun remove(virtualNodeContext: VirtualNodeContext)
+    fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
     fun get(
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext
 
     fun resize(newCapacity: Long): SandboxGroupContextCache
-    fun flush()
+    fun flush(): CompletableFuture<*>
+
+    @Throws(InterruptedException::class)
+    fun waitFor(completion: CompletableFuture<*>, duration: Duration): Boolean
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextImpl.kt
@@ -4,6 +4,7 @@ import net.corda.sandbox.SandboxGroup
 import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -19,6 +20,8 @@ class SandboxGroupContextImpl(
 ) :  MutableSandboxGroupContext {
 
     private val objectByKey = ConcurrentHashMap<String, Any>()
+
+    override val completion: CompletableFuture<Boolean> = CompletableFuture()
 
     override fun <T : Any> put(key: String, value: T) {
         if (objectByKey.putIfAbsent(key, value) != null) {

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -12,17 +12,30 @@ import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Duration.ofSeconds
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
 
+@Suppress("ExplicitGarbageCollectionCall")
 class SandboxGroupContextCacheTest {
     private companion object {
         private const val TIMEOUT = 60L
+
+        private fun createRandomFilter() = "(uuid=${UUID.randomUUID()})"
+        private fun mockSandboxContext(name: String? = null): CloseableSandboxGroupContext = mock(name = name) {
+            val completable = CompletableFuture<Boolean>()
+            whenever(it.completion).doReturn(completable)
+        }
     }
+
     private lateinit var idBob: HoldingIdentity
     private lateinit var idAlice: HoldingIdentity
     private lateinit var vNodeContext1: VirtualNodeContext
@@ -43,18 +56,19 @@ class SandboxGroupContextCacheTest {
     @Test
     fun `when cache is full, evict and do not close evicted sandbox if still in use`() {
         val cache = SandboxGroupContextCacheImpl(1)
-        val sandboxContext1 = mock<CloseableSandboxGroupContext>()
+        val sandboxContext1 = mockSandboxContext()
         val contextStrongRef = cache.get(vNodeContext1) { sandboxContext1 }
         assertThat(contextStrongRef).isNotNull
 
         @Suppress("UnusedPrivateMember")
         for (i in 1..50) {
-            cache.get(mock {
-                on { holdingIdentity } doReturn idBob
-                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            }) { mock() }
+            cache.get(VirtualNodeContext(
+                holdingIdentity = idBob,
+                cpkFileChecksums = emptySet(),
+                sandboxGroupType = SandboxGroupType.FLOW,
+                serviceFilter = createRandomFilter()
+            )) { mockSandboxContext() }
 
-            @Suppress("ExplicitGarbageCollectionCall")
             System.gc()
         }
 
@@ -65,17 +79,24 @@ class SandboxGroupContextCacheTest {
     @Test
     fun `when cache is full, evict and close evicted sandbox if not in use anymore`() {
         val cache = SandboxGroupContextCacheImpl(1)
-        val sandboxContext1: CloseableSandboxGroupContext = spy()
+        val sandboxContext1: CloseableSandboxGroupContext = spy() {
+            val completable = CompletableFuture<Boolean>()
+            whenever(it.completion).doReturn(completable)
+        }
         var contextStrongRef: SandboxGroupContext? = cache.get(vNodeContext1) { sandboxContext1 }
         assertThat(contextStrongRef).isNotNull
 
         // Trigger some evictions, close should not be invoked (there's at least one strong reference to the context)
         @Suppress("UnusedPrivateMember")
         for (i in 1..50) {
-            cache.get(mock {
-                on { holdingIdentity } doReturn idBob
-                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            }) { mock() }
+            cache.get(
+                VirtualNodeContext(
+                holdingIdentity = idBob,
+                cpkFileChecksums = emptySet(),
+                sandboxGroupType = SandboxGroupType.FLOW,
+                serviceFilter = createRandomFilter()
+            )
+            ) { mockSandboxContext() }
         }
         verify(sandboxContext1, never()).close()
 
@@ -87,37 +108,40 @@ class SandboxGroupContextCacheTest {
         // references to the wrapper and the Garbage Collector should eventually update the internal [ReferenceQueue])
         eventually(duration = ofSeconds(TIMEOUT), waitBetween = ofSeconds(1)) {
             // Trigger Garbage Collection so the internal [ReferenceQueue] is updated
-            @Suppress("ExplicitGarbageCollectionCall")
             System.gc()
 
             // Trigger another Cache Eviction to force the internal purge
-            cache.get(mock {
-                on { holdingIdentity } doReturn idBob
-                on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            }) { mock() }
+            cache.get(VirtualNodeContext(
+                holdingIdentity = idBob,
+                cpkFileChecksums = emptySet(),
+                sandboxGroupType = SandboxGroupType.FLOW,
+                serviceFilter = createRandomFilter()
+            )) { mockSandboxContext() }
 
             // Check that the evicted SandBoxGroup has been closed
             verify(sandboxContext1).close()
         }
     }
 
-    @Suppress("unused_variable", "unused_value")
+    @Suppress("unused_value")
     @Test
-    fun `when cache flushed, close everything`() {
+    fun `when cache closed, close everything`() {
         val cache = SandboxGroupContextCacheImpl(10)
-        val vNodeContext2 = mock<VirtualNodeContext> {
-            on { sandboxGroupType } doReturn SandboxGroupType.FLOW
-            on { holdingIdentity } doReturn idBob
-        }
-        val sandboxContext1 = mock<CloseableSandboxGroupContext>()
-        val sandboxContext2 = mock<CloseableSandboxGroupContext>()
+        val vNodeContext2 = VirtualNodeContext(
+            holdingIdentity = idBob,
+            cpkFileChecksums = setOf(SecureHash.parse("DUMMY:1234567890abcdef")),
+            sandboxGroupType = SandboxGroupType.FLOW,
+            serviceFilter = createRandomFilter()
+        )
+        val sandboxContext1 = mockSandboxContext()
+        val sandboxContext2 = mockSandboxContext()
 
         var ref1: SandboxGroupContext? = cache.get(vNodeContext1) { sandboxContext1 }
         assertThat(ref1).isNotNull
         var ref2: SandboxGroupContext? = cache.get(vNodeContext2) { sandboxContext2 }
         assertThat(ref2).isNotNull
 
-        cache.flush()
+        cache.close()
 
         eventually(duration = ofSeconds(TIMEOUT)) {
             assertThat(cache.evictedContextsToBeClosed).isEqualTo(2)
@@ -125,10 +149,9 @@ class SandboxGroupContextCacheTest {
 
         ref1 = null
         ref2 = null
-        @Suppress("ExplicitGarbageCollectionCall")
-        System.gc()
 
         eventually(duration = ofSeconds(TIMEOUT)) {
+            System.gc()
             assertThat(cache.evictedContextsToBeClosed).isEqualTo(0)
         }
 
@@ -140,32 +163,40 @@ class SandboxGroupContextCacheTest {
     @Test
     fun `when remove also close`() {
         val cache = SandboxGroupContextCacheImpl(10)
-        val sandboxContext1 = mock<CloseableSandboxGroupContext>()
+        val sandboxContext1 = mockSandboxContext()
 
         var ref: SandboxGroupContext? = cache.get(vNodeContext1) { sandboxContext1 }
         assertThat(ref).isNotNull
-        cache.remove(vNodeContext1)
+        val completion = cache.remove(vNodeContext1.copy())
+            ?: fail("No sandbox for $vNodeContext1")
 
         eventually(duration = ofSeconds(TIMEOUT)) {
             assertThat(cache.evictedContextsToBeClosed).isEqualTo(1)
+            assertThat(completion.isDone).isFalse
         }
 
         ref = null
-        @Suppress("ExplicitGarbageCollectionCall")
-        System.gc()
 
         eventually(duration = ofSeconds(TIMEOUT)) {
+            System.gc()
             assertThat(cache.evictedContextsToBeClosed).isEqualTo(0)
+            assertThat(completion.isDone).isTrue
         }
 
         verify(sandboxContext1).close()
     }
 
     @Test
+    fun removingMissingKeyReturnsNull() {
+        val cache = SandboxGroupContextCacheImpl(10)
+        assertThat(cache.remove(vNodeContext1)).isNull()
+    }
+
+    @Test
     fun `when in cache retrieve same`() {
         val cache = SandboxGroupContextCacheImpl(10)
-        val sandboxContext1 = cache.get(vNodeContext1) { mock(name = "ctx1") }
-        val retrievedContext = cache.get(vNodeContext1) { mock(name = "ctx2") }
+        val sandboxContext1 = cache.get(vNodeContext1) { mockSandboxContext(name = "ctx1") }
+        val retrievedContext = cache.get(vNodeContext1) { mockSandboxContext(name = "ctx2") }
 
         assertThat(cache.evictedContextsToBeClosed).isEqualTo(0)
         assertThat(retrievedContext).isSameAs(sandboxContext1)
@@ -187,10 +218,92 @@ class SandboxGroupContextCacheTest {
             "filter"
         )
 
-        val sandboxContext1 = cache.get(vnodeContext1) { mock(name = "ctx1") }
-        val retrievedContext = cache.get(equalVnodeContext1) { mock(name = "ctx2") }
+        val sandboxContext1 = cache.get(vnodeContext1) { mockSandboxContext(name = "ctx1") }
+        val retrievedContext = cache.get(equalVnodeContext1) { mockSandboxContext(name = "ctx2") }
 
         assertThat(cache.evictedContextsToBeClosed).isEqualTo(0)
         assertThat(retrievedContext).isSameAs(sandboxContext1)
+    }
+
+    @Test
+    fun testEmptyCacheFlushesImmediately() {
+        val cache = SandboxGroupContextCacheImpl(10)
+        val completion = cache.flush()
+        assertThat(completion.isDone).isTrue
+        assertThat(cache.waitFor(completion, ofSeconds(0))).isTrue
+    }
+
+    @Suppress("unused_value")
+    @Test
+    fun testCacheFlushesCurrentContents() {
+        val cache = SandboxGroupContextCacheImpl(10)
+        val vNodeContext2 = VirtualNodeContext(
+            holdingIdentity = idAlice,
+            cpkFileChecksums = emptySet(),
+            sandboxGroupType = SandboxGroupType.FLOW,
+            serviceFilter = createRandomFilter()
+        )
+        val vNodeContext3 = VirtualNodeContext(
+            holdingIdentity = idBob,
+            cpkFileChecksums = emptySet(),
+            sandboxGroupType = SandboxGroupType.FLOW,
+            serviceFilter = createRandomFilter()
+        )
+
+        val sandboxContext1 = mockSandboxContext()
+        val sandboxContext2 = mockSandboxContext()
+        val sandboxContext3 = mockSandboxContext()
+
+        var ref1: SandboxGroupContext? = cache.get(vNodeContext1) { sandboxContext1 }
+        var ref2: SandboxGroupContext? = cache.get(vNodeContext2) { sandboxContext2 }
+        assertThat(ref1).isNotNull
+        assertThat(ref2).isNotNull
+
+        val completion = cache.flush()
+        assertThat(completion.isDone).isFalse
+
+        cache.get(vNodeContext3) { sandboxContext3 }
+
+        ref1 = null
+        ref2 = null
+
+        eventually(duration = ofSeconds(TIMEOUT)) {
+            System.gc()
+            assertThat(cache.waitFor(completion, ofSeconds(1))).isTrue
+            assertThat(completion.isDone).isTrue
+        }
+        assertThat(sandboxContext1.completion.isDone).isTrue
+        assertThat(sandboxContext2.completion.isDone).isTrue
+        assertThat(sandboxContext3.completion.isDone).isFalse
+        verify(sandboxContext1).close()
+        verify(sandboxContext2).close()
+        verify(sandboxContext3, never()).close()
+    }
+
+    @Suppress("unused_value")
+    @Test
+    fun testFlushingSandboxWithExceptionOnClose() {
+        val cache = SandboxGroupContextCacheImpl(10)
+
+        val sandboxContext1 = mock<CloseableSandboxGroupContext> {
+            val completable = CompletableFuture<Boolean>()
+            whenever(it.completion).doReturn(completable)
+            whenever(it.close()).doThrow(Exception("Failed to close sandbox"))
+        }
+        var ref1: SandboxGroupContext? = cache.get(vNodeContext1) { sandboxContext1 }
+        assertThat(ref1).isNotNull
+
+        val completion = cache.flush()
+        assertThat(completion.isDone).isFalse
+
+        ref1 = null
+
+        eventually(duration = ofSeconds(TIMEOUT)) {
+            System.gc()
+            assertThat(cache.waitFor(completion, ofSeconds(1))).isTrue
+            assertThat(completion.isDone).isTrue
+        }
+        assertThat(sandboxContext1.completion.isCompletedExceptionally).isTrue
+        verify(sandboxContext1).close()
     }
 }

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContext.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupContext.kt
@@ -1,5 +1,6 @@
 package net.corda.sandboxgroupcontext
 
+import java.util.concurrent.CompletableFuture
 import net.corda.sandbox.SandboxGroup
 
 /**
@@ -26,4 +27,9 @@ interface SandboxGroupContext : SandboxGroupContextData {
      * @return null if it doesn't exist.
      */
     fun <T : Any> get(key: String, valueType: Class<out T>): T?
+
+    /**
+     * This completes when this [SandboxGroupContext] is ready to destroy.
+     */
+    val completion: CompletableFuture<Boolean>
 }

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/VirtualNodeService.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/VirtualNodeService.kt
@@ -1,9 +1,11 @@
 package net.corda.testing.sandboxes.testkit
 
-import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.virtualnode.VirtualNodeInfo
+import java.util.concurrent.CompletableFuture
 
 interface VirtualNodeService {
     fun loadVirtualNode(resourceName: String): VirtualNodeInfo
-    fun unloadSandbox(sandboxGroupContext: SandboxGroupContext)
+    fun releaseVirtualNode(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
+    fun unloadVirtualNode(completion: CompletableFuture<*>)
 }

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
@@ -1,6 +1,6 @@
 package net.corda.testing.sandboxes.testkit.impl
 
-import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
@@ -11,6 +11,8 @@ import net.corda.virtualnode.VirtualNodeInfo
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.time.Duration.ofSeconds
+import java.util.concurrent.CompletableFuture
 import java.util.UUID
 
 @Suppress("unused")
@@ -27,16 +29,13 @@ class VirtualNodeServiceImpl @Activate constructor(
 ) : VirtualNodeService {
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
+        private val ONE_SECOND = ofSeconds(1)
 
         private fun generateHoldingIdentity()
             = HoldingIdentity(MemberX500Name.parse(X500_NAME), UUID.randomUUID().toString())
     }
 
     init {
-        resetSandboxCache()
-    }
-
-    private fun resetSandboxCache() {
         sandboxGroupContextComponent.initCache(1)
     }
 
@@ -44,8 +43,18 @@ class VirtualNodeServiceImpl @Activate constructor(
         return virtualNodeLoader.loadVirtualNode(resourceName, generateHoldingIdentity())
     }
 
-    override fun unloadSandbox(sandboxGroupContext: SandboxGroupContext) {
-        (sandboxGroupContext as? AutoCloseable)?.close()
-        resetSandboxCache()
+    override fun releaseVirtualNode(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>? {
+        return sandboxGroupContextComponent.remove(virtualNodeContext)
+    }
+
+    /**
+     * Wait for a sandbox to be garbage collected. Ensure that invoking test can time out,
+     * because the sandbox cannot be collected if it is still referenced somewhere.
+     */
+    override fun unloadVirtualNode(completion: CompletableFuture<*>) {
+        do {
+            @Suppress("ExplicitGarbageCollectionCall")
+            System.gc()
+        } while (!sandboxGroupContextComponent.waitFor(completion, ONE_SECOND))
     }
 }


### PR DESCRIPTION
Add a `CompletableFuture` to each `SandboxGroupContext` that completes once it is closed. This allows us to wait until sandboxes that have been flushed or removed from the cache are actually destroyed, although this isn't something that we are likely to _want_ to do outside of test code.

In practice, sandboxes should not be destroyed while still in use, and so the `CompletableFuture` will _not_ complete until all strong references to the sandbox have been lost and the Garbage Collector has run. I have therefore refactored the integration tests accordingly.