### PR TITLE
NOTICK: Declare UtxoRepositoryImpl as a prototype persistence service.

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
@@ -33,7 +33,6 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.PrivacySalt
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -71,7 +70,6 @@ class ConsensualLedgerRepositoryTest {
     private lateinit var entityManagerFactory: EntityManagerFactory
     private lateinit var repository: ConsensualRepository
     private lateinit var persistenceService: ConsensualPersistenceService
-    private val emConfig = DbUtils.getEntityManagerConfiguration("ledger_db_for_test")
 
     companion object {
         private const val TESTING_DATAMODEL_CPB = "/META-INF/testing-datamodel.cpb"
@@ -108,12 +106,6 @@ class ConsensualLedgerRepositoryTest {
                 digestService,
                 TEST_CLOCK)
         }
-    }
-
-    @Suppress("Unused")
-    @AfterAll
-    fun cleanup() {
-        emConfig.close()
     }
 
     @Test

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/DelegatedRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/DelegatedRequestHandlerSelectorImpl.kt
@@ -21,8 +21,8 @@ class DelegatedRequestHandlerSelectorImpl @Activate constructor(
     private val utxoRequestHandlerSelector: UtxoRequestHandlerSelector,
 ) : DelegatedRequestHandlerSelector {
 
-    companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    private companion object {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun selectHandler(sandbox: SandboxGroupContext, request: LedgerPersistenceRequest): RequestHandler {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -7,6 +7,8 @@ import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.ledger.persistence.common.ComponentLeafDto
 import net.corda.ledger.persistence.common.mapToComponentGroups
 import net.corda.ledger.persistence.utxo.UtxoRepository
+import net.corda.sandbox.type.SandboxConstants.CORDA_MARKER_ONLY_SERVICE
+import net.corda.sandbox.type.UsedByPersistence
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
@@ -14,6 +16,10 @@ import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.ledger.utxo.StateRef
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.time.Instant
@@ -22,11 +28,25 @@ import javax.persistence.Query
 import javax.persistence.Tuple
 
 @Suppress("TooManyFunctions")
-class UtxoRepositoryImpl(
+/**
+ * Reads and writes ledger transaction data to and from the virtual node vault database.
+ * The component only exists to be created inside a PERSISTENCE sandbox. We denote it
+ * as "corda.marker.only" to force the sandbox to create it, despite it implementing
+ * only the [UsedByPersistence] marker interface.
+ */
+@Component(
+    service = [ UtxoRepository::class, UsedByPersistence::class ],
+    property = [ CORDA_MARKER_ONLY_SERVICE ],
+    scope = PROTOTYPE
+)
+class UtxoRepositoryImpl @Activate constructor(
+    @Reference
     private val digestService: DigestService,
+    @Reference
     private val serializationService: SerializationService,
+    @Reference
     private val wireTransactionFactory: WireTransactionFactory
-) : UtxoRepository {
+) : UtxoRepository, UsedByPersistence {
     private companion object {
         private val UNVERIFIED = TransactionStatus.UNVERIFIED.value
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -32,15 +32,10 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
 ): UtxoRequestHandlerSelector {
 
     override fun selectHandler(sandbox: SandboxGroupContext, request: LedgerPersistenceRequest): RequestHandler {
-        val repository =  UtxoRepositoryImpl(
-            sandbox.getSandboxSingletonService(),
-            sandbox.getSandboxSingletonService(),
-            sandbox.getSandboxSingletonService()
-        )
         val persistenceService = UtxoPersistenceServiceImpl(
             sandbox.getEntityManagerFactory(),
-            repository,
             sandbox.getSandboxSingletonService(),
+            sandbox.getSerializationService(),
             sandbox.getSandboxSingletonService(),
             UTCClock()
         )


### PR DESCRIPTION
Declare `UtxoRepositoryImpl` as a `PROTOTYPE` service for use in `PERSISTENCE` sandboxes. This allows Corda to construct its instance automatically. It also aligns the UTXO code with the Consensual code.

Also remove unsed `EntityManagerConfiguration` from the `ConsensualLedgerRepositoryTest`, because this is already handled by `persistence-testkit`.