### PR TITLE
CORE-9006: Use correct commit ID in downstream jobs 

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -61,6 +61,13 @@ pipeline {
         }
     }
 
+    parameters {
+        string(name: 'BUILD_REV', defaultValue: '', description: 'Short git hash of the build revision to test - leave blank to test unstable')
+        choice(name: 'BUILD_ARCH', choices: ['amd64', 'arm64'], description: 'Build architecture')
+        booleanParam(name: 'KEEP_NS', defaultValue: false, description: 'Determines if the k8s Namespace is to be preserved or deleted at the end of the build.')
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: '', description: 'Commit ID to check out of SCM - leave blan to take HEAD of current brabranchcnh ')
+    }
+
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         BASE_IMAGE = getBaseImage(params.BUILD_REV, architectureTag)
@@ -90,13 +97,6 @@ pipeline {
         E2E_WORKER_ARCH = "${e2eArchitecture}"
     }
 
-    parameters {
-        string(name: 'BUILD_REV', defaultValue: '', description: 'Short git hash of the build revision to test - leave blank to test unstable')
-        choice(name: 'BUILD_ARCH', choices: ['amd64', 'arm64'], description: 'Build architecture')
-        booleanParam(name: 'KEEP_NS', defaultValue: false, description: 'Determines if the k8s Namespace is to be preserved or deleted at the end of the build.')
-        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.CORDA_REVISION, description: 'Commit ID to check out of SCM')
-    }
-
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
         timeout(time: 45, unit: 'MINUTES')
@@ -107,8 +107,11 @@ pipeline {
     stages {
         stage('check out') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: "*/${params.COMMIT_TO_CHECKOUT}"]], extensions: [],
