### PR TITLE
CORE-7276 argumentless sign

### DIFF
--- a/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/transaction/TransactionSignatureService.kt
+++ b/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/transaction/TransactionSignatureService.kt
@@ -8,7 +8,7 @@ import java.security.PublicKey
 
 interface TransactionSignatureService {
     @Suspendable
-    fun sign(transactionId: SecureHash, publicKeys: Set<PublicKey>): List<DigitalSignatureAndMetadata>
+    fun sign(transactionId: SecureHash, publicKeys: Iterable<PublicKey>): List<DigitalSignatureAndMetadata>
 
     /**
      * The underlying verification service signals the verification failures with different exceptions.

--- a/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/transaction/TransactionSignatureService.kt
+++ b/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/transaction/TransactionSignatureService.kt
@@ -8,7 +8,7 @@ import java.security.PublicKey
 
 interface TransactionSignatureService {
     @Suspendable
-    fun sign(transactionId: SecureHash, publicKey: PublicKey): DigitalSignatureAndMetadata
+    fun sign(transactionId: SecureHash, publicKeys: Set<PublicKey>): List<DigitalSignatureAndMetadata>
 
     /**
      * The underlying verification service signals the verification failures with different exceptions.

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -48,8 +48,8 @@ class TransactionSignatureServiceImpl @Activate constructor(
     private val digestService: DigestService,
 ) : TransactionSignatureService, SingletonSerializeAsToken, UsedByFlow {
     @Suspendable
-    override fun sign(transactionId: SecureHash, publicKeys: Set<PublicKey>): List<DigitalSignatureAndMetadata> {
-        return signingService.findMySigningKeys(publicKeys).values.filterNotNull().map { publicKey ->
+    override fun sign(transactionId: SecureHash, publicKeys: Iterable<PublicKey>): List<DigitalSignatureAndMetadata> {
+        return signingService.findMySigningKeys(publicKeys.toSet()).values.filterNotNull().map { publicKey ->
             val signatureSpec = signatureSpecService.defaultSignatureSpec(publicKey)
             requireNotNull(signatureSpec) {
                 "There are no available signature specs for this public key. ($publicKey ${publicKey.algorithm})"

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -34,27 +34,22 @@ class ConsensualSignedTransactionImpl(
     override fun toLedgerTransaction(): ConsensualLedgerTransaction =
         ConsensualLedgerTransactionImpl(this.wireTransaction, serializationService)
 
-    @Suspendable
-    override fun sign(publicKey: PublicKey): Pair<ConsensualSignedTransactionInternal, DigitalSignatureAndMetadata> {
-        val newSignature = transactionSignatureService.sign(id, publicKey)
-        return Pair(
-            ConsensualSignedTransactionImpl(
-                serializationService,
-                transactionSignatureService,
-                wireTransaction,
-            signatures + newSignature
-            ),
-            newSignature
-        )
-    }
-
     override fun addSignature(signature: DigitalSignatureAndMetadata): ConsensualSignedTransactionInternal =
         ConsensualSignedTransactionImpl(serializationService, transactionSignatureService,
             wireTransaction, signatures + signature)
 
     @Suspendable
     override fun addMissingSignatures(): Pair<ConsensualSignedTransactionInternal, List<DigitalSignatureAndMetadata>>{
-        TODO("Not implemented yet")
+        val newSignatures = transactionSignatureService.sign(id, getMissingSignatories())
+        return Pair(
+            ConsensualSignedTransactionImpl(
+                serializationService,
+                transactionSignatureService,
+                wireTransaction,
+                signatures + newSignatures
+            ),
+            newSignatures
+        )
     }
 
     override fun getMissingSignatories(): Set<PublicKey> {

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
@@ -17,16 +17,6 @@ interface ConsensualSignedTransactionInternal: ConsensualSignedTransaction {
     val wireTransaction: WireTransaction
 
     /**
-     * Sign the current [ConsensualSignedTransactionInternal] with the specified key.
-     *
-     * @param publicKey The private counterpart of the specified public key will be used for signing the
-     *      [ConsensualSignedTransaction].
-     * @return Returns the new [ConsensualSignedTransactionInternal] containing the applied signature and the signature itself.
-     */
-    @Suspendable
-    fun sign(publicKey: PublicKey): Pair<ConsensualSignedTransactionInternal, DigitalSignatureAndMetadata>
-
-    /**
      * Adds a signature to the current [ConsensualSignedTransactionInternal].
      *
      * @param signature The signature to be added to the [ConsensualSignedTransactionInternal].
@@ -40,12 +30,10 @@ interface ConsensualSignedTransactionInternal: ConsensualSignedTransaction {
      * if there are any. (Disabled until crypto support becomes available.)
      *
      * @return Returns the new [ConsensualSignedTransactionInternal] containing the applied signature and a
-     *          list of added signatures.
+     *          list of the added signatures.
      */
     @Suspendable
-    fun addMissingSignatures(): Pair<ConsensualSignedTransactionInternal, List<DigitalSignatureAndMetadata>>{
-        TODO("Not implemented yet")
-    }
+    fun addMissingSignatures(): Pair<ConsensualSignedTransactionInternal, List<DigitalSignatureAndMetadata>>
 
     /**
      * Gets the missing signatories from the current [ConsensualSignedTransactionInternal].

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactory.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactory.kt
@@ -5,13 +5,11 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
-import java.security.PublicKey
 
 interface ConsensualSignedTransactionFactory {
     @Suspendable
     fun create(
         consensualTransactionBuilder: ConsensualTransactionBuilder,
-        signatories: Iterable<PublicKey>
     ): ConsensualSignedTransaction
 
     fun create(

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -18,6 +18,7 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
@@ -70,6 +71,9 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
                 wireTransaction.id,
                 consensualTransactionBuilder.states.flatMap { it.participants }.toSet()
             )
+        if (signaturesWithMetadata.isEmpty()){
+            throw CordaRuntimeException("None of the required keys were available to sign the transaction.")
+        }
         return ConsensualSignedTransactionImpl(
             serializationService,
             transactionSignatureService,

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -69,7 +69,7 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
         val signaturesWithMetadata =
             transactionSignatureService.sign(
                 wireTransaction.id,
-                consensualTransactionBuilder.states.flatMap { it.participants }.toSet()
+                consensualTransactionBuilder.states.flatMap { it.participants }
             )
         if (signaturesWithMetadata.isEmpty()){
             throw CordaRuntimeException("None of the required keys were available to sign the transaction.")

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.ledger.consensual.flow.impl
 
-import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.ledger.consensual.testkit.consensualStateExample
 import net.corda.v5.crypto.SecureHash
@@ -17,12 +16,11 @@ class ConsensualLedgerServiceImplTest: ConsensualLedgerTest() {
     }
 
     @Test
-    @Suppress("DEPRECATION")
     fun `ConsensualLedgerServiceImpl's getTransactionBuilder() can build a SignedTransaction`() {
         val transactionBuilder = consensualLedgerService.getTransactionBuilder()
         val signedTransaction = transactionBuilder
             .withStates(consensualStateExample)
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
         assertIs<ConsensualSignedTransaction>(signedTransaction)
         assertIs<SecureHash>(signedTransaction.id)
     }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualLedgerTransactionImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualLedgerTransactionImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.ledger.consensual.flow.impl.transaction
 
-import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.ledger.consensual.testkit.ConsensualStateClassExample
 import net.corda.ledger.consensual.testkit.consensualStateExample
@@ -13,7 +12,6 @@ import java.time.Instant
 import kotlin.math.abs
 import kotlin.test.assertIs
 
-@Suppress("DEPRECATION")
 class ConsensualLedgerTransactionImplTest: ConsensualLedgerTest() {
     @Test
     fun `ledger transaction contains the same data what it was created with`() {
@@ -21,7 +19,7 @@ class ConsensualLedgerTransactionImplTest: ConsensualLedgerTest() {
         val signedTransaction = ConsensualTransactionBuilderImpl(
             consensualSignedTransactionFactory)
             .withStates(consensualStateExample)
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
         val ledgerTransaction = signedTransaction.toLedgerTransaction()
         assertTrue(abs(ledgerTransaction.timestamp.toEpochMilli() / 1000 - testTimestamp.toEpochMilli() / 1000) < 5)
         assertIs<List<ConsensualState>>(ledgerTransaction.states)

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
@@ -2,7 +2,6 @@ package net.corda.ledger.consensual.flow.impl.transaction
 
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.common.test.dummyCpkSignerSummaryHash
-import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.ledger.consensual.testkit.ConsensualStateClassExample
 import net.corda.ledger.consensual.testkit.consensualStateExample
@@ -12,13 +11,12 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import kotlin.test.assertIs
 
-@Suppress("DEPRECATION")
 internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
     @Test
     fun `can build a simple Transaction`() {
         val tx = consensualTransactionBuilder
             .withStates(consensualStateExample)
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
         assertIs<SecureHash>(tx.id)
     }
 
@@ -28,15 +26,15 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
             val builder = consensualTransactionBuilder
                 .withStates(consensualStateExample)
 
-            builder.toSignedTransaction(publicKeyExample)
-            builder.toSignedTransaction(publicKeyExample)
+            builder.toSignedTransaction()
+            builder.toSignedTransaction()
         }
     }
 
     @Test
     fun `cannot build Transaction without Consensual States`() {
         val exception = assertThrows(IllegalArgumentException::class.java) {
-            consensualTransactionBuilder.toSignedTransaction(publicKeyExample)
+            consensualTransactionBuilder.toSignedTransaction()
         }
         assertEquals("At least one consensual state is required", exception.message)
     }
@@ -47,7 +45,7 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
             consensualTransactionBuilder
                 .withStates(consensualStateExample)
                 .withStates(ConsensualStateClassExample("test", emptyList()))
-                .toSignedTransaction(publicKeyExample)
+                .toSignedTransaction()
         }
         assertEquals("All consensual states must have participants", exception.message)
     }
@@ -56,7 +54,7 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
     fun `includes CPI and CPK information in metadata`() {
         val tx = consensualTransactionBuilder
             .withStates(consensualStateExample)
-            .toSignedTransaction(publicKeyExample) as ConsensualSignedTransactionImpl
+            .toSignedTransaction() as ConsensualSignedTransactionImpl
 
         val metadata = tx.wireTransaction.metadata
         assertEquals(1, metadata.getLedgerVersion())

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
@@ -3,8 +3,6 @@ package net.corda.ledger.persistence.consensual.tests
 import net.corda.common.json.validation.JsonValidator
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.testkit.DbUtils
-import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
-import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
@@ -29,12 +27,9 @@ import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.utilities.time.Clock
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
-import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.PrivacySalt
 import org.assertj.core.api.Assertions.assertThat
@@ -60,7 +55,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.persistence.EntityManagerFactory
-import kotlin.random.Random
 
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -3,8 +3,6 @@ package net.corda.ledger.persistence.utxo.tests
 import net.corda.common.json.validation.JsonValidator
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.testkit.DbUtils
-import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
-import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
@@ -33,13 +31,10 @@ import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.utilities.time.Clock
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
-import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.PrivacySalt
@@ -75,7 +70,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.persistence.EntityManagerFactory
-import kotlin.random.Random
 
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
@@ -93,24 +93,9 @@ class UtxoReceiveFinalityFlow(
     private fun signTransaction(
         initialTransaction: UtxoSignedTransactionInternal,
     ): Pair<UtxoSignedTransactionInternal, Payload<List<DigitalSignatureAndMetadata>>> {
-        val myKeys = memberLookup.getMyLedgerKeys()
-        // Which of our keys are required.
-        val myExpectedSigningKeys = initialTransaction
-            .getMissingSignatories()
-            .intersect(myKeys)
-
-        if (myExpectedSigningKeys.isEmpty()) {
-            log.debug { "We are not required signer of ${initialTransaction.id}." }
-        }
-
-        var transaction = initialTransaction
-        val mySignatures = myExpectedSigningKeys.map { publicKey ->
-            log.debug { "Signing transaction: ${initialTransaction.id} with $publicKey" }
-            transaction.sign(publicKey).also {
-                transaction = it.first
-            }.second
-        }
-
+        log.debug { "Signing transaction: ${initialTransaction.id} with our available required keys." }
+        val (transaction, mySignatures) = initialTransaction.addMissingSignatures()
+        log.debug { "Signing transaction: ${initialTransaction.id} resulted (${mySignatures.size}) signatures." }
         return transaction to Payload.Success(mySignatures)
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -54,28 +54,23 @@ data class UtxoSignedTransactionImpl(
     override val commands: List<Command>
         get() = wrappedWireTransaction.commands
 
+    override fun addSignature(signature: DigitalSignatureAndMetadata): UtxoSignedTransactionInternal =
+        UtxoSignedTransactionImpl(serializationService, transactionSignatureService, utxoLedgerTransactionFactory,
+            wireTransaction, signatures + signature)
+
     @Suspendable
-    override fun sign(publicKey: PublicKey): Pair<UtxoSignedTransactionInternal, DigitalSignatureAndMetadata> {
-        val newSignature = transactionSignatureService.sign(id, publicKey)
+    override fun addMissingSignatures(): Pair<UtxoSignedTransactionInternal, List<DigitalSignatureAndMetadata>> {
+        val newSignatures = transactionSignatureService.sign(id, getMissingSignatories())
         return Pair(
             UtxoSignedTransactionImpl(
                 serializationService,
                 transactionSignatureService,
                 utxoLedgerTransactionFactory,
                 wireTransaction,
-                signatures + newSignature
+                signatures + newSignatures
             ),
-            newSignature
+            newSignatures
         )
-    }
-
-    override fun addSignature(signature: DigitalSignatureAndMetadata): UtxoSignedTransactionInternal =
-        UtxoSignedTransactionImpl(serializationService, transactionSignatureService, utxoLedgerTransactionFactory,
-            wireTransaction, signatures + signature)
-
-    @Suspendable
-    override fun addMissingSignatures(): Pair<UtxoSignedTransactionInternal, List<DigitalSignatureAndMetadata>>{
-        TODO("Not implemented yet")
     }
 
     override fun getMissingSignatories(): Set<PublicKey> {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
@@ -17,16 +17,6 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
     val wireTransaction: WireTransaction
 
     /**
-     * Sign the current [UtxoSignedTransactionInternal] with the specified key.
-     *
-     * @param publicKey The private counterpart of the specified public key will be used for signing the
-     *      [UtxoSignedTransaction].
-     * @return Returns the new [UtxoSignedTransactionInternal] containing the applied signature and the signature itself.
-     */
-    @Suspendable
-    fun sign(publicKey: PublicKey): Pair<UtxoSignedTransactionInternal, DigitalSignatureAndMetadata>
-
-    /**
      * Adds a signature to the current [UtxoSignedTransactionInternal].
      *
      * @param signature The signature to be added to the [UtxoSignedTransactionInternal].
@@ -40,12 +30,10 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
      * if there are any. (Disabled until crypto support becomes available.)
      *
      * @return Returns the new [UtxoSignedTransactionInternal] containing the applied signature and a
-     *          list of added signatures.
+     *          list of the added signatures.
      */
     @Suspendable
-    fun addMissingSignatures(): Pair<UtxoSignedTransactionInternal, List<DigitalSignatureAndMetadata>>{
-        TODO("Not implemented yet")
-    }
+    fun addMissingSignatures(): Pair<UtxoSignedTransactionInternal, List<DigitalSignatureAndMetadata>>
 
     /**
      * Gets the missing signatories from the current [UtxoSignedTransactionInternal].

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -123,34 +123,16 @@ data class UtxoTransactionBuilderImpl(
     }
 
     @Suspendable
-    override fun toSignedTransaction(): UtxoSignedTransaction {
-        TODO("Not yet implemented")
-    }
-
-    @Suspendable
-    @Deprecated("Temporary function until the argumentless version gets available")
-    override fun toSignedTransaction(signatory: PublicKey): UtxoSignedTransaction =
-        sign(listOf(signatory))
+    override fun toSignedTransaction(): UtxoSignedTransaction =
+        sign()
 
     @Suspendable
     fun sign(): UtxoSignedTransaction {
-        TODO("Not yet implemented")
-    }
-
-    @Suspendable
-    fun sign(vararg signatories: PublicKey): UtxoSignedTransaction =
-        sign(signatories.toList())
-
-    @Suspendable
-    fun sign(signatories: Iterable<PublicKey>): UtxoSignedTransaction {
         check(!alreadySigned) { "The transaction cannot be signed twice." }
-        require(signatories.toList().isNotEmpty()) {
-            "At least one key needs to be provided in order to create a signed Transaction!"
-        }
         UtxoTransactionBuilderVerifier(this).verify()
-        val tx = utxoSignedTransactionFactory.create(this, signatories)
-        alreadySigned = true
-        return tx
+        return utxoSignedTransactionFactory.create(this, signatories).also {
+            alreadySigned = true
+        }
     }
 
     private fun ContractState.withEncumbrance(tag: String?): ContractStateAndEncumbranceTag {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -75,7 +75,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
         val signaturesWithMetadata =
             transactionSignatureService.sign(
                 wireTransaction.id,
-                utxoTransactionBuilder.signatories.toSet()
+                utxoTransactionBuilder.signatories
             )
         if (signaturesWithMetadata.isEmpty()){
             throw CordaRuntimeException("None of the required keys were available to sign the transaction")

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -71,8 +71,11 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
 
         UtxoLedgerTransactionVerifier(utxoLedgerTransactionFactory.create(wireTransaction)).verify(utxoTransactionBuilder.notary!!)
 
-        val signaturesWithMetadata = signatories.map { transactionSignatureService.sign(wireTransaction.id, it) }
-
+        val signaturesWithMetadata =
+            transactionSignatureService.sign(
+                wireTransaction.id,
+                utxoTransactionBuilder.signatories.toSet()
+            )
         return UtxoSignedTransactionImpl(
             serializationService,
             transactionSignatureService,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -22,6 +22,7 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -76,6 +77,9 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
                 wireTransaction.id,
                 utxoTransactionBuilder.signatories.toSet()
             )
+        if (signaturesWithMetadata.isEmpty()){
+            throw CordaRuntimeException("None of the required keys were available to sign the transaction")
+        }
         return UtxoSignedTransactionImpl(
             serializationService,
             transactionSignatureService,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
@@ -19,7 +19,6 @@ import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import kotlin.test.assertIs
 
-@Suppress("DEPRECATION")
 class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
     @Test
     fun `getTransactionBuilder should return a Transaction Builder`() {
@@ -51,7 +50,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(command)
             .addAttachment(attachment)
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
 
         assertIs<UtxoSignedTransaction>(signedTransaction)
         assertIs<SecureHash>(signedTransaction.id)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoLedgerTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoLedgerTransactionImplTest.kt
@@ -18,7 +18,6 @@ import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import kotlin.test.assertIs
 
-@Suppress("DEPRECATION")
 internal class UtxoLedgerTransactionImplTest: UtxoLedgerTest() {
     @Test
     fun `ledger transaction contains the same data what it was created with`() {
@@ -45,7 +44,7 @@ internal class UtxoLedgerTransactionImplTest: UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(command)
             .addAttachment(attachment)
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
         val ledgerTransaction = signedTransaction.toLedgerTransaction()
 
         assertIs<SecureHash>(ledgerTransaction.id)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -19,7 +19,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import kotlin.test.assertIs
 
-@Suppress("DEPRECATION")
 internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
     @Test
     fun `can build a simple Transaction`() {
@@ -41,7 +40,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
         assertIs<SecureHash>(tx.id)
         assertEquals(inputStateRef, tx.inputStateRefs.single())
         assertEquals(referenceStateRef, tx.referenceStateRefs.single())
@@ -59,13 +58,13 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .addOutputState(utxoStateExample)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
         assertIs<SecureHash>(tx.id)
         assertThat(tx.inputStateRefs).isEmpty()
         assertThat(tx.referenceStateRefs).isEmpty()
         assertEquals(utxoStateExample, tx.outputStateAndRefs.single().state.contractState)
         assertEquals(utxoNotaryExample, tx.notary)
-        assertEquals(utxoTimeWindowExample, tx.timeWindow, )
+        assertEquals(utxoTimeWindowExample, tx.timeWindow,)
         assertEquals(publicKeyExample, tx.signatories.first())
     }
 
@@ -80,7 +79,7 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
-            .toSignedTransaction(publicKeyExample) as UtxoSignedTransactionImpl
+            .toSignedTransaction() as UtxoSignedTransactionImpl
 
         val metadata = tx.wireTransaction.metadata
         assertEquals(1, metadata.getLedgerVersion())
@@ -121,13 +120,13 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
                 .addCommand(UtxoCommandExample())
                 .addAttachment(SecureHash("SHA-256", ByteArray(12)))
 
-            builder.toSignedTransaction(publicKeyExample)
-            builder.toSignedTransaction(publicKeyExample)
+            builder.toSignedTransaction()
+            builder.toSignedTransaction()
         }
     }
 
     @Test
-    fun `Calculate encumbrance groups correctly`(){
+    fun `Calculate encumbrance groups correctly`() {
         val inputStateAndRef = getUtxoInvalidStateAndRef()
         val inputStateRef = inputStateAndRef.ref
         val referenceStateAndRef = getUtxoInvalidStateAndRef()
@@ -139,42 +138,54 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
         val tx = utxoTransactionBuilder
             .setNotary(utxoNotaryExample)
             .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
-            .addEncumberedOutputStates("encumbrance 1",
+            .addEncumberedOutputStates(
+                "encumbrance 1",
                 UtxoStateClassExample("test 1", listOf(publicKeyExample)),
-                UtxoStateClassExample("test 2", listOf(publicKeyExample)))
+                UtxoStateClassExample("test 2", listOf(publicKeyExample))
+            )
             .addOutputState(utxoStateExample)
-            .addEncumberedOutputStates("encumbrance 2",
+            .addEncumberedOutputStates(
+                "encumbrance 2",
                 UtxoStateClassExample("test 3", listOf(publicKeyExample)),
                 UtxoStateClassExample("test 4", listOf(publicKeyExample)),
-                UtxoStateClassExample("test 5", listOf(publicKeyExample)))
-            .addEncumberedOutputStates("encumbrance 1",
-                UtxoStateClassExample("test 6", listOf(publicKeyExample)))
+                UtxoStateClassExample("test 5", listOf(publicKeyExample))
+            )
+            .addEncumberedOutputStates(
+                "encumbrance 1",
+                UtxoStateClassExample("test 6", listOf(publicKeyExample))
+            )
             .addInputState(inputStateRef)
             .addReferenceState(referenceStateRef)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
 
         assertThat(tx.outputStateAndRefs).hasSize(7)
-        assertThat(tx.outputStateAndRefs[0].state.encumbrance).isNotNull().extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(tx.outputStateAndRefs[0].state.encumbrance).isNotNull().extracting { it?.tag }
+            .isEqualTo("encumbrance 1")
         assertThat(tx.outputStateAndRefs[0].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[1].state.encumbrance).isNotNull().extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(tx.outputStateAndRefs[1].state.encumbrance).isNotNull().extracting { it?.tag }
+            .isEqualTo("encumbrance 1")
         assertThat(tx.outputStateAndRefs[1].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
 
         assertThat(tx.outputStateAndRefs[2].state.encumbrance).isNull()
 
-        assertThat(tx.outputStateAndRefs[3].state.encumbrance).isNotNull().extracting { it?.tag }.isEqualTo("encumbrance 2")
+        assertThat(tx.outputStateAndRefs[3].state.encumbrance).isNotNull().extracting { it?.tag }
+            .isEqualTo("encumbrance 2")
         assertThat(tx.outputStateAndRefs[3].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[4].state.encumbrance).isNotNull().extracting { it?.tag }.isEqualTo("encumbrance 2")
+        assertThat(tx.outputStateAndRefs[4].state.encumbrance).isNotNull().extracting { it?.tag }
+            .isEqualTo("encumbrance 2")
         assertThat(tx.outputStateAndRefs[4].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[5].state.encumbrance).isNotNull().extracting { it?.tag }.isEqualTo("encumbrance 2")
+        assertThat(tx.outputStateAndRefs[5].state.encumbrance).isNotNull().extracting { it?.tag }
+            .isEqualTo("encumbrance 2")
         assertThat(tx.outputStateAndRefs[5].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[6].state.encumbrance).isNotNull().extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(tx.outputStateAndRefs[6].state.encumbrance).isNotNull().extracting { it?.tag }
+            .isEqualTo("encumbrance 1")
         assertThat(tx.outputStateAndRefs[6].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
 
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializerTest.kt
@@ -35,7 +35,6 @@ class UtxoSignedTransactionSerializerTest : UtxoLedgerTest() {
         assertEquals(utxoSignedTransactionExample.id, deserialized.id)
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun `serialize and deserialize with encumbrance`() {
         val inputStateAndRef = getUtxoInvalidStateAndRef()
@@ -60,7 +59,7 @@ class UtxoSignedTransactionSerializerTest : UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
-            .toSignedTransaction(publicKeyExample)
+            .toSignedTransaction()
 
         val bytes = serializationService.serialize(signedTx)
         val deserialized = serializationService.deserialize(bytes)

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,9 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-#cordaApiVersion=5.0.0.626-beta+
-#cordaApiVersion=5.0.0.626-beta+
-cordaApiVersion=5.0.0.626-alpha-1674726995669
+cordaApiVersion=5.0.0.626-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,9 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.625-beta+
+#cordaApiVersion=5.0.0.626-beta+
+#cordaApiVersion=5.0.0.626-beta+
+cordaApiVersion=5.0.0.626-alpha-1674726995669
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
@@ -54,10 +54,9 @@ class DoorCodeChangeFlow : ClientStartableFlow {
         val doorCodeState = DoorCodeConsensualState(newDoorCode, participants.map { getPublicKey(it) })
 
         val txBuilder = consensualLedgerService.getTransactionBuilder()
-        @Suppress("DEPRECATION")
         val signedTransaction = txBuilder
             .withStates(doorCodeState)
-            .toSignedTransaction(memberLookup.myInfo().ledgerKeys.first())
+            .toSignedTransaction()
 
         val sessions = initiateSessions(participants.minus(memberLookup.myInfo().name))
         val result = consensualLedgerService.finalize(signedTransaction, sessions)

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/ConsensualTransactionBuilderBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/ConsensualTransactionBuilderBase.kt
@@ -6,7 +6,6 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
-import java.security.PublicKey
 
 class ConsensualTransactionBuilderBase(
     override val states: List<ConsensualState>,
@@ -20,11 +19,6 @@ class ConsensualTransactionBuilderBase(
     }
 
     override fun toSignedTransaction(): ConsensualSignedTransaction {
-        TODO("Not yet implemented")
-    }
-
-    @Deprecated("Will be replaced by parameterless version")
-    override fun toSignedTransaction(signatory: PublicKey): ConsensualSignedTransaction {
         val unsignedTx = ConsensualSignedTransactionBase(
             listOf(),
             ConsensualStateLedgerInfo(
@@ -34,6 +28,6 @@ class ConsensualTransactionBuilderBase(
             signingService,
             configuration
         )
-        return unsignedTx.addSignature(signatory)
+        return unsignedTx.addSignature(memberLookup.myInfo().ledgerKeys.first())
     }
 }

--- a/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
+++ b/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
@@ -62,10 +62,9 @@ class ConsensualDemoFlow : ClientStartableFlow {
 
             val txBuilder = consensualLedgerService.getTransactionBuilder()
 
-            @Suppress("DEPRECATION")
             val signedTransaction = txBuilder
                 .withStates(testConsensualState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val sessions = members.map { flowMessaging.initiateFlow(it.name) }
 

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
@@ -63,7 +63,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
     @CordaInject
     lateinit var memberLookup: MemberLookup
 
-    @Suppress("DEPRECATION", "LongMethod")
+    @Suppress("LongMethod")
     @Suspendable
     override fun call(requestBody: RestRequestBody): String {
         log.info("UTXO backchain resolution demo flow starting!!...")
@@ -96,7 +96,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addOutputState(testState)
                 .addOutputState(testState)
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx2 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -106,7 +106,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addInputState(StateRef(signedTransaction.id, 0))
                 .addInputState(StateRef(signedTransaction.id, 1))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx3 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -116,7 +116,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addInputState(StateRef(signedTransaction.id, 2))
                 .addInputState(StateRef(signedTransaction.id, 3))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx4 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -125,7 +125,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addSignatories(listOf(myInfo.ledgerKeys.first()))
                 .addInputState(StateRef(signedTransaction.id, 4))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx5 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -134,7 +134,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addSignatories(listOf(myInfo.ledgerKeys.first()))
                 .addInputState(StateRef(tx2.id, 1))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx6 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -144,7 +144,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addInputState(StateRef(tx4.id, 0))
                 .addInputState(StateRef(tx5.id, 0))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx7 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -153,7 +153,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addSignatories(listOf(myInfo.ledgerKeys.first()))
                 .addInputState(StateRef(tx3.id, 0))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx8 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -164,7 +164,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addInputState(StateRef(tx7.id, 0))
                 .addOutputState(testState)
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx9 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -173,7 +173,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addSignatories(listOf(myInfo.ledgerKeys.first()))
                 .addInputState(StateRef(tx8.id, 0))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx10 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -182,7 +182,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addSignatories(listOf(myInfo.ledgerKeys.first()))
                 .addInputState(StateRef(tx8.id, 1))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val tx11 = utxoLedgerService.getTransactionBuilder()
                 .setNotary(Party(members.first().name, members.first().ledgerKeys.first()))
@@ -192,7 +192,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
                 .addInputState(StateRef(tx9.id, 0))
                 .addInputState(StateRef(tx10.id, 0))
                 .addOutputState(testState)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             /*
                     tx5
@@ -208,7 +208,21 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
              */
 
             for (session in sessions) {
-                session.send(listOf(signedTransaction.id, tx2.id, tx3.id, tx4.id, tx5.id, tx6.id, tx7.id, tx8.id, tx9.id, tx10.id, tx11.id))
+                session.send(
+                    listOf(
+                        signedTransaction.id,
+                        tx2.id,
+                        tx3.id,
+                        tx4.id,
+                        tx5.id,
+                        tx6.id,
+                        tx7.id,
+                        tx8.id,
+                        tx9.id,
+                        tx10.id,
+                        tx11.id
+                    )
+                )
             }
 
             utxoLedgerService.finalize(signedTransaction, emptyList())
@@ -244,7 +258,6 @@ class UtxoBackchainResolutionDemoResponderFlow : ResponderFlow {
     lateinit var utxoLedgerService: UtxoLedgerService
 
 
-    @Suppress("DEPRECATION")
     @Suspendable
     override fun call(session: FlowSession) {
         val txs = session.receive<List<SecureHash>>()

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
@@ -72,14 +72,13 @@ class UtxoDemoFlow : ClientStartableFlow {
             val notary = notaryLookup.notaryServices.single()
             val txBuilder = utxoLedgerService.getTransactionBuilder()
 
-            @Suppress("DEPRECATION")
             val signedTransaction = txBuilder
                 .setNotary(Party(notary.name, notary.publicKey))
                 .setTimeWindowBetween(Instant.now(), Instant.now().plusMillis(1.days.toMillis()))
                 .addOutputState(testUtxoState)
                 .addCommand(TestCommand())
                 .addSignatories(testUtxoState.participants)
-                .toSignedTransaction(myInfo.ledgerKeys.first())
+                .toSignedTransaction()
 
             val sessions = members.map { flowMessaging.initiateFlow(it.name) }
 

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -179,9 +179,6 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
      * A helper function that will build a UTXO signed transaction from the provided input parameters using the
      * [UtxoTransactionBuilder] utility class.
      */
-    @Suppress(
-        "deprecation", // Can be removed once the new `sign` function on the TX builder is added
-    )
     @Suspendable
     private fun buildSignedTransaction(
         notaryServerParty: Party,
@@ -192,38 +189,38 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
     ): UtxoSignedTransaction {
         val myKey = memberLookup.myInfo().sessionInitiationKey
         return utxoLedgerService.getTransactionBuilder()
-            .setNotary(notaryServerParty)
-            .addCommand(TestCommand())
-            .run {
-                // TODO CORE-8726 Since the builder will always be copied with the new attributes,
-                //  we always need to re-assign it
-                var builder = if (timeWindowBounds.first != null) {
-                    setTimeWindowBetween(
-                        Instant.now().plusMillis(timeWindowBounds.first!!),
-                        Instant.now().plusMillis(timeWindowBounds.second)
-                    )
-                } else {
-                    setTimeWindowUntil(
-                        Instant.now().plusMillis(timeWindowBounds.second)
-                    )
-                }
+                .setNotary(notaryServerParty)
+                .addCommand(TestCommand())
+                .run {
+                    // TODO CORE-8726 Since the builder will always be copied with the new attributes,
+                    //  we always need to re-assign it
+                    var builder = if (timeWindowBounds.first != null) {
+                        setTimeWindowBetween(
+                            Instant.now().plusMillis(timeWindowBounds.first!!),
+                            Instant.now().plusMillis(timeWindowBounds.second)
+                        )
+                    } else {
+                        setTimeWindowUntil(
+                            Instant.now().plusMillis(timeWindowBounds.second)
+                        )
+                    }
 
-                repeat(outputStateCount) {
-                    builder = builder.addOutputState(
-                        TestContract.TestState(emptyList())
-                    )
-                }
+                    repeat(outputStateCount) {
+                        builder = builder.addOutputState(
+                            TestContract.TestState(emptyList())
+                        )
+                    }
 
-                inputStateRefs.forEach {
-                    builder = builder.addInputState(StateRef.parse(it))
-                }
+                    inputStateRefs.forEach {
+                        builder = builder.addInputState(StateRef.parse(it))
+                    }
 
-                referenceStateRefs.forEach {
-                    builder = builder.addReferenceState(StateRef.parse(it))
-                }
-                builder = builder.addSignatories(listOf(myKey))
-                builder
-            }.toSignedTransaction(myKey)
+                    referenceStateRefs.forEach {
+                        builder = builder.addReferenceState(StateRef.parse(it))
+                    }
+                    builder = builder.addSignatories(listOf(myKey))
+                    builder
+                }.toSignedTransaction()
     }
 
     /**

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
@@ -6,8 +6,8 @@ import net.corda.v5.crypto.SecureHash
 import java.security.PublicKey
 
 private class MockTransactionSignatureService: TransactionSignatureService {
-    override fun sign(transactionId: SecureHash, publicKey: PublicKey): DigitalSignatureAndMetadata =
-        getSignatureWithMetadataExample()
+    override fun sign(transactionId: SecureHash, publicKeys: Set<PublicKey>): List<DigitalSignatureAndMetadata> =
+        listOf(getSignatureWithMetadataExample())
 
     override fun verifySignature(transactionId: SecureHash, signatureWithMetadata: DigitalSignatureAndMetadata) {}
     override fun verifyNotarySignature(transactionId: SecureHash, signatureWithMetadata: DigitalSignatureAndMetadata) {}

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
@@ -6,7 +6,7 @@ import net.corda.v5.crypto.SecureHash
 import java.security.PublicKey
 
 private class MockTransactionSignatureService: TransactionSignatureService {
-    override fun sign(transactionId: SecureHash, publicKeys: Set<PublicKey>): List<DigitalSignatureAndMetadata> =
+    override fun sign(transactionId: SecureHash, publicKeys: Iterable<PublicKey>): List<DigitalSignatureAndMetadata> =
         listOf(getSignatureWithMetadataExample())
 
     override fun verifySignature(transactionId: SecureHash, signatureWithMetadata: DigitalSignatureAndMetadata) {}


### PR DESCRIPTION
CORE-7276 Remove toSignedTransaction(PublicKey)s from TxBuilders
CORE-7276 Implement the `toSignedTransaction()` version.
CORE-7276 Update everything to use the `toSignedTransaction()` version.

A few XReceiveFinalityFlow unit tests became a bit less useful since the key-finding logic is not in the finality flows anymore.

API: https://github.com/corda/corda-api/pull/809