### PR TITLE
CORE-8984 Add extra logging to finality and notary flows

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
@@ -83,10 +83,10 @@ abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
             }
             transactionSignatureService.verifyNotarySignature(transaction.id, signature)
             log.debug {
-                "Successfully verified signature($signature) by ${signature.by.encoded} (encoded) for transaction ${transaction.id}"
+                "Successfully verified signature($signature) by notary ${transaction.notary} for transaction ${transaction.id}"
             }
         } catch (e: Exception) {
-            val message ="Failed to verify transaction's signature($signature) by ${signature.by.encoded} (encoded) for " +
+            val message ="Failed to verify transaction's signature($signature) by notary ${transaction.notary} for " +
                     "transaction ${transaction.id}. Message: ${e.message}"
             log.warn(message)
             throw e

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -160,9 +160,9 @@ class UtxoFinalityFlow(
         transaction: UtxoSignedTransactionInternal
     ): Pair<UtxoSignedTransactionInternal, List<DigitalSignatureAndMetadata>> {
         val notary = transaction.notary
-        log.trace { "Finding pluggable notary client flow for $notary to notarise transaction $transactionId" }
-        val notarizationFlow = pluggableNotaryClientFlowFactory.create(transaction.notary, transaction)
+        val notarizationFlow = pluggableNotaryClientFlowFactory.create(notary, transaction)
 
+        // `log.trace {}` and `log.debug {}` are not used in this method due to a Quasar issue.
         if (log.isTraceEnabled) {
             log.trace(
                 "Notarizing transaction $transactionId using pluggable notary client flow of ${notarizationFlow::class.java.name} with " +

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -90,7 +90,7 @@ class UtxoFinalityFlow(
                 CordaRuntimeException(message)
             }
 
-            log.debug { "Received ${signatures.size} signatures from ${session.counterparty} for transaction $transactionId" }
+            log.debug { "Received ${signatures.size} signature(s) from ${session.counterparty} for transaction $transactionId" }
 
             signatures.forEach { signature ->
                 transaction = verifyAndAddSignature(transaction, signature)
@@ -149,6 +149,7 @@ class UtxoFinalityFlow(
                 it !in signatures                                   // These came from that party
             }
         }.toMap()
+        log.trace { "Sending updated signatures to counterparties for transaction $transactionId" }
         flowMessaging.sendAllMap(notSeenSignaturesBySessions)
         log.debug { "Sent updated signatures to counterparties for transaction $transactionId" }
     }
@@ -158,24 +159,31 @@ class UtxoFinalityFlow(
     private fun notarize(
         transaction: UtxoSignedTransactionInternal
     ): Pair<UtxoSignedTransactionInternal, List<DigitalSignatureAndMetadata>> {
-        val notarisationFlow = pluggableNotaryClientFlowFactory.create(transaction.notary, transaction)
-
+        val notary = transaction.notary
+        log.trace { "Finding pluggable notary client flow for $notary to notarise transaction $transactionId" }
+        val notarizationFlow = pluggableNotaryClientFlowFactory.create(transaction.notary, transaction)
+        log.trace {
+            "Notarizing transaction $transactionId using pluggable notary client flow of ${notarizationFlow::class.java.name} with notary" +
+                    notary
+        }
         val notarySignatures = try {
-            flowEngine.subFlow(notarisationFlow)
+            flowEngine.subFlow(notarizationFlow)
         } catch (e: CordaRuntimeException) {
             val message = "Notarization failed with ${e.message}."
             flowMessaging.sendAll(Payload.Failure<List<DigitalSignatureAndMetadata>>(message), sessions.toSet())
             log.warn(message)
             throw e
         }
-
+        log.trace {
+            "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of " +
+                    "transaction $transactionId"
+        }
         if (notarySignatures.isEmpty()) {
-            val message = "Notary has not returned any signatures."
+            val message = "Notary $notary did not return any signatures after requesting notarization of transaction $transactionId"
             log.warn(message)
             flowMessaging.sendAll(Payload.Failure<List<DigitalSignatureAndMetadata>>(message), sessions.toSet())
             throw CordaRuntimeException(message)
         }
-
         var notarizedTransaction = transaction
         notarySignatures.forEach { signature ->
             notarizedTransaction = try {
@@ -186,7 +194,9 @@ class UtxoFinalityFlow(
                 throw e
             }
         }
-
+        log.debug {
+            "Successfully notarized transaction $transactionId using notary $notary and received ${notarySignatures.size} signature(s)"
+        }
         return notarizedTransaction to notarySignatures
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -162,10 +162,14 @@ class UtxoFinalityFlow(
         val notary = transaction.notary
         log.trace { "Finding pluggable notary client flow for $notary to notarise transaction $transactionId" }
         val notarizationFlow = pluggableNotaryClientFlowFactory.create(transaction.notary, transaction)
-        log.trace {
-            "Notarizing transaction $transactionId using pluggable notary client flow of ${notarizationFlow::class.java.name} with notary" +
-                    notary
+
+        if (log.isTraceEnabled) {
+            log.trace(
+                "Notarizing transaction $transactionId using pluggable notary client flow of ${notarizationFlow::class.java.name} with " +
+                        "notary $notary"
+            )
         }
+
         val notarySignatures = try {
             flowEngine.subFlow(notarizationFlow)
         } catch (e: CordaRuntimeException) {
@@ -174,10 +178,14 @@ class UtxoFinalityFlow(
             log.warn(message)
             throw e
         }
-        log.trace {
-            "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of " +
-                    "transaction $transactionId"
+
+        if (log.isTraceEnabled) {
+            log.trace(
+                "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of transaction " +
+                        transactionId
+            )
         }
+
         if (notarySignatures.isEmpty()) {
             val message = "Notary $notary did not return any signatures after requesting notarization of transaction $transactionId"
             log.warn(message)
@@ -194,9 +202,13 @@ class UtxoFinalityFlow(
                 throw e
             }
         }
-        log.debug {
-            "Successfully notarized transaction $transactionId using notary $notary and received ${notarySignatures.size} signature(s)"
+
+        if (log.isDebugEnabled) {
+            log.debug(
+                "Successfully notarized transaction $transactionId using notary $notary and received ${notarySignatures.size} signature(s)"
+            )
         }
+
         return notarizedTransaction to notarySignatures
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
@@ -146,7 +146,7 @@ class UtxoReceiveFinalityFlow(
         val notarySignaturesPayload = session.receive<Payload<List<DigitalSignatureAndMetadata>>>()
 
         val notarySignatures = notarySignaturesPayload.getOrThrow { failure ->
-            val message = "Notarisation failed. Failure received from ${session.counterparty} for transaction " +
+            val message = "Notarization failed. Failure received from ${session.counterparty} for transaction " +
                     "${transaction.id} with message: ${failure.message}"
             log.warn(message)
             CordaRuntimeException(message)

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -17,6 +17,7 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.loggerFor
+import net.corda.v5.base.util.trace
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.StateAndRef
@@ -35,6 +36,10 @@ import kotlin.IllegalStateException
 @InitiatedBy(protocol = "non-validating-notary")
 class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
+    private companion object {
+        val logger: Logger = loggerFor<NonValidatingNotaryServerFlowImpl>()
+    }
+
     @CordaInject
     private lateinit var clientService: LedgerUniquenessCheckerClientService
 
@@ -46,10 +51,6 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
     @CordaInject
     private lateinit var memberLookup: MemberLookup
-
-    private companion object {
-        val logger: Logger = loggerFor<NonValidatingNotaryServerFlowImpl>()
-    }
 
     /**
      * Constructor used for testing to initialize the necessary services
@@ -85,7 +86,10 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
             val requestPayload = session.receive(NonValidatingNotarisationPayload::class.java)
 
             val txDetails = validateRequest(requestPayload)
+
             val request = NotarisationRequest(txDetails.inputs, txDetails.id)
+
+            logger.trace { "Received notarization request for transaction ${request.transactionId}" }
 
             val otherMemberInfo = memberLookup.lookup(session.counterparty)
                 ?: throw IllegalStateException("Could not find counterparty on the network: ${session.counterparty}")
@@ -107,6 +111,8 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
             val notaryServicePublicKeys = (requestPayload.notaryKey as? CompositeKey)?.leafKeys?.toList()
                 ?: listOf(requestPayload.notaryKey)
 
+            logger.trace { "Requesting uniqueness check for transaction ${txDetails.id}" }
+
             val uniquenessResponse = clientService.requestUniquenessCheck(
                 txDetails.id.toString(),
                 txDetails.inputs.map { it.toString() },
@@ -118,8 +124,8 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
             )
 
             logger.debug {
-                "Uniqueness check completed for transaction with Tx [${txDetails.id}], " +
-                        "result is: ${uniquenessResponse.result}"
+                "Uniqueness check completed for transaction ${txDetails.id}, result is: ${uniquenessResponse.result}. Sending response " +
+                        "to ${session.counterparty}"
             }
 
             session.send(uniquenessResponse.toNotarisationResponse())
@@ -200,8 +206,13 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
         try {
             (requestPayload.transaction as UtxoFilteredTransaction).verify()
         } catch (e: Exception) {
-            logger.warn("Error while validating the transaction, reason: ${e.message}")
-            throw IllegalStateException("Error while validating the transaction", e)
+            logger.warn(
+                "Error while validating transaction ${(requestPayload.transaction as UtxoFilteredTransaction).id}, reason: ${e.message}"
+            )
+            throw IllegalStateException(
+                "Error while validating transaction ${(requestPayload.transaction as UtxoFilteredTransaction).id}",
+                e
+            )
         }
     }
 

--- a/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
@@ -12,12 +12,14 @@
 
         <logger name="net.corda.ledger.utxo.flow.impl" level="debug" additivity="false">
             <AppenderRef ref="Console" level="debug"/>
-            <AppenderRef ref="App" level="debug"/>
         </logger>
 
         <logger name="net.corda.ledger.utxo.flow.impl.flows.finality" level="trace" additivity="false">
             <AppenderRef ref="Console" level="trace"/>
-            <AppenderRef ref="App" level="trace"/>
+        </logger>
+
+        <logger name="com.r3.corda.notary.plugin.nonvalidating" level="trace" additivity="false">
+            <AppenderRef ref="Console" level="trace"/>
         </logger>
 
         <!-- log warn only for these 3rd party libs -->

--- a/osgi-framework-bootstrap/src/main/resources/log4j2.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2.xml
@@ -43,6 +43,11 @@
             <AppenderRef ref="App" level="trace"/>
         </logger>
 
+        <logger name="com.r3.corda.notary.plugin.nonvalidating" level="trace" additivity="false">
+            <AppenderRef ref="Console" level="trace"/>
+            <AppenderRef ref="App" level="trace"/>
+        </logger>
+
         <!-- log warn only for these 3rd party libs -->
         <Logger name="com.zaxxer.hikari" level="warn" />
         <Logger name="io.javalin.Javalin" level="warn" />


### PR DESCRIPTION
Add extra `trace` and `debug` logging to the finality and notary flows. These logs have been added to identify an issue in the UTXO finality flows; however, these logs will generally be useful when identifying issues in production when more detail is needed.

Changes to the log4j2 files have been made and should be reverted when the underlying issue has been diagnosed and fixed.