### PR TITLE
CORE-9429/fix-dynamic-service-discovery 

### DIFF
--- a/applications/workers/release/db-worker/build.gradle
+++ b/applications/workers/release/db-worker/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     testImplementation 'org.osgi:osgi.core'
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation project(':libs:application:addon')
     testImplementation project(':libs:application:banner')
 
     runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {

--- a/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
+++ b/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
@@ -1,6 +1,7 @@
 package net.corda.applications.workers.db.test
 
 import com.typesafe.config.Config
+import net.corda.application.addon.CordaAddonResolver
 import net.corda.application.banner.StartupBanner
 import java.io.InputStream
 import net.corda.applications.workers.db.DBWorker
@@ -22,6 +23,7 @@ import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
 import net.corda.v5.base.versioning.Version
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.osgi.framework.Bundle
 
@@ -33,6 +35,10 @@ import org.osgi.framework.Bundle
 class ConfigTests {
 
     val defaultArgs = listOf("-spassphrase=password", "-ssalt=salt")
+    val applicationBanner = ApplicationBanner(DummyStartupBanner(), mock<CordaAddonResolver> {
+        on { findAll() } doReturn emptyList()})
+    val smartConfigFactoryFactory = SmartConfigFactoryFactory(mock {
+        on { findAll() } doReturn listOf(EncryptionSecretsServiceFactory())})
 
     @Test
     @Suppress("MaxLineLength")
@@ -45,8 +51,8 @@ class ConfigTests {
             DummyWorkerMonitor(),
             DummyValidatorFactory(),
             DummyPlatformInfoProvider(),
-            ApplicationBanner(DummyStartupBanner(), emptyList()),
-            SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory()))
+            applicationBanner,
+            smartConfigFactoryFactory
         )
         val args = defaultArgs + arrayOf(
             FLAG_INSTANCE_ID, VAL_INSTANCE_ID,
@@ -85,8 +91,8 @@ class ConfigTests {
             DummyWorkerMonitor(),
             DummyValidatorFactory(),
             DummyPlatformInfoProvider(),
-            ApplicationBanner(DummyStartupBanner(), emptyList()),
-            SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory()))
+            applicationBanner,
+            smartConfigFactoryFactory
         )
 
         val args = defaultArgs + arrayOf(
@@ -117,8 +123,8 @@ class ConfigTests {
             DummyWorkerMonitor(),
             DummyValidatorFactory(),
             DummyPlatformInfoProvider(),
-            ApplicationBanner(DummyStartupBanner(), emptyList()),
-            SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory()))
+            applicationBanner,
+            smartConfigFactoryFactory
         )
 
         dbWorker.startup(defaultArgs.toTypedArray())
