### PR TITLE
CORE-9187 Fix flakey test in VirtualNodeRpcTest

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -322,8 +322,8 @@ class VirtualNodeRpcTest {
                 timeout(Duration.of(30, ChronoUnit.SECONDS))
                 command { getVNode(aliceHoldingId) }
                 condition { response ->
-                    val vNodeInfo = response.toJson()["holdingIdentity"]["x500Name"].textValue()
-                    response.code == 200 && vNodeInfo.contains(aliceX500)
+                    response.code == 200 &&
+                        response.toJson()["holdingIdentity"]["x500Name"].textValue().contains(aliceX500)
                 }
             }
         }


### PR DESCRIPTION
Changed the test to check the response code before trying to use the response. 