### PR TITLE
CORE-4251: Conditionally Add Topic Prefix

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaConversions.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaConversions.kt
@@ -29,7 +29,11 @@ fun CordaConsumerRecord<*, *>.toKafkaRecord():
 }
 
 fun CordaTopicPartition.toTopicPartition(topicPrefix: String): TopicPartition {
-    return TopicPartition(topicPrefix + topic, partition)
+    return if (topic.startsWith(topicPrefix)) {
+        TopicPartition(topic, partition)
+    } else {
+        TopicPartition(topicPrefix + topic, partition)
+    }
 }
 
 fun TopicPartition.toCordaTopicPartition(topicPrefix: String): CordaTopicPartition {
@@ -38,4 +42,3 @@ fun TopicPartition.toCordaTopicPartition(topicPrefix: String): CordaTopicPartiti
 
 fun Collection<CordaTopicPartition>.toTopicPartitions(topicPrefix: String) = this.map { it.toTopicPartition(topicPrefix) }
 fun Collection<TopicPartition>.toCordaTopicPartitions(topicPrefix: String ) = this.map { it.toCordaTopicPartition(topicPrefix) }
-

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
@@ -1,0 +1,50 @@
+package net.corda.messaging.kafka.subscription.net.corda.messagebus.kafka.utils
+
+import net.corda.messagebus.api.CordaTopicPartition
+import net.corda.messagebus.kafka.utils.toCordaTopicPartition
+import net.corda.messagebus.kafka.utils.toTopicPartition
+import org.apache.kafka.common.TopicPartition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class KafkaConversionsTest {
+    private val partition = 100
+    private val topicName = "topic1"
+    private val testTopicPrefix = "test-"
+
+    @Test
+    fun toTopicPartitionAddsPrefixToTopic() {
+        val cordaTopicPartition = CordaTopicPartition(topicName, partition)
+        val topicPartition = cordaTopicPartition.toTopicPartition(testTopicPrefix)
+
+        assertThat(topicPartition.partition()).isEqualTo(partition)
+        assertThat(topicPartition.topic()).isEqualTo("$testTopicPrefix$topicName")
+    }
+
+    @Test
+    fun toTopicPartitionDoesNotAddPrefixToTopicWhenPrefixAlreadyAdded() {
+        val cordaTopicPartition = CordaTopicPartition("$testTopicPrefix$topicName", partition)
+        val topicPartition = cordaTopicPartition.toTopicPartition(testTopicPrefix)
+
+        assertThat(topicPartition.partition()).isEqualTo(partition)
+        assertThat(topicPartition.topic()).isEqualTo("$testTopicPrefix$topicName")
+    }
+
+    @Test
+    fun toCordaTopicPartitionRemovesPrefixFromTopic() {
+        val topicPartition = TopicPartition("$testTopicPrefix$topicName", partition)
+        val cordaTopicPartition = topicPartition.toCordaTopicPartition(testTopicPrefix)
+
+        assertThat(cordaTopicPartition.partition).isEqualTo(partition)
+        assertThat(cordaTopicPartition.topic).isEqualTo(topicName)
+    }
+
+    @Test
+    fun toCordaTopicPartitionDoesNotRemoveAnythingWhenPrefixIsNotFound() {
+        val topicPartition = TopicPartition(topicName, partition)
+        val cordaTopicPartition = topicPartition.toCordaTopicPartition(testTopicPrefix)
+
+        assertThat(cordaTopicPartition.partition).isEqualTo(partition)
+        assertThat(cordaTopicPartition.topic).isEqualTo(topicName)
+    }
+}

--- a/testing/message-patterns/kafka-docker/single-kafka-cluster.yml
+++ b/testing/message-patterns/kafka-docker/single-kafka-cluster.yml
@@ -41,7 +41,7 @@ services:
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=0.0.0.0:2888:3888;2181
 
   broker1:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: broker1
     container_name: broker1
@@ -61,7 +61,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INTER_BROKER
 
   broker2:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: broker2
     container_name: broker2
@@ -81,7 +81,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INTER_BROKER
 
   broker3:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: broker3
     container_name: broker3

--- a/testing/message-patterns/kafka-docker/two-kafka-clusters.yml
+++ b/testing/message-patterns/kafka-docker/two-kafka-clusters.yml
@@ -36,7 +36,7 @@ services:
   ## Kafka cluster 1
 
   cluster1-broker1:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: cluster1-broker1
     container_name: cluster1-broker1
@@ -54,7 +54,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INTER_BROKER
 
   cluster1-broker2:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: cluster1-broker2
     container_name: cluster1-broker2
@@ -72,7 +72,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INTER_BROKER
 
   cluster1-broker3:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: cluster1-broker3
     container_name: cluster1-broker3
@@ -93,7 +93,7 @@ services:
   ## Kafka cluster 2
 
   cluster2-broker1:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: cluster2-broker1
     container_name: cluster2-broker1
@@ -111,7 +111,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INTER_BROKER
 
   cluster2-broker2:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: cluster2-broker2
     container_name: cluster2-broker2
@@ -129,7 +129,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INTER_BROKER
 
   cluster2-broker3:
-    image: confluentinc/cp-kafka:6.1.1
+    image: confluentinc/cp-kafka
     restart: "no"
     hostname: cluster2-broker3
     container_name: cluster2-broker3


### PR DESCRIPTION
When mapping between corda TopicPartition and kafka TopicPartition, add
the prefix to the name if and only if it does not exist already.

- Add unit tests.
- Remove duplicate methods.
- Update latest kafka image in docker compose configuration to be
  aligned with the other containers and allow using ARM architectures.
