### PR TITLE
NOTICK: Allow Jenkins to configure PostgreSQL using Gradle properties.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,19 +242,25 @@ allprojects {
     }
 
     tasks.register('integrationTest', Test) {
+        inputs.property('postgresHost', postgresHost)
+        inputs.property('postgresDb', postgresDb)
+        inputs.property('postgresPort', postgresPort)
+        inputs.property('postresUser', postgresUser)
+        inputs.property('postgresPassword', postgresPassword)
+
         description = "Runs integration tests."
         group = "verification"
 
         testClassesDirs = project.sourceSets["integrationTest"].output.classesDirs
         classpath = project.sourceSets["integrationTest"].runtimeClasspath
 
-        systemProperty "postgresHost", project.getProperty("postgresHost")
-        systemProperty "postgresDb", project.getProperty("postgresDb")
-        systemProperty "postgresPort", project.getProperty("postgresPort")
-        systemProperty "postgresUser", project.getProperty("postgresUser")
-        systemProperty "postgresPassword", project.getProperty("postgresPassword")
+        systemProperty 'postgresHost', postgresHost
+        systemProperty 'postgresDb', postgresDb
+        systemProperty 'postgresPort', postgresPort
+        systemProperty 'postgresUser', postgresUser
+        systemProperty 'postgresPassword', postgresPassword
 
-        shouldRunAfter tasks.named('test')
+        shouldRunAfter tasks.named('test', Test)
     }
 
     dependencies {

--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -23,14 +23,6 @@ configurations {
     integrationTestImplementation.extendsFrom testImplementation
 }
 
-ext {
-    postgresHost = providers.systemProperty('postgresHost').orElse("")
-    postgresPort = providers.systemProperty('postgresPort').orElse("")
-    postgresDb = providers.systemProperty('postgresDb').orElse("")
-    postgresUser = providers.systemProperty('postgresUser').orElse("")
-    postgresPassword = providers.systemProperty('postgresPassword').orElse("")
-}
-
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -12,7 +12,6 @@ import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.data.ledger.persistence.LedgerTypes
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.persistence.EntityResponse
-import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.testkit.DbUtils
@@ -65,7 +64,7 @@ import java.util.UUID
  * Rather than creating a new serializer in these tests from scratch,
  * we grab a reference to the one in the sandbox and use that to serialize and de-serialize.
  */
-@ExtendWith(ServiceExtension::class, BundleContextExtension::class, DBSetup::class)
+@ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class ConsensualLedgerMessageProcessorTests {
     companion object {

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -12,7 +12,6 @@ import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.data.ledger.persistence.LedgerTypes
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.persistence.EntityResponse
-import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.testkit.DbUtils
@@ -71,7 +70,7 @@ import java.util.UUID
  * Rather than creating a new serializer in these tests from scratch,
  * we grab a reference to the one in the sandbox and use that to serialize and de-serialize.
  */
-@ExtendWith(ServiceExtension::class, BundleContextExtension::class, DBSetup::class)
+@ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class UtxoLedgerMessageProcessorTests {
     companion object {

--- a/testing/db-message-bus-testkit/src/main/kotlin/net/corda/db/messagebus/testkit/DBSetup.kt
+++ b/testing/db-message-bus-testkit/src/main/kotlin/net/corda/db/messagebus/testkit/DBSetup.kt
@@ -8,23 +8,22 @@ import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.osgi.framework.BundleContext
 import org.osgi.framework.FrameworkUtil
-import org.slf4j.LoggerFactory
 import java.io.StringWriter
 
 object DBSetup: BeforeAllCallback {
 
-    private val logger = LoggerFactory.getLogger(this::class.java.name)
-
     var isDB = false
+        private set
 
     private fun BundleContext.isDBBundle() =
         bundles.find { it.symbolicName.contains("db-message-bus-impl") } != null
 
     override fun beforeAll(context: ExtensionContext?) {
-        val bundleContext = FrameworkUtil.getBundle(this::class.java.classLoader).get().bundleContext
-        isDB = bundleContext.isDBBundle()
-        if (isDB) {
-            setupEntities()
+        FrameworkUtil.getBundle(this::class.java)?.also { bundle ->
+            isDB = bundle.bundleContext.isDBBundle()
+            if (isDB) {
+                setupEntities()
+            }
         }
     }
 


### PR DESCRIPTION
The codebase expects PostgreSQL to be configured via Java system properties, but Jenkins actually passes them to Gradle as Gradle properties. This means that the OSGi test convention plugin doesn't need to examine the Java system properties.

Also remove `DbSetup` from the Ledger's integration tests because `DbSetup` _always_ uses HSQL, whereas the Ledger's tests are expected to use PostgreSQL when running on Jenkins.