### PR TITLE
CORE-9733 Fix secret handling logic

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -529,7 +529,7 @@ Cluster DB name
 {{- end -}}
 
 {{/*
-Cluster DB secret name
+Default name for cluster DB secret
 */}}
 {{- define "corda.clusterDbDefaultSecretName" -}}
 {{ printf "%s-cluster-db" (include "corda.fullname" .) }}
@@ -725,10 +725,10 @@ NOTE: some of then naming here is incorrect.
 {{- end }}
 
 {{/*
-Bootstrap RBAC User secret name 
+Default name for RBAC DB secret
 */}}
-{{- define "corda.rbacDbUserSecretName" -}}
-{{ printf "%s-rbac-db-user" (include "corda.fullname" .) }}
+{{- define "corda.rbacDbDefaultSecretName" -}}
+{{ printf "%s-rbac-db" (include "corda.fullname" .) }}
 {{- end -}}
 
 {{/*
@@ -742,7 +742,7 @@ RBAC User environment variable
       name: {{ .Values.bootstrap.db.rbac.username.valueFrom.secretKeyRef.name | quote }}
       key: {{ required "Must specify bootstrap.db.rbac.username.valueFrom.secretKeyRef.key" .Values.bootstrap.db.rbac.username.valueFrom.secretKeyRef.key | quote }}
       {{- else }}
-      name: {{ include "corda.rbacDbUserSecretName" . | quote }}
+      name: {{ include "corda.rbacDbDefaultSecretName" . | quote }}
       key: "username" 
       {{- end }}
 - name: RBAC_DB_USER_PASSWORD
@@ -752,16 +752,16 @@ RBAC User environment variable
       name: {{ .Values.bootstrap.db.rbac.password.valueFrom.secretKeyRef.name | quote }}
       key: {{ required "Must specify bootstrap.db.rbac.password.valueFrom.secretKeyRef.key" .Values.bootstrap.db.rbac.password.valueFrom.secretKeyRef.key | quote }}
       {{- else }}
-      name: {{ include "corda.rbacDbUserSecretName" . | quote }}
+      name: {{ include "corda.rbacDbDefaultSecretName" . | quote }}
       key: "password" 
       {{- end }}
 {{- end -}}
 
 {{/*
-Bootstrap crypto Worker secret name 
+Default name for crypto DB secret
 */}}
