### PR TITLE
CORE-8420: Simulator's RequestData outputs correct json to logs

### DIFF
--- a/simulator/api/src/main/kotlin/net/corda/simulator/RequestData.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/RequestData.kt
@@ -26,7 +26,7 @@ interface RequestData {
     /**
      * A JSON string containing the request body to be passed to the flow.
      */
-    val requestBody: String
+    val requestData: String
     fun toRPCRequestData(): RPCRequestData
 
     companion object {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/RPCRequestDataWrapper.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/RPCRequestDataWrapper.kt
@@ -15,7 +15,7 @@ import net.corda.v5.application.marshalling.MarshallingService
 data class RPCRequestDataWrapper(
     override val clientRequestId : String,
     override val flowClassName: String,
-    override val requestBody: String)
+    override val requestData: String)
     : RequestData {
 
     /**
@@ -24,15 +24,15 @@ data class RPCRequestDataWrapper(
     override fun toRPCRequestData() : RPCRequestData {
         return object : RPCRequestData {
             override fun getRequestBody(): String {
-                return requestBody
+                return requestData
             }
 
             override fun <T> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
-                return marshallingService.parse(requestBody, clazz)
+                return marshallingService.parse(requestData, clazz)
             }
 
             override fun <T> getRequestBodyAsList(marshallingService: MarshallingService, clazz: Class<T>): List<T> {
-                return marshallingService.parseList(requestBody, clazz)
+                return marshallingService.parseList(requestData, clazz)
             }
 
         }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
@@ -54,10 +54,8 @@ class SimulatedInstanceNodeBase(
                         "was not an RPCStartableFlow"
             )
         }
-        log.info(
-            "Calling flow instance for member \"$member\" and protocol \"$protocol\" " +
-                    "with request: ${input.requestBody}"
-        )
+        log.info("Calling flow instance for member \"$member\" and protocol \"$protocol\" " +
+                "with request: ${input.requestData}")
         injector.injectServices(
             FlowAndProtocol(flow, protocol),
             member,

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
@@ -44,7 +44,7 @@ class SimulatedVirtualNodeBase(
 
     private fun doCallFlow(input: RequestData, contextPropertiesMap: Map<String, String>): String{
         val flowClassName = input.flowClassName
-        log.info("Calling flow $flowClassName for member \"$member\" with request: ${input.requestBody}")
+        log.info("Calling flow $flowClassName for member \"$member\" with request: ${input.requestData}")
         val flow = flowFactory.createInitiatingFlow(member, flowClassName)
         injector.injectServices(
             FlowAndProtocol(flow),

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/serialization/SimpleJsonMarshallingService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/serialization/SimpleJsonMarshallingService.kt
@@ -59,9 +59,9 @@ class SimpleJsonMarshallingService(
             val node: JsonNode = p.codec.readTree(p)
             val clientRequestId = node.get("clientRequestId").asText()
             val flowClassName = node.get("flowClassName").asText()
-            val requestBody = node.get("requestBody").asText()
+            val requestData = node.get("requestData").asText()
 
-            return RPCRequestDataWrapper(clientRequestId, flowClassName, requestBody)
+            return RPCRequestDataWrapper(clientRequestId, flowClassName, requestData)
         }
 
     }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/RPCRequestDataWrapperFactoryTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/RPCRequestDataWrapperFactoryTest.kt
@@ -16,7 +16,7 @@ class RPCRequestDataWrapperFactoryTest {
           "httpStartFlow": {
             "clientRequestId": "r1",
             "flowClassName": "${HelloFlow::class.java.name}",
-            "requestBody":  "{ \"a\" : 6, \"b\" : 7 }"
+            "requestData":  "{ \"a\" : 6, \"b\" : 7 }"
           }
         }
         """.trimIndent()


### PR DESCRIPTION
Simulator's RequestData object had "requestBody" instead of "requestData". The json output from this object can now be used with real Corda too.