### PR TITLE
NOTICK: Enable startup probes for Kafka/ZooKeeper

### DIFF
--- a/.ci/e2eTests/prereqs.yaml
+++ b/.ci/e2eTests/prereqs.yaml
@@ -27,8 +27,12 @@ kafka:
     limits:
       memory: 800Mi
       cpu: 1000m
+  startupProbe:
+    enabled: true
   zookeeper:
     replicaCount: 3
+    startupProbe:
+      enabled: true
   offsetsTopicReplicationFactor: 3
   transactionStateLogReplicationFactor: 3
 


### PR DESCRIPTION
In an attempt to increase the stability of Kafka in the E2E tests, give Kafka/ZooKeeper longer to start up by enabling startup probes.