### PR TITLE
CORE-7099 move change vnode state to virtualnode resource path

### DIFF
--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CheckClusterRolesE2eTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/CheckClusterRolesE2eTest.kt
@@ -65,7 +65,7 @@ class CheckClusterRolesE2eTest {
             testToolkit.httpClientFor(PermissionEndpoint::class.java).use { permClient ->
                 val permProxy = permClient.start().proxy
                 val permissions = requiredRole.permissions.map { permProxy.getPermission(it.id) }
-                assertThat(permissions.size).withFailMessage("Permissions: $permissions").isEqualTo(6)
+                assertThat(permissions.size).withFailMessage("Permissions: $permissions").isEqualTo(8)
                 assertThat(permissions.map { it.permissionString }).contains("POST:/api/v1/virtualnode")
             }
         }
@@ -84,7 +84,7 @@ class CheckClusterRolesE2eTest {
             testToolkit.httpClientFor(PermissionEndpoint::class.java).use { permClient ->
                 val permProxy = permClient.start().proxy
                 val permissions = requiredRole.permissions.map { permProxy.getPermission(it.id) }
-                assertThat(permissions.size).withFailMessage("Permissions: $permissions").isEqualTo(3)
+                assertThat(permissions.size).withFailMessage("Permissions: $permissions").isEqualTo(2)
                 assertThat(permissions.map { it.permissionString }).contains("POST:/api/v1/maintenance/virtualnode/forcecpiupload")
             }
         }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/helpers/ClusterBuilder.kt
@@ -70,7 +70,7 @@ class ClusterBuilder {
         uploadCpiResource("/api/v1/cpi/", resourceName, groupId, staticMemberNames, cpiName)
 
     fun updateVirtualNodeState(holdingIdHash: String, newState: String) =
-        put("/api/v1/maintenance/virtualnode/$holdingIdHash/state/$newState", "")
+        put("/api/v1/virtualnode/$holdingIdHash/state/$newState", "")
 
     /** Assumes the resource is a CPB and converts it to CPI by adding a group policy file */
     fun forceCpiUpload(resourceName: String, groupId: String, staticMemberNames: List<String>, cpiName: String) =

--- a/components/virtual-node/virtual-node-rpcops-maintenance-impl/src/test/kotlin/net/corda/libs/virtualnode/maintenance/rpcops/impl/v1/VirtualNodeMaintenanceRPCOpsImplTest.kt
+++ b/components/virtual-node/virtual-node-rpcops-maintenance-impl/src/test/kotlin/net/corda/libs/virtualnode/maintenance/rpcops/impl/v1/VirtualNodeMaintenanceRPCOpsImplTest.kt
@@ -90,17 +90,6 @@ class VirtualNodeMaintenanceRPCOpsImplTest {
 
             verify(mockDownCoordinator).isRunning
         }
-
-        @Test
-        fun `verify exception throw if updateVirtualNodeState is performed while coordinator is not running`() {
-            val vnodeMaintenanceRpcOps =
-                VirtualNodeMaintenanceRPCOpsImpl(mockDownCoordinatorFactory, mock(), mock(), mock())
-            assertThrows<IllegalStateException> {
-                vnodeMaintenanceRpcOps.updateVirtualNodeState("someId", "someState")
-            }
-
-            verify(mockDownCoordinator).isRunning
-        }
     }
 
     @Nested

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRPCOpsImpl.kt
@@ -3,18 +3,23 @@ package net.corda.virtualnode.rpcops.impl.v1
 import java.time.Duration
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.data.ExceptionEnvelope
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.data.virtualnode.VirtualNodeCreateResponse
 import net.corda.data.virtualnode.VirtualNodeManagementRequest
 import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
+import net.corda.data.virtualnode.VirtualNodeStateChangeRequest
+import net.corda.data.virtualnode.VirtualNodeStateChangeResponse
 import net.corda.httprpc.PluggableRPCOps
