### PR TITLE
CORE-9710 - Move serial to MGM provided

### DIFF
--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMOpsClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMOpsClientTest.kt
@@ -148,12 +148,12 @@ class MGMOpsClientTest {
             *convertEndpoints().toTypedArray(),
             MemberInfoExtension.SOFTWARE_VERSION to "5.0.0",
             MemberInfoExtension.PLATFORM_VERSION to "5000",
-            MemberInfoExtension.SERIAL to "1"
         ),
         sortedMapOf(
             MemberInfoExtension.STATUS to MemberInfoExtension.MEMBER_STATUS_ACTIVE,
             MemberInfoExtension.MODIFIED_TIME to clock.instant().toString(),
-            IS_MGM to "true"
+            IS_MGM to "true",
+            MemberInfoExtension.SERIAL to "1",
         )
     )
 

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
@@ -91,11 +91,11 @@ class MemberListProcessorTest {
                 *convertEndpoints().toTypedArray(),
                 SOFTWARE_VERSION to "5.0.0",
                 PLATFORM_VERSION to "5000",
-                SERIAL to "1",
             ),
             sortedMapOf(
                 STATUS to status,
                 MODIFIED_TIME to modifiedTime.toString(),
+                SERIAL to "1",
             )
 
         )

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
@@ -129,11 +129,11 @@ class MemberLookupRestResourceTest {
             *convertEndpoints().toTypedArray(),
             SOFTWARE_VERSION to "5.0.0",
             PLATFORM_VERSION to "5000",
-            SERIAL to "1"
         ),
         sortedMapOf(
             STATUS to MEMBER_STATUS_ACTIVE,
-            MODIFIED_TIME to clock.instant().toString()
+            MODIFIED_TIME to clock.instant().toString(),
+            SERIAL to "1",
         )
     )
 

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -605,20 +605,20 @@ class MembershipPersistenceTest {
                 KeyValuePair(GROUP_ID, groupId),
                 KeyValuePair(PARTY_NAME, memberx500Name.toString()),
                 KeyValuePair(PLATFORM_VERSION, "11"),
-                KeyValuePair(SERIAL, "1"),
                 KeyValuePair(SOFTWARE_VERSION, "5.0.0"),
                 KeyValuePair("corda.notary.service.name", notaryServiceName),
                 KeyValuePair("corda.notary.service.plugin", notaryServicePlugin),
                 KeyValuePair("corda.roles.0", "notary"),
                 KeyValuePair("corda.notary.keys.0.pem", keyEncodingService.encodeAsString(notaryKey)),
                 KeyValuePair("corda.notary.keys.0.signature.spec", "SHA512withECDSA"),
-                KeyValuePair("corda.notary.keys.0.hash", notaryKeyHash.value)
+                KeyValuePair("corda.notary.keys.0.hash", notaryKeyHash.value),
             ).sorted()
         )
         val mgmContext = KeyValuePairList(
             listOf(
-                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE)
-            )
+                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE),
+                KeyValuePair(SERIAL, "1"),
+            ).sorted()
         )
         val notary = memberInfoFactory.create(memberContext.toSortedMap(), mgmContext.toSortedMap())
         val expectedGroupParameters = listOf(
@@ -671,20 +671,20 @@ class MembershipPersistenceTest {
                 KeyValuePair(GROUP_ID, groupId),
                 KeyValuePair(PARTY_NAME, memberx500Name.toString()),
                 KeyValuePair(PLATFORM_VERSION, "11"),
-                KeyValuePair(SERIAL, "1"),
                 KeyValuePair(SOFTWARE_VERSION, "5.0.0"),
                 KeyValuePair("corda.notary.service.name", notaryServiceName),
                 KeyValuePair("corda.notary.service.plugin", notaryServicePlugin),
                 KeyValuePair("corda.roles.0", "notary"),
                 KeyValuePair("corda.notary.keys.0.pem", notaryKeyAsString),
                 KeyValuePair("corda.notary.keys.0.signature.spec", "SHA512withECDSA"),
-                KeyValuePair("corda.notary.keys.0.hash", notaryKeyHash.value)
+                KeyValuePair("corda.notary.keys.0.hash", notaryKeyHash.value),
             ).sorted()
         )
         val mgmContext = KeyValuePairList(
             listOf(
-                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE)
-            )
+                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE),
+                KeyValuePair(SERIAL, "1"),
+            ).sorted()
         )
         val notary = memberInfoFactory.create(memberContext.toSortedMap(), mgmContext.toSortedMap())
         vnodeEmf.transaction {
@@ -756,20 +756,20 @@ class MembershipPersistenceTest {
                 KeyValuePair(GROUP_ID, groupId),
                 KeyValuePair(PARTY_NAME, memberx500Name.toString()),
                 KeyValuePair(PLATFORM_VERSION, "11"),
-                KeyValuePair(SERIAL, "1"),
                 KeyValuePair(SOFTWARE_VERSION, "5.0.0"),
                 KeyValuePair("corda.notary.service.name", notaryServiceName),
                 KeyValuePair("corda.notary.service.plugin", notaryServicePlugin),
                 KeyValuePair("corda.roles.0", "notary"),
                 KeyValuePair("corda.notary.keys.0.pem", notaryKeyAsString),
                 KeyValuePair("corda.notary.keys.0.signature.spec", "SHA512withECDSA"),
-                KeyValuePair("corda.notary.keys.0.hash", notaryKeyHash.value)
+                KeyValuePair("corda.notary.keys.0.hash", notaryKeyHash.value),
             ).sorted()
         )
         val mgmContext = KeyValuePairList(
             listOf(
-                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE)
-            )
+                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE),
+                KeyValuePair(SERIAL, "1"),
+            ).sorted()
         )
         val notary = memberInfoFactory.create(memberContext.toSortedMap(), mgmContext.toSortedMap())
         val oldNotaryKey = with(keyGenerator) {
@@ -838,14 +838,14 @@ class MembershipPersistenceTest {
                 KeyValuePair(GROUP_ID, groupId),
                 KeyValuePair(PARTY_NAME, memberx500Name.toString()),
                 KeyValuePair(PLATFORM_VERSION, "5000"),
-                KeyValuePair(SERIAL, "1"),
-                KeyValuePair(SOFTWARE_VERSION, "5.0.0")
-            )
+                KeyValuePair(SOFTWARE_VERSION, "5.0.0"),
+            ).sorted()
         )
         val mgmContext = KeyValuePairList(
             listOf(
-                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE)
-            )
+                KeyValuePair(STATUS, MEMBER_STATUS_ACTIVE),
+                KeyValuePair(SERIAL, "1"),
+            ).sorted()
         )
 
         val result = membershipPersistenceClientWrapper.persistMemberInfo(
@@ -874,10 +874,10 @@ class MembershipPersistenceTest {
         assertThat(persistedEntity.serialNumber).isEqualTo(1)
         assertThat(persistedEntity.status).isEqualTo(MEMBER_STATUS_ACTIVE)
 
-        fun contextIsEqual(actual: String?, expected: String) = assertThat(actual).isEqualTo(expected)
-
         val persistedMgmContext = persistedEntity.mgmContext.deserializeContextAsMap()
-        contextIsEqual(persistedMgmContext[STATUS], MEMBER_STATUS_ACTIVE)
+        assertThat(persistedMgmContext)
+            .containsEntry(STATUS, MEMBER_STATUS_ACTIVE)
+            .containsEntry(SERIAL, "1")
 
         val persistedMemberContext = persistedEntity.memberContext.deserializeContextAsMap()
         assertThat(persistedMemberContext)
@@ -886,7 +886,6 @@ class MembershipPersistenceTest {
             .containsEntry(GROUP_ID, groupId)
             .containsEntry(PARTY_NAME, memberx500Name.toString())
             .containsEntry(PLATFORM_VERSION, "5000")
-            .containsEntry(SERIAL, "1")
             .containsEntry(SOFTWARE_VERSION, "5.0.0")
     }
 
@@ -1177,14 +1176,14 @@ class MembershipPersistenceTest {
                 KeyValuePair(GROUP_ID, groupId),
                 KeyValuePair(PARTY_NAME, memberName.toString()),
                 KeyValuePair(PLATFORM_VERSION, "5000"),
-                KeyValuePair(SERIAL, "1"),
-                KeyValuePair(SOFTWARE_VERSION, "5.0.0")
-            )
+                KeyValuePair(SOFTWARE_VERSION, "5.0.0"),
+            ).sorted()
         )
         val mgmContext = KeyValuePairList(
             listOf(
-                KeyValuePair(STATUS, MEMBER_STATUS_PENDING)
-            )
+                KeyValuePair(STATUS, MEMBER_STATUS_PENDING),
+                KeyValuePair(SERIAL, "1"),
+            ).sorted()
         )
 
         return membershipPersistenceClientWrapper.persistMemberInfo(

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -37,7 +37,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
-import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.registration.RegistrationProxy
@@ -162,7 +161,6 @@ class MemberRegistrationIntegrationTest {
         const val CPI_VERSION = "1.1"
         const val CPI_SIGNER_HASH = "ALG:A1B2C3D4"
         const val CPI_NAME = "cpi-name"
-        const val TEST_SERIAL = 1
 
         @JvmStatic
         @BeforeAll
@@ -309,7 +307,6 @@ class MemberRegistrationIntegrationTest {
                     it.assertThat(getValue(MEMBER_CPI_SIGNER_HASH)).isEqualTo(CPI_SIGNER_HASH)
                     it.assertThat(getValue(PLATFORM_VERSION)).isEqualTo(TEST_ACTIVE_PLATFORM_VERSION.toString())
                     it.assertThat(getValue(SOFTWARE_VERSION)).isEqualTo(TEST_SOFTWARE_VERSION)
-                    it.assertThat(getValue(SERIAL)).isEqualTo(TEST_SERIAL.toString())
 
                     with(map { pair -> pair.key }) {
                         it.assertThat(contains(String.format(LEDGER_KEYS_KEY, 0))).isTrue

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -16,6 +16,7 @@ import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandle
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
@@ -51,6 +52,7 @@ internal class StartRegistrationHandler(
 
     private companion object {
         val logger = contextLogger()
+        const val SERIAL_CONST = "1"
     }
 
     private val keyValuePairListDeserializer =
@@ -185,7 +187,8 @@ internal class StartRegistrationHandler(
             sortedMapOf(
                 CREATION_TIME to now,
                 MODIFIED_TIME to now,
-                STATUS to MEMBER_STATUS_PENDING
+                STATUS to MEMBER_STATUS_PENDING,
+                SERIAL to SERIAL_CONST,
             )
         )
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -50,7 +50,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
-import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.ecdhKey
@@ -155,7 +154,6 @@ class DynamicMemberRegistrationService @Activate constructor(
         const val NOTARY_KEY_ID = "corda.notary.keys.%s.id"
         const val LEDGER_KEY_SIGNATURE_SPEC = "$LEDGER_KEYS.%s.signature.spec"
         const val MEMBERSHIP_P2P_SUBSYSTEM = "membership"
-        const val SERIAL_CONST = "1"
 
         val notaryIdRegex = NOTARY_KEY_ID.format("[0-9]+").toRegex()
         val ledgerIdRegex = LEDGER_KEY_ID.format("[0-9]+").toRegex()
@@ -390,7 +388,6 @@ class DynamicMemberRegistrationService @Activate constructor(
                 SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
                 MEMBER_CPI_NAME to cpi.name,
                 MEMBER_CPI_VERSION to cpi.version,
-                SERIAL to SERIAL_CONST,
             )
             val roleContext = roles.toMemberInfo { notaryKeys }
             val optionalContext = mapOf(MEMBER_CPI_SIGNER_HASH to cpi.signerSummaryHash.toString())

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -141,7 +141,6 @@ internal class MGMRegistrationMemberInfoHandler(
             SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
             MEMBER_CPI_NAME to cpi.name,
             MEMBER_CPI_VERSION to cpi.version,
-            SERIAL to SERIAL_CONST,
         ) + optionalContext
         return memberInfoFactory.create(
             memberContext = memberContext.toSortedMap(),
@@ -149,7 +148,8 @@ internal class MGMRegistrationMemberInfoHandler(
                 CREATION_TIME to now,
                 MODIFIED_TIME to now,
                 STATUS to MEMBER_STATUS_ACTIVE,
-                IS_MGM to "true"
+                IS_MGM to "true",
+                SERIAL to SERIAL_CONST,
             )
         )
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -332,7 +332,6 @@ class StaticMemberRegistrationService @Activate constructor(
             PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
             MEMBER_CPI_NAME to cpi.name,
             MEMBER_CPI_VERSION to cpi.version,
-            SERIAL to staticMemberInfo.serial,
         ) + optionalContext
 
         val memberInfo = memberInfoFactory.create(
@@ -340,6 +339,7 @@ class StaticMemberRegistrationService @Activate constructor(
             sortedMapOf(
                 STATUS to staticMemberInfo.status,
                 MODIFIED_TIME to staticMemberInfo.modifiedTime,
+                SERIAL to staticMemberInfo.serial,
             )
         )
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -46,7 +46,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
-import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_SIGNATURE_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
@@ -425,7 +424,6 @@ class DynamicMemberRegistrationServiceTest {
                 SOFTWARE_VERSION,
                 PLATFORM_VERSION,
                 REGISTRATION_ID,
-                SERIAL,
                 URL_KEY.format(0),
                 PROTOCOL_VERSION.format(0),
                 PARTY_SESSION_KEY,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
@@ -278,7 +278,6 @@ class MGMRegistrationMemberInfoHandlerTest {
             SOFTWARE_VERSION,
             MEMBER_CPI_NAME,
             MEMBER_CPI_VERSION,
-            SERIAL,
             URL_KEY.format(0),
             PROTOCOL_VERSION.format(0),
             MEMBER_CPI_SIGNER_HASH
@@ -296,7 +295,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         }
 
         assertThat(mgmContext)
-            .containsOnlyKeys(CREATION_TIME, MODIFIED_TIME, STATUS, IS_MGM)
+            .containsOnlyKeys(CREATION_TIME, MODIFIED_TIME, STATUS, IS_MGM, SERIAL)
             .containsEntry(STATUS, MEMBER_STATUS_ACTIVE)
             .containsEntry(IS_MGM, true.toString())
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -352,7 +352,6 @@ class MGMRegistrationServiceTest {
                             MEMBER_CPI_NAME,
                             MEMBER_CPI_VERSION,
                             MEMBER_CPI_SIGNER_HASH,
-                            SERIAL,
                             URL_KEY.format(0),
                             PROTOCOL_VERSION.format(0),
                         )
@@ -363,7 +362,8 @@ class MGMRegistrationServiceTest {
                             CREATION_TIME,
                             MODIFIED_TIME,
                             STATUS,
-                            IS_MGM
+                            IS_MGM,
+                            SERIAL,
                         )
                     )
 

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
@@ -376,11 +376,11 @@ class SynchronisationIntegrationTest {
                 String.format(MemberInfoExtension.PROTOCOL_VERSION, 0) to "1",
                 MemberInfoExtension.SOFTWARE_VERSION to "5.0.0",
                 MemberInfoExtension.PLATFORM_VERSION to PLATFORM_VERSION,
-                MemberInfoExtension.SERIAL to "1",
             ),
             sortedMapOf(
                 MemberInfoExtension.STATUS to MEMBER_STATUS_ACTIVE,
                 MemberInfoExtension.MODIFIED_TIME to clock.instant().toString(),
+                MemberInfoExtension.SERIAL to "1",
             )
 
         )

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/MemberInfoImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/MemberInfoImpl.kt
@@ -36,7 +36,7 @@ class MemberInfoImpl(
 
     override val platformVersion: Int get() = memberProvidedContext.parse(PLATFORM_VERSION)
 
-    override val serial: Long get() = memberProvidedContext.parse(SERIAL)
+    override val serial: Long get() = mgmProvidedContext.parse(SERIAL)
 
     override val isActive: Boolean get() = mgmProvidedContext.parse(STATUS, String::class.java) == MEMBER_STATUS_ACTIVE
 

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImpl.kt
@@ -6,6 +6,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
@@ -153,12 +154,13 @@ class GroupPolicyParserImpl @Activate constructor(
         return parsedGroupPolicy?.mgmInfo?.let {
             val now = clock.instant().toString()
             memberInfoFactory.create(
-                it.toSortedMap(),
+                it.filterKeys { !it.equals(SERIAL) }.toSortedMap(),
                 sortedMapOf(
                     CREATION_TIME to now,
                     MODIFIED_TIME to now,
                     STATUS to MEMBER_STATUS_ACTIVE,
-                    IS_MGM to "true"
+                    IS_MGM to "true",
+                    SERIAL to it.get(SERIAL)
                 )
             )
         }

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
@@ -116,9 +116,8 @@ class MemberInfoTest {
                     *createInvalidListFormat().toTypedArray(),
                     SOFTWARE_VERSION to "5.0.0",
                     PLATFORM_VERSION to "5000",
-                    SERIAL to "1",
                     DUMMY_KEY to "dummyValue",
-                    NULL_KEY to null
+                    NULL_KEY to null,
                 ),
                 converters
             ),
@@ -126,7 +125,8 @@ class MemberInfoTest {
                 sortedMapOf(
                     STATUS to MEMBER_STATUS_ACTIVE,
                     MODIFIED_TIME to modifiedTime.toString(),
-                    DUMMY_KEY to "dummyValue"
+                    DUMMY_KEY to "dummyValue",
+                    SERIAL to "1",
                 ),
                 converters
             )


### PR DESCRIPTION
Move serial field from the MemberContext, into the MGMContext.
For dynamic registrations the value for this key should be populated in StartRegistrationHandler instead of the DynamicMemberRegistrationService.