### PR TITLE
CORE-9416 Extend timeout for probes

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -141,18 +141,21 @@ readinessProbe:
     port: monitor
   periodSeconds: 10
   failureThreshold: 3
+  timeoutSeconds: 5
 livenessProbe:
   httpGet:
     path: /isHealthy
     port: monitor
   periodSeconds: 10
   failureThreshold: 3
+  timeoutSeconds: 5
 startupProbe:
   httpGet:
     path: /isHealthy
     port: monitor
   periodSeconds: 5
   failureThreshold: 20
+  timeoutSeconds: 5
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This is not entirely desirable but it seems like GC is still causing the liveness probe to fail. If we can keep the workers up, then we have a better change of tuning the GC to bring the pauses down again.