### PR TITLE
CORE-9131 Add extra error scenario, extend error message

### DIFF
--- a/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
+++ b/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
@@ -55,7 +55,7 @@ class PluggableNotaryClientFlowFactoryImpl @Activate constructor(
 
         if (pluginClass == null) {
             throw CordaRuntimeException(
-                "Plugin class not found for notary service $notaryService. This means that no notary service " +  
+                "Plugin class not found for notary service ${notaryService.name}. This means that no notary service " +
                         "matching this name has been registered on the network."
             )
         }

--- a/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
+++ b/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
@@ -56,7 +56,7 @@ class PluggableNotaryClientFlowFactoryImpl @Activate constructor(
         if (pluginClass == null) {
             throw CordaRuntimeException(
                 "Plugin class could not be retrieved. That either means there's no notary registered on the network, " +
-                        "or the provided notary party is not matching with the one registered on the network."
+                        "or the provided notary party is not matching the one registered on the network."
             )
         }
 
@@ -64,7 +64,7 @@ class PluggableNotaryClientFlowFactoryImpl @Activate constructor(
             ?: throw CordaRuntimeException(
                 "Notary flow provider not found for type: $pluginClass. This means no plugin has been installed for " +
                         "the given type. Please make sure you have a plugin provider class and it is annotated with " +
-                        "the @PluggableNotaryType annotation."
+                        "the proper @PluggableNotaryType annotation."
             )
 
         return try {

--- a/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
+++ b/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
@@ -55,8 +55,8 @@ class PluggableNotaryClientFlowFactoryImpl @Activate constructor(
 
         if (pluginClass == null) {
             throw CordaRuntimeException(
-                "Plugin class could not be retrieved. That either means there's no notary registered on the network, " +
-                        "or the provided notary party is not matching the one registered on the network."
+                "Plugin class not found for notary service $notaryService. This means that no notary service " +  
+                        "matching this name has been registered on the network."
             )
         }
 

--- a/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
+++ b/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
@@ -53,8 +53,19 @@ class PluggableNotaryClientFlowFactoryImpl @Activate constructor(
             }
         }
 
+        if (pluginClass == null) {
+            throw CordaRuntimeException(
+                "Plugin class could not be retrieved. That either means there's no notary registered on the network, " +
+                        "or the provided notary party is not matching with the one registered on the network."
+            )
+        }
+
         val provider = pluggableNotaryClientFlowProviders[pluginClass]
-            ?: throw IllegalStateException("Notary flow provider not found for type: $pluginClass")
+            ?: throw CordaRuntimeException(
+                "Notary flow provider not found for type: $pluginClass. This means no plugin has been installed for " +
+                        "the given type. Please make sure you have a plugin provider class and it is annotated with " +
+                        "the @PluggableNotaryType annotation."
+            )
 
         return try {
             val selected = virtualNodeSelectorService.selectVirtualNode(notaryService)

--- a/components/virtual-node/sandbox-notary-impl/src/test/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImplTest.kt
+++ b/components/virtual-node/sandbox-notary-impl/src/test/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImplTest.kt
@@ -202,7 +202,7 @@ class PluggableNotaryClientFlowFactoryImplTest {
         }
 
         assertThat(exception.message)
-            .contains("Plugin class could not be retrieved.")
+            .contains("Plugin class not found for notary service")
     }
 
     @Test


### PR DESCRIPTION
### Overview

- The error message in the notary plugin factory was quite short and misleading, added extra details.
- We didn't have an error scenario for when the `pluginClass` was null, added the check and a different error message for that scenario.