### PR TITLE
CORE-5005 Virtual node upgrade related entity changes

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -336,7 +336,7 @@ class VirtualNodeRpcTest {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
             val vnodesWithStates: List<Pair<String, String>> = vNodeList().toJson()["virtualNodes"].map {
-                it["holdingIdentity"]["shortHash"].textValue() to it["flow_p2p_operational_status"].textValue()
+                it["holdingIdentity"]["shortHash"].textValue() to it["flowP2pOperationalStatus"].textValue()
             }
 
             val (vnodeId, oldState) = vnodesWithStates.last()
@@ -353,10 +353,10 @@ class VirtualNodeRpcTest {
                             val vNodeInfo = it.toJson()["virtualNodes"].single { virtualNode ->
                                 virtualNode["holdingIdentity"]["shortHash"].textValue() == vnodeId
                             }
-                            vNodeInfo["flow_p2p_operational_status"].textValue() == "INACTIVE" &&
-                                    vNodeInfo["flow_start_operational_status"].textValue() == "INACTIVE" &&
-                                    vNodeInfo["flow_operational_status"].textValue() == "INACTIVE" &&
-                                    vNodeInfo["vault_db_operational_status"].textValue() == "INACTIVE"
+                            vNodeInfo["flowP2pOperationalStatus"].textValue() == "INACTIVE" &&
+                                    vNodeInfo["flowStartOperationalStatus"].textValue() == "INACTIVE" &&
+                                    vNodeInfo["flowOperationalStatus"].textValue() == "INACTIVE" &&
+                                    vNodeInfo["vaultDbOperationalStatus"].textValue() == "INACTIVE"
                         } else {
                             false
                         }
@@ -378,10 +378,10 @@ class VirtualNodeRpcTest {
                             val vNodeInfo = it.toJson()["virtualNodes"].single { virtualNode ->
                                 virtualNode["holdingIdentity"]["shortHash"].textValue() == vnodeId
                             }
-                            vNodeInfo["flow_p2p_operational_status"].textValue() == oldState &&
-                                    vNodeInfo["flow_start_operational_status"].textValue() == oldState &&
-                                    vNodeInfo["flow_operational_status"].textValue() == oldState &&
-                                    vNodeInfo["vault_db_operational_status"].textValue() == oldState
+                            vNodeInfo["flowP2pOperationalStatus"].textValue() == oldState &&
+                                    vNodeInfo["flowStartOperationalStatus"].textValue() == oldState &&
+                                    vNodeInfo["flowOperationalStatus"].textValue() == oldState &&
+                                    vNodeInfo["vaultDbOperationalStatus"].textValue() == oldState
                         } else {
                             false
                         }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -340,7 +340,7 @@ class VirtualNodeRpcTest {
             }
 
             val (vnodeId, oldState) = vnodesWithStates.last()
-            val newState = "IN_MAINTENANCE"
+            val newState = "maintenance"
 
             updateVirtualNodeState(vnodeId, newState)
 

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRPCOpsImplTest.kt
@@ -13,7 +13,6 @@ import net.corda.lifecycle.test.impl.LifecycleTest
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.VirtualNodeState
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -52,9 +51,8 @@ class FlowClassRPCOpsImplTest {
             UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID(),
-            VirtualNodeState.ACTIVE,
-            0,
-            Instant.now()
+            version = 0,
+            timestamp = Instant.now()
         )
     }
 

--- a/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
+++ b/components/flow/flow-rpcops-service-impl/src/test/kotlin/net/corda/flow/rpcops/impl/v1/FlowRPCOpsImplTest.kt
@@ -33,7 +33,6 @@ import net.corda.rbac.schema.RbacKeys.START_FLOW_PREFIX
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.VirtualNodeState
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.BeforeEach
@@ -103,9 +102,8 @@ class FlowRPCOpsImplTest {
             UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID(),
-            VirtualNodeState.ACTIVE,
-            0,
-            Instant.now()
+            version = 0,
+            timestamp = Instant.now()
         )
     }
 

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -40,6 +40,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -241,7 +242,10 @@ internal class VirtualNodeRestResourceImpl @Activate constructor(
                         uniquenessDdlConnectionId,
                         uniquenessDmlConnectionId,
                         hsmConnectionId,
-                        virtualNodeState
+                        OperationalStatus.ACTIVE,
+                        OperationalStatus.ACTIVE,
+                        OperationalStatus.ACTIVE,
+                        OperationalStatus.ACTIVE,
                     )
                 }
             }
@@ -314,7 +318,10 @@ internal class VirtualNodeRestResourceImpl @Activate constructor(
             uniquenessDdlConnectionId?.toString(),
             uniquenessDmlConnectionId.toString(),
             hsmConnectionId.toString(),
-            state.name
+            flowP2pOperationalStatus,
+            flowStartOperationalStatus,
+            flowOperationalStatus,
+            vaultDbOperationalStatus,
         )
 
     private fun net.corda.libs.packaging.core.CpiIdentifier.toEndpointType(): CpiIdentifier =

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -285,7 +285,7 @@ internal class VirtualNodeRestResourceImpl @Activate constructor(
         return when (val resolvedResponse = resp.responseType) {
             is VirtualNodeStateChangeResponse -> {
                 resolvedResponse.run {
-                    ChangeVirtualNodeStateResponse(holdingIdentityShortHash, virtualNodeState)
+                    ChangeVirtualNodeStateResponse(holdingIdentityShortHash, newState)
                 }
             }
             is VirtualNodeManagementResponseFailure -> throw handleFailure(resolvedResponse.exception)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -49,7 +49,7 @@ import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.VirtualNodeState
+import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
 import java.lang.System.currentTimeMillis
@@ -364,7 +364,7 @@ internal class VirtualNodeWriterProcessor(
                 virtualNodeRepository.updateVirtualNodeState(
                     entityManager,
                     stateChangeRequest.holdingIdentityShortHash,
-                    VirtualNodeState.valueOf(stateChangeRequest.newState)
+                    stateChangeRequest.newState
                 )
             }
 
@@ -490,14 +490,17 @@ internal class VirtualNodeWriterProcessor(
                     holdingIdentityRepository.put(
                         entityManager,
                         holdingIdentity,
+                    )
+                    virtualNodeRepository.put(
+                        entityManager,
+                        holdingIdentity,
+                        cpiId,
                         dbConnections.vaultDdlConnectionId,
                         dbConnections.vaultDmlConnectionId,
                         dbConnections.cryptoDdlConnectionId,
                         dbConnections.cryptoDmlConnectionId,
                         dbConnections.uniquenessDdlConnectionId,
-                        dbConnections.uniquenessDmlConnectionId,
-                    )
-                    virtualNodeRepository.put(entityManager, holdingIdentity, cpiId)
+                        dbConnections.uniquenessDmlConnectionId,)
                     dbConnections
                 }
         } catch (e: Exception) {
@@ -602,7 +605,6 @@ internal class VirtualNodeWriterProcessor(
                 uniquenessDdlConnectionId,
                 uniquenessDmlConnectionId,
                 timestamp = clock.instant(),
-                state = VirtualNodeInfo.DEFAULT_INITIAL_STATE
             )
                 .toAvro()
         }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -391,7 +391,10 @@ internal class VirtualNodeWriterProcessor(
                 instant,
                 VirtualNodeStateChangeResponse(
                     stateChangeRequest.holdingIdentityShortHash,
-                    stateChangeRequest.newState
+                    VirtualNodeInfo.DEFAULT_INITIAL_STATE.name,
+                    VirtualNodeInfo.DEFAULT_INITIAL_STATE.name,
+                    VirtualNodeInfo.DEFAULT_INITIAL_STATE.name,
+                    VirtualNodeInfo.DEFAULT_INITIAL_STATE.name
                 )
             )
             respFuture.complete(response)
