### PR TITLE
CORE-7100 Add getVirtualNode endpoint

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -314,6 +314,23 @@ class VirtualNodeRpcTest {
 
     @Test
     @Order(61)
+    fun `get a virtual node`() {
+        cluster {
+            endpoint(CLUSTER_URI, USERNAME, PASSWORD)
+
+            assertWithRetry {
+                timeout(Duration.of(30, ChronoUnit.SECONDS))
+                command { getVNode(aliceHoldingId) }
+                condition { response ->
+                    val vNodeInfo = response.toJson()["holdingIdentity"]["x500Name"].textValue()
+                    response.code == 200 && vNodeInfo.contains(aliceX500)
+                }
+            }
+        }
+    }
+
+    @Test
+    @Order(62)
     fun `set virtual node state`() {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
@@ -117,6 +117,9 @@ class ClusterBuilder {
     /** List all virtual nodes */
     fun vNodeList() = client!!.get("/api/v1/virtualnode")
 
+    /** List all virtual nodes */
+    fun getVNode(holdingIdentityShortHash: String) = client!!.get("/api/v1/virtualnode/$holdingIdentityShortHash")
+
     /**
      * Register a member to the network
      */

--- a/components/virtual-node/virtual-node-rpcops-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':components:configuration:configuration-read-service')
     implementation project(':components:virtual-node:virtual-node-management-sender')
     implementation project(':components:virtual-node:virtual-node-info-read-service')
+    implementation project(":components:virtual-node:virtual-node-info-read-service-rpc-extensions")
     implementation project(':libs:virtual-node:virtual-node-common')
     implementation project(':libs:virtual-node:virtual-node-endpoints')
     implementation project(':libs:virtual-node:virtual-node-info')

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
@@ -10,6 +10,7 @@ import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.httprpc.PluggableRPCOps
 import net.corda.httprpc.exception.InvalidInputDataException
+import net.corda.httprpc.exception.ResourceNotFoundException
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.cpiupload.endpoints.v1.CpiIdentifier
@@ -34,6 +35,8 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.ShortHash
+import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.rpcops.common.VirtualNodeSender
 import net.corda.virtualnode.rpcops.common.VirtualNodeSenderFactory
@@ -163,6 +166,25 @@ internal class VirtualNodeRPCOpsImpl @Activate constructor(
             "${this.javaClass.simpleName} is not running! Its status is: ${lifecycleCoordinator.status}"
         )
         return VirtualNodes(virtualNodeInfoReadService.getAll().map { it.toEndpointType() })
+    }
+
+    /**
+     * Retrieves the VirtualNodeInfo for a virtual node with the given ShortHash from the message bus
+     *
+     * @throws ResourceNotFoundException is thrown if no Virtual node with the given ShortHash was found.
+     * @return [VirtualNodeInfo] for the corresponding ShortHash
+     *
+     * @see VirtualNodes
+     * @see VirtualNodeInfo
+     */
+    override fun getVirtualNode(holdingIdentityShortHash: String): VirtualNodeInfo {
+        val shortHash = ShortHash.parseOrThrow(holdingIdentityShortHash)
+        val virtualNode = virtualNodeInfoReadService.getByHoldingIdentityShortHash(shortHash)
+
+        if (virtualNode == null) {
+            throw ResourceNotFoundException("VirtualNode with shortHash $holdingIdentityShortHash could not be found.")
+        }
+        return virtualNode.toEndpointType()
     }
 
     /**

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRPCOps.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRPCOps.kt
@@ -5,6 +5,8 @@ import net.corda.httprpc.annotations.HttpRpcGET
 import net.corda.httprpc.annotations.HttpRpcPOST
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
 import net.corda.httprpc.annotations.HttpRpcResource
+import net.corda.httprpc.annotations.HttpRpcPathParameter
+import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
@@ -44,4 +46,21 @@ interface VirtualNodeRPCOps : RpcOps {
         responseDescription = "List of virtual node details."
     )
     fun getAllVirtualNodes(): VirtualNodes
+
+    /**
+     * Returns the VirtualNodeInfo for a given [HoldingIdentity].
+     *
+     * @throws 'ResourceNotFoundException' If the virtual node was not found.
+     * @throws `HttpApiException` If the request returns an exceptional response.
+     */
+    @HttpRpcGET(
+        path = "{holdingIdentityShortHash}",
+        title = "Gets the VirtualNodeInfo for a HoldingIdentity",
+        description = "This method returns the VirtualNodeInfo for a given Holding Identity.",
+        responseDescription = "VirtualNodeInfo for the specified virtual node."
+    )
+    fun getVirtualNode(
+        @HttpRpcPathParameter(description = "The short hash of the holding identity; obtained during node registration")
+        holdingIdentityShortHash: String
+    ): VirtualNodeInfo
 }

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRPCOps.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRPCOps.kt
@@ -55,8 +55,8 @@ interface VirtualNodeRPCOps : RpcOps {
      */
     @HttpRpcGET(
         path = "{holdingIdentityShortHash}",
-        title = "Gets the VirtualNodeInfo for a HoldingIdentity",
-        description = "This method returns the VirtualNodeInfo for a given Holding Identity.",
+        title = "Gets the VirtualNodeInfo for a HoldingIdentityShortHash",
+        description = "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
         responseDescription = "VirtualNodeInfo for the specified virtual node."
     )
     fun getVirtualNode(

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -2919,6 +2919,43 @@
           }
         }
       }
+    },
+    "/virtualnode/{holdingidentityshorthash}" : {
+      "get" : {
+        "tags" : [ "Virtual Node API" ],
+        "description" : "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
+        "operationId" : "get_virtualnode__holdingidentityshorthash_",
+        "parameters" : [ {
+          "name" : "holdingidentityshorthash",
+          "in" : "path",
+          "description" : "The short hash of the holding identity; obtained during node registration",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The short hash of the holding identity; obtained during node registration",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "VirtualNodeInfo for the specified virtual node.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VirtualNodeInfo"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
     }
   },
   "components" : {


### PR DESCRIPTION
Adds the getVirtualNode endpoint to VirtualNodeRpcOps. This returns the VirtualNodeInfo for the virtual node with the specified HoldingIdentityShorthash. 