### PR TITLE
NOTICK Ledger test cleanups

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -68,7 +68,6 @@ dependencies {
     smokeTestImplementation project(':testing:test-utilities')
 
     smokeTestImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    smokeTestImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     smokeTestImplementation "org.apache.commons:commons-text:$commonsTextVersion"
     smokeTestImplementation "org.assertj:assertj-core:$assertjVersion"
     smokeTestImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
@@ -77,7 +76,6 @@ dependencies {
     smokeTestImplementation project(":testing:packaging-test-utilities")
     smokeTestImplementation "org.eclipse.jetty.websocket:websocket-client:$jettyVersion"
     smokeTestImplementation "org.slf4j:slf4j-api:$slf4jVersion"
-    smokeTestImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
 
     smokeTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
     smokeTestRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
@@ -25,7 +25,8 @@ class ConsensualSignedTransactionKryoSerializerTest: ConsensualLedgerTest() {
                 DigitalSignatureAndMetadata::class.java,
                 consensualSignedTransactionExample.signatures[0].by::class.java,
                 emptyMap<String, String>()::class.java,
-                DigitalSignature.WithKey::class.java
+                DigitalSignature.WithKey::class.java,
+                mapOf("" to "")::class.java
             )
         )
         val bytes = serializer.serialize(consensualSignedTransactionExample)

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -18,10 +18,9 @@ import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.testkit.DbUtils
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
-import net.corda.ledger.common.testkit.getWireTransactionExample
-import net.corda.ledger.common.testkit.signatureWithMetadataExample
-import net.corda.ledger.common.testkit.transactionMetadataExample
-import net.corda.ledger.consensual.data.transaction.ConsensualComponentGroup
+import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
+import net.corda.ledger.common.testkit.createExample
+import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
 import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
 import net.corda.messaging.api.records.Record
@@ -153,16 +152,14 @@ class ConsensualLedgerMessageProcessorTests {
     }
 
     private fun createTestTransaction(ctx: SandboxGroupContext): SignedTransactionContainer {
-        val wireTransaction = getWireTransactionExample(
+        val wireTransactionFactory: WireTransactionFactory = ctx.getSandboxSingletonService()
+        val wireTransaction = wireTransactionFactory.createExample(
             ctx.getSandboxSingletonService(),
-            ctx.getSandboxSingletonService(),
-            ctx.getSandboxSingletonService(),
-            ctx.getSandboxSingletonService(),
-            metadata = transactionMetadataExample(numberOfComponentGroups = ConsensualComponentGroup.values().size),
+            ctx.getSandboxSingletonService()
         )
         return SignedTransactionContainer(
             wireTransaction,
-            listOf(signatureWithMetadataExample)
+            listOf(getSignatureWithMetadataExample())
         )
     }
 

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -18,12 +18,11 @@ import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.testkit.DbUtils
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
-import net.corda.ledger.common.testkit.getWireTransactionExample
-import net.corda.ledger.common.testkit.signatureWithMetadataExample
-import net.corda.ledger.common.testkit.transactionMetadataExample
+import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
+import net.corda.ledger.common.testkit.createExample
+import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
 import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
-import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.ResponseFactory
@@ -73,6 +72,7 @@ import java.util.UUID
  */
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class, DBSetup::class)
 @TestInstance(PER_CLASS)
+@Suppress("FunctionName")
 class UtxoLedgerMessageProcessorTests {
     companion object {
         const val TOPIC = "utxo-ledger-dummy-topic"
@@ -173,12 +173,11 @@ class UtxoLedgerMessageProcessorTests {
             null, null, notaryExample, TestContractState::class.java.name, "contract tag"
             )
         ).bytes
-        val wireTransaction = getWireTransactionExample(
+        val wireTransactionFactory: WireTransactionFactory = ctx.getSandboxSingletonService()
+        val wireTransaction = wireTransactionFactory.createExample(
             ctx.getSandboxSingletonService(),
             ctx.getSandboxSingletonService(),
-            ctx.getSandboxSingletonService(),
-            ctx.getSandboxSingletonService(),
-            componentGroupLists = listOf(
+            listOf(
                 listOf("1".toByteArray()),
                 listOf("2".toByteArray()),
                 listOf(outputInfo),
@@ -188,12 +187,11 @@ class UtxoLedgerMessageProcessorTests {
                 listOf("7".toByteArray()),
                 listOf(outputState),
                 listOf("9".toByteArray())
-            ),
-            metadata = transactionMetadataExample(numberOfComponentGroups = UtxoComponentGroup.values().size)
+            )
         )
         return SignedTransactionContainer(
             wireTransaction,
-            listOf(signatureWithMetadataExample)
+            listOf(getSignatureWithMetadataExample())
         )
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/timewindow/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/timewindow/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.utxo.flow.impl.timewindow;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/timewindow/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/timewindow/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.ledger.utxo.flow.impl.timewindow;
-
-import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.ledger.utxo.flow.impl.transaction.factory.impl;
-
-import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/impl/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/impl/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.ledger.utxo.impl;
-
-import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/impl/timewindow/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/impl/timewindow/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.ledger.utxo.impl.timewindow;
-
-import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/impl/transaction/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/impl/transaction/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.ledger.utxo.impl.transaction;
-
-import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
@@ -27,6 +27,7 @@ class UtxoSignedTransactionKryoSerializerTest: UtxoLedgerTest() {
                 emptyMap<String, String>()::class.java,
                 emptyList<String>()::class.java,
                 DigitalSignature.WithKey::class.java,
+                mapOf("" to "")::class.java
             )
         )
         val bytes = serializer.serialize(utxoSignedTransactionExample)

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/CpkPackageSummaryListExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/CpkPackageSummaryListExample.kt
@@ -2,15 +2,23 @@ package net.corda.ledger.common.testkit
 
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 
-val cpkPackageSummaryListExample = listOf(
+fun cpkPackageSummaryListExample(seed: String? = "123CBA") = listOf(
     CordaPackageSummaryImpl(
-        "MockCpk",
-        "1",
-        "",
-        "0101010101010101010101010101010101010101010101010101010101010101"),
+        "$seed-cpk1",
+        "signerSummaryHash1",
+        "1.0",
+        "$seed-fileChecksum1"
+    ),
     CordaPackageSummaryImpl(
-        "MockCpk",
-        "3",
-        "",
-        "0303030303030303030303030303030303030303030303030303030303030303")
+        "$seed-cpk2",
+        "signerSummaryHash2",
+        "2.0",
+        "$seed-fileChecksum2"
+    ),
+    CordaPackageSummaryImpl(
+        "$seed-cpk3",
+        "signerSummaryHash3",
+        "3.0",
+        "$seed-fileChecksum3"
+    )
 )

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
@@ -7,7 +7,7 @@ import java.security.PublicKey
 
 private class MockTransactionSignatureService: TransactionSignatureService {
     override fun sign(transactionId: SecureHash, publicKey: PublicKey): DigitalSignatureAndMetadata =
-        signatureWithMetadataExample
+        getSignatureWithMetadataExample()
 
     override fun verifySignature(transactionId: SecureHash, signatureWithMetadata: DigitalSignatureAndMetadata) {}
     override fun verifyNotarySignature(transactionId: SecureHash, signatureWithMetadata: DigitalSignatureAndMetadata) {}

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PrivacySaltImplExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PrivacySaltImplExample.kt
@@ -2,5 +2,6 @@ package net.corda.ledger.common.testkit
 
 import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.v5.ledger.common.transaction.PrivacySalt
+import kotlin.random.Random
 
-fun getPrivacySalt(): PrivacySalt = PrivacySaltImpl("1".repeat(32).toByteArray())
+fun getPrivacySalt(): PrivacySalt = PrivacySaltImpl(Random.nextBytes(32))

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
@@ -2,10 +2,9 @@ package net.corda.ledger.common.testkit
 
 import java.security.KeyPairGenerator
 import java.security.PublicKey
+import java.security.spec.ECGenParameterSpec
 
-// TODO change this to something safer. (ECDSA)
-private val kpg: KeyPairGenerator = KeyPairGenerator.getInstance("RSA").also {
-    it.initialize(512)
-}
 
-val publicKeyExample: PublicKey = kpg.genKeyPair().public
+val publicKeyExample: PublicKey = KeyPairGenerator.getInstance("EC")
+    .apply { initialize(ECGenParameterSpec("secp256r1")) }
+    .generateKeyPair().public

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
@@ -3,9 +3,11 @@ package net.corda.ledger.common.testkit
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.crypto.DigitalSignature
+import java.security.PublicKey
 import java.time.Instant
 
-private val signature = DigitalSignature.WithKey(publicKeyExample, "0".toByteArray(), mapOf())
-private val digitalSignatureMetadata =
-    DigitalSignatureMetadata(Instant.now(), mapOf())
-val signatureWithMetadataExample = DigitalSignatureAndMetadata(signature, digitalSignatureMetadata)
+fun getSignatureWithMetadataExample(publicKey: PublicKey = publicKeyExample, createdTs: Instant = Instant.now()) =
+    DigitalSignatureAndMetadata(
+        DigitalSignature.WithKey(publicKey, "signature".toByteArray(), mapOf("contextKey1" to "contextValue1")),
+        DigitalSignatureMetadata(createdTs, mapOf("propertyKey1" to "propertyValue1"))
+    )

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/TransactionMetadataExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/TransactionMetadataExample.kt
@@ -7,7 +7,8 @@ import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
 fun transactionMetadataExample(
     cpiMetadata: CordaPackageSummaryImpl = cpiPackageSummaryExample,
-    cpkMetadata: List<CordaPackageSummaryImpl> = cpkPackageSummaryListExample,
+    cpkPackageSeed: String? = null,
+    cpkMetadata: List<CordaPackageSummaryImpl> = cpkPackageSummaryListExample(cpkPackageSeed),
     numberOfComponentGroups: Int
 ): TransactionMetadata {
     return TransactionMetadataImpl(

--- a/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualSignedTransactionExample.kt
+++ b/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualSignedTransactionExample.kt
@@ -6,7 +6,7 @@ import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.common.testkit.createExample
 import net.corda.ledger.common.testkit.getWireTransactionExample
-import net.corda.ledger.common.testkit.signatureWithMetadataExample
+import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
 import net.corda.ledger.consensual.flow.impl.transaction.factory.ConsensualSignedTransactionFactory
 import net.corda.v5.application.crypto.DigestService
@@ -20,7 +20,7 @@ fun ConsensualSignedTransactionFactory.createExample(
     wireTransactionFactory: WireTransactionFactory
 ): ConsensualSignedTransaction {
     val wireTransaction = wireTransactionFactory.createExample(jsonMarshallingService, jsonValidator)
-    return create(wireTransaction, listOf(signatureWithMetadataExample))
+    return create(wireTransaction, listOf(getSignatureWithMetadataExample()))
 }
 
 @Suppress("LongParameterList")
@@ -30,19 +30,20 @@ fun getConsensualSignedTransactionExample(
     serializationService: SerializationService,
     jsonMarshallingService: JsonMarshallingService,
     jsonValidator: JsonValidator,
-    transactionSignatureService: TransactionSignatureService
+    transactionSignatureService: TransactionSignatureService,
+    cpkPackageSeed: String? = null
 ): ConsensualSignedTransaction {
     val wireTransaction = getWireTransactionExample(
         digestService,
         merkleTreeProvider,
         jsonMarshallingService,
         jsonValidator,
-        metadata = consensualTransactionMetadataExample
+        metadata = consensualTransactionMetadataExample(cpkPackageSeed)
     )
     return ConsensualSignedTransactionImpl(
         serializationService,
         transactionSignatureService,
         wireTransaction,
-        listOf(signatureWithMetadataExample)
+        listOf(getSignatureWithMetadataExample())
     )
 }

--- a/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualTransactionMetadataExample.kt
+++ b/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualTransactionMetadataExample.kt
@@ -8,13 +8,13 @@ import net.corda.ledger.consensual.data.transaction.ConsensualComponentGroup
 import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl
 import net.corda.ledger.consensual.data.transaction.TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION
 
-val consensualTransactionMetadataExample = TransactionMetadataImpl(linkedMapOf(
+fun consensualTransactionMetadataExample(cpkPackageSeed: String? = null) = TransactionMetadataImpl(linkedMapOf(
     TransactionMetadataImpl.LEDGER_MODEL_KEY to ConsensualLedgerTransactionImpl::class.java.canonicalName,
     TransactionMetadataImpl.LEDGER_VERSION_KEY to TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION,
     TransactionMetadataImpl.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,
     TransactionMetadataImpl.PLATFORM_VERSION_KEY to 123,
     TransactionMetadataImpl.CPI_METADATA_KEY to cpiPackageSummaryExample,
-    TransactionMetadataImpl.CPK_METADATA_KEY to cpkPackageSummaryListExample,
+    TransactionMetadataImpl.CPK_METADATA_KEY to cpkPackageSummaryListExample(cpkPackageSeed),
     TransactionMetadataImpl.SCHEMA_VERSION_KEY to TransactionMetadataImpl.SCHEMA_VERSION,
     TransactionMetadataImpl.NUMBER_OF_COMPONENT_GROUPS to ConsensualComponentGroup.values().size
 ))

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
@@ -7,7 +7,7 @@ import net.corda.ledger.common.flow.transaction.TransactionSignatureService
 import net.corda.ledger.common.testkit.createExample
 import net.corda.ledger.common.testkit.defaultComponentGroups
 import net.corda.ledger.common.testkit.getWireTransactionExample
-import net.corda.ledger.common.testkit.signatureWithMetadataExample
+import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
@@ -25,7 +25,7 @@ fun UtxoSignedTransactionFactory.createExample(
             List(UtxoComponentGroup.values().size - defaultComponentGroups.size) { emptyList() }
 ):UtxoSignedTransaction {
     val wireTransaction = wireTransactionFactory.createExample(jsonMarshallingService, jsonValidator, componentGroups)
-    return create(wireTransaction, listOf(signatureWithMetadataExample))
+    return create(wireTransaction, listOf(getSignatureWithMetadataExample()))
 }
 
 @Suppress("LongParameterList")
@@ -36,20 +36,21 @@ fun getUtxoSignedTransactionExample(
     jsonMarshallingService: JsonMarshallingService,
     jsonValidator: JsonValidator,
     transactionSignatureService: TransactionSignatureService,
-    utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory
+    utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory,
+    cpkPackageSeed: String? = null
 ): UtxoSignedTransaction {
     val wireTransaction = getWireTransactionExample(
         digestService,
         merkleTreeProvider,
         jsonMarshallingService,
         jsonValidator,
-        metadata = utxoTransactionMetadataExample
+        metadata = utxoTransactionMetadataExample(cpkPackageSeed)
     )
     return UtxoSignedTransactionImpl(
         serializationService,
         transactionSignatureService,
         utxoLedgerTransactionFactory,
         wireTransaction,
-        listOf(signatureWithMetadataExample)
+        listOf(getSignatureWithMetadataExample())
     )
 }

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoTransactionMetadataExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoTransactionMetadataExample.kt
@@ -8,14 +8,14 @@ import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionMetadata
 
-val utxoTransactionMetadataExample = TransactionMetadataImpl(linkedMapOf(
+fun utxoTransactionMetadataExample(cpkPackageSeed: String? = null) = TransactionMetadataImpl(linkedMapOf(
     TransactionMetadataImpl.LEDGER_MODEL_KEY to UtxoLedgerTransactionImpl::class.java.canonicalName,
     TransactionMetadataImpl.LEDGER_VERSION_KEY to UtxoTransactionMetadata.LEDGER_VERSION,
     TransactionMetadataImpl.TRANSACTION_SUBTYPE_KEY to UtxoTransactionMetadata.TransactionSubtype.GENERAL,
     TransactionMetadataImpl.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,
     TransactionMetadataImpl.PLATFORM_VERSION_KEY to 123,
     TransactionMetadataImpl.CPI_METADATA_KEY to cpiPackageSummaryExample,
-    TransactionMetadataImpl.CPK_METADATA_KEY to cpkPackageSummaryListExample,
+    TransactionMetadataImpl.CPK_METADATA_KEY to cpkPackageSummaryListExample(cpkPackageSeed),
     TransactionMetadataImpl.SCHEMA_VERSION_KEY to TransactionMetadataImpl.SCHEMA_VERSION,
     TransactionMetadataImpl.NUMBER_OF_COMPONENT_GROUPS to UtxoComponentGroup.values().size
 // TODO


### PR DESCRIPTION
* Remove a few duplicated dependencies
* Use slightly more compact `wireTransactionFactory.createExample` in ledger integration tests.
* Reuse CPK example and signature example classes in a few more places.
* CORE-7649 Remove a few package-info.javas