@@ -687,6 +690,9 @@ internal class VirtualNodeWriterProcessor(
                 dbConnections.uniquenessDdlConnectionId?.toString(),
                 dbConnections.uniquenessDmlConnectionId.toString(),
                 null,
+                VirtualNodeInfo.DEFAULT_INITIAL_STATE.name,
+                VirtualNodeInfo.DEFAULT_INITIAL_STATE.name,
+                VirtualNodeInfo.DEFAULT_INITIAL_STATE.name,
                 VirtualNodeInfo.DEFAULT_INITIAL_STATE.name
             )
         )

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -49,7 +49,6 @@ import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
 import java.lang.System.currentTimeMillis

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -37,6 +37,7 @@ import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
@@ -107,8 +108,7 @@ class VirtualNodeWriterProcessorTests {
      */
     private val clock = TestClock(Instant.now())
 
-    private val vnodeInfo =
-        VirtualNodeInfo(
+    private val vnodeInfo = VirtualNodeInfo(
             holdingIdentity.toAvro(),
             cpiIdentifier,
             connectionId,
@@ -117,8 +117,11 @@ class VirtualNodeWriterProcessorTests {
             connectionId,
             connectionId,
             connectionId,
-            null,
-            "ACTIVE",
+            OperationalStatus.ACTIVE.name,
+            OperationalStatus.ACTIVE.name,
+            OperationalStatus.ACTIVE.name,
+            OperationalStatus.ACTIVE.name,
+            OperationalStatus.ACTIVE.name,
             -1,
             clock.instant()
         )

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -446,7 +446,10 @@ class VirtualNodeWriterProcessorTests {
                 connectionId,
                 connectionId,
                 null,
-                "ACTIVE"
+                OperationalStatus.ACTIVE.name,
+                OperationalStatus.ACTIVE.name,
+                OperationalStatus.ACTIVE.name,
+                OperationalStatus.ACTIVE.name
             )
         )
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -117,7 +117,7 @@ class VirtualNodeWriterProcessorTests {
             connectionId,
             connectionId,
             connectionId,
-            OperationalStatus.ACTIVE.name,
+            null,
             OperationalStatus.ACTIVE.name,
             OperationalStatus.ACTIVE.name,
             OperationalStatus.ACTIVE.name,

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.624-alpha-1674563496439
+cordaApiVersion=5.0.0.624-beta-1674578569358
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=624-alpha-1674563496439
+cordaApiVersion=5.0.0.624-alpha-1674563496439
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.624-beta-1674578569358
+cordaApiVersion=5.0.0.624-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.623-beta+
+cordaApiVersion=624-alpha-1674563496439
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/HoldingIdentityRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/HoldingIdentityRepositoryTest.kt
@@ -64,12 +64,6 @@ class HoldingIdentityRepositoryTest {
     fun find() {
         val holdingIdentity = entityManagerFactory.createEntityManager().transaction { em ->
             val hi = VNodeTestUtils.newHoldingIdentityEntity("Fred")
-            em.persist(VNodeTestUtils.newDbConnection(hi.cryptoDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.cryptoDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(hi.vaultDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.vaultDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(hi.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.uniquenessDMLConnectionId!!, DbPrivilege.DML))
             em.persist(hi)
             hi
         }
@@ -86,12 +80,6 @@ class HoldingIdentityRepositoryTest {
     fun `find returns null when not in DB`() {
         entityManagerFactory.createEntityManager().transaction { em ->
             val hi = VNodeTestUtils.newHoldingIdentityEntity("Jon")
-            em.persist(VNodeTestUtils.newDbConnection(hi.cryptoDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.cryptoDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(hi.vaultDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.vaultDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(hi.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.uniquenessDMLConnectionId!!, DbPrivilege.DML))
             em.persist(hi)
             hi
         }
@@ -107,25 +95,10 @@ class HoldingIdentityRepositoryTest {
     fun put() {
         val hi = VNodeTestUtils.newHoldingIdentityEntity("Merinda")
 
-        entityManagerFactory.createEntityManager().transaction { em ->
-            em.persist(VNodeTestUtils.newDbConnection(hi.cryptoDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.cryptoDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(hi.vaultDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.vaultDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(hi.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(hi.uniquenessDMLConnectionId!!, DbPrivilege.DML))
-        }
-
         entityManagerFactory.createEntityManager().transaction {
             HoldingIdentityRepositoryImpl().put(
                 it,
                 hi.toHoldingIdentity(),
-                hi.vaultDDLConnectionId,
-                hi.vaultDMLConnectionId!!,
-                hi.cryptoDDLConnectionId,
-                hi.cryptoDMLConnectionId!!,
-                hi.uniquenessDDLConnectionId,
-                hi.uniquenessDMLConnectionId,
             )
         }
     }

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
@@ -25,6 +25,7 @@ internal object VNodeTestUtils {
 
         val cpiMetadata = newCpiMetadataEntity(name, version, hash)
         val holdingIdentity = newHoldingIdentityEntity(name)
+        println(holdingIdentity.x500Name)
         val virtualNode = VirtualNodeEntity(
             holdingIdentity.holdingIdentityShortHash,
             holdingIdentity,

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
@@ -40,8 +40,15 @@ internal object VNodeTestUtils {
         )
 
         entityManagerFactory.createEntityManager().transaction { em ->
+            em.persist(newDbConnection(virtualNode.cryptoDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(newDbConnection(virtualNode.cryptoDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(newDbConnection(virtualNode.vaultDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(newDbConnection(virtualNode.vaultDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(newDbConnection(virtualNode.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(newDbConnection(virtualNode.uniquenessDMLConnectionId!!, DbPrivilege.DML))
             em.persist(holdingIdentity)
         }
+
         entityManagerFactory.createEntityManager().transaction { em -> em.persist(cpiMetadata) }
         entityManagerFactory.createEntityManager().transaction { em -> return em.merge(virtualNode) }
     }

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
@@ -25,6 +25,7 @@ internal object VNodeTestUtils {
         val cpiMetadata = newCpiMetadataEntity(name, version, hash)
         val holdingIdentity = newHoldingIdentityEntity(name)
         val virtualNode = VirtualNodeEntity(
+            holdingIdentity.holdingIdentityShortHash,
             holdingIdentity,
             name,
             version,

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
@@ -9,7 +9,7 @@ import net.corda.orm.utils.transaction
 import net.corda.test.util.TestRandom
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
-import net.corda.virtualnode.VirtualNodeState
+import net.corda.virtualnode.VirtualNodeInfo
 import java.time.Instant
 import java.util.*
 import javax.persistence.EntityManagerFactory
@@ -25,15 +25,21 @@ internal object VNodeTestUtils {
 
         val cpiMetadata = newCpiMetadataEntity(name, version, hash)
         val holdingIdentity = newHoldingIdentityEntity(name)
-        val virtualNode = VirtualNodeEntity(holdingIdentity, name, version, hash, VirtualNodeState.ACTIVE.name)
+        val virtualNode = VirtualNodeEntity(
+            holdingIdentity,
+            name,
+            version,
+            hash,
+            VirtualNodeInfo.DEFAULT_INITIAL_STATE,
+            vaultDDLConnectionId = UUID.randomUUID(),
+            vaultDMLConnectionId = UUID.randomUUID(),
+            cryptoDDLConnectionId = UUID.randomUUID(),
+            cryptoDMLConnectionId = UUID.randomUUID(),
+            uniquenessDDLConnectionId = UUID.randomUUID(),
+            uniquenessDMLConnectionId = UUID.randomUUID()
+        )
 
         entityManagerFactory.createEntityManager().transaction { em ->
-            em.persist(newDbConnection(holdingIdentity.cryptoDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(newDbConnection(holdingIdentity.cryptoDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(newDbConnection(holdingIdentity.vaultDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(newDbConnection(holdingIdentity.vaultDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(newDbConnection(holdingIdentity.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(newDbConnection(holdingIdentity.uniquenessDMLConnectionId!!, DbPrivilege.DML))
             em.persist(holdingIdentity)
         }
         entityManagerFactory.createEntityManager().transaction { em -> em.persist(cpiMetadata) }
@@ -59,12 +65,6 @@ internal object VNodeTestUtils {
             holdingIdentityFullHash = hi.fullHash,
             x500Name = hi.x500Name.toString(),
             mgmGroupId = hi.groupId,
-            vaultDDLConnectionId = UUID.randomUUID(),
-            vaultDMLConnectionId = UUID.randomUUID(),
-            cryptoDDLConnectionId = UUID.randomUUID(),
-            cryptoDMLConnectionId = UUID.randomUUID(),
-            uniquenessDDLConnectionId = UUID.randomUUID(),
-            uniquenessDMLConnectionId = UUID.randomUUID(),
             hsmConnectionId = UUID.randomUUID()
         )
     }

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
@@ -11,6 +11,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import java.time.Instant
 import java.util.*
+import javax.persistence.Column
 import javax.persistence.EntityManagerFactory
 
 internal object VNodeTestUtils {

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
@@ -9,7 +9,6 @@ import net.corda.orm.utils.transaction
 import net.corda.test.util.TestRandom
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
-import net.corda.virtualnode.VirtualNodeInfo
 import java.time.Instant
 import java.util.*
 import javax.persistence.EntityManagerFactory
@@ -30,13 +29,12 @@ internal object VNodeTestUtils {
             name,
             version,
             hash,
-            VirtualNodeInfo.DEFAULT_INITIAL_STATE,
-            vaultDDLConnectionId = UUID.randomUUID(),
-            vaultDMLConnectionId = UUID.randomUUID(),
-            cryptoDDLConnectionId = UUID.randomUUID(),
-            cryptoDMLConnectionId = UUID.randomUUID(),
-            uniquenessDDLConnectionId = UUID.randomUUID(),
-            uniquenessDMLConnectionId = UUID.randomUUID()
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID()
         )
 
         entityManagerFactory.createEntityManager().transaction { em ->

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -138,7 +138,7 @@ class VirtualNodeEntitiesIntegrationTest {
 
         val foundEntity = entityManagerFactory.createEntityManager().find(VirtualNodeEntity::class.java, vnodeEntity.holdingIdentityId)
         val operationEntity =
-            entityManagerFactory.createEntityManager().find(VirtualNodeOperationEntity::class.java, rand)
+            entityManagerFactory.createEntityManager().find(VirtualNodeOperationEntity::class.java, rand.toString())
         assertThat(foundEntity).isEqualTo(vnodeEntity)
         assertThat(foundEntity.operationInProgress).isEqualTo(virtualNodeOperationEntity)
         assertThat(operationEntity).isEqualTo(virtualNodeOperationEntity)

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -15,7 +15,6 @@ import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntityKey
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
 import net.corda.test.util.TestRandom
-import net.corda.virtualnode.VirtualNodeState
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -76,12 +75,6 @@ class VirtualNodeEntitiesIntegrationTest {
             "OU=LLC, O=Bob, L=Dublin, C=IE",
             "${random.nextInt()}",
             null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
         )
 
         entityManagerFactory.createEntityManager().transaction { em ->
@@ -104,19 +97,19 @@ class VirtualNodeEntitiesIntegrationTest {
         val cpiMetadata = VNodeTestUtils.newCpiMetadataEntity(name, version, hash)
         val entity = VNodeTestUtils.newHoldingIdentityEntity("test")
 
+        val virtualNode = VNodeTestUtils.newVNode(entityManagerFactory, name, version, hash)
+
         entityManagerFactory.createEntityManager().transaction { em ->
-            em.persist(VNodeTestUtils.newDbConnection(entity.cryptoDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(entity.cryptoDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(entity.vaultDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(entity.vaultDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(entity.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(entity.uniquenessDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.cryptoDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.cryptoDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.vaultDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.vaultDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.uniquenessDMLConnectionId!!, DbPrivilege.DML))
         }
 
         val holdingIdentityEntity = entityManagerFactory.createEntityManager()
             .transaction { em -> em.getReference(HoldingIdentityEntity::class.java, entity.holdingIdentityShortHash) }
-
-        val virtualNode = VirtualNodeEntity(entity, name, version, hash, VirtualNodeState.ACTIVE.name)
 
         entityManagerFactory.createEntityManager().transaction { em ->
             em.persist(cpiMetadata)
@@ -137,13 +130,15 @@ class VirtualNodeEntitiesIntegrationTest {
         val cpiMetadata = VNodeTestUtils.newCpiMetadataEntity(name, version, hash)
         val holdingIdentityEntity = VNodeTestUtils.newHoldingIdentityEntity("test - ${UUID.randomUUID()}")
 
+        val virtualNode = VNodeTestUtils.newVNode(entityManagerFactory, name, version, hash)
+
         entityManagerFactory.createEntityManager().transaction { em ->
-            em.persist(VNodeTestUtils.newDbConnection(holdingIdentityEntity.cryptoDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(holdingIdentityEntity.cryptoDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(holdingIdentityEntity.vaultDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(holdingIdentityEntity.vaultDMLConnectionId!!, DbPrivilege.DML))
-            em.persist(VNodeTestUtils.newDbConnection(holdingIdentityEntity.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
-            em.persist(VNodeTestUtils.newDbConnection(holdingIdentityEntity.uniquenessDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.cryptoDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.cryptoDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.vaultDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.vaultDMLConnectionId!!, DbPrivilege.DML))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
+            em.persist(VNodeTestUtils.newDbConnection(virtualNode.uniquenessDMLConnectionId!!, DbPrivilege.DML))
         }
 
         // Persist holding identity...
@@ -151,7 +146,6 @@ class VirtualNodeEntitiesIntegrationTest {
 
         // Now persist the virtual node but use the merge operation because we've
         // already persisted the holding identity (i.e. REST end-point - "create holding identity")
-        val virtualNode = VirtualNodeEntity(holdingIdentityEntity, name, version, hash, VirtualNodeState.ACTIVE.name)
         entityManagerFactory.createEntityManager().transaction { em ->
             em.persist(cpiMetadata)
             em.merge(virtualNode)

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -11,7 +11,6 @@ import net.corda.libs.cpi.datamodel.CpiEntities
 import net.corda.libs.virtualnode.datamodel.entities.HoldingIdentityEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntities
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntity
-import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntityKey
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
 import net.corda.test.util.TestRandom
@@ -116,7 +115,7 @@ class VirtualNodeEntitiesIntegrationTest {
             em.persist(virtualNode)
         }
 
-        val key = VirtualNodeEntityKey(holdingIdentityEntity, name, version, hash)
+        val key = holdingIdentityEntity.holdingIdentityShortHash
 
         assertThat(virtualNode == entityManagerFactory.createEntityManager().find(VirtualNodeEntity::class.java, key))
     }
@@ -151,11 +150,7 @@ class VirtualNodeEntitiesIntegrationTest {
             em.merge(virtualNode)
         }
 
-        // Use a reference to *find* only - we do NOT need the other fields in the HoldingIdentityEntity
-        // (and in fact, neither does hibernate - it only cares about the primary keys).
-        val holdingIdentityReference = entityManagerFactory.createEntityManager()
-            .transaction { em -> em.getReference(HoldingIdentityEntity::class.java, holdingIdentityEntity.holdingIdentityShortHash) }
-        val key = VirtualNodeEntityKey(holdingIdentityReference, name, version, hash)
+        val key = holdingIdentityEntity.holdingIdentityShortHash
 
         assertThat(virtualNode == entityManagerFactory.createEntityManager().find(VirtualNodeEntity::class.java, key))
     }

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -96,7 +96,7 @@ class VirtualNodeEntitiesIntegrationTest {
         val hash = TestRandom.secureHash().toString()
 
         val cpiMetadata = VNodeTestUtils.newCpiMetadataEntity(name, version, hash)
-        val entity = VNodeTestUtils.newHoldingIdentityEntity("test")
+        val entity = VNodeTestUtils.newHoldingIdentityEntity("test - ${UUID.randomUUID()}")
 
         entityManagerFactory.createEntityManager().transaction { em ->
             em.persist(VNodeTestUtils.newDbConnection(UUID.randomUUID(), DbPrivilege.DDL))
@@ -162,7 +162,7 @@ class VirtualNodeEntitiesIntegrationTest {
         val hash = TestRandom.secureHash().toString()
 
         val cpiMetadata = VNodeTestUtils.newCpiMetadataEntity(name, version, hash)
-        val entity = VNodeTestUtils.newHoldingIdentityEntity("test")
+        val entity = VNodeTestUtils.newHoldingIdentityEntity("test - ${UUID.randomUUID()}")
         val operationEntity = VirtualNodeOperationEntity(entity.holdingIdentityShortHash, "request-id", "data", VirtualNodeOperationState.IN_PROGRESS, Instant.now())
 
         entityManagerFactory.createEntityManager().transaction { em ->

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -161,7 +161,6 @@ class VirtualNodeEntitiesIntegrationTest {
         val version = "1.0-${Instant.now().toEpochMilli()}"
         val hash = TestRandom.secureHash().toString()
 
-
         val cpiMetadata = VNodeTestUtils.newCpiMetadataEntity(name, version, hash)
         val entity = VNodeTestUtils.newHoldingIdentityEntity("test")
         val operationEntity = VirtualNodeOperationEntity(entity.holdingIdentityShortHash, "request-id", "data", VirtualNodeOperationState.IN_PROGRESS, Instant.now())
@@ -177,14 +176,13 @@ class VirtualNodeEntitiesIntegrationTest {
 
         val virtualNode = VirtualNodeEntity(entity.holdingIdentityShortHash, entity, name, version, hash, operationInProgress = operationEntity)
 
-        val holdingIdentityEntity = entityManagerFactory.createEntityManager()
-            .transaction { em -> em.getReference(HoldingIdentityEntity::class.java, entity.holdingIdentityShortHash) }
-
         entityManagerFactory.createEntityManager().transaction { em ->
             em.persist(cpiMetadata)
-            em.persist(operationEntity)
             em.persist(virtualNode)
         }
+
+        val holdingIdentityEntity = entityManagerFactory.createEntityManager()
+            .transaction { em -> em.getReference(HoldingIdentityEntity::class.java, entity.holdingIdentityShortHash) }
 
         val key = holdingIdentityEntity.holdingIdentityShortHash
         val foundVirtualNode = entityManagerFactory.createEntityManager().find(VirtualNodeEntity::class.java, key)

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -99,121 +99,121 @@ class VirtualNodeRepositoryTest {
         }
     }
 
-    @Test
-    fun find() {
-        // "set up"
-        val numberOfVNodes = 5
-        val vnodes = (1..numberOfVNodes).map {
-            VNodeTestUtils.newVNode(
-                entityManagerFactory,
-                "Test CPI ${UUID.randomUUID()}",
-                "1.0-${Instant.now().toEpochMilli()}",
-                TestRandom.secureHash().toString())
-        }
+//    @Test
+//    fun find() {
+//        // "set up"
+//        val numberOfVNodes = 5
+//        val vnodes = (1..numberOfVNodes).map {
+//            VNodeTestUtils.newVNode(
+//                entityManagerFactory,
+//                "Test CPI ${UUID.randomUUID()}",
+//                "1.0-${Instant.now().toEpochMilli()}",
+//                TestRandom.secureHash().toString())
+//        }
+//
+//        // Now check the query - and also we should look at the console output for this
+//        val virtualNode = entityManagerFactory.createEntityManager().use {
+//            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnodes.last().holdingIdentity.holdingIdentityShortHash))
+//        }!!
+//
+//        // Validate relation for holdingIdentity has been resolved
+//        assertNotNull(virtualNode.holdingIdentity.x500Name)
+//        assertEquals(virtualNode.holdingIdentity.x500Name.toString(), vnodes.last().holdingIdentity.x500Name)
+//    }
 
-        // Now check the query - and also we should look at the console output for this
-        val virtualNode = entityManagerFactory.createEntityManager().use {
-            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnodes.last().holdingIdentity.holdingIdentityShortHash))
-        }!!
+//    @Test
+//    fun `find returns null if no vnode found`() {
+//        // "set up"
+//        val numberOfVNodes = 5
+//        (1..numberOfVNodes).forEach { i ->
+//            VNodeTestUtils.newVNode(
+//                entityManagerFactory,
+//                "Test CPI $i ${UUID.randomUUID()}",
+//                "1.0-${Instant.now().toEpochMilli()}",
+//                TestRandom.secureHash().toString())
+//        }
+//
+//        val virtualNode = entityManagerFactory.createEntityManager().use {
+//            VirtualNodeRepositoryImpl().find(it, ShortHash.of(TestRandom.holdingIdentityShortHash()))
+//        }
+//
+//        assertEquals(virtualNode, null)
+//    }
 
-        // Validate relation for holdingIdentity has been resolved
-        assertNotNull(virtualNode.holdingIdentity.x500Name)
-        assertEquals(virtualNode.holdingIdentity.x500Name.toString(), vnodes.last().holdingIdentity.x500Name)
-    }
+//    @Test
+//    fun put() {
+//        val hash = TestRandom.secureHash()
+//        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
+//
+//        val hi = vnode.holdingIdentity.toHoldingIdentity()
+//        val cpiId = CpiIdentifier(vnode.cpiName, vnode.cpiVersion, hash)
+//
+//        entityManagerFactory.createEntityManager().transaction {
+//            VirtualNodeRepositoryImpl().put(
+//                it,
+//                hi,
+//                cpiId,
+//                vnode.vaultDDLConnectionId,
+//                vnode.vaultDMLConnectionId!!,
+//                vnode.cryptoDDLConnectionId,
+//                vnode.cryptoDMLConnectionId!!,
+//                vnode.uniquenessDDLConnectionId,
+//                vnode.uniquenessDMLConnectionId,
+//            )
+//        }
+//
+//        val putEntity = entityManagerFactory.createEntityManager().use {
+//            VirtualNodeRepositoryImpl().find(it, hi.shortHash)
+//        }
+//
+//        assertThat(putEntity).isNotNull
+//        assertThat(putEntity!!.holdingIdentity).isEqualTo(hi)
+//        assertThat(putEntity.cpiIdentifier).isEqualTo(cpiId)
+//    }
 
-    @Test
-    fun `find returns null if no vnode found`() {
-        // "set up"
-        val numberOfVNodes = 5
-        (1..numberOfVNodes).forEach { i ->
-            VNodeTestUtils.newVNode(
-                entityManagerFactory,
-                "Test CPI $i ${UUID.randomUUID()}",
-                "1.0-${Instant.now().toEpochMilli()}",
-                TestRandom.secureHash().toString())
-        }
+//    @Test
+//    fun `put throws when Holding Identity does not exist`() {
+//        val hi = HoldingIdentity(
+//            MemberX500Name.Companion.parse("C=GB,L=London,O=Test"),
+//            "group"
+//        )
+//        val cpiId = CpiIdentifier("cpi ${UUID.randomUUID()}", "1.0", TestRandom.secureHash())
+//
+//        assertThrows<CordaRuntimeException> {
+//            entityManagerFactory.createEntityManager().transaction {
+//                VirtualNodeRepositoryImpl().put(
+//                    it,
+//                    hi,
+//                    cpiId,
+//                    null,
+//                    UUID.randomUUID(),
+//                    null,
+//                    UUID.randomUUID(),
+//                    null,
+//                    UUID.randomUUID())
+//            }
+//        }
+//    }
 
-        val virtualNode = entityManagerFactory.createEntityManager().use {
-            VirtualNodeRepositoryImpl().find(it, ShortHash.of(TestRandom.holdingIdentityShortHash()))
-        }
-
-        assertEquals(virtualNode, null)
-    }
-
-    @Test
-    fun put() {
-        val hash = TestRandom.secureHash()
-        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
-
-        val hi = vnode.holdingIdentity.toHoldingIdentity()
-        val cpiId = CpiIdentifier(vnode.cpiName, vnode.cpiVersion, hash)
-
-        entityManagerFactory.createEntityManager().transaction {
-            VirtualNodeRepositoryImpl().put(
-                it,
-                hi,
-                cpiId,
-                vnode.vaultDDLConnectionId,
-                vnode.vaultDMLConnectionId!!,
-                vnode.cryptoDDLConnectionId,
-                vnode.cryptoDMLConnectionId!!,
-                vnode.uniquenessDDLConnectionId,
-                vnode.uniquenessDMLConnectionId,
-            )
-        }
-
-        val putEntity = entityManagerFactory.createEntityManager().use {
-            VirtualNodeRepositoryImpl().find(it, hi.shortHash)
-        }
-
-        assertThat(putEntity).isNotNull
-        assertThat(putEntity!!.holdingIdentity).isEqualTo(hi)
-        assertThat(putEntity.cpiIdentifier).isEqualTo(cpiId)
-    }
-
-    @Test
-    fun `put throws when Holding Identity does not exist`() {
-        val hi = HoldingIdentity(
-            MemberX500Name.Companion.parse("C=GB,L=London,O=Test"),
-            "group"
-        )
-        val cpiId = CpiIdentifier("cpi ${UUID.randomUUID()}", "1.0", TestRandom.secureHash())
-
-        assertThrows<CordaRuntimeException> {
-            entityManagerFactory.createEntityManager().transaction {
-                VirtualNodeRepositoryImpl().put(
-                    it,
-                    hi,
-                    cpiId,
-                    null,
-                    UUID.randomUUID(),
-                    null,
-                    UUID.randomUUID(),
-                    null,
-                    UUID.randomUUID())
-            }
-        }
-    }
-
-    @Test
-    fun updateVirtualNodeState() {
-        val hash = TestRandom.secureHash()
-        val vnode = VNodeTestUtils
-            .newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
-
-        entityManagerFactory.createEntityManager().use {
-            VirtualNodeRepositoryImpl().updateVirtualNodeState(
-                it, vnode.holdingIdentity.holdingIdentityShortHash, "maintenance")
-        }
-
-        val changedEntity = entityManagerFactory.createEntityManager().use {
-            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnode.holdingIdentity.holdingIdentityShortHash))
-        }
-
-        assertThat(changedEntity).isNotNull
-        assertThat(changedEntity!!.flowP2pOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-        assertThat(changedEntity.flowStartOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-        assertThat(changedEntity.flowOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-        assertThat(changedEntity.vaultDbOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-    }
+//    @Test
+//    fun updateVirtualNodeState() {
+//        val hash = TestRandom.secureHash()
+//        val vnode = VNodeTestUtils
+//            .newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
+//
+//        entityManagerFactory.createEntityManager().use {
+//            VirtualNodeRepositoryImpl().updateVirtualNodeState(
+//                it, vnode.holdingIdentity.holdingIdentityShortHash, "maintenance")
+//        }
+//
+//        val changedEntity = entityManagerFactory.createEntityManager().use {
+//            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnode.holdingIdentity.holdingIdentityShortHash))
+//        }
+//
+//        assertThat(changedEntity).isNotNull
+//        assertThat(changedEntity!!.flowP2pOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+//        assertThat(changedEntity.flowStartOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+//        assertThat(changedEntity.flowOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+//        assertThat(changedEntity.vaultDbOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+//    }
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -2,14 +2,12 @@ package net.corda.libs.configuration.datamodel.tests
 
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
-import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
 import net.corda.libs.configuration.datamodel.ConfigurationEntities
 import net.corda.libs.cpi.datamodel.CpiEntities
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntities
-import net.corda.libs.virtualnode.datamodel.repository.HoldingIdentityRepositoryImpl
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepositoryImpl
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
@@ -172,38 +170,6 @@ class VirtualNodeRepositoryTest {
         assertThat(putEntity!!.holdingIdentity).isEqualTo(hi)
         assertThat(putEntity.cpiIdentifier).isEqualTo(cpiId)
     }
-
-//    @Test
-//    fun put() {
-//        val hash = TestRandom.secureHash()
-//        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
-//
-//        val hi = vnode.holdingIdentity.toHoldingIdentity()
-//        val cpiId = CpiIdentifier(vnode.cpiName, vnode.cpiVersion, hash)
-//
-//        entityManagerFactory.createEntityManager().transaction { em ->
-//            em.persist(VNodeTestUtils.newDbConnection(vnode.cryptoDDLConnectionId!!, DbPrivilege.DDL))
-//            em.persist(VNodeTestUtils.newDbConnection(vnode.cryptoDMLConnectionId!!, DbPrivilege.DML))
-//            em.persist(VNodeTestUtils.newDbConnection(vnode.vaultDDLConnectionId!!, DbPrivilege.DDL))
-//            em.persist(VNodeTestUtils.newDbConnection(vnode.vaultDMLConnectionId!!, DbPrivilege.DML))
-//            em.persist(VNodeTestUtils.newDbConnection(vnode.uniquenessDDLConnectionId!!, DbPrivilege.DDL))
-//            em.persist(VNodeTestUtils.newDbConnection(vnode.uniquenessDMLConnectionId!!, DbPrivilege.DML))
-//        }
-//
-//        entityManagerFactory.createEntityManager().transaction {
-//            VirtualNodeRepositoryImpl().put(
-//                it,
-//                hi,
-//                cpiId,
-//                vnode.vaultDDLConnectionId,
-//                vnode.vaultDMLConnectionId!!,
-//                vnode.cryptoDDLConnectionId,
-//                vnode.cryptoDMLConnectionId!!,
-//                vnode.uniquenessDDLConnectionId,
-//                vnode.uniquenessDMLConnectionId,
-//            )
-//        }
-//    }
 
     @Test
     fun `put throws when Holding Identity does not exist`() {

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -212,8 +212,8 @@ class VirtualNodeRepositoryTest {
 
         assertThat(changedEntity).isNotNull
         assertThat(changedEntity!!.flowP2pOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-        assertThat(changedEntity!!.flowStartOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-        assertThat(changedEntity!!.flowOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-        assertThat(changedEntity!!.vaultDbOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+        assertThat(changedEntity.flowStartOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+        assertThat(changedEntity.flowOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+        assertThat(changedEntity.vaultDbOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
     }
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -99,121 +99,121 @@ class VirtualNodeRepositoryTest {
         }
     }
 
-//    @Test
-//    fun find() {
-//        // "set up"
-//        val numberOfVNodes = 5
-//        val vnodes = (1..numberOfVNodes).map {
-//            VNodeTestUtils.newVNode(
-//                entityManagerFactory,
-//                "Test CPI ${UUID.randomUUID()}",
-//                "1.0-${Instant.now().toEpochMilli()}",
-//                TestRandom.secureHash().toString())
-//        }
-//
-//        // Now check the query - and also we should look at the console output for this
-//        val virtualNode = entityManagerFactory.createEntityManager().use {
-//            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnodes.last().holdingIdentity.holdingIdentityShortHash))
-//        }!!
-//
-//        // Validate relation for holdingIdentity has been resolved
-//        assertNotNull(virtualNode.holdingIdentity.x500Name)
-//        assertEquals(virtualNode.holdingIdentity.x500Name.toString(), vnodes.last().holdingIdentity.x500Name)
-//    }
+    @Test
+    fun find() {
+        // "set up"
+        val numberOfVNodes = 5
+        val vnodes = (1..numberOfVNodes).map {
+            VNodeTestUtils.newVNode(
+                entityManagerFactory,
+                "Test CPI ${UUID.randomUUID()}",
+                "1.0-${Instant.now().toEpochMilli()}",
+                TestRandom.secureHash().toString())
+        }
 
-//    @Test
-//    fun `find returns null if no vnode found`() {
-//        // "set up"
-//        val numberOfVNodes = 5
-//        (1..numberOfVNodes).forEach { i ->
-//            VNodeTestUtils.newVNode(
-//                entityManagerFactory,
-//                "Test CPI $i ${UUID.randomUUID()}",
-//                "1.0-${Instant.now().toEpochMilli()}",
-//                TestRandom.secureHash().toString())
-//        }
-//
-//        val virtualNode = entityManagerFactory.createEntityManager().use {
-//            VirtualNodeRepositoryImpl().find(it, ShortHash.of(TestRandom.holdingIdentityShortHash()))
-//        }
-//
-//        assertEquals(virtualNode, null)
-//    }
+        // Now check the query - and also we should look at the console output for this
+        val virtualNode = entityManagerFactory.createEntityManager().use {
+            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnodes.last().holdingIdentity.holdingIdentityShortHash))
+        }!!
 
-//    @Test
-//    fun put() {
-//        val hash = TestRandom.secureHash()
-//        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
-//
-//        val hi = vnode.holdingIdentity.toHoldingIdentity()
-//        val cpiId = CpiIdentifier(vnode.cpiName, vnode.cpiVersion, hash)
-//
-//        entityManagerFactory.createEntityManager().transaction {
-//            VirtualNodeRepositoryImpl().put(
-//                it,
-//                hi,
-//                cpiId,
-//                vnode.vaultDDLConnectionId,
-//                vnode.vaultDMLConnectionId!!,
-//                vnode.cryptoDDLConnectionId,
-//                vnode.cryptoDMLConnectionId!!,
-//                vnode.uniquenessDDLConnectionId,
-//                vnode.uniquenessDMLConnectionId,
-//            )
-//        }
-//
-//        val putEntity = entityManagerFactory.createEntityManager().use {
-//            VirtualNodeRepositoryImpl().find(it, hi.shortHash)
-//        }
-//
-//        assertThat(putEntity).isNotNull
-//        assertThat(putEntity!!.holdingIdentity).isEqualTo(hi)
-//        assertThat(putEntity.cpiIdentifier).isEqualTo(cpiId)
-//    }
+        // Validate relation for holdingIdentity has been resolved
+        assertNotNull(virtualNode.holdingIdentity.x500Name)
+        assertEquals(virtualNode.holdingIdentity.x500Name.toString(), vnodes.last().holdingIdentity.x500Name)
+    }
 
-//    @Test
-//    fun `put throws when Holding Identity does not exist`() {
-//        val hi = HoldingIdentity(
-//            MemberX500Name.Companion.parse("C=GB,L=London,O=Test"),
-//            "group"
-//        )
-//        val cpiId = CpiIdentifier("cpi ${UUID.randomUUID()}", "1.0", TestRandom.secureHash())
-//
-//        assertThrows<CordaRuntimeException> {
-//            entityManagerFactory.createEntityManager().transaction {
-//                VirtualNodeRepositoryImpl().put(
-//                    it,
-//                    hi,
-//                    cpiId,
-//                    null,
-//                    UUID.randomUUID(),
-//                    null,
-//                    UUID.randomUUID(),
-//                    null,
-//                    UUID.randomUUID())
-//            }
-//        }
-//    }
+    @Test
+    fun `find returns null if no vnode found`() {
+        // "set up"
+        val numberOfVNodes = 5
+        (1..numberOfVNodes).forEach { i ->
+            VNodeTestUtils.newVNode(
+                entityManagerFactory,
+                "Test CPI $i ${UUID.randomUUID()}",
+                "1.0-${Instant.now().toEpochMilli()}",
+                TestRandom.secureHash().toString())
+        }
 
-//    @Test
-//    fun updateVirtualNodeState() {
-//        val hash = TestRandom.secureHash()
-//        val vnode = VNodeTestUtils
-//            .newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
-//
-//        entityManagerFactory.createEntityManager().use {
-//            VirtualNodeRepositoryImpl().updateVirtualNodeState(
-//                it, vnode.holdingIdentity.holdingIdentityShortHash, "maintenance")
-//        }
-//
-//        val changedEntity = entityManagerFactory.createEntityManager().use {
-//            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnode.holdingIdentity.holdingIdentityShortHash))
-//        }
-//
-//        assertThat(changedEntity).isNotNull
-//        assertThat(changedEntity!!.flowP2pOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-//        assertThat(changedEntity.flowStartOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-//        assertThat(changedEntity.flowOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-//        assertThat(changedEntity.vaultDbOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
-//    }
+        val virtualNode = entityManagerFactory.createEntityManager().use {
+            VirtualNodeRepositoryImpl().find(it, ShortHash.of(TestRandom.holdingIdentityShortHash()))
+        }
+
+        assertEquals(virtualNode, null)
+    }
+
+    @Test
+    fun put() {
+        val hash = TestRandom.secureHash()
+        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
+
+        val hi = vnode.holdingIdentity.toHoldingIdentity()
+        val cpiId = CpiIdentifier(vnode.cpiName, vnode.cpiVersion, hash)
+
+        entityManagerFactory.createEntityManager().transaction {
+            VirtualNodeRepositoryImpl().put(
+                it,
+                hi,
+                cpiId,
+                vnode.vaultDDLConnectionId,
+                vnode.vaultDMLConnectionId!!,
+                vnode.cryptoDDLConnectionId,
+                vnode.cryptoDMLConnectionId!!,
+                vnode.uniquenessDDLConnectionId,
+                vnode.uniquenessDMLConnectionId,
+            )
+        }
+
+        val putEntity = entityManagerFactory.createEntityManager().use {
+            VirtualNodeRepositoryImpl().find(it, hi.shortHash)
+        }
+
+        assertThat(putEntity).isNotNull
+        assertThat(putEntity!!.holdingIdentity).isEqualTo(hi)
+        assertThat(putEntity.cpiIdentifier).isEqualTo(cpiId)
+    }
+
+    @Test
+    fun `put throws when Holding Identity does not exist`() {
+        val hi = HoldingIdentity(
+            MemberX500Name.Companion.parse("C=GB,L=London,O=Test"),
+            "group"
+        )
+        val cpiId = CpiIdentifier("cpi ${UUID.randomUUID()}", "1.0", TestRandom.secureHash())
+
+        assertThrows<CordaRuntimeException> {
+            entityManagerFactory.createEntityManager().transaction {
+                VirtualNodeRepositoryImpl().put(
+                    it,
+                    hi,
+                    cpiId,
+                    null,
+                    UUID.randomUUID(),
+                    null,
+                    UUID.randomUUID(),
+                    null,
+                    UUID.randomUUID())
+            }
+        }
+    }
+
+    @Test
+    fun updateVirtualNodeState() {
+        val hash = TestRandom.secureHash()
+        val vnode = VNodeTestUtils
+            .newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", hash.toString())
+
+        entityManagerFactory.createEntityManager().use {
+            VirtualNodeRepositoryImpl().updateVirtualNodeState(
+                it, vnode.holdingIdentity.holdingIdentityShortHash, "maintenance")
+        }
+
+        val changedEntity = entityManagerFactory.createEntityManager().use {
+            VirtualNodeRepositoryImpl().find(it, ShortHash.of(vnode.holdingIdentity.holdingIdentityShortHash))
+        }
+
+        assertThat(changedEntity).isNotNull
+        assertThat(changedEntity!!.flowP2pOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+        assertThat(changedEntity.flowStartOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+        assertThat(changedEntity.flowOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+        assertThat(changedEntity.vaultDbOperationalStatus).isEqualTo(OperationalStatus.INACTIVE)
+    }
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/VirtualNodeEntities.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/VirtualNodeEntities.kt
@@ -7,5 +7,6 @@ object VirtualNodeEntities {
     val classes = setOf(
         HoldingIdentityEntity::class.java,
         VirtualNodeEntity::class.java,
+        VirtualNodeOperationEntity::class.java,
     )
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/VirtualNodeEntities.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/VirtualNodeEntities.kt
@@ -2,6 +2,7 @@ package net.corda.libs.virtualnode.datamodel
 
 import net.corda.libs.virtualnode.datamodel.entities.HoldingIdentityEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntity
+import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationEntity
 
 object VirtualNodeEntities {
     val classes = setOf(

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/HoldingIdentityEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/HoldingIdentityEntity.kt
@@ -17,10 +17,6 @@ import javax.persistence.Table
  * @param holdingIdentityFullHash The full hash of the holding identity.
  * @param x500Name The X.500 name of the holding identity.
  * @param mgmGroupId The MGM group of the holding identity.
- * @param vaultDDLConnectionId A pointer to the holding identity's vault DDL details in the DB connection table.
- * @param cryptoDDLConnectionId A pointer to the holding identity's crypto DDL details in the DB connection table.
- * @param vaultDMLConnectionId A pointer to the holding identity's vault DML details in the DB connection table.
- * @param cryptoDMLConnectionId A pointer to the holding identity's crypto DML details in the DB connection table.
  * @param hsmConnectionId A pointer to the holding identity's entry in the HSM connection table.
  */
 @Entity

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/HoldingIdentityEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/HoldingIdentityEntity.kt
@@ -36,36 +36,9 @@ internal class HoldingIdentityEntity(
     var x500Name: String,
     @Column(name = "mgm_group_id", nullable = false)
     var mgmGroupId: String,
-    @Column(name = "vault_ddl_connection_id", nullable = true)
-    var vaultDDLConnectionId: UUID?,
-    @Column(name = "vault_dml_connection_id", nullable = true)
-    var vaultDMLConnectionId: UUID?,
-    @Column(name = "crypto_ddl_connection_id", nullable = true)
-    var cryptoDDLConnectionId: UUID?,
-    @Column(name = "crypto_dml_connection_id", nullable = true)
-    var cryptoDMLConnectionId: UUID?,
-    @Column(name = "uniqueness_ddl_connection_id", nullable = true)
-    var uniquenessDDLConnectionId: UUID?,
-    @Column(name = "uniqueness_dml_connection_id", nullable = true)
-    var uniquenessDMLConnectionId: UUID?,
     @Column(name = "hsm_connection_id", nullable = true)
     var hsmConnectionId: UUID?
 ) {
-    fun update(
-        vaultDdlConnectionId: UUID?,
-        vaultDmlConnectionId: UUID?,
-        cryptoDdlConnectionId: UUID?,
-        cryptoDmlConnectionId: UUID?,
-        uniquenessDDLConnectionId: UUID?,
-        uniquenessDMLConnectionId: UUID?
-    ) {
-        this.vaultDDLConnectionId = vaultDdlConnectionId
-        this.vaultDMLConnectionId = vaultDmlConnectionId
-        this.cryptoDDLConnectionId = cryptoDdlConnectionId
-        this.cryptoDMLConnectionId = cryptoDmlConnectionId
-        this.uniquenessDDLConnectionId = uniquenessDDLConnectionId
-        this.uniquenessDMLConnectionId = uniquenessDMLConnectionId
-    }
 
     fun toHoldingIdentity(): HoldingIdentity {
         return HoldingIdentity(MemberX500Name.parse(x500Name), mgmGroupId)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -98,7 +98,7 @@ internal class VirtualNodeEntity(
     @Column(name = "vault_db_operational_status", nullable = false)
     var vaultDbOperationalStatus: OperationalStatus = OperationalStatus.ACTIVE,
 
-    @OneToOne(cascade = [CascadeType.MERGE], fetch = FetchType.LAZY)
+    @OneToOne(cascade = [CascadeType.PERSIST, CascadeType.MERGE], fetch = FetchType.LAZY)
     @JoinColumn(name = "operation_in_progress")
     var operationInProgress: VirtualNodeOperationEntity? = null,
 

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -1,7 +1,7 @@
 package net.corda.libs.virtualnode.datamodel.entities
 
 import net.corda.db.schema.DbSchema.CONFIG
-import net.corda.db.schema.DbSchema.VNODE_INSTANCE_DB_TABLE
+import net.corda.db.schema.DbSchema.VIRTUAL_NODE_DB_TABLE
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.datamodel.VirtualNodeOperationEntity
 import net.corda.v5.crypto.SecureHash
@@ -42,7 +42,7 @@ import javax.persistence.Version
  * @param operationInProgress Details of the current operation in progress.
  */
 @Entity
-@Table(name = VNODE_INSTANCE_DB_TABLE, schema = CONFIG)
+@Table(name = VIRTUAL_NODE_DB_TABLE, schema = CONFIG)
 @Suppress("LongParameterList")
 internal class VirtualNodeEntity(
     @OneToOne(

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -54,6 +54,24 @@ internal class VirtualNodeEntity(
     @Column(name = "cpi_signer_summary_hash", nullable = false)
     var cpiSignerSummaryHash: String,
 
+    @Column(name = "vault_ddl_connection_id")
+    var vaultDDLConnectionId: UUID? = null,
+
+    @Column(name = "vault_dml_connection_id")
+    var vaultDMLConnectionId: UUID? = null,
+
+    @Column(name = "crypto_ddl_connection_id")
+    var cryptoDDLConnectionId: UUID? = null,
+
+    @Column(name = "crypto_dml_connection_id")
+    var cryptoDMLConnectionId: UUID? = null,
+
+    @Column(name = "uniqueness_ddl_connection_id")
+    var uniquenessDDLConnectionId: UUID? = null,
+
+    @Column(name = "uniqueness_dml_connection_id")
+    var uniquenessDMLConnectionId: UUID? = null,
+
     @Enumerated(value = EnumType.STRING)
     @Column(name = "flow_p2p_operational_status", nullable = false)
     var flowP2pOperationalStatus: OperationalStatus = OperationalStatus.ACTIVE,
@@ -73,24 +91,6 @@ internal class VirtualNodeEntity(
     @OneToOne(cascade = [CascadeType.MERGE], fetch = FetchType.LAZY)
     @JoinColumn(name = "operation_in_progress")
     var operationInProgress: VirtualNodeOperationEntity? = null,
-
-    @Column(name = "vault_ddl_connection_id")
-    var vaultDDLConnectionId: UUID? = null,
-
-    @Column(name = "vault_dml_connection_id")
-    var vaultDMLConnectionId: UUID? = null,
-
-    @Column(name = "crypto_ddl_connection_id")
-    var cryptoDDLConnectionId: UUID? = null,
-
-    @Column(name = "crypto_dml_connection_id")
-    var cryptoDMLConnectionId: UUID? = null,
-
-    @Column(name = "uniqueness_ddl_connection_id")
-    var uniquenessDDLConnectionId: UUID? = null,
-
-    @Column(name = "uniqueness_dml_connection_id")
-    var uniquenessDMLConnectionId: UUID? = null,
 
     @Column(name = "insert_ts", insertable = false)
     var insertTimestamp: Instant? = null,

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -17,6 +17,7 @@ import javax.persistence.Entity
 import javax.persistence.Enumerated
 import javax.persistence.EnumType
 import javax.persistence.FetchType
+import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
 import javax.persistence.Table
@@ -49,6 +50,7 @@ internal class VirtualNodeEntity(
         cascade = [CascadeType.PERSIST, CascadeType.MERGE]
     )
     @JoinColumn(name = "holding_identity_id")
+    @Id
     val holdingIdentity: HoldingIdentityEntity,
 
     @Column(name = "cpi_name", nullable = false)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -17,11 +17,7 @@ import javax.persistence.Entity
 import javax.persistence.Enumerated
 import javax.persistence.EnumType
 import javax.persistence.FetchType
-import javax.persistence.Id
-import javax.persistence.IdClass
 import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
-import javax.persistence.MapsId
 import javax.persistence.OneToOne
 import javax.persistence.Table
 import javax.persistence.Version
@@ -39,7 +35,7 @@ import javax.persistence.Version
  * @param cryptoDMLConnectionId A pointer to the virtual node's crypto DML details in the DB connection table.
  * @param uniquenessDDLConnectionId A pointer to the virtual node's crypto DDL details in the DB connection table.
  * @param flowP2pOperationalStatus  The virtual node's ability to communicate with peers, both inbound and outbound.
- * @param flowStartOperationalStatus The virtual node's ability to start new flows, from both the REST endpoint and start flow events arriving to the flow mapper.
+ * @param flowStartOperationalStatus The virtual node's ability to start new flows.
  * @param flowOperationalStatus The virtual node's ability to run flows, to have checkpoints, to continue in-progress flows.
  * @param vaultDbOperationalStatus The virtual node's ability to perform persistence operations on the virtual node's vault.
  * @param operationInProgress Details of the current operation in progress.

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -127,26 +127,6 @@ internal class VirtualNodeEntity(
     }
 
     fun toVirtualNodeInfo(): VirtualNodeInfo {
-        println("Converting to VirtualNodeInfo")
-        println(holdingIdentity.x500Name)
-        println(insertTimestamp)
-        println(holdingIdentity.toHoldingIdentity())
-        println(CpiIdentifier(cpiName, cpiVersion, SecureHash.parse(cpiSignerSummaryHash)))
-        println(vaultDDLConnectionId.toString())
-        println(vaultDMLConnectionId.toString())
-        println(cryptoDDLConnectionId.toString())
-        println(cryptoDMLConnectionId.toString())
-        println(uniquenessDDLConnectionId.toString())
-        println(uniquenessDMLConnectionId.toString())
-        println(holdingIdentity.hsmConnectionId)
-        println(flowP2pOperationalStatus)
-        println(flowStartOperationalStatus)
-        println(flowOperationalStatus)
-        println(vaultDbOperationalStatus)
-        println(entityVersion)
-        println(insertTimestamp!!)
-        println(isDeleted)
-
         return VirtualNodeInfo(
             holdingIdentity.toHoldingIdentity(),
             CpiIdentifier(cpiName, cpiVersion, SecureHash.parse(cpiSignerSummaryHash)),

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -3,7 +3,7 @@ package net.corda.libs.virtualnode.datamodel.entities
 import net.corda.db.schema.DbSchema.CONFIG
 import net.corda.db.schema.DbSchema.VIRTUAL_NODE_DB_TABLE
 import net.corda.libs.packaging.core.CpiIdentifier
-import net.corda.libs.virtualnode.datamodel.VirtualNodeOperationEntity
+import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationEntity
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.OperationalStatus
@@ -130,13 +130,22 @@ internal class VirtualNodeEntity(
         println("Converting to VirtualNodeInfo")
         println(holdingIdentity.x500Name)
         println(insertTimestamp)
-
+        println(holdingIdentity.toHoldingIdentity())
+        println(CpiIdentifier(cpiName, cpiVersion, SecureHash.parse(cpiSignerSummaryHash)))
         println(vaultDDLConnectionId.toString())
         println(vaultDMLConnectionId.toString())
         println(cryptoDDLConnectionId.toString())
         println(cryptoDMLConnectionId.toString())
         println(uniquenessDDLConnectionId.toString())
         println(uniquenessDMLConnectionId.toString())
+        println(holdingIdentity.hsmConnectionId)
+        println(flowP2pOperationalStatus)
+        println(flowStartOperationalStatus)
+        println(flowOperationalStatus)
+        println(vaultDbOperationalStatus)
+        println(entityVersion)
+        println(insertTimestamp!!)
+        println(isDeleted)
 
         return VirtualNodeInfo(
             holdingIdentity.toHoldingIdentity(),

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -127,20 +127,31 @@ internal class VirtualNodeEntity(
     }
 
     fun toVirtualNodeInfo(): VirtualNodeInfo {
+        println("Converting to VirtualNodeInfo")
+        println(holdingIdentity.x500Name)
+        println(insertTimestamp)
+
+        println(vaultDDLConnectionId.toString())
+        println(vaultDMLConnectionId.toString())
+        println(cryptoDDLConnectionId.toString())
+        println(cryptoDMLConnectionId.toString())
+        println(uniquenessDDLConnectionId.toString())
+        println(uniquenessDMLConnectionId.toString())
+
         return VirtualNodeInfo(
             holdingIdentity.toHoldingIdentity(),
             CpiIdentifier(cpiName, cpiVersion, SecureHash.parse(cpiSignerSummaryHash)),
-            this.vaultDDLConnectionId,
-            this.vaultDMLConnectionId!!,
-            this.cryptoDDLConnectionId,
-            this.cryptoDMLConnectionId!!,
-            this.uniquenessDDLConnectionId,
-            this.uniquenessDMLConnectionId!!,
+            vaultDDLConnectionId,
+            vaultDMLConnectionId!!,
+            cryptoDDLConnectionId,
+            cryptoDMLConnectionId!!,
+            uniquenessDDLConnectionId,
+            uniquenessDMLConnectionId!!,
             holdingIdentity.hsmConnectionId,
-            this.flowP2pOperationalStatus,
-            this.flowStartOperationalStatus,
-            this.flowOperationalStatus,
-            this.vaultDbOperationalStatus,
+            flowP2pOperationalStatus,
+            flowStartOperationalStatus,
+            flowOperationalStatus,
+            vaultDbOperationalStatus,
             entityVersion,
             insertTimestamp!!,
             isDeleted

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -33,6 +33,16 @@ import javax.persistence.Version
  * @param cpiName The name of the CPI the virtual node is created for.
  * @param cpiVersion The version of the CPI the virtual node is created for.
  * @param cpiSignerSummaryHash The signer summary hash of the CPI the virtual node is created for.
+ * @param vaultDDLConnectionId A pointer to the virtual node's vault DDL details in the DB connection table.
+ * @param vaultDMLConnectionId A pointer to the virtual node's vault DML details in the DB connection table.
+ * @param cryptoDDLConnectionId A pointer to the virtual node's crypto DDL details in the DB connection table.
+ * @param cryptoDMLConnectionId A pointer to the virtual node's crypto DML details in the DB connection table.
+ * @param uniquenessDDLConnectionId A pointer to the virtual node's crypto DDL details in the DB connection table.
+ * @param flowP2pOperationalStatus  The virtual node's ability to communicate with peers, both inbound and outbound.
+ * @param flowStartOperationalStatus The virtual node's ability to start new flows, from both the REST endpoint and start flow events arriving to the flow mapper.
+ * @param flowOperationalStatus The virtual node's ability to run flows, to have checkpoints, to continue in-progress flows.
+ * @param vaultDbOperationalStatus The virtual node's ability to perform persistence operations on the virtual node's vault.
+ * @param operationInProgress Details of the current operation in progress.
  */
 @Entity
 @Table(name = VNODE_INSTANCE_DB_TABLE, schema = CONFIG)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -9,16 +9,17 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.OperationalStatus
 import java.io.Serializable
 import java.time.Instant
-import java.util.*
+import java.util.Objects
+import java.util.UUID
 import javax.persistence.CascadeType
 import javax.persistence.Column
-import javax.persistence.Embeddable
 import javax.persistence.Entity
 import javax.persistence.Enumerated
 import javax.persistence.EnumType
 import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
+import javax.persistence.MapsId
 import javax.persistence.OneToOne
 import javax.persistence.Table
 import javax.persistence.Version
@@ -45,12 +46,13 @@ import javax.persistence.Version
 @Table(name = VIRTUAL_NODE_DB_TABLE, schema = CONFIG)
 @Suppress("LongParameterList")
 internal class VirtualNodeEntity(
-    @OneToOne(
-        fetch = FetchType.LAZY,
-        cascade = [CascadeType.PERSIST, CascadeType.MERGE]
-    )
-    @JoinColumn(name = "holding_identity_id")
     @Id
+    @Column(name = "holding_identity_id")
+    val holdingIdentityId: String,
+
+    @MapsId
+    @OneToOne(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "holding_identity_id")
     val holdingIdentity: HoldingIdentityEntity,
 
     @Column(name = "cpi_name", nullable = false)
@@ -110,6 +112,7 @@ internal class VirtualNodeEntity(
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int = 0,
 ) : Serializable {
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -117,9 +120,6 @@ internal class VirtualNodeEntity(
         other as VirtualNodeEntity
 
         return Objects.equals(holdingIdentity, other.holdingIdentity)
-                && Objects.equals(cpiName, other.cpiName)
-                && Objects.equals(cpiVersion, other.cpiVersion)
-                && Objects.equals(cpiSignerSummaryHash, other.cpiSignerSummaryHash)
     }
 
     override fun hashCode(): Int {
@@ -171,13 +171,3 @@ internal class VirtualNodeEntity(
         this.uniquenessDMLConnectionId = uniquenessDMLConnectionId
     }
 }
-
-/** The composite primary key for a virtual node instance. */
-@Embeddable
-@Suppress("Unused")
-internal class VirtualNodeEntityKey(
-    private val holdingIdentity: HoldingIdentityEntity,
-    private val cpiName: String,
-    private val cpiVersion: String,
-    private val cpiSignerSummaryHash: String
-) : Serializable

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -3,7 +3,6 @@ package net.corda.libs.virtualnode.datamodel.entities
 import net.corda.db.schema.DbSchema.CONFIG
 import net.corda.db.schema.DbSchema.VIRTUAL_NODE_DB_TABLE
 import net.corda.libs.packaging.core.CpiIdentifier
-import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationEntity
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.OperationalStatus

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
@@ -13,6 +13,7 @@ import net.corda.db.schema.DbSchema.CONFIG
 
 @Entity
 @Table(name = "virtual_node_operation", schema = CONFIG)
+@Suppress("LongParameterList")
 internal class VirtualNodeOperationEntity(
     @Id
     @Column(name = "id", nullable = false)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
@@ -19,7 +19,7 @@ internal class VirtualNodeOperationEntity(
     @Column(name = "id", nullable = false)
     var id: String,
 
-    @Column(name = "requestId", nullable = false)
+    @Column(name = "request_id", nullable = false)
     var requestId: String,
 
     @Column(name = "data", nullable = false)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
@@ -1,0 +1,60 @@
+package net.corda.libs.virtualnode.datamodel
+
+import java.io.Serializable
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.Table
+import javax.persistence.Version
+import net.corda.db.schema.DbSchema.CONFIG
+
+@Entity
+@Table(name = "virtual_node_operation", schema = CONFIG)
+internal class VirtualNodeOperationEntity(
+    @Id
+    @Column(name = "id", nullable = false)
+    var id: String,
+
+    @Column(name = "requestId", nullable = false)
+    var requestId: String,
+
+    @Column(name = "data", nullable = false)
+    var data: String,
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "state", nullable = false)
+    var state: VirtualNodeOperationState,
+
+    @Column(name = "request_timestamp")
+    var requestTimestamp: Instant,
+
+    @Column(name = "latest_update_timestamp", insertable = false)
+    var latestUpdateTimestamp: Instant? = null,
+
+    @Column(name = "heartbeat_timestamp")
+    var heartbeatTimestamp: Instant? = null,
+
+    @Version
+    @Column(name = "entity_version", nullable = false)
+    var entityVersion: Int = 0,
+): Serializable {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is VirtualNodeOperationEntity) return false
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}
+
+enum class VirtualNodeOperationState {
+    IN_PROGRESS, COMPLETED, ABORTED
+}

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
@@ -1,4 +1,4 @@
-package net.corda.libs.virtualnode.datamodel
+package net.corda.libs.virtualnode.datamodel.entities
 
 import java.io.Serializable
 import java.time.Instant

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/HoldingIdentityRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/HoldingIdentityRepository.kt
@@ -11,13 +11,7 @@ interface HoldingIdentityRepository {
     @Suppress("LongParameterList")
     fun put(
         entityManager: EntityManager,
-        holdingIdentity: HoldingIdentity,
-        vaultDdlConnectionId: UUID?,
-        vaultDmlConnectionId: UUID,
-        cryptoDdlConnectionId: UUID?,
-        cryptoDmlConnectionId: UUID,
-        uniquenessDdlConnectionId: UUID?,
-        uniquenessDmlConnectionId: UUID?
+        holdingIdentity: HoldingIdentity
     )
 }
 

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/HoldingIdentityRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/HoldingIdentityRepositoryImpl.kt
@@ -21,33 +21,12 @@ class HoldingIdentityRepositoryImpl: HoldingIdentityRepository {
     override fun put(
         entityManager: EntityManager,
         holdingIdentity: HoldingIdentity,
-        vaultDdlConnectionId: UUID?,
-        vaultDmlConnectionId: UUID,
-        cryptoDdlConnectionId: UUID?,
-        cryptoDmlConnectionId: UUID,
-        uniquenessDdlConnectionId: UUID?,
-        uniquenessDmlConnectionId: UUID?
     ) {
-        val entity = entityManager.find(HoldingIdentityEntity::class.java, holdingIdentity.shortHash.value)?.apply {
-            update(
-                vaultDdlConnectionId,
-                vaultDmlConnectionId,
-                cryptoDdlConnectionId,
-                cryptoDmlConnectionId,
-                uniquenessDdlConnectionId,
-                uniquenessDmlConnectionId
-            )
-        } ?: HoldingIdentityEntity(
+        val entity = entityManager.find(HoldingIdentityEntity::class.java, holdingIdentity.shortHash.value) ?: HoldingIdentityEntity(
             holdingIdentity.shortHash.value,
             holdingIdentity.fullHash,
             holdingIdentity.x500Name.toString(),
             holdingIdentity.groupId,
-            vaultDdlConnectionId,
-            vaultDmlConnectionId,
-            cryptoDdlConnectionId,
-            cryptoDmlConnectionId,
-            uniquenessDdlConnectionId,
-            uniquenessDmlConnectionId,
             null
         )
         entityManager.persist(entity)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -4,7 +4,7 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.VirtualNodeState
+import java.util.UUID
 import java.util.stream.Stream
 import javax.persistence.EntityManager
 
@@ -12,7 +12,17 @@ import javax.persistence.EntityManager
 interface VirtualNodeRepository {
     fun findAll(entityManager: EntityManager): Stream<VirtualNodeInfo>
     fun find(entityManager: EntityManager, holdingIdentityShortHash: ShortHash): VirtualNodeInfo?
-    fun put(entityManager: EntityManager, holdingId: HoldingIdentity, cpiId: CpiIdentifier)
-    fun updateVirtualNodeState(entityManager: EntityManager, holdingIdentityShortHash: String, newState: VirtualNodeState): VirtualNodeInfo
+    fun put(
+        entityManager: EntityManager,
+        holdingId: HoldingIdentity,
+        cpiId: CpiIdentifier,
+        vaultDDLConnectionId: UUID?,
+        vaultDMLConnectionId: UUID,
+        cryptoDDLConnectionId: UUID?,
+        cryptoDMLConnectionId: UUID,
+        uniquenessDDLConnectionId: UUID?,
+        uniquenessDMLConnectionId: UUID?
+    )
+    fun updateVirtualNodeState(entityManager: EntityManager, holdingIdentityShortHash: String, newState: String): VirtualNodeInfo
 }
 

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -12,6 +12,9 @@ import javax.persistence.EntityManager
 interface VirtualNodeRepository {
     fun findAll(entityManager: EntityManager): Stream<VirtualNodeInfo>
     fun find(entityManager: EntityManager, holdingIdentityShortHash: ShortHash): VirtualNodeInfo?
+
+    @Suppress("LongParameterList")
+
     fun put(
         entityManager: EntityManager,
         holdingId: HoldingIdentity,

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -71,7 +71,7 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
             ?: throw CordaRuntimeException("Could not find holding identity")
 
         val virtualNodeEntityKey = hie.holdingIdentityShortHash
-        val foundVNode = entityManager.find(VirtualNodeEntity::class.java, virtualNodeEntityKey).apply {
+        val foundVNode = entityManager.find(VirtualNodeEntity::class.java, virtualNodeEntityKey)?.apply {
             this.update(
                 vaultDDLConnectionId = vaultDDLConnectionId,
                 vaultDMLConnectionId = vaultDMLConnectionId,

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -4,7 +4,6 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.datamodel.entities.HoldingIdentityEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntity
 import net.corda.libs.virtualnode.datamodel.VirtualNodeNotFoundException
-import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntityKey
 import net.corda.orm.utils.transaction
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.HoldingIdentity
@@ -71,7 +70,7 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
         val hie = entityManager.find(HoldingIdentityEntity::class.java, holdingId.shortHash.value)
             ?: throw CordaRuntimeException("Could not find holding identity")
 
-        val virtualNodeEntityKey = VirtualNodeEntityKey(hie, cpiId.name, cpiId.version, signerSummaryHash)
+        val virtualNodeEntityKey = hie.holdingIdentityShortHash
         val foundVNode = entityManager.find(VirtualNodeEntity::class.java, virtualNodeEntityKey).apply {
             this.update(
                 vaultDDLConnectionId = vaultDDLConnectionId,
@@ -82,6 +81,7 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
                 uniquenessDMLConnectionId = uniquenessDMLConnectionId
             )
         } ?: VirtualNodeEntity(
+            hie.holdingIdentityShortHash,
             hie,
             cpiId.name,
             cpiId.version,

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -8,9 +8,10 @@ import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntityKey
 import net.corda.orm.utils.transaction
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
-import net.corda.virtualnode.VirtualNodeState
+import java.util.UUID
 import java.util.stream.Stream
 import javax.persistence.EntityManager
 

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodeInfo.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.virtualnode.endpoints.v1.types
 
 import net.corda.libs.cpiupload.endpoints.v1.CpiIdentifier
+import net.corda.virtualnode.OperationalStatus
 
 /**
  * This class is serialized and returned as JSON in the REST api
@@ -31,5 +32,8 @@ data class VirtualNodeInfo(
     val uniquenessDdlConnectionId: String? = null,
     val uniquenessDmlConnectionId: String,
     val hsmConnectionId: String? = null,
-    val state: String,
+    val flowP2pOperationalStatus: OperationalStatus,
+    val flowStartOperationalStatus: OperationalStatus,
+    val flowOperationalStatus: OperationalStatus,
+    val vaultDbOperationalStatus: OperationalStatus,
 )

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -33,7 +33,13 @@ data class VirtualNodeInfo(
     /** HSM connection ID */
     val hsmConnectionId: UUID? = null,
     /** Current state of the virtual node instance */
-    val state: VirtualNodeState = DEFAULT_INITIAL_STATE,
+    val flowP2pOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
+    /** Current state of the virtual node instance */
+    val flowStartOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
+    /** Current state of the virtual node instance */
+    val flowOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
+    /** Current state of the virtual node instance */
+    val vaultDbOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
     /** Version of this vnode */
     val version: Int = -1,
     /** Creation timestamp */
@@ -42,7 +48,7 @@ data class VirtualNodeInfo(
     val isDeleted: Boolean = false,
 ) {
     companion object {
-        val DEFAULT_INITIAL_STATE = VirtualNodeState.ACTIVE
+        val DEFAULT_INITIAL_STATE = OperationalStatus.ACTIVE
     }
 }
 
@@ -61,7 +67,10 @@ fun VirtualNodeInfo.toAvro(): VirtualNodeInfoAvro =
             uniquenessDdlConnectionId?.let{ uniquenessDdlConnectionId.toString() },
             uniquenessDmlConnectionId.toString(),
             hsmConnectionId?.let { hsmConnectionId.toString() },
-            state.name,
+            flowP2pOperationalStatus.toString(),
+            flowStartOperationalStatus.toString(),
+            flowOperationalStatus.toString(),
+            vaultDbOperationalStatus.toString(),
             version,
             timestamp
         )
@@ -79,16 +88,17 @@ fun VirtualNodeInfoAvro.toCorda(): VirtualNodeInfo {
         uniquenessDdlConnectionId?.let { UUID.fromString(uniquenessDdlConnectionId) },
         UUID.fromString(uniquenessDmlConnectionId),
         hsmConnectionId?.let { UUID.fromString(hsmConnectionId) },
-        VirtualNodeState.valueOf(virtualNodeState),
+        OperationalStatus.valueOf(flowP2pOperationalStatus),
+        OperationalStatus.valueOf(flowStartOperationalStatus),
+        OperationalStatus.valueOf(flowOperationalStatus),
+        OperationalStatus.valueOf(vaultDbOperationalStatus),
         version,
         timestamp,
         false
     )
 }
 
-enum class VirtualNodeState {
+enum class OperationalStatus {
     ACTIVE,
-    INACTIVE,
-    IN_MAINTENANCE,
-    DRAINING
+    INACTIVE
 }

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
@@ -41,13 +41,16 @@ class VirtualNodeDbReconcilerReaderTest {
             whenever(it.holdingIdentity).then { mockHoldingIdentity }
             whenever(it.timestamp).then { timestamp }
             whenever(it.version).then { entityVersion }
-            whenever(it.state).then { VirtualNodeInfo.DEFAULT_INITIAL_STATE.name }
             whenever(it.vaultDmlConnectionId).then { vaultDmlConnectionId }
             whenever(it.vaultDdlConnectionId).then { vaultDdlConnectionId }
             whenever(it.cryptoDmlConnectionId).then { cryptoDmlConnectionId }
             whenever(it.cryptoDdlConnectionId).then { cryptoDdlConnectionId }
             whenever(it.uniquenessDmlConnectionId).then { uniquenessDmlConnectionId }
             whenever(it.uniquenessDdlConnectionId).then { uniquenessDdlConnectionId }
+            whenever(it.flowP2pOperationalStatus).then { VirtualNodeInfo.DEFAULT_INITIAL_STATE }
+            whenever(it.flowStartOperationalStatus).then { VirtualNodeInfo.DEFAULT_INITIAL_STATE }
+            whenever(it.flowOperationalStatus).then { VirtualNodeInfo.DEFAULT_INITIAL_STATE }
+            whenever(it.vaultDbOperationalStatus).then { VirtualNodeInfo.DEFAULT_INITIAL_STATE }
             whenever(it.hsmConnectionId).then { null }
         }
     }

--- a/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rpc-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -3493,7 +3493,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -3632,7 +3631,6 @@
       },
       "GenerateCsrWrapperRequest" : {
         "required" : [ "x500Name" ],
-        "type" : "object",
         "properties" : {
           "contextMap" : {
             "type" : "object",
@@ -3918,7 +3916,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -3962,7 +3959,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4045,7 +4041,6 @@
             "example" : "2022-06-24T10:15:30Z"
           },
           "registrationStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "PENDING_MEMBER_VERIFICATION",
             "enum" : [ "NEW", "PENDING_MEMBER_VERIFICATION", "PENDING_APPROVAL_FLOW", "PENDING_MANUAL_APPROVAL", "PENDING_AUTO_APPROVAL", "DECLINED", "APPROVED" ]
@@ -4371,7 +4366,7 @@
         }
       },
       "VirtualNodeInfo" : {
-        "required" : [ "cpiIdentifier", "cryptoDmlConnectionId", "holdingIdentity", "state", "uniquenessDmlConnectionId", "vaultDmlConnectionId" ],
+        "required" : [ "cpiIdentifier", "cryptoDmlConnectionId", "flowOperationalStatus", "flowP2pOperationalStatus", "flowStartOperationalStatus", "holdingIdentity", "uniquenessDmlConnectionId", "vaultDbOperationalStatus", "vaultDmlConnectionId" ],
         "type" : "object",
         "properties" : {
           "cpiIdentifier" : {
@@ -4387,17 +4382,27 @@
             "nullable" : false,
             "example" : "string"
           },
+          "flowOperationalStatus" : {
+            "nullable" : false,
+            "example" : "INACTIVE",
+            "enum" : [ "ACTIVE", "INACTIVE" ]
+          },
+          "flowP2pOperationalStatus" : {
+            "nullable" : false,
+            "example" : "INACTIVE",
+            "enum" : [ "ACTIVE", "INACTIVE" ]
+          },
+          "flowStartOperationalStatus" : {
+            "nullable" : false,
+            "example" : "INACTIVE",
+            "enum" : [ "ACTIVE", "INACTIVE" ]
+          },
           "holdingIdentity" : {
             "$ref" : "#/components/schemas/HoldingIdentity"
           },
           "hsmConnectionId" : {
             "type" : "string",
             "nullable" : true,
-            "example" : "string"
-          },
-          "state" : {
-            "type" : "string",
-            "nullable" : false,
             "example" : "string"
           },
           "uniquenessDdlConnectionId" : {
@@ -4409,6 +4414,11 @@
             "type" : "string",
             "nullable" : false,
             "example" : "string"
+          },
+          "vaultDbOperationalStatus" : {
+            "nullable" : false,
+            "example" : "INACTIVE",
+            "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "vaultDdlConnectionId" : {
             "type" : "string",

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
@@ -59,7 +59,6 @@ class VirtualNodeLoaderImpl @Activate constructor(
             UUID.randomUUID(),
             null,
             timestamp = Instant.now(),
-            state = VirtualNodeInfo.DEFAULT_INITIAL_STATE // Leaving as a constant value as this is just for testing
         ).also(::put)
     }
 


### PR DESCRIPTION
This PR updates VirtualNodeEntity with the fields needed to support CPI upgrade, as described in the [CPI upgrade design documentation](https://github.com/corda/platform-eng-design/blob/master/core/corda-5/corda-5.0/virtual-node/cpi-upgrade/database-schema-changes.md). The corresponding corda-api changes are being made in https://github.com/corda/corda-api/pull/803

The fields being added to VirtualNodeEntity are:
- flowP2pOperationalStatus
- flowStartOperationalStatus
- flowOperationalStatus
- vaultDbOperationalStatus
- operationInProgress
- vaultDDLConnectionId
- vaultDMLConnectionId
- cryptoDDLConnectionId
- cryptoDMLConnectionId
- uniquenessDDLConnectionId
- uniquenessDMLConnectionId

Additionally, this PR moves the connectionId fields from the HoldingIdentityEntity to VirtualNodeEntity. 