### PR TITLE
CORE-8226: Prevent blank client request ID by adding regex validation

### DIFF
--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -81,6 +81,7 @@ class FlowRPCOpsImpl @Activate constructor(
         publisher?.close()
         publisher = publisherFactory.createPublisher(PublisherConfig("FlowRPCOps"), config)
     }
+
     private fun regexMatch(input: String, regex: String): Boolean {
         return input.matches(regex.toRegex(RegexOption.IGNORE_CASE))
     }
@@ -93,7 +94,6 @@ class FlowRPCOpsImpl @Activate constructor(
         }
     }
 
-    @Suppress("SpreadOperator")
     override fun startFlow(
         holdingIdentityShortHash: String,
         startFlow: StartFlowParameters

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.rpcops.impl.v1
 
-import java.util.concurrent.TimeUnit
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.virtualnode.VirtualNodeInfo
 import net.corda.flow.rpcops.FlowRPCOpsServiceException
@@ -31,6 +30,7 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.publisher.waitOnPublisherFutures
 import net.corda.messaging.api.records.Record
 import net.corda.permissions.validation.PermissionValidationService
+import net.corda.rbac.schema.RbacKeys
 import net.corda.rbac.schema.RbacKeys.PREFIX_SEPARATOR
 import net.corda.rbac.schema.RbacKeys.START_FLOW_PREFIX
 import net.corda.schema.Schemas.Flow.Companion.FLOW_MAPPER_EVENT_TOPIC
@@ -43,6 +43,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
 @Component(service = [FlowRpcOps::class, PluggableRPCOps::class], immediate = true)
@@ -80,6 +81,9 @@ class FlowRPCOpsImpl @Activate constructor(
         publisher?.close()
         publisher = publisherFactory.createPublisher(PublisherConfig("FlowRPCOps"), config)
     }
+    private fun regexMatch(input: String, regex: String): Boolean {
+        return input.matches(regex.toRegex(RegexOption.IGNORE_CASE))
+    }
 
     @Suppress("SpreadOperator")
     override fun startFlow(
@@ -101,6 +105,12 @@ class FlowRPCOpsImpl @Activate constructor(
         val vNode = getVirtualNode(holdingIdentityShortHash)
         val clientRequestId = startFlow.clientRequestId
         val flowStatus = flowStatusCacheService.getStatus(clientRequestId, vNode.holdingIdentity)
+
+        if (!regexMatch(clientRequestId, RbacKeys.CLIENT_REQ_REGEX)) {
+            throw IllegalArgumentException(
+                """Supplied Client Request ID "$clientRequestId" is invalid,""" +
+                        """ it must conform to the pattern "${RbacKeys.CLIENT_REQ_REGEX}".""")
+        }
 
         if (flowStatus != null) {
             throw ResourceAlreadyExistsException("A flow has already been started with for the requested holdingId and clientRequestId")

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -201,8 +201,6 @@ class FlowRPCOpsImpl @Activate constructor(
     override fun getFlowStatus(holdingIdentityShortHash: String, clientRequestId: String): FlowStatusResponse {
         val vNode = getVirtualNode(holdingIdentityShortHash)
 
-        validateClientRequestId(clientRequestId)
-
         val flowStatus = flowStatusCacheService.getStatus(clientRequestId, vNode.holdingIdentity)
             ?: throw ResourceNotFoundException(
                 "Failed to find the flow status for holding identity='${holdingIdentityShortHash} " +

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImpl.kt
@@ -87,7 +87,7 @@ class FlowRPCOpsImpl @Activate constructor(
 
     private fun validateClientRequestId(clientRequestId: String) {
         if (!regexMatch(clientRequestId, RbacKeys.CLIENT_REQ_REGEX)) {
-            throw IllegalArgumentException(
+            throw BadRequestException(
                 """Supplied Client Request ID "$clientRequestId" is invalid,""" +
                         """ it must conform to the pattern "${RbacKeys.CLIENT_REQ_REGEX}".""")
         }

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -533,4 +533,15 @@ class FlowRPCOpsImplTest {
             flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
     }
+
+    @Test
+    fun `get flow status throws illegal argument if clientRequestId is empty`() {
+        whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(FlowStatus())
+
+        val flowRPCOps = createFlowRpcOps()
+
+        assertThrows<java.lang.IllegalArgumentException> {
+            flowRPCOps.getFlowStatus(VALID_SHORT_HASH, "")
+        }
+    }
 }

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -167,7 +167,7 @@ class FlowRPCOpsImplTest {
     fun `get flow status`() {
         whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(FlowStatus())
         val flowRPCOps = createFlowRpcOps()
-        flowRPCOps.getFlowStatus(VALID_SHORT_HASH, "")
+        flowRPCOps.getFlowStatus(VALID_SHORT_HASH, clientRequestId)
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -522,5 +522,15 @@ class FlowRPCOpsImplTest {
         }
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(fatalErrorFunction, never()).invoke()
+    }
+    @Test
+    fun `start flow throws illegal argument if clientRequestId is empty`() {
+        val flowRPCOps = createFlowRpcOps()
+
+        whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
+
+        assertThrows<java.lang.IllegalArgumentException> {
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+        }
     }
 }

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -524,12 +524,12 @@ class FlowRPCOpsImplTest {
         verify(fatalErrorFunction, never()).invoke()
     }
     @Test
-    fun `start flow throws illegal argument if clientRequestId is empty`() {
+    fun `start flow throws bad request if clientRequestId is empty`() {
         val flowRPCOps = createFlowRpcOps()
 
         whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
 
-        assertThrows<java.lang.IllegalArgumentException> {
+        assertThrows<BadRequestException> {
             flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
     }

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -533,15 +533,4 @@ class FlowRPCOpsImplTest {
             flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
         }
     }
-
-    @Test
-    fun `get flow status throws illegal argument if clientRequestId is empty`() {
-        whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(FlowStatus())
-
-        val flowRPCOps = createFlowRpcOps()
-
-        assertThrows<java.lang.IllegalArgumentException> {
-            flowRPCOps.getFlowStatus(VALID_SHORT_HASH, "")
-        }
-    }
 }

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -1,7 +1,5 @@
 package net.corda.flow.rpcops.impl.v1
 
-import java.time.Instant
-import java.util.UUID
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.output.FlowStatus
@@ -54,6 +52,8 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 class FlowRPCOpsImplTest {
@@ -67,6 +67,7 @@ class FlowRPCOpsImplTest {
     private lateinit var permissionValidationService: PermissionValidationService
     private lateinit var permissionValidator: PermissionValidator
     private lateinit var fatalErrorFunction: () -> Unit
+    private val clientRequestId = UUID.randomUUID().toString()
 
     private companion object {
         val loginName = "${FlowRPCOpsImplTest::class.java.simpleName}-User"
@@ -181,7 +182,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps()
 
         assertThrows<ResourceNotFoundException> {
-            flowRPCOps.getFlowStatus(VALID_SHORT_HASH, "")
+            flowRPCOps.getFlowStatus(VALID_SHORT_HASH, clientRequestId)
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -256,7 +257,7 @@ class FlowRPCOpsImplTest {
 
         whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
 
-        flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+        flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, times(1)).get(any())
@@ -273,7 +274,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps(false)
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
@@ -292,7 +293,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps()
 
         assertThrows<BadRequestException> {
-            flowRPCOps.startFlow(invalidShortHash, StartFlowParameters("", "", TestJsonObject()))
+            flowRPCOps.startFlow(invalidShortHash, StartFlowParameters(clientRequestId, "", TestJsonObject()))
         }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())
@@ -310,7 +311,7 @@ class FlowRPCOpsImplTest {
         val flowRPCOps = createFlowRpcOps()
 
         assertThrows<ResourceNotFoundException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", "", TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, "", TestJsonObject()))
         }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())
@@ -327,7 +328,7 @@ class FlowRPCOpsImplTest {
 
         whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(mock())
         assertThrows<ResourceAlreadyExistsException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -366,7 +367,7 @@ class FlowRPCOpsImplTest {
 
         doThrow(CordaMessageAPIIntermittentException("")).whenever(publisher).publish(any())
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -388,7 +389,7 @@ class FlowRPCOpsImplTest {
         }))
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -406,7 +407,7 @@ class FlowRPCOpsImplTest {
 
         doThrow(CordaMessageAPIFatalException("")).whenever(publisher).publish(any())
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -421,7 +422,7 @@ class FlowRPCOpsImplTest {
         // attempting to start the flow
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -443,7 +444,7 @@ class FlowRPCOpsImplTest {
         }))
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -458,7 +459,7 @@ class FlowRPCOpsImplTest {
         // attempting to start the flow
 
         assertThrows<FlowRPCOpsServiceException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -480,7 +481,7 @@ class FlowRPCOpsImplTest {
 
         val flowRPCOps = createFlowRpcOps()
 
-        flowRPCOps.registerFlowStatusUpdatesFeed(duplexChannel, VALID_SHORT_HASH, "")
+        flowRPCOps.registerFlowStatusUpdatesFeed(duplexChannel, VALID_SHORT_HASH, clientRequestId)
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(duplexChannel, times(1)).error(any())
@@ -497,7 +498,7 @@ class FlowRPCOpsImplTest {
 
         val flowRPCOps = createFlowRpcOps()
 
-        flowRPCOps.registerFlowStatusUpdatesFeed(duplexChannel, "invalid", "")
+        flowRPCOps.registerFlowStatusUpdatesFeed(duplexChannel, "invalid", clientRequestId)
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
         verify(duplexChannel, times(1)).error(any())
@@ -517,7 +518,7 @@ class FlowRPCOpsImplTest {
         ).thenReturn(false)
 
         assertThrows<ForbiddenException> {
-            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
+            flowRPCOps.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
         }
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(fatalErrorFunction, never()).invoke()

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -523,6 +523,7 @@ class FlowRPCOpsImplTest {
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(fatalErrorFunction, never()).invoke()
     }
+
     @Test
     fun `start flow throws bad request if clientRequestId is empty`() {
         val flowRPCOps = createFlowRpcOps()


### PR DESCRIPTION
Flow Endpoint - Cordapp can call the endpoint with a blank ClientRequestId, when it should throw an error. This PR adds regex validation to prevent blank ClientRequestId from being accepted and instead throw an exception.

_Testing_
Manual testing by running the combined worker and smoketests. Replicated QA's issue on swagger and got the 202 response. 
Tested solution for startFlow using above.

_Other_
Noted that could not add validation for getFlowStatus as requested as javelin evaluates the url beforehand so a blank clientRequestId will return 404:
{
    "title": "Not found",
    "status": 404,
    "details": {}
}%  