-                    userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])
+                script {
+                    def commitID = params.COMMIT_TO_CHECKOUT ?: env.CORDA_REVISION
+                    checkout([$class: 'GitSCM', branches: [[name: "*/${commitID}"]], extensions: [],
+                        userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])
+                }
             }
         }
         stage ('Create namespace') {

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -65,6 +65,7 @@ pipeline {
         string(name: 'BUILD_REV', defaultValue: '', description: 'Short git hash of the build revision to test - leave blank to test unstable')
         choice(name: 'BUILD_ARCH', choices: ['amd64', 'arm64'], description: 'Build architecture')
         booleanParam(name: 'KEEP_NS', defaultValue: false, description: 'Determines if the k8s Namespace is to be preserved or deleted at the end of the build.')
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.GIT_COMMIT description: 'Commit ID to check out of SCM')
     }
 
     environment {
@@ -100,9 +101,16 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
         timeout(time: 45, unit: 'MINUTES')
         timestamps()
+        skipDefaultCheckout()
     }
 
     stages {
+        stage('check out') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: "*/${params.COMMIT_TO_CHECKOUT}"]], extensions: [],
+                    userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])
+            }
+        }
         stage ('Create namespace') {
             steps {
                 sh '''\

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -108,11 +108,11 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    println "CommitID to checkOut ${env.CORDA_REVISION}"
+                    println "CommitID to checkOut ${env.COMMIT_TO_CHECKOUT}"
 
-                    println "CommitID to checkOut ${COMMIT_TO_CHECKOUT}"
+                    println "CommitID to checkOut ${BRANCH_NAME}"
 
-                    def commitID = params.COMMIT_TO_CHECKOUT ?: env.CORDA_REVISION
+                    def commitID = params.COMMIT_TO_CHECKOUT ?: env.BRANCH_NAME
                     println "CommitID to checkOut $commitID"
                     checkout([$class: 'GitSCM', branches: [[name: "*/${commitID}"]], extensions: [],
                         userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -108,7 +108,12 @@ pipeline {
         stage('check out') {
             steps {
                 script {
+                    println "CommitID to checkOut ${env.CORDA_REVISION}"
+
+                    println "CommitID to checkOut ${COMMIT_TO_CHECKOUT}"
+
                     def commitID = params.COMMIT_TO_CHECKOUT ?: env.CORDA_REVISION
+                    println "CommitID to checkOut $commitID"
                     checkout([$class: 'GitSCM', branches: [[name: "*/${commitID}"]], extensions: [],
                         userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])
                 }

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
         string(name: 'BUILD_REV', defaultValue: '', description: 'Short git hash of the build revision to test - leave blank to test unstable')
         choice(name: 'BUILD_ARCH', choices: ['amd64', 'arm64'], description: 'Build architecture')
         booleanParam(name: 'KEEP_NS', defaultValue: false, description: 'Determines if the k8s Namespace is to be preserved or deleted at the end of the build.')
-        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: '', description: 'Commit ID to check out of SCM - leave blan to take HEAD of current brabranchcnh ')
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: '', description: 'Commit ID to check out of SCM - leave blank to take head of current branch')
     }
 
     environment {
@@ -107,7 +107,7 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) {
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) {  // CHANGE_ID only populated in PRs
                         echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && !changeRequest()) {
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID != null) {
                         echo "CommitID to checkOut ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -111,7 +111,11 @@ pipeline {
                         echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
-                        echo "Checking out Head revision of ${env.BRANCH_NAME} and merging into ${env.CHANGE_TARGET}"
+                        if (env.CHANGE_ID) {
+                            echo "Checking out head revision of ${env.BRANCH_NAME} and merging into ${env.CHANGE_TARGET}"
+                        } else {
+                            echo "Checking out head revision of ${env.BRANCH_NAME}"
+                        }
                     }
                 }
             }

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
         string(name: 'BUILD_REV', defaultValue: '', description: 'Short git hash of the build revision to test - leave blank to test unstable')
         choice(name: 'BUILD_ARCH', choices: ['amd64', 'arm64'], description: 'Build architecture')
         booleanParam(name: 'KEEP_NS', defaultValue: false, description: 'Determines if the k8s Namespace is to be preserved or deleted at the end of the build.')
-        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.GIT_COMMIT description: 'Commit ID to check out of SCM')
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.GIT_COMMIT, description: 'Commit ID to check out of SCM')
     }
 
     environment {

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -108,11 +108,19 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    println "CommitID to checkOut ${env.COMMIT_TO_CHECKOUT}"
+                    def commitID
 
-                    println "CommitID to checkOut ${BRANCH_NAME}"
+                    if (changeRequest() && params.COMMIT_TO_CHECKOUT != null) {
+                        println "checking out ${params.COMMIT_TO_CHECKOUT}"
+                        commitID = params.COMMIT_TO_CHECKOUT
+                    } else if (changeRequest() && params.COMMIT_TO_CHECKOUT == null) {
+                        println "checking out ${env.CHANGE_TARGET}"
+                        commitID = env.CHANGE_TARGET
+                    } else {
+                        println "checking out ${env.BRANCH_NAME}"
+                        commitID = env.BRANCH_NAME
+                    }
 
-                    def commitID = params.COMMIT_TO_CHECKOUT ?: env.BRANCH_NAME
                     println "CommitID to checkOut $commitID"
                     checkout([$class: 'GitSCM', branches: [[name: "*/${commitID}"]], extensions: [],
                         userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -107,11 +107,11 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID != null) {
-                        echo "CommitID to checkOut ${params.COMMIT_TO_CHECKOUT}"
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) {
+                        echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
-                        echo "checking out Head revision of ${env.BRANCH_NAME}"
+                        echo "Checking out Head revision of ${env.BRANCH_NAME} and merging into ${env.CHANGE_TARGET}"
                     }
                 }
             }

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -61,13 +61,6 @@ pipeline {
         }
     }
 
-    parameters {
-        string(name: 'BUILD_REV', defaultValue: '', description: 'Short git hash of the build revision to test - leave blank to test unstable')
-        choice(name: 'BUILD_ARCH', choices: ['amd64', 'arm64'], description: 'Build architecture')
-        booleanParam(name: 'KEEP_NS', defaultValue: false, description: 'Determines if the k8s Namespace is to be preserved or deleted at the end of the build.')
-        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.GIT_COMMIT, description: 'Commit ID to check out of SCM')
-    }
-
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         BASE_IMAGE = getBaseImage(params.BUILD_REV, architectureTag)
@@ -95,6 +88,13 @@ pipeline {
         E2E_CLUSTER_C_P2P_HOST="corda-caroline-p2p-gateway-worker.${NAMESPACE}.svc.cluster.local"
         E2E_BRANCH_LABEL = "${sanitizedBranchName()}"
         E2E_WORKER_ARCH = "${e2eArchitecture}"
+    }
+
+    parameters {
+        string(name: 'BUILD_REV', defaultValue: '', description: 'Short git hash of the build revision to test - leave blank to test unstable')
+        choice(name: 'BUILD_ARCH', choices: ['amd64', 'arm64'], description: 'Build architecture')
+        booleanParam(name: 'KEEP_NS', defaultValue: false, description: 'Determines if the k8s Namespace is to be preserved or deleted at the end of the build.')
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.CORDA_REVISION, description: 'Commit ID to check out of SCM')
     }
 
     options {

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -101,29 +101,18 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
         timeout(time: 45, unit: 'MINUTES')
         timestamps()
-        skipDefaultCheckout()
     }
 
     stages {
         stage('check out') {
             steps {
                 script {
-                    def commitID
-
-                    if (changeRequest() && params.COMMIT_TO_CHECKOUT != null) {
-                        println "checking out ${params.COMMIT_TO_CHECKOUT}"
-                        commitID = params.COMMIT_TO_CHECKOUT
-                    } else if (changeRequest() && params.COMMIT_TO_CHECKOUT == null) {
-                        println "checking out ${env.CHANGE_TARGET}"
-                        commitID = env.CHANGE_TARGET
+                    if (params.COMMIT_TO_CHECKOUT && !changeRequest()) {
+                        echo "CommitID to checkOut ${params.COMMIT_TO_CHECKOUT}"
+                        sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
-                        println "checking out ${env.BRANCH_NAME}"
-                        commitID = env.BRANCH_NAME
+                        echo "checking out Head revision of ${env.BRANCH_NAME}"
                     }
-
-                    println "CommitID to checkOut $commitID"
-                    checkout([$class: 'GitSCM', branches: [[name: "*/${commitID}"]], extensions: [],
-                        userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])
                 }
             }
         }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -64,7 +64,6 @@ pipeline {
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
         timestamps()
-        skipDefaultCheckout()
     }
 
     stages {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -58,7 +58,7 @@ pipeline {
     }
 
     parameters {
-        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.CORDA_REVISION, description: 'Commit ID to check out of SCM')
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: '', description: 'Commit ID to check out of SCM - leave blank to take head of current branch')
     }
 
     options {
@@ -70,7 +70,7 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) {
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) { // CHANGE_ID only populated in PRs
                         echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -70,8 +70,14 @@ pipeline {
     stages {
         stage('check out') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: "*/${params.COMMIT_TO_CHECKOUT}"]], extensions: [],
-                    userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])
+                script {
+                    if (params.COMMIT_TO_CHECKOUT && !changeRequest()) {
+                        echo "CommitID to checkOut ${params.COMMIT_TO_CHECKOUT}"
+                        sh 'git checkout "$COMMIT_TO_CHECKOUT"'
+                    } else {
+                        echo "checking out Head revision of ${env.BRANCH_NAME}"
+                    }
+                }
             }
         }
 		  

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -70,7 +70,7 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && !changeRequest()) {
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID != null) {
                         echo "CommitID to checkOut ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -56,12 +56,26 @@ pipeline {
         CORDA_REVISION = "${env.GIT_COMMIT}"
         GRADLE_PERFORMANCE_TUNING = "--max-workers=4 --parallel -Dscan.tag.combined-worker --build-cache -Si"
     }
+
+    parameters {
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.GIT_COMMIT, description: 'Commit ID to check out of SCM')
+    }
+
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
         timestamps()
+        skipDefaultCheckout()
     }
+
     stages {
-		  //stage create DB - see shared pipline
+        stage('check out') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: "*/${params.COMMIT_TO_CHECKOUT}"]], extensions: [],
+                    userRemoteConfigs: [[credentialsId: 'corda-jenkins-ci02', url: 'https://github.com/corda/corda-runtime-os.git']]])
+            }
+        }
+		  
+        //stage create DB - see shared pipline
         stage('create DBs') {
             environment {
                 KUBECONFIG = credentials('e2e-tests-credentials')

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -70,11 +70,11 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID != null) {
-                        echo "CommitID to checkOut ${params.COMMIT_TO_CHECKOUT}"
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) {
+                        echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
-                        echo "checking out Head revision of ${env.BRANCH_NAME}"
+                        echo "Checking out Head revision of ${env.BRANCH_NAME} and merging into ${env.CHANGE_TARGET}"
                     }
                 }
             }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -58,7 +58,7 @@ pipeline {
     }
 
     parameters {
-        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.GIT_COMMIT, description: 'Commit ID to check out of SCM')
+        string(name: 'COMMIT_TO_CHECKOUT', defaultValue: env.CORDA_REVISION, description: 'Commit ID to check out of SCM')
     }
 
     options {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -74,7 +74,11 @@ pipeline {
                         echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
-                        echo "Checking out Head revision of ${env.BRANCH_NAME} and merging into ${env.CHANGE_TARGET}"
+                        if (env.CHANGE_ID) {
+                            echo "Checking out head revision of ${env.BRANCH_NAME} and merging into ${env.CHANGE_TARGET}"
+                        } else {
+                            echo "Checking out head revision of ${env.BRANCH_NAME}"
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@ronanb/CORE-9006/ensure-correct-commit-ID-used') _
+@Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaPipeline(
     dailyBuildCron: 'H H/6 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
+@Library('corda-shared-build-pipeline-steps@ronanb/CORE-9006/ensure-correct-commit-ID-used') _
 
 cordaPipeline(
     dailyBuildCron: 'H H/6 * * *',


### PR DESCRIPTION
- add needed logic to ensure combined worker and E2E test pipeline commit ID lines up with that of triggering job in all cases. 

As it stands, it is possible that if a second PR is merged prior to the release branch hitting these downstream jobs it will not be testing the expected code.  

This commit adds a new Jenkins parameter 'COMMIT_ID' to both embedded jobs, logic in the shared library will pass this downstream to ensure correct code is under test in all cases

**Not to be merged before:**
https://github.com/corda/corda-shared-build-pipeline-steps/pull/519
