### PR TITLE
CORE-9670: Register Transient Kafka Commit Errors

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImpl.kt
@@ -100,37 +100,44 @@ class CordaKafkaProducerImpl(
     }
 
     override fun commitTransaction() {
-        var failedDueToRetryable = false
+        var retryableException: KafkaException? = null
+
         tryWithCleanupOnFailure("committing transaction") {
-            if (!commitTransactionAndCatchRetryable()) {
+            retryableException = commitTransactionAndCatchRetryable()
+
+            if (retryableException != null) {
                 // We can/should retry this kind of failure under the contract of the Kafka producer, abort is neither
                 // required nor allowed. We allow a single retry only.
-                failedDueToRetryable = !commitTransactionAndCatchRetryable()
+                log.warn("Unexpected transient error committing transaction, re-trying", retryableException)
+                retryableException = commitTransactionAndCatchRetryable()
             }
         }
 
-        if (failedDueToRetryable) {
-            // We have retired once, we are not retrying again, so the only other option compatible with the producer
+        if (retryableException != null) {
+            // We have retried once, we are not retrying again, so the only other option compatible with the producer
             // contract is to close the producer without aborting. That is the responsibility of the client, which we
             // notify by throwing the relevant exception.
-            throw CordaMessageAPIProducerRequiresReset("Unexpected error occurred committing transaction")
+            throw CordaMessageAPIProducerRequiresReset(
+                "Unexpected error occurred committing transaction",
+                retryableException
+            )
         }
     }
 
     /**
      * The contract of the Kafka producer is that certain types of errors have their own process for handling.
      * If a commit is interrupted or timed out, we cannot abort, but it is safe to retry the commit if we want.
-     * This method catches those exceptions and returns whether that happened or not.
+     * This method catches those exceptions and returns them if they happened.
      *
-     * @return true if successful, false if not and can be retried, otherwise throws whatever the producer throws
+     * @return null if successful, exception instance transaction can be retried, otherwise throws whatever thrown by the producer.
      */
     private fun commitTransactionAndCatchRetryable() = try {
         producer.commitTransaction()
-        true
+        null
     } catch (ex: TimeoutException) {
-        false
+        ex
     } catch (ex: InterruptException) {
-        false
+        ex
     }
 
     override fun sendAllOffsetsToTransaction(consumer: CordaConsumer<*, *>) {
@@ -163,8 +170,10 @@ class CordaKafkaProducerImpl(
         try {
             producer.close()
         } catch (ex: Exception) {
-            log.info("CordaKafkaProducer failed to close producer safely. This can be observed when there are " +
-                    "no reachable brokers. ClientId: ${config.clientId}", ex)
+            log.info(
+                "CordaKafkaProducer failed to close producer safely. This can be observed when there are " +
+                        "no reachable brokers. ClientId: ${config.clientId}", ex
+            )
         }
     }
 

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImplTest.kt
@@ -20,7 +20,7 @@ import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.errors.InvalidProducerEpochException
 import org.apache.kafka.common.errors.ProducerFencedException
 import org.apache.kafka.common.errors.TimeoutException
-import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -188,8 +188,10 @@ class CordaKafkaProducerImplTest {
     @Test
     fun testTryCommitTransactionRetry() {
         whenever(producer.commitTransaction()).thenThrow(TimeoutException()).thenThrow(InterruptException(""))
-        assertThrows<CordaMessageAPIProducerRequiresReset> { cordaKafkaProducer.commitTransaction() }
+        val exception = assertThrows<CordaMessageAPIProducerRequiresReset> { cordaKafkaProducer.commitTransaction() }
         verify(producer, times(2)).commitTransaction()
+        assertNotNull(exception.cause)
+        assertInstanceOf(InterruptException::class.java, exception.cause)
     }
 
     @Test

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImplTest.kt
@@ -20,7 +20,9 @@ import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.errors.InvalidProducerEpochException
 import org.apache.kafka.common.errors.ProducerFencedException
 import org.apache.kafka.common.errors.TimeoutException
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows


### PR DESCRIPTION
Log a warning message with the actual exception whenever a retryable
error is thrown by Kafka while trying to commit a transaction. If the
error persists, use the exception as the root cause when throwing
CordaMessageAPIProducerRequiresReset so no information is lost.
