### PR TITLE
CORE-9150: Ensure only modules which should be promoted externally are marked for release 

### DIFF
--- a/libs/layered-property-map/layered-property-map-test-converter/build.gradle
+++ b/libs/layered-property-map/layered-property-map-test-converter/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'corda.common-library'
 }
 
+ext {
+    releasable = true
+}
+
 description 'Custom converter for layered property map intergration tests'
 
 dependencies {

--- a/libs/layered-property-map/layered-property-map-test-converter/build.gradle
+++ b/libs/layered-property-map/layered-property-map-test-converter/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 ext {
-    releasable = true
+    releasable = false
 }
 
 description 'Custom converter for layered property map intergration tests'

--- a/tools/plugins/plugins-http-rpc/build.gradle
+++ b/tools/plugins/plugins-http-rpc/build.gradle
@@ -2,7 +2,10 @@ plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
 }
-description 'Plugins Common'
+
+ext {
+    releasable = false
+}
 
 dependencies {
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'


### PR DESCRIPTION
- Below modules be marked for exclusion when promoting to S3, and therefore not promoted to maven central. 
 