+import net.corda.httprpc.exception.InternalServerException
 import net.corda.httprpc.exception.InvalidInputDataException
 import net.corda.httprpc.exception.ResourceNotFoundException
 import net.corda.httprpc.security.CURRENT_RPC_CONTEXT
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.cpiupload.endpoints.v1.CpiIdentifier
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRPCOps
+import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
@@ -243,6 +248,56 @@ internal class VirtualNodeRPCOpsImpl @Activate constructor(
             is VirtualNodeManagementResponseFailure -> throw translate(resolvedResponse.exception)
             else -> throw UnknownResponseTypeException(resp.responseType::class.java.name)
         }
+    }
+
+    // Lookup and update the virtual node for the given virtual node short ID.
+    //  This will update the last instance of said virtual node, sorted by CPI version
+    @Suppress("ForbiddenComment")
+    override fun updateVirtualNodeState(
+        virtualNodeShortId: String,
+        newState: String
+    ): ChangeVirtualNodeStateResponse {
+        val instant = clock.instant()
+        // Lookup actor to keep track of which RPC user triggered an update
+        val actor = CURRENT_RPC_CONTEXT.get().principal
+        logger.debug { "Received request to update state for $virtualNodeShortId to $newState by $actor at $instant" }
+        if (!isRunning) throw IllegalStateException(
+            "${this.javaClass.simpleName} is not running! Its status is: ${lifecycleCoordinator.status}"
+        )
+        // TODO: Validate newState
+        // Send request for update to kafka, precessed by the db worker in VirtualNodeWriterProcessor
+        val rpcRequest = VirtualNodeManagementRequest(
+            instant,
+            VirtualNodeStateChangeRequest(
+                virtualNodeShortId,
+                newState,
+                actor
+            )
+        )
+        // Actually send request and await response message on bus
+        val resp: VirtualNodeManagementResponse = sendAndReceive(rpcRequest)
+        logger.debug { "Received response to update for $virtualNodeShortId to $newState by $actor" }
+
+        return when (val resolvedResponse = resp.responseType) {
+            is VirtualNodeStateChangeResponse -> {
+                resolvedResponse.run {
+                    ChangeVirtualNodeStateResponse(holdingIdentityShortHash, virtualNodeState)
+                }
+            }
+            is VirtualNodeManagementResponseFailure -> throw handleFailure(resolvedResponse.exception)
+            else -> throw UnknownResponseTypeException(resp.responseType::class.java.name)
+        }
+    }
+
+    private fun handleFailure(exception: ExceptionEnvelope?): java.lang.Exception {
+        if (exception == null) {
+            logger.warn("Configuration Management request was unsuccessful but no exception was provided.")
+            return InternalServerException("Request was unsuccessful but no exception was provided.")
+        }
+        logger.warn(
+            "Remote request failed with exception of type ${exception.errorType}: ${exception.errorMessage}"
+        )
+        return InternalServerException(exception.errorMessage)
     }
 
     private fun HoldingIdentity.toEndpointType(): HoldingIdentityEndpointType =

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/v1/VirtualNodeRPCOpsImplTest.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/test/kotlin/net/corda/configuration/rpcops/impl/v1/VirtualNodeRPCOpsImplTest.kt
@@ -96,5 +96,16 @@ class VirtualNodeRPCOpsImplTest {
 
             verify(mockDownCoordinator).isRunning
         }
+
+        @Test
+        fun `verify exception throw if updateVirtualNodeState is performed while coordinator is not running`() {
+            val vnodeMaintenanceRpcOps =
+                VirtualNodeRPCOpsImpl(mockDownCoordinatorFactory, mock(), mock(), mock(), mockClockFactory)
+            assertThrows<IllegalStateException> {
+                vnodeMaintenanceRpcOps.updateVirtualNodeState("someId", "someState")
+            }
+
+            verify(mockDownCoordinator).isRunning
+        }
     }
 }

--- a/libs/virtual-node/virtual-node-endpoints-maintenance/src/main/kotlin/net/corda/libs/virtualnode/maintenance/endpoints/v1/VirtualNodeMaintenanceRPCOps.kt
+++ b/libs/virtual-node/virtual-node-endpoints-maintenance/src/main/kotlin/net/corda/libs/virtualnode/maintenance/endpoints/v1/VirtualNodeMaintenanceRPCOps.kt
@@ -3,11 +3,9 @@ package net.corda.libs.virtualnode.maintenance.endpoints.v1
 import net.corda.httprpc.HttpFileUpload
 import net.corda.httprpc.RpcOps
 import net.corda.httprpc.annotations.HttpRpcPOST
