### PR TITLE
NOTICK - Fix for windows test issue

### DIFF
--- a/libs/application/banner/src/test/kotlin/net/corda/application/banner/ConsolePrinterTest.kt
+++ b/libs/application/banner/src/test/kotlin/net/corda/application/banner/ConsolePrinterTest.kt
@@ -74,13 +74,8 @@ class ConsolePrinterTest {
     fun `when printLeftPad print multiline`() {
         val printer = ConsolePrinter(this::mockPrinter)
 
-        printer.printLeftPad("""
-hello world
-and mars
-        """.trimIndent(), 4)
+        printer.printLeftPad("hello world${System.lineSeparator()}and mars", 4)
 
-        assertThat(printed).contains(
-            """    hello world
-    and mars""")
+        assertThat(printed).contains("    hello world${System.lineSeparator()}    and mars",)
     }
 }


### PR DESCRIPTION
Use System.lineSeparator() to avoid issues between different OS line endings.