### PR TITLE
CORE-9163: Resume With Up To Date Partitions

### DIFF
--- a/libs/messaging/messaging-impl/build.gradle
+++ b/libs/messaging/messaging-impl/build.gradle
@@ -32,5 +32,5 @@ dependencies {
     testImplementation project(":testing:test-utilities")
 
     testRuntimeOnly 'org.osgi:osgi.core'
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
-

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
-import java.util.*
+import java.util.UUID
 
 @Suppress("LongParameterList")
 internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
@@ -316,8 +316,8 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
     /**
      * Handle retries for event processing.
      * Reset [nullableEventConsumer] position and retry poll and process of eventRecords
-     * Retry a max of [consumerPollAndProcessMaxRetries] times.
-     * If [consumerPollAndProcessMaxRetries] is exceeded then throw a [CordaMessageAPIIntermittentException]
+     * Retry a max of [ResolvedSubscriptionConfig.processorRetries] times.
+     * If [ResolvedSubscriptionConfig.processorRetries] is exceeded then throw a [CordaMessageAPIIntermittentException]
      */
     private fun handleProcessEventRetries(
         attempts: Int,

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -138,7 +138,7 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
     }
 
     private fun pauseEventConsumerAndWaitForFutureToFinish(future: CompletableFuture<*>, timeout: Long) {
-        val assignment = eventConsumer.assignment() - eventConsumer.paused()
+        val assignment = eventConsumer.assignment()
         log.debug { "Pause partitions and wait for future to finish. Assignment: $assignment"}
         eventConsumer.pause(assignment)
         val maxWaitTime = System.currentTimeMillis() + timeout

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -151,9 +151,9 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
             done = future.isDone
         }
 
-        // A rebalance might have been executed while waiting for the future to complete, and we might have lost
-        // ownership of some partitions, so we need to resume the consumer for the current assignment (otherwise we
-        // might end up polling from an unassigned partition, resulting in IllegalStateException being thrown by Kafka)
+        // A rebalance might have been executed while waiting for the future to complete and the consumer might have
+        // lost ownership of some previously owned partitions. Make sure to resume only those partitions currently
+        // assigned to prevent IllegalStateExceptions due to the consumer trying to poll from unassigned partitions.
         val currentAssignment = eventConsumer.assignment()
         log.debug { "Resume partitions. Finished wait for future[completed=${future.isDone}]. Assignment: $currentAssignment" }
         eventConsumer.resume(currentAssignment)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
@@ -198,8 +198,8 @@ class StateAndEventConsumerImplTest {
         }, 200L, "test ")
         latch.countDown()
 
-        verify(eventConsumer, times(1)).assignment()
         verify(eventConsumer, times(1)).paused()
+        verify(eventConsumer, times(2)).assignment()
         verify(eventConsumer, times(1)).pause(any())
         verify(eventConsumer, times(1)).resume(any())
         verify(stateConsumer, atLeast(1)).poll(any())
@@ -252,6 +252,37 @@ class StateAndEventConsumerImplTest {
         )
 
         assertThat(consumer.resetPollInterval()).isFalse
+    }
+
+    @Test
+    fun usesCorrectPartitionAssignmentsWhenPausingAndResumingEventConsumerWhileWaitingForFutureToComplete() {
+        val (stateAndEventListener, eventConsumer, stateConsumer, _) = setupMocks()
+        val assignedTopicPartitions = setOf(CordaTopicPartition(TOPIC, 0), CordaTopicPartition(TOPIC, 1))
+        val assignedTopicPartitionsAfterRebalance = setOf(CordaTopicPartition(TOPIC, 0))
+
+        whenever(eventConsumer.assignment())
+            .thenReturn(assignedTopicPartitions)
+            .thenReturn(assignedTopicPartitionsAfterRebalance)
+
+        val consumer = StateAndEventConsumerImpl(
+            config, eventConsumer, stateConsumer, StateAndEventPartitionState
+                (mutableMapOf(), mutableMapOf()), stateAndEventListener
+        )
+
+        val latch = CountDownLatch(1)
+        consumer.waitForFunctionToFinish({
+            while (latch.count > 0) {
+                Thread.sleep(10)
+            }
+        }, 200L, "test ")
+        latch.countDown()
+
+        verify(eventConsumer, times(2)).assignment()
+        verify(eventConsumer, times(1)).paused()
+        verify(eventConsumer, times(1)).pause(assignedTopicPartitions)
+        verify(eventConsumer, times(1)).resume(assignedTopicPartitionsAfterRebalance)
+        verify(stateConsumer, atLeast(1)).poll(any())
+        verify(stateAndEventListener, times(0)).onPartitionSynced(any())
     }
 
     private fun setupMocks(): Mocks {

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
@@ -198,7 +198,6 @@ class StateAndEventConsumerImplTest {
         }, 200L, "test ")
         latch.countDown()
 
-        verify(eventConsumer, times(1)).paused()
         verify(eventConsumer, times(2)).assignment()
         verify(eventConsumer, times(1)).pause(any())
         verify(eventConsumer, times(1)).resume(any())
@@ -278,7 +277,6 @@ class StateAndEventConsumerImplTest {
         latch.countDown()
 
         verify(eventConsumer, times(2)).assignment()
-        verify(eventConsumer, times(1)).paused()
         verify(eventConsumer, times(1)).pause(assignedTopicPartitions)
         verify(eventConsumer, times(1)).resume(assignedTopicPartitionsAfterRebalance)
         verify(stateConsumer, atLeast(1)).poll(any())


### PR DESCRIPTION
If a rebalance is triggered by Kafka in between pausing and resuming
the event consumer within the state and event message pattern, an
IllegalStateException might be thrown if the 'resume' operation tries
to use partitions that are not owned anymore by the consumer.

- Add unit tests.
- Use current partition assignment when resuming the event consumer.
- Add 'slf4j-simple' dependency so log is captured when running tests.
