### PR TITLE
CORE-9124: Flow tries to use fiber before it is initialised

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -95,10 +95,16 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
         exception: FlowFatalException,
         context: FlowEventContext<*>
     ): StateAndEventProcessor.Response<Checkpoint> = withEscalation {
-        val msg =
-            "Flow processing for flow ID ${context.checkpoint.flowId} has failed due to a fatal exception. " +
-                    "Checkpoint size: ${context.checkpoint.serializedFiber.position()}"
+        val msg = if(!context.checkpoint.doesExist) {
+                "Flow processing for flow ID ${context.checkpoint.flowId} has failed due to a fatal exception. " +
+                        "doesExist was false"
+
+        } else {
+                "Flow processing for flow ID ${context.checkpoint.flowId} has failed due to a fatal exception. " +
+                        "Flow start context: ${context.checkpoint.flowStartContext}"
+        }
         log.warn(msg, exception)
+
         val records = createStatusRecord(context.checkpoint.flowId) {
             flowMessageFactory.createFlowFailedStatusMessage(
                 context.checkpoint,

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -268,6 +268,7 @@ class FlowEventExceptionProcessorImplTest {
             )
         ).thenReturn(flowStatusUpdate)
         whenever(flowRecordFactory.createFlowStatusRecord(flowStatusUpdate)).thenReturn(flowStatusUpdateRecord)
+        target.process(error, context)
 
         verify(flowCheckpoint, times(0)).flowStartContext
     }


### PR DESCRIPTION
 A fiber was being referenced before it was initialised within the exception handler. This PR checks if the flow exists (using doesExist) and if false only returns the flow ID. If the flow exists the flow start context is returned also (potentially more useful). 