### PR TITLE
CORE-9065 - Add pre-auth token and skip-approval mode for corda-cli

### DIFF
--- a/tools/plugins/mgm/README.md
+++ b/tools/plugins/mgm/README.md
@@ -141,9 +141,13 @@ To decide which CPI to use, there are three options:
 * If you have the CPI file (for example, from the [package command](../package/README.md)), you can use it with the `--cpi-file` option.
 * If you have a CPB and a group policy file (from the `onboard mgm` command), you can use the `--cpb-file` and `--group-policy-file` option. This will create an unsigned CPI and save it in your home directory.
 
+If you want to wait until your request gets approved/declined you should use the `--wait` option. Although, this is only advised if you are sure your request will be finalized automatically.
+Default value is `false`, so we won't wait by default until your member is fully onboarded. Note that, the MGM might need to manually approve (or decline) your submitted registration to be fully onboarded by using the `registrationId`.
+
 Few examples of on-boarding a member can be:
 ```shell
 ./corda-cli.sh mgm onboard member demo-cluster-two --x500-name='O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb
+./corda-cli.sh mgm onboard member demo-cluster-two --x500-name='O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb --wait
 ./corda-cli.sh mgm onboard member demo-cluster-one --cpi-file /tmp/calculator.cpi
 ./corda-cli.sh mgm onboard member --cpi-hash 200E86176EF2
 ```

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
@@ -250,7 +250,7 @@ abstract class BaseOnboard : Runnable {
             .bodyOrThrow()
     }
 
