### PR TITLE
CORE-9471 - Fix issue with views

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
@@ -24,7 +24,6 @@ internal class QueryRegistrationRequestHandler(persistenceHandlerServices: Persi
                 .where(
                     criteriaBuilder.and(
                         criteriaBuilder.equal(root.get<String>("registrationId"), request.registrationRequestId),
-                        criteriaBuilder.equal(root.get<String>("holdingIdentityShortHash"), shortHash.value),
                     )
                 ).orderBy()
             val details =

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
@@ -20,15 +20,11 @@ internal class QueryRegistrationRequestHandler(persistenceHandlerServices: Persi
             val root = queryBuilder.from(RegistrationRequestEntity::class.java)
             val query = queryBuilder
                 .select(root)
-                .where(
-                    criteriaBuilder.and(
-                        criteriaBuilder.equal(root.get<String>("registrationId"), request.registrationRequestId),
-                    )
-                ).orderBy()
+                .where(criteriaBuilder.equal(root.get<String>("registrationId"), request.registrationRequestId))
             val details =
                 em.createQuery(query)
                     .resultList
-                    .firstOrNull()
+                    .singleOrNull()
                     ?.toDetails()
             RegistrationRequestQueryResponse(details)
         }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
@@ -15,7 +15,6 @@ internal class QueryRegistrationRequestHandler(persistenceHandlerServices: Persi
     ): RegistrationRequestQueryResponse {
         val shortHash = context.holdingIdentity.toCorda().shortHash
         return transaction(shortHash) { em ->
-
             val criteriaBuilder = em.criteriaBuilder
             val queryBuilder = criteriaBuilder.createQuery(RegistrationRequestEntity::class.java)
             val root = queryBuilder.from(RegistrationRequestEntity::class.java)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
@@ -24,7 +24,7 @@ internal class QueryRegistrationRequestHandler(persistenceHandlerServices: Persi
             val details =
                 em.createQuery(query)
                     .resultList
-                    .singleOrNull()
+                    .firstOrNull()
                     ?.toDetails()
             RegistrationRequestQueryResponse(details)
         }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
@@ -42,18 +42,15 @@ class QueryRegistrationRequestHandlerTest {
     }
     private val entityTransaction = mock<EntityTransaction>()
     private val registrationIdPath = mock<Path<String>>()
-    private val holdingIdentityShortHashPath = mock<Path<String>>()
     private val registrationId = "id"
     private val root = mock<Root<RegistrationRequestEntity>> {
         on { get<String>("registrationId") } doReturn registrationIdPath
-        on { get<String>("holdingIdentityShortHash") } doReturn holdingIdentityShortHashPath
     }
     private val predicate = mock<Predicate>()
     private val query = mock<CriteriaQuery<RegistrationRequestEntity>> {
         on { from(RegistrationRequestEntity::class.java) } doReturn root
         on { select(root) } doReturn mock
         on { where(predicate) } doReturn mock
-        on { orderBy() } doReturn mock
     }
     private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>> {
         on { deserialize(any()) } doReturn KeyValuePairList(emptyList())
@@ -65,8 +62,6 @@ class QueryRegistrationRequestHandlerTest {
     private val criteriaBuilder = mock<CriteriaBuilder> {
         on { createQuery(RegistrationRequestEntity::class.java) } doReturn query
         on { equal(registrationIdPath, registrationId) } doReturn predicate
-        on { equal(holdingIdentityShortHashPath, shortHash.value) } doReturn predicate
-        on { and(predicate, predicate) } doReturn predicate
     }
     private val actualQuery = mock<TypedQuery<RegistrationRequestEntity>>()
     private val entityManager = mock<EntityManager> {


### PR DESCRIPTION
**Description of the issue**
Unable to get registration status of member’s registration ID using the MGM’s holding identity on the MGM’s cluster.

**Fix**
The built query contained a filter for the holding identity by mistake. The holding ID provided for querying should only determine which member's view we want to see. Not whose request we want to see.

**Testing**
1) From MGM's POV Alice's registration request:
![Screenshot 2023-01-24 at 14 43 04](https://user-images.githubusercontent.com/61757742/214340941-ca3cccdc-eef6-4843-ae43-aac59ce16e4d.png)
2) From Alice's POV Alice's registration request:
![Screenshot 2023-01-24 at 14 43 34](https://user-images.githubusercontent.com/61757742/214341018-ace738d9-afd2-46e2-8c80-9b2584f4bafa.png)

