### PR TITLE
CORE-9624: Increase Test Stage Timeout

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -179,7 +179,7 @@ pipeline {
                 INITIAL_ADMIN_USER_PASSWORD = "${E2E_CLUSTER_B_RPC_PASSWORD}"
             }
             options {
-                timeout(time: 20, unit: 'MINUTES')
+                timeout(time: 30, unit: 'MINUTES')
             }
             steps {
                 script {


### PR DESCRIPTION
Considering that smokeTest + e2eTest generally take ~18m, having a
timeout of 20 minutes seems too tight for situations on which there's
infrastructure slowness or hiccups. Increase the timeout to 30 minutes
to have some extra room and reduce cancelled builds.
