### PR TITLE
CORE-9233 Refactor UTXO transaction `persistIfDoesNotExist` to use `persist`

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -11,13 +11,9 @@ interface UtxoPersistenceService {
 
     fun <T: ContractState> findUnconsumedRelevantStatesByType(stateClass: Class<out T>): List<TransactionOutputDto>
 
-    fun persistTransaction(transaction: UtxoTransactionReader)
+    fun persistTransaction(transaction: UtxoTransactionReader): List<CordaPackageSummary>
 
-    fun persistTransactionIfDoesNotExist(
-        transaction: SignedTransactionContainer,
-        transactionStatus: TransactionStatus,
-        account: String
-    ): Pair<String?, List<CordaPackageSummary>>
+    fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): Pair<String?, List<CordaPackageSummary>>
 
     fun updateStatus(id: String, transactionStatus: TransactionStatus)
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionIfDoesNotExistRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionIfDoesNotExistRequestHandler.kt
@@ -1,41 +1,26 @@
 package net.corda.ledger.persistence.utxo.impl
 
 import net.corda.data.flow.event.external.ExternalEventContext
-import net.corda.data.ledger.persistence.PersistTransactionIfDoesNotExist
 import net.corda.data.persistence.EntityResponse
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
-import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
+import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.messaging.api.records.Record
-import net.corda.persistence.common.exceptions.NullParameterException
 import net.corda.v5.application.serialization.SerializationService
-import net.corda.v5.application.serialization.deserialize
-import net.corda.v5.base.util.contextLogger
 import java.nio.ByteBuffer
 
 class UtxoPersistTransactionIfDoesNotExistRequestHandler(
-    private val request: PersistTransactionIfDoesNotExist,
+    private val transaction: UtxoTransactionReader,
     private val externalEventContext: ExternalEventContext,
     private val externalEventResponseFactory: ExternalEventResponseFactory,
     private val serializationService: SerializationService,
     private val persistenceService: UtxoPersistenceService
 ) : RequestHandler {
 
-    private companion object {
-        const val CORDA_ACCOUNT = "corda.account"
-        val log = contextLogger()
-    }
-
     override fun execute(): List<Record<*, *>> {
-        val account = externalEventContext.contextProperties.items.find { it.key == CORDA_ACCOUNT }?.value
-            ?: throw NullParameterException("Flow external event context property '$CORDA_ACCOUNT' not set")
-
-        val result = persistenceService.persistTransactionIfDoesNotExist(
-            serializationService.deserialize(request.transaction.array()),
-            request.status.toTransactionStatus(),
-            account
-        )
+        // persist the transaction if it doesn't exist
+        val result = persistenceService.persistTransactionIfDoesNotExist(transaction)
 
         // should this do token related side effect things?
         return listOf(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -59,7 +59,7 @@ class UtxoPersistenceServiceImpl constructor(
         } ?: emptyList()
     }
 
-    override fun persistTransaction(transaction: UtxoTransactionReader) {
+    override fun persistTransaction(transaction: UtxoTransactionReader): List<CordaPackageSummary> {
         val nowUtc = utcClock.instant()
         val transactionIdString = transaction.id.toString()
 
@@ -159,16 +159,11 @@ class UtxoPersistenceServiceImpl constructor(
             // Insert the CPK details liked to this transaction
             // TODOs: The CPK file meta does not exist yet, this will be implemented by
             // https://r3-cev.atlassian.net/browse/CORE-7626
+            return emptyList()
         }
     }
 
-    override fun persistTransactionIfDoesNotExist(
-        transaction: SignedTransactionContainer,
-        transactionStatus: TransactionStatus,
-        account: String
-    ): Pair<String?, List<CordaPackageSummary>> {
-        val nowUtc = utcClock.instant()
-
+    override fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): Pair<String?, List<CordaPackageSummary>> {
         return entityManagerFactory.transaction { em ->
             val transactionIdString = transaction.id.toString()
 
@@ -178,54 +173,9 @@ class UtxoPersistenceServiceImpl constructor(
                 return@transaction status to emptyList()
             }
 
-            // Insert the Transaction
-            repository.persistTransaction(
-                em,
-                transactionIdString,
-                transaction.wireTransaction.privacySalt.bytes,
-                account,
-                nowUtc
-            )
+            val cpkDetails = persistTransaction(transaction)
 
-            // Insert the Transactions components
-            transaction.wireTransaction.componentGroupLists.mapIndexed { groupIndex, leaves ->
-                leaves.mapIndexed { leafIndex, data ->
-                    repository.persistTransactionComponentLeaf(
-                        em,
-                        transactionIdString,
-                        groupIndex,
-                        leafIndex,
-                        data,
-                        sandboxDigestService.hash(data, DigestAlgorithmName.SHA2_256).toString(),
-                        nowUtc
-                    )
-                }
-            }
-
-            // Insert the Transactions signatures
-            transaction.signatures.forEachIndexed { index, digitalSignatureAndMetadata ->
-                repository.persistTransactionSignature(
-                    em,
-                    transactionIdString,
-                    index,
-                    digitalSignatureAndMetadata,
-                    nowUtc
-                )
-            }
-
-            // Insert the transactions current status
-            repository.persistTransactionStatus(
-                em,
-                transactionIdString,
-                transactionStatus,
-                nowUtc
-            )
-
-            // Insert the CPK details liked to this transaction
-            // TODOs: The CPK file meta does not exist yet, this will be implemented by
-            // https://r3-cev.atlassian.net/browse/CORE-7626
-
-            return null to emptyList()
+            return null to cpkDetails
         }
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -75,7 +75,7 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
             }
             is PersistTransactionIfDoesNotExist -> {
                 UtxoPersistTransactionIfDoesNotExistRequestHandler(
-                    req,
+                    UtxoTransactionReaderImpl(sandbox, request.flowExternalEventContext, req),
                     request.flowExternalEventContext,
                     externalEventResponseFactory,
                     sandbox.getSandboxSingletonService(),


### PR DESCRIPTION
- Refactored function `UtxoPersistenceServiceImpl.persistTransactionIfDoesNotExist` (it's not possible to use a single query as there are multiple tables e.g. transaction, component, status, signature, etc, it was refactored to reuse `UtxoPersistenceServiceImpl.persist`)