### PR TITLE
NOTICK - secrets-exception-change

### DIFF
--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/SecretsConfigurationException.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/SecretsConfigurationException.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.configuration.secret
 
-import net.corda.v5.base.exceptions.CordaRuntimeException
-
+/**
+ * Exception thrown to indicate a problem with using configuration items that are marked as secrets.
+ */
 class SecretsConfigurationException(message: String, cause: Throwable? = null):
-    CordaRuntimeException(message, cause)
+    Exception(message, cause)


### PR DESCRIPTION
`SecretsConfigurationException` does not need to be a `CordaRuntimeException` as it never is used as part of a CorDapp.