### PR TITLE
CORE-9206: Add localWorkerPlatformVersion to the PlatformInfoProvider

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -351,16 +351,22 @@ class OsgiRun {
     private final NamedDomainObjectContainer<JavaAgent> javaAgents
     private final MapProperty<String, String> frameworkProperties
     private final SetProperty<String> addOpensAttribute
+    private final Provider<? extends String> platformVersion
 
     @Inject
-    OsgiRun(ObjectFactory objects) {
+    OsgiRun(ObjectFactory objects, ProviderFactory providers) {
         javaAgents = objects.domainObjectContainer(JavaAgent)
         frameworkProperties = objects.mapProperty(String, String).convention(new HashMap<String,String>())
         addOpensAttribute = objects.setProperty(String)
+        platformVersion = providers.gradleProperty('platformVersion')
     }
 
     void javaAgents(Action<? super NamedDomainObjectContainer<JavaAgent>> action) {
         action.execute(javaAgents)
+    }
+
+    Provider<? extends String> getPlatformVersion() {
+        return platformVersion
     }
 
     NamedDomainObjectContainer<JavaAgent> getJavaAgents() {
@@ -410,6 +416,7 @@ class FrameworkPropertyFile extends DefaultTask {
 
 TaskProvider<FrameworkPropertyFile> writeFrameworkPropertyFile = tasks.register("writeFrameworkPropertyFile", FrameworkPropertyFile) {
     frameworkProperties = osgiRun.frameworkProperties
+    frameworkProperties.put('net.corda.platform.version', osgiRun.platformVersion)
 }
 
 @CompileStatic

--- a/libs/platform-info/build.gradle
+++ b/libs/platform-info/build.gradle
@@ -17,5 +17,6 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion") {
         exclude group: 'mockito-core'
     }
+    testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
 }

--- a/libs/platform-info/build.gradle
+++ b/libs/platform-info/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion") {
         exclude group: 'mockito-core'
     }
-    testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
+    testImplementation "org.osgi:osgi.core"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
 }

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -24,13 +24,10 @@ class PlatformInfoProviderTest {
         assertThat(platformVersion).isEqualTo(EXPECTED_STUB_PLATFORM_VERSION)
     }
 