-{{- define "corda.cryptoDbUserSecretName" -}}
-{{ printf "%s-crypto-db-user" (include "corda.fullname" .) }}
+{{- define "corda.cryptoDbDefaultSecretName" -}}
+{{ printf "%s-crypto-db" (include "corda.fullname" .) }}
 {{- end -}}
 
 {{/*
@@ -775,7 +775,7 @@ Crypto worker environment variable
       name: {{ .Values.bootstrap.db.crypto.username.valueFrom.secretKeyRef.name | quote }}
       key: {{ required "Must specify bootstrap.db.crypto.username.valueFrom.secretKeyRef.key" .Values.bootstrap.db.crypto.username.valueFrom.secretKeyRef.key | quote }}
       {{- else }}
-      name: {{ include "corda.cryptoDbUserSecretName" . | quote }}
+      name: {{ include "corda.cryptoDbDefaultSecretName" . | quote }}
       key: "username" 
       {{- end }}
 - name: CRYPTO_DB_USER_PASSWORD
@@ -785,7 +785,7 @@ Crypto worker environment variable
       name: {{ .Values.bootstrap.db.crypto.password.valueFrom.secretKeyRef.name | quote }}
       key: {{ required "Must specify bootstrap.db.crypto.password.valueFrom.secretKeyRef.key" .Values.bootstrap.db.crypto.password.valueFrom.secretKeyRef.key | quote }}
       {{- else }}
-      name: {{ include "corda.cryptoDbUserSecretName" . | quote }}
+      name: {{ include "corda.cryptoDbDefaultSecretName" . | quote }}
       key: "password" 
       {{- end }}
 {{- end -}}

--- a/charts/corda/templates/crypto-db-secret.yaml
+++ b/charts/corda/templates/crypto-db-secret.yaml
@@ -1,6 +1,5 @@
 {{- if or ( not .Values.bootstrap.db.crypto.password.valueFrom.secretKeyRef.name) ( not .Values.bootstrap.db.crypto.username.valueFrom.secretKeyRef.name) }}
-{{- $name := include "corda.cryptoDbUserSecretName" . }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- $name := include "corda.cryptoDbDefaultSecretName" . }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,18 +12,18 @@ metadata:
 type: Opaque
 data:
 {{- if (not .Values.bootstrap.db.crypto.password.valueFrom.secretKeyRef.name) }}
-{{- if  $existingSecret }}
+{{- if .Values.bootstrap.db.crypto.password.value }}
+  password: {{ .Values.bootstrap.db.crypto.password.value | b64enc | quote }}
+{{- else }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- if $existingSecret }}
   password: {{ $existingSecret.data.password }}
 {{- else }}
-  password: {{ .Values.bootstrap.db.crypto.password.value | default (randAlphaNum 12) | b64enc | quote }}
+  password: {{ randAlphaNum 12 | b64enc | quote }}
 {{- end }}
 {{- end }}
-
+{{- end }}
 {{- if (not .Values.bootstrap.db.crypto.username.valueFrom.secretKeyRef.name) }}
-{{- if $existingSecret }}
-  username: {{ $existingSecret.data.username }}
-{{- else }}
   username: {{ required "Must specify bootstrap.db.crypto.username.valueFrom.secretKeyRef.name or bootstrap.db.crypto.username.value" .Values.bootstrap.db.crypto.username.value | b64enc | quote }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/corda/templates/db-worker-secret.yaml
+++ b/charts/corda/templates/db-worker-secret.yaml
@@ -14,19 +14,25 @@ metadata:
 type: Opaque
 data:
 {{- if (not .Values.workers.db.salt.valueFrom.secretKeyRef.name) }}
+{{- if .Values.workers.db.salt.value }}
+  salt: {{ .Values.workers.db.salt.value }}
+{{- else }}
 {{- if $existingSecret }}
   salt: {{ index $existingSecret.data "salt" }}
 {{- else }}
-  salt: {{ .Values.workers.db.salt.value | default (randAlphaNum 32) | b64enc | quote }}
+  salt: {{ randAlphaNum 32 | b64enc | quote }}
 {{- end }}
 {{- end }}
-
-
+{{- end }}
 {{- if (not .Values.workers.db.passphrase.valueFrom.secretKeyRef.name) }}
+{{- if .Values.workers.db.passphrase.value }}
+  passphrase: {{ .Values.workers.db.passphrase.value }}
+{{- else }}
 {{- if $existingSecret }}
   passphrase: {{ index $existingSecret.data "passphrase" }}
 {{- else }}
-  passphrase: {{ .Values.workers.db.passphrase.value | default (randAlphaNum 32) | b64enc | quote }}
+  passphrase: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/corda/templates/initial-admin-user-secret.yaml
+++ b/charts/corda/templates/initial-admin-user-secret.yaml
@@ -1,7 +1,6 @@
 
 {{- if or ( not .Values.bootstrap.initialAdminUser.password.valueFrom.secretKeyRef.name) ( not .Values.bootstrap.initialAdminUser.username.valueFrom.secretKeyRef.name) }}
 {{- $name := include "corda.initialAdminUserSecretName" . }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,19 +13,18 @@ metadata:
 type: Opaque
 data:
 {{- if (not .Values.bootstrap.initialAdminUser.password.valueFrom.secretKeyRef.name) }}
+{{- if .Values.bootstrap.initialAdminUser.password.value }}
+  password: {{ .Values.bootstrap.initialAdminUser.password.value | b64enc | quote }}
+{{- else }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
 {{- if  $existingSecret }}
   password: {{ $existingSecret.data.password }}
 {{- else }}
-  password: {{ .Values.bootstrap.initialAdminUser.password.value | default (randAlphaNum 12) | b64enc | quote }}
+  password: {{ randAlphaNum 12 | b64enc | quote }}
 {{- end }}
 {{- end }}
-
-
+{{- end }}
 {{- if (not .Values.bootstrap.initialAdminUser.username.valueFrom.secretKeyRef.name) }}
-{{- if $existingSecret }}
-  username: {{ $existingSecret.data.username }}
-{{- else }}
   username: {{ required "Must specify bootstrap.initialAdminUser.username.valueFrom.secretKeyRef.name or bootstrap.initialAdminUser.username.value" .Values.bootstrap.initialAdminUser.username.value | b64enc | quote }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/corda/templates/rbac-db-secret.yaml
+++ b/charts/corda/templates/rbac-db-secret.yaml
@@ -1,6 +1,5 @@
 {{- if or ( not .Values.bootstrap.db.rbac.password.valueFrom.secretKeyRef.name) ( not .Values.bootstrap.db.rbac.username.valueFrom.secretKeyRef.name) }}
-{{- $name := include "corda.rbacDbUserSecretName" . }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- $name := include "corda.rbacDbDefaultSecretName" . }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,19 +12,20 @@ metadata:
 type: Opaque
 data:
 {{- if (not .Values.bootstrap.db.rbac.password.valueFrom.secretKeyRef.name) }}
+{{- if  .Values.bootstrap.db.rbac.password.value }}
+  password: {{ .Values.bootstrap.db.rbac.password.value }}
+{{- else }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
 {{- if  $existingSecret }}
   password: {{ $existingSecret.data.password }}
 {{- else }}
-  password: {{ .Values.bootstrap.db.rbac.password.value | default (randAlphaNum 12) | b64enc | quote }}
+  password: {{ randAlphaNum 12 | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 
 
 {{- if (not .Values.bootstrap.db.rbac.username.valueFrom.secretKeyRef.name) }}
-{{- if $existingSecret }}
-  username: {{ $existingSecret.data.username }}
-{{- else }}
   username: {{ required "Must specify bootstrap.db.rbac.username.valueFrom.secretKeyRef.name or bootstrap.db.rbac.username.value" .Values.bootstrap.db.rbac.username.value | b64enc | quote }}
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Only use the existing secret if we'd otherwise be generating a new value. Rationalised the secret names whilst I was at it.