### PR TITLE
CORE-8108 Add `SignatureSpec` field to `DigitalSignatureMetadata`

### DIFF
--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -62,7 +62,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
     }
 
     override fun verifySignature(transactionId: SecureHash, signatureWithMetadata: DigitalSignatureAndMetadata) {
-        val signatureSpec = extractSignatureSpec(signatureWithMetadata)
+        val signatureSpec = checkSignatureSpecCompatibility(signatureWithMetadata)
 
         val signedData = SignableData(transactionId, signatureWithMetadata.metadata)
         digitalSignatureVerificationService.verify(
@@ -73,7 +73,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
         )
     }
 
-    private fun extractSignatureSpec(signatureWithMetadata: DigitalSignatureAndMetadata): SignatureSpec {
+    private fun checkSignatureSpecCompatibility(signatureWithMetadata: DigitalSignatureAndMetadata): SignatureSpec {
         val signatureSpec = signatureWithMetadata.metadata.signatureSpec
 
         val compatibleSpecs = signatureSpecService.compatibleSignatureSpecs(signatureWithMetadata.by)
@@ -113,7 +113,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
         )
         // End of Copy
 
-        val signatureSpec = extractSignatureSpec(signatureWithMetadata)
+        val signatureSpec = checkSignatureSpecCompatibility(signatureWithMetadata)
 
         digitalSignatureVerificationService.verify(
             publicKey = signatureWithMetadata.by,

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -62,7 +62,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
     }
 
     override fun verifySignature(transactionId: SecureHash, signatureWithMetadata: DigitalSignatureAndMetadata) {
-        val signatureSpec = checkSignatureSpecCompatibility(signatureWithMetadata)
+        val signatureSpec = checkAndGetSignatureSpec(signatureWithMetadata)
 
         val signedData = SignableData(transactionId, signatureWithMetadata.metadata)
         digitalSignatureVerificationService.verify(
@@ -73,7 +73,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
         )
     }
 
-    private fun checkSignatureSpecCompatibility(signatureWithMetadata: DigitalSignatureAndMetadata): SignatureSpec {
+    private fun checkAndGetSignatureSpec(signatureWithMetadata: DigitalSignatureAndMetadata): SignatureSpec {
         val signatureSpec = signatureWithMetadata.metadata.signatureSpec
 
         val compatibleSpecs = signatureSpecService.compatibleSignatureSpecs(signatureWithMetadata.by)
@@ -113,7 +113,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
         )
         // End of Copy
 
-        val signatureSpec = checkSignatureSpecCompatibility(signatureWithMetadata)
+        val signatureSpec = checkAndGetSignatureSpec(signatureWithMetadata)
 
         digitalSignatureVerificationService.verify(
             publicKey = signatureWithMetadata.by,

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -27,8 +27,6 @@ import org.osgi.service.component.annotations.ServiceScope
 import java.security.PublicKey
 import java.time.Instant
 
-const val SIGNATURE_METADATA_SIGNATURE_SPEC_KEY = "signatureSpec"
-
 @Suppress("Unused", "LongParameterList")
 @Component(
     service = [TransactionSignatureService::class, UsedByFlow::class],
@@ -76,9 +74,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
     }
 
     private fun extractSignatureSpec(signatureWithMetadata: DigitalSignatureAndMetadata): SignatureSpec {
-        val signatureSpecStr = signatureWithMetadata.metadata.properties[SIGNATURE_METADATA_SIGNATURE_SPEC_KEY]
-        requireNotNull(signatureSpecStr) { "There are no signature spec in the Signature's metadata $signatureWithMetadata" }
-        val signatureSpec = SignatureSpec(signatureSpecStr)
+        val signatureSpec = signatureWithMetadata.metadata.signatureSpec
 
         val compatibleSpecs = signatureSpecService.compatibleSignatureSpecs(signatureWithMetadata.by)
         require(signatureSpec in compatibleSpecs) {
@@ -131,11 +127,11 @@ class TransactionSignatureServiceImpl @Activate constructor(
         val cpiSummary = getCpiSummary()
         return DigitalSignatureMetadata(
             Instant.now(),
+            signatureSpec,
             linkedMapOf(
                 "cpiName" to cpiSummary.name,
                 "cpiVersion" to cpiSummary.version,
-                "cpiSignerSummaryHash" to cpiSummary.signerSummaryHash.toString(),
-                SIGNATURE_METADATA_SIGNATURE_SPEC_KEY to signatureSpec.signatureName
+                "cpiSignerSummaryHash" to cpiSummary.signerSummaryHash.toString()
             )
         )
     }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
@@ -18,6 +18,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionVerificationException
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
@@ -239,7 +240,7 @@ class ConsensualFinalityFlowTest {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
-            DigitalSignatureMetadata(Instant.now(), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
@@ -17,6 +17,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.transaction.TransactionVerificationException
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionValidator
 import net.corda.v5.membership.MemberInfo
@@ -200,7 +201,7 @@ class ConsensualReceiveFinalityFlowTest {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
-            DigitalSignatureMetadata(Instant.now(), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransac
 import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -26,6 +27,7 @@ class ConsensualSignedTransactionKryoSerializerTest: ConsensualLedgerTest() {
                 consensualSignedTransactionExample.signatures[0].by::class.java,
                 emptyMap<String, String>()::class.java,
                 DigitalSignature.WithKey::class.java,
+                SignatureSpec::class.java,
                 mapOf("" to "")::class.java
             )
         )

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
@@ -34,6 +34,7 @@ import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.PrivacySalt
 import org.assertj.core.api.Assertions.assertThat

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -39,6 +39,7 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.PrivacySalt

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
@@ -24,6 +24,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
@@ -716,7 +717,7 @@ class UtxoFinalityFlowTest {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
-            DigitalSignatureMetadata(Instant.now(), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlowTest.kt
@@ -21,6 +21,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
@@ -358,7 +359,7 @@ class UtxoReceiveFinalityFlowTest {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
-            DigitalSignatureMetadata(Instant.now(), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.test.UtxoLedgerTest
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -27,6 +28,7 @@ class UtxoSignedTransactionKryoSerializerTest: UtxoLedgerTest() {
                 emptyMap<String, String>()::class.java,
                 emptyList<String>()::class.java,
                 DigitalSignature.WithKey::class.java,
+                SignatureSpec::class.java,
                 mapOf("" to "")::class.java
             )
         )

--- a/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
@@ -129,9 +129,9 @@ class LedgerUniquenessCheckerClientServiceImpl @Activate constructor(
                 sig,
                 DigitalSignatureMetadata(
                     Instant.now(),
+                    SignatureSpec.ECDSA_SHA256,
                     mapOf(
-                        "platformVersion" to memberLookup.myInfo().platformVersion.toString(),
-                        "signatureSpec" to SignatureSpec.ECDSA_SHA256.signatureName
+                        "platformVersion" to memberLookup.myInfo().platformVersion.toString()
                     )
                 )
             ),

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.622-beta+
+cordaApiVersion=5.0.0.623-alpha-1674554279822
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.623-alpha-1674554279822
+cordaApiVersion=5.0.0.623-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializationScheme.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializationScheme.kt
@@ -7,6 +7,7 @@ import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.amqpMagic
 import net.corda.internal.serialization.amqp.currentSandboxGroup
+import net.corda.internal.serialization.amqp.custom.AlgorithmParameterSpecSerializer
 import net.corda.internal.serialization.amqp.custom.BigDecimalSerializer
 import net.corda.internal.serialization.amqp.custom.BigIntegerSerializer
 import net.corda.internal.serialization.amqp.custom.BitSetSerializer
@@ -21,12 +22,14 @@ import net.corda.internal.serialization.amqp.custom.InstantSerializer
 import net.corda.internal.serialization.amqp.custom.LocalDateSerializer
 import net.corda.internal.serialization.amqp.custom.LocalDateTimeSerializer
 import net.corda.internal.serialization.amqp.custom.LocalTimeSerializer
+import net.corda.internal.serialization.amqp.custom.MGF1ParameterSpecSerializer
 import net.corda.internal.serialization.amqp.custom.MonthDaySerializer
 import net.corda.internal.serialization.amqp.custom.MonthSerializer
 import net.corda.internal.serialization.amqp.custom.OffsetDateTimeSerializer
 import net.corda.internal.serialization.amqp.custom.OffsetTimeSerializer
 import net.corda.internal.serialization.amqp.custom.OpaqueBytesSubSequenceSerializer
 import net.corda.internal.serialization.amqp.custom.OptionalSerializer
+import net.corda.internal.serialization.amqp.custom.PSSParameterSpecSerializer
 import net.corda.internal.serialization.amqp.custom.PairSerializer
 import net.corda.internal.serialization.amqp.custom.PeriodSerializer
 import net.corda.internal.serialization.amqp.custom.StackTraceElementSerializer
@@ -143,5 +146,8 @@ fun registerCustomSerializers(factory: SerializerFactory) {
         register(MonthSerializer(), this)
         register(PairSerializer(), this)
         register(UnitSerializer(), this)
+        register(AlgorithmParameterSpecSerializer(), this)
+        register(PSSParameterSpecSerializer(), this)
+        register(MGF1ParameterSpecSerializer(), this)
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ParameterizedSignatureSpecSerializers.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ParameterizedSignatureSpecSerializers.kt
@@ -1,0 +1,66 @@
+package net.corda.internal.serialization.amqp.custom
+
+import net.corda.serialization.BaseDirectSerializer
+import net.corda.serialization.BaseProxySerializer
+import net.corda.serialization.InternalDirectSerializer
+import java.security.spec.AlgorithmParameterSpec
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.PSSParameterSpec
+
+class AlgorithmParameterSpecSerializer : BaseDirectSerializer<AlgorithmParameterSpec>() {
+    override fun readObject(reader: InternalDirectSerializer.ReadObject): AlgorithmParameterSpec {
+        return reader.getAs(AlgorithmParameterSpec::class.java)
+    }
+
+    override fun writeObject(obj: AlgorithmParameterSpec, writer: InternalDirectSerializer.WriteObject) {
+        writer.putAsObject(obj)
+    }
+
+    override val type: Class<AlgorithmParameterSpec> = AlgorithmParameterSpec::class.java
+    override val withInheritance = false
+}
+
+class PSSParameterSpecSerializer : BaseProxySerializer<PSSParameterSpec, PSSParameterSpecSerializer.PSSParameterSpecProxy>() {
+    override val type: Class<PSSParameterSpec> = PSSParameterSpec::class.java
+    override val withInheritance: Boolean = true
+    override val revealSubclasses: Boolean = true
+    override val proxyType: Class<PSSParameterSpecProxy> = PSSParameterSpecProxy::class.java
+
+    override fun toProxy(obj: PSSParameterSpec): PSSParameterSpecProxy =
+        PSSParameterSpecProxy(
+            obj.digestAlgorithm,
+            obj.mgfAlgorithm,
+            obj.mgfParameters,
+            obj.saltLength,
+            obj.trailerField
+        )
+
+    override fun fromProxy(proxy: PSSParameterSpecProxy): PSSParameterSpec =
+        PSSParameterSpec(
+            proxy.mdName,
+            proxy.mgfName,
+            proxy.mgfSpec,
+            proxy.saltLen,
+            proxy.trailerField
+        )
+
+    data class PSSParameterSpecProxy(
+        val mdName: String,
+        val mgfName: String,
+        val mgfSpec: AlgorithmParameterSpec,
+        val saltLen: Int,
+        val trailerField: Int
+    )
+}
+
+class MGF1ParameterSpecSerializer : BaseDirectSerializer<MGF1ParameterSpec>() {
+    override val type: Class<MGF1ParameterSpec> = MGF1ParameterSpec::class.java
+    override val withInheritance: Boolean = false
+
+    override fun readObject(reader: InternalDirectSerializer.ReadObject): MGF1ParameterSpec =
+        MGF1ParameterSpec(reader.getAs(String::class.java))
+
+    override fun writeObject(obj: MGF1ParameterSpec, writer: InternalDirectSerializer.WriteObject) {
+        writer.putAsString(obj.digestAlgorithm)
+    }
+}

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ParameterizedSignatureSpecTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ParameterizedSignatureSpecTest.kt
@@ -1,0 +1,13 @@
+package net.corda.internal.serialization.amqp.custom
+
+import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert
+import net.corda.v5.crypto.SignatureSpec
+import org.junit.jupiter.api.Test
+
+class ParameterizedSignatureSpecTest {
+    @Test
+    fun `ParameterizedSignatureSpec taking PSSParameterSpec as AlgorithmParameterSpec is serializable`() {
+        val parameterizedSignatureSpec = SignatureSpec.RSASSA_PSS_SHA256
+        ReusableSerialiseDeserializeAssert.serializeDeserializeAssert(parameterizedSignatureSpec)
+    }
+}

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
@@ -11,6 +11,7 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
@@ -42,7 +43,7 @@ class NonValidatingNotaryClientFlowImplTest {
         val mockRequestSignature = mock<DigitalSignature.WithKey>()
         val dummyUniquenessSignature = DigitalSignatureAndMetadata(
             mock(),
-            DigitalSignatureMetadata(Instant.now(), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
 
         /* State Refs */

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -19,6 +19,7 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
@@ -72,7 +73,7 @@ class NonValidatingNotaryServerFlowImplTest {
         /* Uniqueness Client Service */
         val uniquenessCheckResponseSignature = DigitalSignatureAndMetadata(
             mock(),
-            DigitalSignatureMetadata(Instant.now(), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
 
         /* Services */

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBase.kt
@@ -118,7 +118,10 @@ class ConsensualSignedTransactionBase(
 
     private fun signWithMetadata(key: PublicKey, timestamp: Instant) : DigitalSignatureAndMetadata {
         val signature = signingService.sign(ledgerTransaction.bytes, key, SignatureSpec.ECDSA_SHA256)
-        return DigitalSignatureAndMetadata(signature, DigitalSignatureMetadata(timestamp, mapOf()))
+        return DigitalSignatureAndMetadata(
+            signature,
+            DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
+        )
     }
 
     override fun equals(other: Any?): Boolean {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerService.kt
@@ -95,7 +95,10 @@ class SimConsensualLedgerService(
         val bytesToSign = serializer.format(signedTransaction.toLedgerTransaction().states).toByteArray()
         val signatures = publicKeys.map {
             val signature = signingService.sign(bytesToSign, it, SignatureSpec.ECDSA_SHA256)
-            DigitalSignatureAndMetadata(signature, DigitalSignatureMetadata(Instant.now(), mapOf()))
+            DigitalSignatureAndMetadata(
+                signature,
+                DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
+            )
         }
         return signatures
     }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBaseTest.kt
@@ -8,6 +8,7 @@ import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import org.hamcrest.MatcherAssert.assertThat
@@ -147,7 +148,7 @@ class ConsensualSignedTransactionBaseTest {
 
     private fun toSignatureWithMetadata(key: PublicKey, timestamp: Instant = now()) = DigitalSignatureAndMetadata(
         DigitalSignature.WithKey(key, "some bytes".toByteArray(), mapOf()),
-        DigitalSignatureMetadata(timestamp, mapOf())
+        DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
     )
 
     @CordaSerializable

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerServiceTest.kt
@@ -13,6 +13,7 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
@@ -97,7 +98,7 @@ class SimConsensualLedgerServiceTest {
         val sessions = publicKeys.minus(publicKeys[0]).map {
             val signature = DigitalSignatureAndMetadata(
                 toSignature(it).signature,
-                DigitalSignatureMetadata(Instant.now(), mapOf())
+                DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
             )
             val flowSession = mock<FlowSession>()
             whenever(flowSession.receive<Any>(any())).thenReturn(listOf(signature), Unit)
@@ -217,7 +218,7 @@ class SimConsensualLedgerServiceTest {
 
     private fun toSignature(key: PublicKey) = DigitalSignatureAndMetadata(
         DigitalSignature.WithKey(key, "some bytes".toByteArray(), mapOf()),
-        DigitalSignatureMetadata(Instant.now(), mapOf())
+        DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
     )
 
     data class NameConsensualState(val name: String, override val participants: List<PublicKey>) : ConsensualState {

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
@@ -3,11 +3,12 @@ package net.corda.ledger.common.testkit
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import java.security.PublicKey
 import java.time.Instant
 
 fun getSignatureWithMetadataExample(publicKey: PublicKey = publicKeyExample, createdTs: Instant = Instant.now()) =
     DigitalSignatureAndMetadata(
         DigitalSignature.WithKey(publicKey, "signature".toByteArray(), mapOf("contextKey1" to "contextValue1")),
-        DigitalSignatureMetadata(createdTs, mapOf("propertyKey1" to "propertyValue1"))
+        DigitalSignatureMetadata(createdTs, SignatureSpec("dummySignatureName"), mapOf("propertyKey1" to "propertyValue1"))
     )


### PR DESCRIPTION
- adds custom serializers to make `ParameterizedSignatureSpec` corda serializable due to it referencing `AlgorithmParameterSpec`.
- updates storing sites of signature spec in `DigitalSignatureMetadata` (previously added to `DigitalSignatureMetadata.properties`).

api PR: [#769](https://github.com/corda/corda-api/pull/769)