### PR TITLE
CORE-9163: Fix ResetPollInterval Resume Assignment

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/FlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/FlowEventHandler.kt
@@ -23,7 +23,7 @@ interface FlowEventHandler<T> {
      *
      * It is assumed that the flow is initialised in the checkpoint after the event handler has been executed. For most
      * handlers, this will be true on input and no action is required. When handling events that represent a request to
-     * start a flow, the flow state inside the checkpoint object must be initiatlised before [preProcess] returns.
+     * start a flow, the flow state inside the checkpoint object must be initialised before [preProcess] returns.
      *
      * @param context The [FlowEventContext] that should be modified within this processing step.
      *

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
@@ -209,13 +209,13 @@ class StateAndEventConsumerImplTest {
         val (stateAndEventListener, eventConsumer, stateConsumer, _) = setupMocks()
 
         val assignedEventTopicPartitions = setOf(CordaTopicPartition(TOPIC, 0), CordaTopicPartition(TOPIC, 1))
-        val assignedEventTopicPartitionsAfterRebalance = setOf(CordaTopicPartition(TOPIC, 0), CordaTopicPartition(TOPIC, 1))
+        val assignedEventTopicPartitionsAfterRebalance = setOf(CordaTopicPartition(TOPIC, 0))
         whenever(eventConsumer.assignment())
             .thenReturn(assignedEventTopicPartitions)
             .thenReturn(assignedEventTopicPartitionsAfterRebalance)
 
         val assignedStateTopicPartitions = setOf(CordaTopicPartition(TOPIC, 2), CordaTopicPartition(TOPIC, 4))
-        val assignedStateTopicPartitionsAfterRebalance = setOf(CordaTopicPartition(TOPIC, 2), CordaTopicPartition(TOPIC, 4))
+        val assignedStateTopicPartitionsAfterRebalance = setOf(CordaTopicPartition(TOPIC, 2))
         whenever(stateConsumer.assignment())
             .thenReturn(assignedStateTopicPartitions)
             .thenReturn(assignedStateTopicPartitionsAfterRebalance)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/wrapper/StateAndEventConsumerImplTest.kt
@@ -13,7 +13,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.inOrder
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
@@ -208,38 +207,38 @@ class StateAndEventConsumerImplTest {
     @Test
     fun testResetPollPosition() {
         val (stateAndEventListener, eventConsumer, stateConsumer, _) = setupMocks()
+
+        val assignedEventTopicPartitions = setOf(CordaTopicPartition(TOPIC, 0), CordaTopicPartition(TOPIC, 1))
+        val assignedEventTopicPartitionsAfterRebalance = setOf(CordaTopicPartition(TOPIC, 0), CordaTopicPartition(TOPIC, 1))
+        whenever(eventConsumer.assignment())
+            .thenReturn(assignedEventTopicPartitions)
+            .thenReturn(assignedEventTopicPartitionsAfterRebalance)
+
+        val assignedStateTopicPartitions = setOf(CordaTopicPartition(TOPIC, 2), CordaTopicPartition(TOPIC, 4))
+        val assignedStateTopicPartitionsAfterRebalance = setOf(CordaTopicPartition(TOPIC, 2), CordaTopicPartition(TOPIC, 4))
+        whenever(stateConsumer.assignment())
+            .thenReturn(assignedStateTopicPartitions)
+            .thenReturn(assignedStateTopicPartitionsAfterRebalance)
+
         val consumer = StateAndEventConsumerImpl(
             config, eventConsumer, stateConsumer, StateAndEventPartitionState
                 (mutableMapOf(), mutableMapOf()), stateAndEventListener
         )
-
-        val assignedTopicPartitions = setOf(CordaTopicPartition(TOPIC, 0), CordaTopicPartition(TOPIC, 1))
-        val pausedTopicPartitions = setOf(CordaTopicPartition(TOPIC, 1))
-        whenever(eventConsumer.assignment()).thenReturn(assignedTopicPartitions)
-        whenever(eventConsumer.paused()).thenReturn(pausedTopicPartitions)
-
         consumer.resetPollInterval()
 
         val eventConsumerOrder = inOrder(eventConsumer)
-
-        verify(eventConsumer, times(1)).assignment()
-        verify(eventConsumer, times(1)).paused()
-
-        eventConsumerOrder.verify(eventConsumer, times(1))
-            .pause(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
+        eventConsumerOrder.verify(eventConsumer, times(1)).assignment()
+        eventConsumerOrder.verify(eventConsumer, times(1)).pause(assignedEventTopicPartitions)
         eventConsumerOrder.verify(eventConsumer, times(1)).poll(any())
-        eventConsumerOrder.verify(eventConsumer, times(1))
-            .resume(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
+        eventConsumerOrder.verify(eventConsumer, times(1)).assignment()
+        eventConsumerOrder.verify(eventConsumer, times(1)).resume(assignedEventTopicPartitionsAfterRebalance)
 
         val stateConsumerOrder = inOrder(stateConsumer)
-
-        verify(stateConsumer, times(1)).assignment()
-        verify(stateConsumer, times(1)).paused()
-        stateConsumerOrder.verify(stateConsumer, times(1))
-            .pause(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
+        stateConsumerOrder.verify(stateConsumer, times(1)).assignment()
+        stateConsumerOrder.verify(stateConsumer, times(1)).pause(assignedStateTopicPartitions)
         stateConsumerOrder.verify(stateConsumer, times(1)).poll(any())
-        stateConsumerOrder.verify(stateConsumer, times(1))
-            .resume(argThat { contains(CordaTopicPartition(TOPIC, 0)) && size == 1 })
+        stateConsumerOrder.verify(stateConsumer, times(1)).assignment()
+        stateConsumerOrder.verify(stateConsumer, times(1)).resume(assignedStateTopicPartitionsAfterRebalance)
     }
 
     @Test


### PR DESCRIPTION
If a rebalance is triggered by Kafka in between pausing and resuming
the event and/or state consumers as part of the reset poll interval
implementation, an IllegalStateException will be thrown if the 'resume'
operation tries to use partitions that are not owned anymore by the
consumer.

- Fix spelling typo in KDocs.
- Use current partition assignment when resuming event and state 
  consumers.
