### PR TITLE
CORE-7707 Liquibase logging through SLF4J

### DIFF
--- a/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogService.kt
+++ b/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogService.kt
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 
 class Slf4jLogService : AbstractLogService() {
 
-    override fun getPriority() = 5
+    override fun getPriority() = PRIORITY_SPECIALIZED
     override fun getLog(clazz: Class<*>?) = Slf4jLogger(LoggerFactory.getLogger(clazz))
 
 }

--- a/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogService.kt
+++ b/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogService.kt
@@ -1,0 +1,11 @@
+package net.corda.cli.plugins.dbconfig
+
+import liquibase.logging.core.AbstractLogService
+import org.slf4j.LoggerFactory
+
+class Slf4jLogService : AbstractLogService() {
+
+    override fun getPriority() = 5
+    override fun getLog(clazz: Class<*>?) = Slf4jLogger(LoggerFactory.getLogger(clazz))
+
+}

--- a/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogger.kt
+++ b/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogger.kt
@@ -1,0 +1,90 @@
+package net.corda.cli.plugins.dbconfig
+
+import org.slf4j.Logger
+import java.util.logging.Level
+
+class Slf4jLogger(private val logger: Logger) : liquibase.logging.core.AbstractLogger() {
+
+    companion object {
+        private val TRACE_THRESHOLD = Level.FINEST.intValue()
+        private val DEBUG_THRESHOLD = Level.FINE.intValue()
+        private val INFO_THRESHOLD = Level.INFO.intValue()
+        private val WARN_THRESHOLD = Level.WARNING.intValue()
+    }
+
+    override fun log(level: Level, message: String?, e: Throwable?) {
+        val levelValue = level.intValue()
+        if (levelValue <= TRACE_THRESHOLD) {
+            logger.trace(message, e)
+        } else if (levelValue <= DEBUG_THRESHOLD) {
+            logger.debug(message, e)
+        } else if (levelValue <= INFO_THRESHOLD) {
+            logger.info(message, e)
+        } else if (levelValue <= WARN_THRESHOLD) {
+            logger.warn(message, e)
+        } else {
+            logger.error(message, e)
+        }
+    }
+
+    override fun severe(message: String?) {
+        if (logger.isErrorEnabled) {
+            logger.error(message)
+        }
+    }
+
+    override fun severe(message: String?, e: Throwable?) {
+        if (logger.isErrorEnabled) {
+            logger.error(message, e)
+        }
+    }
+
+    override fun warning(message: String?) {
+        if (logger.isWarnEnabled) {
+            logger.warn(message)
+        }
+    }
+
+    override fun warning(message: String?, e: Throwable?) {
+        if (logger.isWarnEnabled) {
+            logger.warn(message, e)
+        }
+    }
+    
+    override fun info(message: String?) {
+        if (logger.isInfoEnabled) {
+            logger.info(message)
+        }
+    }
+
+    override fun info(message: String?, e: Throwable?) {
+        if (logger.isInfoEnabled) {
+            logger.info(message, e)
+        }
+    }
+
+    override fun config(message: String?) {
+        if (logger.isInfoEnabled) {
+            logger.info(message)
+        }
+    }
+    
+    override fun config(message: String?, e: Throwable?) {
+        if (logger.isInfoEnabled) {
+            logger.info(message, e)
+        }
+    }
+    
+    override fun fine(message: String?) {
+        if (logger.isDebugEnabled) {
+            logger.debug(message)
+        }
+    }
+
+    override fun fine(message: String?, e: Throwable?) {
+        if (logger.isDebugEnabled) {
+            logger.debug(message, e)
+        }
+    }
+
+}

--- a/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogger.kt
+++ b/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/Slf4jLogger.kt
@@ -28,63 +28,43 @@ class Slf4jLogger(private val logger: Logger) : liquibase.logging.core.AbstractL
     }
 
     override fun severe(message: String?) {
-        if (logger.isErrorEnabled) {
-            logger.error(message)
-        }
+        logger.error(message)
     }
 
     override fun severe(message: String?, e: Throwable?) {
-        if (logger.isErrorEnabled) {
-            logger.error(message, e)
-        }
+        logger.error(message, e)
     }
 
     override fun warning(message: String?) {
-        if (logger.isWarnEnabled) {
-            logger.warn(message)
-        }
+        logger.warn(message)
     }
 
     override fun warning(message: String?, e: Throwable?) {
-        if (logger.isWarnEnabled) {
-            logger.warn(message, e)
-        }
+        logger.warn(message, e)
     }
     
     override fun info(message: String?) {
-        if (logger.isInfoEnabled) {
-            logger.info(message)
-        }
+        logger.info(message)
     }
 
     override fun info(message: String?, e: Throwable?) {
-        if (logger.isInfoEnabled) {
-            logger.info(message, e)
-        }
+        logger.info(message, e)
     }
 
     override fun config(message: String?) {
-        if (logger.isInfoEnabled) {
-            logger.info(message)
-        }
+        logger.info(message)
     }
     
     override fun config(message: String?, e: Throwable?) {
-        if (logger.isInfoEnabled) {
-            logger.info(message, e)
-        }
+        logger.info(message, e)
     }
     
     override fun fine(message: String?) {
-        if (logger.isDebugEnabled) {
-            logger.debug(message)
-        }
+        logger.debug(message)
     }
 
     override fun fine(message: String?, e: Throwable?) {
-        if (logger.isDebugEnabled) {
-            logger.debug(message, e)
-        }
+        logger.debug(message, e)
     }
 
 }

--- a/tools/plugins/db-config/src/main/resources/META-INF/services/liquibase.logging.LogService
+++ b/tools/plugins/db-config/src/main/resources/META-INF/services/liquibase.logging.LogService
@@ -1,0 +1,1 @@
+net.corda.cli.plugins.dbconfig.Slf4jLogService


### PR DESCRIPTION
By default, Liquibase sends all logs to stderr as stdout may be used for outputting the generating SQL. The CLI is writing SQL to files though and we'd rather not see "errors" in the install logs as they tend to jump out at customers. This PR adds a custom logger to Liquibase that just forwards through to SLF4J at the expected log levels.