### PR TITLE
NOTICK: use latest version of Corda Gradle Plugins

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ cordaRuntimeRevision=0
 
 # Plugin dependency versions
 bndVersion=6.4.0
-cordaGradlePluginsVersion=7.0.0
+cordaGradlePluginsVersion=7.0.1
 detektPluginVersion=1.22.+
 internalPublishVersion=1.+
 internalDockerVersion=1.+


### PR DESCRIPTION
[7.0.1 Corda Gradle Plugins](https://github.com/corda/corda-gradle-plugins/releases/tag/release%2F7.0.1) has been released bumping version in runtime-os to coincide with this 