### PR TITLE
CORE-9416 Increase failureThreshold for probes

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -131,6 +131,32 @@ Worker image
 {{- end }}
 
 {{/*
+Worker probes
+*/}}
+{{- define "corda.workerProbes" -}}
+{{- if not ( get .Values.workers .worker ).debug.enabled }}
+readinessProbe:
+  httpGet:
+    path: /status
+    port: monitor
+  periodSeconds: 10
+  failureThreshold: 3
+livenessProbe:
+  httpGet:
+    path: /isHealthy
+    port: monitor
+  periodSeconds: 10
+  failureThreshold: 3
+startupProbe:
+  httpGet:
+    path: /isHealthy
+    port: monitor
+  periodSeconds: 5
+  failureThreshold: 20
+{{- end }}
+{{- end }}
+
+{{/*
 Pod security context
 */}}
 {{- define "corda.podSecurityContext" -}}

--- a/charts/corda/templates/crypto-worker.yaml
+++ b/charts/corda/templates/crypto-worker.yaml
@@ -65,26 +65,7 @@ spec:
           - name: profiling
             containerPort: 10045
         {{- end }}
-        {{- if not .Values.workers.crypto.debug.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 5
-          failureThreshold: 20
-        {{- end }}
+        {{- include "corda.workerProbes" . | nindent 8 }}
       initContainers:
       {{ include "corda.kafkaSaslInitContainer" . | nindent 8 }}
       volumes:

--- a/charts/corda/templates/db-worker.yaml
+++ b/charts/corda/templates/db-worker.yaml
@@ -64,26 +64,7 @@ spec:
           - name: profiling
             containerPort: 10045
         {{- end }}
-        {{- if not .Values.workers.db.debug.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 5
-          failureThreshold: 20
-        {{- end }}
+        {{- include "corda.workerProbes" . | nindent 8 }}
       initContainers:
       {{ include "corda.kafkaSaslInitContainer" . | nindent 8 }}
       volumes:

--- a/charts/corda/templates/flow-worker.yaml
+++ b/charts/corda/templates/flow-worker.yaml
@@ -55,26 +55,7 @@ spec:
           - name: profiling
             containerPort: 10045
         {{- end }}
-        {{- if not .Values.workers.flow.debug.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 5
-          failureThreshold: 20
-        {{- end }}
+        {{- include "corda.workerProbes" . | nindent 8 }}
       initContainers:
       {{ include "corda.kafkaSaslInitContainer" . | nindent 8 }}
       volumes:

--- a/charts/corda/templates/membership-worker.yaml
+++ b/charts/corda/templates/membership-worker.yaml
@@ -43,26 +43,7 @@ spec:
           - name: profiling
             containerPort: 10045
         {{- end }}
-        {{- if not .Values.workers.membership.debug.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 5
-          failureThreshold: 20
-        {{- end }}
+        {{- include "corda.workerProbes" . | nindent 8 }}
       initContainers:
       {{ include "corda.kafkaSaslInitContainer" . | nindent 8 }}        
       volumes:

--- a/charts/corda/templates/p2p-gateway.yaml
+++ b/charts/corda/templates/p2p-gateway.yaml
@@ -72,26 +72,7 @@ spec:
         {{- end }}
           - name: monitor
             containerPort: 7000
-        {{- if not .Values.workers.p2pGateway.debug.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 5
-          failureThreshold: 20
-        {{- end }}
+        {{- include "corda.workerProbes" . | nindent 8 }}
       initContainers:
       {{ include "corda.kafkaSaslInitContainer" . | nindent 8 }}        
       volumes:

--- a/charts/corda/templates/p2p-link-manager.yaml
+++ b/charts/corda/templates/p2p-link-manager.yaml
@@ -55,26 +55,7 @@ spec:
           - name: profiling
             containerPort: 10045
         {{- end }}
-        {{- if not .Values.workers.p2pLinkManager.debug.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 5
-          failureThreshold: 20
-        {{- end }}
+        {{- include "corda.workerProbes" . | nindent 8 }}
       initContainers:
       {{ include "corda.kafkaSaslInitContainer" . | nindent 8 }}        
       volumes:

--- a/charts/corda/templates/rpc-worker.yaml
+++ b/charts/corda/templates/rpc-worker.yaml
@@ -83,26 +83,7 @@ spec:
           - name: profiling
             containerPort: 10045
         {{- end }}
-        {{- if not .Values.workers.rpc.debug.enabled }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 10
-          failureThreshold: 1
-        startupProbe:
-          httpGet:
-            path: /isHealthy
-            port: monitor
-          periodSeconds: 5
-          failureThreshold: 20
-        {{- end }}
+        {{- include "corda.workerProbes" . | nindent 8 }}
       initContainers:
       {{ include "corda.kafkaSaslInitContainer" . | nindent 8 }}        
       volumes:


### PR DESCRIPTION
We're seeing livenessProbes time out due to GC. Rather than increase the timeout, I'm setting the failureThreshold back to the default of 3 so that we'll still see livenessProbe failures if they hit a significant GC but that should then not lead to a restart of the worker.