-import net.corda.httprpc.annotations.HttpRpcPUT
 import net.corda.httprpc.annotations.HttpRpcPathParameter
 import net.corda.httprpc.annotations.HttpRpcResource
 import net.corda.libs.cpiupload.endpoints.v1.CpiUploadRPCOps
-import net.corda.libs.virtualnode.maintenance.endpoints.v1.types.ChangeVirtualNodeStateResponse
 
 /**
  * Maintenance RPC operations for virtual node management.
@@ -51,24 +49,4 @@ interface VirtualNodeMaintenanceRPCOps : RpcOps {
         @HttpRpcPathParameter(description = "Short ID of the virtual node instance to rollback")
         virtualNodeShortId: String
     )
-
-    /**
-     * Updates a virtual nodes state.
-     *
-     * @throws `VirtualNodeRPCOpsServiceException` If the virtual node update request could not be published.
-     * @throws `HttpApiException` If the request returns an exceptional response.
-     */
-    @HttpRpcPUT(
-        path = "{virtualNodeShortId}/state/{newState}",
-        title = "Update virtual node state",
-        description = "This method updates the state of a new virtual node to one of the pre-defined values.",
-        responseDescription = "Complete information about updated virtual node which will also contain the updated state."
-    )
-    fun updateVirtualNodeState(
-        @HttpRpcPathParameter(description = "Short ID of the virtual node instance to update")
-        virtualNodeShortId: String,
-        @HttpRpcPathParameter(description = "State to transition virtual node instance into. " +
-                "Possible values are: IN_MAINTENANCE and ACTIVE.")
-        newState: String
-    ): ChangeVirtualNodeStateResponse
 }

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRPCOps.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRPCOps.kt
@@ -3,9 +3,11 @@ package net.corda.libs.virtualnode.endpoints.v1
 import net.corda.httprpc.RpcOps
 import net.corda.httprpc.annotations.HttpRpcGET
 import net.corda.httprpc.annotations.HttpRpcPOST
+import net.corda.httprpc.annotations.HttpRpcPUT
 import net.corda.httprpc.annotations.HttpRpcRequestBodyParameter
-import net.corda.httprpc.annotations.HttpRpcResource
 import net.corda.httprpc.annotations.HttpRpcPathParameter
+import net.corda.httprpc.annotations.HttpRpcResource
+import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
 import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
@@ -46,6 +48,26 @@ interface VirtualNodeRPCOps : RpcOps {
         responseDescription = "List of virtual node details."
     )
     fun getAllVirtualNodes(): VirtualNodes
