### PR TITLE
NOTICK Enforce gradle rerun smoke tests regardless of previous successful runs

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -121,6 +121,8 @@ tasks.register('smokeTest', Test) {
 
     systemProperty "combinedWorkerHealthHttp",
             project.getProperties().getOrDefault("combinedWorkerHealthHttp",combinedWorker ? "http://localhost:7000/" : null)
+
+    outputs.upToDateWhen { false }
 }
 
 


### PR DESCRIPTION
Enforce gradle to rerun smoke tests regardless of previous successful runs.