### PR TITLE
NOTICK Resolve StateRefs should find only Verified Transactions

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -173,9 +173,9 @@ class UtxoPersistenceServiceImplTest {
 
             em.createNativeQuery("DELETE FROM {h-schema}utxo_relevant_transaction_state").executeUpdate()
 
-            val transaction1Entity = createTransactionEntity(entityFactory, transaction1)
+            val transaction1Entity = createTransactionEntity(entityFactory, transaction1, status = VERIFIED)
                 .also { em.persist(it) }
-            val transaction2Entity = createTransactionEntity(entityFactory, transaction2)
+            val transaction2Entity = createTransactionEntity(entityFactory, transaction2, status = VERIFIED)
                 .also { em.persist(it) }
 
             entityFactory.createUtxoRelevantTransactionStateEntity(
@@ -199,16 +199,6 @@ class UtxoPersistenceServiceImplTest {
                 true,
                 createdTs
             ).also { em.persist(it) }
-
-            em
-                .createNativeQuery("""UPDATE {h-schema}utxo_transaction_status
-                    SET
-                        status=:verified
-                    WHERE
-                        transaction_id in (:transactionIds)""" )
-                .setParameter("verified", VERIFIED.value)
-                .setParameter("transactionIds", listOf(transaction1.id.toString(), transaction2.id.toString()))
-                .executeUpdate()
         }
 
         val stateClass = TestContractState2::class.java

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -206,7 +206,7 @@ class UtxoPersistenceServiceImplTest {
                         status=:verified
                     WHERE
                         transaction_id in (:transactionIds)""" )
-                .setParameter("verified", TransactionStatus.VERIFIED.value)
+                .setParameter("verified", VERIFIED.value)
                 .setParameter("transactionIds", listOf(transaction1.id.toString(), transaction2.id.toString()))
                 .executeUpdate()
         }
@@ -226,8 +226,8 @@ class UtxoPersistenceServiceImplTest {
     fun `resolve staterefs`() {
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
         val transactions = listOf(
-            persistTransactionViaEntity(entityFactory),
-            persistTransactionViaEntity(entityFactory)
+            persistTransactionViaEntity(entityFactory, VERIFIED),
+            persistTransactionViaEntity(entityFactory, VERIFIED)
         )
 
         val stateRefs = listOf(
@@ -412,10 +412,10 @@ class UtxoPersistenceServiceImplTest {
         }
     }
 
-    private fun persistTransactionViaEntity(entityFactory: UtxoEntityFactory): SignedTransactionContainer {
+    private fun persistTransactionViaEntity(entityFactory: UtxoEntityFactory, status: TransactionStatus = UNVERIFIED): SignedTransactionContainer {
         val signedTransaction = createSignedTransaction()
         entityManagerFactory.transaction { em ->
-            em.persist(createTransactionEntity(entityFactory, signedTransaction))
+            em.persist(createTransactionEntity(entityFactory, signedTransaction, status = status))
         }
         return signedTransaction
     }
@@ -424,7 +424,8 @@ class UtxoPersistenceServiceImplTest {
         entityFactory: UtxoEntityFactory,
         signedTransaction: SignedTransactionContainer,
         account: String = "Account",
-        createdTs: Instant = TEST_CLOCK.instant()
+        createdTs: Instant = TEST_CLOCK.instant(),
+        status: TransactionStatus = UNVERIFIED
     ): Any {
         return entityFactory.createUtxoTransactionEntity(
                 signedTransaction.id.toString(),
@@ -459,7 +460,7 @@ class UtxoPersistenceServiceImplTest {
                 )
                 transaction.field<MutableCollection<Any>>("statuses").addAll(
                     listOf(
-                        entityFactory.createUtxoTransactionStatusEntity(transaction, UNVERIFIED.value, createdTs)
+                        entityFactory.createUtxoTransactionStatusEntity(transaction, status.value, createdTs)
                     )
                 )
             }


### PR DESCRIPTION
Since only verified transactions’ output states should be used as input or reference states for other transactions.