### PR TITLE
NOTICK: Fix failing AmqpSerializationTests

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
@@ -8,7 +8,6 @@ import net.corda.applications.workers.smoketest.awaitRpcFlowFinished
 import net.corda.applications.workers.smoketest.conditionallyUploadCordaPackage
 import net.corda.applications.workers.smoketest.getHoldingIdShortHash
 import net.corda.applications.workers.smoketest.getOrCreateVirtualNodeFor
-import net.corda.applications.workers.smoketest.registerMember
 import net.corda.applications.workers.smoketest.startRpcFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
@@ -42,8 +41,6 @@ class AmqpSerializationTests {
             // Just validate the function and actual vnode holding ID hash are in sync
             // if this fails the X500_BOB formatting could have changed or the hash implementation might have changed
             assertThat(bobActualHoldingId).isEqualTo(bobActualHoldingId)
-
-            registerMember(bobActualHoldingId)
         }
     }
 


### PR DESCRIPTION
Remove member registration from `AmqpSerializationTests`.