-    protected fun register(skipWaitingForFinalStatus: Boolean = false) {
+    protected fun register(waitForFinalStatus: Boolean = false) {
         val response = Unirest.post("/membership/$holdingId")
             .body(
                 mapOf(
@@ -268,7 +268,7 @@ abstract class BaseOnboard : Runnable {
         }
         val id = body.get("registrationId").toString()
         println("Registration ID of $x500Name is $id")
-        if (!skipWaitingForFinalStatus) {
+        if (waitForFinalStatus) {
             waitForFinalStatus(id)
         }
     }

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
@@ -281,7 +281,7 @@ abstract class BaseOnboard : Runnable {
             if (registrationStatus == "APPROVED") {
                 return
             } else if (registrationStatus =="DECLINED") {
-                throw OnboardException("Registration got declined!")
+                throw OnboardException("Registration has been declined.")
             } else {
                 println("Status of $x500Name registration is $registrationStatus")
                 Thread.sleep(400)

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
@@ -250,7 +250,7 @@ abstract class BaseOnboard : Runnable {
             .bodyOrThrow()
     }
 
-    protected fun register(waitForFinalStatus: Boolean = false) {
+    protected fun register(waitForFinalStatus: Boolean = true) {
         val response = Unirest.post("/membership/$holdingId")
             .body(
                 mapOf(

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
@@ -68,10 +68,10 @@ class OnBoardMember : Runnable, BaseOnboard() {
     var preAuthToken: String? = null
 
     @Option(
-        names = ["--skip-approval"],
-        description = ["Skip waiting until member gets approved, this should be used in manual-approval mode. False, by default."]
+        names = ["--ignore-status"],
+        description = ["Skip waiting until member gets approved/declined, this should be used in manual-approval mode. False, by default."]
     )
-    var skipWaitingForApproval: Boolean = false
+    var skipWaitingForFinalStatus: Boolean = false
 
     override val cpiFileChecksum by lazy {
         if (cpiHash != null) {
@@ -235,9 +235,9 @@ class OnBoardMember : Runnable, BaseOnboard() {
         println("Provided registration context: ")
         println(registrationContext)
 
-        register(skipWaitingForApproval)
+        register(skipWaitingForFinalStatus)
 
-        if (skipWaitingForApproval) {
+        if (skipWaitingForFinalStatus) {
             println("Member can be approved/declined by using it's registration ID.")
         } else {
             println("Member $x500Name was onboarded.")

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
@@ -238,7 +238,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
         register(skipWaitingForFinalStatus)
 
         if (skipWaitingForFinalStatus) {
-            println("Member can be approved/declined by using it's registration ID.")
+            println("Registration request has been submitted. Wait for MGM manual approval to finalize registration.")
         } else {
             println("Member $x500Name was onboarded.")
         }

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
@@ -68,10 +68,10 @@ class OnBoardMember : Runnable, BaseOnboard() {
     var preAuthToken: String? = null
 
     @Option(
-        names = ["--ignore-status"],
-        description = ["Skip waiting until member gets approved/declined, this should be used in manual-approval mode. False, by default."]
+        names = ["--wait"],
+        description = ["Wait until member gets approved/declined. False, by default."]
     )
-    var skipWaitingForFinalStatus: Boolean = false
+    var waitForFinalStatus: Boolean = false
 
     override val cpiFileChecksum by lazy {
         if (cpiHash != null) {
@@ -235,12 +235,13 @@ class OnBoardMember : Runnable, BaseOnboard() {
         println("Provided registration context: ")
         println(registrationContext)
 
-        register(skipWaitingForFinalStatus)
+        register(waitForFinalStatus)
 
-        if (skipWaitingForFinalStatus) {
-            println("Registration request has been submitted. Wait for MGM manual approval to finalize registration.")
-        } else {
+        if (waitForFinalStatus) {
             println("Member $x500Name was onboarded.")
+        } else {
+            println("Registration request has been submitted. Wait for MGM approval to finalize registration. " +
+                    "MGM may need to approve your request manually.")
         }
     }
 }

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/SetupCordaCluster.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/SetupCordaCluster.kt
@@ -106,19 +106,25 @@ class SetupCordaCluster : Runnable {
             // Do nothing, the secret might already be there
         }
 
+        val prereqsYaml = File(File(File(cordaOsRuntimeDir, ".ci"), "e2eTests"), "prereqs.yaml")
+        val prereqsEksYaml = File(File(File(cordaOsRuntimeDir, ".ci"), "e2eTests"), "prereqs-eks.yaml")
         helm(
             "install", "prereqs", "oci://corda-os-docker.software.r3.com/helm-charts/corda-dev",
+            "-f", prereqsYaml.absolutePath,
+            "-f", prereqsEksYaml.absolutePath,
             "--set", "kafka.replicaCount=$kafkaReplicas,kafka.zookeeper.replicaCount=$zooKeeperReplicas,kafka.auth.clientProtocol=tls",
             "-n", clusterName, "--wait", "--timeout", "600s"
         )
 
         val chart = File(cordaOsRuntimeDir, "charts")
         val cordaChart = File(chart, "corda")
-        val yaml = File(File(File(cordaOsRuntimeDir, ".ci"), "e2eTests"), "corda.yaml")
+        val cordaYaml = File(File(File(cordaOsRuntimeDir, ".ci"), "e2eTests"), "corda.yaml")
+        val cordaEksYaml = File(File(File(cordaOsRuntimeDir, ".ci"), "e2eTests"), "corda-eks.yaml")
         helm(
             "install",
             "corda", cordaChart.absolutePath,
-            "-f", yaml.absolutePath,
+            "-f", cordaYaml.absolutePath,
+            "-f", cordaEksYaml.absolutePath,
             "--set",
             "image.tag=$actualBaseImage," +
                 "bootstrap.kafka.replicas=$kafkaReplicas," +


### PR DESCRIPTION
**Description**

Include optional parameter for the onboard member plugin to accept a pre-auth token and include it in the registration context sent to the MGM.
e.g. --pre-auth=<my-token>
Existing behaviour for waiting for approved registration can be used if flag is set
e.g. --wait-for-approval
If flag is not set, return registration ID

_Also added a fix for broken cluster deployment._

**Testing:**

1) Wait for approval and having pre-auth token
![Screenshot 2023-01-10 at 16 12 24](https://user-images.githubusercontent.com/61757742/211604107-1c46b774-1b39-4275-956d-e583e60572af.png)

2) Do not wait for approval and having pre-auth token
![Screenshot 2023-01-10 at 16 12 08](https://user-images.githubusercontent.com/61757742/211604215-a205e219-188e-4fdc-9994-14e28a0997eb.png)

3) Do not wait for approval without pre-auth token
![Screenshot 2023-01-10 at 16 11 51](https://user-images.githubusercontent.com/61757742/211604322-1b93a35a-a0ef-498f-9dfe-d8c440e77349.png)

4) Wait for approval without pre-auth token
![Screenshot 2023-01-10 at 16 11 17](https://user-images.githubusercontent.com/61757742/211604441-f208f490-fae4-4344-97b7-5c912de28227.png)



