### PR TITLE
CORE-9054 Starting a flow fails due to security permissions

### DIFF
--- a/applications/workers/release/combined-worker/README.md
+++ b/applications/workers/release/combined-worker/README.md
@@ -191,4 +191,5 @@ See [metrics](../../../../metrics/readme.md) for further documentation.
 
 Security Manager can get in the way when debugging the code that runs inside the sandbox. For example, evaluating an expression while debugging a flow might result with access denied error. 
 To initialize Security Manager with all permissions enabled, start the worker with command line argument `-DsecurityPolicyAllPermissions=true`.
-Note that this argument should be used only for development purposes.  
+To disable Security Manager, start the worker with command line argument `-DsecurityMangerEnabled=false`.
+Note that these arguments should be used only for development purposes.  

--- a/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityManagerServiceImpl.kt
+++ b/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityManagerServiceImpl.kt
@@ -46,9 +46,14 @@ class SecurityManagerServiceImpl @Activate constructor(
     private var cordaSecurityManager: CordaSecurityManager? = null
 
     init {
-        enablePackageAccessPermission("net.corda.")
-        startRestrictiveMode()
-        applyDefaultSecurityPolicy(bundleContext)
+        if (System.getProperty("securityMangerEnabled", "true").toBoolean()) {
+            enablePackageAccessPermission("net.corda.")
+            startRestrictiveMode()
+            applyDefaultSecurityPolicy(bundleContext)
+        } else {
+            log.warn("Security Manager disabled")
+            System.setSecurityManager(null)
+        }
     }
 
     /**


### PR DESCRIPTION
- Added system property `securityMangerEnabled` that can be used to disable Security Manager