### PR TITLE
NOTICK: revert to build 3 times a day for beta1 branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('corda-shared-build-pipeline-steps@beta-program') _
 
 cordaPipeline(
-    dailyBuildCron: 'H H/3 * * *',
+    dailyBuildCron: 'H 07 * * *',
     nexusAppId: 'flow-worker-5.0',
     runIntegrationTests: true,
     createPostgresDb: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('corda-shared-build-pipeline-steps@beta-program') _
 
 cordaPipeline(
-    dailyBuildCron: 'H 07 * * *',
+    dailyBuildCron: 'H H/3 * * *,
     nexusAppId: 'flow-worker-5.0',
     runIntegrationTests: true,
     createPostgresDb: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 @Library('corda-shared-build-pipeline-steps@beta-program') _
 
 cordaPipeline(
-    dailyBuildCron: 'H H/3 * * *,
+    dailyBuildCron: 'H H/8 * * *',
     nexusAppId: 'flow-worker-5.0',
     runIntegrationTests: true,
     createPostgresDb: true,


### PR DESCRIPTION
Having both release branches producing docker images every 3 hours is hammering corda-os-docker repo,  scale this back to just build 3 times a day for beta1 branch