### PR TITLE
NOTICK: ensure correct tag is consumed for beta1 corda-cli base image

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -296,7 +296,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             tagContainer(builder, "${tagPrefix}${version}")
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "${tagPrefix}unstable-fox") //not to be merged back to release/os/5.0
+            tagContainer(builder, "${tagPrefix}unstable-fox") // not to be merged back to release/os/5.0
             gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -296,7 +296,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             tagContainer(builder, "${tagPrefix}${version}")
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "${tagPrefix}unstable-fox")
+            tagContainer(builder, "${tagPrefix}unstable-fox") //not to be merged back to release/os/5.0
             gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -296,7 +296,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             tagContainer(builder, "${tagPrefix}${version}")
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com/corda-os-${containerName}"
-            tagContainer(builder, "${tagPrefix}unstable")
+            tagContainer(builder, "${tagPrefix}unstable-fox")
             gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -133,7 +133,7 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('cliBaseTag')) {
         baseImageTag = cliBaseTag
     } else {
-        it.baseImageTag = (cordaCliIncluded) ? "latest-local" : "unstable-fox" //not to be merged back to release/os/5.0
+        it.baseImageTag = (cordaCliIncluded) ? "latest-local" : "unstable-fox" // not to be merged back to release/os/5.0
     }
 
     if (project.hasProperty('useDockerDaemon')) {

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -133,7 +133,7 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('cliBaseTag')) {
         baseImageTag = cliBaseTag
     } else {
-        it.baseImageTag = (cordaCliIncluded) ? "latest-local" : "unstable"
+        it.baseImageTag = (cordaCliIncluded) ? "latest-local" : "unstable-fox" //not to be merged back to release/os/5.0
     }
 
     if (project.hasProperty('useDockerDaemon')) {


### PR DESCRIPTION
Follow on from https://github.com/corda/corda-cli-plugin-host/pull/127 

- update tagging to ensure we are consuming the correct base image from the beta1 release branch (unstable-fox)
- ensure we don't clobber `unstable` update to `unstable-fox` in line with product code name