### PR TITLE
CORE-8965: Ignore trailing `/` in URL path

### DIFF
--- a/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/HttpRpcServerRequestsTest.kt
@@ -200,13 +200,15 @@ class HttpRpcServerRequestsTest : HttpRpcServerTestBase() {
     @Test
     fun `Verify permission check is performed on entity retrieval`() {
 
-        val fullUrl = "testentity/1234"
-        val helloResponse = client.call(GET, WebRequest<Any>(fullUrl), userName, password)
+        val fullUrlWithSlashes = "testentity/1234/"
+        val fullUrlWithoutSlash = "testentity/1234"
+        val helloResponse = client.call(GET, WebRequest<Any>(fullUrlWithSlashes), userName, password)
         assertEquals(HttpStatus.SC_OK, helloResponse.responseStatus)
         assertEquals("Retrieved using id: 1234", helloResponse.body)
 
         // Check full URL received by the Security Manager
-        assertThat(securityManager.checksExecuted.map { it.action }).hasSize(1).allMatch { it.contains(fullUrl) }
+        assertThat(securityManager.checksExecuted.map { it.action }).hasSize(1)
+            .allMatch { it == "GET:/api/v1/$fullUrlWithoutSlash" }
     }
 
     @Test

--- a/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ClientRequestContext.kt
+++ b/libs/http-rpc/http-rpc-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/context/ClientRequestContext.kt
@@ -86,7 +86,7 @@ interface ClientRequestContext {
         // Examples of strings will look like:
         // GET:/api/v1/permission/getpermission?id=c048679a-9654-4359-befc-9d2d22695a43
         // POST:/api/v1/user/createuser
-        return method + METHOD_SEPARATOR + path + if (!queryString.isNullOrBlank()) "?$queryString" else ""
+        return method + METHOD_SEPARATOR + path.trimEnd('/') + if (!queryString.isNullOrBlank()) "?$queryString" else ""
     }
 
     /**


### PR DESCRIPTION
When making permissions checks.