### PR TITLE
CORE-9692: Upgrade OSGi SCR 2.2.4 -> 2.2.6.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ cordaApiVersion=5.0.0.624-beta+
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5
-felixScrVersion=2.2.4
+felixScrVersion=2.2.6
 felixSecurityVersion=2.8.3
 # NOTE: Guava cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.


### PR DESCRIPTION
This upgrade fixes [FELIX-6581](https://issues.apache.org/jira/browse/FELIX-6581), which (based solely on its description) we're unlikely to hit. But we should be running the latest version regardless.