### PR TITLE
CORE-8402 Separate EKS overrides

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -120,7 +120,7 @@ pipeline {
                     sh '''#!/bin/bash
                         echo "${PASSWORD}" | helm registry login corda-os-docker.software.r3.com -u "${USER}" --password-stdin
                         helm install prereqs oci://corda-os-docker.software.r3.com/helm-charts/corda-dev \
-                            -f .ci/e2eTests/prereqs.yaml --set postgresql.enabled=false -n "${NAMESPACE}" --wait --timeout 600s
+                            -f .ci/e2eTests/prereqs.yaml -f .ci/e2eTests/prereqs-eks.yaml --set postgresql.enabled=false -n "${NAMESPACE}" --wait --timeout 600s
                         KAFKA_PASSWORDS=$(kubectl get secret prereqs-kafka-jaas -n "${NAMESPACE}" -o go-template="{{ index .data \\\"client-passwords\\\" | base64decode }}")
                         IFS=',' read -r -a KAFKA_PASSWORDS_ARRAY <<< "$KAFKA_PASSWORDS"
                         kubectl create secret generic kafka-credentials -n "${NAMESPACE}" \
@@ -236,11 +236,13 @@ def portForwarding(def name, def port, def portMapping = null){
 }
 
 def deployCorda(def name, def namespace, def base_image){
-    sh """\
+    sh """
        helm install $name-db oci://corda-os-docker.software.r3.com/helm-charts/corda-dev \
-           -f .ci/e2eTests/prereqs.yaml --set kafka.enabled=false -n $namespace --wait --timeout 600s
+           -f .ci/e2eTests/prereqs.yaml  -f .ci/e2eTests/prereqs-eks.yaml --set kafka.enabled=false \
+           -n $namespace --wait --timeout 600s
        helm install corda-$name ./charts/corda \
            -f .ci/e2eTests/corda.yaml \
+           -f .ci/e2eTests/corda-eks.yaml \
            --set image.tag=$base_image \
            --set nodeSelector.kubernetes\\\\.io/os=linux \
            --set nodeSelector.kubernetes\\\\.io/arch=${E2E_WORKER_ARCH} \

--- a/.ci/e2eTests/corda-eks.yaml
+++ b/.ci/e2eTests/corda-eks.yaml
@@ -1,0 +1,15 @@
+imagePullSecrets:
+  - "docker-registry-cred"
+
+bootstrap:
+  db:
+    clientImage:
+      registry: docker-remotes.software.r3.com
+
+resources:
+  requests:
+    memory: "620Mi"
+    cpu: "500m"
+  limits:
+    memory: "1250Mi"
+    cpu: "1000m"

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -1,10 +1,4 @@
-imagePullSecrets:
-  - "docker-registry-cred"
-
 bootstrap:
-  db:
-    clientImage:
-      registry: docker-remotes.software.r3.com
   kafka:
     sasl:
       username:
@@ -39,14 +33,6 @@ kafka:
           key: "ca.crt"
   sasl:
     enabled: true
-
-resources:
-  requests:
-    memory: "620Mi"
-    cpu: "500m"
-  limits:
-    memory: "1250Mi"
-    cpu: "1000m"
 
 workers:
   crypto:

--- a/.ci/e2eTests/prereqs-eks.yaml
+++ b/.ci/e2eTests/prereqs-eks.yaml
@@ -1,0 +1,33 @@
+global:
+  imageRegistry: docker-remotes.software.r3.com
+  imagePullSecrets:
+    - docker-registry-cred
+  storageClass: corda-sc
+
+kafka:
+  replicaCount: 7
+  resources:
+    requests:
+      memory: 390Mi
+      cpu: 1000m
+    limits:
+      memory: 800Mi
+      cpu: 1000m
+  startupProbe:
+    enabled: true
+  zookeeper:
+    replicaCount: 3
+    startupProbe:
+      enabled: true
+  offsetsTopicReplicationFactor: 3
+  transactionStateLogReplicationFactor: 3
+
+postgresql:
+  primary:
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 300m
+      limits:  
+        memory: 512Mi
+        cpu: 600m

--- a/.ci/e2eTests/prereqs.yaml
+++ b/.ci/e2eTests/prereqs.yaml
@@ -1,12 +1,5 @@
-global:
-  imageRegistry: docker-remotes.software.r3.com
-  imagePullSecrets:
-    - docker-registry-cred
-  storageClass: corda-sc
-
 kafka:
   auth:
-    clientProtocol: sasl_tls
     sasl:
       jaas:
         clientUsers:
@@ -18,30 +11,3 @@ kafka:
           - "p2pGateway"
           - "p2pLinkManager"
           - "rpc"
-        clientPasswords:
-  replicaCount: 7
-  resources:
-    requests:
-      memory: 390Mi
-      cpu: 1000m
-    limits:
-      memory: 800Mi
-      cpu: 1000m
-  startupProbe:
-    enabled: true
-  zookeeper:
-    replicaCount: 3
-    startupProbe:
-      enabled: true
-  offsetsTopicReplicationFactor: 3
-  transactionStateLogReplicationFactor: 3
-
-postgresql:
-  primary:
-    resources:
-      requests:
-        memory: 256Mi
-        cpu: 300m
-      limits:  
-        memory: 512Mi
-        cpu: 600m


### PR DESCRIPTION
To make it easier for developers to recreate issues with the E2E tests locally, separate out the EKS-specific parts of the override files. Once merged, I'll update the instructions in the GitHub wiki.