### PR TITLE
CORE-7309 Api to find my signing keys

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -657,15 +657,15 @@ class FlowTests {
     }
 
     @Test
-    fun `Crypto - Signing service returns my keys`() {
+    fun `Crypto - Signing service returns my signing keys`() {
         val requestBody = RpcSmokeTestInput()
-        requestBody.command = "crypto_get_my_keys"
+        requestBody.command = "crypto_get_my_signing_keys"
         val requestId = startRpcFlow(bobHoldingId, requestBody)
         val result = awaitRpcFlowFinished(bobHoldingId, requestId)
         val flowResult = result.getRpcFlowResult()
         assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
         assertThat(result.flowResult).isNotNull
-        assertThat(flowResult.command).isEqualTo("crypto_get_my_keys")
+        assertThat(flowResult.command).isEqualTo("crypto_get_my_signing_keys")
         assertThat(flowResult.result).isEqualTo("success")
     }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -657,6 +657,19 @@ class FlowTests {
     }
 
     @Test
+    fun `Crypto - Signing service returns my keys`() {
+        val requestBody = RpcSmokeTestInput()
+        requestBody.command = "crypto_get_my_keys"
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
+        val flowResult = result.getRpcFlowResult()
+        assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result.flowResult).isNotNull
+        assertThat(flowResult.command).isEqualTo("crypto_get_my_keys")
+        assertThat(flowResult.result).isEqualTo("success")
+    }
+
+    @Test
     fun `Context is propagated to initiated and sub flows`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "context_propagation"

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -657,15 +657,15 @@ class FlowTests {
     }
 
     @Test