+
+    /**
+     * Updates a virtual nodes state.
+     *
+     * @throws `VirtualNodeRPCOpsServiceException` If the virtual node update request could not be published.
+     * @throws `HttpApiException` If the request returns an exceptional response.
+     */
+    @HttpRpcPUT(
+        path = "{virtualNodeShortId}/state/{newState}",
+        title = "Update virtual node state",
+        description = "This method updates the state of a new virtual node to one of the pre-defined values.",
+        responseDescription = "Complete information about updated virtual node which will also contain the updated state."
+    )
+    fun updateVirtualNodeState(
+        @HttpRpcPathParameter(description = "Short ID of the virtual node instance to update")
+        virtualNodeShortId: String,
+        @HttpRpcPathParameter(description = "State to transition virtual node instance into. " +
+                "Possible values are: IN_MAINTENANCE and ACTIVE.")
+        newState: String
+    ): ChangeVirtualNodeStateResponse
 
     /**
      * Returns the VirtualNodeInfo for a given [HoldingIdentity].

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/ChangeVirtualNodeStateResponse.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/ChangeVirtualNodeStateResponse.kt
@@ -1,4 +1,4 @@
-package net.corda.libs.virtualnode.maintenance.endpoints.v1.types
+package net.corda.libs.virtualnode.endpoints.v1.types
 
 /**
  * The data object received via HTTP in response to a request to update the state of a virtual node.

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -1631,54 +1631,6 @@
         }
       }
     },
-    "/maintenance/virtualnode/{virtualnodeshortid}/state/{newstate}" : {
-      "put" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
-        "description" : "This method updates the state of a new virtual node to one of the pre-defined values.",
-        "operationId" : "put_maintenance_virtualnode__virtualnodeshortid__state__newstate_",
-        "parameters" : [ {
-          "name" : "virtualnodeshortid",
-          "in" : "path",
-          "description" : "Short ID of the virtual node instance to update",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "Short ID of the virtual node instance to update",
-            "nullable" : false,
-            "example" : "string"
-          }
-        }, {
-          "name" : "newstate",
-          "in" : "path",
-          "description" : "State to transition virtual node instance into. Possible values are: IN_MAINTENANCE and ACTIVE.",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "State to transition virtual node instance into. Possible values are: IN_MAINTENANCE and ACTIVE.",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Complete information about updated virtual node which will also contain the updated state.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ChangeVirtualNodeStateResponse"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/maintenance/virtualnode/{virtualnodeshortid}/vault-schema/force-resync" : {
       "post" : {
         "tags" : [ "Virtual Node Maintenance API" ],
@@ -2920,6 +2872,43 @@
         }
       }
     },
+    "/virtualnode/{holdingidentityshorthash}" : {
+      "get" : {
+        "tags" : [ "Virtual Node API" ],
+        "description" : "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
+        "operationId" : "get_virtualnode__holdingidentityshorthash_",
+        "parameters" : [ {
+          "name" : "holdingidentityshorthash",
+          "in" : "path",
+          "description" : "The short hash of the holding identity; obtained during node registration",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The short hash of the holding identity; obtained during node registration",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "VirtualNodeInfo for the specified virtual node.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VirtualNodeInfo"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
     "/virtualnode/{virtualnodeshortid}/state/{newstate}" : {
       "put" : {
         "tags" : [ "Virtual Node API" ],
@@ -2955,43 +2944,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/ChangeVirtualNodeStateResponse"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/virtualnode/{holdingidentityshorthash}" : {
-      "get" : {
-        "tags" : [ "Virtual Node API" ],
-        "description" : "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
-        "operationId" : "get_virtualnode__holdingidentityshorthash_",
-        "parameters" : [ {
-          "name" : "holdingidentityshorthash",
-          "in" : "path",
-          "description" : "The short hash of the holding identity; obtained during node registration",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The short hash of the holding identity; obtained during node registration",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "VirtualNodeInfo for the specified virtual node.",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/VirtualNodeInfo"
                 }
               }
             }

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -2924,7 +2924,7 @@
       "put" : {
         "tags" : [ "Virtual Node API" ],
         "description" : "This method updates the state of a new virtual node to one of the pre-defined values.",
-        "operationId" : "put_maintenance_virtualnode__virtualnodeshortid__state__newstate_",
+        "operationId" : "put_virtualnode__virtualnodeshortid__state__newstate_",
         "parameters" : [ {
           "name" : "virtualnodeshortid",
           "in" : "path",

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -2920,6 +2920,54 @@
         }
       }
     },
+    "/virtualnode/{virtualnodeshortid}/state/{newstate}" : {
+      "put" : {
+        "tags" : [ "Virtual Node API" ],
+        "description" : "This method updates the state of a new virtual node to one of the pre-defined values.",
+        "operationId" : "put_maintenance_virtualnode__virtualnodeshortid__state__newstate_",
+        "parameters" : [ {
+          "name" : "virtualnodeshortid",
+          "in" : "path",
+          "description" : "Short ID of the virtual node instance to update",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "Short ID of the virtual node instance to update",
+            "nullable" : false,
+            "example" : "string"
+          }
+        }, {
+          "name" : "newstate",
+          "in" : "path",
+          "description" : "State to transition virtual node instance into. Possible values are: IN_MAINTENANCE and ACTIVE.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "State to transition virtual node instance into. Possible values are: IN_MAINTENANCE and ACTIVE.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Complete information about updated virtual node which will also contain the updated state.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ChangeVirtualNodeStateResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
     "/virtualnode/{holdingidentityshorthash}" : {
       "get" : {
         "tags" : [ "Virtual Node API" ],

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/CordaDeveloperSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/CordaDeveloperSubcommand.kt
@@ -3,7 +3,6 @@ package net.corda.cli.plugin.initialRbac.commands
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.checkOrCreateRole
 import net.corda.cli.plugins.common.HttpRpcCommand
 import net.corda.rbac.schema.RbacKeys.VNODE_SHORT_HASH_REGEX
-import net.corda.rbac.schema.RbacKeys.VNODE_STATE_REGEX
 import picocli.CommandLine
 import java.util.concurrent.Callable
 

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/CordaDeveloperSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/CordaDeveloperSubcommand.kt
@@ -21,7 +21,6 @@ class CordaDeveloperSubcommand : HttpRpcCommand(), Callable<Int> {
     private val permissionsToCreate: Map<String, String> = listOf(
         "Force CPI upload" to "POST:/api/v1/maintenance/virtualnode/forcecpiupload",
         "Resync the virtual node vault" to "POST:/api/v1/maintenance/virtualnode/$VNODE_SHORT_HASH_REGEX/vault-schema/force-resync",
-        "Update virtual node state" to "PUT:/api/v1/maintenance/virtualnode/$VNODE_SHORT_HASH_REGEX/state/$VNODE_STATE_REGEX"
     ).toMap()
 
     override fun call(): Int {

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
@@ -2,9 +2,9 @@ package net.corda.cli.plugin.initialRbac.commands
 
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.checkOrCreateRole
 import net.corda.cli.plugins.common.HttpRpcCommand
-import net.corda.rbac.schema.RbacKeys
 import net.corda.rbac.schema.RbacKeys.UUID_REGEX
 import net.corda.rbac.schema.RbacKeys.VNODE_SHORT_HASH_REGEX
+import net.corda.rbac.schema.RbacKeys.VNODE_STATE_REGEX
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
@@ -30,7 +30,7 @@ class VNodeCreatorSubcommand : HttpRpcCommand(), Callable<Int> {
         "Get all vNodes" to "GET:/api/v1/virtualnode",
         "Get a vNode" to "GET:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX",
         "Update vNode" to "PUT:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX", // TBC
-        "Update virtual node state" to "PUT:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX/state/${RbacKeys.VNODE_STATE_REGEX}"
+        "Update virtual node state" to "PUT:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX/state/${VNODE_STATE_REGEX}"
     ).toMap()
 
     override fun call(): Int {

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
@@ -2,6 +2,7 @@ package net.corda.cli.plugin.initialRbac.commands
 
 import net.corda.cli.plugin.initialRbac.commands.RoleCreationUtils.checkOrCreateRole
 import net.corda.cli.plugins.common.HttpRpcCommand
+import net.corda.rbac.schema.RbacKeys
 import net.corda.rbac.schema.RbacKeys.UUID_REGEX
 import net.corda.rbac.schema.RbacKeys.VNODE_SHORT_HASH_REGEX
 import picocli.CommandLine
@@ -27,7 +28,9 @@ class VNodeCreatorSubcommand : HttpRpcCommand(), Callable<Int> {
         // vNode related
         "Create vNode" to "POST:/api/v1/virtualnode",
         "Get all vNodes" to "GET:/api/v1/virtualnode",
-        "Update vNode" to "PUT:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX" // TBC
+        "Get a vNode" to "GET:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX",
+        "Update vNode" to "PUT:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX", // TBC
+        "Update virtual node state" to "PUT:/api/v1/virtualnode/$VNODE_SHORT_HASH_REGEX/state/${RbacKeys.VNODE_STATE_REGEX}"
     ).toMap()
 
     override fun call(): Int {


### PR DESCRIPTION
This PR moves the ChangeVirtualNodeState endpoint from the maintenance resouce path to virtual node. 
As part of this, it updates the swaggerBaseline.json, some tests and it moves the permissions for this endpoint for the vnode-creator and corda-developer Roles. 

Additionally, it adds a permission to the vnode-creator role for the "Get a Vnode" endpoint which was added earlier in the week.