### PR TITLE
NOTICK: Pass PostgreSQL system properties into OSGi tests.

### DIFF
--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -23,6 +23,14 @@ configurations {
     integrationTestImplementation.extendsFrom testImplementation
 }
 
+ext {
+    postgresHost = providers.systemProperty('postgresHost').orElse("")
+    postgresPort = providers.systemProperty('postgresPort').orElse("")
+    postgresDb = providers.systemProperty('postgresDb').orElse("")
+    postgresUser = providers.systemProperty('postgresUser').orElse("")
+    postgresPassword = providers.systemProperty('postgresPassword').orElse("")
+}
+
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'

--- a/components/crypto/crypto-persistence-impl/test.bndrun
+++ b/components/crypto/crypto-persistence-impl/test.bndrun
@@ -3,6 +3,13 @@
 -runee: JavaSE-11
 -runtrace: true
 
+-runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword}
+
 -runsystempackages: \
     sun.security.x509
 
@@ -32,12 +39,6 @@
     begin=-1
 
 -runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword},\
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\

--- a/components/ledger/ledger-persistence/test.bndrun
+++ b/components/ledger/ledger-persistence/test.bndrun
@@ -5,6 +5,11 @@
 -runtrace: true
 
 -runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword},\
     --add-opens, 'java.base/java.net=ALL-UNNAMED'
 
 -runsystempackages: \
@@ -21,12 +26,7 @@
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\
     org.slf4j.simpleLogger.showDateTime=true,\
-    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z',\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword}
+    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z'
 
 # Include the the tests since they're the bundle to be run inside an osgi framework.
 # This should make bnd resolve everything else we need.

--- a/components/membership/membership-persistence-service-impl/test.bndrun
+++ b/components/membership/membership-persistence-service-impl/test.bndrun
@@ -4,6 +4,13 @@
 -runtrace: true
 #-runjdb: 5006
 
+-runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword}
+
 -runsystempackages: \
     sun.security.x509
 
@@ -36,12 +43,6 @@
     begin=-1
 
 -runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword},\
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\

--- a/components/persistence/entity-processor-service-impl/test.bndrun
+++ b/components/persistence/entity-processor-service-impl/test.bndrun
@@ -5,6 +5,11 @@
 -runtrace: true
 
 -runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword},\
     --add-opens, 'java.base/java.net=ALL-UNNAMED'
 
 -runsystempackages: \
@@ -21,12 +26,7 @@
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\
     org.slf4j.simpleLogger.showDateTime=true,\
-    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z',\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword}
+    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z'
 
 # Include the the tests since they're the bundle to be run inside an osgi framework.
 # This should make bnd resolve everything else we need.

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/test.bndrun
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/test.bndrun
@@ -5,6 +5,11 @@
 -runtrace: true
 
 -runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword},\
     --add-opens, 'java.base/java.net=ALL-UNNAMED'
 
 -runsystempackages: \
@@ -21,12 +26,7 @@
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\
     org.slf4j.simpleLogger.showDateTime=true,\
-    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z',\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword}
+    org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z'
 
 # Include the the tests since they're the bundle to be run inside an osgi framework.
 # This should make bnd resolve everything else we need.

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -3,6 +3,13 @@
 -runee: JavaSE-11
 -runtrace: true
 
+-runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword}
+
 -runsystempackages: \
     sun.security.x509
 
@@ -23,11 +30,3 @@
 -runstartlevel: \
     order=sortbynameversion,\
     begin=-1
-
--runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword}

--- a/libs/permissions/permission-datamodel/test.bndrun
+++ b/libs/permissions/permission-datamodel/test.bndrun
@@ -3,6 +3,13 @@
 -runee: JavaSE-11
 -runtrace: true
 
+-runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword}
+
 -runsystempackages: \
     sun.security.x509
 
@@ -22,11 +29,3 @@
 -runstartlevel: \
     order=sortbynameversion,\
     begin=-1
-
--runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword}

--- a/processors/crypto-processor/test.bndrun
+++ b/processors/crypto-processor/test.bndrun
@@ -3,6 +3,13 @@
 -runee: JavaSE-11
 -runtrace: true
 
+-runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword}
+
 -runsystempackages: \
     sun.security.x509
 
@@ -43,12 +50,6 @@
     begin=-1
 
 -runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword},\
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\

--- a/processors/member-processor/test.bndrun
+++ b/processors/member-processor/test.bndrun
@@ -6,6 +6,13 @@
 #uncomment to remote debug
 # -runjdb: 5005
 
+-runvm: \
+    -DpostgresHost=${project.postgresHost},\
+    -DpostgresPort=${project.postgresPort},\
+    -DpostgresDb=${project.postgresDb},\
+    -DpostgresUser=${project.postgresUser},\
+    -DpostgresPassword=${project.postgresPassword}
+
 -runsystempackages: \
     sun.security.x509
 
@@ -56,12 +63,6 @@
     begin=-1
 
 -runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
-    postgresHost=${project.postgresHost},\
-    postgresPort=${project.postgresPort},\
-    postgresDb=${project.postgresDb},\
-    postgresUser=${project.postgresUser},\
-    postgresPassword=${project.postgresPassword},\
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\


### PR DESCRIPTION
I really cannot stress this strongly enough:

- **_Gradle properties are not the same as Java system properties._**
- **_And neither are OSGi Framework properties._**

Our test code is examining the Java system properties for `postgresPort` to determine whether it should expect a PostgreSQL database vs a HSQLDB one. We therefore need to pass these system properties _as system properties_ into the JVM running the testing OSGi framework. We do this via the `-runvm` instruction in the `.bndrun` file.

The `-runproperties` instruction sets OSGi framework properties, and `${project.postgresPort}` is examining the Gradle project's properties. So
```
-runproperties:\
    postgresPort=${project.postgresPort}
```
simply doesn't work at all.