### PR TITLE
CORE-9154: key already exists reporting verbosity reduction

### DIFF
--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/ExceptionsUtils.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/ExceptionsUtils.kt
@@ -12,7 +12,7 @@ val exceptionFactories = mapOf<String, (String, Throwable) -> Throwable>(
     IllegalStateException::class.java.name to { m, e -> IllegalStateException(m, e) },
     CryptoSignatureException::class.java.name to { m, e -> CryptoSignatureException(m, e) },
     CryptoRetryException::class.java.name to { m, e -> CryptoRetryException(m, e) },
-    KeyAlreadyExistsException::class.java.name to { m, _ -> KeyAlreadyExistsException(m) },
+    KeyAlreadyExistsException::class.java.name to { m, _ -> KeyAlreadyExistsException(m, "", "") },
     InvalidParamsException::class.java.name to { m, _ -> InvalidParamsException(m) },
 )
 

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -237,7 +237,11 @@ class SigningServiceImpl(
         logger.info("generateKeyPair(tenant={}, category={}, alias={}))", tenantId, category, alias)
         val ref = cryptoServiceFactory.findInstance(tenantId = tenantId, category = category)
         if (alias != null && store.find(tenantId, alias) != null) {
-            throw KeyAlreadyExistsException("The key with alias $alias already exists for tenant $tenantId")
+            throw KeyAlreadyExistsException(
+                "The key with alias $alias already exists for tenant $tenantId",
+                alias,
+                tenantId
+            )
         }
         val generatedKey = ref.instance.generateKeyPair(
             KeyGenerationSpec(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
@@ -84,7 +84,7 @@ class CryptoOpsBusProcessor(
             }
             respFuture.complete(result)
         } catch (e: KeyAlreadyExistsException) {
-            logger.trace("Key alias ${e.alias} already exists in tenant ${e.tenantId}; returning error rather than recreating")
+            logger.info("Key alias ${e.alias} already exists in tenant ${e.tenantId}; returning error rather than recreating")
             respFuture.completeExceptionally(e)
         } catch (e: Throwable) {
             logger.error("Failed to handle ${request.request::class.java} for tenant ${request.context.tenantId}", e)

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
@@ -3,6 +3,7 @@ package net.corda.crypto.service.impl.bus
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.crypto.config.impl.opsBusProcessor
 import net.corda.crypto.config.impl.toCryptoConfig
+import net.corda.crypto.core.KeyAlreadyExistsException
 import net.corda.crypto.impl.retrying.BackoffStrategy
 import net.corda.crypto.impl.retrying.CryptoRetryingExecutor
 import net.corda.crypto.impl.toMap
@@ -82,6 +83,9 @@ class CryptoOpsBusProcessor(
                         " ${if (result.response != null) result.response::class.java.name else "null"}"
             }
             respFuture.complete(result)
+        } catch (e: KeyAlreadyExistsException) {
+            logger.trace("Key alias ${e.alias} already exists in tenant ${e.tenantId}; returning error rather than recreating")
+            respFuture.completeExceptionally(e)
         } catch (e: Throwable) {
             logger.error("Failed to handle ${request.request::class.java} for tenant ${request.context.tenantId}", e)
             respFuture.completeExceptionally(e)

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -142,14 +142,13 @@ class CryptoOpsBusProcessorTests {
 
     private fun process(
         request: Any,
-        context: CryptoRequestContext? = null,
     ): ProcessResult {
-        val contextDef = context ?: createRequestContext()
+        val context = createRequestContext()
         val future = CompletableFuture<RpcOpsResponse>()
-        processor.onNext(RpcOpsRequest(contextDef, request), future)
+        processor.onNext(RpcOpsRequest(context, request), future)
         val result = future.get() ?: throw UnsupportedOperationException()
-        assertResponseContext(contextDef, result.context)
-        return ProcessResult(result, contextDef)
+        assertResponseContext(context, result.context)
+        return ProcessResult(result, context)
     }
 
 

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -42,6 +42,7 @@ import net.corda.data.crypto.wire.ops.rpc.queries.ByIdsRpcQuery
 import net.corda.data.crypto.wire.ops.rpc.queries.CryptoKeyOrderBy
 import net.corda.data.crypto.wire.ops.rpc.queries.KeysRpcQuery
 import net.corda.data.crypto.wire.ops.rpc.queries.SupportedSchemesRpcQuery
+import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigestAlgorithmName
@@ -51,7 +52,9 @@ import net.corda.v5.crypto.RSA_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.X25519_CODE_NAME
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -69,6 +72,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CryptoOpsBusProcessorTests {
     companion object {
         private val logger = contextLogger()
@@ -86,7 +90,8 @@ class CryptoOpsBusProcessorTests {
     private lateinit var verifier: SignatureVerificationService
     private lateinit var processor: CryptoOpsBusProcessor
 
-    private fun setup() {
+    @BeforeAll
+    fun setup() {
         tenantId = UUID.randomUUID().toString()
         factory = TestServicesFactory()
         schemeMetadata = factory.schemeMetadata
@@ -133,7 +138,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should return empty list for unknown key id`() {
-        setup()
         val context = createRequestContext()
         val future = CompletableFuture<RpcOpsResponse>()
         processor.onNext(
@@ -156,7 +160,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should return empty list for look up when the filter does not match`() {
-        setup()
         val context = createRequestContext()
         val future = CompletableFuture<RpcOpsResponse>()
         processor.onNext(
@@ -180,7 +183,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should generate key pair and be able to find and lookup and then sign using default and custom schemes`() {
-        setup()
         val data = UUID.randomUUID().toString().toByteArray()
         val alias = newAlias()
         // generate
@@ -265,7 +267,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Second attempt to generate key with same alias should throw KeyAlreadyExistsException`() {
-        setup()
         val alias = newAlias()
         // generate
         val context1 = createRequestContext()
@@ -314,7 +315,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should generate key pair and be able to find and lookup and then sign with parameterised signature params`() {
-        setup()
         val signatureSpec4 = ParameterizedSignatureSpec(
             "RSASSA-PSS",
             PSSParameterSpec(
@@ -435,7 +435,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should generate fresh key pair without external id and be able to sign using default and custom schemes`() {
-        setup()
         val data = UUID.randomUUID().toString().toByteArray()
         // generate
         val context1 = createRequestContext()
@@ -477,7 +476,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should handle generating fresh keys twice without external id`() {
-        setup()
         // generate
         val context1 = createRequestContext()
         val operationContext = listOf(
@@ -521,7 +519,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should handle generating fresh keys twice with external id`() {
-        setup()
         val externalId = UUID.randomUUID()
 
         // generate
@@ -567,7 +564,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should generate fresh key pair with external id and be able to sign using default and custom schemes`() {
-        setup()
         val data = UUID.randomUUID().toString().toByteArray()
         // generate
         val context1 = createRequestContext()
@@ -610,7 +606,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should generate wrapping key`() {
-        setup()
         val context1 = createRequestContext()
         val operationContext = listOf(
             KeyValuePair(CTX_TRACKING, UUID.randomUUID().toString()),
@@ -645,7 +640,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should derive shared secret key`() {
-        setup()
         val context1 = createRequestContext()
         val operationContext = listOf(
             KeyValuePair(CTX_TRACKING, UUID.randomUUID().toString()),
@@ -685,7 +679,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should complete future exceptionally in case of service failure`() {
-        setup()
         val data = UUID.randomUUID().toString().toByteArray()
         val alias = newAlias()
         // generate
@@ -750,7 +743,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should complete future exceptionally with IllegalArgumentException in case of unknown request`() {
-        setup()
         val context = createRequestContext()
         val future = CompletableFuture<RpcOpsResponse>()
         processor.onNext(
@@ -769,7 +761,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should return all supported scheme codes`() {
-        setup()
         val context = createRequestContext()
         val future = CompletableFuture<RpcOpsResponse>()
         processor.onNext(
@@ -797,7 +788,6 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should return all supported scheme codes for fresh keys`() {
-        setup()
         val context = createRequestContext()
         val future = CompletableFuture<RpcOpsResponse>()
         processor.onNext(

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -151,17 +151,14 @@ class CryptoOpsBusProcessorTests {
         assertEquals(category, operationContextMap[CRYPTO_CATEGORY])
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun <T> process(request: Any): T {
+    private inline fun <reified T> process(request: Any): T {
         val context = createRequestContext()
         val future = CompletableFuture<RpcOpsResponse>()
         processor.onNext(RpcOpsRequest(context, request), future)
-        val result = future.get() ?: throw UnsupportedOperationException()
+        val result = future.get()!!
         assertResponseContext(context, result.context)
         assertNotNull(result.response)
-        val response = (result.response) as? T
-        assertNotNull(response)
-        return response
+        return (result.response) as T
     }
 
     @Test

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -185,23 +185,18 @@ class CryptoOpsBusProcessorTests {
         val data = UUID.randomUUID().toString().toByteArray()
         val alias = newAlias()
         // generate
-        val operationContext = listOf(
-            KeyValuePair(CTX_TRACKING, UUID.randomUUID().toString()),
-            KeyValuePair("reason", "Hello World!")
+        val l = KeyValuePairList(
+            listOf(
+                KeyValuePair(CTX_TRACKING, UUID.randomUUID().toString()),
+                KeyValuePair("reason", "Hello World!")
+            )
         )
-        val request = GenerateKeyPairCommand(
-            LEDGER,
-            alias,
-            null,
-            ECDSA_SECP256R1_CODE_NAME,
-            KeyValuePairList(operationContext)
-        )
-        val (result1, _) = process(request)
-        val operationContextMap = factory.recordedCryptoContexts[operationContext[0].value]
+        val (result1, _) = process(GenerateKeyPairCommand(LEDGER, alias, null, ECDSA_SECP256R1_CODE_NAME, l))
+        val operationContextMap = factory.recordedCryptoContexts[l.items[0].value]
         assertNotNull(operationContextMap)
         assertEquals(4, operationContextMap.size)
-        assertEquals(operationContext[0].value, operationContextMap[CTX_TRACKING])
-        assertEquals(operationContext[1].value, operationContextMap["reason"])
+        assertEquals(l.items[0].value, operationContextMap[CTX_TRACKING])
+        assertEquals(l.items[1].value, operationContextMap["reason"])
         assertEquals(tenantId, operationContextMap[CRYPTO_TENANT_ID])
         assertEquals(LEDGER, operationContextMap[CRYPTO_CATEGORY])
         assertThat(result1.response).isInstanceOf(CryptoPublicKey::class.java)

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -206,16 +206,9 @@ class CryptoOpsBusProcessorTests {
     @Test
     fun `Second attempt to generate key with same alias should throw KeyAlreadyExistsException`() {
         val alias = newAlias()
-        // generate
-        val l = KeyValuePairList(
-            listOf(
-                KeyValuePair(CTX_TRACKING, UUID.randomUUID().toString()),
-                KeyValuePair("reason", "Hello World!")
-            )
-        )
+        val l = KeyValuePairList(emptyList())
         val result = process(GenerateKeyPairCommand(LEDGER, alias, null, ECDSA_SECP256R1_CODE_NAME, l))
         assertThat(result.response).isInstanceOf(CryptoPublicKey::class.java)
-        // generate again
         val e = assertFailsWith<ExecutionException> {
             process(GenerateKeyPairCommand(LEDGER, alias, null, ECDSA_SECP256R1_CODE_NAME, l))
         }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -212,16 +212,8 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should generate key pair and be able to find and lookup and then sign with parameterised signature params`() {
-        val signatureSpec4 = ParameterizedSignatureSpec(
-            "RSASSA-PSS",
-            PSSParameterSpec(
-                "SHA-256",
-                "MGF1",
-                MGF1ParameterSpec.SHA256,
-                32,
-                1
-            )
-        )
+        val spec4 = PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1)
+        val signatureSpec4 = ParameterizedSignatureSpec("RSASSA-PSS", spec4)
         val data = UUID.randomUUID().toString().toByteArray()
         val alias = newAlias()
         // generate
@@ -244,8 +236,8 @@ class CryptoOpsBusProcessorTests {
         // sign
         val encKey4 = ByteBuffer.wrap(factory.schemeMetadata.encodeAsByteArray(publicKey))
         val params4 = factory.schemeMetadata.serialize(signatureSpec4.params)
-        val parameterSpec = ByteBuffer.wrap(CryptoSignatureParameterSpec(params4.clazz, ByteBuffer.wrap(params4.bytes)))
-        val cryptoSignatureSpec4 = CryptoSignatureSpec(signatureSpec4.signatureName, null, parameterSpec))
+        val parameterSpec = CryptoSignatureParameterSpec(params4.clazz, ByteBuffer.wrap(params4.bytes))
+        val cryptoSignatureSpec4 = CryptoSignatureSpec(signatureSpec4.signatureName, null, parameterSpec)
         val signatureCommand = SignRpcCommand(encKey4, cryptoSignatureSpec4, ByteBuffer.wrap(data), emptyContext)
         val signature4 = process<CryptoSignatureWithKey>(signatureCommand)
         assertEquals(publicKey, factory.schemeMetadata.decodePublicKey(signature4.publicKey.array()))

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -161,19 +161,21 @@ class CryptoOpsBusProcessorTests {
         return result
     }
 
+    private fun process2(request: Any): Any = process(request).response
+
     @Test
     fun `Should return empty list for unknown key id`() {
-        val result = process(ByIdsRpcQuery(listOf(publicKeyIdFromBytes(UUID.randomUUID().toString().toByteArray()))))
-        assertThat(result.response).isInstanceOf(CryptoSigningKeys::class.java)
-        assertEquals(0, (result.response as CryptoSigningKeys).keys.size)
+        val response = process2(ByIdsRpcQuery(listOf(publicKeyIdFromBytes(UUID.randomUUID().toString().toByteArray()))))
+        assertThat(response).isInstanceOf(CryptoSigningKeys::class.java)
+        assertEquals(0, (response as CryptoSigningKeys).keys.size)
     }
 
     @Test
     fun `Should return empty list for look up when the filter does not match`() {
         val l = KeyValuePairList(listOf(KeyValuePair(ALIAS_FILTER, UUID.randomUUID().toString())))
-        val result = process(KeysRpcQuery(0, 10, CryptoKeyOrderBy.NONE, l))
-        assertThat(result.response).isInstanceOf(CryptoSigningKeys::class.java)
-        assertEquals(0, (result.response as CryptoSigningKeys).keys.size)
+        val response = process2(KeysRpcQuery(0, 10, CryptoKeyOrderBy.NONE, l))
+        assertThat(response).isInstanceOf(CryptoSigningKeys::class.java)
+        assertEquals(0, (response as CryptoSigningKeys).keys.size)
     }
 
     @Test
@@ -190,9 +192,9 @@ class CryptoOpsBusProcessorTests {
         assertNotNull(info)
         assertEquals(alias, info.alias)
         // find
-        val result2 = process(ByIdsRpcQuery(listOf(publicKeyIdFromBytes(info.publicKey))))
-        assertThat(result2.response).isInstanceOf(CryptoSigningKeys::class.java)
-        val key = result2.response as CryptoSigningKeys
+        val response2 = process2(ByIdsRpcQuery(listOf(publicKeyIdFromBytes(info.publicKey))))
+        assertThat(response2).isInstanceOf(CryptoSigningKeys::class.java)
+        val key = response2 as CryptoSigningKeys
         assertEquals(1, key.keys.size)
         assertEquals(publicKey, factory.schemeMetadata.decodePublicKey(key.keys[0].publicKey.array()))
         // lookup

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -92,6 +92,9 @@ class CryptoOpsBusProcessorTests {
 
     @BeforeAll
     fun setup() {
+        // none of these services store critical state, so we are safe to share them between
+        // test runs. This test class takes 1.7s for me if this is @BeforeAll, compared with 15s
+        // if this is @BeforeEach.
         tenantId = UUID.randomUUID().toString()
         factory = TestServicesFactory()
         schemeMetadata = factory.schemeMetadata
@@ -322,12 +325,7 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should handle generating fresh keys twice without external id`() {
-        val l = KeyValuePairList(
-            listOf(
-                KeyValuePair(CTX_TRACKING, UUID.randomUUID().toString()),
-                KeyValuePair("reason", "Hello World!")
-            )
-        ) // TODO: remove me?
+        val l = KeyValuePairList(emptyList())
         val result1 = process(GenerateFreshKeyRpcCommand(CI, null, ECDSA_SECP256R1_CODE_NAME, l))
         val result2 = process(GenerateFreshKeyRpcCommand(CI, null, ECDSA_SECP256R1_CODE_NAME, l))
         assertThat(result1.response).isNotEqualTo(result2.response)
@@ -335,19 +333,12 @@ class CryptoOpsBusProcessorTests {
 
     @Test
     fun `Should handle generating fresh keys twice with external id`() {
-        val externalId = UUID.randomUUID()
-        // generate
-        val l = KeyValuePairList(
-            listOf(
-                KeyValuePair(CTX_TRACKING, UUID.randomUUID().toString()),
-                KeyValuePair("reason", "Hello World!")
-            )
-        ) // TODO: remove me?
-        val result1 = process(GenerateFreshKeyRpcCommand(CI, externalId.toString(), ECDSA_SECP256R1_CODE_NAME, l))
-        val result2 = process(GenerateFreshKeyRpcCommand(CI, externalId.toString(), ECDSA_SECP256R1_CODE_NAME, l))
+        val externalId = UUID.randomUUID().toString()
+        val l = KeyValuePairList(emptyList())
+        val result1 = process(GenerateFreshKeyRpcCommand(CI, externalId, ECDSA_SECP256R1_CODE_NAME, l))
+        val result2 = process(GenerateFreshKeyRpcCommand(CI, externalId, ECDSA_SECP256R1_CODE_NAME, l))
         assertThat(result1.response).isNotEqualTo(result2.response)
     }
-
 
     @Test
     fun `Should generate fresh key pair with external id and be able to sign using default and custom schemes`() {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
@@ -74,7 +74,7 @@ class KeysFactoryTest {
                 scheme = eq(scheme),
                 context = any(),
             )
-        } doThrow KeyAlreadyExistsException("")
+        } doThrow KeyAlreadyExistsException("", "", "")
         on {
             lookup(tenantId, listOf(publicKey.publicKeyId()))
         } doReturn listOf(cryptoSigningKey)

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyAlreadyExistsException.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyAlreadyExistsException.kt
@@ -2,5 +2,5 @@ package net.corda.crypto.core
 
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
-class KeyAlreadyExistsException(message: String) :
+class KeyAlreadyExistsException(message: String, val alias: String, val tenantId: String) :
     CordaRuntimeException(message)

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyAlreadyExistsException.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyAlreadyExistsException.kt
@@ -2,5 +2,5 @@ package net.corda.crypto.core
 
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
-class KeyAlreadyExistsException(message: String, val alias: String, val tenantId: String) :
+class KeyAlreadyExistsException(message: String, val alias: String = "", val tenantId: String = "") :
     CordaRuntimeException(message)


### PR DESCRIPTION
CORE-9154: reduce logging on KeyAlreadyExistsException.kt to a trace without a backtrace

Also share test set up in CryptoOpsBusProcessorTests, and refactor them to make them easier to read.