-    @Test
-    fun `Service returns expected stub value for local worker platform version`() {
-        val platformVersion = assertDoesNotThrow {
-            platformInfoProvider.localWorkerPlatformVersion
-        }
-        assertThat(platformVersion).isEqualTo(EXPECTED_STUB_PLATFORM_VERSION)
-    }
+    // Note: We aren't testing for local worker platform version here because the bundleContext for integration
+    // tests is different to that for a running worker.  We can still mock in the unit test, though.
+    //@Test
+    //fun `Service returns expected stub value for local worker platform version`() {
 
     @Test
     fun `Service returns expected value from bundle manifest for local worker software version`() {

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.osgi.test.common.annotation.InjectService
-import java.util.jar.Manifest
 
 class PlatformInfoProviderTest {
 
@@ -24,37 +23,7 @@ class PlatformInfoProviderTest {
         assertThat(platformVersion).isEqualTo(EXPECTED_STUB_PLATFORM_VERSION)
     }
 
-    // Note: We aren't testing for local worker platform version here because the bundleContext for integration
-    // tests is different to that for a running worker.  We can still mock in the unit test, though.
-    //@Test
-    //fun `Service returns expected stub value for local worker platform version`() {
-
-    @Test
-    fun `Service returns expected value from bundle manifest for local worker software version`() {
-        val platformVersion = assertDoesNotThrow {
-            platformInfoProvider.localWorkerSoftwareVersion
-        }
-        val expectedValue = PlatformInfoProvider::class.java.classLoader
-            .getResources("META-INF/MANIFEST.MF")
-            .asSequence()
-            .map {
-                it.openStream().use { input ->
-                    Manifest(input)
-                }
-            }.mapNotNull {
-                it.mainAttributes
-            }.filter {
-                it.getValue("Bundle-SymbolicName") == "net.corda.platform-info"
-            }.mapNotNull {
-                it.getValue("Bundle-Version")
-            }.firstOrNull()
-
-        assertThat(expectedValue)
-            .isNotNull
-            .withFailMessage("Could not read expected software version from bundle manifest.")
-
-        assertThat(platformVersion)
-            .isEqualTo(expectedValue)
-            .withFailMessage("Platform info service did not return the expected software version.")
-    }
+    // Note: We aren't testing for local worker platform version or software version here because the
+    // bundleContext for integration tests is different to that for a running worker.  We can still mock in the unit
+    // test, though.
 }

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -1,55 +1,23 @@
 package net.corda.libs.platform.impl
 
 import net.corda.libs.platform.PlatformInfoProvider
-import net.corda.v5.base.util.contextLogger
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import java.util.jar.Manifest
 
 @Component(service = [PlatformInfoProvider::class])
-class PlatformInfoProviderImpl internal constructor(
-    private val classLoader: ClassLoader,
-    private val bundleContext: BundleContext
+class PlatformInfoProviderImpl @Activate constructor(
+    bundleContext: BundleContext,
 ) : PlatformInfoProvider {
 
-    @Activate
-    constructor(bundleContext: BundleContext) : this(PlatformInfoProvider::class.java.classLoader, bundleContext)
-
     internal companion object {
-        val logger = contextLogger()
-
         const val STUB_PLATFORM_VERSION = 5000
-
-        const val DEFAULT_SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
-        const val MANIFEST_FILE_NAME = "META-INF/MANIFEST.MF"
-        const val BUNDLE_VERSION = "Bundle-Version"
     }
 
     /** Temporary stub values **/
     override val activePlatformVersion = STUB_PLATFORM_VERSION
 
-    override val localWorkerPlatformVersion by lazy {
-        bundleContext.getProperty("net.corda.platform.version").toInt()
-    }
+    override val localWorkerPlatformVersion = bundleContext.getProperty("net.corda.platform.version").toInt()
 
-    override val localWorkerSoftwareVersion by lazy {
-        bundleManifest?.mainAttributes?.getValue(BUNDLE_VERSION)
-            ?: DEFAULT_SOFTWARE_VERSION.also {
-                logger.warn("Unable to retrieve software version from the Manifest file. Defaulting to \"$it\"")
-            }
-    }
-
-    private val bundleManifest by lazy {
-        classLoader
-            .getResources(MANIFEST_FILE_NAME)
-            .asSequence()
-            .map {
-                it.openStream().use { input ->
-                    Manifest(input)
-                }
-            }.filter {
-                it.mainAttributes.getValue("Bundle-SymbolicName") == "net.corda.platform-info"
-            }.firstOrNull()
-    }
+    override val localWorkerSoftwareVersion = bundleContext.bundle.version.toString()
 }

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -5,6 +5,7 @@ import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 
+
 @Component(service = [PlatformInfoProvider::class])
 class PlatformInfoProviderImpl @Activate constructor(
     bundleContext: BundleContext,
@@ -12,12 +13,15 @@ class PlatformInfoProviderImpl @Activate constructor(
 
     internal companion object {
         const val STUB_PLATFORM_VERSION = 5000
+
+        private const val DEFAULT_PLATFORM_VERSION = 5000
+        private const val PLATFORM_VERSION_KEY = "net.corda.platform.version"
     }
 
     /** Temporary stub values **/
     override val activePlatformVersion = STUB_PLATFORM_VERSION
 
-    override val localWorkerPlatformVersion = bundleContext.getProperty("net.corda.platform.version").toInt()
+    override val localWorkerPlatformVersion = bundleContext.getProperty(PLATFORM_VERSION_KEY)?.toInt() ?: DEFAULT_PLATFORM_VERSION
 
     override val localWorkerSoftwareVersion = bundleContext.bundle.version.toString()
 }

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -2,17 +2,19 @@ package net.corda.libs.platform.impl
 
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.v5.base.util.contextLogger
+import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import java.util.jar.Manifest
 
 @Component(service = [PlatformInfoProvider::class])
 class PlatformInfoProviderImpl internal constructor(
-    private val classLoader: ClassLoader
+    private val classLoader: ClassLoader,
+    private val bundleContext: BundleContext
 ) : PlatformInfoProvider {
 
     @Activate
-    public constructor() : this(PlatformInfoProvider::class.java.classLoader)
+    constructor(bundleContext: BundleContext) : this(PlatformInfoProvider::class.java.classLoader, bundleContext)
 
     internal companion object {
         val logger = contextLogger()
@@ -26,7 +28,10 @@ class PlatformInfoProviderImpl internal constructor(
 
     /** Temporary stub values **/
     override val activePlatformVersion = STUB_PLATFORM_VERSION
-    override val localWorkerPlatformVersion = STUB_PLATFORM_VERSION
+
+    override val localWorkerPlatformVersion by lazy {
+        bundleContext.getProperty("net.corda.platform.version").toInt()
+    }
 
     override val localWorkerSoftwareVersion by lazy {
         bundleManifest?.mainAttributes?.getValue(BUNDLE_VERSION)

--- a/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
+++ b/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
@@ -3,7 +3,10 @@ package net.corda.libs.platform.impl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.osgi.framework.BundleContext
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.net.URL
@@ -13,7 +16,14 @@ import java.util.jar.Manifest
 
 class PlatformInfoProviderImplTest {
 
-    private val platformVersionService = PlatformInfoProviderImpl()
+    companion object {
+        const val PLATFORM_VERSION = "999"
+    }
+
+    private val bundleContext = mock<BundleContext>().also {
+        whenever(it.getProperty(eq("net.corda.platform.version"))).thenReturn(PLATFORM_VERSION)
+    }
+    private val platformVersionService = PlatformInfoProviderImpl(bundleContext)
 
     /**
      * Temporary test until real implementation is added.
@@ -28,17 +38,9 @@ class PlatformInfoProviderImplTest {
         )
     }
 
-    /**
-     * Temporary test until real implementation is added.
-     * Stub value and this can be removed once real implementation is available.
-     */
     @Test
     fun `local worker platform version returns stub value`() {
-        assertThat(
-            platformVersionService.localWorkerPlatformVersion
-        ).isEqualTo(
-            PlatformInfoProviderImpl.STUB_PLATFORM_VERSION
-        )
+        assertThat(platformVersionService.localWorkerPlatformVersion).isEqualTo(PLATFORM_VERSION.toInt())
     }
 
     @Test
@@ -58,7 +60,7 @@ class PlatformInfoProviderImplTest {
                     )
                 )
         }
-        val platformVersionService = PlatformInfoProviderImpl(classLoader)
+        val platformVersionService = PlatformInfoProviderImpl(classLoader, bundleContext)
 
         assertThat(
             platformVersionService.localWorkerSoftwareVersion

--- a/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
+++ b/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
@@ -39,12 +39,12 @@ class PlatformInfoProviderImplTest {
     }
 
     @Test
-    fun `local worker platform version returns stub value`() {
+    fun `local worker platform version returns platform version from bundle context`() {
         assertThat(platformVersionService.localWorkerPlatformVersion).isEqualTo(PLATFORM_VERSION.toInt())
     }
 
     @Test
-    fun `local worker software version returns software version from bundle manifest`() {
+    fun `local worker software version returns software version from bundle context`() {
         assertThat(platformVersionService.localWorkerSoftwareVersion).isEqualTo(SOFTWARE_VERSION)
     }
 }


### PR DESCRIPTION
Plumb in `PlatformInfoProvider.localWorkerPlatformVersion`.

We're reading the version defined in `gradle.properties` and feeding it to the Bundle context.  We can then read it back out in the `PlatformInfoProvider`.