@@ -147,8 +153,8 @@ class ConfigTests {
             DummyWorkerMonitor(),
             DummyValidatorFactory(),
             DummyPlatformInfoProvider(),
-            ApplicationBanner(DummyStartupBanner(), emptyList()),
-            SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory()))
+            applicationBanner,
+            smartConfigFactoryFactory
         )
 
         val args = defaultArgs + arrayOf(
@@ -172,8 +178,8 @@ class ConfigTests {
             DummyWorkerMonitor(),
             DummyValidatorFactory(),
             DummyPlatformInfoProvider(),
-            ApplicationBanner(DummyStartupBanner(), emptyList()),
-            SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory()))
+            applicationBanner,
+            smartConfigFactoryFactory
         )
         val args = defaultArgs + arrayOf(
             FLAG_DB_PARAM, "$DB_KEY_ONE=$DB_VAL_ONE",

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/ApplicationBanner.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/ApplicationBanner.kt
@@ -1,6 +1,6 @@
 package net.corda.applications.workers.workercommon
 
-import net.corda.application.addon.CordaAddon
+import net.corda.application.addon.CordaAddonResolver
 import net.corda.application.banner.ConsolePrinter
 import net.corda.application.banner.StartupBanner
 import net.corda.libs.platform.PlatformInfoProvider
@@ -8,12 +8,11 @@ import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ReferenceCardinality
 
 @Component(service = [ApplicationBanner::class])
 class ApplicationBanner(
     val startupBanner: StartupBanner,
-    val addons: List<CordaAddon>,
+    val addonResolver: CordaAddonResolver,
     private val consolePrinter: ConsolePrinter
 )
 {
@@ -21,9 +20,9 @@ class ApplicationBanner(
     constructor(
         @Reference(service = StartupBanner::class)
         startupBanner: StartupBanner,
-        @Reference(service = CordaAddon::class, cardinality = ReferenceCardinality.MULTIPLE)
-        addons: List<CordaAddon>,
-    ):this(startupBanner, addons, ConsolePrinter())
+        @Reference(service = CordaAddonResolver::class)
+        addonResolver: CordaAddonResolver,
+    ):this(startupBanner, addonResolver, ConsolePrinter())
 
     private companion object {
         private val logger = contextLogger()
@@ -32,6 +31,7 @@ class ApplicationBanner(
     fun show(name: String, platformInfoProvider: PlatformInfoProvider) {
         consolePrinter.println(
             startupBanner.get(name, platformInfoProvider.localWorkerSoftwareVersion))
+        val addons = addonResolver.findAll()
         if(addons.isEmpty()) return
 
         consolePrinter.printPaddedLine("Available add-ons:")

--- a/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/ApplicationBannerTest.kt
+++ b/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/ApplicationBannerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.applications.workers.workercommon.internal
 
 import net.corda.application.addon.CordaAddon
+import net.corda.application.addon.CordaAddonResolver
 import net.corda.application.banner.ConsolePrinter
 import net.corda.application.banner.StartupBanner
 import net.corda.applications.workers.workercommon.ApplicationBanner
@@ -39,10 +40,14 @@ class ApplicationBannerTest {
         on { localWorkerSoftwareVersion } doReturn "1.2.3.4"
     }
 
+    private val resolver = mock<CordaAddonResolver> { on { findAll() } doReturn listOf(addOn1, addOn2) }
 
     @Test
     fun `when show print banner`() {
-        val banner = ApplicationBanner(mockBanner, listOf(addOn1, addOn2), ConsolePrinter(mockPrinter::print))
+        val banner = ApplicationBanner(
+            mockBanner,
+            resolver,
+            ConsolePrinter(mockPrinter::print))
         banner.show("test", platformInfoProvider)
 
         verify(mockBanner).get("test", "1.2.3.4")
@@ -51,7 +56,7 @@ class ApplicationBannerTest {
 
     @Test
     fun `when addons print details`() {
-        val banner = ApplicationBanner(mockBanner, listOf(addOn1, addOn2), ConsolePrinter(mockPrinter::print))
+        val banner = ApplicationBanner(mockBanner, resolver, ConsolePrinter(mockPrinter::print))
         banner.show("test", platformInfoProvider)
 
         assertSoftly {

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoConfigurationSetup.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoConfigurationSetup.kt
@@ -9,6 +9,7 @@ import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactoryFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
@@ -109,7 +110,9 @@ object CryptoConfigurationSetup {
         )
 
     private fun makeBootstrapConfig(extra: Map<String, SmartConfig>): SmartConfig {
-        var cfg = SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory())).create(
+        var cfg = SmartConfigFactoryFactory(object: SecretsServiceFactoryResolver {
+            override fun findAll() = listOf(EncryptionSecretsServiceFactory())
+        }).create(
             ConfigFactory.parseString(
                 """
             ${EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY}=passphrase

--- a/components/db/db-connection-manager-impl/src/integrationTest/kotlin/net/corda/db/connection/manager/impl/tests/DbAdminTest.kt
+++ b/components/db/db-connection-manager-impl/src/integrationTest/kotlin/net/corda/db/connection/manager/impl/tests/DbAdminTest.kt
@@ -14,6 +14,7 @@ import net.corda.db.testkit.DbUtils.getPostgresDatabase
 import net.corda.libs.configuration.SmartConfigFactoryFactory
 import net.corda.libs.configuration.datamodel.ConfigurationEntities
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.orm.EntityManagerConfiguration
@@ -37,8 +38,11 @@ class DbAdminTest {
     private val entityManagerFactory: EntityManagerFactory
 
     private companion object {
+        val resolver = object: SecretsServiceFactoryResolver {
+            override fun findAll() = listOf(EncryptionSecretsServiceFactory())
+        }
         private const val MIGRATION_FILE_LOCATION = "net/corda/db/schema/config/db.changelog-master.xml"
-        private val configFactory = SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory())).create(
+        private val configFactory = SmartConfigFactoryFactory(resolver).create(
             ConfigFactory.parseString(
                 """
             ${EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY}=key

--- a/libs/application/addon/build.gradle
+++ b/libs/application/addon/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
+    compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
+
     implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation 'org.slf4j:slf4j-api'
 

--- a/libs/application/addon/src/main/kotlin/net/corda/application/addon/CordaAddon.kt
+++ b/libs/application/addon/src/main/kotlin/net/corda/application/addon/CordaAddon.kt
@@ -15,4 +15,3 @@ interface CordaAddon {
             return "UNKNOWN"
         }
 }
-

--- a/libs/application/addon/src/main/kotlin/net/corda/application/addon/CordaAddon.kt
+++ b/libs/application/addon/src/main/kotlin/net/corda/application/addon/CordaAddon.kt
@@ -15,3 +15,4 @@ interface CordaAddon {
             return "UNKNOWN"
         }
 }
+

--- a/libs/application/addon/src/main/kotlin/net/corda/application/addon/CordaAddonResolver.kt
+++ b/libs/application/addon/src/main/kotlin/net/corda/application/addon/CordaAddonResolver.kt
@@ -1,0 +1,12 @@
+package net.corda.application.addon
+
+/**
+ * Implementations of [CordaAddonResolver] need to be able to resolve all implementations of [CordaAddon] that are
+ * available.
+ */
+interface CordaAddonResolver {
+    /**
+     * Find all implementations of [CordaAddon].
+     */
+    fun findAll(): Collection<CordaAddon>
+}

--- a/libs/application/addon/src/main/kotlin/net/corda/application/addon/OsgiCordaAddonResolver.kt
+++ b/libs/application/addon/src/main/kotlin/net/corda/application/addon/OsgiCordaAddonResolver.kt
@@ -1,0 +1,31 @@
+package net.corda.application.addon
+
+import org.osgi.service.component.ComponentContext
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceCardinality
+
+@Component(
+    service = [CordaAddonResolver::class],
+    reference = [
+        Reference(
+            name = OsgiCordaAddonResolver.ADDONS_SERVICE_NAME,
+            service = CordaAddonResolver::class,
+            cardinality = ReferenceCardinality.MULTIPLE
+        )
+    ]
+)
+class OsgiCordaAddonResolver @Activate constructor(
+    private val componentContext: ComponentContext
+)    : CordaAddonResolver {
+
+    companion object {
+        const val ADDONS_SERVICE_NAME = "CordaAddon"
+    }
+
+    override fun findAll(): Collection<CordaAddon> {
+        @Suppress("unchecked_cast")
+        return (componentContext.locateServices(ADDONS_SERVICE_NAME) as? Array<CordaAddon>)?.toList() ?: emptyList()
+    }
+}

--- a/libs/application/addon/src/main/kotlin/net/corda/application/addon/OsgiCordaAddonResolver.kt
+++ b/libs/application/addon/src/main/kotlin/net/corda/application/addon/OsgiCordaAddonResolver.kt
@@ -25,7 +25,7 @@ class OsgiCordaAddonResolver @Activate constructor(
     }
 
     override fun findAll(): Collection<CordaAddon> {
-        @Suppress("unchecked_cast")
-        return (componentContext.locateServices(ADDONS_SERVICE_NAME) as? Array<CordaAddon>)?.toList() ?: emptyList()
+        return componentContext.locateServices(ADDONS_SERVICE_NAME)
+            ?.filterIsInstance<CordaAddon>() ?: emptyList()
     }
 }

--- a/libs/configuration/configuration-core/build.gradle
+++ b/libs/configuration/configuration-core/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
+    compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
+
     api "com.typesafe:config:$typeSafeConfigVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")

--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/OsgiSecretsServiceFactoryResolver.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/OsgiSecretsServiceFactoryResolver.kt
@@ -1,0 +1,31 @@
+package net.corda.libs.configuration.secret
+
+import org.osgi.service.component.ComponentContext
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceCardinality
+
+@Component(
+    service = [SecretsServiceFactoryResolver::class],
+    reference = [
+        Reference(
+            name = OsgiSecretsServiceFactoryResolver.SECRETS_SERVICE_FACTORY_SERVICE_NAME,
+            service = SecretsServiceFactory::class,
+            cardinality = ReferenceCardinality.MULTIPLE
+        )
+    ]
+)
+class OsgiSecretsServiceFactoryResolver @Activate constructor(
+    private val componentContext: ComponentContext
+)    : SecretsServiceFactoryResolver {
+
+    companion object {
+        const val SECRETS_SERVICE_FACTORY_SERVICE_NAME = "SecretsServiceFactories"
+    }
+
+    override fun findAll(): Collection<SecretsServiceFactory> {
+        return componentContext.locateServices(SECRETS_SERVICE_FACTORY_SERVICE_NAME)
+            ?.filterIsInstance<SecretsServiceFactory>() ?: emptyList()
+    }
+}

--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/SecretsServiceFactoryResolver.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/SecretsServiceFactoryResolver.kt
@@ -1,0 +1,12 @@
+package net.corda.libs.configuration.secret
+
+/**
+ * Implementations of [SecretsServiceFactoryResolver] need to be able to resolve all implementations of
+ * [SecretsServiceFactory] that are available.
+ */
+interface SecretsServiceFactoryResolver {
+    /**
+     * Find all implementations of [SecretsServiceFactory].
+     */
+    fun findAll(): Collection<SecretsServiceFactory>
+}

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/ConfigEncryptor.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/ConfigEncryptor.kt
@@ -5,6 +5,8 @@ import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class ConfigEncryptor {
     /** NOTE: this isn't really a test, but an easy way to generate encrypted configuration.
@@ -25,7 +27,9 @@ class ConfigEncryptor {
             EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY to passphrase
         )
 
-        val configFactory = SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory()))
+        val configFactory = SmartConfigFactoryFactory(mock() {
+            on { findAll() } doReturn listOf(EncryptionSecretsServiceFactory())
+        })
             .create(ConfigFactory.parseMap(secretsConfig))
         val config = configFactory.create(configSection)
 

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigFactoryFactoryTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigFactoryFactoryTest.kt
@@ -25,7 +25,8 @@ class SmartConfigFactoryFactoryTest {
 
     @Test
     fun `when create, choose matching secrets provider from list`() {
-        val cff = SmartConfigFactoryFactory(listOf(mockSecretsServiceFactory1, mockSecretsServiceFactory2))
+        val cff = SmartConfigFactoryFactory(
+            mock { on { findAll() } doReturn listOf(mockSecretsServiceFactory1, mockSecretsServiceFactory2)})
         val cf = cff.create(secretsServiceConfig)
         val config = ConfigFactory.parseMap(
             mapOf(SmartConfig.SECRET_KEY to mapOf(
@@ -39,7 +40,8 @@ class SmartConfigFactoryFactoryTest {
 
     @Test
     fun `when create and no matching secrets provider, throw`() {
-        val cff = SmartConfigFactoryFactory(listOf(mockSecretsServiceFactory1))
+        val cff = SmartConfigFactoryFactory(
+            mock { on { findAll() } doReturn listOf(mockSecretsServiceFactory1)})
         assertThrows<SecretsConfigurationException> {
             cff.create(
                 ConfigFactory.parseMap(mapOf(SmartConfigFactoryFactory.SECRET_SERVICE_TYPE to "micky"))

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
@@ -12,9 +12,10 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigFactoryFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.schema.configuration.ConfigKeys.CRYPTO_CONFIG
 import net.corda.v5.crypto.exceptions.CryptoException
-import java.util.*
+import java.util.UUID
 
 // NOTE: hsmId is part of the bootstrap configuration
 
@@ -248,7 +249,11 @@ fun createCryptoBootstrapParamsMap(hsmId: String): Map<String, String> =
 
 fun createCryptoSmartConfigFactory(smartFactoryKey: KeyCredentials): SmartConfigFactory =
     // TODO - figure out why this is here and how that is going to work with other SecretsServiceFactory implementations
-    SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory())).create(
+    //  is this test-only? If so, why is it not in a test utils module?
+    SmartConfigFactoryFactory(object: SecretsServiceFactoryResolver {
+        override fun findAll() = listOf(EncryptionSecretsServiceFactory())
+
+    }).create(
         ConfigFactory.parseString(
             """
             ${EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY}=${smartFactoryKey.passphrase}

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -7,6 +7,7 @@ import net.corda.crypto.core.aes.KeyCredentials
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigFactoryFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.schema.configuration.ConfigKeys.CRYPTO_CONFIG
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import org.assertj.core.api.Assertions.assertThat
@@ -25,7 +26,9 @@ class CryptoConfigUtilsTests {
         @JvmStatic
         @BeforeAll
         fun setup() {
-            configFactory = SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory())).create(
+            configFactory = SmartConfigFactoryFactory(object: SecretsServiceFactoryResolver {
+                override fun findAll() = listOf(EncryptionSecretsServiceFactory())
+            }).create(
                 ConfigFactory.parseString(
                     """
             ${EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY}=key

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestUtils.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestUtils.kt
@@ -9,6 +9,7 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigFactoryFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
@@ -45,7 +46,9 @@ private const val BOOT_CONFIGURATION = """
     """
 
 private val smartConfigFactory: SmartConfigFactory =
-    SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory())).create(
+    SmartConfigFactoryFactory(object: SecretsServiceFactoryResolver {
+        override fun findAll() = listOf(EncryptionSecretsServiceFactory())
+    }).create(
     ConfigFactory.parseString(
         """
             ${EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY}=passphrase

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -13,6 +13,8 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigFactoryFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.lifecycle.Lifecycle
@@ -47,6 +49,8 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import java.time.Duration
 import java.time.Instant
 import java.util.*
@@ -87,9 +91,10 @@ class MemberProcessorTestUtils {
                         ConfigValueFactory.fromAnyRef(100L))
             )
 
-        private val smartConfigFactory: SmartConfigFactory = SmartConfigFactoryFactory(listOf(
-            EncryptionSecretsServiceFactory()
-        )).create(
+        private val smartConfigFactory: SmartConfigFactory = SmartConfigFactoryFactory(object : SecretsServiceFactoryResolver {
+            override fun findAll() = listOf(EncryptionSecretsServiceFactory())
+        })
+            .create(
             ConfigFactory.parseString(
                 """
             ${EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY}=passphrase

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/TestDbInfo.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/TestDbInfo.kt
@@ -5,6 +5,7 @@ import net.corda.db.schema.CordaDb
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactoryFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.orm.EntityManagerConfiguration
 
 /**
@@ -17,7 +18,9 @@ class TestDbInfo(
     rewriteBatchedInserts: Boolean = false
 ) {
     companion object {
-        private val configFactory = SmartConfigFactoryFactory(listOf(EncryptionSecretsServiceFactory())).create(
+        private val configFactory = SmartConfigFactoryFactory(object: SecretsServiceFactoryResolver {
+            override fun findAll() = listOf(EncryptionSecretsServiceFactory())
+        }).create(
             ConfigFactory.parseString(
                 """
             ${EncryptionSecretsServiceFactory.SECRET_PASSPHRASE_KEY}=key


### PR DESCRIPTION
Refactor of ApplicationBanner and SmartConfigFactoryFactory to use a resolver object that uses `componentContext` context. This should avoid potential timing issues with services not having registered yet when the parent object activates.