### PR TITLE
CORE-9149 Remove temporary methods for backchain testing

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -1,8 +1,6 @@
 package net.corda.ledger.utxo.flow.impl
 
 import net.corda.ledger.common.data.transaction.TransactionStatus
-import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
-import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.flows.finality.UtxoFinalityFlow
 import net.corda.ledger.utxo.flow.impl.flows.finality.UtxoReceiveFinalityFlow
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
@@ -111,23 +109,5 @@ class UtxoLedgerServiceImpl @Activate constructor(
             throw e.exception
         }
         return flowEngine.subFlow(utxoReceiveFinalityFlow)
-    }
-
-    @Deprecated("Temporary until finality flow is completed")
-    @Suspendable
-    override fun persistTransaction(signedTransaction: UtxoSignedTransaction) {
-        utxoLedgerPersistenceService.persist(signedTransaction, TransactionStatus.VERIFIED)
-    }
-
-    @Deprecated("Temporary until finality flow is completed")
-    @Suspendable
-    override fun resolveBackchain(signedTransaction: UtxoSignedTransaction, session: FlowSession) {
-        flowEngine.subFlow(TransactionBackchainResolutionFlow(signedTransaction, session))
-    }
-
-    @Deprecated("Temporary until finality flow is completed")
-    @Suspendable
-    override fun sendBackchain(session: FlowSession) {
-        flowEngine.subFlow(TransactionBackchainSenderFlow(session))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.524-Fox-alpha-1672415546189
+cordaApiVersion=5.0.0.524-Fox-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.70
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.523-Fox-beta+
+cordaApiVersion=5.0.0.524-Fox-alpha-1672415546189
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.24


### PR DESCRIPTION
These methods are no longer needed and should exist on the API.