### PR TITLE
CORE-8867 Add DynamicX509ExtendedTrustManager inside Gateway

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
@@ -1,0 +1,90 @@
+package net.corda.p2p.gateway.messaging.http
+
+import net.corda.p2p.gateway.certificates.RevocationChecker
+import net.corda.p2p.gateway.messaging.RevocationConfig
+import java.net.Socket
+import java.security.KeyStore
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.CertPathTrustManagerParameters
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedTrustManager
+
+internal class DynamicX509ExtendedTrustManager(
+    private val trustStoresMap: TrustStoresMap,
+    private val revocationConfig: RevocationConfig,
+    private val trustManagerFactory: TrustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+): X509ExtendedTrustManager() {
+    private companion object {
+        val wrongUsageMessage = this::class.java.simpleName + " can only be used by the gateway server."
+        const val invalidClientMessage = "None of the possible trust roots were valid for the client certificate. Error(s): "
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: Socket?) {
+        val exceptionMessages = mutableSetOf<String>()
+        trustStoresMap.getTrustStores().flatMap { it.x509ExtendedTrustManager() }.forEach {
+            if (doesNotThrowCertificateException(exceptionMessages) { it.checkClientTrusted(chain, authType, socket) }) {
+                return
+            }
+        }
+        throw CertificateException(invalidClientMessage + exceptionMessages.joinToString())
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: SSLEngine?) {
+        val exceptionMessages = mutableSetOf<String>()
+        trustStoresMap.getTrustStores().flatMap { it.x509ExtendedTrustManager() }.forEach {
+            if (doesNotThrowCertificateException(exceptionMessages) { it.checkClientTrusted(chain, authType, engine) }) {
+                return
+            }
+        }
+        throw CertificateException(invalidClientMessage + exceptionMessages.joinToString())
+    }
+
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        val exceptionMessages = mutableSetOf<String>()
+        trustStoresMap.getTrustStores().flatMap { it.x509ExtendedTrustManager() }.forEach {
+            if (doesNotThrowCertificateException(exceptionMessages) { it.checkClientTrusted(chain, authType) }) {
+                return
+            }
+        }
+        throw CertificateException(invalidClientMessage + exceptionMessages.joinToString())
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: Socket?) {
+        throw IllegalStateException(wrongUsageMessage)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, engine: SSLEngine?) {
+        throw IllegalStateException(wrongUsageMessage)
+    }
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+        throw IllegalStateException(wrongUsageMessage)
+    }
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> {
+        // We assume here that all the trust stores were issued by the same CA.
+         return trustStoresMap.getTrustStores().flatMap {
+             it.x509ExtendedTrustManager() }
+         .map {
+             it.acceptedIssuers.toList()
+         }.flatten().toTypedArray()
+    }
+
+    private fun doesNotThrowCertificateException(exceptionMessages: MutableSet<String>, function : (() -> Unit)): Boolean {
+        return try {
+            function()
+            true
+        } catch (except: CertificateException) {
+            except.message?.let { message -> exceptionMessages.add(message) }
+            false
+        }
+    }
+
+    private fun KeyStore.x509ExtendedTrustManager(): List<X509ExtendedTrustManager> {
+        val pkixParams = RevocationChecker.getCertCheckingParameters(this, revocationConfig)
+        trustManagerFactory.init(CertPathTrustManagerParameters(pkixParams))
+        return trustManagerFactory.trustManagers.filterIsInstance<X509ExtendedTrustManager>()
+    }
+}

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
@@ -10,7 +10,6 @@ import javax.net.ssl.CertPathTrustManagerParameters
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509ExtendedTrustManager
-import javax.net.ssl.X509TrustManager
 
 internal class DynamicX509ExtendedTrustManager(
     private val trustStoresMap: TrustStoresMap,

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -59,6 +59,8 @@ internal class TrustStoresMap(
             ?: throw IllegalArgumentException("Unknown trust store for source X500 name ($sourceX500Name) " +
                     "and group ID ($destinationGroupId)")
 
+    fun getTrustStores() = trustRootsPerHoldingIdentity.values.mapNotNull { it.trustStore }
+
     private val blockingDominoTile = BlockingDominoTile(
         this::class.java.simpleName,
         lifecycleCoordinatorFactory,

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.net.Socket
 import java.security.KeyStore
 import java.security.cert.CertificateException
@@ -44,7 +45,7 @@ class DynamicX509ExtendedTrustManagerTest {
 
     @Test
     fun `if any inner X509ExtendedTrustManager does not throw a CertificateException then checkClientTrusted succeeds`() {
-        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
+        whenever(mockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
         doNothing().`when`(secondMockX509ExtendedTrustManager).checkClientTrusted(any(), any())
 
         dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "")
@@ -52,7 +53,7 @@ class DynamicX509ExtendedTrustManagerTest {
 
     @Test
     fun `if any inner X509ExtendedTrustManager does not throw a CertificateException then checkClientTrusted with Socket succeeds`() {
-        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
+        whenever(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
         doNothing().`when`(secondMockX509ExtendedTrustManager).checkClientTrusted(any(), any(), any<Socket>())
 
         dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<Socket>())
@@ -60,7 +61,7 @@ class DynamicX509ExtendedTrustManagerTest {
 
     @Test
     fun `if any inner X509ExtendedTrustManager does not throw a CertificateException then checkClientTrusted with SSLEngine succeeds`() {
-        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
+        whenever(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
         doNothing().`when`(secondMockX509ExtendedTrustManager).checkClientTrusted(any(), any(), any<SSLEngine>())
 
         dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<SSLEngine>())
@@ -68,16 +69,16 @@ class DynamicX509ExtendedTrustManagerTest {
 
     @Test
     fun `if all inner X509ExtendedTrustManager throw a CertificateException then checkClientTrusted throws`() {
-        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
-        `when`(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
+        whenever(mockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
+        whenever(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
 
         assertThrows<CertificateException> { dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "") }
     }
 
     @Test
     fun `if all inner X509ExtendedTrustManager throw a CertificateException then checkClientTrusted with Socket throws`() {
-        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
-        `when`(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
+        whenever(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
+        whenever(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
 
         assertThrows<CertificateException> {
             dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<Socket>())
@@ -86,8 +87,8 @@ class DynamicX509ExtendedTrustManagerTest {
 
     @Test
     fun `if all inner X509ExtendedTrustManager throw a CertificateException then checkClientTrusted with SSLEngine throws`() {
-        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
-        `when`(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
+        whenever(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
+        whenever(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
 
         assertThrows<CertificateException> {
             dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<SSLEngine>())

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
@@ -1,0 +1,117 @@
+package net.corda.p2p.gateway.messaging.http
+
+import net.corda.p2p.gateway.messaging.RevocationConfig
+import net.corda.p2p.gateway.messaging.RevocationConfigMode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.net.Socket
+import java.security.KeyStore
+import java.security.cert.CertificateException
+import java.security.cert.PKIXBuilderParameters
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedTrustManager
+
+class DynamicX509ExtendedTrustManagerTest {
+
+    private val mockX509ExtendedTrustManager = mock<X509ExtendedTrustManager>()
+    private val secondMockX509ExtendedTrustManager = mock<X509ExtendedTrustManager>()
+    private val mockTrustManagerFactory = mock<TrustManagerFactory> {
+        on { trustManagers } doReturn arrayOf(mockX509ExtendedTrustManager, secondMockX509ExtendedTrustManager)
+    }
+    private val mockTrustStore = mock<KeyStore>()
+    private val trustStoresMap = mock<TrustStoresMap> {
+        on { getTrustStores() } doReturn listOf(mockTrustStore)
+    }
+    private val dynamicX509ExtendedTrustManager = DynamicX509ExtendedTrustManager(
+        trustStoresMap,
+        RevocationConfig(RevocationConfigMode.OFF),
+        mockTrustManagerFactory
+    )
+    private val pkixBuilderParameters = Mockito.mockConstruction(PKIXBuilderParameters::class.java)
+
+    @AfterEach
+    fun cleanup() {
+        pkixBuilderParameters.close()
+    }
+
+    @Test
+    fun `if any inner X509ExtendedTrustManager does not throw a CertificateException then checkClientTrusted succeeds`() {
+        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
+        doNothing().`when`(secondMockX509ExtendedTrustManager).checkClientTrusted(any(), any())
+
+        dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "")
+    }
+
+    @Test
+    fun `if any inner X509ExtendedTrustManager does not throw a CertificateException then checkClientTrusted with Socket succeeds`() {
+        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
+        doNothing().`when`(secondMockX509ExtendedTrustManager).checkClientTrusted(any(), any(), any<Socket>())
+
+        dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<Socket>())
+    }
+
+    @Test
+    fun `if any inner X509ExtendedTrustManager does not throw a CertificateException then checkClientTrusted with SSLEngine succeeds`() {
+        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
+        doNothing().`when`(secondMockX509ExtendedTrustManager).checkClientTrusted(any(), any(), any<SSLEngine>())
+
+        dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<SSLEngine>())
+    }
+
+    @Test
+    fun `if all inner X509ExtendedTrustManager throw a CertificateException then checkClientTrusted throws`() {
+        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
+        `when`(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any())).thenThrow(CertificateException())
+
+        assertThrows<CertificateException> { dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "") }
+    }
+
+    @Test
+    fun `if all inner X509ExtendedTrustManager throw a CertificateException then checkClientTrusted with Socket throws`() {
+        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
+        `when`(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<Socket>())).thenThrow(CertificateException())
+
+        assertThrows<CertificateException> {
+            dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<Socket>())
+        }
+    }
+
+    @Test
+    fun `if all inner X509ExtendedTrustManager throw a CertificateException then checkClientTrusted with SSLEngine throws`() {
+        `when`(mockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
+        `when`(secondMockX509ExtendedTrustManager.checkClientTrusted(any(), any(), any<SSLEngine>())).thenThrow(CertificateException())
+
+        assertThrows<CertificateException> {
+            dynamicX509ExtendedTrustManager.checkClientTrusted(arrayOf(mock()), "", mock<SSLEngine>())
+        }
+    }
+
+    @Test
+    fun `checkServerTrusted throws an InvalidStateException`() {
+        assertThrows<IllegalStateException> {
+            dynamicX509ExtendedTrustManager.checkServerTrusted(arrayOf(mock()), "")
+        }
+    }
+
+    @Test
+    fun `checkServerTrusted with Socket throws an InvalidStateException`() {
+        assertThrows<IllegalStateException> {
+            dynamicX509ExtendedTrustManager.checkServerTrusted(arrayOf(mock()), "", mock<Socket>())
+        }
+    }
+
+    @Test
+    fun `checkServerTrusted with SSLEngine throws an InvalidStateException`() {
+        assertThrows<IllegalStateException> {
+            dynamicX509ExtendedTrustManager.checkServerTrusted(arrayOf(mock()), "", mock<SSLEngine>())
+        }
+    }
+}


### PR DESCRIPTION
For now this is only used in a unit test. Eventually this will be used by the Gateway Server to verify the client SSL certificate, when using Mutual TLS. DynamicX509ExtendedTrustManager delegates to a X509ExtendedTrustManager for each possible trust root.