-    fun `Crypto - Signing service returns my signing keys`() {
+    fun `Crypto - Signing service finds my signing keys`() {
         val requestBody = RpcSmokeTestInput()
-        requestBody.command = "crypto_get_my_signing_keys"
+        requestBody.command = "crypto_find_my_signing_keys"
         val requestId = startRpcFlow(bobHoldingId, requestBody)
         val result = awaitRpcFlowFinished(bobHoldingId, requestId)
         val flowResult = result.getRpcFlowResult()
         assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
         assertThat(result.flowResult).isNotNull
-        assertThat(flowResult.command).isEqualTo("crypto_get_my_signing_keys")
+        assertThat(flowResult.command).isEqualTo("crypto_find_my_signing_keys")
         assertThat(flowResult.result).isEqualTo("success")
     }
 

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
@@ -154,8 +154,8 @@ class CryptoOpsClientComponent @Activate constructor(
     override fun filterMyKeysProxy(tenantId: String, candidateKeys: Iterable<ByteBuffer>): CryptoSigningKeys =
         impl.ops.filterMyKeysProxy(tenantId, candidateKeys)
 
-    override fun filterMyKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys =
-        impl.ops.filterMyKeysByIdsProxy(tenantId, candidateKeys)
+    override fun lookUpForKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys =
+        impl.ops.lookUpForKeysByIdsProxy(tenantId, candidateKeys)
 
     override fun signProxy(
         tenantId: String,

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
@@ -154,6 +154,9 @@ class CryptoOpsClientComponent @Activate constructor(
     override fun filterMyKeysProxy(tenantId: String, candidateKeys: Iterable<ByteBuffer>): CryptoSigningKeys =
         impl.ops.filterMyKeysProxy(tenantId, candidateKeys)
 
+    override fun filterMyKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys =
+        impl.ops.filterMyKeysByIdsProxy(tenantId, candidateKeys)
+
     override fun signProxy(
         tenantId: String,
         publicKey: ByteBuffer,

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -94,10 +94,10 @@ class CryptoOpsClientImpl(
         val publicKeyIds = candidateKeys.map {
             publicKeyIdFromBytes(it.array())
         }
-        return filterMyKeysByIdsProxy(tenantId, publicKeyIds)
+        return lookUpForKeysByIdsProxy(tenantId, publicKeyIds)
     }
 
-    fun filterMyKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys {
+    fun lookUpForKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys {
         logger.info(
             "Sending '{}'(tenant={},candidateKeys={})",
             ByIdsRpcQuery::class.java.simpleName,

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -91,18 +91,24 @@ class CryptoOpsClientImpl(
     }
 
     fun filterMyKeysProxy(tenantId: String, candidateKeys: Iterable<ByteBuffer>): CryptoSigningKeys {
+        val publicKeyIds = candidateKeys.map {
+            publicKeyIdFromBytes(it.array())
+        }
+        return filterMyKeysByIdsProxy(tenantId, publicKeyIds)
+    }
+
+    fun filterMyKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys {
         logger.info(
             "Sending '{}'(tenant={},candidateKeys={})",
             ByIdsRpcQuery::class.java.simpleName,
             tenantId,
-            candidateKeys.joinToString { it.array().sha256Bytes().toBase58().take(12) + ".." }
+            candidateKeys.joinToString { "$it.." }
         )
+
         val request = createRequest(
             tenantId = tenantId,
             request = ByIdsRpcQuery(
-                candidateKeys.map {
-                    publicKeyIdFromBytes(it.array())
-                }
+                candidateKeys
             )
         )
         return request.execute(Duration.ofSeconds(20), CryptoSigningKeys::class.java)!!

--- a/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/CryptoOpsProxyClient.kt
+++ b/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/CryptoOpsProxyClient.kt
@@ -25,10 +25,9 @@ interface CryptoOpsProxyClient : CryptoOpsClient {
     fun filterMyKeysProxy(tenantId: String, candidateKeys: Iterable<ByteBuffer>): CryptoSigningKeys
 
     /**
-     * Filters the input [PublicKey]s down to a collection of keys that this tenant owns (has private keys for)
-     * by public key ids (See [PublicKeyHash.id]).
+     * Looks up for keys by ids owned by tenant of [tenantId] (has private keys for).
      */
-    fun filterMyKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys
+    fun lookUpForKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys
 
     /**
      * Using the provided signing public key internally looks up the matching private key information and signs the data.

--- a/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/CryptoOpsProxyClient.kt
+++ b/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/CryptoOpsProxyClient.kt
@@ -25,6 +25,12 @@ interface CryptoOpsProxyClient : CryptoOpsClient {
     fun filterMyKeysProxy(tenantId: String, candidateKeys: Iterable<ByteBuffer>): CryptoSigningKeys
 
     /**
+     * Filters the input [PublicKey]s down to a collection of keys that this tenant owns (has private keys for)
+     * by public key ids (See [PublicKeyHash.id]).
+     */
+    fun filterMyKeysByIdsProxy(tenantId: String, candidateKeys: List<String>): CryptoSigningKeys
+
+    /**
      * Using the provided signing public key internally looks up the matching private key information and signs the data.
      * If the [PublicKey] is actually a [CompositeKey] the first leaf signing key hosted by the node is used.
      * Default signature scheme for the key scheme is used.

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -14,6 +14,7 @@ import net.corda.data.crypto.wire.CryptoResponseContext
 import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
+import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
 import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysFlowQuery
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.messaging.api.processor.DurableProcessor
@@ -108,6 +109,11 @@ class CryptoFlowOpsBusProcessor(
                 cryptoOpsClient.filterMyKeysProxy(
                     tenantId = context.tenantId,
                     candidateKeys = request.keys
+                )
+            is FilterMyKeysByIdsFlowQuery ->
+                cryptoOpsClient.filterMyKeysByIdsProxy(
+                    tenantId = context.tenantId,
+                    candidateKeys = request.keyIds
                 )
             is SignFlowCommand ->
                 cryptoOpsClient.signProxy(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -14,7 +14,7 @@ import net.corda.data.crypto.wire.CryptoResponseContext
 import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.ByIdsFlowQuery
 import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysFlowQuery
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.messaging.api.processor.DurableProcessor
@@ -110,7 +110,7 @@ class CryptoFlowOpsBusProcessor(
                     tenantId = context.tenantId,
                     candidateKeys = request.keys
                 )
-            is FilterMyKeysByIdsFlowQuery ->
+            is ByIdsFlowQuery ->
                 cryptoOpsClient.filterMyKeysByIdsProxy(
                     tenantId = context.tenantId,
                     candidateKeys = request.keyIds

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -111,7 +111,7 @@ class CryptoFlowOpsBusProcessor(
                     candidateKeys = request.keys
                 )
             is ByIdsFlowQuery ->
-                cryptoOpsClient.filterMyKeysByIdsProxy(
+                cryptoOpsClient.lookUpForKeysByIdsProxy(
                     tenantId = context.tenantId,
                     candidateKeys = request.keyIds
                 )

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
@@ -212,7 +212,7 @@ class CryptoFlowOpsBusProcessorTests {
                     )
                 )
             )
-        }.whenever(cryptoOpsClient).filterMyKeysByIdsProxy(any(), any())
+        }.whenever(cryptoOpsClient).lookUpForKeysByIdsProxy(any(), any())
         val transformer = buildTransformer()
         val result = act {
             processor.onNext(
@@ -401,7 +401,7 @@ class CryptoFlowOpsBusProcessorTests {
                     )
                 )
             )
-        }.whenever(cryptoOpsClient).filterMyKeysByIdsProxy(any(), any())
+        }.whenever(cryptoOpsClient).lookUpForKeysByIdsProxy(any(), any())
         val transformer = buildTransformer()
         val result = act {
             processor.onNext(
@@ -527,7 +527,7 @@ class CryptoFlowOpsBusProcessorTests {
                     )
                 )
             )
-        }.whenever(cryptoOpsClient).filterMyKeysByIdsProxy(any(), any())
+        }.whenever(cryptoOpsClient).lookUpForKeysByIdsProxy(any(), any())
         val transformer = buildTransformer()
         val result = act {
             processor.onNext(
@@ -677,7 +677,7 @@ class CryptoFlowOpsBusProcessorTests {
                     )
                 )
             )
-        }.whenever(cryptoOpsClient).filterMyKeysByIdsProxy(any(), any())
+        }.whenever(cryptoOpsClient).lookUpForKeysByIdsProxy(any(), any())
         val transformer = buildTransformer()
         val result = act {
             processor.onNext(

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
@@ -22,7 +22,7 @@ import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.crypto.wire.CryptoSigningKeys
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.ByIdsFlowQuery
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
@@ -230,7 +230,7 @@ class CryptoFlowOpsBusProcessorTests {
             )
         }
         assertEquals(recordKey, result.value?.get(0)?.key)
-        val response = assertResponseContext<FilterMyKeysByIdsFlowQuery, CryptoSigningKeys>(
+        val response = assertResponseContext<ByIdsFlowQuery, CryptoSigningKeys>(
             result,
             flowOpsResponseArgumentCaptor.firstValue
         )
@@ -424,7 +424,7 @@ class CryptoFlowOpsBusProcessorTests {
             )
         }
         assertEquals(recordKey, result.value?.get(0)?.key)
-        val response = assertResponseContext<FilterMyKeysByIdsFlowQuery, CryptoSigningKeys>(
+        val response = assertResponseContext<ByIdsFlowQuery, CryptoSigningKeys>(
             result,
             flowOpsResponseArgumentCaptor.firstValue
         )
@@ -569,7 +569,7 @@ class CryptoFlowOpsBusProcessorTests {
             assertInstanceOf(CryptoSigningKeys::class.java, flowOpsResponse.response)
             val context1 = flowOpsResponse.context
             val response1 = flowOpsResponse.response as CryptoSigningKeys
-            assertResponseContext<FilterMyKeysByIdsFlowQuery>(result, context1, 123)
+            assertResponseContext<ByIdsFlowQuery>(result, context1, 123)
             assertNotNull(response1.keys)
             assertEquals(2, response1.keys.size)
             assertTrue(
@@ -714,7 +714,7 @@ class CryptoFlowOpsBusProcessorTests {
             assertInstanceOf(CryptoSigningKeys::class.java, flowOpsResponse.response)
             val context1 = flowOpsResponse.context
             val response1 = flowOpsResponse.response as CryptoSigningKeys
-            assertResponseContext<FilterMyKeysByIdsFlowQuery>(result, context1, 123, tenantId)
+            assertResponseContext<ByIdsFlowQuery>(result, context1, 123, tenantId)
             assertNotNull(response1.keys)
             assertEquals(2, response1.keys.size)
             assertTrue(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -2,6 +2,7 @@ package net.corda.flow.application.crypto
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.flow.application.crypto.external.events.CreateSignatureExternalEventFactory
+import net.corda.flow.application.crypto.external.events.FilterMyKeysExternalEventFactory
 import net.corda.flow.application.crypto.external.events.SignParameters
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.sandbox.type.UsedByFlow
@@ -32,6 +33,14 @@ class SigningServiceImpl @Activate constructor(
         return externalEventExecutor.execute(
             CreateSignatureExternalEventFactory::class.java,
             SignParameters(bytes, keyEncodingService.encodeAsByteArray(publicKey), signatureSpec)
+        )
+    }
+
+    @Suspendable
+    override fun getMyKeys(keys: Set<PublicKey>): Set<PublicKey> {
+        return externalEventExecutor.execute(
+            FilterMyKeysExternalEventFactory::class.java,
+            keys
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -71,7 +71,7 @@ class SigningServiceImpl @Activate constructor(
                         foundLeaf = leaf
                     } else {
                         throw IllegalStateException(
-                            "A node should be owning one key at most per composite key, but found two owned keys for composite key: \"$it\" " +
+                            "A node should be owning one key at most per composite key, but two owned keys were found for composite key: \"$it\" " +
                                     " first: \"$foundLeaf\" second: \"$leaf\""
                         )
                     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -37,7 +37,7 @@ class SigningServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun getMyKeys(keys: Set<PublicKey>): Set<PublicKey> {
+    override fun getMySigningKeys(keys: Set<PublicKey>): Set<PublicKey> {
         return externalEventExecutor.execute(
             FilterMyKeysExternalEventFactory::class.java,
             keys

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -43,7 +43,7 @@ class SigningServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun getMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
+    override fun findMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
         val compositeKeys: Set<CompositeKey> = keys.filterIsInstanceTo(linkedSetOf(), CompositeKey::class.java)
         val plainKeys = keys - compositeKeys
         val compositeKeysLeaves: Set<PublicKey> = compositeKeys.flatMapTo(linkedSetOf()) {
@@ -62,7 +62,7 @@ class SigningServiceImpl @Activate constructor(
                 null
         }
 
-        // TODO For now we are going to be matching composite key request with first leaf found
+        // TODO For now we are going to be matching composite key request with first leaf found ignoring other found leaves
         //  Perhaps we should revisit this behavior in the future.
         val compositeKeysReqResp = compositeKeys.associateWith {
             var foundLeaf: PublicKey? = null

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -50,11 +50,11 @@ class SigningServiceImpl @Activate constructor(
             plainKeys + compositeKeysLeaves
         ).toSet()
 
-        val plainKeysReqResp = plainKeys.associate {
+        val plainKeysReqResp = plainKeys.associateWith {
             if (it in foundSigningKeys) {
-                it to it
+                it
             } else
-                it to null
+                null
         }
 
         val compositeKeysReqResp = compositeKeys.associateWith {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -74,7 +74,7 @@ class SigningServiceImpl @Activate constructor(
                         log.info(
                             "Found multiple composite key leaves to be owned for the same composite key by the same node " +
                                     "while there should only be one per composite key per node. " +
-                                    "Composite key: \"$it\"" +
+                                    "Composite key: \"$it\" " +
                                     "Will make use of firstly found leaf: \"$foundLeaf\" " +
                                     "Will ignore also found leaf: \"$leaf\""
                         )

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -37,10 +37,20 @@ class SigningServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun getMySigningKeys(keys: Set<PublicKey>): Set<PublicKey> {
-        return externalEventExecutor.execute(
+    override fun getMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
+        val foundToBeMySigningKeys = externalEventExecutor.execute(
             FilterMyKeysExternalEventFactory::class.java,
             keys
-        )
+        ).toSet()
+
+        require(foundToBeMySigningKeys.size <= keys.size) {
+            "Found keys cannot be more than requested keys"
+        }
+        return keys.associate {
+            if (it in foundToBeMySigningKeys) {
+                Pair(it, it)
+            } else
+                Pair(it, null)
+        }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -65,8 +65,8 @@ class SigningServiceImpl @Activate constructor(
                         foundLeaf = leaf
                     } else {
                         throw IllegalStateException(
-                            "A node should be owning one key at most per composite key, but two owned keys were found for composite key: \"$it\" " +
-                                    " first: \"$foundLeaf\" second: \"$leaf\""
+                            "A node should be owning one key at most per composite key, but two owned keys were found " +
+                                    "for composite key: \"$it\" first: \"$foundLeaf\" second: \"$leaf\""
                         )
                     }
                 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -41,7 +41,6 @@ class SigningServiceImpl @Activate constructor(
     override fun getMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
         val compositeKeys: Set<CompositeKey> = keys.filterIsInstanceTo(linkedSetOf(), CompositeKey::class.java)
         val plainKeys = keys - compositeKeys
-
         val compositeKeysLeaves: Set<PublicKey> = compositeKeys.flatMapTo(linkedSetOf()) {
             it.leafKeys
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -46,15 +46,10 @@ class SigningServiceImpl @Activate constructor(
             it.leafKeys
         }
 
-        val keysToLookFor = plainKeys + compositeKeysLeaves
         val foundSigningKeys = externalEventExecutor.execute(
             FilterMyKeysExternalEventFactory::class.java,
-            keysToLookFor
+            plainKeys + compositeKeysLeaves
         ).toSet()
-
-        require(foundSigningKeys.size <= keysToLookFor.size) {
-            "Found keys cannot be more than requested keys"
-        }
 
         val plainKeysReqResp = plainKeys.associate {
             if (it in foundSigningKeys) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/FilterMyKeysExternalEventFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/FilterMyKeysExternalEventFactory.kt
@@ -1,0 +1,41 @@
+package net.corda.flow.application.crypto.external.events
+
+import net.corda.crypto.flow.CryptoFlowOpsTransformer
+import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.flow.external.events.factory.ExternalEventFactory
+import net.corda.flow.external.events.factory.ExternalEventRecord
+import net.corda.flow.state.FlowCheckpoint
+import net.corda.schema.Schemas
+import net.corda.v5.base.util.uncheckedCast
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import java.security.PublicKey
+
+@Component(service = [ExternalEventFactory::class])
+class FilterMyKeysExternalEventFactory @Activate constructor(
+    @Reference(service = CryptoFlowOpsTransformer::class)
+    private val cryptoFlowOpsTransformer: CryptoFlowOpsTransformer
+) : ExternalEventFactory<Collection<PublicKey>, FlowOpsResponse, Set<PublicKey>> {
+    override val responseType: Class<FlowOpsResponse> = FlowOpsResponse::class.java
+
+    override fun createExternalEvent(
+        checkpoint: FlowCheckpoint,
+        flowExternalEventContext: ExternalEventContext,
+        parameters: Collection<PublicKey>
+    ): ExternalEventRecord {
+        val flowOpsRequest =
+            cryptoFlowOpsTransformer
+                .createFilterMyKeys(
+                    tenantId = checkpoint.holdingIdentity.shortHash.value,
+                    candidateKeys = parameters,
+                    flowExternalEventContext = flowExternalEventContext
+                )
+        return ExternalEventRecord(topic = Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC, payload = flowOpsRequest)
+    }
+
+    override fun resumeWith(checkpoint: FlowCheckpoint, response: FlowOpsResponse): Set<PublicKey> {
+        return uncheckedCast<Any, List<PublicKey>>(cryptoFlowOpsTransformer.transform(response)).toSet()
+    }
+}

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/FilterMyKeysExternalEventFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/external/events/FilterMyKeysExternalEventFactory.kt
@@ -17,7 +17,7 @@ import java.security.PublicKey
 class FilterMyKeysExternalEventFactory @Activate constructor(
     @Reference(service = CryptoFlowOpsTransformer::class)
     private val cryptoFlowOpsTransformer: CryptoFlowOpsTransformer
-) : ExternalEventFactory<Collection<PublicKey>, FlowOpsResponse, Set<PublicKey>> {
+) : ExternalEventFactory<Collection<PublicKey>, FlowOpsResponse, List<PublicKey>> {
     override val responseType: Class<FlowOpsResponse> = FlowOpsResponse::class.java
 
     override fun createExternalEvent(
@@ -35,7 +35,7 @@ class FilterMyKeysExternalEventFactory @Activate constructor(
         return ExternalEventRecord(topic = Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC, payload = flowOpsRequest)
     }
 
-    override fun resumeWith(checkpoint: FlowCheckpoint, response: FlowOpsResponse): Set<PublicKey> {
-        return uncheckedCast<Any, List<PublicKey>>(cryptoFlowOpsTransformer.transform(response)).toSet()
+    override fun resumeWith(checkpoint: FlowCheckpoint, response: FlowOpsResponse): List<PublicKey> {
+        return uncheckedCast(cryptoFlowOpsTransformer.transform(response))
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -9,7 +9,6 @@ import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -70,7 +69,7 @@ class SigningServiceImplTest {
     }
 
     @Test
-    fun `get my signing keys throws if more than one leaves are found to be owned for the same composite key`() {
+    fun `get my signing keys only makes use of the firstly found composite key leaf and ignores the rest found leaves`() {
         val compositeKeyLeaf1 = mock<PublicKey>()
         val compositeKeyLeaf2 = mock<PublicKey>()
         val compositeKey = mock<CompositeKey>()
@@ -82,11 +81,9 @@ class SigningServiceImplTest {
             )
         ).thenReturn(listOf(compositeKeyLeaf1, compositeKeyLeaf2))
 
-        assertThrows<IllegalStateException>(
-            "A node should be owning one key at most per composite key, but two owned keys were found " +
-                    "for composite key: \"$compositeKey\" first: \"$compositeKeyLeaf1\" second: \"$compositeKeyLeaf2\""
-        ) {
+        assertEquals(
+            mapOf(compositeKey to compositeKeyLeaf1),
             signingService.getMySigningKeys(setOf(compositeKey))
-        }
+        )
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -2,6 +2,7 @@ package net.corda.flow.application.crypto
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.flow.application.crypto.external.events.CreateSignatureExternalEventFactory
+import net.corda.flow.application.crypto.external.events.FilterMyKeysExternalEventFactory
 import net.corda.flow.application.crypto.external.events.SignParameters
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.v5.crypto.DigitalSignature
@@ -30,5 +31,20 @@ class SigningServiceImplTest {
             .thenReturn(signature)
         assertEquals(signature, signingService.sign(byteArrayOf(1), publicKey, mock()))
         assertEquals(encodedPublicKeyBytes, captor.firstValue.encodedPublicKeyBytes)
+    }
+
+    @Test
+    fun `get my signing keys returns requested signing keys to owned signing keys`() {
+        val key1 = mock<PublicKey>()
+        val key2 = mock<PublicKey>()
+        val keys = setOf(key1, key2)
+        whenever(
+            externalEventExecutor.execute(
+                FilterMyKeysExternalEventFactory::class.java,
+                keys
+            )
+        ).thenReturn(listOf(key1))
+
+        assertEquals(mapOf(key1 to key1, key2 to null), signingService.getMySigningKeys(keys))
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -83,7 +83,7 @@ class SigningServiceImplTest {
         ).thenReturn(listOf(compositeKeyLeaf1, compositeKeyLeaf2))
 
         assertThrows<IllegalStateException>(
-            "A node should be owning one key at most per composite key, but found two owned keys for composite key: \"$compositeKey\" " +
+            "A node should be owning one key at most per composite key, but two owned keys were found for composite key: \"$compositeKey\" " +
                     " first: \"$compositeKeyLeaf1\" second: \"$compositeKeyLeaf2\""
         ) {
             signingService.getMySigningKeys(setOf(compositeKey))

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -5,9 +5,11 @@ import net.corda.flow.application.crypto.external.events.CreateSignatureExternal
 import net.corda.flow.application.crypto.external.events.FilterMyKeysExternalEventFactory
 import net.corda.flow.application.crypto.external.events.SignParameters
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -37,14 +39,54 @@ class SigningServiceImplTest {
     fun `get my signing keys returns requested signing keys to owned signing keys`() {
         val key1 = mock<PublicKey>()
         val key2 = mock<PublicKey>()
-        val keys = setOf(key1, key2)
         whenever(
             externalEventExecutor.execute(
                 FilterMyKeysExternalEventFactory::class.java,
-                keys
+                setOf(key1, key2)
             )
         ).thenReturn(listOf(key1))
 
-        assertEquals(mapOf(key1 to key1, key2 to null), signingService.getMySigningKeys(keys))
+        assertEquals(mapOf(key1 to key1, key2 to null), signingService.getMySigningKeys(setOf(key1, key2)))
+    }
+
+    @Test
+    fun `get my signing keys returns requested signing keys to owned signing keys for both plain and composite keys`() {
+        val plainKey = mock<PublicKey>()
+        val compositeKeyLeaf1 = mock<PublicKey>()
+        val compositeKeyLeaf2 = mock<PublicKey>()
+        val compositeKey = mock<CompositeKey>()
+        whenever(compositeKey.leafKeys).thenReturn(setOf(compositeKeyLeaf1, compositeKeyLeaf2))
+        whenever(
+            externalEventExecutor.execute(
+                FilterMyKeysExternalEventFactory::class.java,
+                setOf(plainKey, compositeKeyLeaf1, compositeKeyLeaf2)
+            )
+        ).thenReturn(listOf(plainKey, compositeKeyLeaf1))
+
+        assertEquals(
+            mapOf(plainKey to plainKey, compositeKey to compositeKeyLeaf1),
+            signingService.getMySigningKeys(setOf(plainKey, compositeKey))
+        )
+    }
+
+    @Test
+    fun `get my signing keys throws if more than one leaves are found to be owned for the same composite key`() {
+        val compositeKeyLeaf1 = mock<PublicKey>()
+        val compositeKeyLeaf2 = mock<PublicKey>()
+        val compositeKey = mock<CompositeKey>()
+        whenever(compositeKey.leafKeys).thenReturn(setOf(compositeKeyLeaf1, compositeKeyLeaf2))
+        whenever(
+            externalEventExecutor.execute(
+                FilterMyKeysExternalEventFactory::class.java,
+                setOf(compositeKeyLeaf1, compositeKeyLeaf2)
+            )
+        ).thenReturn(listOf(compositeKeyLeaf1, compositeKeyLeaf2))
+
+        assertThrows<IllegalStateException>(
+            "A node should be owning one key at most per composite key, but found two owned keys for composite key: \"$compositeKey\" " +
+                    " first: \"$compositeKeyLeaf1\" second: \"$compositeKeyLeaf2\""
+        ) {
+            signingService.getMySigningKeys(setOf(compositeKey))
+        }
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -83,8 +83,8 @@ class SigningServiceImplTest {
         ).thenReturn(listOf(compositeKeyLeaf1, compositeKeyLeaf2))
 
         assertThrows<IllegalStateException>(
-            "A node should be owning one key at most per composite key, but two owned keys were found for composite key: \"$compositeKey\" " +
-                    " first: \"$compositeKeyLeaf1\" second: \"$compositeKeyLeaf2\""
+            "A node should be owning one key at most per composite key, but two owned keys were found " +
+                    "for composite key: \"$compositeKey\" first: \"$compositeKeyLeaf1\" second: \"$compositeKeyLeaf2\""
         ) {
             signingService.getMySigningKeys(setOf(compositeKey))
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -35,7 +35,7 @@ class SigningServiceImplTest {
     }
 
     @Test
-    fun `get my signing keys returns requested signing keys to owned signing keys`() {
+    fun `find my signing keys returns requested signing keys to owned signing keys`() {
         val key1 = mock<PublicKey>()
         val key2 = mock<PublicKey>()
         whenever(
@@ -45,11 +45,11 @@ class SigningServiceImplTest {
             )
         ).thenReturn(listOf(key1))
 
-        assertEquals(mapOf(key1 to key1, key2 to null), signingService.getMySigningKeys(setOf(key1, key2)))
+        assertEquals(mapOf(key1 to key1, key2 to null), signingService.findMySigningKeys(setOf(key1, key2)))
     }
 
     @Test
-    fun `get my signing keys returns requested signing keys to owned signing keys for both plain and composite keys`() {
+    fun `find my signing keys returns requested signing keys to owned signing keys for both plain and composite keys`() {
         val plainKey = mock<PublicKey>()
         val compositeKeyLeaf1 = mock<PublicKey>()
         val compositeKeyLeaf2 = mock<PublicKey>()
@@ -64,12 +64,12 @@ class SigningServiceImplTest {
 
         assertEquals(
             mapOf(plainKey to plainKey, compositeKey to compositeKeyLeaf1),
-            signingService.getMySigningKeys(setOf(plainKey, compositeKey))
+            signingService.findMySigningKeys(setOf(plainKey, compositeKey))
         )
     }
 
     @Test
-    fun `get my signing keys only makes use of the firstly found composite key leaf and ignores the rest found leaves`() {
+    fun `find my signing keys only makes use of the firstly found composite key leaf and ignores the rest found leaves`() {
         val compositeKeyLeaf1 = mock<PublicKey>()
         val compositeKeyLeaf2 = mock<PublicKey>()
         val compositeKey = mock<CompositeKey>()
@@ -83,7 +83,7 @@ class SigningServiceImplTest {
 
         assertEquals(
             mapOf(compositeKey to compositeKeyLeaf1),
-            signingService.getMySigningKeys(setOf(compositeKey))
+            signingService.findMySigningKeys(setOf(compositeKey))
         )
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.616-alpha-1674050278816
+cordaApiVersion=5.0.0.616-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.615-beta+
+cordaApiVersion=5.0.0.616-alpha-1674050278816
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/CryptoFlowOpsTransformer.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/CryptoFlowOpsTransformer.kt
@@ -7,7 +7,7 @@ import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.GenerateFreshKeyFlowCommand
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.ByIdsFlowQuery
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -28,7 +28,7 @@ interface CryptoFlowOpsTransformer {
     }
 
     /**
-     * Creates a crypto request to filter which of the specified keys are owned by the [tenantId].
+     * Creates a crypto request to query which of the specified keys are owned by the [tenantId].
      */
     fun createFilterMyKeys(
         tenantId: String,
@@ -54,7 +54,7 @@ interface CryptoFlowOpsTransformer {
      * Returns request's type.
      *
      * @throws [IllegalArgumentException] if the request type is not one of [SignFlowCommand], [GenerateFreshKeyFlowCommand],
-     * [FilterMyKeysByIdsFlowQuery]
+     * [ByIdsFlowQuery]
      */
     fun inferRequestType(response: FlowOpsResponse): Class<*>?
 
@@ -62,11 +62,11 @@ interface CryptoFlowOpsTransformer {
      * Transforms the response type.
      *
      * @return [PublicKey] for [GenerateFreshKeyFlowCommand] request and [CryptoPublicKey] response type, [List<PublicKey>] for
-     * [FilterMyKeysByIdsFlowQuery] request and [CryptoSigningKeys] response type [DigitalSignature.WithKey] for [SignFlowCommand] or
+     * [ByIdsFlowQuery] request and [CryptoSigningKeys] response type [DigitalSignature.WithKey] for [SignFlowCommand] or
      * [SignWithSpecFlowCommand] request with [CryptoSignatureWithKey] response type
      *
      * @throws [IllegalArgumentException] if the request type is not one of [SignWithSpecFlowCommand], [SignFlowCommand],
-     * [GenerateFreshKeyFlowCommand], [FilterMyKeysByIdsFlowQuery] or the response is not one of [CryptoPublicKey], [CryptoSigningKeys],
+     * [GenerateFreshKeyFlowCommand], [ByIdsFlowQuery] or the response is not one of [CryptoPublicKey], [CryptoSigningKeys],
      * [CryptoSignatureWithKey]
      *
      * @throws [IllegalStateException]  if the response contains error or its TTL is greater than expected.

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/CryptoFlowOpsTransformer.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/CryptoFlowOpsTransformer.kt
@@ -7,7 +7,7 @@ import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.GenerateFreshKeyFlowCommand
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -28,7 +28,7 @@ interface CryptoFlowOpsTransformer {
     }
 
     /**
-     * Creates [FilterMyKeysFlowQuery].
+     * Creates a crypto request to filter which of the specified keys are owned by the [tenantId].
      */
     fun createFilterMyKeys(
         tenantId: String,
@@ -54,7 +54,7 @@ interface CryptoFlowOpsTransformer {
      * Returns request's type.
      *
      * @throws [IllegalArgumentException] if the request type is not one of [SignFlowCommand], [GenerateFreshKeyFlowCommand],
-     * [FilterMyKeysFlowQuery]
+     * [FilterMyKeysByIdsFlowQuery]
      */
     fun inferRequestType(response: FlowOpsResponse): Class<*>?
 
@@ -62,11 +62,11 @@ interface CryptoFlowOpsTransformer {
      * Transforms the response type.
      *
      * @return [PublicKey] for [GenerateFreshKeyFlowCommand] request and [CryptoPublicKey] response type, [List<PublicKey>] for
-     * [FilterMyKeysFlowQuery] request and [CryptoSigningKeys] response type [DigitalSignature.WithKey] for [SignFlowCommand] or
+     * [FilterMyKeysByIdsFlowQuery] request and [CryptoSigningKeys] response type [DigitalSignature.WithKey] for [SignFlowCommand] or
      * [SignWithSpecFlowCommand] request with [CryptoSignatureWithKey] response type
      *
      * @throws [IllegalArgumentException] if the request type is not one of [SignWithSpecFlowCommand], [SignFlowCommand],
-     * [GenerateFreshKeyFlowCommand], [FilterMyKeysFlowQuery] or the response is not one of [CryptoPublicKey], [CryptoSigningKeys],
+     * [GenerateFreshKeyFlowCommand], [FilterMyKeysByIdsFlowQuery] or the response is not one of [CryptoPublicKey], [CryptoSigningKeys],
      * [CryptoSignatureWithKey]
      *
      * @throws [IllegalStateException]  if the response contains error or its TTL is greater than expected.

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
@@ -19,7 +19,7 @@ import net.corda.data.crypto.wire.CryptoSigningKeys
 import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.ByIdsFlowQuery
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -58,7 +58,7 @@ class CryptoFlowOpsTransformerImpl(
         return createRequest(
             requestId = UUID.randomUUID().toString(),
             tenantId = tenantId,
-            request = FilterMyKeysByIdsFlowQuery(
+            request = ByIdsFlowQuery(
                 candidateKeys.map {
                     val keyBytes = keyEncodingService.encodeAsByteArray(it)
                     publicKeyIdFromBytes(keyBytes)
@@ -93,7 +93,7 @@ class CryptoFlowOpsTransformerImpl(
     override fun inferRequestType(response: FlowOpsResponse): Class<*>? {
         return when (response.getContextValue(REQUEST_OP_KEY)) {
             SignFlowCommand::class.java.simpleName -> SignFlowCommand::class.java
-            FilterMyKeysByIdsFlowQuery::class.java.simpleName -> FilterMyKeysByIdsFlowQuery::class.java
+            ByIdsFlowQuery::class.java.simpleName -> ByIdsFlowQuery::class.java
             else -> null
         }
     }
@@ -107,7 +107,7 @@ class CryptoFlowOpsTransformerImpl(
         }
         return when (inferRequestType(response)) {
             SignFlowCommand::class.java -> transformCryptoSignatureWithKey(response)
-            FilterMyKeysByIdsFlowQuery::class.java -> transformCryptoSigningKeys(response)
+            ByIdsFlowQuery::class.java -> transformCryptoSigningKeys(response)
             else -> throw IllegalArgumentException(
                 "Unknown request type: $REQUEST_OP_KEY=${response.getContextValue(REQUEST_OP_KEY)}"
             )

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
@@ -2,6 +2,7 @@ package net.corda.crypto.flow.impl
 
 import net.corda.crypto.cipher.suite.AlgorithmParameterSpecEncodingService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.publicKeyIdFromBytes
 import net.corda.crypto.flow.CryptoFlowOpsTransformer
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.REQUEST_OP_KEY
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.REQUEST_TTL_KEY
@@ -18,7 +19,7 @@ import net.corda.data.crypto.wire.CryptoSigningKeys
 import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -57,9 +58,10 @@ class CryptoFlowOpsTransformerImpl(
         return createRequest(
             requestId = UUID.randomUUID().toString(),
             tenantId = tenantId,
-            request = FilterMyKeysFlowQuery(
+            request = FilterMyKeysByIdsFlowQuery(
                 candidateKeys.map {
-                    ByteBuffer.wrap(keyEncodingService.encodeAsByteArray(it))
+                    val keyBytes = keyEncodingService.encodeAsByteArray(it)
+                    publicKeyIdFromBytes(keyBytes)
                 }
             ),
             flowExternalEventContext = flowExternalEventContext
@@ -91,7 +93,7 @@ class CryptoFlowOpsTransformerImpl(
     override fun inferRequestType(response: FlowOpsResponse): Class<*>? {
         return when (response.getContextValue(REQUEST_OP_KEY)) {
             SignFlowCommand::class.java.simpleName -> SignFlowCommand::class.java
-            FilterMyKeysFlowQuery::class.java.simpleName -> FilterMyKeysFlowQuery::class.java
+            FilterMyKeysByIdsFlowQuery::class.java.simpleName -> FilterMyKeysByIdsFlowQuery::class.java
             else -> null
         }
     }
@@ -105,7 +107,7 @@ class CryptoFlowOpsTransformerImpl(
         }
         return when (inferRequestType(response)) {
             SignFlowCommand::class.java -> transformCryptoSignatureWithKey(response)
-            FilterMyKeysFlowQuery::class.java -> transformCryptoSigningKeys(response)
+            FilterMyKeysByIdsFlowQuery::class.java -> transformCryptoSigningKeys(response)
             else -> throw IllegalArgumentException(
                 "Unknown request type: $REQUEST_OP_KEY=${response.getContextValue(REQUEST_OP_KEY)}"
             )

--- a/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
+++ b/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
@@ -20,7 +20,7 @@ import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.GenerateFreshKeyFlowCommand
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.ByIdsFlowQuery
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -185,8 +185,8 @@ class CryptoFlowOpsTransformerImplTests {
         }
         assertNotNull(result.value)
         assertEquals(knownTenantId, result.value.context.tenantId)
-        assertInstanceOf(FilterMyKeysByIdsFlowQuery::class.java, result.value.request)
-        val query = result.value.request as FilterMyKeysByIdsFlowQuery
+        assertInstanceOf(ByIdsFlowQuery::class.java, result.value.request)
+        val query = result.value.request as ByIdsFlowQuery
         assertEquals(3, query.keyIds.size)
         assertTrue(
             query.keyIds.any {
@@ -203,7 +203,7 @@ class CryptoFlowOpsTransformerImplTests {
                 it!!.contentEquals(publicKeyIdFromBytes(keyEncodingService.encodeAsByteArray(notMyKey)))
             }
         )
-        assertRequestContext<FilterMyKeysByIdsFlowQuery>(result)
+        assertRequestContext<ByIdsFlowQuery>(result)
     }
 
     @Test
@@ -213,10 +213,10 @@ class CryptoFlowOpsTransformerImplTests {
         }
         assertNotNull(result.value)
         assertEquals(knownTenantId, result.value.context.tenantId)
-        assertInstanceOf(FilterMyKeysByIdsFlowQuery::class.java, result.value.request)
-        val query = result.value.request as FilterMyKeysByIdsFlowQuery
+        assertInstanceOf(ByIdsFlowQuery::class.java, result.value.request)
+        val query = result.value.request as ByIdsFlowQuery
         assertThat(query.keyIds).isEmpty()
-        assertRequestContext<FilterMyKeysByIdsFlowQuery>(result)
+        assertRequestContext<ByIdsFlowQuery>(result)
     }
 
     @Test
@@ -273,16 +273,16 @@ class CryptoFlowOpsTransformerImplTests {
 
     @Test
     fun `Should infer filter my keys query from response`() {
-        val response = createResponse(CryptoSigningKeys(), FilterMyKeysByIdsFlowQuery::class.java)
+        val response = createResponse(CryptoSigningKeys(), ByIdsFlowQuery::class.java)
         val result = buildTransformer().inferRequestType(response)
-        assertEquals(result, FilterMyKeysByIdsFlowQuery::class.java)
+        assertEquals(result, ByIdsFlowQuery::class.java)
     }
 
     @Test
     fun `Should infer filter my keys query from response containing error`() {
-        val response = createResponse(CryptoNoContentValue(), FilterMyKeysByIdsFlowQuery::class.java, "failed")
+        val response = createResponse(CryptoNoContentValue(), ByIdsFlowQuery::class.java, "failed")
         val result = buildTransformer().inferRequestType(response)
-        assertEquals(result, FilterMyKeysByIdsFlowQuery::class.java)
+        assertEquals(result, ByIdsFlowQuery::class.java)
     }
 
     @Test
@@ -359,7 +359,7 @@ class CryptoFlowOpsTransformerImplTests {
                     )
                 )
             ),
-            FilterMyKeysByIdsFlowQuery::class.java
+            ByIdsFlowQuery::class.java
         )
         val result = buildTransformer().transform(response)
         assertThat(result).isInstanceOf(List::class.java)
@@ -406,7 +406,7 @@ class CryptoFlowOpsTransformerImplTests {
                     )
                 )
             ),
-            requestType = FilterMyKeysByIdsFlowQuery::class.java,
+            requestType = ByIdsFlowQuery::class.java,
             error = null,
             ttl = -1
         )
@@ -419,7 +419,7 @@ class CryptoFlowOpsTransformerImplTests {
     fun `Should throw IllegalStateException when transforming error response to filter my keys query`() {
         val response = createResponse(
             CryptoNoContentValue(),
-            FilterMyKeysByIdsFlowQuery::class.java,
+            ByIdsFlowQuery::class.java,
             "--failed--"
         )
         val result = assertThrows<IllegalStateException> {
@@ -432,7 +432,7 @@ class CryptoFlowOpsTransformerImplTests {
     fun `Should throw IllegalStateException when transforming empty error response to filter my keys query`() {
         val response = createResponse(
             CryptoNoContentValue(),
-            FilterMyKeysByIdsFlowQuery::class.java,
+            ByIdsFlowQuery::class.java,
             ""
         )
         assertThrows<IllegalStateException> {
@@ -444,7 +444,7 @@ class CryptoFlowOpsTransformerImplTests {
     fun `Should throw IllegalStateException when transforming unexpected response to filter my keys query`() {
         val response = createResponse(
             CryptoSignatureWithKey(),
-            FilterMyKeysByIdsFlowQuery::class.java
+            ByIdsFlowQuery::class.java
         )
         val result = assertThrows<IllegalStateException> {
             buildTransformer().transform(response)

--- a/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
+++ b/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
@@ -1,6 +1,7 @@
 package net.corda.crypto.flow.impl
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.publicKeyIdFromBytes
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.REQUEST_OP_KEY
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.REQUEST_TTL_KEY
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.RESPONSE_ERROR_KEY
@@ -19,7 +20,7 @@ import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.flow.FlowOpsResponse
 import net.corda.data.crypto.wire.ops.flow.commands.GenerateFreshKeyFlowCommand
 import net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand
-import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysFlowQuery
+import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysByIdsFlowQuery
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -184,13 +185,25 @@ class CryptoFlowOpsTransformerImplTests {
         }
         assertNotNull(result.value)
         assertEquals(knownTenantId, result.value.context.tenantId)
-        assertInstanceOf(FilterMyKeysFlowQuery::class.java, result.value.request)
-        val query = result.value.request as FilterMyKeysFlowQuery
-        assertEquals(3, query.keys.size)
-        assertTrue(query.keys.any { it.array().contentEquals(keyEncodingService.encodeAsByteArray(myPublicKeys[0])) })
-        assertTrue(query.keys.any { it.array().contentEquals(keyEncodingService.encodeAsByteArray(myPublicKeys[1])) })
-        assertTrue(query.keys.any { it.array().contentEquals(keyEncodingService.encodeAsByteArray(notMyKey)) })
-        assertRequestContext<FilterMyKeysFlowQuery>(result)
+        assertInstanceOf(FilterMyKeysByIdsFlowQuery::class.java, result.value.request)
+        val query = result.value.request as FilterMyKeysByIdsFlowQuery
+        assertEquals(3, query.keyIds.size)
+        assertTrue(
+            query.keyIds.any {
+                it!!.contentEquals(publicKeyIdFromBytes(keyEncodingService.encodeAsByteArray(myPublicKeys[0])))
+            }
+        )
+        assertTrue(
+            query.keyIds.any {
+                it!!.contentEquals(publicKeyIdFromBytes(keyEncodingService.encodeAsByteArray(myPublicKeys[1])))
+            }
+        )
+        assertTrue(
+            query.keyIds.any {
+                it!!.contentEquals(publicKeyIdFromBytes(keyEncodingService.encodeAsByteArray(notMyKey)))
+            }
+        )
+        assertRequestContext<FilterMyKeysByIdsFlowQuery>(result)
     }
 
     @Test
@@ -200,10 +213,10 @@ class CryptoFlowOpsTransformerImplTests {
         }
         assertNotNull(result.value)
         assertEquals(knownTenantId, result.value.context.tenantId)
-        assertInstanceOf(FilterMyKeysFlowQuery::class.java, result.value.request)
-        val query = result.value.request as FilterMyKeysFlowQuery
-        assertThat(query.keys).isEmpty()
-        assertRequestContext<FilterMyKeysFlowQuery>(result)
+        assertInstanceOf(FilterMyKeysByIdsFlowQuery::class.java, result.value.request)
+        val query = result.value.request as FilterMyKeysByIdsFlowQuery
+        assertThat(query.keyIds).isEmpty()
+        assertRequestContext<FilterMyKeysByIdsFlowQuery>(result)
     }
 
     @Test
@@ -260,16 +273,16 @@ class CryptoFlowOpsTransformerImplTests {
 
     @Test
     fun `Should infer filter my keys query from response`() {
-        val response = createResponse(CryptoSigningKeys(), FilterMyKeysFlowQuery::class.java)
+        val response = createResponse(CryptoSigningKeys(), FilterMyKeysByIdsFlowQuery::class.java)
         val result = buildTransformer().inferRequestType(response)
-        assertEquals(result, FilterMyKeysFlowQuery::class.java)
+        assertEquals(result, FilterMyKeysByIdsFlowQuery::class.java)
     }
 
     @Test
     fun `Should infer filter my keys query from response containing error`() {
-        val response = createResponse(CryptoNoContentValue(), FilterMyKeysFlowQuery::class.java, "failed")
+        val response = createResponse(CryptoNoContentValue(), FilterMyKeysByIdsFlowQuery::class.java, "failed")
         val result = buildTransformer().inferRequestType(response)
-        assertEquals(result, FilterMyKeysFlowQuery::class.java)
+        assertEquals(result, FilterMyKeysByIdsFlowQuery::class.java)
     }
 
     @Test
@@ -346,7 +359,7 @@ class CryptoFlowOpsTransformerImplTests {
                     )
                 )
             ),
-            FilterMyKeysFlowQuery::class.java
+            FilterMyKeysByIdsFlowQuery::class.java
         )
         val result = buildTransformer().transform(response)
         assertThat(result).isInstanceOf(List::class.java)
@@ -393,7 +406,7 @@ class CryptoFlowOpsTransformerImplTests {
                     )
                 )
             ),
-            requestType = FilterMyKeysFlowQuery::class.java,
+            requestType = FilterMyKeysByIdsFlowQuery::class.java,
             error = null,
             ttl = -1
         )
@@ -406,7 +419,7 @@ class CryptoFlowOpsTransformerImplTests {
     fun `Should throw IllegalStateException when transforming error response to filter my keys query`() {
         val response = createResponse(
             CryptoNoContentValue(),
-            FilterMyKeysFlowQuery::class.java,
+            FilterMyKeysByIdsFlowQuery::class.java,
             "--failed--"
         )
         val result = assertThrows<IllegalStateException> {
@@ -419,7 +432,7 @@ class CryptoFlowOpsTransformerImplTests {
     fun `Should throw IllegalStateException when transforming empty error response to filter my keys query`() {
         val response = createResponse(
             CryptoNoContentValue(),
-            FilterMyKeysFlowQuery::class.java,
+            FilterMyKeysByIdsFlowQuery::class.java,
             ""
         )
         assertThrows<IllegalStateException> {
@@ -431,7 +444,7 @@ class CryptoFlowOpsTransformerImplTests {
     fun `Should throw IllegalStateException when transforming unexpected response to filter my keys query`() {
         val response = createResponse(
             CryptoSignatureWithKey(),
-            FilterMyKeysFlowQuery::class.java
+            FilterMyKeysByIdsFlowQuery::class.java
         )
         val result = assertThrows<IllegalStateException> {
             buildTransformer().transform(response)

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -831,7 +831,7 @@ class CryptoProcessorTests {
     }
 
     @Test
-    fun `filterMyKeys filters and returns keys owned by the vnode`() {
+    fun `filterMyKeys filters and returns keys owned by the specified vnode`() {
         val vnodeKey1 = generateLedgerKey(vnodeId, "vnode-key-1")
         val vnodeKey2 = generateLedgerKey(vnodeId, "vnode-key-2")
 

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -831,7 +831,7 @@ class CryptoProcessorTests {
     }
 
     @Test
-    fun `filterMyKeys returns keys owned by the vnode only`() {
+    fun `filterMyKeys filters and returns keys owned by the vnode`() {
         val vnodeKey1 = generateLedgerKey(vnodeId, "vnode-key-1")
         val vnodeKey2 = generateLedgerKey(vnodeId, "vnode-key-2")
 

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -80,6 +80,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -160,28 +161,30 @@ class CryptoProcessorTests {
 
         private val vnodeIdentity =
             createTestHoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", UUID.randomUUID().toString())
-
         private val vnodeId: String = vnodeIdentity.shortHash.value
-
-        private val clusterDb = TestDbInfo.createConfig()
-
-        private val cryptoDb = TestDbInfo(
-            name = CordaDb.Crypto.persistenceUnitName,
-            schemaName = DbSchema.CRYPTO
-        )
-
         private val vnodeDb = TestDbInfo(
             name = VirtualNodeDbType.CRYPTO.getConnectionName(vnodeIdentity.shortHash),
             schemaName = "vnode_crypto"
         )
 
-        private lateinit var connectionIds: Map<String, UUID>
+        private val vnodeIdentity2 =
+            createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", UUID.randomUUID().toString())
+        private val vnodeId2: String = vnodeIdentity2.shortHash.value
+        private val vnodeDb2 = TestDbInfo(
+            name = VirtualNodeDbType.CRYPTO.getConnectionName(vnodeIdentity2.shortHash),
+            schemaName = "vnode_crypto"
+        )
 
+        private val clusterDb = TestDbInfo.createConfig()
+        private val cryptoDb = TestDbInfo(
+            name = CordaDb.Crypto.persistenceUnitName,
+            schemaName = DbSchema.CRYPTO
+        )
         private val boostrapConfig = makeBootstrapConfig(clusterDb.config)
-
         private val messagingConfig = makeMessagingConfig()
-
         private val cryptoConfig = makeCryptoConfig()
+
+        private lateinit var connectionIds: Map<String, UUID>
 
         private lateinit var tracker: TestDependenciesTracker
 
@@ -272,7 +275,12 @@ class CryptoProcessorTests {
                 "vnode-crypto",
                 CryptoEntities.classes
             ).close()
-            connectionIds = addDbConnectionConfigs(configEmf, cryptoDb, vnodeDb)
+            databaseInstaller.setupDatabase(
+                vnodeDb2,
+                "vnode-crypto",
+                CryptoEntities.classes
+            ).close()
+            connectionIds = addDbConnectionConfigs(configEmf, cryptoDb, vnodeDb, vnodeDb2)
             configEmf.close()
         }
 
@@ -327,6 +335,20 @@ class CryptoProcessorTests {
                     timestamp = Instant.now()
                 )
             )
+            publisher.publishVirtualNodeInfo(
+                VirtualNodeInfo(
+                    holdingIdentity = vnodeIdentity2,
+                    cpiIdentifier = CpiIdentifier(
+                        name = "cpi",
+                        version = "1",
+                        signerSummaryHash = TestRandom.secureHash()
+                    ),
+                    cryptoDmlConnectionId = connectionIds.getValue(vnodeDb2.name),
+                    uniquenessDmlConnectionId = UUID.randomUUID(),
+                    vaultDmlConnectionId = UUID.randomUUID(),
+                    timestamp = Instant.now()
+                )
+            )
         }
 
         private fun startDependencies() {
@@ -369,6 +391,8 @@ class CryptoProcessorTests {
                     hsmRegistrationClient.assignSoftHSM(vnodeId, it)
                 }
             }
+
+            hsmRegistrationClient.assignSoftHSM(vnodeId2, CryptoConsts.Categories.LEDGER)
         }
 
         @JvmStatic
@@ -805,4 +829,29 @@ class CryptoProcessorTests {
             )
         }
     }
+
+    @Test
+    fun `filterMyKeys returns keys owned by the vnode only`() {
+        val vnodeKey1 = generateLedgerKey(vnodeId, "vnode-key-1")
+        val vnodeKey2 = generateLedgerKey(vnodeId, "vnode-key-2")
+
+        val vnode2Key1 = generateLedgerKey(vnodeId2, "vnode2-key-1")
+        val vnode2Key2 = generateLedgerKey(vnodeId2, "vnode2-key-2")
+        val vnode2Key3 = generateLedgerKey(vnodeId2, "vnode2-key-3")
+
+        val vnodeKeys = listOf(vnodeKey1, vnodeKey2)
+        val vnode2Keys = listOf(vnode2Key1, vnode2Key2, vnode2Key3)
+        val allKeys = vnodeKeys + vnode2Keys
+
+        assertEquals(vnodeKeys, opsClient.filterMyKeys(vnodeId, allKeys))
+        assertEquals(vnode2Keys, opsClient.filterMyKeys(vnodeId2, allKeys))
+    }
+
+    private fun generateLedgerKey(tenantId: String, keyAlias: String): PublicKey =
+        opsClient.generateKeyPair(
+            tenantId = tenantId,
+            category = CryptoConsts.Categories.LEDGER,
+            alias = keyAlias,
+            scheme = ECDSA_SECP256R1_CODE_NAME
+        )
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
@@ -50,7 +50,7 @@ class SimWithJsonSigningService(private val keyStore: SimKeyStore) : SigningServ
         return DigitalSignature.WithKey(publicKey, opaqueBytes, mapOf())
     }
 
-    override fun getMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
+    override fun findMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
         TODO("Not yet implemented")
     }
 

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
@@ -50,4 +50,8 @@ class SimWithJsonSigningService(private val keyStore: SimKeyStore) : SigningServ
         return DigitalSignature.WithKey(publicKey, opaqueBytes, mapOf())
     }
 
+    override fun getMyKeys(keys: Set<PublicKey>): Set<PublicKey> {
+        TODO("Not yet implemented")
+    }
+
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
@@ -50,7 +50,7 @@ class SimWithJsonSigningService(private val keyStore: SimKeyStore) : SigningServ
         return DigitalSignature.WithKey(publicKey, opaqueBytes, mapOf())
     }
 
-    override fun getMySigningKeys(keys: Set<PublicKey>): Set<PublicKey> {
+    override fun getMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
         TODO("Not yet implemented")
     }
 

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
@@ -50,7 +50,7 @@ class SimWithJsonSigningService(private val keyStore: SimKeyStore) : SigningServ
         return DigitalSignature.WithKey(publicKey, opaqueBytes, mapOf())
     }
 
-    override fun getMyKeys(keys: Set<PublicKey>): Set<PublicKey> {
+    override fun getMySigningKeys(keys: Set<PublicKey>): Set<PublicKey> {
         TODO("Not yet implemented")
     }
 

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -64,7 +64,7 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         "crypto_verify_invalid_signature" to this::verifyInvalidSignature,
         "crypto_get_default_signature_spec" to this::getDefaultSignatureSpec,
         "crypto_get_compatible_signature_specs" to this::getCompatibleSignatureSpecs,
-        "crypto_get_my_signing_keys" to this::getMySigningKeys,
+        "crypto_find_my_signing_keys" to this::findMySigningKeys,
         "context_propagation" to { contextPropagation() },
         "serialization" to this::serialization,
         "lookup_member_by_x500_name" to this::lookupMember,
@@ -417,10 +417,10 @@ class RpcSmokeTestFlow : RPCStartableFlow {
 
     @Suppress("unused_parameter")
     @Suspendable
-    private fun getMySigningKeys(input: RpcSmokeTestInput): String {
+    private fun findMySigningKeys(input: RpcSmokeTestInput): String {
         val myInfo = memberLookup.myInfo()
         val myKeysFromMemberInfo = myInfo.ledgerKeys.toSet()
-        val myKeysFromCryptoWorker = signingService.getMySigningKeys(myKeysFromMemberInfo)
+        val myKeysFromCryptoWorker = signingService.findMySigningKeys(myKeysFromMemberInfo)
         val requestResponseKey =
             myKeysFromCryptoWorker
                 .map {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -64,7 +64,7 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         "crypto_verify_invalid_signature" to this::verifyInvalidSignature,
         "crypto_get_default_signature_spec" to this::getDefaultSignatureSpec,
         "crypto_get_compatible_signature_specs" to this::getCompatibleSignatureSpecs,
-        "crypto_get_my_keys" to this::getMyKeys,
+        "crypto_get_my_signing_keys" to this::getMySigningKeys,
         "context_propagation" to { contextPropagation() },
         "serialization" to this::serialization,
         "lookup_member_by_x500_name" to this::lookupMember,
@@ -417,11 +417,11 @@ class RpcSmokeTestFlow : RPCStartableFlow {
 
     @Suspendable
     @Suppress("unused_parameter")
-    private fun getMyKeys(input: RpcSmokeTestInput): String {
+    private fun getMySigningKeys(input: RpcSmokeTestInput): String {
         val myInfo = memberLookup.myInfo()
         // Include my keys and others to see they are being filtered properly
         val myKeysFromMemberInfo = myInfo.ledgerKeys.toSet()
-        val myKeysFromCryptoWorker = signingService.getMyKeys(myKeysFromMemberInfo)
+        val myKeysFromCryptoWorker = signingService.getMySigningKeys(myKeysFromMemberInfo)
         return if (myKeysFromMemberInfo == myKeysFromCryptoWorker) {
             "success"
         } else {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -415,17 +415,28 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         return outputs.joinToString("; ")
     }
 
-    @Suspendable
     @Suppress("unused_parameter")
+    @Suspendable
     private fun getMySigningKeys(input: RpcSmokeTestInput): String {
         val myInfo = memberLookup.myInfo()
         val myKeysFromMemberInfo = myInfo.ledgerKeys.toSet()
         val myKeysFromCryptoWorker = signingService.getMySigningKeys(myKeysFromMemberInfo)
-        return if (myKeysFromMemberInfo == myKeysFromCryptoWorker) {
-            "success"
-        } else {
-            "failure"
+        val requestResponseKey =
+            myKeysFromCryptoWorker
+                .map {
+                    it
+                }.single()
+
+        require(requestResponseKey.value != null) {
+            "Requested key was not found"
         }
+        require(requestResponseKey.key == requestResponseKey.value) {
+            "Response key should be same with the requested"
+        }
+        require(myKeysFromMemberInfo.single() == requestResponseKey.key) {
+            "Request key in mapping should match specified request key"
+        }
+        return "success"
     }
 
     @Suspendable

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -1,7 +1,5 @@
 package net.cordapp.testing.smoketests.flow
 
-import java.time.Instant
-import java.util.UUID
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
 import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.crypto.SigningService
@@ -33,6 +31,8 @@ import net.cordapp.testing.smoketests.flow.messages.JsonSerializationInput
 import net.cordapp.testing.smoketests.flow.messages.JsonSerializationOutput
 import net.cordapp.testing.smoketests.flow.messages.RpcSmokeTestInput
 import net.cordapp.testing.smoketests.flow.messages.RpcSmokeTestOutput
+import java.time.Instant
+import java.util.UUID
 
 @Suppress("unused", "TooManyFunctions")
 @InitiatingFlow(protocol = "smoke-test-protocol")
@@ -419,7 +419,6 @@ class RpcSmokeTestFlow : RPCStartableFlow {
     @Suppress("unused_parameter")
     private fun getMySigningKeys(input: RpcSmokeTestInput): String {
         val myInfo = memberLookup.myInfo()
-        // Include my keys and others to see they are being filtered properly
         val myKeysFromMemberInfo = myInfo.ledgerKeys.toSet()
         val myKeysFromCryptoWorker = signingService.getMySigningKeys(myKeysFromMemberInfo)
         return if (myKeysFromMemberInfo == myKeysFromCryptoWorker) {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -64,6 +64,7 @@ class RpcSmokeTestFlow : RPCStartableFlow {
         "crypto_verify_invalid_signature" to this::verifyInvalidSignature,
         "crypto_get_default_signature_spec" to this::getDefaultSignatureSpec,
         "crypto_get_compatible_signature_specs" to this::getCompatibleSignatureSpecs,
+        "crypto_get_my_keys" to this::getMyKeys,
         "context_propagation" to { contextPropagation() },
         "serialization" to this::serialization,
         "lookup_member_by_x500_name" to this::lookupMember,
@@ -412,6 +413,20 @@ class RpcSmokeTestFlow : RPCStartableFlow {
             it.signatureName
         }
         return outputs.joinToString("; ")
+    }
+
+    @Suspendable
+    @Suppress("unused_parameter")
+    private fun getMyKeys(input: RpcSmokeTestInput): String {
+        val myInfo = memberLookup.myInfo()
+        // Include my keys and others to see they are being filtered properly
+        val myKeysFromMemberInfo = myInfo.ledgerKeys.toSet()
+        val myKeysFromCryptoWorker = signingService.getMyKeys(myKeysFromMemberInfo)
+        return if (myKeysFromMemberInfo == myKeysFromCryptoWorker) {
+            "success"
+        } else {
+            "failure"
+        }
     }
 
     @Suspendable


### PR DESCRIPTION
- implements find my signing keys API on `SigningServiceImpl`. Delegates to existing underlying infrastructure to find owned keys and then creates a mapping from requested key to found to be owned key or null if key is not owned by caller. In case of composite keys it maps the composite key to the first found key leaf.
- converts requested keys to their IDs to create Kafka request containing the key IDs instead serialized keys.

api PR: [#794](https://github.com/corda/corda-api/pull/794)