### PR TITLE
CORE-9732 - remove-contextLogger

### DIFF
--- a/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/ExampleFlow.kt
+++ b/applications/examples/sandbox-app/example-cpi/src/main/kotlin/com/example/cpk/ExampleFlow.kt
@@ -7,13 +7,13 @@ import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.marshalling.parse
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 
 @Suppress("unused")
 class ExampleFlow : ClientStartableFlow {
-    private val logger = loggerFor<ExampleFlow>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     @CordaInject
     private lateinit var jsonMarshaller: JsonMarshallingService

--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
@@ -5,14 +5,6 @@ import co.paralleluniverse.fibers.instrument.QuasarInstrumentor
 import com.sun.management.HotSpotDiagnosticMXBean
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
-import java.lang.management.ManagementFactory
-import java.time.Duration.ofSeconds
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit.SECONDS
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicInteger
 import net.corda.data.flow.FlowInitiatorType
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
@@ -36,7 +28,6 @@ import net.corda.schema.configuration.FlowConfig.SESSION_HEARTBEAT_TIMEOUT_WINDO
 import net.corda.schema.configuration.FlowConfig.SESSION_MESSAGE_RESEND_WINDOW
 import net.corda.schema.configuration.MessagingConfig.Subscription.PROCESSOR_TIMEOUT
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.loggerFor
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.osgi.framework.BundleReference
@@ -48,6 +39,15 @@ import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL
 import org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC
+import org.slf4j.LoggerFactory
+import java.lang.management.ManagementFactory
+import java.time.Duration.ofSeconds
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 
 const val VNODE_SERVICE = "vnode"
 const val SHUTDOWN_GRACE = 30L
@@ -99,7 +99,7 @@ class CordaVNode @Activate constructor(
     }
 
     private val appName: String = System.getProperty("app.name", "heap")
-    private val logger = loggerFor<CordaVNode>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     private val counter = AtomicInteger()
     private val mxBean = ManagementFactory.newPlatformMXBeanProxy(

--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -1,18 +1,18 @@
 package net.corda.example.vnode
 
-import java.time.Duration
-import java.util.concurrent.CompletableFuture
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.VirtualNodeLoader
-import net.corda.v5.base.util.loggerFor
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
 
 interface VNodeService {
     fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo
@@ -38,7 +38,7 @@ class VNodeServiceImpl @Activate constructor(
     @Reference
     private val virtualNodeLoader: VirtualNodeLoader
 ) : VNodeService {
-    private val logger = loggerFor<VNodeService>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
         sandboxGroupContextComponent.initCache(1)

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
@@ -30,12 +30,12 @@ import net.corda.schema.configuration.MessagingConfig
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import picocli.CommandLine
 import java.io.File
 import java.time.Duration
@@ -57,7 +57,7 @@ class AppSimulator @Activate constructor(
 ) : Application {
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val clock: Clock = UTCClock()
         const val DB_PARAMS_PREFIX = "dbParams"
         const val TOPIC_CREATION_PREFIX = "topicCreationParams"

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Receiver.kt
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.typesafe.config.ConfigValueFactory
 import net.corda.comp.kafka.topic.admin.KafkaTopicAdmin
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.AuthenticatedMessage
 import net.corda.libs.configuration.merger.ConfigMerger
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
@@ -13,12 +15,10 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.AuthenticatedMessage
 import net.corda.p2p.app.simulator.AppSimulator.Companion.APP_SIMULATOR_SUBSYSTEM
 import net.corda.p2p.app.simulator.AppSimulatorTopicCreator.Companion.APP_RECEIVED_MESSAGES_TOPIC
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.time.Duration
 import java.time.Instant
@@ -31,7 +31,7 @@ class Receiver(private val subscriptionFactory: SubscriptionFactory,
     ): Closeable {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sender.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sender.kt
@@ -4,6 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.typesafe.config.ConfigValueFactory
+import net.corda.data.identity.HoldingIdentity
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.AuthenticatedMessage
+import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.libs.configuration.merger.ConfigMerger
+import net.corda.messaging.api.publisher.config.PublisherConfig
+import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.messaging.api.records.Record
+import net.corda.p2p.app.simulator.AppSimulator.Companion.APP_SIMULATOR_SUBSYSTEM
+import net.corda.schema.configuration.BootConfig.INSTANCE_ID
+import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_PRODUCER_CLIENT_ID
+import net.corda.utilities.time.Clock
+import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.nio.ByteBuffer
 import java.time.Duration
@@ -15,19 +28,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.thread
 import kotlin.concurrent.write
-import net.corda.data.identity.HoldingIdentity
-import net.corda.libs.configuration.merger.ConfigMerger
-import net.corda.messaging.api.publisher.config.PublisherConfig
-import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.AuthenticatedMessageHeader
-import net.corda.p2p.app.simulator.AppSimulator.Companion.APP_SIMULATOR_SUBSYSTEM
-import net.corda.schema.configuration.BootConfig.INSTANCE_ID
-import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_PRODUCER_CLIENT_ID
-import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 
 @Suppress("LongParameterList")
 class Sender(private val publisherFactory: PublisherFactory,
@@ -39,7 +39,7 @@ class Sender(private val publisherFactory: PublisherFactory,
     ): Closeable {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val random = Random()

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/Sink.kt
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.typesafe.config.ConfigValueFactory
 import net.corda.libs.configuration.merger.ConfigMerger
-import java.io.Closeable
-import java.sql.Timestamp
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
@@ -15,7 +13,9 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.app.simulator.AppSimulatorTopicCreator.Companion.APP_RECEIVED_MESSAGES_TOPIC
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
+import java.io.Closeable
+import java.sql.Timestamp
 
 @Suppress("LongParameterList")
 class Sink(
@@ -26,7 +26,7 @@ class Sink(
     ) : Closeable {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -29,10 +29,10 @@ import net.corda.processors.uniqueness.UniquenessProcessor
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
 import net.corda.schema.configuration.DatabaseConfig
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 
@@ -71,7 +71,7 @@ class CombinedWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /** Parses the arguments, then initialises and starts the processors. */

--- a/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
+++ b/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
@@ -20,10 +20,10 @@ import net.corda.osgi.api.Shutdown
 import net.corda.processors.crypto.CryptoProcessor
 import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine
 import picocli.CommandLine.Mixin
 
@@ -48,7 +48,7 @@ class CryptoWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun startup(args: Array<String>) {

--- a/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
+++ b/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
@@ -18,10 +18,10 @@ import net.corda.osgi.api.Shutdown
 import net.corda.processors.db.DBProcessor
 import net.corda.processors.uniqueness.UniquenessProcessor
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
 
@@ -48,7 +48,7 @@ class DBWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /** Parses the arguments, then initialises and starts the [processor]. */

--- a/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
+++ b/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
@@ -16,10 +16,10 @@ import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.flow.FlowProcessor
 import net.corda.processors.verification.VerificationProcessor
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine.Mixin
 
 /** The worker for handling flows. */
@@ -45,7 +45,7 @@ class FlowWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /** Parses the arguments, then initialises and starts the [flowProcessor] and [verificationProcessor]. */

--- a/applications/workers/release/member-worker/src/main/kotlin/net/corda/applications/workers/member/MemberWorker.kt
+++ b/applications/workers/release/member-worker/src/main/kotlin/net/corda/applications/workers/member/MemberWorker.kt
@@ -14,10 +14,10 @@ import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.member.MemberProcessor
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine.Mixin
 
 /** The worker for handling member services. */
@@ -41,7 +41,7 @@ class MemberWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /** Parses the arguments, then initialises and starts the [processor]. */

--- a/applications/workers/release/p2p-gateway-worker/src/main/kotlin/net.corda.applications.workers.p2p.gateway/GatewayWorker.kt
+++ b/applications/workers/release/p2p-gateway-worker/src/main/kotlin/net.corda.applications.workers.p2p.gateway/GatewayWorker.kt
@@ -11,10 +11,10 @@ import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.p2p.gateway.GatewayProcessor
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine
 
 @Component
@@ -37,7 +37,7 @@ class GatewayWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun startup(args: Array<String>) {

--- a/applications/workers/release/p2p-link-manager-worker/src/main/kotlin/net.corda.applications.workers.p2p.linkmanager/LinkManagerWorker.kt
+++ b/applications/workers/release/p2p-link-manager-worker/src/main/kotlin/net.corda.applications.workers.p2p.linkmanager/LinkManagerWorker.kt
@@ -11,10 +11,10 @@ import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.p2p.linkmanager.LinkManagerProcessor
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine
 
 @Component
@@ -37,7 +37,7 @@ class LinkManagerWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun startup(args: Array<String>) {

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/http/EndpointAvailabilityCondition.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/http/EndpointAvailabilityCondition.kt
@@ -1,11 +1,11 @@
 package net.corda.applications.workers.rpc.http
 
 import net.corda.libs.permissions.endpoints.v1.user.UserEndpoint
-import net.corda.v5.base.util.contextLogger
 import org.junit.jupiter.api.extension.ConditionEvaluationResult
 import org.junit.jupiter.api.extension.ExecutionCondition
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.platform.commons.util.AnnotationUtils
+import org.slf4j.LoggerFactory
 
 /**
  * Endpoint availability condition
@@ -15,7 +15,7 @@ import org.junit.platform.commons.util.AnnotationUtils
 internal class EndpointAvailabilityCondition : ExecutionCondition {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val testToolkit by TestToolkitProperty()

--- a/applications/workers/release/rpc-worker/src/main/kotlin/net/corda/applications/workers/rpc/RPCWorker.kt
+++ b/applications/workers/release/rpc-worker/src/main/kotlin/net/corda/applications/workers/rpc/RPCWorker.kt
@@ -15,10 +15,10 @@ import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.rpc.RPCProcessor
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import picocli.CommandLine.Mixin
 
 /** The worker for handling RPC requests. */
@@ -42,7 +42,7 @@ class RPCWorker @Activate constructor(
 ) : Application {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /** Parses the arguments, then initialises and starts the [processor]. */

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/ApplicationBanner.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/ApplicationBanner.kt
@@ -4,10 +4,10 @@ import net.corda.application.addon.CordaAddonResolver
 import net.corda.application.banner.ConsolePrinter
 import net.corda.application.banner.StartupBanner
 import net.corda.libs.platform.PlatformInfoProvider
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [ApplicationBanner::class])
 class ApplicationBanner(
@@ -25,7 +25,7 @@ class ApplicationBanner(
     ):this(startupBanner, addonResolver, ConsolePrinter())
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     fun show(name: String, platformInfoProvider: PlatformInfoProvider) {

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
@@ -14,10 +14,10 @@ import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.framework.FrameworkUtil
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import picocli.CommandLine
 import java.io.InputStream
 import java.lang.management.ManagementFactory
@@ -33,7 +33,7 @@ enum class BusType {
 /** Helpers used across multiple workers. */
 class WorkerHelpers {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val BOOT_CONFIG_PATH = "net/corda/applications/workers/workercommon/boot/corda.boot.json"
 
         /**

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/WorkerMonitorImpl.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/internal/WorkerMonitorImpl.kt
@@ -18,12 +18,12 @@ import net.corda.metrics.CordaMetrics
 import net.corda.utilities.classload.OsgiClassLoader
 import net.corda.utilities.classload.executeWithThreadContextClassLoader
 import net.corda.utilities.executeWithStdErrSuppressed
-import net.corda.v5.base.util.contextLogger
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * An implementation of [WorkerMonitor].
@@ -37,7 +37,7 @@ internal class WorkerMonitorImpl @Activate constructor(
     private val lifecycleRegistry: LifecycleRegistry
 ) : WorkerMonitor {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     // The use of Javalin is temporary, and will be replaced in the future.

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/BasicAuthUpgradeListener.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/BasicAuthUpgradeListener.kt
@@ -1,9 +1,9 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
-import net.corda.e2etest.utilities.contextLogger
 import org.eclipse.jetty.websocket.api.UpgradeRequest
 import org.eclipse.jetty.websocket.api.UpgradeResponse
 import org.eclipse.jetty.websocket.client.io.UpgradeListener
+import org.slf4j.LoggerFactory
 import java.util.Base64
 
 class BasicAuthUpgradeListener(
@@ -11,7 +11,7 @@ class BasicAuthUpgradeListener(
     private val password: String
 ) : UpgradeListener {
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val AUTHORIZATION_HEADER = "Authorization"
     }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebSocketHandler.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/MessageQueueWebSocketHandler.kt
@@ -1,8 +1,8 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
-import net.corda.e2etest.utilities.contextLogger
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.client.NoOpEndpoint
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -14,7 +14,7 @@ class MessageQueueWebSocketHandler : NoOpEndpoint(), InternalWebsocketHandler {
         get() = ArrayList(_messageQueue)
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun onWebSocketConnect(session: Session) {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
@@ -2,7 +2,6 @@ package net.corda.applications.workers.smoketest.websocket.client
 
 import net.corda.e2etest.utilities.PASSWORD
 import net.corda.e2etest.utilities.USERNAME
-import net.corda.e2etest.utilities.contextLogger
 import net.corda.e2etest.utilities.getOrThrow
 import net.corda.test.util.consistently
 import net.corda.test.util.eventually
@@ -15,6 +14,7 @@ import org.eclipse.jetty.websocket.api.StatusCode
 import org.eclipse.jetty.websocket.api.WebSocketAdapter
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest
 import org.eclipse.jetty.websocket.client.WebSocketClient
+import org.slf4j.LoggerFactory
 import java.net.URI
 import java.time.Duration
 import java.util.LinkedList
@@ -55,7 +55,7 @@ class SmokeTestWebsocketClient(
 ) : AutoCloseable {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val baseWssPath = "wss://localhost:8888/api/v1"
     }
 

--- a/buildSrc/README.md
+++ b/buildSrc/README.md
@@ -121,7 +121,7 @@ companion object {
 or
 
 ```kotlin
-val logger = contextLogger()
+val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 ```
 
 if the module depends on `net.corda:corda-base`.

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessor.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkWriteToDbProcessor.kt
@@ -10,7 +10,7 @@ import net.corda.libs.cpiupload.DuplicateCpiUploadException
 import net.corda.libs.cpiupload.ValidationException
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * Persist a [Chunk] to the database and send an [UploadStatus] message
@@ -21,7 +21,7 @@ class ChunkWriteToDbProcessor(
     private val validator: CpiValidator
 ) : DurableProcessor<RequestId, Chunk> {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private fun processChunk(request: Chunk) {

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractor.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractor.kt
@@ -3,12 +3,12 @@ package net.corda.chunking.db.impl.cpi.liquibase
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.Cpk
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 
 class LiquibaseExtractor {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractorHelpers.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/cpi/liquibase/LiquibaseExtractorHelpers.kt
@@ -4,7 +4,7 @@ import net.corda.db.admin.LiquibaseXmlConstants.DB_CHANGE_LOG_ROOT_ELEMENT
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogKey
 import net.corda.libs.packaging.Cpk
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.StringReader
@@ -19,7 +19,7 @@ import javax.xml.stream.events.XMLEvent
 class LiquibaseExtractorHelpers {
     companion object {
         private const val MIGRATION_FOLDER = "migration"
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/StatusPublisher.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/StatusPublisher.kt
@@ -6,12 +6,12 @@ import net.corda.data.chunking.UploadStatus
 import net.corda.data.chunking.UploadStatusKey
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 
 class StatusPublisher(private val statusTopic: String, private val publisher: Publisher) {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val sequenceNumberByRequestId = mutableMapOf<String, Int>()

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseCpiPersistence.kt
@@ -16,8 +16,8 @@ import net.corda.libs.cpiupload.ValidationException
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.Cpk
 import net.corda.orm.utils.transaction
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.util.UUID
 import javax.persistence.EntityManager
@@ -31,7 +31,7 @@ import javax.persistence.NonUniqueResultException
 class DatabaseCpiPersistence(private val entityManagerFactory: EntityManagerFactory) : CpiPersistence {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CertificateExtractor.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CertificateExtractor.kt
@@ -2,7 +2,7 @@ package net.corda.chunking.db.impl.validation
 
 import net.corda.data.certificates.CertificateUsage
 import net.corda.membership.certificate.service.CertificatesService
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 
@@ -11,7 +11,7 @@ internal class CertificateExtractor(
     private val certificateFactory: CertificateFactory = CertificateFactory.getInstance("X.509")
 ) {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     fun getAllCertificates(): Collection<X509Certificate> {
         return certificatesService

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -20,9 +20,9 @@ import net.corda.membership.lib.schema.validation.MembershipSchemaValidationExce
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidator
 import net.corda.schema.membership.MembershipSchema.GroupPolicySchema
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.versioning.Version
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.cert.X509Certificate
@@ -42,7 +42,7 @@ class CpiValidatorImpl(
     private val clock: Clock,
 ) : CpiValidator {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val certificateExtractor by lazy {

--- a/components/chunking/chunk-read-service-impl/src/main/kotlin/net/corda/chunking/read/impl/ChunkReadServiceImpl.kt
+++ b/components/chunking/chunk-read-service-impl/src/main/kotlin/net/corda/chunking/read/impl/ChunkReadServiceImpl.kt
@@ -22,12 +22,12 @@ import net.corda.lifecycle.createCoordinator
 import net.corda.membership.group.policy.validation.MembershipGroupPolicyValidator
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @Suppress("UNUSED")
 @Component(service = [ChunkReadService::class])
@@ -44,7 +44,7 @@ class ChunkReadServiceImpl @Activate constructor(
     private val cpiInfoWriteService: CpiInfoWriteService
 ) : ChunkReadService, LifecycleEventHandler {
     companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<ChunkReadService>(this)

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -2,7 +2,6 @@ package net.corda.configuration.read.impl
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigRenderOptions
-import java.util.concurrent.ConcurrentHashMap
 import net.corda.data.config.Configuration
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
@@ -14,8 +13,9 @@ import net.corda.messaging.api.records.Record
 import net.corda.reconciliation.VersionedRecord
 import net.corda.schema.configuration.ConfigKeys.DB_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 // This should be used by our class that needs to cache config
 
@@ -27,7 +27,7 @@ internal class ConfigProcessor(
 ) : CompactedProcessor<String, Configuration> {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val configCache = ConcurrentHashMap<String, VersionedRecord<String, Configuration>>()

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
@@ -18,8 +18,8 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.Config.Companion.CONFIG_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 internal class ConfigReadServiceEventHandler(
     private val subscriptionFactory: SubscriptionFactory,
@@ -36,7 +36,7 @@ internal class ConfigReadServiceEventHandler(
     private val configuration = mutableMapOf<String, SmartConfig>()
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val GROUP = "CONFIGURATION_READ"
     }

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigurationChangeRegistration.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigurationChangeRegistration.kt
@@ -4,7 +4,7 @@ import net.corda.configuration.read.ConfigurationHandler
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.Resource
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
 
 class ConfigurationChangeRegistration(
@@ -13,7 +13,7 @@ class ConfigurationChangeRegistration(
 ) : Resource {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val isClosed = AtomicBoolean(false)

--- a/components/configuration/configuration-rpcops-service-impl/src/main/kotlin/net/corda/configuration/rpcops/impl/v1/ConfigRestResourceImpl.kt
+++ b/components/configuration/configuration-rpcops-service-impl/src/main/kotlin/net/corda/configuration/rpcops/impl/v1/ConfigRestResourceImpl.kt
@@ -19,8 +19,8 @@ import net.corda.httprpc.exception.ResourceNotFoundException
 import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.security.CURRENT_REST_CONTEXT
 import net.corda.libs.configuration.SmartConfig
-import net.corda.libs.configuration.endpoints.v1.ConfigRestResource
 import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.libs.configuration.endpoints.v1.ConfigRestResource
 import net.corda.libs.configuration.endpoints.v1.types.ConfigSchemaVersion
 import net.corda.libs.configuration.endpoints.v1.types.GetConfigResponse
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
@@ -47,12 +47,12 @@ import net.corda.schema.Schemas.Config.Companion.CONFIG_MGMT_REQUEST_TOPIC
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.VisibleForTesting
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.versioning.Version
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 /** An implementation of [ConfigRestResource]. */
@@ -79,7 +79,7 @@ internal class ConfigRestResourceImpl @Activate constructor(
             ConfigurationManagementRequest::class.java,
             ConfigurationManagementResponse::class.java
         )
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val REGISTRATION = "REGISTRATION"
         const val SENDER = "SENDER"

--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/ConfigWriteEventHandler.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/ConfigWriteEventHandler.kt
@@ -15,15 +15,15 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StopEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 /** Handles incoming [LifecycleCoordinator] events for [ConfigWriteServiceImpl]. */
 internal class ConfigWriteEventHandler(
     private val rpcSubscriptionFactory: RPCSubscriptionFactory,
     private val configMerger: ConfigMerger) : LifecycleEventHandler {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var rpcSubscription: ConfigurationManagementRPCSubscription? = null

--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/ConfigWriteServiceImpl.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/ConfigWriteServiceImpl.kt
@@ -10,10 +10,10 @@ import net.corda.libs.configuration.validation.ConfigurationValidatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.createCoordinator
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /** An implementation of [ConfigWriteService]. */
 @Suppress("Unused", "LongParameterList")
@@ -34,7 +34,7 @@ internal class ConfigWriteServiceImpl @Activate constructor(
 ) : ConfigWriteService {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator = let {

--- a/components/crypto/crypto-client-hsm-impl/src/main/kotlin/net/corda/crypto/client/hsm/impl/HSMRegistrationClientImpl.kt
+++ b/components/crypto/crypto-client-hsm-impl/src/main/kotlin/net/corda/crypto/client/hsm/impl/HSMRegistrationClientImpl.kt
@@ -14,8 +14,8 @@ import net.corda.data.crypto.wire.hsm.registration.queries.AssignedHSMQuery
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.UUID
 
@@ -23,7 +23,7 @@ class HSMRegistrationClientImpl(
     private val sender: RPCSender<HSMRegistrationRequest, HSMRegistrationResponse>
 ) {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     fun assignHSM(tenantId: String, category: String, context: Map<String, String>): HSMAssociationInfo {

--- a/components/crypto/crypto-client-hsm-impl/src/test/kotlin/net/corda/crypto/client/hsm/impl/HSMRegistrationClientComponentTests.kt
+++ b/components/crypto/crypto-client-hsm-impl/src/test/kotlin/net/corda/crypto/client/hsm/impl/HSMRegistrationClientComponentTests.kt
@@ -23,19 +23,19 @@ import net.corda.lifecycle.test.impl.TestLifecycleCoordinatorFactoryImpl
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.toHex
 import net.corda.v5.crypto.exceptions.CryptoException
 import net.corda.v5.crypto.sha256Bytes
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -47,7 +47,7 @@ import kotlin.test.assertTrue
 
 class HSMRegistrationClientComponentTests {
     companion object {
-        private val  logger = contextLogger()
+        private val  logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @JvmStatic
         fun knownCordaRPCAPIResponderExceptions(): List<Class<*>> =

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -31,7 +31,6 @@ import net.corda.data.crypto.wire.ops.rpc.queries.SupportedSchemesRpcQuery
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.toBase58
 import net.corda.v5.crypto.DigitalSignature
@@ -40,6 +39,7 @@ import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.publicKeyId
 import net.corda.v5.crypto.sha256Bytes
 import net.corda.v5.crypto.toStringShort
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.PublicKey
 import java.time.Duration
@@ -51,7 +51,7 @@ class CryptoOpsClientImpl(
     private val sender: RPCSender<RpcOpsRequest, RpcOpsResponse>
 ) {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     fun getSupportedSchemes(tenantId: String, category: String): List<String> {

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -48,7 +48,6 @@ import net.corda.lifecycle.test.impl.TestLifecycleCoordinatorFactoryImpl
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.toHex
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
@@ -71,6 +70,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.time.Instant
 import java.util.UUID
@@ -80,7 +80,7 @@ import kotlin.test.assertTrue
 
 class CryptoOpsClientComponentTests {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @JvmStatic
         fun knownCordaRPCAPIResponderExceptions(): List<Class<*>> =

--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractComponent.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractComponent.kt
@@ -1,6 +1,5 @@
 package net.corda.crypto.component.impl
 
-import java.util.concurrent.atomic.AtomicInteger
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -14,6 +13,7 @@ import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
 
 abstract class AbstractComponent<IMPL : AbstractComponent.AbstractImpl>(
     coordinatorFactory: LifecycleCoordinatorFactory,

--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractConfigurableComponent.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractConfigurableComponent.kt
@@ -1,6 +1,5 @@
 package net.corda.crypto.component.impl
 
-import java.util.concurrent.atomic.AtomicInteger
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.SmartConfig
@@ -17,6 +16,7 @@ import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * A base abstract class that can be used to provide basic functionality relating to lifecycle management for components

--- a/components/crypto/crypto-component-test-utils/src/main/kotlin/net/corda/crypto/component/test/utils/TestRPCSender.kt
+++ b/components/crypto/crypto-component-test-utils/src/main/kotlin/net/corda/crypto/component/test/utils/TestRPCSender.kt
@@ -5,7 +5,7 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.messaging.api.publisher.RPCSender
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -14,7 +14,7 @@ class TestRPCSender<REQUEST, RESPONSE>(
     override val subscriptionName: LifecycleCoordinatorName = LifecycleCoordinatorName("TestSender"),
 ) : RPCSender<REQUEST, RESPONSE> {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val lifecycleCoordinator = coordinatorFactory.createCoordinator(subscriptionName) { event, coordinator ->

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/TestDependenciesTracker.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/TestDependenciesTracker.kt
@@ -12,10 +12,10 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.registry.LifecycleRegistry
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.contextLogger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.osgi.framework.BundleContext
 import org.osgi.framework.FrameworkUtil
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 class TestDependenciesTracker private constructor(
@@ -26,7 +26,7 @@ class TestDependenciesTracker private constructor(
     private val dependencies: Set<LifecycleCoordinatorName>
 ) : Lifecycle {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         fun create(myName: LifecycleCoordinatorName, dependencies: Set<Class<out Lifecycle>>): TestDependenciesTracker {
             val bundleContext = FrameworkUtil.getBundle(this::class.java.classLoader).get().bundleContext

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryImpl.kt
@@ -30,11 +30,11 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.schema.configuration.ConfigKeys.CRYPTO_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 /**
@@ -73,7 +73,7 @@ class CryptoServiceFactoryImpl @Activate constructor(
     configKeys = setOf(CRYPTO_CONFIG)
 ), CryptoServiceFactory {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val jsonMapper = JsonMapper
             .builder()

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceFactoryImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceFactoryImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.crypto.service.impl
 
+import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.component.impl.AbstractComponent
 import net.corda.crypto.component.impl.DependenciesTracker
 import net.corda.crypto.persistence.SigningKeyStore
@@ -8,12 +9,11 @@ import net.corda.crypto.service.SigningService
 import net.corda.crypto.service.SigningServiceFactory
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
-import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [SigningServiceFactory::class])
 class SigningServiceFactoryImpl @Activate constructor(
@@ -36,7 +36,7 @@ class SigningServiceFactoryImpl @Activate constructor(
     )
 ), SigningServiceFactory {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createActiveImpl(): Impl = Impl(schemeMetadata, store, cryptoServiceFactory)

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -18,13 +18,13 @@ import net.corda.crypto.service.CryptoServiceFactory
 import net.corda.crypto.service.KeyOrderBy
 import net.corda.crypto.service.SigningKeyInfo
 import net.corda.crypto.service.SigningService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.KEY_LOOKUP_INPUT_ITEMS_LIMIT
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.publicKeyId
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 
 @Suppress("TooManyFunctions")
@@ -34,7 +34,7 @@ class SigningServiceImpl(
     override val schemeMetadata: CipherSchemeMetadata
 ) : SigningService {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     data class OwnedKeyRecord(val publicKey: PublicKey, val data: SigningCachedKey)

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -19,8 +19,8 @@ import net.corda.data.crypto.wire.ops.flow.queries.FilterMyKeysFlowQuery
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 class CryptoFlowOpsBusProcessor(
@@ -29,7 +29,7 @@ class CryptoFlowOpsBusProcessor(
     event: ConfigChangedEvent
 ) : DurableProcessor<String, FlowOpsRequest> {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val keyClass: Class<String> = String::class.java

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
@@ -33,9 +33,9 @@ import net.corda.data.crypto.wire.ops.rpc.queries.ByIdsRpcQuery
 import net.corda.data.crypto.wire.ops.rpc.queries.KeysRpcQuery
 import net.corda.data.crypto.wire.ops.rpc.queries.SupportedSchemesRpcQuery
 import net.corda.messaging.api.processor.RPCResponderProcessor
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
@@ -45,7 +45,7 @@ class CryptoOpsBusProcessor(
     event: ConfigChangedEvent
 ) : RPCResponderProcessor<RpcOpsRequest, RpcOpsResponse> {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private fun SigningKeyInfo.toAvro(): CryptoSigningKey =
             CryptoSigningKey(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessor.kt
@@ -16,9 +16,9 @@ import net.corda.data.crypto.wire.hsm.registration.commands.AssignHSMCommand
 import net.corda.data.crypto.wire.hsm.registration.commands.AssignSoftHSMCommand
 import net.corda.data.crypto.wire.hsm.registration.queries.AssignedHSMQuery
 import net.corda.messaging.api.processor.RPCResponderProcessor
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 
@@ -27,7 +27,7 @@ class HSMRegistrationBusProcessor(
     event: ConfigChangedEvent
 ) : RPCResponderProcessor<HSMRegistrationRequest, HSMRegistrationResponse> {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val config = event.config.toCryptoConfig().hsmRegistrationBusProcessor()

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusServiceTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusServiceTests.kt
@@ -9,13 +9,13 @@ import net.corda.data.crypto.wire.ops.rpc.RpcOpsResponse
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.contextLogger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.slf4j.LoggerFactory
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -25,7 +25,7 @@ import kotlin.test.assertTrue
 
 class CryptoOpsBusServiceTests {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private lateinit var factory: TestServicesFactory

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestDurableSubscription.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestDurableSubscription.kt
@@ -5,7 +5,7 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.messaging.api.subscription.Subscription
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class TestDurableSubscription<K, V>(
     coordinatorFactory: LifecycleCoordinatorFactory,
@@ -13,7 +13,7 @@ class TestDurableSubscription<K, V>(
         LifecycleCoordinatorName("TestDurableSubscription"),
 ) : Subscription<K, V> {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
 

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestHSMStore.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestHSMStore.kt
@@ -1,17 +1,17 @@
 package net.corda.crypto.service.impl.infra
 
 import net.corda.crypto.config.impl.MasterKeyPolicy
+import net.corda.crypto.persistence.HSMStore
+import net.corda.crypto.persistence.HSMUsage
 import net.corda.crypto.persistence.db.model.HSMAssociationEntity
 import net.corda.crypto.persistence.db.model.HSMCategoryAssociationEntity
-import net.corda.crypto.persistence.HSMUsage
-import net.corda.crypto.persistence.HSMStore
 import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.toHex
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
@@ -21,7 +21,7 @@ class TestHSMStore(
     coordinatorFactory: LifecycleCoordinatorFactory
 ) : HSMStore {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lock = ReentrantLock()

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestRPCSubscription.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestRPCSubscription.kt
@@ -5,7 +5,7 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.messaging.api.subscription.RPCSubscription
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class TestRPCSubscription<REQUEST, RESPONSE>(
     coordinatorFactory: LifecycleCoordinatorFactory,
@@ -13,7 +13,7 @@ class TestRPCSubscription<REQUEST, RESPONSE>(
         LifecycleCoordinatorName("TestRPCSubscription"),
 ) : RPCSubscription<REQUEST, RESPONSE> {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
 

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -21,7 +21,6 @@ import net.corda.crypto.impl.SignatureInstances
 import net.corda.crypto.impl.getSigningData
 import net.corda.crypto.softhsm.SoftKeyMap
 import net.corda.crypto.softhsm.SoftWrappingKeyMap
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.ECDSA_SECP256K1_CODE_NAME
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
@@ -32,6 +31,7 @@ import net.corda.v5.crypto.SM2_CODE_NAME
 import net.corda.v5.crypto.SPHINCS256_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.X25519_CODE_NAME
+import org.slf4j.LoggerFactory
 import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.Provider
@@ -44,7 +44,7 @@ class SoftCryptoService(
     private val digestService: PlatformDigestService
 ) : CryptoService {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         fun produceSupportedSchemes(schemeMetadata: CipherSchemeMetadata): Map<KeyScheme, List<SignatureSpec>> =
             mutableMapOf<KeyScheme, List<SignatureSpec>>().apply {

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
@@ -22,12 +22,12 @@ import net.corda.crypto.softhsm.WRAPPING_DEFAULT_NAME
 import net.corda.crypto.softhsm.WRAPPING_HSM_NAME
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * The service ranking is set to the smallest possible number to allow the upstream implementation to pick other
@@ -54,7 +54,7 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
     )
 ), SoftCryptoServiceProvider {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val lifecycleCoordinatorName = LifecycleCoordinatorName.forComponent<SoftCryptoServiceProvider>()
     }
 

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbAdminImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbAdminImpl.kt
@@ -3,10 +3,10 @@ package net.corda.db.connection.manager.impl
 import net.corda.db.connection.manager.DbAdmin
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.core.DbPrivilege
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.sql.SQLException
 
 @Component(service = [DbAdmin::class])
@@ -16,7 +16,7 @@ class DbAdminImpl @Activate constructor(
 ): DbAdmin {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createDbAndUser(

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerEventHandler.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerEventHandler.kt
@@ -10,15 +10,15 @@ import net.corda.lifecycle.LifecycleEventHandler
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 class DbConnectionManagerEventHandler(
     private val dbConnectionManager: DbConnectionManager
 ) : LifecycleEventHandler {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private lateinit var bootstrapConfig: SmartConfig

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerImpl.kt
@@ -14,11 +14,11 @@ import net.corda.lifecycle.createCoordinator
 import net.corda.orm.DbEntityManagerConfiguration
 import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.orm.JpaEntitiesRegistry
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import javax.persistence.EntityManagerFactory
 import javax.sql.DataSource
@@ -56,7 +56,7 @@ class DbConnectionManagerImpl (
                 { d -> Thread.sleep(d.toMillis()) })
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val eventHandler = DbConnectionManagerEventHandler(this)

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsImpl.kt
@@ -11,8 +11,8 @@ import net.corda.orm.DbEntityManagerConfiguration
 import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
-import net.corda.v5.base.util.contextLogger
-import java.util.*
+import org.slf4j.LoggerFactory
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.sql.DataSource
@@ -26,7 +26,7 @@ class DbConnectionOpsImpl(
     private val clusterEntityManagerFactory = createManagerFactory(CordaDb.CordaCluster.persistenceUnitName, getClusterDataSource())
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun getClusterDataSource(): CloseableDataSource =

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionsRepositoryImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionsRepositoryImpl.kt
@@ -14,7 +14,7 @@ import net.corda.libs.configuration.datamodel.DbConnectionConfig
 import net.corda.libs.configuration.datamodel.findDbConnectionByNameAndPrivilege
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
@@ -33,7 +33,7 @@ class DbConnectionsRepositoryImpl(
 ): DbConnectionsRepository {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun put(

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/BlockingDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/BlockingDominoTile.kt
@@ -7,7 +7,7 @@ import net.corda.lifecycle.LifecycleEvent
 import net.corda.lifecycle.LifecycleEventHandler
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StopEvent
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
@@ -26,7 +26,7 @@ class BlockingDominoTile(componentName: String,
 ): DominoTile() {
     companion object {
         private val instancesIndex = ConcurrentHashMap<String, Int>()
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val coordinatorName: LifecycleCoordinatorName by lazy {

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/ResourcesHolder.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/ResourcesHolder.kt
@@ -1,11 +1,11 @@
 package net.corda.lifecycle.domino.logic.util
 
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentLinkedDeque
 
 class ResourcesHolder : AutoCloseable {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     private val resources = ConcurrentLinkedDeque<AutoCloseable>()
 

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/FlowMapperService.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/FlowMapperService.kt
@@ -1,6 +1,5 @@
 package net.corda.session.mapper.service
 
-import java.util.concurrent.Executors
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.flow.mapper.factory.FlowMapperEventExecutorFactory
@@ -26,11 +25,12 @@ import net.corda.session.mapper.service.executor.FlowMapperListener
 import net.corda.session.mapper.service.executor.FlowMapperMessageProcessor
 import net.corda.session.mapper.service.executor.ScheduledTaskState
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.util.concurrent.Executors
 
 @Component(service = [FlowMapperService::class], immediate = true)
 class FlowMapperService @Activate constructor(
@@ -47,7 +47,7 @@ class FlowMapperService @Activate constructor(
 ) : Lifecycle {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val CONSUMER_GROUP = "FlowMapperConsumer"
 
         private const val SUBSCRIPTION = "SUBSCRIPTION"

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
@@ -7,9 +7,9 @@ import net.corda.data.flow.state.mapper.FlowMapperStateType
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
 import net.corda.schema.Schemas.Flow.Companion.FLOW_MAPPER_EVENT_TOPIC
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.util.concurrent.TimeUnit
 
@@ -22,7 +22,7 @@ class FlowMapperListener(
     private val scheduledTasks = scheduledTaskState.tasks
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun onPartitionSynced(states: Map<String, FlowMapperState>) {

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
@@ -1,6 +1,5 @@
 package net.corda.session.mapper.service.executor
 
-import java.time.Instant
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.ExecuteCleanup
@@ -13,9 +12,10 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.FlowConfig
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 /**
  * The [FlowMapperMessageProcessor] receives states and events that are keyed by strings. These strings can be either:
@@ -29,7 +29,7 @@ class FlowMapperMessageProcessor(
 ) : StateAndEventProcessor<String, FlowMapperState, FlowMapperEvent> {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val sessionP2PTtl = flowConfig.getLong(FlowConfig.SESSION_P2P_TTL)

--- a/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterProcessor.kt
+++ b/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterProcessor.kt
@@ -5,15 +5,15 @@ import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.flow.event.MessageDirection
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
-import net.corda.messaging.api.processor.DurableProcessor
-import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.AuthenticatedMessage
+import net.corda.messaging.api.processor.DurableProcessor
+import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Flow.Companion.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.session.manager.Constants.Companion.FLOW_SESSION_SUBSYSTEM
 import net.corda.session.manager.Constants.Companion.INITIATED_SESSION_ID_SUFFIX
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 /**
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer
 class FlowP2PFilterProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFactory) : DurableProcessor<String, AppMessage> {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     private val cordaAvroDeserializer: CordaAvroDeserializer<SessionEvent> = cordaAvroSerializationFactory.createAvroDeserializer({},
         SessionEvent::class.java)

--- a/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterService.kt
+++ b/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterService.kt
@@ -17,11 +17,11 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.P2P.Companion.P2P_IN_TOPIC
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [FlowP2PFilterService::class], immediate = true)
 class FlowP2PFilterService @Activate constructor(
@@ -36,7 +36,7 @@ class FlowP2PFilterService @Activate constructor(
 ) : Lifecycle {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val CONSUMER_GROUP = "FlowSessionFilterConsumer"
         private const val SUBSCRIPTION = "SUBSCRIPTION"
         private const val REGISTRATION = "REGISTRATION"

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowRPCOpsServiceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowRPCOpsServiceImpl.kt
@@ -18,12 +18,12 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /** An implementation of [FlowRPCOpsService]. */
 @Component(immediate = true, service = [FlowRPCOpsService::class])
@@ -41,7 +41,7 @@ internal class FlowRPCOpsServiceImpl @Activate constructor(
 ) : FlowRPCOpsService {
 
     private companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var isUp = false

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/FlowStatusCacheServiceImpl.kt
@@ -2,7 +2,6 @@ package net.corda.flow.rpcops.impl
 
 import com.google.common.collect.Multimap
 import com.google.common.collect.Multimaps
-import java.util.LinkedList
 import net.corda.data.flow.FlowInitiatorType
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.output.FlowStatus
@@ -24,11 +23,12 @@ import net.corda.messaging.api.subscription.CompactedSubscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.Flow.Companion.FLOW_STATUS_TOPIC
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.util.LinkedList
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReadWriteLock
 import java.util.concurrent.locks.ReentrantReadWriteLock
@@ -43,7 +43,7 @@ class FlowStatusCacheServiceImpl @Activate constructor(
 ) : FlowStatusCacheService, CompactedProcessor<FlowKey, FlowStatus> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var flowStatusSubscription: CompactedSubscription<FlowKey, FlowStatus>? = null

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/flowstatus/websocket/WebSocketFlowStatusUpdateListener.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/flowstatus/websocket/WebSocketFlowStatusUpdateListener.kt
@@ -1,7 +1,5 @@
 package net.corda.flow.rpcops.impl.flowstatus.websocket
 
-import java.time.Instant
-import java.util.concurrent.TimeUnit
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.identity.HoldingIdentity
@@ -10,9 +8,11 @@ import net.corda.flow.rpcops.v1.types.response.FlowStateErrorResponse
 import net.corda.flow.rpcops.v1.types.response.FlowStatusResponse
 import net.corda.httprpc.ws.DuplexChannel
 import net.corda.httprpc.ws.WebSocketProtocolViolationException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 /**
  * Flow status update handler that uses websockets to communicate updates to the counterpart connection.
@@ -24,7 +24,7 @@ class WebSocketFlowStatusUpdateListener(
 ) : FlowStatusUpdateListener {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val id: String

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRestResourceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowClassRestResourceImpl.kt
@@ -18,7 +18,6 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.read.rpc.extensions.getByHoldingIdentityShortHashOrThrow
 import net.corda.virtualnode.toAvro
@@ -26,6 +25,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @Component(service = [FlowClassRestResource::class, PluggableRestResource::class], immediate = true)
 class FlowClassRestResourceImpl @Activate constructor(
@@ -38,7 +38,7 @@ class FlowClassRestResourceImpl @Activate constructor(
 ) : FlowClassRestResource, PluggableRestResource<FlowClassRestResource>, Lifecycle {
 
     companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun start() = coordinator.start()

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRestResourceImpl.kt
@@ -35,7 +35,6 @@ import net.corda.rbac.schema.RbacKeys.PREFIX_SEPARATOR
 import net.corda.rbac.schema.RbacKeys.START_FLOW_PREFIX
 import net.corda.schema.Schemas.Flow.Companion.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.Companion.FLOW_STATUS_TOPIC
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.read.rpc.extensions.getByHoldingIdentityShortHashOrThrow
 import net.corda.virtualnode.toAvro
@@ -43,6 +42,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
@@ -63,7 +63,7 @@ class FlowRestResourceImpl @Activate constructor(
 ) : FlowRestResource, PluggableRestResource<FlowRestResource>, Lifecycle {
 
     private companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val PUBLICATION_TIMEOUT_SECONDS = 30L
     }
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -1,9 +1,6 @@
 package net.corda.flow.testing.context
 
 import com.typesafe.config.ConfigFactory
-import java.nio.ByteBuffer
-import java.time.Instant
-import java.util.UUID
 import net.corda.cpiinfo.read.fake.CpiInfoReadServiceFake
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.ExceptionEnvelope
@@ -49,7 +46,6 @@ import net.corda.schema.configuration.FlowConfig
 import net.corda.schema.configuration.MessagingConfig
 import net.corda.test.flow.util.buildSessionEvent
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.fake.VirtualNodeInfoReadServiceFake
@@ -58,6 +54,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.util.UUID
 
 @Suppress("Unused")
 @Component(service = [FlowServiceTestContext::class])
@@ -79,7 +79,7 @@ class FlowServiceTestContext @Activate constructor(
 ) : StepSetup, ThenSetup {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val testConfig = mutableMapOf<String, Any>(

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -21,7 +21,6 @@ import net.corda.flow.fiber.FlowContinuation
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.uncheckedCast
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -30,6 +29,7 @@ import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.slf4j.LoggerFactory
 
 class OutputAssertionsImpl(
     private val serializer: CordaAvroSerializer<Any>,
@@ -42,7 +42,7 @@ class OutputAssertionsImpl(
 ) : OutputAssertions {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val asserts = mutableListOf<(TestRun) -> Unit>()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -8,7 +8,6 @@ import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -17,6 +16,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 
 @Component(
@@ -31,7 +31,7 @@ class SigningServiceImpl @Activate constructor(
 ) : SigningService, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceImpl.kt
@@ -8,13 +8,13 @@ import net.corda.sandboxgroupcontext.RequireSandboxAMQP.AMQP_SERIALIZATION_SERVI
 import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.utilities.reflection.castIfPossible
 import net.corda.v5.application.serialization.SerializationService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.serialization.SerializedBytes
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 
 @Component(
@@ -28,7 +28,7 @@ class SerializationServiceImpl @Activate constructor(
 ) : SerializationServiceInternal, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val serializationService

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
@@ -11,9 +11,9 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 class FlowSessionImpl(
@@ -26,7 +26,7 @@ class FlowSessionImpl(
 ) : FlowSession, FlowSessionInternal {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val contextProperties: FlowContextProperties = flowContext

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImpl.kt
@@ -14,11 +14,11 @@ import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.FlowConfig
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -32,7 +32,7 @@ class ExternalEventManagerImpl(
 ) : ExternalEventManager {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Activate

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -9,10 +9,10 @@ import net.corda.utilities.clearMDC
 import net.corda.utilities.setMDC
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.Serializable
 import java.nio.ByteBuffer
 import java.util.UUID
@@ -29,7 +29,7 @@ class FlowFiberImpl(
     private fun interface SerializableFiberWriter : FiberWriter, Serializable
 
     companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Transient

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
@@ -4,11 +4,11 @@ import net.corda.data.flow.event.external.ExternalEventResponse
 import net.corda.flow.external.events.impl.ExternalEventManager
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowEventException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [FlowEventHandler::class])
 class ExternalEventResponseHandler @Activate constructor(
@@ -17,7 +17,7 @@ class ExternalEventResponseHandler @Activate constructor(
 ) : FlowEventHandler<ExternalEventResponse> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val type = ExternalEventResponse::class.java

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -13,13 +13,13 @@ import net.corda.flow.pipeline.handlers.waiting.sessions.WaitingForSessionInit
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.flow.utils.emptyKeyValuePairList
 import net.corda.session.manager.SessionManager
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 @Component(service = [FlowEventHandler::class])
@@ -31,7 +31,7 @@ class SessionEventHandler @Activate constructor(
 ) : FlowEventHandler<SessionEvent> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val type = SessionEvent::class.java

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/WakeupEventHandler.kt
@@ -3,15 +3,15 @@ package net.corda.flow.pipeline.handlers.events
 import net.corda.data.flow.event.Wakeup
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowEventException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 
 @Component(service = [FlowEventHandler::class])
 class WakeupEventHandler : FlowEventHandler<Wakeup> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val type = Wakeup::class.java

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.pipeline.handlers.requests
 
-import java.time.Instant
 import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.state.waiting.WaitingFor
@@ -10,10 +9,11 @@ import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.flow.pipeline.handlers.requests.helper.recordFlowRuntimeMetric
 import net.corda.schema.configuration.FlowConfig.PROCESSING_FLOW_CLEANUP_TIME
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 @Suppress("Unused")
 @Component(service = [FlowRequestHandler::class])
@@ -25,7 +25,7 @@ class FlowFinishedRequestHandler @Activate constructor(
 ) : FlowRequestHandler<FlowIORequest.FlowFinished> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val type = FlowIORequest.FlowFinished::class.java

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/ExternalEventResponseWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/ExternalEventResponseWaitingForHandler.kt
@@ -12,11 +12,11 @@ import net.corda.flow.state.FlowCheckpoint
 import net.corda.libs.configuration.SmartConfig
 import net.corda.schema.configuration.FlowConfig
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [FlowWaitingForHandler::class])
 class ExternalEventResponseWaitingForHandler @Activate constructor(
@@ -27,7 +27,7 @@ class ExternalEventResponseWaitingForHandler @Activate constructor(
 ) : FlowWaitingForHandler<net.corda.data.flow.state.waiting.external.ExternalEventResponse> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val type = net.corda.data.flow.state.waiting.external.ExternalEventResponse::class.java

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.pipeline.impl
 
-import java.time.Instant
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
@@ -28,11 +27,12 @@ import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.FlowConfig
 import net.corda.schema.configuration.FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 @Suppress("Unused")
 @Component(service = [FlowEventExceptionProcessor::class])
@@ -48,7 +48,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
 ) : FlowEventExceptionProcessor {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var maxRetryAttempts = 0

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
@@ -12,9 +12,9 @@ import net.corda.flow.pipeline.handlers.events.FlowEventHandler
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
 import net.corda.flow.pipeline.handlers.waiting.FlowWaitingForHandler
 import net.corda.flow.pipeline.runner.FlowRunner
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.util.uncheckedCast
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -42,7 +42,7 @@ class FlowEventPipelineImpl(
 ) : FlowEventPipeline {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override var context: FlowEventContext<Any> = context

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
@@ -16,9 +16,9 @@ import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.MessagingConfig.Subscription.PROCESSOR_TIMEOUT
 import net.corda.utilities.withMDC
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 
 class FlowEventProcessorImpl(
     private val flowEventPipelineFactory: FlowEventPipelineFactory,
@@ -29,7 +29,7 @@ class FlowEventProcessorImpl(
 ) : StateAndEventProcessor<String, Checkpoint, FlowEvent> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val keyClass = String::class.java

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.pipeline.impl
 
-import java.time.Instant
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
@@ -14,10 +13,11 @@ import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.FlowConfig.SESSION_FLOW_CLEANUP_TIME
 import net.corda.session.manager.SessionManager
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 @Component(service = [FlowGlobalPostProcessor::class])
 class FlowGlobalPostProcessorImpl @Activate constructor(
@@ -32,7 +32,7 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
 ) : FlowGlobalPostProcessor {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun postProcess(context: FlowEventContext<Any>): FlowEventContext<Any> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
@@ -8,9 +8,9 @@ import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.flow.state.checkpoint.FlowState
 import net.corda.data.flow.state.external.ExternalEventStateType
 import net.corda.flow.pipeline.FlowMDCService
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 
 @Component(service = [FlowMDCService::class])
 class FlowMDCServiceImpl : FlowMDCService {
@@ -21,7 +21,7 @@ class FlowMDCServiceImpl : FlowMDCService {
         const val MDC_VNODE_ID = "vnode_id"
         const val MDC_SESSION_EVENT_ID = "session_event_id"
         const val MDC_EXTERNAL_EVENT_ID = "external_event_id"
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     
     override fun getMDCLogging(checkpoint: Checkpoint?, event: FlowEvent?, flowId: String): Map<String, String> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/factory/SandboxDependencyInjectorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/factory/SandboxDependencyInjectorFactoryImpl.kt
@@ -6,7 +6,6 @@ import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CORDA_SANDBOX_FILTER
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType.FLOW
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.framework.Bundle
 import org.osgi.framework.Constants.OBJECTCLASS
@@ -14,13 +13,14 @@ import org.osgi.framework.Constants.SCOPE_SINGLETON
 import org.osgi.framework.Constants.SERVICE_SCOPE
 import org.osgi.framework.ServiceReference
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import java.util.Collections.unmodifiableSet
 import java.util.LinkedList
 
 @Component(service = [SandboxDependencyInjectorFactory::class])
 class SandboxDependencyInjectorFactoryImpl : SandboxDependencyInjectorFactory {
     private companion object {
-        private val logger = loggerFor<SandboxDependencyInjectorFactoryImpl>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val INJECTOR_FILTER = "(&$CORDA_SANDBOX_FILTER($SERVICE_SCOPE=$SCOPE_SINGLETON))"
         private val FORBIDDEN_INTERFACES: Set<String> = unmodifiableSet(setOf(
             SingletonSerializeAsToken::class.java.name,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/CheckpointSerializerProvider.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/impl/CheckpointSerializerProvider.kt
@@ -11,13 +11,13 @@ import net.corda.sandboxgroupcontext.getSandboxSingletonServices
 import net.corda.sandboxgroupcontext.putObjectByKey
 import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
 import net.corda.serialization.checkpoint.factory.CheckpointSerializerBuilderFactory
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceScope
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 
 /**
  * This component allows [FlowSandboxServiceImpl] to create and install a
@@ -37,7 +37,7 @@ class CheckpointSerializerProvider @Activate constructor(
     private val checkpointInternalCustomSerializers: List<CheckpointInternalCustomSerializer<*>>
 ) : UsedByFlow, CustomMetadataConsumer {
     private companion object {
-        private val logger = loggerFor<CheckpointSerializerProvider>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun accept(context: MutableSandboxGroupContext) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreFactoryImpl.kt
@@ -9,15 +9,15 @@ import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.ResponderFlow
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 
 @Component(service = [FlowProtocolStoreFactory::class])
 class FlowProtocolStoreFactoryImpl : FlowProtocolStoreFactory {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private fun extractDataForFlow(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
@@ -21,11 +21,11 @@ import net.corda.schema.Schemas.Flow.Companion.FLOW_EVENT_TOPIC
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.MessagingConfig.Subscription.PROCESSOR_TIMEOUT
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [FlowExecutor::class])
@@ -56,7 +56,7 @@ class FlowExecutorImpl constructor(
     )
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val CONSUMER_GROUP = "FlowEventConsumer"
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
@@ -19,11 +19,11 @@ import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [FlowService::class])
@@ -39,7 +39,7 @@ class FlowService @Activate constructor(
 ) : Lifecycle {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val configSections = setOf(BOOT_CONFIG, MESSAGING_CONFIG, FLOW_CONFIG)
     }
 

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -13,6 +13,15 @@ import net.corda.crypto.test.certificates.generation.toKeystore
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.p2p.GatewayTlsCertificates
+import net.corda.data.p2p.GatewayTruststore
+import net.corda.data.p2p.LinkInMessage
+import net.corda.data.p2p.LinkOutHeader
+import net.corda.data.p2p.LinkOutMessage
+import net.corda.data.p2p.NetworkType
+import net.corda.data.p2p.SessionPartitions
+import net.corda.data.p2p.crypto.AuthenticatedDataMessage
+import net.corda.data.p2p.crypto.CommonHeader
+import net.corda.data.p2p.crypto.MessageType
 import net.corda.data.p2p.gateway.GatewayMessage
 import net.corda.data.p2p.gateway.GatewayResponse
 import net.corda.libs.configuration.SmartConfigImpl
@@ -29,15 +38,6 @@ import net.corda.messaging.emulation.publisher.factory.CordaPublisherFactory
 import net.corda.messaging.emulation.rpc.RPCTopicServiceImpl
 import net.corda.messaging.emulation.subscription.factory.InMemSubscriptionFactory
 import net.corda.messaging.emulation.topic.service.impl.TopicServiceImpl
-import net.corda.data.p2p.GatewayTruststore
-import net.corda.data.p2p.LinkInMessage
-import net.corda.data.p2p.LinkOutHeader
-import net.corda.data.p2p.LinkOutMessage
-import net.corda.data.p2p.NetworkType
-import net.corda.data.p2p.SessionPartitions
-import net.corda.data.p2p.crypto.AuthenticatedDataMessage
-import net.corda.data.p2p.crypto.CommonHeader
-import net.corda.data.p2p.crypto.MessageType
 import net.corda.p2p.gateway.messaging.ConnectionConfiguration
 import net.corda.p2p.gateway.messaging.GatewayConfiguration
 import net.corda.p2p.gateway.messaging.RevocationConfig
@@ -64,7 +64,6 @@ import net.corda.schema.registry.impl.AvroSchemaRegistryImpl
 import net.corda.test.util.eventually
 import net.corda.test.util.lifecycle.usingLifecycle
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.seconds
 import net.corda.v5.base.util.toHex
 import org.assertj.core.api.Assertions.assertThat
@@ -78,6 +77,7 @@ import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
+import org.slf4j.LoggerFactory
 import java.io.StringWriter
 import java.net.ConnectException
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
@@ -106,7 +106,7 @@ import java.net.http.HttpRequest as JavaHttpRequest
 
 class GatewayIntegrationTest : TestBase() {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val GROUP_ID = "Group - 1"
 
         const val aliceX500name = "CN=Alice, O=Alice Corp, L=LDN, C=GB"

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
@@ -6,6 +6,7 @@ import net.corda.crypto.delegated.signing.CertificateChain
 import net.corda.crypto.delegated.signing.DelegatedCertificateStore
 import net.corda.crypto.delegated.signing.DelegatedSigner
 import net.corda.data.identity.HoldingIdentity
+import net.corda.data.p2p.GatewayTlsCertificates
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -18,11 +19,10 @@ import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.GatewayTlsCertificates
 import net.corda.p2p.gateway.messaging.http.KeyStoreWithPassword
 import net.corda.schema.Schemas
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SignatureSpec
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.security.InvalidKeyException
 import java.security.PublicKey
@@ -45,7 +45,7 @@ internal class DynamicKeyStore(
 
     companion object {
         private const val CONSUMER_GROUP_ID = "gateway_certificates_truststores_reader"
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     override val aliasToCertificates = ConcurrentHashMap<Alias, CertificateChain>()
 

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/ReconfigurableConnectionManager.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/ReconfigurableConnectionManager.kt
@@ -2,14 +2,14 @@ package net.corda.p2p.gateway.messaging
 
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
+import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.lifecycle.domino.logic.util.ResourcesHolder
 import net.corda.p2p.gateway.messaging.http.DestinationInfo
 import net.corda.p2p.gateway.messaging.http.HttpClient
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 
 class ReconfigurableConnectionManager(
@@ -29,7 +29,7 @@ class ReconfigurableConnectionManager(
     private var manager: ConnectionManager? = null
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     fun acquire(destinationInfo: DestinationInfo): HttpClient {

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServer.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpServer.kt
@@ -12,7 +12,7 @@ import io.netty.handler.codec.http.HttpServerCodec
 import io.netty.handler.timeout.IdleStateHandler
 import net.corda.lifecycle.Resource
 import net.corda.p2p.gateway.messaging.GatewayConfiguration
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.net.SocketAddress
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
@@ -38,7 +38,7 @@ class HttpServer(
     HttpServerListener {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         /**
          * Default number of thread to use for the worker group

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
@@ -14,7 +14,7 @@ import net.corda.p2p.gateway.messaging.DynamicKeyStore
 import net.corda.p2p.gateway.messaging.GatewayConfiguration
 import net.corda.p2p.gateway.messaging.toGatewayConfiguration
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.net.SocketAddress
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.locks.ReentrantReadWriteLock
@@ -51,7 +51,7 @@ class ReconfigurableHttpServer(
     )
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     fun writeResponse(status: HttpResponseStatus, address: SocketAddress, payload: ByteArray = ByteArray(0)) {

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -1,6 +1,7 @@
 package net.corda.p2p.gateway.messaging.http
 
 import net.corda.crypto.utils.convertToKeyStore
+import net.corda.data.p2p.GatewayTruststore
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.BlockingDominoTile
@@ -11,10 +12,9 @@ import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.GatewayTruststore
 import net.corda.schema.Schemas
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.util.concurrent.CompletableFuture
@@ -30,7 +30,7 @@ internal class TrustStoresMap(
 
     companion object {
         private const val CONSUMER_GROUP_ID = "gateway_tls_truststores_reader"
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     private val ready = CompletableFuture<Unit>()
     private val subscriptionConfig = SubscriptionConfig(CONSUMER_GROUP_ID, Schemas.P2P.GATEWAY_TLS_TRUSTSTORES)

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -3,6 +3,14 @@ package net.corda.p2p.gateway.messaging.internal
 import io.netty.handler.codec.http.HttpResponseStatus
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.p2p.LinkInMessage
+import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.crypto.AuthenticatedDataMessage
+import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
+import net.corda.data.p2p.crypto.InitiatorHandshakeMessage
+import net.corda.data.p2p.crypto.InitiatorHelloMessage
+import net.corda.data.p2p.crypto.ResponderHandshakeMessage
+import net.corda.data.p2p.crypto.ResponderHelloMessage
 import net.corda.data.p2p.gateway.GatewayMessage
 import net.corda.data.p2p.gateway.GatewayResponse
 import net.corda.libs.configuration.SmartConfig
@@ -14,14 +22,6 @@ import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.LinkInMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.p2p.crypto.AuthenticatedDataMessage
-import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
-import net.corda.data.p2p.crypto.InitiatorHandshakeMessage
-import net.corda.data.p2p.crypto.InitiatorHelloMessage
-import net.corda.data.p2p.crypto.ResponderHandshakeMessage
-import net.corda.data.p2p.crypto.ResponderHelloMessage
 import net.corda.p2p.gateway.messaging.http.HttpRequest
 import net.corda.p2p.gateway.messaging.http.HttpServerListener
 import net.corda.p2p.gateway.messaging.http.ReconfigurableHttpServer
@@ -29,7 +29,7 @@ import net.corda.p2p.gateway.messaging.session.SessionPartitionMapperImpl
 import net.corda.schema.Schemas.P2P.Companion.LINK_IN_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.util.UUID
 
@@ -55,7 +55,7 @@ internal class InboundMessageHandler(
 
     companion object {
         const val AVRO_LIMIT = 5_000_000
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var p2pInPublisher = PublisherWithDominoLogic(

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityBase.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityBase.kt
@@ -7,16 +7,16 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 abstract class ConsensualFinalityBase : SubFlow<ConsensualSignedTransaction> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
@@ -16,9 +16,9 @@ import net.corda.v5.application.messaging.receive
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 class ConsensualFinalityFlow(
@@ -27,7 +27,7 @@ class ConsensualFinalityFlow(
 ) : ConsensualFinalityBase() {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val transactionId = initialTransaction.id

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.consensual.flow.impl.flows.finality
 
+import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.consensual.flow.impl.persistence.ConsensualLedgerPersistenceService
-import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
 import net.corda.ledger.consensual.flow.impl.transaction.verifier.ConsensualLedgerTransactionVerifier
 import net.corda.sandbox.CordaSystemFlow
@@ -13,11 +13,11 @@ import net.corda.v5.application.messaging.receive
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionValidator
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 class ConsensualReceiveFinalityFlow(
@@ -26,7 +26,7 @@ class ConsensualReceiveFinalityFlow(
 ) : ConsensualFinalityBase() {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -31,7 +31,6 @@ import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.v5.application.serialization.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
@@ -48,6 +47,7 @@ import org.osgi.test.common.annotation.InjectBundleContext
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.time.Instant
@@ -72,7 +72,7 @@ class ConsensualLedgerMessageProcessorTests {
         val EXTERNAL_EVENT_CONTEXT = ExternalEventContext(
             "request id", "flow id", KeyValuePairList(listOf(KeyValuePair("corda.account", "test account")))
         )
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @RegisterExtension

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -33,7 +33,6 @@ import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.ContractState
@@ -52,6 +51,7 @@ import org.osgi.test.common.annotation.InjectBundleContext
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.security.KeyPairGenerator
@@ -85,7 +85,7 @@ class UtxoLedgerMessageProcessorTests {
                 it.initialize(512)
             }.genKeyPair().public
         private val notaryExample = Party(notaryX500Name, publicKeyExample)
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @RegisterExtension

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/LedgerPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/LedgerPersistenceService.kt
@@ -21,12 +21,12 @@ import net.corda.messaging.api.subscription.Subscription
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [LedgerPersistenceService::class])
@@ -48,7 +48,7 @@ class LedgerPersistenceService @Activate constructor(
     private var ledgerProcessorSubscription: Subscription<String, LedgerPersistenceRequest>? = null
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRepositoryImpl.kt
@@ -12,7 +12,6 @@ import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
@@ -20,6 +19,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.Query
@@ -47,7 +47,7 @@ class ConsensualRepositoryImpl @Activate constructor(
     companion object {
         private val UNVERIFIED = TransactionStatus.UNVERIFIED.value
         private val consensualComponentGroupMapper = ConsensualComponentGroupMapper()
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun findTransaction(entityManager: EntityManager, id: String): SignedTransactionContainer? {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
@@ -8,9 +8,9 @@ import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.EntitySandboxService
 import net.corda.persistence.common.ResponseFactory
 import net.corda.utilities.withMDC
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 /**
  * Handles incoming requests, typically from the flow worker, and sends responses.
@@ -23,7 +23,7 @@ class PersistenceRequestProcessor(
 ) : DurableProcessor<String, LedgerPersistenceRequest> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val MDC_EXTERNAL_EVENT_ID = "external_event_id"
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/DelegatedRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/DelegatedRequestHandlerSelectorImpl.kt
@@ -2,16 +2,16 @@ package net.corda.ledger.persistence.processor.impl
 
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.data.ledger.persistence.LedgerTypes
-import net.corda.ledger.persistence.common.UnsupportedLedgerTypeException
 import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.common.UnsupportedLedgerTypeException
 import net.corda.ledger.persistence.consensual.ConsensualRequestHandlerSelector
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
 import net.corda.ledger.persistence.utxo.UtxoRequestHandlerSelector
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [DelegatedRequestHandlerSelector::class])
 class DelegatedRequestHandlerSelectorImpl @Activate constructor(
@@ -22,7 +22,7 @@ class DelegatedRequestHandlerSelectorImpl @Activate constructor(
 ) : DelegatedRequestHandlerSelector {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun selectHandler(sandbox: SandboxGroupContext, request: LedgerPersistenceRequest): RequestHandler {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionRequestHandler.kt
@@ -8,11 +8,11 @@ import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.ledger.persistence.utxo.UtxoTokenObserverMap
 import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.virtualnode.HoldingIdentity
+import org.slf4j.LoggerFactory
 
 class UtxoPersistTransactionRequestHandler @Suppress("LongParameterList") constructor(
     private val holdingIdentity: HoldingIdentity,
@@ -24,7 +24,7 @@ class UtxoPersistTransactionRequestHandler @Suppress("LongParameterList") constr
 ) : RequestHandler {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): List<Record<*, *>> {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -11,10 +11,10 @@ import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.ledger.utxo.StateRef
+import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.time.Instant
 import javax.persistence.EntityManager
@@ -29,7 +29,7 @@ class UtxoRepositoryImpl(
 ) : UtxoRepository {
     private companion object {
         private val UNVERIFIED = TransactionStatus.UNVERIFIED.value
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun findTransaction(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainReceiverFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainReceiverFlow.kt
@@ -9,10 +9,10 @@ import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.messaging.sendAndReceive
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 class TransactionBackchainReceiverFlow(
@@ -22,7 +22,7 @@ class TransactionBackchainReceiverFlow(
 ) : SubFlow<TopologicalSort> {
 
     private companion object {
-        val log = loggerFor<TransactionBackchainReceiverFlow>()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlow.kt
@@ -10,15 +10,15 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.debug
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 class TransactionBackchainResolutionFlow(private val transaction: UtxoSignedTransaction, private val session: FlowSession) : SubFlow<Unit> {
 
     private companion object {
-        val log = loggerFor<TransactionBackchainResolutionFlow>()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
@@ -8,7 +8,6 @@ import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -16,6 +15,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 
 @Component(
     service = [ TransactionBackchainVerifier::class, UsedByFlow::class ],
@@ -28,7 +28,7 @@ class TransactionBackchainVerifierImpl @Activate constructor(
 ) : TransactionBackchainVerifier, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
-        val log = loggerFor<TransactionBackchainVerifierImpl>()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
@@ -13,17 +13,17 @@ import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.containsAny
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -14,10 +14,10 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.messaging.receive
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 class UtxoFinalityFlow(
@@ -26,7 +26,7 @@ class UtxoFinalityFlow(
 ) : UtxoFinalityBase() {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val transactionId = initialTransaction.id

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
@@ -10,11 +10,11 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.messaging.receive
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionValidator
+import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
 class UtxoReceiveFinalityFlow(
@@ -23,7 +23,7 @@ class UtxoReceiveFinalityFlow(
 ) : UtxoFinalityBase() {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenClaimReleaseEventHandler.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/handlers/TokenClaimReleaseEventHandler.kt
@@ -1,20 +1,20 @@
 package net.corda.ledger.utxo.token.cache.handlers
 
 import net.corda.data.flow.event.FlowEvent
-import net.corda.messaging.api.records.Record
 import net.corda.ledger.utxo.token.cache.entities.ClaimRelease
 import net.corda.ledger.utxo.token.cache.entities.PoolCacheState
 import net.corda.ledger.utxo.token.cache.entities.TokenCache
 import net.corda.ledger.utxo.token.cache.factories.RecordFactory
-import net.corda.v5.base.util.contextLogger
+import net.corda.messaging.api.records.Record
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 class TokenClaimReleaseEventHandler(
     private val recordFactory: RecordFactory,
 ) : TokenEventHandler<ClaimRelease> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun handle(

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheComponent.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheComponent.kt
@@ -14,8 +14,8 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 class TokenCacheComponent constructor(
     coordinatorFactory: LifecycleCoordinatorFactory,
@@ -24,7 +24,7 @@ class TokenCacheComponent constructor(
 ) : Lifecycle {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val configSections = setOf(ConfigKeys.BOOT_CONFIG, ConfigKeys.MESSAGING_CONFIG)
     }
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
@@ -3,13 +3,13 @@ package net.corda.ledger.utxo.token.cache.services
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
-import net.corda.messaging.api.processor.StateAndEventProcessor
-import net.corda.messaging.api.records.Record
 import net.corda.ledger.utxo.token.cache.converters.EntityConverter
 import net.corda.ledger.utxo.token.cache.converters.EventConverter
 import net.corda.ledger.utxo.token.cache.entities.TokenEvent
 import net.corda.ledger.utxo.token.cache.handlers.TokenEventHandler
-import net.corda.v5.base.util.contextLogger
+import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.records.Record
+import org.slf4j.LoggerFactory
 
 class TokenCacheEventProcessor constructor(
     private val eventConverter: EventConverter,
@@ -18,7 +18,7 @@ class TokenCacheEventProcessor constructor(
 ) : StateAndEventProcessor<TokenPoolCacheKey, TokenPoolCacheState, TokenPoolCacheEvent> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val keyClass = TokenPoolCacheKey::class.java

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheSubscriptionHandlerImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheSubscriptionHandlerImpl.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.utxo.token.cache.services
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
+import net.corda.ledger.utxo.token.cache.factories.TokenCacheEventProcessorFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleEvent
@@ -15,9 +16,8 @@ import net.corda.messaging.api.subscription.StateAndEventSubscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
-import net.corda.ledger.utxo.token.cache.factories.TokenCacheEventProcessorFactory
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 class TokenCacheSubscriptionHandlerImpl constructor(
     coordinatorFactory: LifecycleCoordinatorFactory,
@@ -27,7 +27,7 @@ class TokenCacheSubscriptionHandlerImpl constructor(
 ) : TokenCacheSubscriptionHandler {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val CONSUMER_GROUP = "TokenEventConsumer"
     }
 

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/LedgerVerificationComponent.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/LedgerVerificationComponent.kt
@@ -21,12 +21,12 @@ import net.corda.messaging.api.subscription.Subscription
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [LedgerVerificationComponent::class])
@@ -48,7 +48,7 @@ class LedgerVerificationComponent @Activate constructor(
     private var verificationProcessorSubscription: Subscription<String, VerifyContractsRequest>? = null
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/ResponseFactoryImpl.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/ResponseFactoryImpl.kt
@@ -10,10 +10,10 @@ import net.corda.ledger.verification.exceptions.NullParameterException
 import net.corda.ledger.verification.exceptions.VirtualNodeException
 import net.corda.ledger.verification.processor.ResponseFactory
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 
 @Component(service = [ResponseFactory::class])
@@ -23,7 +23,7 @@ class ResponseFactoryImpl @Activate constructor(
 ) : ResponseFactory {
 
     companion object{
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun successResponse(

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
@@ -7,10 +7,10 @@ import net.corda.ledger.verification.sanbox.VerificationSandboxService
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.utilities.withMDC
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 /**
  * Handles incoming requests, typically from the flow worker, and sends responses.
@@ -23,7 +23,7 @@ class VerificationRequestProcessor(
 ) : DurableProcessor<String, VerifyContractsRequest> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val MDC_EXTERNAL_EVENT_ID = "external_event_id"
     }
 

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/sanbox/impl/VerificationSandboxServiceImpl.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/sanbox/impl/VerificationSandboxServiceImpl.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.verification.sanbox.impl
 
-import net.corda.ledger.verification.sanbox.VerificationSandboxService
 import net.corda.ledger.verification.exceptions.NotReadyException
+import net.corda.ledger.verification.sanbox.VerificationSandboxService
 import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
 import net.corda.sandboxgroupcontext.RequireSandboxAMQP
 import net.corda.sandboxgroupcontext.RequireSandboxJSON
@@ -13,12 +13,12 @@ import net.corda.sandboxgroupcontext.service.registerCordappCustomSerializers
 import net.corda.sandboxgroupcontext.service.registerCustomCryptography
 import net.corda.sandboxgroupcontext.service.registerCustomJsonDeserializers
 import net.corda.sandboxgroupcontext.service.registerCustomJsonSerializers
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * This is a sandbox service that is internal to this component.
@@ -38,7 +38,7 @@ class VerificationSandboxServiceImpl @Activate constructor(
     private val sandboxService: SandboxGroupContextComponent,
 ) : VerificationSandboxService {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun get(holdingIdentity: HoldingIdentity, cpkFileChecksums: Set<SecureHash>): SandboxGroupContext {

--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
@@ -39,7 +39,6 @@ import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.test.util.eventually
 import net.corda.test.util.lifecycle.usingLifecycle
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -50,6 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.mock
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 
 @ExtendWith(ServiceExtension::class, DBSetup::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -75,7 +75,7 @@ class LinkManagerIntegrationTest {
         private const val cryptoConf = """
         dummy=1
     """
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @InjectService(timeout = 4000)
         lateinit var publisherFactory: PublisherFactory

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -2,6 +2,12 @@ package net.corda.p2p.linkmanager.delivery
 
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
+import net.corda.data.p2p.AuthenticatedMessageAndKey
+import net.corda.data.p2p.AuthenticatedMessageDeliveryState
+import net.corda.data.p2p.markers.AppMessageMarker
+import net.corda.data.p2p.markers.LinkManagerProcessedMarker
+import net.corda.data.p2p.markers.LinkManagerReceivedMarker
+import net.corda.data.p2p.markers.TtlExpiredMarker
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -19,16 +25,9 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
-import net.corda.data.p2p.AuthenticatedMessageAndKey
-import net.corda.data.p2p.AuthenticatedMessageDeliveryState
 import net.corda.p2p.linkmanager.sessions.SessionManager
-import net.corda.data.p2p.markers.AppMessageMarker
-import net.corda.data.p2p.markers.LinkManagerProcessedMarker
-import net.corda.data.p2p.markers.LinkManagerReceivedMarker
-import net.corda.data.p2p.markers.TtlExpiredMarker
 import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_MARKERS
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
@@ -102,7 +101,7 @@ internal class DeliveryTracker(
 
         companion object {
             const val MESSAGE_REPLAYER_CLIENT_ID = "message-replayer-client"
-            private val logger = contextLogger()
+            private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         }
 
         private val publisher = PublisherWithDominoLogic(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
@@ -5,22 +5,27 @@ import com.typesafe.config.ConfigException
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.BASE_REPLAY_PERIOD_KEY
-import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_PERIOD_CUTOFF_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MAX_REPLAYING_MESSAGES_PER_PEER
-import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_ALGORITHM_KEY
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.MESSAGE_REPLAY_PERIOD_KEY
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_ALGORITHM_KEY
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.REPLAY_PERIOD_CUTOFF_KEY
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
 import net.corda.lifecycle.domino.logic.ComplexDominoTile
+import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.lifecycle.domino.logic.util.ResourcesHolder
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.utilities.time.Clock
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import net.corda.utilities.time.Clock
+import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.concurrent.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -83,7 +88,7 @@ internal class ReplayScheduler<M>(
     }
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisher.kt
@@ -1,6 +1,7 @@
 package net.corda.p2p.linkmanager.forwarding.gateway
 
 import net.corda.crypto.utils.PemCertificate
+import net.corda.data.p2p.GatewayTruststore
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.BlockingDominoTile
@@ -15,12 +16,11 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.GatewayTruststore
 import net.corda.schema.Schemas.P2P.Companion.GATEWAY_TLS_TRUSTSTORES
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -34,7 +34,7 @@ internal class TrustStoresPublisher(
 ) : LifecycleWithDominoTile {
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val CURRENT_DATA_READER_GROUP_NAME = "linkmanager_truststore_reader"
         private const val MISSING_DATA_WRITER_GROUP_NAME = "linkmanager_truststore_writer"
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/PendingSessionMessageQueuesImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/PendingSessionMessageQueuesImpl.kt
@@ -1,17 +1,17 @@
 package net.corda.p2p.linkmanager.sessions
 
-import java.util.LinkedList
-import java.util.Queue
+import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.p2p.crypto.protocol.api.Session
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.util.LinkedList
+import java.util.Queue
 
 internal class PendingSessionMessageQueuesImpl(
     publisherFactory: PublisherFactory,
@@ -20,7 +20,7 @@ internal class PendingSessionMessageQueuesImpl(
 ) : PendingSessionMessageQueues {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val LINK_MANAGER_PUBLISHER_CLIENT_ID = "pending_session_messages_publisher"
     }
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/RevocationCheckerClient.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/RevocationCheckerClient.kt
@@ -13,8 +13,7 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.schema.Schemas
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
-import java.lang.IllegalStateException
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 
@@ -26,7 +25,7 @@ class RevocationCheckerClient(
     private companion object {
         const val groupAndClientName = "GatewayRevocationChecker"
         val timeout: Duration = Duration.ofSeconds(60)
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val publisherConfig = RPCConfig(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -3,26 +3,6 @@ package net.corda.p2p.linkmanager.sessions
 import com.typesafe.config.Config
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
-import net.corda.libs.configuration.SmartConfig
-import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration
-import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.lifecycle.LifecycleCoordinatorName
-import net.corda.lifecycle.domino.logic.ComplexDominoTile
-import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
-import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
-import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
-import net.corda.lifecycle.domino.logic.util.ResourcesHolder
-import net.corda.membership.grouppolicy.GroupPolicyProvider
-import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
-import net.corda.membership.lib.grouppolicy.GroupPolicy
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.NO_PKI
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.CORDA_4
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.STANDARD
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.STANDARD_EV3
-import net.corda.membership.read.MembershipGroupReaderProvider
-import net.corda.messaging.api.publisher.config.PublisherConfig
-import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.data.p2p.HeartbeatMessage
 import net.corda.data.p2p.LinkInMessage
@@ -35,29 +15,49 @@ import net.corda.data.p2p.crypto.ResponderHandshakeMessage
 import net.corda.data.p2p.crypto.ResponderHelloMessage
 import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.data.p2p.markers.LinkManagerSentMarker
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.domino.logic.ComplexDominoTile
+import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
+import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
+import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
+import net.corda.lifecycle.domino.logic.util.ResourcesHolder
+import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
+import net.corda.membership.lib.grouppolicy.GroupPolicy
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.CORDA_4
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.NO_PKI
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.STANDARD
+import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.STANDARD_EV3
+import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.messaging.api.publisher.config.PublisherConfig
+import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.messaging.api.records.Record
 import net.corda.p2p.crypto.protocol.api.AuthenticationProtocolInitiator
 import net.corda.p2p.crypto.protocol.api.AuthenticationProtocolResponder
+import net.corda.p2p.crypto.protocol.api.CertificateCheckMode
+import net.corda.p2p.crypto.protocol.api.HandshakeIdentityData
 import net.corda.p2p.crypto.protocol.api.InvalidHandshakeMessageException
 import net.corda.p2p.crypto.protocol.api.InvalidHandshakeResponderKeyHash
 import net.corda.p2p.crypto.protocol.api.InvalidPeerCertificate
-import net.corda.p2p.crypto.protocol.api.CertificateCheckMode
-import net.corda.p2p.crypto.protocol.api.HandshakeIdentityData
 import net.corda.p2p.crypto.protocol.api.RevocationCheckMode
 import net.corda.p2p.crypto.protocol.api.Session
 import net.corda.p2p.crypto.protocol.api.WrongPublicKeyHashException
 import net.corda.p2p.linkmanager.LinkManager
-import net.corda.p2p.linkmanager.hosting.LinkManagerHostingMap
-import net.corda.p2p.linkmanager.outbound.OutboundMessageProcessor
+import net.corda.p2p.linkmanager.common.MessageConverter
+import net.corda.p2p.linkmanager.common.MessageConverter.Companion.createLinkOutMessage
 import net.corda.p2p.linkmanager.common.PublicKeyReader.Companion.getSignatureSpec
 import net.corda.p2p.linkmanager.common.PublicKeyReader.Companion.toKeyAlgorithm
 import net.corda.p2p.linkmanager.delivery.InMemorySessionReplayer
-import net.corda.p2p.linkmanager.common.MessageConverter
-import net.corda.p2p.linkmanager.common.MessageConverter.Companion.createLinkOutMessage
 import net.corda.p2p.linkmanager.grouppolicy.networkType
 import net.corda.p2p.linkmanager.grouppolicy.protocolModes
+import net.corda.p2p.linkmanager.hosting.LinkManagerHostingMap
 import net.corda.p2p.linkmanager.inbound.InboundAssignmentListener
 import net.corda.p2p.linkmanager.membership.lookup
 import net.corda.p2p.linkmanager.membership.lookupByKey
+import net.corda.p2p.linkmanager.outbound.OutboundMessageProcessor
 import net.corda.p2p.linkmanager.sessions.SessionManager.SessionCounterparties
 import net.corda.p2p.linkmanager.sessions.SessionManager.SessionState
 import net.corda.p2p.linkmanager.sessions.SessionManagerWarnings.alreadySessionWarning
@@ -72,16 +72,16 @@ import net.corda.schema.Schemas.P2P.Companion.LINK_OUT_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_MARKERS
 import net.corda.schema.Schemas.P2P.Companion.SESSION_OUT_PARTITIONS
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.utilities.time.Clock
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import net.corda.utilities.time.Clock
 import net.corda.v5.base.util.trace
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.*
+import java.util.Base64
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
@@ -844,7 +844,7 @@ internal class SessionManagerImpl(
     ) : LifecycleWithDominoTile {
 
         companion object {
-            private val logger = contextLogger()
+            private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
             const val HEARTBEAT_MANAGER_CLIENT_ID = "heartbeat-manager-client"
         }
 

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -12,7 +12,15 @@ import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.config.Configuration
 import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.data.p2p.HostedIdentityEntry
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.AuthenticatedMessage
+import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.data.p2p.markers.AppMessageMarker
+import net.corda.data.p2p.markers.LinkManagerProcessedMarker
+import net.corda.data.p2p.markers.LinkManagerReceivedMarker
+import net.corda.data.p2p.markers.TtlExpiredMarker
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.merger.impl.ConfigMergerImpl
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration
 import net.corda.libs.configuration.schema.p2p.LinkManagerConfiguration.Companion.HEARTBEAT_MESSAGE_PERIOD_KEY
@@ -48,9 +56,6 @@ import net.corda.messaging.emulation.publisher.factory.CordaPublisherFactory
 import net.corda.messaging.emulation.rpc.RPCTopicServiceImpl
 import net.corda.messaging.emulation.subscription.factory.InMemSubscriptionFactory
 import net.corda.messaging.emulation.topic.service.impl.TopicServiceImpl
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.AuthenticatedMessageHeader
 import net.corda.p2p.crypto.protocol.ProtocolConstants
 import net.corda.p2p.crypto.protocol.api.RevocationCheckMode
 import net.corda.p2p.gateway.Gateway
@@ -59,11 +64,6 @@ import net.corda.p2p.gateway.messaging.RevocationConfigMode
 import net.corda.p2p.gateway.messaging.SslConfiguration
 import net.corda.p2p.gateway.messaging.TlsType
 import net.corda.p2p.linkmanager.LinkManager
-import net.corda.data.p2p.markers.AppMessageMarker
-import net.corda.data.p2p.markers.LinkManagerProcessedMarker
-import net.corda.data.p2p.markers.LinkManagerReceivedMarker
-import net.corda.data.p2p.markers.TtlExpiredMarker
-import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.schema.Schemas.Config.Companion.CONFIG_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_HOSTED_IDENTITIES_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_IN_TOPIC
@@ -75,7 +75,6 @@ import net.corda.schema.registry.impl.AvroSchemaRegistryImpl
 import net.corda.test.util.eventually
 import net.corda.testing.p2p.certificates.Certificates
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.seconds
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.ParameterizedSignatureSpec
@@ -84,8 +83,8 @@ import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
-import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.PEMKeyPair
@@ -99,6 +98,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.slf4j.LoggerFactory
 import java.io.StringWriter
 import java.net.URL
 import java.nio.ByteBuffer
@@ -120,7 +120,7 @@ class P2PLayerEndToEndTest {
     companion object {
         private val EXPIRED_TTL = Instant.ofEpochMilli(0)
         private const val SUBSYSTEM = "e2e.test.app"
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val GROUP_ID = "group-1"
         private const val TLS_KEY_TENANT_ID = "p2p"
         private const val URL_PATH = "/gateway"

--- a/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactory.kt
+++ b/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactory.kt
@@ -6,6 +6,7 @@ import net.corda.crypto.core.CryptoConsts
 import net.corda.crypto.core.CryptoTenants.P2P
 import net.corda.data.certificates.CertificateUsage
 import net.corda.data.crypto.wire.ops.rpc.queries.CryptoKeyOrderBy
+import net.corda.data.p2p.HostedIdentityEntry
 import net.corda.httprpc.exception.BadRequestException
 import net.corda.membership.certificate.client.CertificatesResourceNotFoundException
 import net.corda.membership.certificates.CertificateUsageUtils.publicName
@@ -13,10 +14,8 @@ import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode.NO_PKI
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.HostedIdentityEntry
 import net.corda.schema.Schemas
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
@@ -25,6 +24,7 @@ import net.corda.virtualnode.toAvro
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.slf4j.LoggerFactory
 import java.io.StringWriter
 import java.security.InvalidKeyException
 import java.security.cert.CertificateFactory
@@ -39,7 +39,7 @@ internal class HostedIdentityEntryFactory(
     private val retrieveCertificates: (ShortHash?, CertificateUsage, String) -> String?,
 ) {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private fun getNode(holdingIdentityShortHash: ShortHash): VirtualNodeInfo {

--- a/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
+++ b/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
@@ -23,11 +23,11 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [CertificatesService::class])
 @Suppress("LongParameterList")
@@ -64,7 +64,7 @@ class CertificatesServiceImpl internal constructor(
     )
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val GROUP_NAME = "membership.certificates.service"
         const val CLIENT_NAME = "membership.certificates.service"
     }

--- a/components/membership/group-params-writer-service-impl/src/main/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceImpl.kt
+++ b/components/membership/group-params-writer-service-impl/src/main/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceImpl.kt
@@ -3,7 +3,6 @@ package net.corda.membership.groupparams.writer.service.impl
 import jdk.jshell.spi.ExecutionControl.NotImplementedException
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.data.membership.GroupParameters as GroupParametersAvro
 import net.corda.layeredpropertymap.toAvro
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator
@@ -23,13 +22,14 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.GROUP_PARAMETERS_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import net.corda.data.membership.GroupParameters as GroupParametersAvro
 
 @Component(service = [GroupParametersWriterService::class])
 class GroupParametersWriterServiceImpl @Activate constructor(
@@ -41,7 +41,7 @@ class GroupParametersWriterServiceImpl @Activate constructor(
     private val publisherFactory: PublisherFactory,
 ) : GroupParametersWriterService {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val SERVICE = "GroupParametersWriterService"
     }
 

--- a/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
+++ b/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.membership.impl.grouppolicy
 
-import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
@@ -38,7 +37,6 @@ import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -47,6 +45,8 @@ import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 @Suppress("LongParameterList")
 @Component(service = [GroupPolicyProvider::class])
@@ -74,7 +74,7 @@ class GroupPolicyProviderImpl @Activate constructor(
     }
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val CONSUMER_GROUP = "membership.group.policy.provider.group"
     }
     private val groupPolicies: MutableMap<HoldingIdentity, GroupPolicy?> = ConcurrentHashMap()

--- a/components/membership/locally-hosted-identities-service-impl/src/main/kotlin/net/corda/membership/locally/hosted/identities/impl/LocallyHostedIdentitiesServiceImpl.kt
+++ b/components/membership/locally-hosted-identities-service-impl/src/main/kotlin/net/corda/membership/locally/hosted/identities/impl/LocallyHostedIdentitiesServiceImpl.kt
@@ -21,13 +21,13 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.millis
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.util.concurrent.ConcurrentHashMap
@@ -63,7 +63,7 @@ class LocallyHostedIdentitiesServiceImpl(
         const val SUBSCRIPTION_GROUP_NAME = "locally-hosted-identities-service"
         const val defaultRetries = 4
         val waitBetweenRetries = 100.millis
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val identities = ConcurrentHashMap<HoldingIdentity, IdentityInfo>()

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMOpsClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMOpsClientImpl.kt
@@ -36,7 +36,6 @@ import net.corda.utilities.concurrent.getOrThrow
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.seconds
 import net.corda.virtualnode.HoldingIdentity
@@ -46,6 +45,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @Component(service = [MGMOpsClient::class])
@@ -68,7 +68,7 @@ class MGMOpsClientImpl @Activate constructor(
 ) : MGMOpsClient {
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val ERROR_MSG = "Service is in an incorrect state for calling."
 
         const val CLIENT_ID = "mgm-ops-client"

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberOpsClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberOpsClientImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.membership.impl.client
 
-import java.util.UUID
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.membership.common.RegistrationStatus
@@ -43,7 +42,6 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.concurrent.getOrThrow
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.seconds
 import net.corda.virtualnode.ShortHash
@@ -51,6 +49,8 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.UUID
 import java.util.concurrent.TimeoutException
 
 @Component(service = [MemberOpsClient::class])
@@ -63,7 +63,7 @@ class MemberOpsClientImpl @Activate constructor(
     val configurationReadService: ConfigurationReadService
 ) : MemberOpsClient {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val ERROR_MSG = "Service is in an incorrect state for calling."
 
         const val CLIENT_ID = "membership.ops.rpc"

--- a/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
+++ b/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
@@ -1,7 +1,6 @@
 package net.corda.membership.impl.read
 
 import com.typesafe.config.ConfigFactory
-import kotlin.reflect.KFunction
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.config.Configuration
 import net.corda.data.config.ConfigurationSchemaVersion
@@ -20,7 +19,6 @@ import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.test.util.eventually
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -33,6 +31,8 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
+import kotlin.reflect.KFunction
 
 @ExtendWith(ServiceExtension::class, DBSetup::class)
 class MembershipGroupReaderProviderIntegrationTest {
@@ -40,7 +40,7 @@ class MembershipGroupReaderProviderIntegrationTest {
     companion object {
         const val CLIENT_ID = "group-read-integration-test"
 
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @InjectService(timeout = 4000L)

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderImpl.kt
@@ -2,27 +2,27 @@ package net.corda.membership.impl.read
 
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.impl.read.cache.MembershipGroupReadCache
 import net.corda.membership.impl.read.lifecycle.MembershipGroupReadLifecycleHandler
 import net.corda.membership.impl.read.reader.MembershipGroupReaderFactory
 import net.corda.membership.impl.read.subscription.MembershipGroupReadSubscriptions
+import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.read.GroupParametersReaderService
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
-import net.corda.libs.configuration.helper.getConfig
-import net.corda.membership.read.GroupParametersReaderService
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * Membership component implementing [MembershipGroupReaderProvider].
@@ -51,7 +51,7 @@ class MembershipGroupReaderProviderImpl @Activate constructor(
 ) : MembershipGroupReaderProvider {
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val ILLEGAL_ACCESS = "Tried to read group data before starting the component " +
                 "or while the component is down."

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberDataCache.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberDataCache.kt
@@ -1,7 +1,7 @@
 package net.corda.membership.impl.read.cache
 
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -41,7 +41,7 @@ interface MemberDataCache<T> {
     class Impl<T> : MemberDataCache<T> {
 
         companion object {
-            val logger = contextLogger()
+            val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         }
 
         private val cache = ConcurrentHashMap<HoldingIdentity, T>()

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
@@ -1,9 +1,8 @@
 package net.corda.membership.impl.read.cache
 
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
-import java.util.ArrayList
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -25,7 +24,7 @@ interface MemberListCache : MemberDataListCache<MemberInfo> {
     class Impl : MemberListCache {
 
         companion object {
-            val logger = contextLogger()
+            val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         }
 
         private val cache = ConcurrentHashMap<HoldingIdentity, ReplaceableList<MemberInfo>>()

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MembershipGroupReadCache.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MembershipGroupReadCache.kt
@@ -1,7 +1,7 @@
 package net.corda.membership.impl.read.cache
 
 import net.corda.membership.read.MembershipGroupReader
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * Interface wrapping all caches required for the membership group read service component.
@@ -29,7 +29,7 @@ interface MembershipGroupReadCache {
      */
     class Impl : MembershipGroupReadCache {
         companion object {
-            private val logger = contextLogger()
+            private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         }
 
         override var memberListCache: MemberListCache = MemberListCache.Impl()

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/lifecycle/MembershipGroupReadLifecycleHandler.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/lifecycle/MembershipGroupReadLifecycleHandler.kt
@@ -15,7 +15,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * Lifecycle handler for the membership group read component.
@@ -30,7 +30,7 @@ interface MembershipGroupReadLifecycleHandler : LifecycleEventHandler {
         private val deactivateImplFunction: (String) -> Unit
     ) : MembershipGroupReadLifecycleHandler {
         companion object {
-            val logger = contextLogger()
+            val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         }
 
         private var configRegistrationHandle: AutoCloseable? = null

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/GroupParametersReaderServiceImpl.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/reader/GroupParametersReaderServiceImpl.kt
@@ -2,7 +2,6 @@ package net.corda.membership.impl.read.reader
 
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.data.membership.GroupParameters as GroupParametersAvro
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -24,13 +23,14 @@ import net.corda.reconciliation.VersionedRecord
 import net.corda.schema.Schemas.Membership.Companion.GROUP_PARAMETERS_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
+import net.corda.data.membership.GroupParameters as GroupParametersAvro
 
 
 @Component(service = [GroupParametersReaderService::class])
@@ -60,7 +60,7 @@ class GroupParametersReaderServiceImpl internal constructor(
     )
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val serviceName = GroupParametersReaderService::class.java.simpleName
         const val CONSUMER_GROUP = "GROUP_PARAMETERS_READER"
     }

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImpl.kt
@@ -21,7 +21,6 @@ import net.corda.membership.certificates.CertificateUsageUtils.publicName
 import net.corda.membership.httprpc.v1.CertificatesRestResource
 import net.corda.membership.httprpc.v1.CertificatesRestResource.Companion.SIGNATURE_SPEC
 import net.corda.membership.impl.httprpc.v1.lifecycle.RpcOpsLifecycleHandler
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.ECDSA_SECP256K1_CODE_NAME
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.RSA_CODE_NAME
@@ -48,6 +47,7 @@ import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.StringWriter
 import java.security.PublicKey
@@ -67,7 +67,7 @@ class CertificatesRestResourceImpl @Activate constructor(
 ) : CertificatesRestResource, PluggableRestResource<CertificatesRestResource>, Lifecycle {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val defaultCodeNameToSpec = mapOf(
             ECDSA_SECP256K1_CODE_NAME to SignatureSpec.ECDSA_SHA256,

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MGMRestResourceImpl.kt
@@ -23,13 +23,13 @@ import net.corda.membership.lib.approval.ApprovalRuleParams
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.TlsType
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.regex.PatternSyntaxException
 
 @Component(service = [PluggableRestResource::class])
@@ -42,7 +42,7 @@ class MGMRestResourceImpl @Activate constructor(
     private val configurationGetService: ConfigurationGetService,
 ) : MGMRestResource, PluggableRestResource<MGMRestResource>, Lifecycle {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private interface InnerMGMRpcOps {

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceImpl.kt
@@ -11,7 +11,6 @@ import net.corda.membership.httprpc.v1.types.response.RpcMemberInfo
 import net.corda.membership.httprpc.v1.types.response.RpcMemberInfoList
 import net.corda.membership.impl.httprpc.v1.lifecycle.RpcOpsLifecycleHandler
 import net.corda.membership.read.MembershipGroupReaderProvider
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.read.rpc.extensions.getByHoldingIdentityShortHashOrThrow
@@ -20,6 +19,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @Component(service = [PluggableRestResource::class])
 class MemberLookupRestResourceImpl @Activate constructor(
@@ -31,7 +31,7 @@ class MemberLookupRestResourceImpl @Activate constructor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService
 ) : MemberLookupRestResource, PluggableRestResource<MemberLookupRestResource>, Lifecycle {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private interface InnerMemberLookupRpcOps {

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberRegistrationRestResourceImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/MemberRegistrationRestResourceImpl.kt
@@ -14,13 +14,13 @@ import net.corda.membership.httprpc.v1.types.request.MemberRegistrationRequest
 import net.corda.membership.httprpc.v1.types.response.RegistrationRequestProgress
 import net.corda.membership.httprpc.v1.types.response.RegistrationRequestStatus
 import net.corda.membership.impl.httprpc.v1.lifecycle.RpcOpsLifecycleHandler
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @Component(service = [PluggableRestResource::class])
 class MemberRegistrationRestResourceImpl @Activate constructor(
@@ -30,7 +30,7 @@ class MemberRegistrationRestResourceImpl @Activate constructor(
     private val memberOpsClient: MemberOpsClient
 ) : MemberRegistrationRestResource, PluggableRestResource<MemberRegistrationRestResource>, Lifecycle {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private interface InnerMemberRegistrationRpcOps {

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRestResourceImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/NetworkRestResourceImpl.kt
@@ -13,12 +13,12 @@ import net.corda.membership.certificate.client.CertificatesResourceNotFoundExcep
 import net.corda.membership.httprpc.v1.NetworkRestResource
 import net.corda.membership.httprpc.v1.types.request.HostedIdentitySetupRequest
 import net.corda.membership.impl.httprpc.v1.lifecycle.RpcOpsLifecycleHandler
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.security.SignatureException
 
 @Component(service = [PluggableRestResource::class])
@@ -30,7 +30,7 @@ class NetworkRestResourceImpl @Activate constructor(
 ) : NetworkRestResource, PluggableRestResource<NetworkRestResource>, Lifecycle {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun setupHostedIdentities(

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -30,6 +30,11 @@ import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequestHeader
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse
 import net.corda.data.membership.state.RegistrationState
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.AuthenticatedMessage
+import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.data.sync.BloomFilter
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.libs.configuration.SmartConfigFactory
@@ -65,11 +70,6 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.AuthenticatedMessageHeader
-import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.schema.Schemas
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.Schemas.Membership.Companion.SYNCHRONIZATION_TOPIC
@@ -81,7 +81,6 @@ import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.utilities.concurrent.getOrThrow
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
@@ -92,6 +91,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.time.Duration
 import java.time.Instant
@@ -139,7 +139,7 @@ class MembershipP2PIntegrationTest {
         @InjectService(timeout = 5000)
         lateinit var ephemeralKeyPairEncryptor: TestEphemeralKeyPairEncryptor
 
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val clock: Clock = TestClock(Instant.ofEpochSecond(100))
 
         const val MEMBER_CONTEXT_KEY = "key"

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/dummy/TestCryptoOpsClient.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/dummy/TestCryptoOpsClient.kt
@@ -8,7 +8,6 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -16,6 +15,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.security.KeyPairGenerator
 import java.security.PublicKey
 
@@ -30,7 +30,7 @@ internal class TestCryptoOpsClientImpl @Activate constructor(
     private val schemeMetadata: CipherSchemeMetadata,
 ) : TestCryptoOpsClient {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
     }
 

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/dummy/TestGroupReaderProvider.kt
@@ -8,7 +8,6 @@ import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.read.NotaryVirtualNodeLookup
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
@@ -17,6 +16,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 
 interface TestGroupReaderProvider : MembershipGroupReaderProvider {
     fun loadMember(holdingIdentity: HoldingIdentity, member: MemberInfo)
@@ -29,7 +29,7 @@ internal class TestGroupReaderProviderImpl @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory
 )  : TestGroupReaderProvider {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator = coordinatorFactory.createCoordinator(
@@ -65,7 +65,7 @@ internal class TestGroupReaderProviderImpl @Activate constructor(
 
 class TestGroupReader : MembershipGroupReader {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
     }
 

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/dummy/TestStableKeyPairDecryptor.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/dummy/TestStableKeyPairDecryptor.kt
@@ -5,11 +5,11 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 
 interface TestStableKeyPairDecryptor : StableKeyPairDecryptor
@@ -21,7 +21,7 @@ internal class TestStableKeyPairDecryptorImpl @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
 ) : TestStableKeyPairDecryptor {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator =

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PMarkersProcessor.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PMarkersProcessor.kt
@@ -2,18 +2,18 @@ package net.corda.membership.impl.p2p
 
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
+import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.membership.p2p.helpers.TtlIdsFactory
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.schema.Schemas
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 internal class MembershipP2PMarkersProcessor(
     private val ttlIdsFactory: TtlIdsFactory = TtlIdsFactory()
 ) : DurableProcessor<String, AppMessageMarker> {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun onNext(events: List<Record<String, AppMessageMarker>>): List<Record<*, *>> {

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
@@ -8,6 +8,9 @@ import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.AuthenticatedMessage
+import net.corda.data.p2p.app.UnauthenticatedMessage
 import net.corda.membership.impl.p2p.handler.MembershipPackageHandler
 import net.corda.membership.impl.p2p.handler.MembershipSyncRequestHandler
 import net.corda.membership.impl.p2p.handler.MessageHandler
@@ -18,12 +21,9 @@ import net.corda.membership.impl.p2p.handler.VerificationResponseHandler
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 class MembershipP2PProcessor(
@@ -36,7 +36,7 @@ class MembershipP2PProcessor(
     override val valueClass = AppMessage::class.java
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val MEMBERSHIP_P2P_SUBSYSTEM = "membership"
     }

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PReadServiceImpl.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PReadServiceImpl.kt
@@ -26,10 +26,10 @@ import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_MARKERS
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.registry.AvroSchemaRegistry
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [MembershipP2PReadService::class])
@@ -51,7 +51,7 @@ class MembershipP2PReadServiceImpl @Activate constructor(
 ) : MembershipP2PReadService {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val CONSUMER_GROUP = "membership_p2p_read"
         const val MARKER_CONSUMER_GROUP = "membership_p2p_read_markers"

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/MembershipPackageHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/MembershipPackageHandler.kt
@@ -3,20 +3,20 @@ package net.corda.membership.impl.p2p.handler
 import net.corda.data.membership.command.synchronisation.SynchronisationCommand
 import net.corda.data.membership.command.synchronisation.SynchronisationMetaData
 import net.corda.data.membership.command.synchronisation.member.ProcessMembershipUpdates
-import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.SYNCHRONIZATION_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 internal class MembershipPackageHandler(
     private val avroSchemaRegistry: AvroSchemaRegistry
 ) : AuthenticatedMessageHandler() {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invokeAuthenticatedMessage(

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/MembershipSyncRequestHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/MembershipSyncRequestHandler.kt
@@ -4,21 +4,21 @@ import net.corda.data.membership.command.synchronisation.SynchronisationCommand
 import net.corda.data.membership.command.synchronisation.SynchronisationMetaData
 import net.corda.data.membership.command.synchronisation.mgm.ProcessSyncRequest
 import net.corda.data.membership.p2p.MembershipSyncRequest
-import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.SYNCHRONIZATION_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 internal class MembershipSyncRequestHandler(
     private val avroSchemaRegistry: AvroSchemaRegistry
 ) : AuthenticatedMessageHandler() {
     private companion object {
-        val logger: Logger = contextLogger()
+        val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invokeAuthenticatedMessage(

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/RegistrationRequestHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/RegistrationRequestHandler.kt
@@ -6,17 +6,17 @@ import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.StartRegistration
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
+import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.membership.lib.MemberInfoExtension.Companion.ecdhKey
 import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.PublicKey
 
@@ -27,7 +27,7 @@ internal class RegistrationRequestHandler(
     private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
 ) : UnauthenticatedMessageHandler() {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invokeUnauthenticatedMessage(

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/VerificationRequestHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/VerificationRequestHandler.kt
@@ -3,20 +3,20 @@ package net.corda.membership.impl.p2p.handler
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.member.ProcessMemberVerificationRequest
 import net.corda.data.membership.p2p.VerificationRequest
-import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 internal class VerificationRequestHandler(
     private val avroSchemaRegistry: AvroSchemaRegistry
 ) : AuthenticatedMessageHandler()  {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invokeAuthenticatedMessage(

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/VerificationResponseHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/VerificationResponseHandler.kt
@@ -3,20 +3,20 @@ package net.corda.membership.impl.p2p.handler
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.ProcessMemberVerificationResponse
 import net.corda.data.membership.p2p.VerificationResponse
-import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 internal class VerificationResponseHandler(
     private val avroSchemaRegistry: AvroSchemaRegistry
 ) : AuthenticatedMessageHandler() {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invokeAuthenticatedMessage(

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
@@ -17,12 +17,12 @@ import net.corda.layeredpropertymap.toAvro
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 @Suppress("LongParameterList")
@@ -35,7 +35,7 @@ class MembershipPackageFactory(
     private val idFactory: () -> String,
 ) {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     private fun DigitalSignature.WithKey.toAvro() =
         CryptoSignatureWithKey.newBuilder()

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MerkleTreeGenerator.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MerkleTreeGenerator.kt
@@ -5,20 +5,20 @@ import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
 import net.corda.layeredpropertymap.toAvro
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_LEAF_PREFIX_OPTION
 import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_NODE_PREFIX_OPTION
 import net.corda.v5.crypto.merkle.HASH_DIGEST_PROVIDER_TWEAKABLE_NAME
 import net.corda.v5.crypto.merkle.MerkleTree
 import net.corda.v5.membership.MemberInfo
+import org.slf4j.LoggerFactory
 
 class MerkleTreeGenerator(
     private val merkleTreeProvider: MerkleTreeProvider,
     cordaAvroSerializationFactory: CordaAvroSerializationFactory,
 ) {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val NODE_HASH_PREFIX = "CORDA_MEMBERSHIP_NODE"
         const val LEAF_HASH_PREFIX = "CORDA_MEMBERSHIP_LEAF"
     }

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/P2pRecordsFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/P2pRecordsFactory.kt
@@ -2,16 +2,16 @@ package net.corda.membership.p2p.helpers
 
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.identity.HoldingIdentity
-import net.corda.libs.configuration.SmartConfig
-import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.AuthenticatedMessage
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.libs.configuration.SmartConfig
+import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.P2P.Companion.P2P_OUT_TOPIC
 import net.corda.schema.configuration.MembershipConfig.TtlsConfig.TTLS
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -23,7 +23,7 @@ class P2pRecordsFactory(
     companion object {
         const val MEMBERSHIP_P2P_SUBSYSTEM = "membership"
 
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         fun SmartConfig.getTtlMinutes(ttlConfiguration: String?): Long? {
             return ttlConfiguration?.let { configurationName ->

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/AbstractPersistenceClient.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/AbstractPersistenceClient.kt
@@ -1,7 +1,5 @@
 package net.corda.membership.impl.persistence.client
 
-import java.time.Duration
-import java.util.UUID
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.identity.HoldingIdentity
@@ -29,7 +27,9 @@ import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.concurrent.getOrThrow
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.TimeoutException
 
 abstract class AbstractPersistenceClient(
@@ -41,7 +41,7 @@ abstract class AbstractPersistenceClient(
 ) : Lifecycle {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val RPC_TIMEOUT_MS = 10000L
     }
 

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
@@ -37,7 +37,6 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -45,6 +44,7 @@ import net.corda.virtualnode.toAvro
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @Suppress("LongParameterList")
@@ -81,7 +81,7 @@ class MembershipPersistenceClientImpl(
     )
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val groupName = "membership.db.persistence.client.group"

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
@@ -33,7 +33,6 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
@@ -41,6 +40,7 @@ import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [MembershipQueryClient::class])
@@ -73,7 +73,7 @@ class MembershipQueryClientImpl(
     ) : this(coordinatorFactory, publisherFactory, configurationReadService, memberInfoFactory, UTCClock(), layeredPropertyMapFactory)
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val groupName = "membership.db.query.client.group"

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -82,7 +82,6 @@ import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.seconds
 import net.corda.v5.crypto.calculateHash
 import net.corda.v5.membership.GroupParameters
@@ -102,6 +101,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
 import java.time.Instant
@@ -120,7 +120,7 @@ class MembershipPersistenceTest {
         private const val RULE_REGEX = "rule-regex"
         private const val RULE_LABEL = "rule-label"
 
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val BOOT_CONFIG_STRING = """
             $INSTANCE_ID = 1

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/dummy/TestVirtualNodeInfoReadService.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/dummy/TestVirtualNodeInfoReadService.kt
@@ -5,9 +5,8 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.reconciliation.VersionedRecord
-import net.corda.v5.base.util.contextLogger
-import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoListener
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -15,6 +14,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 
@@ -30,7 +30,7 @@ class TestVirtualNodeInfoReadServiceImpl @Activate constructor(
 ) : TestVirtualNodeInfoReadService {
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
     }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessor.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessor.kt
@@ -5,9 +5,9 @@ import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.AddNotaryToGroupParameters
+import net.corda.data.membership.db.request.command.DeleteApprovalRule
 import net.corda.data.membership.db.request.command.MutualTlsAddToAllowedCertificates
 import net.corda.data.membership.db.request.command.MutualTlsRemoveFromAllowedCertificates
-import net.corda.data.membership.db.request.command.DeleteApprovalRule
 import net.corda.data.membership.db.request.command.PersistApprovalRule
 import net.corda.data.membership.db.request.command.PersistGroupParameters
 import net.corda.data.membership.db.request.command.PersistGroupParametersInitialSnapshot
@@ -30,10 +30,10 @@ import net.corda.data.membership.db.response.query.PersistenceFailedResponse
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.impl.persistence.service.handler.AddNotaryToGroupParametersHandler
+import net.corda.membership.impl.persistence.service.handler.DeleteApprovalRuleHandler
 import net.corda.membership.impl.persistence.service.handler.MutualTlsAddToAllowedCertificatesHandler
 import net.corda.membership.impl.persistence.service.handler.MutualTlsListAllowedCertificatesHandler
 import net.corda.membership.impl.persistence.service.handler.MutualTlsRemoveFromAllowedCertificatesHandler
-import net.corda.membership.impl.persistence.service.handler.DeleteApprovalRuleHandler
 import net.corda.membership.impl.persistence.service.handler.PersistApprovalRuleHandler
 import net.corda.membership.impl.persistence.service.handler.PersistGroupParametersHandler
 import net.corda.membership.impl.persistence.service.handler.PersistGroupParametersInitialSnapshotHandler
@@ -57,8 +57,8 @@ import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderW
 import net.corda.messaging.api.processor.RPCResponderProcessor
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 
 @Suppress("LongParameterList")
@@ -75,7 +75,7 @@ internal class MembershipPersistenceRPCProcessor(
 ) : RPCResponderProcessor<MembershipPersistenceRequest, MembershipPersistenceResponse> {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val persistenceHandlerServices = PersistenceHandlerServices(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
@@ -31,11 +31,11 @@ import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [MembershipPersistenceService::class])
@@ -65,7 +65,7 @@ class MembershipPersistenceServiceImpl @Activate constructor(
 ) : MembershipPersistenceService {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val GROUP_NAME = "membership.db.persistence"
         const val CLIENT_NAME = "membership.db.persistence"

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -12,10 +12,10 @@ import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderW
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.utils.transaction
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
@@ -28,7 +28,7 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
 ) : PersistenceHandler<REQUEST, RESPONSE> {
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dbConnectionManager get() = persistenceHandlerServices.dbConnectionManager

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
@@ -5,6 +5,7 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.membership.rpc.request.MembershipRpcRequest
 import net.corda.data.membership.rpc.response.MembershipRpcResponse
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -12,25 +13,24 @@ import net.corda.lifecycle.LifecycleEvent
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.membership.registration.RegistrationProxy
-import net.corda.membership.service.MemberOpsService
-import net.corda.libs.configuration.helper.getConfig
-import net.corda.lifecycle.Resource
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.membership.registration.RegistrationProxy
+import net.corda.membership.service.MemberOpsService
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [MemberOpsService::class])
 @Suppress("LongParameterList")
@@ -51,7 +51,7 @@ class MemberOpsServiceImpl @Activate constructor(
     private val membershipQueryClient: MembershipQueryClient,
 ): MemberOpsService {
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val GROUP_NAME = "membership.ops.rpc"
         const val CLIENT_NAME = "membership.ops.rpc"
 

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
@@ -50,13 +50,12 @@ import net.corda.membership.registration.RegistrationStatusQueryException
 import net.corda.messaging.api.processor.RPCResponderProcessor
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.parse
 import net.corda.v5.base.util.parseList
-import net.corda.v5.base.util.parseOrNull
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
@@ -74,7 +73,7 @@ class MemberOpsServiceProcessor(
     }
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val handlers = mapOf<Class<*>, (MemberOpsServiceProcessor) -> RpcHandler<*>>(
             RegistrationRpcRequest::class.java to { it.RegistrationRequestHandler() },

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestCryptoOpsClient.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestCryptoOpsClient.kt
@@ -9,7 +9,6 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -18,6 +17,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
 import java.security.PublicKey
@@ -34,7 +34,7 @@ class TestCryptoOpsClientImpl @Activate constructor(
     private val schemeMetadata: CipherSchemeMetadata,
 ) : TestCryptoOpsClient {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
         private val keys: ConcurrentHashMap<String, CryptoSigningKey> = ConcurrentHashMap()
     }

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupPolicyProvider.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupPolicyProvider.kt
@@ -6,12 +6,12 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.grouppolicy.GroupPolicy
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 
 interface TestGroupPolicyProvider : GroupPolicyProvider {
     fun putGroupPolicy(groupPolicy: GroupPolicy)
@@ -24,7 +24,7 @@ class TestGroupPolicyProviderImpl @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
 ) : TestGroupPolicyProvider {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
     }
 

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestGroupReaderProvider.kt
@@ -18,7 +18,6 @@ import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.read.NotaryVirtualNodeLookup
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.membership.GroupParameters
@@ -28,6 +27,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 
 interface TestGroupReaderProvider : MembershipGroupReaderProvider
 
@@ -44,7 +44,7 @@ class TestGroupReaderProviderImpl @Activate constructor(
     private val keyEncodingService: KeyEncodingService,
 ) : TestGroupReaderProvider {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
     }
 
@@ -82,7 +82,7 @@ class TestGroupReader @Activate constructor(
     private val keyEncodingService: KeyEncodingService,
 ) : MembershipGroupReader {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/RegistrationProxyImpl.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/RegistrationProxyImpl.kt
@@ -9,19 +9,19 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.membership.lib.exceptions.RegistrationProtocolSelectionException
-import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.registration.MemberRegistrationService
 import net.corda.membership.registration.MembershipRequestRegistrationResult
 import net.corda.membership.registration.RegistrationProxy
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality
 import org.osgi.service.component.annotations.ReferencePolicyOption
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @Component(service = [RegistrationProxy::class])
@@ -50,7 +50,7 @@ class RegistrationProxyImpl @Activate constructor(
     }
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val SERVICE_STARTING_LOG = "Registration proxy starting."
         const val SERVICE_STOPPING_LOG = "Registration proxy stopping."

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationManagementServiceImpl.kt
@@ -35,10 +35,10 @@ import net.corda.schema.configuration.ConfigKeys.MEMBERSHIP_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [RegistrationManagementService::class])
@@ -72,7 +72,7 @@ class RegistrationManagementServiceImpl @Activate constructor(
 ) : RegistrationManagementService {
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val CONSUMER_GROUP = "membership.registration.processor.group"
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -36,7 +36,7 @@ import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 class RegistrationProcessor(
@@ -59,7 +59,7 @@ class RegistrationProcessor(
     override val eventValueClass = RegistrationCommand::class.java
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val memberTypeChecker = MemberTypeChecker(membershipGroupReaderProvider)

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/ProcessMemberVerificationRequestHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/ProcessMemberVerificationRequestHandler.kt
@@ -15,8 +15,8 @@ import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandle
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 internal class ProcessMemberVerificationRequestHandler(
     clock: Clock,
@@ -29,7 +29,7 @@ internal class ProcessMemberVerificationRequestHandler(
     )
 ) : RegistrationHandler<ProcessMemberVerificationRequest> {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val commandType = ProcessMemberVerificationRequest::class.java

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -28,8 +28,8 @@ import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 internal class ApproveRegistrationHandler(
@@ -46,7 +46,7 @@ internal class ApproveRegistrationHandler(
     ),
 ) : RegistrationHandler<ApproveRegistration> {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val commandType = ApproveRegistration::class.java

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandler.kt
@@ -15,8 +15,8 @@ import net.corda.membership.p2p.helpers.P2pRecordsFactory.Companion.getTtlMinute
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.schema.configuration.MembershipConfig.TtlsConfig.DECLINE_REGISTRATION
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 internal class DeclineRegistrationHandler(
@@ -31,7 +31,7 @@ internal class DeclineRegistrationHandler(
     ),
 ) : RegistrationHandler<DeclineRegistration> {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     override fun invoke(
         state: RegistrationState?,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandler.kt
@@ -28,11 +28,11 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.configuration.MembershipConfig
 import net.corda.utilities.time.Clock
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @Suppress("LongParameterList")
@@ -63,7 +63,7 @@ class DistributeMembershipPackageHandler(
     ) { UUID.randomUUID().toString() }
 ) : RegistrationHandler<DistributeMembershipPackage> {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val commandType = DistributeMembershipPackage::class.java

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
@@ -29,10 +29,10 @@ import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.configuration.MembershipConfig.TtlsConfig.UPDATE_TO_PENDING_AUTO_APPROVAL
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberContext
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 internal class ProcessMemberVerificationResponseHandler(
@@ -49,7 +49,7 @@ internal class ProcessMemberVerificationResponseHandler(
     ),
 ) : RegistrationHandler<ProcessMemberVerificationResponse> {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val commandType = ProcessMemberVerificationResponse::class.java

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -34,11 +34,11 @@ import net.corda.schema.Schemas
 import net.corda.schema.Schemas.Membership.Companion.REGISTRATION_COMMAND_TOPIC
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 internal class StartRegistrationHandler(
@@ -51,7 +51,7 @@ internal class StartRegistrationHandler(
 ) : RegistrationHandler<StartRegistration> {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val SERIAL_CONST = "1"
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
@@ -23,8 +23,8 @@ import net.corda.schema.Schemas
 import net.corda.schema.configuration.MembershipConfig.TtlsConfig.VERIFY_MEMBER_REQUEST
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 internal class VerifyMemberHandler(
@@ -40,7 +40,7 @@ internal class VerifyMemberHandler(
     private val ttlIdsFactory: TtlIdsFactory = TtlIdsFactory(),
 ) : RegistrationHandler<VerifyMember> {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val commandType = VerifyMember::class.java

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -32,11 +32,11 @@ import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.calculateHash
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.PublicKey
 import java.util.UUID
@@ -55,7 +55,7 @@ internal class MGMRegistrationMemberInfoHandler(
 
     private companion object {
         const val SERIAL_CONST = "1"
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val keyIdList = listOf(SESSION_KEY_ID, ECDH_KEY_ID)
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -35,13 +35,13 @@ import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @Suppress("LongParameterList")
@@ -90,7 +90,7 @@ class MGMRegistrationService @Activate constructor(
     }
 
     private companion object {
-        val logger: Logger = contextLogger()
+        val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     // for watching the config changes

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -13,6 +13,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.p2p.HostedIdentityEntry
 import net.corda.layeredpropertymap.toAvro
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -60,14 +61,12 @@ import net.corda.membership.registration.MembershipRequestRegistrationResult
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.HostedIdentityEntry
 import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.Schemas.P2P.Companion.P2P_HOSTED_IDENTITIES_TOPIC
 import net.corda.schema.membership.MembershipSchema.RegistrationContextSchema
 import net.corda.utilities.concurrent.SecManagerForkJoinPool
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.versioning.Version
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
@@ -78,6 +77,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.util.UUID
 
@@ -120,7 +120,7 @@ class StaticMemberRegistrationService @Activate constructor(
     private val groupParametersWriterService: GroupParametersWriterService,
 ) : MemberRegistrationService {
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val endpointUrlIdentifier = ENDPOINT_URL.substringBefore("-")
         private val endpointProtocolIdentifier = ENDPOINT_PROTOCOL.substringBefore("-")
         private const val KEY_SCHEME = "corda.key.scheme"

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/cache/GroupParametersCache.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/cache/GroupParametersCache.kt
@@ -19,9 +19,9 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.Companion.MEMBERSHIP_STATIC_NETWORK_TOPIC
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 class GroupParametersCache(
@@ -30,7 +30,7 @@ class GroupParametersCache(
     private val keyEncodingService: KeyEncodingService
 ) {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val clock = UTCClock()
 
         val notaryServiceRegex = NOTARY_SERVICE_NAME_KEY.format("([0-9]+)").toRegex()

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
@@ -28,6 +28,9 @@ import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.MembershipSyncRequest
 import net.corda.data.membership.p2p.SignedMemberships
 import net.corda.data.membership.p2p.WireGroupParameters
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.AuthenticatedMessage
+import net.corda.data.p2p.app.AuthenticatedMessageHeader
 import net.corda.data.sync.BloomFilter
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.layeredpropertymap.toAvro
@@ -70,9 +73,6 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.AuthenticatedMessageHeader
 import net.corda.schema.Schemas.Config.Companion.CONFIG_TOPIC
 import net.corda.schema.Schemas.Membership.Companion.GROUP_PARAMETERS_TOPIC
 import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
@@ -91,7 +91,6 @@ import net.corda.test.util.time.TestClock
 import net.corda.utilities.concurrent.getOrThrow
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MemberInfo
@@ -106,6 +105,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.PublicKey
 import java.time.Duration
@@ -194,7 +194,7 @@ class SynchronisationIntegrationTest {
             cordaAvroSerializationFactory.createAvroDeserializer({}, KeyValuePairList::class.java)
         }
         val clock: Clock = TestClock(Instant.ofEpochSecond(100))
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val bootConfig = SmartConfigFactory.createWithoutSecurityServices()
             .create(
                 ConfigFactory.parseString(

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestCryptoOpsClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestCryptoOpsClient.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.impl.synchronisation.dummy
 
+import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.crypto.wire.ops.rpc.queries.CryptoKeyOrderBy
@@ -8,8 +9,6 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.utilities.time.UTCClock
-import net.corda.v5.base.util.contextLogger
-import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
@@ -18,6 +17,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.KeyPair
 import java.security.KeyPairGenerator
@@ -39,7 +39,7 @@ class TestCryptoOpsClientImpl @Activate constructor(
     private val schemeMetadata: CipherSchemeMetadata,
 ) : TestCryptoOpsClient {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
         private val keys: ConcurrentHashMap<String, CryptoSigningKey> = ConcurrentHashMap()
     }

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupPolicyProvider.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupPolicyProvider.kt
@@ -6,12 +6,12 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.grouppolicy.GroupPolicy
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 
 /**
  * Created for mocking and simplifying group policy functionalities used by the membership services.
@@ -27,7 +27,7 @@ class TestGroupPolicyProviderImpl @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
 ) : TestGroupPolicyProvider {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
     }
 

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestGroupReaderProvider.kt
@@ -15,7 +15,6 @@ import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.read.NotaryVirtualNodeLookup
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
@@ -24,6 +23,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 /**
@@ -42,7 +42,7 @@ class TestGroupReaderProviderImpl @Activate constructor(
     private val groupParametersFactory: GroupParametersFactory
 ) : TestGroupReaderProvider {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator = coordinatorFactory.createCoordinator(
@@ -78,7 +78,7 @@ class TestGroupReaderProviderImpl @Activate constructor(
 
 class TestGroupReader(private val groupParametersFactory: GroupParametersFactory) : MembershipGroupReader {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service."
         private const val EPOCH = "5"
         private const val PLATFORM_VERSION = "5000"

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
@@ -13,7 +13,6 @@ import net.corda.membership.lib.registration.RegistrationRequest
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -21,6 +20,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 
 /**
  * Created for mocking and simplifying membership persistence client functionalities used by the membership services.
@@ -36,7 +36,7 @@ class TestMembershipPersistenceClientImpl @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
 ) : TestMembershipPersistenceClient {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
     }
 

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
@@ -13,7 +13,6 @@ import net.corda.membership.lib.registration.RegistrationRequestStatus
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
@@ -21,6 +20,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 /**
@@ -35,7 +35,7 @@ class TestMembershipQueryClientImpl @Activate constructor(
     private val coordinatorFactory: LifecycleCoordinatorFactory,
 ) : TestMembershipQueryClient {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
     }
 

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -16,6 +16,7 @@ import net.corda.data.membership.command.synchronisation.member.ProcessMembershi
 import net.corda.data.membership.p2p.DistributionMetaData
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.MembershipSyncRequest
+import net.corda.data.p2p.app.AppMessage
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator
@@ -47,7 +48,6 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.AppMessage
 import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MEMBERSHIP_CONFIG
@@ -56,7 +56,6 @@ import net.corda.schema.configuration.MembershipConfig.MAX_DURATION_BETWEEN_SYNC
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
@@ -66,6 +65,7 @@ import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.util.Random
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -159,7 +159,7 @@ class MemberSynchronisationServiceImpl internal constructor(
     }
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val PUBLICATION_TIMEOUT_SECONDS = 30L
         const val SERVICE = "MemberSynchronisationService"

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImpl.kt
@@ -43,7 +43,6 @@ import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
@@ -51,6 +50,7 @@ import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @Suppress("LongParameterList")
@@ -135,7 +135,7 @@ class MgmSynchronisationServiceImpl internal constructor(
             )
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val SERVICE = "MgmSynchronisationService"
         private val clock: Clock = UTCClock()
         const val IDENTITY_EX_MESSAGE = "is not part of the membership group!"

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImpl.kt
@@ -33,7 +33,6 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.Membership.Companion.SYNCHRONIZATION_TOPIC
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
@@ -41,6 +40,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality
 import org.osgi.service.component.annotations.ReferencePolicyOption
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [SynchronisationProxy::class])
@@ -89,7 +89,7 @@ class SynchronisationProxyImpl @Activate constructor(
     }
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val SERVICE_STARTING_LOG = "Synchronisation proxy starting."
         const val SERVICE_STOPPING_LOG = "Synchronisation proxy stopping."

--- a/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
+++ b/components/permissions/permission-management-cache-service/src/main/kotlin/net/corda/permissions/management/cache/PermissionManagementCacheService.kt
@@ -34,10 +34,10 @@ import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_ROLE_TOPIC
 import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_USER_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
@@ -58,7 +58,7 @@ class PermissionManagementCacheService @Activate constructor(
     private val coordinator = coordinatorFactory.createCoordinator<PermissionManagementCacheService> { event, _ -> eventHandler(event) }
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val CONSUMER_GROUP = "PERMISSION_MANAGEMENT_SERVICE"
     }
 

--- a/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
+++ b/components/permissions/permission-management-service/src/main/kotlin/net/corda/permissions/management/internal/PermissionManagementServiceEventHandler.kt
@@ -30,7 +30,7 @@ import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.ConfigKeys.REST_CONFIG
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 internal class PermissionManagementServiceEventHandler(
@@ -43,7 +43,7 @@ internal class PermissionManagementServiceEventHandler(
 ) : LifecycleEventHandler {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val GROUP_NAME = "rpc.permission.management"
         const val CLIENT_NAME = "rpc.permission.manager"
     }

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionEndpointEventHandler.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionEndpointEventHandler.kt
@@ -11,13 +11,13 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.permissions.management.PermissionManagementService
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 internal class PermissionEndpointEventHandler(private val endpointName: String) : LifecycleEventHandler {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @VisibleForTesting

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/impl/PermissionEndpointImpl.kt
@@ -22,10 +22,10 @@ import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.createCoordinator
 import net.corda.permissions.management.PermissionManagementService
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * An RPC Ops endpoint for Permission operations.
@@ -40,7 +40,7 @@ class PermissionEndpointImpl @Activate constructor(
 ) : PermissionEndpoint, PluggableRestResource<PermissionEndpoint>, Lifecycle {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val targetInterface: Class<PermissionEndpoint> = PermissionEndpoint::class.java

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/impl/RoleEndpointImpl.kt
@@ -20,10 +20,10 @@ import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.createCoordinator
 import net.corda.permissions.management.PermissionManagementService
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * An RPC Ops endpoint for Role operations.
@@ -37,7 +37,7 @@ class RoleEndpointImpl @Activate constructor(
 ) : RoleEndpoint, PluggableRestResource<RoleEndpoint>, Lifecycle {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @Suppress("ThrowsCount")
         private fun PermissionManager.checkProtectedRole(roleId: String, principal: String) {

--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
@@ -4,14 +4,14 @@ import net.corda.httprpc.PluggableRestResource
 import net.corda.httprpc.exception.BadRequestException
 import net.corda.httprpc.exception.ResourceNotFoundException
 import net.corda.httprpc.response.ResponseEntity
-import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
-import net.corda.libs.permissions.endpoints.v1.converter.convertToDto
-import net.corda.libs.permissions.endpoints.v1.converter.convertToEndpointType
 import net.corda.httprpc.security.CURRENT_REST_CONTEXT
 import net.corda.libs.permissions.common.constant.RoleKeys.DEFAULT_SYSTEM_ADMIN_ROLE
 import net.corda.libs.permissions.common.constant.UserKeys.DEFAULT_ADMIN_FULL_NAME
+import net.corda.libs.permissions.endpoints.common.PermissionEndpointEventHandler
 import net.corda.libs.permissions.endpoints.common.withPermissionManager
 import net.corda.libs.permissions.endpoints.v1.RoleUtils.initialAdminRole
+import net.corda.libs.permissions.endpoints.v1.converter.convertToDto
+import net.corda.libs.permissions.endpoints.v1.converter.convertToEndpointType
 import net.corda.libs.permissions.endpoints.v1.user.UserEndpoint
 import net.corda.libs.permissions.endpoints.v1.user.types.CreateUserType
 import net.corda.libs.permissions.endpoints.v1.user.types.UserPermissionSummaryResponseType
@@ -26,10 +26,10 @@ import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.createCoordinator
 import net.corda.permissions.management.PermissionManagementService
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * An RPC Ops endpoint for User operations.
@@ -43,7 +43,7 @@ class UserEndpointImpl @Activate constructor(
 ) : UserEndpoint, PluggableRestResource<UserEndpoint>, Lifecycle {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @Suppress("ThrowsCount")
         private fun PermissionManager.checkProtectedRole(loginName: String, roleId: String, principal: String) {

--- a/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
+++ b/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/internal/PermissionStorageReaderServiceEventHandler.kt
@@ -1,6 +1,5 @@
 package net.corda.permissions.storage.reader.internal
 
-import javax.persistence.EntityManagerFactory
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.db.connection.manager.DbConnectionManager
@@ -28,8 +27,9 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
 import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
+import javax.persistence.EntityManagerFactory
 
 @Suppress("LongParameterList")
 class PermissionStorageReaderServiceEventHandler(
@@ -45,7 +45,7 @@ class PermissionStorageReaderServiceEventHandler(
 
     private companion object {
         const val CLIENT_NAME = "user.permissions.management"
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @VisibleForTesting

--- a/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
+++ b/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandler.kt
@@ -1,6 +1,5 @@
 package net.corda.permissions.storage.writer.internal
 
-import javax.persistence.EntityManagerFactory
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.permissions.management.PermissionManagementRequest
@@ -22,7 +21,8 @@ import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_MGMT_REQ_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
+import javax.persistence.EntityManagerFactory
 
 @Suppress("LongParameterList")
 class PermissionStorageWriterServiceEventHandler(
@@ -39,7 +39,7 @@ class PermissionStorageWriterServiceEventHandler(
         const val GROUP_NAME = "user.permissions.management"
         const val CLIENT_NAME = "user.permissions.management"
 
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @VisibleForTesting

--- a/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
+++ b/components/permissions/permission-validation-cache-service/src/main/kotlin/net/corda/permissions/validation/cache/PermissionValidationCacheService.kt
@@ -25,10 +25,10 @@ import net.corda.permissions.validation.cache.internal.PermissionSummaryTopicSna
 import net.corda.schema.Schemas.Permissions.Companion.PERMISSIONS_USER_SUMMARY_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
@@ -49,7 +49,7 @@ class PermissionValidationCacheService @Activate constructor(
     private val coordinator = coordinatorFactory.createCoordinator<PermissionValidationCacheService> { event, _ -> eventHandler(event) }
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val CONSUMER_GROUP = "PERMISSION_VALIDATION_SERVICE"
     }
 

--- a/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
+++ b/components/permissions/permission-validation-service/src/main/kotlin/net/corda/permissions/validation/PermissionValidationService.kt
@@ -13,10 +13,10 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.permissions.validation.cache.PermissionValidationCacheService
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * Service for performing permission validation using the RBAC permission system.
@@ -37,7 +37,7 @@ class PermissionValidationService @Activate constructor(
 ) : Lifecycle {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<PermissionValidationService> { event, _ -> eventHandler(event) }

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -18,16 +18,15 @@ import net.corda.entityprocessor.impl.internal.EntityMessageProcessor
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.messaging.api.records.Record
-import net.corda.persistence.common.exceptions.NotReadyException
-import net.corda.persistence.common.exceptions.VirtualNodeException
 import net.corda.persistence.common.EntitySandboxServiceFactory
 import net.corda.persistence.common.ResponseFactory
+import net.corda.persistence.common.exceptions.NotReadyException
+import net.corda.persistence.common.exceptions.VirtualNodeException
 import net.corda.persistence.common.getSerializationService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
@@ -42,6 +41,7 @@ import org.osgi.test.common.annotation.InjectBundleContext
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.util.UUID
@@ -56,7 +56,7 @@ import java.util.UUID
 class PersistenceExceptionTests {
     companion object {
         const val TOPIC = "pretend-topic"
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @RegisterExtension

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -14,9 +14,9 @@ import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.EntityResponse
 import net.corda.data.persistence.FindAll
 import net.corda.data.persistence.FindEntities
+import net.corda.data.persistence.FindWithNamedQuery
 import net.corda.data.persistence.MergeEntities
 import net.corda.data.persistence.PersistEntities
-import net.corda.data.persistence.FindWithNamedQuery
 import net.corda.db.admin.LiquibaseSchemaMigrator
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.connection.manager.DbConnectionManager
@@ -45,13 +45,12 @@ import net.corda.orm.utils.use
 import net.corda.persistence.common.EntitySandboxService
 import net.corda.persistence.common.EntitySandboxServiceFactory
 import net.corda.persistence.common.ResponseFactory
-import net.corda.persistence.common.getSerializationService
 import net.corda.persistence.common.exceptions.KafkaMessageSizeException
+import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.EachTestLifecycle
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -69,6 +68,7 @@ import org.osgi.test.common.annotation.InjectBundleContext
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.time.LocalDate
@@ -97,7 +97,7 @@ class PersistenceServiceInternalTests {
     private companion object {
         const val TOPIC = "pretend-topic"
         val EXTERNAL_EVENT_CONTEXT = ExternalEventContext("request id", "flow id", KeyValuePairList(emptyList()))
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @InjectService

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceServiceImpl.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/FlowPersistenceServiceImpl.kt
@@ -3,8 +3,8 @@ package net.corda.entityprocessor.impl
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
-import net.corda.entityprocessor.EntityProcessorFactory
 import net.corda.entityprocessor.EntityProcessor
+import net.corda.entityprocessor.EntityProcessorFactory
 import net.corda.entityprocessor.FlowPersistenceService
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.DependentComponents
@@ -20,12 +20,12 @@ import net.corda.lifecycle.createCoordinator
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [FlowPersistenceService::class])
@@ -47,7 +47,7 @@ class FlowPersistenceServiceImpl  @Activate constructor(
     private var entityProcessor: EntityProcessor? = null
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
@@ -20,10 +20,10 @@ import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.utilities.withMDC
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 fun EntitySandboxService.getClass(holdingIdentity: HoldingIdentity, fullyQualifiedClassName: String) =
@@ -45,7 +45,7 @@ class EntityMessageProcessor(
     private val payloadCheck: (bytes: ByteBuffer) -> ByteBuffer,
 ) : DurableProcessor<String, EntityRequest> {
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val MDC_EXTERNAL_EVENT_ID = "external_event_id"
     }
 

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/PersistenceServiceInternal.kt
@@ -1,9 +1,5 @@
 package net.corda.entityprocessor.impl.internal
 
-import java.nio.ByteBuffer
-import javax.persistence.EntityManager
-import javax.persistence.Query
-import javax.persistence.criteria.Selection
 import net.corda.data.persistence.DeleteEntities
 import net.corda.data.persistence.DeleteEntitiesById
 import net.corda.data.persistence.EntityResponse
@@ -16,8 +12,12 @@ import net.corda.persistence.common.exceptions.InvalidPaginationException
 import net.corda.persistence.common.exceptions.NullParameterException
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import javax.persistence.EntityManager
+import javax.persistence.Query
+import javax.persistence.criteria.Selection
 
 
 /**
@@ -53,7 +53,7 @@ class PersistenceServiceInternal(
     private val payloadCheck: (bytes: ByteBuffer) -> ByteBuffer
 ) {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private fun SerializationService.toBytes(obj: Any) = ByteBuffer.wrap(serialize(obj).bytes)

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PayloadChecker.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PayloadChecker.kt
@@ -3,12 +3,12 @@ package net.corda.persistence.common
 import net.corda.libs.configuration.SmartConfig
 import net.corda.persistence.common.exceptions.KafkaMessageSizeException
 import net.corda.schema.configuration.MessagingConfig
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 class PayloadChecker(private val maxPayloadSize: Int) {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val CORDA_MESSAGE_OVERHEAD = 1024
     }
 

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
@@ -9,10 +9,10 @@ import net.corda.persistence.common.exceptions.KafkaMessageSizeException
 import net.corda.persistence.common.exceptions.NotReadyException
 import net.corda.persistence.common.exceptions.NullParameterException
 import net.corda.persistence.common.exceptions.VirtualNodeException
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 
 @Component(service = [ResponseFactory::class])
@@ -22,7 +22,7 @@ class ResponseFactoryImpl @Activate constructor(
 ) : ResponseFactory {
 
     private companion object{
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun successResponse(

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -5,8 +5,8 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.orm.JpaEntitiesSet
 import net.corda.persistence.common.EntityExtractor
-import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_TOKEN_STATE_OBSERVERS
 import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_EMF
+import net.corda.persistence.common.EntitySandboxContextTypes.SANDBOX_TOKEN_STATE_OBSERVERS
 import net.corda.persistence.common.EntitySandboxService
 import net.corda.persistence.common.exceptions.NotReadyException
 import net.corda.persistence.common.exceptions.VirtualNodeException
@@ -23,7 +23,6 @@ import net.corda.sandboxgroupcontext.service.registerCordappCustomSerializers
 import net.corda.sandboxgroupcontext.service.registerCustomCryptography
 import net.corda.sandboxgroupcontext.service.registerCustomJsonDeserializers
 import net.corda.sandboxgroupcontext.service.registerCustomJsonSerializers
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.uncheckedCast
 import net.corda.v5.ledger.utxo.ContractState
@@ -34,6 +33,7 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * This is a sandbox service that is internal to this component.
@@ -59,7 +59,7 @@ class EntitySandboxServiceImpl @Activate constructor(
     private val dbConnectionManager: DbConnectionManager
 ) : EntitySandboxService {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun get(holdingIdentity: HoldingIdentity): SandboxGroupContext {

--- a/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
+++ b/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
@@ -15,10 +15,10 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.permissions.management.PermissionManagementService
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [RBACSecurityManagerService::class])
 class RBACSecurityManagerService @Activate constructor(
@@ -29,7 +29,7 @@ class RBACSecurityManagerService @Activate constructor(
 ) : Lifecycle {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val securityManager: RPCSecurityManager

--- a/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rpc/RestGateway.kt
+++ b/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rpc/RestGateway.kt
@@ -13,13 +13,13 @@ import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.createCoordinator
 import net.corda.permissions.management.PermissionManagementService
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.ComponentContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality
 import org.osgi.service.component.annotations.ReferencePolicy
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(
@@ -49,7 +49,7 @@ class RestGateway @Activate constructor(
 ) : Lifecycle {
 
      companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         internal const val INTERNAL_PLUGGABLE_REST_RESOURCES = "internalPluggableRestResources"
 
          private fun <T> ComponentContext.fetchServices(refName: String): List<T> {

--- a/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/RestGatewayEventHandler.kt
+++ b/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rpc/internal/RestGatewayEventHandler.kt
@@ -41,7 +41,7 @@ import net.corda.utilities.NetworkHostAndPort
 import net.corda.utilities.PathProvider
 import net.corda.utilities.TempPathProvider
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.function.Supplier
 
 @Suppress("LongParameterList")
@@ -56,7 +56,7 @@ internal class RestGatewayEventHandler(
 ) : LifecycleEventHandler {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val MULTI_PART_DIR = "multipart"
 

--- a/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityConfigHandlerImpl.kt
+++ b/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityConfigHandlerImpl.kt
@@ -14,12 +14,12 @@ import net.corda.schema.configuration.ConfigKeys.SECURITY_CONFIG
 import net.corda.schema.configuration.ConfigKeys.SECURITY_POLICY
 import net.corda.securitymanager.SecurityConfigHandler
 import net.corda.securitymanager.SecurityManagerService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 
 /** An implementation of [SecurityConfigHandler]. */
@@ -34,7 +34,7 @@ class SecurityConfigHandlerImpl @Activate constructor(
     private val securityManagerService: SecurityManagerService,
 ): SecurityConfigHandler {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<SecurityConfigHandler>(::eventHandler)

--- a/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityManagerServiceImpl.kt
+++ b/components/security-manager/src/main/kotlin/net/corda/securitymanager/internal/SecurityManagerServiceImpl.kt
@@ -5,7 +5,6 @@ import net.corda.securitymanager.ConditionalPermission.Access.ALLOW
 import net.corda.securitymanager.ConditionalPermission.Access.DENY
 import net.corda.securitymanager.SecurityManagerException
 import net.corda.securitymanager.SecurityManagerService
-import net.corda.v5.base.util.contextLogger
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -13,6 +12,7 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.condpermadmin.ConditionalPermissionAdmin
 import org.osgi.service.condpermadmin.ConditionalPermissionInfo
 import org.osgi.service.permissionadmin.PermissionInfo
+import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.io.InputStream
 import java.security.Security
@@ -27,7 +27,7 @@ class SecurityManagerServiceImpl @Activate constructor(
     bundleContext: BundleContext
 ) : SecurityManagerService {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val PACKAGE_ACCESS_PROPERTY = "package.access"
         private const val DEFAULT_SECURITY_POLICY = "high_security.policy"
         private val ALL_PERMISSION_POLICY = listOf(

--- a/components/uniqueness/backing-store-impl/src/backingStoreBenchmark/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplBenchmark.kt
+++ b/components/uniqueness/backing-store-impl/src/backingStoreBenchmark/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplBenchmark.kt
@@ -40,13 +40,12 @@ import org.mockito.kotlin.whenever
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
-import java.io.FileOutputStream
-import java.io.PrintStream
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
-import java.util.*
+import java.util.TreeMap
+import java.util.UUID
 import kotlin.math.roundToInt
 import kotlin.system.measureTimeMillis
 
@@ -59,7 +58,7 @@ import kotlin.system.measureTimeMillis
 class JPABackingStoreImplBenchmark {
 
     private companion object {
-        val log: Logger = LoggerFactory.getLogger(this::class.java)
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     // Controls how many times we invoke the backing store API. Increasing this should not impact

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -37,7 +37,6 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResultFailure
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateDetails
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
@@ -46,6 +45,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityExistsException
 import javax.persistence.EntityManager
 import javax.persistence.OptimisticLockException
@@ -67,7 +67,7 @@ open class JPABackingStoreImpl @Activate constructor(
 ) : BackingStore {
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         // TODO: Replace constants with config
         const val MAX_ATTEMPTS = 10

--- a/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
@@ -11,7 +11,6 @@ import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResultSuccess
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
@@ -26,6 +25,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 import java.time.Instant
 
@@ -49,7 +49,7 @@ class LedgerUniquenessCheckerClientServiceImpl @Activate constructor(
 ): LedgerUniquenessCheckerClientService, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
@@ -41,7 +41,6 @@ import net.corda.uniqueness.checker.UniquenessChecker
 import net.corda.uniqueness.checker.impl.BatchedUniquenessCheckerImpl
 import net.corda.uniqueness.utils.UniquenessAssertions
 import net.corda.uniqueness.utils.UniquenessAssertions.assertUnknownInputStateResponse
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
@@ -53,6 +52,7 @@ import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -98,7 +98,7 @@ class MessageBusIntegrationTests {
             }
         """
 
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         val bootConfig = SmartConfigFactory.createWithoutSecurityServices()
             .create(

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
@@ -35,8 +35,8 @@ import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultFailureImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultSuccessImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateDetailsImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateRefImpl
-import net.corda.uniqueness.datamodel.internal.UniquenessCheckTransactionDetailsInternal
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckRequestInternal
+import net.corda.uniqueness.datamodel.internal.UniquenessCheckTransactionDetailsInternal
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.application.uniqueness.model.UniquenessCheckError
@@ -44,7 +44,6 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResultSuccess
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateDetails
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
@@ -53,9 +52,9 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.time.Instant
-import java.util.*
-import kotlin.collections.HashMap
+import java.util.LinkedList
 
 /**
  * A batched implementation of the uniqueness checker component, which processes batches of requests
@@ -98,7 +97,7 @@ class BatchedUniquenessCheckerImpl(
         const val CONFIG_HANDLE = "CONFIG_HANDLE"
         const val SUBSCRIPTION = "SUBSCRIPTION"
 
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lifecycleCoordinator: LifecycleCoordinator =

--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReadServiceImpl.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReadServiceImpl.kt
@@ -9,13 +9,13 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.reconciliation.VersionedRecord
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 /**
@@ -36,7 +36,7 @@ class CpiInfoReadServiceImpl @Activate constructor(
     subscriptionFactory: SubscriptionFactory
 ) : CpiInfoReadService {
     companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val cpiInfoProcessor = CpiInfoReaderProcessor(::setStatusToUp, ::setStatusToError)

--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderEventHandler.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderEventHandler.kt
@@ -18,8 +18,8 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.VirtualNode.Companion.CPI_INFO_TOPIC
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 /**
  * Handle the events inside the [CpiInfoReader] component.
@@ -33,7 +33,7 @@ class CpiInfoReaderEventHandler(
 ) : LifecycleEventHandler {
     companion object {
         internal const val GROUP_NAME = "CPI_INFO_READER"
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var subscription: CompactedSubscription<CpiIdentifier, CpiMetadata>? = null

--- a/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderProcessor.kt
+++ b/components/virtual-node/cpi-info-read-service-impl/src/main/kotlin/net/corda/cpiinfo/read/impl/CpiInfoReaderProcessor.kt
@@ -4,8 +4,8 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 import java.util.*
 import net.corda.data.packaging.CpiIdentifier as CpiIdAvro
 import net.corda.data.packaging.CpiMetadata as CpiMetadataAvro
@@ -19,7 +19,7 @@ class CpiInfoReaderProcessor(private val onStatusUpCallback: () -> Unit, private
     CompactedProcessor<CpiIdAvro, CpiMetadataAvro> {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/virtual-node/cpi-info-write-service-impl/src/main/kotlin/net/corda/cpiinfo/write/impl/CpiInfoWriterComponentImpl.kt
+++ b/components/virtual-node/cpi-info-write-service-impl/src/main/kotlin/net/corda/cpiinfo/write/impl/CpiInfoWriterComponentImpl.kt
@@ -21,11 +21,11 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.VirtualNode.Companion.CPI_INFO_TOPIC
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import net.corda.data.packaging.CpiIdentifier as CpiIdentifierAvro
 import net.corda.data.packaging.CpiMetadata as CpiMetadataAvro
 
@@ -44,7 +44,7 @@ class CpiInfoWriterComponentImpl @Activate constructor(
     private val publisherFactory: PublisherFactory
 ) : CpiInfoWriteService, LifecycleEventHandler {
     companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         internal const val CLIENT_ID = "CPI_INFO_WRITER"
     }
 

--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/service/impl/CpiUploadRPCOpsServiceHandler.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/service/impl/CpiUploadRPCOpsServiceHandler.kt
@@ -18,7 +18,7 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * Registers to [ConfigurationReadService] for config updates, and on new config updates creates a new [CpiUploadManager]
@@ -32,7 +32,7 @@ class CpiUploadRPCOpsServiceHandler(
 ) : LifecycleEventHandler {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @VisibleForTesting

--- a/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
+++ b/components/virtual-node/cpi-upload-rpcops-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
@@ -18,12 +18,12 @@ import net.corda.libs.cpiupload.endpoints.v1.GetCPIsResponse
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.createCoordinator
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.v5.crypto.SecureHash
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [PluggableRestResource::class])
 class CpiUploadRestResourceImpl @Activate constructor(
@@ -35,7 +35,7 @@ class CpiUploadRestResourceImpl @Activate constructor(
     private val cpiInfoReadService: CpiInfoReadService
 ) : CpiUploadRestResource, PluggableRestResource<CpiUploadRestResource>, Lifecycle {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<CpiUploadRestResource>(

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
@@ -1,12 +1,12 @@
 package net.corda.cpk.read.impl
 
-import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpk.read.CpkReadService
 import net.corda.cpk.read.impl.services.CpkChunksKafkaReader
 import net.corda.cpk.read.impl.services.persistence.CpkChunksFileManagerImpl
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.packaging.Cpk
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -19,7 +19,6 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.libs.configuration.helper.getConfig
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
@@ -28,9 +27,8 @@ import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.PathProvider
 import net.corda.utilities.TempPathProvider
-import net.corda.utilities.WorkspacePathProvider
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import net.corda.utilities.WorkspacePathProvider
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
 import org.osgi.service.component.annotations.Activate
@@ -38,6 +36,8 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 @Component(service = [CpkReadService::class])
 class CpkReadServiceImpl (
@@ -65,7 +65,7 @@ class CpkReadServiceImpl (
     )
 
     companion object {
-        val logger: Logger = contextLogger()
+        val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val CPK_CACHE_DIR = "cpk-cache"
         const val CPK_PARTS_DIR = "cpk-parts"

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
@@ -10,8 +10,8 @@ import net.corda.libs.packaging.CpkReader
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.SortedSet
@@ -23,7 +23,7 @@ class CpkChunksKafkaReader(
     private val onCpkAssembled: (SecureHash, Cpk) -> Unit
 ) : CompactedProcessor<CpkChunkId, Chunk> {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     // Assuming [CompactedProcessor.onSnapshot] and [CompactedProcessor.onNext] are not called concurrently.

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
@@ -3,11 +3,11 @@ package net.corda.cpk.read.impl.services.persistence
 import net.corda.chunking.toCorda
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.CpkChunkId
-import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.util.debug
-import net.corda.v5.crypto.SecureHash
 import net.corda.utilities.inputStream
 import net.corda.utilities.outputStream
+import net.corda.v5.base.util.debug
+import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
@@ -18,7 +18,7 @@ import java.util.SortedSet
  */
 class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileManager {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val DELIMITER = ".cpk.part."
 

--- a/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImpl.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImpl.kt
@@ -40,7 +40,6 @@ import net.corda.schema.configuration.MessagingConfig
 import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CPK_WRITE_INTERVAL_MS
 import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.seconds
 import net.corda.v5.base.util.trace
@@ -49,6 +48,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.time.Duration
 
@@ -68,7 +68,7 @@ class CpkWriteServiceImpl @Activate constructor(
     private val dbConnectionManager: DbConnectionManager
 ) : CpkWriteService, LifecycleEventHandler {
     companion object {
-        val logger: Logger = contextLogger()
+        val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val CPK_WRITE_GROUP = "cpk.writer"
         const val CPK_WRITE_CLIENT = "$CPK_WRITE_GROUP.client"

--- a/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/db/impl/DBCpkStorage.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/db/impl/DBCpkStorage.kt
@@ -1,19 +1,19 @@
 package net.corda.cpk.write.impl.services.db.impl
 
-import net.corda.cpk.write.impl.services.db.CpkStorage
 import net.corda.cpk.write.impl.services.db.CpkChecksumToData
+import net.corda.cpk.write.impl.services.db.CpkStorage
 import net.corda.libs.cpi.datamodel.CpkFileEntity
 import net.corda.libs.cpi.datamodel.findCpkChecksumsNotIn
 import net.corda.orm.utils.transaction
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManagerFactory
 
 // Consider moving following queries in here to be Named queries at entities site so that we save an extra Integration test
 class DBCpkStorage(private val entityManagerFactory: EntityManagerFactory) : CpkStorage {
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun getCpkIdsNotIn(checksums: List<SecureHash>): List<SecureHash> {

--- a/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/kafka/impl/CpkChecksumsCacheImpl.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/kafka/impl/CpkChecksumsCacheImpl.kt
@@ -12,11 +12,11 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
-import java.util.*
+import java.util.Collections
 
 /**
  * This cache will get updated everytime a zero chunk is pushed to Kafka and gets picked up by [CacheSynchronizer].
@@ -27,7 +27,7 @@ class CpkChecksumsCacheImpl(
     nodeConfig: SmartConfig = SmartConfigImpl.empty()
 ) : CpkChecksumsCache {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private fun ByteBuffer.isZeroChunk() = this.limit() == 0
     }

--- a/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/kafka/impl/KafkaCpkChunksPublisher.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/main/kotlin/net/corda/cpk/write/impl/services/kafka/impl/KafkaCpkChunksPublisher.kt
@@ -7,8 +7,8 @@ import net.corda.data.chunking.CpkChunkId
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 class KafkaCpkChunksPublisher(
@@ -17,7 +17,7 @@ class KafkaCpkChunksPublisher(
     private val topicName: String
 ) : CpkChunksPublisher {
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun put(cpkChunkId: CpkChunkId, cpkChunk: Chunk) {

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -1,6 +1,5 @@
 package net.corda.sandbox.serialization.amqp
 
-import java.util.function.Supplier
 import net.corda.internal.serialization.AMQP_P2P_CONTEXT
 import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.DeserializationInput
@@ -20,7 +19,6 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.getMetadataServices
 import net.corda.sandboxgroupcontext.putObjectByKey
 import net.corda.serialization.InternalCustomSerializer
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.serialization.SerializationCustomSerializer
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -29,6 +27,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL
 import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE
 import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope
+import org.slf4j.LoggerFactory
+import java.util.function.Supplier
 
 /**
  * Configures a sandbox with AMQP serialization support.
@@ -46,7 +46,7 @@ class AMQPSerializationProvider @Activate constructor(
     private val serializationServiceProxy: SerializationServiceProxy?
 ) : UsedByFlow, UsedByPersistence, UsedByVerification, CustomMetadataConsumer {
     private companion object {
-        private val logger = loggerFor<AMQPSerializationProvider>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private fun createSerializerFactory(context: SandboxGroupContext): SerializerFactory {

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CloseableSandboxGroupContext.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CloseableSandboxGroupContext.kt
@@ -3,7 +3,7 @@ package net.corda.sandboxgroupcontext.service.impl
 import net.corda.sandbox.SandboxGroup
 import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.v5.base.util.loggerFor
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -21,7 +21,7 @@ internal class CloseableSandboxGroupContextImpl(
     private val closeable: AutoCloseable
 ) : CloseableSandboxGroupContext {
     private companion object {
-        private val logger = loggerFor<CloseableSandboxGroupContext>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lock = ReentrantLock()

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
@@ -3,17 +3,17 @@ package net.corda.sandboxgroupcontext.service.impl
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 
 @Component(service = [CurrentSandboxGroupContext::class, UsedByFlow::class])
 class CurrentSandboxGroupContextImpl : CurrentSandboxGroupContext, SingletonSerializeAsToken, UsedByFlow {
 
     private companion object {
         @JvmField
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         @JvmField
         val currentSandboxGroupContext = ThreadLocal<SandboxGroupContext?>()
     }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -6,7 +6,7 @@ import net.corda.cache.caffeine.CacheFactoryImpl
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.base.annotations.VisibleForTesting
-import net.corda.v5.base.util.loggerFor
+import org.slf4j.LoggerFactory
 import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
 import java.time.Duration
@@ -22,7 +22,7 @@ internal class SandboxGroupContextCacheImpl private constructor(
         : this(capacity, ReferenceQueue<SandboxGroupContextWrapper>(), ConcurrentHashMap.newKeySet())
 
     private companion object {
-        private val logger = loggerFor<SandboxGroupContextCache>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val WAIT_MILLIS = 100L
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -1,8 +1,5 @@
 package net.corda.sandboxgroupcontext.service.impl
 
-import java.time.Duration
-import java.util.Collections.unmodifiableList
-import java.util.concurrent.CompletableFuture
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpk.read.CpkReadService
@@ -22,7 +19,6 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheControl
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
@@ -31,6 +27,10 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.runtime.ServiceComponentRuntime
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.Collections.unmodifiableList
+import java.util.concurrent.CompletableFuture
 
 /**
  * Sandbox group context service component... with lifecycle, since it depends on a CPK service
@@ -52,7 +52,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     private val bundleContext: BundleContext
 ) : SandboxGroupContextComponent, SandboxGroupContextService by sandboxGroupContextService {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val PLATFORM_PUBLIC_BUNDLE_NAMES: List<String> = unmodifiableList(
             listOf(

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -1,23 +1,12 @@
 @file:JvmName("SandboxGroupContextServiceUtils")
 package net.corda.sandboxgroupcontext.service.impl
 
-import java.security.AccessControlContext
-import java.security.AccessControlException
-import java.time.Duration
-import java.util.Collections.singleton
-import java.util.Collections.unmodifiableSet
-import java.util.Deque
-import java.util.Hashtable
-import java.util.LinkedList
-import java.util.SortedMap
-import java.util.TreeMap
-import java.util.concurrent.CompletableFuture
 import net.corda.cpk.read.CpkReadService
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.metrics.CordaMetrics
-import net.corda.sandbox.RequireSandboxHooks
 import net.corda.sandbox.RequireCordaSystem
 import net.corda.sandbox.RequireCordaSystem.CORDA_SYSTEM_NAMESPACE
+import net.corda.sandbox.RequireSandboxHooks
 import net.corda.sandbox.SandboxCreationService
 import net.corda.sandbox.SandboxException
 import net.corda.sandboxgroupcontext.CORDA_SANDBOX
@@ -36,7 +25,6 @@ import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.sandboxgroupcontext.putObjectByKey
 import net.corda.sandboxgroupcontext.service.CacheControl
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.SecureHash
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
@@ -57,6 +45,18 @@ import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.runtime.ServiceComponentRuntime
 import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO
+import org.slf4j.LoggerFactory
+import java.security.AccessControlContext
+import java.security.AccessControlException
+import java.time.Duration
+import java.util.Collections.singleton
+import java.util.Collections.unmodifiableSet
+import java.util.Deque
+import java.util.Hashtable
+import java.util.LinkedList
+import java.util.SortedMap
+import java.util.TreeMap
+import java.util.concurrent.CompletableFuture
 
 typealias SatisfiedServiceReferences = Map<String, SortedMap<ServiceReference<*>, Any>>
 
@@ -95,7 +95,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
         private val uninjectableFilter = FrameworkUtil.createFilter(CORDA_UNINJECTABLE_FILTER)
         private val markerOnlyFilter = FrameworkUtil.createFilter(CORDA_MARKER_ONLY_FILTER)
         private val systemFilter = FrameworkUtil.createFilter(CORDA_SYSTEM_FILTER)
-        private val logger = loggerFor<SandboxGroupContextServiceImpl>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val sandboxServiceProperties = Hashtable<String, Any?>().apply {
             put(CORDA_SANDBOX, true)

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxServiceObjects.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxServiceObjects.kt
@@ -1,9 +1,9 @@
 package net.corda.sandboxgroupcontext.service.impl
 
-import java.lang.reflect.InvocationTargetException
-import net.corda.v5.base.util.loggerFor
 import org.osgi.framework.ServiceObjects
 import org.osgi.framework.ServiceReference
+import org.slf4j.LoggerFactory
+import java.lang.reflect.InvocationTargetException
 
 class SandboxServiceObjects(
     private val reference: ServiceReference<*>,
@@ -11,7 +11,7 @@ class SandboxServiceObjects(
     private val sandboxServices: SatisfiedServiceReferences
 ) : ServiceObjects<Any> {
     private companion object {
-        private val logger = loggerFor<SandboxServiceObjects>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val closeables = mutableListOf<AutoCloseable>()

--- a/components/virtual-node/sandbox-json/src/main/kotlin/net/corda/sandbox/serialization/json/JsonSerializerProvider.kt
+++ b/components/virtual-node/sandbox-json/src/main/kotlin/net/corda/sandbox/serialization/json/JsonSerializerProvider.kt
@@ -8,16 +8,16 @@ import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
 import net.corda.sandboxgroupcontext.CustomMetadataConsumer
 import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
-import net.corda.sandboxgroupcontext.getSandboxSingletonServices
 import net.corda.sandboxgroupcontext.getMetadataServices
+import net.corda.sandboxgroupcontext.getSandboxSingletonServices
 import net.corda.v5.application.marshalling.json.JsonDeserializer
 import net.corda.v5.application.marshalling.json.JsonSerializer
-import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceScope
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 
 /**
  * Configures a sandbox with handwritten JSON serializers and deserializers.
@@ -36,7 +36,7 @@ class JsonSerializerProvider @Activate constructor(
     private val internalJsonDeserializers: List<JsonDeserializer<*>>
 ) : UsedByFlow, UsedByPersistence, UsedByVerification, CustomMetadataConsumer {
     private companion object {
-        private val logger = loggerFor<JsonSerializerProvider>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun accept(context: MutableSandboxGroupContext) {

--- a/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
+++ b/components/virtual-node/sandbox-notary-impl/src/main/kotlin/net/corda/ledger/notary/plugin/factory/impl/PluggableNotaryClientFlowFactoryImpl.kt
@@ -11,7 +11,6 @@ import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
 import net.corda.sandboxgroupcontext.getMetadataServices
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
@@ -23,6 +22,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 
 @Component(
     service = [ PluggableNotaryClientFlowFactory::class, UsedByFlow::class, UsedByVerification::class, UsedByPersistence::class ],
@@ -38,7 +38,7 @@ class PluggableNotaryClientFlowFactoryImpl @Activate constructor(
     UsedByVerification, CustomMetadataConsumer {
 
     private companion object {
-        val logger = loggerFor<PluggableNotaryClientFlowFactoryImpl>()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val pluggableNotaryClientFlowProviders = mutableMapOf<String, PluggableNotaryClientFlowProvider>()

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessor.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessor.kt
@@ -2,7 +2,6 @@ package net.corda.virtualnode.read.impl
 
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.ShortHash
@@ -12,6 +11,7 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -32,7 +32,7 @@ class VirtualNodeInfoProcessor(private val onStatusUpCallback: () -> Unit, priva
     CompactedProcessor<net.corda.data.identity.HoldingIdentity, net.corda.data.virtualnode.VirtualNodeInfo> {
 
     companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /** Holds all the virtual node info we receive off the wire as Avro objects */

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReadServiceImpl.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReadServiceImpl.kt
@@ -8,10 +8,9 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.createCoordinator
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.reconciliation.VersionedRecord
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
-import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoListener
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -20,6 +19,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 /**
@@ -39,7 +39,7 @@ class VirtualNodeInfoReadServiceImpl @Activate constructor(
     subscriptionFactory: SubscriptionFactory
 ) : VirtualNodeInfoReadService {
     companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     // This eventually needs to be passed in to here from the parent `main`

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReaderEventHandler.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoReaderEventHandler.kt
@@ -18,9 +18,9 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.VirtualNode.Companion.VIRTUAL_NODE_INFO_TOPIC
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * Handle the events inside the [VirtualNodeInfo] service component.
@@ -34,7 +34,7 @@ class VirtualNodeInfoReaderEventHandler(
 ) : LifecycleEventHandler {
     companion object {
         internal const val GROUP_NAME = "VIRTUAL_NODE_INFO_READER"
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var subscription: CompactedSubscription<HoldingIdentity, VirtualNodeInfo>? = null

--- a/components/virtual-node/virtual-node-management-sender/src/main/kotlin/net/corda/virtualnode/rpcops/common/impl/VirtualNodeSenderFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-management-sender/src/main/kotlin/net/corda/virtualnode/rpcops/common/impl/VirtualNodeSenderFactoryImpl.kt
@@ -3,12 +3,12 @@ package net.corda.virtualnode.rpcops.common.impl
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.rpcops.common.VirtualNodeSender
 import net.corda.virtualnode.rpcops.common.VirtualNodeSenderFactory
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 @Component(service = [VirtualNodeSenderFactory::class])
@@ -17,7 +17,7 @@ class VirtualNodeSenderFactoryImpl @Activate constructor(
     private val publisherFactory: PublisherFactory,
 ) : VirtualNodeSenderFactory {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/virtual-node/virtual-node-management-sender/src/main/kotlin/net/corda/virtualnode/rpcops/common/impl/VirtualNodeSenderImpl.kt
+++ b/components/virtual-node/virtual-node-management-sender/src/main/kotlin/net/corda/virtualnode/rpcops/common/impl/VirtualNodeSenderImpl.kt
@@ -5,8 +5,8 @@ import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.utilities.concurrent.getOrThrow
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.rpcops.common.VirtualNodeSender
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 class VirtualNodeSenderImpl(
@@ -14,7 +14,7 @@ class VirtualNodeSenderImpl(
     private val sender: RPCSender<VirtualNodeManagementRequest, VirtualNodeManagementResponse>
 ) : VirtualNodeSender {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/virtual-node/virtual-node-rpcops-maintenance-impl/src/main/kotlin/net/corda/libs/virtualnode/maintenance/rpcops/impl/v1/VirtualNodeMaintenanceRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-maintenance-impl/src/main/kotlin/net/corda/libs/virtualnode/maintenance/rpcops/impl/v1/VirtualNodeMaintenanceRestResourceImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.libs.virtualnode.maintenance.rpcops.impl.v1
 
-import java.time.Duration
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpi.upload.endpoints.service.CpiUploadRPCOpsService
@@ -31,14 +30,14 @@ import net.corda.lifecycle.StopEvent
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.rpcops.common.VirtualNodeSender
 import net.corda.virtualnode.rpcops.common.VirtualNodeSenderFactory
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.lang.Exception
+import org.slf4j.LoggerFactory
+import java.time.Duration
 
 @Suppress("unused")
 @Component(service = [PluggableRestResource::class])
@@ -55,7 +54,7 @@ class VirtualNodeMaintenanceRestResourceImpl @Activate constructor(
 
     companion object {
         private val requiredKeys = setOf(ConfigKeys.MESSAGING_CONFIG, ConfigKeys.REST_CONFIG)
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val REGISTRATION = "REGISTRATION"
         private const val SENDER = "SENDER"

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/ExceptionTranslator.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/ExceptionTranslator.kt
@@ -7,11 +7,11 @@ import net.corda.httprpc.exception.InternalServerException
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.libs.virtualnode.common.exception.CpiNotFoundException
 import net.corda.libs.virtualnode.common.exception.VirtualNodeAlreadyExistsException
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class ExceptionTranslator {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         /**
          * Translates [exception] to [HttpApiException]

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.virtualnode.rpcops.impl.v1
 
-import java.time.Duration
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.ExceptionEnvelope
@@ -37,19 +36,20 @@ import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.time.ClockFactory
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.ShortHash
-import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.read.rpc.extensions.parseOrThrow
 import net.corda.virtualnode.rpcops.common.VirtualNodeSender
 import net.corda.virtualnode.rpcops.common.VirtualNodeSenderFactory
 import net.corda.virtualnode.rpcops.impl.v1.ExceptionTranslator.Companion.translate
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.time.Duration
 import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity as HoldingIdentityEndpointType
 
 @Component(service = [PluggableRestResource::class])
@@ -69,7 +69,7 @@ internal class VirtualNodeRestResourceImpl @Activate constructor(
 
     private companion object {
         private val requiredKeys = setOf(ConfigKeys.MESSAGING_CONFIG, ConfigKeys.REST_CONFIG)
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val REGISTRATION = "REGISTRATION"
         private const val SENDER = "SENDER"

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbChangeLogImplementationTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbChangeLogImplementationTest.kt
@@ -2,13 +2,13 @@ package net.corda.virtualnode.write.db.impl.tests
 
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.testkit.DbUtils
-import net.corda.v5.base.util.contextLogger
+import net.corda.libs.cpi.datamodel.CpkDbChangeLog
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import java.util.UUID
-import net.corda.libs.cpi.datamodel.CpkDbChangeLog
 
 class VirtualNodeDbChangeLogImplementationTest  {
     // It hardly seems worth bringing in a template system for one expansion, so we'll just do string replacement on _INCLUDETARGET_
@@ -38,7 +38,7 @@ class VirtualNodeDbChangeLogImplementationTest  {
 </databaseChangeLog>
 """
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val dbConfig = DbUtils.getEntityManagerConfiguration("test")
         private val fakeId = UUID.randomUUID()
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -12,8 +12,8 @@ import net.corda.db.core.DbPrivilege
 import net.corda.db.core.DbPrivilege.DDL
 import net.corda.db.core.DbPrivilege.DML
 import net.corda.db.schema.DbSchema
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.ShortHash
+import org.slf4j.LoggerFactory
 
 /**
  * Encapsulates access to a single database, either of type VAULT or CONFIG, at muliple different provilege levels
@@ -31,7 +31,7 @@ class VirtualNodeDb(
 ) {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
@@ -4,8 +4,8 @@ import net.corda.libs.cpi.datamodel.CpiMetadataEntity
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManagerFactory
 
 /** Reads and writes CPIs, holding identities and virtual nodes to and from the cluster database. */
@@ -16,7 +16,7 @@ internal class VirtualNodeEntityRepository(
     ) {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val SHORT_HASH_LENGTH: Int = 12
     }
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
@@ -18,7 +18,6 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -29,6 +28,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import net.corda.data.identity.HoldingIdentity as HoldingIdentityAvro
 import net.corda.data.virtualnode.VirtualNodeInfo as VirtualNodeInfoAvro
 
@@ -46,7 +46,7 @@ class VirtualNodeInfoWriterComponentImpl @Activate constructor(
     private val publisherFactory: PublisherFactory
 ) : VirtualNodeInfoWriteService {
     companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         internal const val CLIENT_ID = "VIRTUAL_NODE_INFO_WRITER"
     }
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -22,14 +22,16 @@ import net.corda.db.core.DbPrivilege
 import net.corda.db.core.DbPrivilege.DDL
 import net.corda.db.core.DbPrivilege.DML
 import net.corda.layeredpropertymap.toAvro
+import net.corda.libs.cpi.datamodel.CpkDbChangeLog
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.findChangelogEntitiesForGivenCpkFileChecksums
 import net.corda.libs.cpi.datamodel.findCurrentCpkChangeLogsForCpi
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.virtualnode.common.exception.CpiNotFoundException
 import net.corda.libs.virtualnode.common.exception.VirtualNodeAlreadyExistsException
+import net.corda.libs.virtualnode.datamodel.VirtualNodeNotFoundException
 import net.corda.libs.virtualnode.datamodel.repository.HoldingIdentityRepository
 import net.corda.libs.virtualnode.datamodel.repository.HoldingIdentityRepositoryImpl
-import net.corda.libs.virtualnode.datamodel.VirtualNodeNotFoundException
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepository
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepositoryImpl
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
@@ -44,23 +46,21 @@ import net.corda.schema.Schemas.Membership.Companion.MEMBER_LIST_TOPIC
 import net.corda.schema.Schemas.VirtualNode.Companion.VIRTUAL_NODE_INFO_TOPIC
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
+import org.slf4j.LoggerFactory
 import java.lang.System.currentTimeMillis
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import javax.persistence.EntityManager
 import javax.sql.DataSource
 import kotlin.system.measureTimeMillis
-import net.corda.libs.cpi.datamodel.CpkDbChangeLog
-import net.corda.libs.cpi.datamodel.findChangelogEntitiesForGivenCpkFileChecksums
 
 /**
  * An RPC responder processor that handles virtual node creation requests.
@@ -93,7 +93,7 @@ internal class VirtualNodeWriterProcessor(
 ) : RPCResponderProcessor<VirtualNodeManagementRequest, VirtualNodeManagementResponse> {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val PUBLICATION_TIMEOUT_SECONDS = 30L
         val systemTerminatorTag = "${VAULT.name}-system-final"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.626-beta+
+cordaApiVersion=5.0.0.627-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/PostgresDbSetup.kt
+++ b/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/PostgresDbSetup.kt
@@ -15,7 +15,7 @@ import net.corda.libs.configuration.datamodel.DbConnectionConfig
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceImpl
 import net.corda.libs.configuration.secret.SecretsCreateService
 import net.corda.schema.configuration.ConfigKeys.CRYPTO_CONFIG
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.security.SecureRandom
 import java.time.Instant
 import java.util.Base64
@@ -49,7 +49,7 @@ class PostgresDbSetup(
             "net/corda/db/schema/crypto/db.changelog-master.xml" to "CRYPTO"
         )
 
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dbAdminUrl by lazy {

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
@@ -1,15 +1,15 @@
 package net.corda.chunking.impl
 
+import net.corda.chunking.Checksum
 import net.corda.chunking.ChunkReader
 import net.corda.chunking.ChunksCombined
-import net.corda.chunking.Checksum
 import net.corda.chunking.RequestId
 import net.corda.chunking.toCorda
 import net.corda.data.KeyValuePairList
 import net.corda.data.chunking.Chunk
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
@@ -20,7 +20,7 @@ import java.nio.file.StandardOpenOption
  */
 internal class ChunkReaderImpl(private val destDir: Path) : ChunkReader {
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private fun KeyValuePairList.fromAvro(): Map<String, String?> {
             return items.associate { it.key to it.value }

--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceFactory.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceFactory.kt
@@ -2,9 +2,9 @@ package net.corda.libs.configuration.secret
 
 import com.typesafe.config.Config
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 
 @Component(service = [SecretsServiceFactory::class])
 class EncryptionSecretsServiceFactory : SecretsServiceFactory {
@@ -13,7 +13,7 @@ class EncryptionSecretsServiceFactory : SecretsServiceFactory {
         const val SECRET_PASSPHRASE_KEY = "${ConfigKeys.SECRETS_CONFIG}.${ConfigKeys.SECRETS_PASSPHRASE}"
         const val SECRET_SALT_KEY = "${ConfigKeys.SECRETS_CONFIG}.${ConfigKeys.SECRETS_SALT}"
 
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val type = TYPE

--- a/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigurationValidatorImpl.kt
+++ b/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigurationValidatorImpl.kt
@@ -17,15 +17,15 @@ import net.corda.libs.configuration.validation.ConfigurationSchemaFetchException
 import net.corda.libs.configuration.validation.ConfigurationValidationException
 import net.corda.libs.configuration.validation.ConfigurationValidator
 import net.corda.schema.configuration.provider.SchemaProvider
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.versioning.Version
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 
 internal class ConfigurationValidatorImpl(private val schemaProvider: SchemaProvider) : ConfigurationValidator {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val REGISTERED_SCHEMES = listOf("https", "http")
     }
 

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/SignatureVerificationServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/SignatureVerificationServiceImpl.kt
@@ -11,7 +11,6 @@ import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
 import net.corda.v5.application.crypto.DigestService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SignatureSpec
@@ -22,6 +21,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 import javax.crypto.Cipher
 
@@ -37,7 +37,7 @@ class SignatureVerificationServiceImpl @Activate constructor(
 ) : SignatureVerificationService,
     UsedByFlow, UsedByPersistence, UsedByVerification, SingletonSerializeAsToken {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val signatureInstances = SignatureInstances(schemeMetadata.providers)

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CordaSecureRandomService.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CordaSecureRandomService.kt
@@ -1,7 +1,7 @@
 package net.corda.crypto.impl
 
-import net.corda.v5.base.util.loggerFor
 import org.apache.commons.lang3.SystemUtils
+import org.slf4j.LoggerFactory
 import java.io.DataInputStream
 import java.io.File
 import java.io.FileInputStream
@@ -17,7 +17,7 @@ class CordaSecureRandomService(provider: Provider) :
 
     companion object {
         const val algorithm = "CordaPRNG"
-        private val logger = loggerFor<CordaSecureRandomService>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val instance: SecureRandomSpi = if (SystemUtils.IS_OS_LINUX) tryAndUseLinuxSecureRandomSpi() else CordaSecureRandomSpi()

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/decorators/CryptoServiceDecorator.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/decorators/CryptoServiceDecorator.kt
@@ -10,9 +10,9 @@ import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import net.corda.crypto.core.isRecoverable
 import net.corda.crypto.impl.retrying.BackoffStrategy
 import net.corda.crypto.impl.retrying.CryptoRetryingExecutorWithTimeout
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoException
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 class CryptoServiceDecorator(
@@ -21,7 +21,7 @@ class CryptoServiceDecorator(
     private val maxAttempts: Int
 ) : CryptoService, AutoCloseable {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         fun create(
             cryptoService: CryptoService,

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/decorators/CryptoServiceThrottlingDecorator.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/decorators/CryptoServiceThrottlingDecorator.kt
@@ -7,10 +7,10 @@ import net.corda.crypto.cipher.suite.KeyGenerationSpec
 import net.corda.crypto.cipher.suite.SharedSecretSpec
 import net.corda.crypto.cipher.suite.SigningSpec
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoException
 import net.corda.v5.crypto.exceptions.CryptoThrottlingException
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class CryptoServiceThrottlingDecorator(
@@ -18,7 +18,7 @@ class CryptoServiceThrottlingDecorator(
 ) : CryptoService {
     companion object {
         private const val MAX_RETRY_GUARD: Int = 10
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private fun <R> executeWithBackingOff(block: () -> R): R {

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/retrying/CryptoRetryingExecutorsTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/retrying/CryptoRetryingExecutorsTests.kt
@@ -1,6 +1,5 @@
 package net.corda.crypto.impl.retrying
 
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.exceptions.CryptoException
 import net.corda.v5.crypto.exceptions.CryptoRetryException
 import org.assertj.core.api.Assertions.assertThat
@@ -8,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 import javax.persistence.LockTimeoutException
@@ -20,7 +20,7 @@ class CryptoRetryingExecutorsTests {
     private val defaultRetryTimeout = Duration.ofSeconds(5)
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @JvmStatic
         fun mostCommonUnrecoverableExceptions(): List<Throwable> = listOf(

--- a/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/ClassloaderChangeLog.kt
+++ b/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/ClassloaderChangeLog.kt
@@ -2,7 +2,7 @@ package net.corda.db.admin.impl
 
 import net.corda.db.admin.DbChange
 import net.corda.db.admin.impl.ClassloaderChangeLog.ChangeLogResourceFiles
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.net.URLEncoder
@@ -58,7 +58,7 @@ class ClassloaderChangeLog(
     companion object {
         const val CLASS_LOADER_PREFIX = "classloader://"
 
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val allChangeFiles = mutableSetOf<String>()

--- a/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImpl.kt
+++ b/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImpl.kt
@@ -8,8 +8,8 @@ import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.ResourceAccessor
 import net.corda.db.admin.DbChange
 import net.corda.db.admin.LiquibaseSchemaMigrator
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import java.io.Writer
 import java.sql.Connection
 import java.util.UUID
@@ -32,7 +32,7 @@ class LiquibaseSchemaMigratorImpl(
         // default schema
         // NOTE: may need to become variable depending on the DB type
         const val DEFAULT_DB_SCHEMA = "PUBLIC"
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun updateDb(datasource: Connection, dbChange: DbChange, tag: String?) {

--- a/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/StreamResourceAccessor.kt
+++ b/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/StreamResourceAccessor.kt
@@ -7,7 +7,7 @@ import liquibase.resource.Resource
 import liquibase.resource.ResourceAccessor
 import net.corda.db.admin.DbChange
 import net.corda.db.admin.LiquibaseXmlConstants
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -39,7 +39,7 @@ class StreamResourceAccessor(
         ClassLoaderResourceAccessor(ClassLoaderResourceAccessor::class.java.classLoader)
 ) : AbstractResourceAccessor() {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     // transformer only used for debugging

--- a/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/EntityManagerFactoryFactoryImpl.kt
+++ b/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/EntityManagerFactoryFactoryImpl.kt
@@ -4,12 +4,12 @@ import net.corda.db.core.CloseableDataSource
 import net.corda.orm.DdlManage
 import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.EntityManagerFactoryFactory
-import net.corda.v5.base.util.contextLogger
 import org.hibernate.cfg.AvailableSettings
 import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl
 import org.hibernate.jpa.boot.internal.PersistenceUnitInfoDescriptor
 import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManagerFactory
 import javax.persistence.spi.PersistenceUnitInfo
 
@@ -26,7 +26,7 @@ class EntityManagerFactoryFactoryImpl(
         }
 ) : EntityManagerFactoryFactory {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/ExecuteCleanupEventExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/ExecuteCleanupEventExecutor.kt
@@ -2,14 +2,14 @@ package net.corda.flow.mapper.impl.executor
 
 import net.corda.flow.mapper.FlowMapperResult
 import net.corda.flow.mapper.executor.FlowMapperEventExecutor
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.util.Collections.emptyList
 
 class ExecuteCleanupEventExecutor(private val key: String) : FlowMapperEventExecutor {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): FlowMapperResult {

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/ScheduleCleanupEventExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/ScheduleCleanupEventExecutor.kt
@@ -1,13 +1,13 @@
 package net.corda.flow.mapper.impl.executor
 
-import java.util.Collections.emptyList
 import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.state.mapper.FlowMapperState
 import net.corda.data.flow.state.mapper.FlowMapperStateType
 import net.corda.flow.mapper.FlowMapperResult
 import net.corda.flow.mapper.executor.FlowMapperEventExecutor
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.util.Collections.emptyList
 
 class ScheduleCleanupEventExecutor(
     private val eventKey: String,
@@ -16,7 +16,7 @@ class ScheduleCleanupEventExecutor(
 ) : FlowMapperEventExecutor {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): FlowMapperResult {

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.mapper.impl.executor
 
-import java.time.Instant
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.event.FlowEvent
@@ -8,13 +7,14 @@ import net.corda.data.flow.event.MessageDirection
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionError
 import net.corda.data.flow.state.mapper.FlowMapperState
+import net.corda.data.p2p.app.AppMessage
 import net.corda.flow.mapper.FlowMapperResult
 import net.corda.flow.mapper.executor.FlowMapperEventExecutor
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.AppMessage
 import net.corda.schema.Schemas
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 @Suppress("LongParameterList")
 class SessionEventExecutor(
@@ -28,7 +28,7 @@ class SessionEventExecutor(
 ) : FlowMapperEventExecutor {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val messageDirection = sessionEvent.messageDirection

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutor.kt
@@ -11,8 +11,8 @@ import net.corda.flow.mapper.FlowMapperResult
 import net.corda.flow.mapper.executor.FlowMapperEventExecutor
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 class SessionInitExecutor(
@@ -25,7 +25,7 @@ class SessionInitExecutor(
 ) : FlowMapperEventExecutor {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val messageDirection = sessionEvent.messageDirection

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/StartFlowExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/StartFlowExecutor.kt
@@ -7,8 +7,8 @@ import net.corda.data.flow.state.mapper.FlowMapperStateType
 import net.corda.flow.mapper.FlowMapperResult
 import net.corda.flow.mapper.executor.FlowMapperEventExecutor
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 class StartFlowExecutor(
     private val eventKey: String,
@@ -18,7 +18,7 @@ class StartFlowExecutor(
 ) : FlowMapperEventExecutor {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): FlowMapperResult {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/factory/SessionEventProcessorFactory.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/factory/SessionEventProcessorFactory.kt
@@ -19,13 +19,13 @@ import net.corda.session.manager.impl.processor.SessionErrorProcessorReceive
 import net.corda.session.manager.impl.processor.SessionErrorProcessorSend
 import net.corda.session.manager.impl.processor.SessionInitProcessorReceive
 import net.corda.session.manager.impl.processor.SessionInitProcessorSend
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 class SessionEventProcessorFactory {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     /**
      * Get the correct processor for the [sessionEvent] received.

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionAckProcessorReceive.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionAckProcessorReceive.kt
@@ -1,13 +1,13 @@
 package net.corda.session.manager.impl.processor
 
-import java.time.Instant
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionAck
 import net.corda.data.flow.state.session.SessionState
 import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorSessionStateFromSessionEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 /**
  * Process a [SessionAck] received.
@@ -22,7 +22,7 @@ class SessionAckProcessorReceive(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionCloseProcessorReceive.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionCloseProcessorReceive.kt
@@ -1,6 +1,5 @@
 package net.corda.session.manager.impl.processor
 
-import java.time.Instant
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionClose
 import net.corda.data.flow.state.session.SessionState
@@ -9,9 +8,10 @@ import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorEvent
 import net.corda.session.manager.impl.processor.helper.generateErrorSessionStateFromSessionEvent
 import net.corda.session.manager.impl.processor.helper.recalcReceivedProcessState
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 
 /**
@@ -32,7 +32,7 @@ class SessionCloseProcessorReceive(
     private val sessionId = sessionEvent.sessionId
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionCloseProcessorSend.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionCloseProcessorSend.kt
@@ -7,7 +7,7 @@ import net.corda.data.flow.state.session.SessionStateType
 import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorEvent
 import net.corda.session.manager.impl.processor.helper.generateErrorSessionStateFromSessionEvent
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 /**
@@ -27,7 +27,7 @@ class SessionCloseProcessorSend(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorReceive.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorReceive.kt
@@ -1,6 +1,5 @@
 package net.corda.session.manager.impl.processor
 
-import java.time.Instant
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionClose
 import net.corda.data.flow.state.session.SessionProcessState
@@ -10,8 +9,9 @@ import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorEvent
 import net.corda.session.manager.impl.processor.helper.generateErrorSessionStateFromSessionEvent
 import net.corda.session.manager.impl.processor.helper.recalcReceivedProcessState
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 /**
  * Process a [SessionData] event received from a counterparty.
@@ -30,7 +30,7 @@ class SessionDataProcessorReceive(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorSend.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorSend.kt
@@ -6,7 +6,7 @@ import net.corda.data.flow.state.session.SessionStateType
 import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorEvent
 import net.corda.session.manager.impl.processor.helper.generateErrorSessionStateFromSessionEvent
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 /**
@@ -22,7 +22,7 @@ class SessionDataProcessorSend(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionErrorProcessorReceive.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionErrorProcessorReceive.kt
@@ -1,14 +1,14 @@
 package net.corda.session.manager.impl.processor
 
-import java.time.Instant
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorSessionStateFromSessionEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.time.Instant
 
 /**
  * Process a [SessionError] received from a counterparty.
@@ -24,7 +24,7 @@ class SessionErrorProcessorReceive(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionErrorProcessorSend.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionErrorProcessorSend.kt
@@ -6,8 +6,8 @@ import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorSessionStateFromSessionEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 /**
@@ -24,7 +24,7 @@ class SessionErrorProcessorSend(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorReceive.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorReceive.kt
@@ -6,9 +6,9 @@ import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.*
 
@@ -26,7 +26,7 @@ class SessionInitProcessorReceive(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorSend.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionInitProcessorSend.kt
@@ -6,8 +6,8 @@ import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.session.manager.impl.SessionEventProcessor
 import net.corda.session.manager.impl.processor.helper.generateErrorEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 /**
@@ -23,7 +23,7 @@ class SessionInitProcessorSend(
 ) : SessionEventProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun execute(): SessionState {

--- a/libs/http-rpc/rest-client/src/integrationTest/kotlin/net/corda/httprpc/client/stream/FilePositionManager.kt
+++ b/libs/http-rpc/rest-client/src/integrationTest/kotlin/net/corda/httprpc/client/stream/FilePositionManager.kt
@@ -2,7 +2,7 @@ package net.corda.httprpc.client.stream
 
 import net.corda.httprpc.durablestream.api.PositionManager
 import net.corda.httprpc.durablestream.api.PositionManager.Companion.MIN_POSITION
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.file.Path
@@ -13,7 +13,7 @@ import kotlin.concurrent.write
 
 internal class FilePositionManager(private val filePath: Path) : PositionManager, AutoCloseable {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val BUFFER_SIZE = Long.MAX_VALUE.toString().length
     }
 

--- a/libs/http-rpc/rest-client/src/integrationTest/kotlin/net/corda/httprpc/client/stream/FilePositionManagerTest.kt
+++ b/libs/http-rpc/rest-client/src/integrationTest/kotlin/net/corda/httprpc/client/stream/FilePositionManagerTest.kt
@@ -1,13 +1,13 @@
 package net.corda.httprpc.client.stream
 
+import net.corda.httprpc.durablestream.api.PositionManager
 import net.corda.utilities.deleteRecursively
 import net.corda.utilities.div
-import net.corda.httprpc.durablestream.api.PositionManager
-import net.corda.v5.base.util.contextLogger
 import org.assertj.core.api.AbstractThrowableAssert
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.nio.channels.ClosedChannelException
 import java.nio.channels.FileChannel
@@ -20,7 +20,7 @@ import kotlin.test.assertTrue
 class FilePositionManagerTest {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val tempFolder = Files.createTempDirectory(this::class.java.simpleName)

--- a/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/RestClient.kt
+++ b/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/RestClient.kt
@@ -6,11 +6,11 @@ import net.corda.httprpc.client.connect.RestClientProxyHandler
 import net.corda.httprpc.client.connect.RestConnectionListenerDistributor
 import net.corda.httprpc.client.connect.remote.RemoteUnirestClient
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.util.uncheckedCast
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.lang.reflect.Proxy
 import java.time.Duration
 import java.util.*
@@ -52,7 +52,7 @@ class RestClient<I : RestResource> internal constructor(
     ) : this(baseAddress, restResourceClass, clientConfig, healthCheckInterval, Companion::defaultProxyGenerator)
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val defaultHealthCheckInterval = 10000L
 

--- a/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/RestClientProxyHandler.kt
+++ b/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/RestClientProxyHandler.kt
@@ -1,5 +1,6 @@
 package net.corda.httprpc.client.connect
 
+import net.corda.httprpc.ResponseCode
 import net.corda.httprpc.RestResource
 import net.corda.httprpc.annotations.HttpDELETE
 import net.corda.httprpc.annotations.HttpGET
@@ -12,21 +13,20 @@ import net.corda.httprpc.client.auth.RequestContext
 import net.corda.httprpc.client.config.AuthenticationConfig
 import net.corda.httprpc.client.connect.remote.RemoteClient
 import net.corda.httprpc.client.connect.stream.RestFiniteDurableCursorClientBuilderImpl
+import net.corda.httprpc.client.exceptions.InternalErrorException
 import net.corda.httprpc.client.processing.endpointHttpVerb
 import net.corda.httprpc.client.processing.parametersFrom
 import net.corda.httprpc.client.processing.toWebRequest
+import net.corda.httprpc.durablestream.api.returnsDurableCursorBuilder
+import net.corda.httprpc.response.ResponseEntity
 import net.corda.httprpc.tools.HttpPathUtils.joinResourceAndEndpointPaths
 import net.corda.httprpc.tools.annotations.extensions.path
 import net.corda.httprpc.tools.isStaticallyExposedGet
-import net.corda.httprpc.durablestream.api.returnsDurableCursorBuilder
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.ParameterizedType
-import net.corda.httprpc.ResponseCode
-import net.corda.httprpc.client.exceptions.InternalErrorException
-import net.corda.httprpc.response.ResponseEntity
 
 /**
  * [RestClientProxyHandler] is responsible for converting method invocations to web requests that are called against the server,
@@ -43,7 +43,7 @@ internal class RestClientProxyHandler<I : RestResource>(
 ) : InvocationHandler {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var serverProtocolVersion: Int? = null

--- a/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/RestConnectionListenerDistributor.kt
+++ b/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/RestConnectionListenerDistributor.kt
@@ -4,9 +4,9 @@ import net.corda.httprpc.RestResource
 import net.corda.httprpc.client.RestConnection
 import net.corda.httprpc.client.RestConnectionListener
 import net.corda.httprpc.client.auth.credentials.CredentialsProvider
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class RestConnectionListenerDistributor<I : RestResource>
     (private val listeners: Iterable<RestConnectionListener<I>>, private val credentialsProvider: CredentialsProvider) {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private data class RestConnectionContextImpl<I : RestResource>(
             override val credentialsProvider: CredentialsProvider,

--- a/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/remote/RemoteClient.kt
+++ b/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/remote/RemoteClient.kt
@@ -5,6 +5,7 @@ import kong.unirest.HttpRequest
 import kong.unirest.HttpRequestWithBody
 import kong.unirest.HttpResponse
 import kong.unirest.HttpStatus
+import kong.unirest.MultipartBody
 import kong.unirest.Unirest
 import kong.unirest.UnirestException
 import kong.unirest.apache.ApacheClient
@@ -14,21 +15,20 @@ import net.corda.httprpc.client.exceptions.InternalErrorException
 import net.corda.httprpc.client.exceptions.MissingRequestedResourceException
 import net.corda.httprpc.client.exceptions.PermissionException
 import net.corda.httprpc.client.exceptions.RequestErrorException
+import net.corda.httprpc.client.processing.RestClientFileUpload
 import net.corda.httprpc.client.processing.WebRequest
 import net.corda.httprpc.client.processing.WebResponse
 import net.corda.httprpc.client.serialization.objectMapper
+import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.httprpc.tools.HttpVerb
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.TrustAllStrategy
 import org.apache.http.impl.client.HttpClients
 import org.apache.http.ssl.SSLContexts
+import org.slf4j.LoggerFactory
 import java.lang.reflect.Type
 import javax.net.ssl.SSLContext
-import kong.unirest.MultipartBody
-import net.corda.httprpc.client.processing.RestClientFileUpload
-import net.corda.httprpc.exception.ResourceAlreadyExistsException
 
 /**
  * [RemoteClient] implementations are responsible for making remote calls to the server and returning the response,
@@ -43,7 +43,7 @@ internal interface RemoteClient {
 
 internal class RemoteUnirestClient(override val baseAddress: String, private val enableSsl: Boolean = false) : RemoteClient {
     internal companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     init {

--- a/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/stream/RestFiniteDurableCursorClientBuilderImpl.kt
+++ b/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/connect/stream/RestFiniteDurableCursorClientBuilderImpl.kt
@@ -12,9 +12,9 @@ import net.corda.httprpc.durablestream.api.Cursor
 import net.corda.httprpc.durablestream.api.FiniteDurableCursor
 import net.corda.httprpc.durablestream.api.FiniteDurableCursorBuilder
 import net.corda.httprpc.durablestream.api.PositionManager
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.util.uncheckedCast
+import org.slf4j.LoggerFactory
 import java.lang.reflect.Method
 import java.lang.reflect.ParameterizedType
 import java.time.Duration
@@ -43,7 +43,7 @@ private class RestFiniteDurableCursorClientImpl(
     override val positionManager: PositionManager
 ) : FiniteDurableCursor<Any> {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun poll(maxCount: Int, awaitForResultTimeout: Duration): Cursor.PollResult<Any> {

--- a/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/serialization/RestClientSerialization.kt
+++ b/libs/http-rpc/rest-client/src/main/kotlin/net/corda/httprpc/client/serialization/RestClientSerialization.kt
@@ -3,12 +3,12 @@ package net.corda.httprpc.client.serialization
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.BeanProperty
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.BeanProperty
 import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
 import net.corda.common.json.serialization.jacksonObjectMapper

--- a/libs/http-rpc/rest-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/RestServerAzureAdTest.kt
+++ b/libs/http-rpc/rest-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/RestServerAzureAdTest.kt
@@ -16,7 +16,7 @@ import net.corda.httprpc.test.utils.WebRequest
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.httprpc.tools.HttpVerb
 import net.corda.utilities.NetworkHostAndPort
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ import kotlin.test.assertEquals
 class RestServerAzureAdTest {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private lateinit var restServer: RestServer

--- a/libs/http-rpc/rest-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/RestServerHTTPSWebsocketTest.kt
+++ b/libs/http-rpc/rest-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/RestServerHTTPSWebsocketTest.kt
@@ -7,7 +7,7 @@ import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.utilities.NetworkHostAndPort
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.websocket.client.WebSocketClient
@@ -18,7 +18,7 @@ import java.nio.file.Files
 class RestServerHTTPSWebsocketTest : AbstractWebsocketTest() {
     private companion object {
 
-        val LOG = contextLogger()
+        val LOG = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val sslService = SslCertReadServiceStubImpl {
             Files.createTempDirectory("RestServerHTTPSWebsocketTest")

--- a/libs/http-rpc/rest-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/RestServerWebsocketTest.kt
+++ b/libs/http-rpc/rest-server-impl/src/integrationTest/kotlin/net/corda/httprpc/server/impl/RestServerWebsocketTest.kt
@@ -5,7 +5,7 @@ import net.corda.httprpc.test.TestHealthCheckAPIImpl
 import net.corda.httprpc.test.utils.TestHttpClientUnirestImpl
 import net.corda.httprpc.test.utils.multipartDir
 import net.corda.utilities.NetworkHostAndPort
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import org.eclipse.jetty.websocket.client.WebSocketClient
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeAll
 class RestServerWebsocketTest : AbstractWebsocketTest() {
     private companion object {
 
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val restServerSettings = RestServerSettings(
             NetworkHostAndPort("localhost", 0),

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/RestServerImpl.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/RestServerImpl.kt
@@ -17,7 +17,7 @@ import net.corda.httprpc.server.impl.security.provider.AuthenticationProvider
 import net.corda.httprpc.server.impl.security.provider.basic.UsernamePasswordAuthenticationProvider
 import net.corda.httprpc.server.impl.security.provider.bearer.azuread.AzureAdAuthenticationProvider
 import net.corda.httprpc.server.impl.websocket.deferred.DeferredWebSocketCloserService
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import java.nio.file.Path
@@ -34,7 +34,7 @@ class RestServerImpl(
     devMode: Boolean
 ) : RestServer {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Volatile

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/APIStructureRetriever.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/APIStructureRetriever.kt
@@ -1,7 +1,7 @@
 package net.corda.httprpc.server.impl.apigen.processing
 
 import net.corda.httprpc.durablestream.DurableStreamContext
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.httprpc.annotations.HttpGET
 import net.corda.httprpc.annotations.HttpPOST
 import net.corda.httprpc.annotations.HttpRestResource
@@ -41,7 +41,7 @@ import kotlin.reflect.jvm.kotlinFunction
 @Suppress("UNCHECKED_CAST", "TooManyFunctions", "TooGenericExceptionThrown")
 internal class APIStructureRetriever(private val opsImplList: List<PluggableRestResource<*>>) {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val structure: List<Resource> by lazy { retrieveResources() }

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/MethodInvoker.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/MethodInvoker.kt
@@ -9,7 +9,7 @@ import net.corda.httprpc.server.impl.apigen.processing.streams.FiniteDurableRetu
 import net.corda.lifecycle.Lifecycle
 import net.corda.v5.base.util.uncheckedCast
 import net.corda.httprpc.durablestream.api.Cursor
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.lang.IllegalArgumentException
 import net.corda.v5.base.util.trace
 import java.util.function.Supplier
@@ -26,7 +26,7 @@ interface MethodInvoker {
 internal open class DefaultMethodInvoker(private val invocationMethod: InvocationMethod) :
     MethodInvoker {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invoke(vararg args: Any?): Any? {
@@ -52,7 +52,7 @@ internal open class DefaultMethodInvoker(private val invocationMethod: Invocatio
 internal open class DurableStreamsMethodInvoker(private val invocationMethod: InvocationMethod) :
     DefaultMethodInvoker(invocationMethod) {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invoke(vararg args: Any?): DurableReturnResult<Any> {
@@ -102,7 +102,7 @@ internal open class DurableStreamsMethodInvoker(private val invocationMethod: In
 internal class FiniteDurableStreamsMethodInvoker(private val invocationMethod: InvocationMethod) :
     DurableStreamsMethodInvoker(invocationMethod) {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun invoke(vararg args: Any?): FiniteDurableReturnResult<Any> {

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/ParametersTransformer.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/ParametersTransformer.kt
@@ -8,7 +8,7 @@ import net.corda.httprpc.server.impl.apigen.models.EndpointParameter
 import net.corda.httprpc.server.impl.apigen.models.ParameterType
 import net.corda.httprpc.server.impl.apigen.models.GenericParameterizedType
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.v5.base.util.trace
 import net.corda.httprpc.annotations.isHttpRpcParameterAnnotation
 import net.corda.httprpc.tools.annotations.extensions.name
@@ -50,7 +50,7 @@ private class PathParametersTransformer(
     private val annotation: RestPathParameter
 ) : ParametersTransformer {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun transform(): EndpointParameter {
@@ -74,7 +74,7 @@ private class QueryParametersTransformer(
     private val annotation: RestQueryParameter
 ) : ParametersTransformer {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun transform(): EndpointParameter {
@@ -99,7 +99,7 @@ internal class BodyParametersTransformer(
     private val annotation: RestRequestBodyParameter?
 ) : ParametersTransformer {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun transform(): EndpointParameter {
@@ -136,7 +136,7 @@ internal class BodyParametersTransformer(
 private class BodyParametersExplicitTransformer(private val name: String, private val type: GenericParameterizedType) :
     ParametersTransformer {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun transform(): EndpointParameter {

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/RouteProvider.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/RouteProvider.kt
@@ -14,7 +14,7 @@ import net.corda.httprpc.tools.isDuplexChannel
 import net.corda.httprpc.tools.isStaticallyExposedGet
 import net.corda.httprpc.durablestream.api.isFiniteDurableStreamsMethod
 import net.corda.httprpc.durablestream.api.returnsDurableCursorBuilder
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import java.lang.reflect.InvocationTargetException
@@ -40,7 +40,7 @@ internal class JavalinRouteProviderImpl(
 ) : RouteProvider {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val httpNoAuthRequiredGetRoutes = mapResourcesToRoutesByHttpMethod(EndpointMethod.GET)
@@ -93,7 +93,7 @@ internal class RouteInfo(
     private val endpoint: Endpoint
 ) {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val parameters = mapEndpointParameters(endpoint.parameters)

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/OpenApiInfoProvider.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/OpenApiInfoProvider.kt
@@ -15,7 +15,7 @@ import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.SchemaMode
 import net.corda.httprpc.server.config.RestServerSettingsProvider
 import net.corda.httprpc.server.impl.internal.SwaggerUIRenderer
 import net.corda.httprpc.server.impl.security.provider.bearer.azuread.AzureAdAuthenticationProvider
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.v5.base.util.trace
 
 /**
@@ -29,7 +29,7 @@ internal class OpenApiInfoProvider(
 
     internal companion object {
         internal fun String.jsonPath() = "$this.json"
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val pathForOpenApiUI = "/${configurationsProvider.getBasePath()}/v${configurationsProvider.getApiVersion()}/swagger"

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/SchemaObjectBuilder.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/apigen/processing/openapi/schema/builders/SchemaObjectBuilder.kt
@@ -9,7 +9,7 @@ import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.Sche
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaObjectModel
 import net.corda.httprpc.server.impl.apigen.processing.openapi.schema.model.SchemaRefObjectModel
 import net.corda.httprpc.server.impl.apigen.processing.toEndpointParameterParameterizedType
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.memberProperties
@@ -22,7 +22,7 @@ internal class SchemaObjectBuilder(
 ) : SchemaBuilder {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val keys: List<Class<*>> = listOf(Any::class.java)

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/ParameterRetriever.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/ParameterRetriever.kt
@@ -8,7 +8,7 @@ import net.corda.httprpc.server.impl.apigen.processing.Parameter
 import net.corda.httprpc.server.impl.apigen.processing.ParameterType
 import net.corda.httprpc.server.impl.apigen.processing.RouteInfo
 import net.corda.httprpc.server.impl.utils.mapTo
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.v5.base.util.trace
 import java.net.URLDecoder
 import java.util.function.Function
@@ -38,7 +38,7 @@ internal object ParameterRetrieverFactory {
 @Suppress("TooGenericExceptionThrown")
 private class PathParameterRetriever(private val parameter: Parameter) : ParameterRetriever {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun apply(ctx: ParametersRetrieverContext): Any {
@@ -60,7 +60,7 @@ private class PathParameterRetriever(private val parameter: Parameter) : Paramet
 @Suppress("TooGenericExceptionThrown")
 private class QueryParameterListRetriever(private val parameter: Parameter) : ParameterRetriever {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun apply(ctx: ParametersRetrieverContext): Any {
@@ -85,7 +85,7 @@ private class QueryParameterListRetriever(private val parameter: Parameter) : Pa
 @Suppress("TooGenericExceptionThrown")
 private class QueryParameterRetriever(private val parameter: Parameter) : ParameterRetriever {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun apply(ctx: ParametersRetrieverContext): Any? {
@@ -110,7 +110,7 @@ private class QueryParameterRetriever(private val parameter: Parameter) : Parame
 @Suppress("TooGenericExceptionThrown")
 private class BodyParameterRetriever(private val parameter: Parameter, private val routeInfo: RouteInfo) : ParameterRetriever {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val RouteInfo.isSingleBodyParam: Boolean
@@ -155,7 +155,7 @@ private class BodyParameterRetriever(private val parameter: Parameter, private v
 @Suppress("TooGenericExceptionThrown")
 private class MultipartParameterRetriever(private val parameter: Parameter) : ParameterRetriever {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suppress("ComplexMethod")

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/ParametersRetrieverContext.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/ParametersRetrieverContext.kt
@@ -3,7 +3,7 @@ package net.corda.httprpc.server.impl.internal
 import io.javalin.http.util.ContextUtil
 import net.corda.httprpc.HttpFileUpload
 import net.corda.httprpc.server.impl.context.ClientRequestContext
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * Internal Context that wrap Javalin's Context.
@@ -14,7 +14,7 @@ import net.corda.v5.base.util.contextLogger
 internal class ParametersRetrieverContext(private val ctx: ClientRequestContext) {
 
     private companion object {
-       val logger = contextLogger()
+       val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val pathParamsMap: Map<String, String?>

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/RestServerInternal.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/RestServerInternal.kt
@@ -26,7 +26,7 @@ import net.corda.utilities.classload.executeWithThreadContextClassLoader
 import net.corda.utilities.classload.OsgiClassLoader
 import net.corda.utilities.executeWithStdErrSuppressed
 import net.corda.utilities.VisibleForTesting
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.eclipse.jetty.http2.HTTP2Cipher
@@ -58,7 +58,7 @@ internal class RestServerInternal(
 ) {
 
     internal companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @VisibleForTesting
         internal const val SSL_PASSWORD_MISSING =

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/SwaggerUIRenderer.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/internal/SwaggerUIRenderer.kt
@@ -4,7 +4,7 @@ import io.javalin.core.util.Util
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.http.InternalServerErrorResponse
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.httprpc.server.impl.apigen.processing.openapi.OpenApiInfoProvider.Companion.jsonPath
 import net.corda.httprpc.server.config.RestServerSettingsProvider
 import org.osgi.framework.FrameworkUtil
@@ -16,7 +16,7 @@ import org.osgi.framework.FrameworkUtil
 internal class SwaggerUIRenderer(private val configurationProvider: RestServerSettingsProvider) : Handler {
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun handle(ctx: Context) {

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/security/provider/bearer/azuread/AzureAdIssuerJWSKeySelector.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/security/provider/bearer/azuread/AzureAdIssuerJWSKeySelector.kt
@@ -10,7 +10,7 @@ import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jose.util.ResourceRetriever
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.proc.JWTClaimsSetAwareJWSKeySelector
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.security.Key
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -24,7 +24,7 @@ internal class AzureAdIssuerJWSKeySelector(
         private const val DEFAULT_REFRESH_TIME_MINUTES = 5L
         private val DEFAULT_JWK_SET_CACHE_LIFESPAN = TimeUnit.MINUTES.toMillis(5L)
 
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val keySelectors = ConcurrentHashMap<String, JWSKeySelector<SecurityContext>>()

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/security/provider/bearer/oauth/JwtAuthenticationProvider.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/security/provider/bearer/oauth/JwtAuthenticationProvider.kt
@@ -7,7 +7,7 @@ import net.corda.httprpc.security.AuthorizingSubject
 import net.corda.httprpc.security.read.RPCSecurityManager
 import net.corda.httprpc.server.impl.security.provider.bearer.BearerTokenAuthenticationProvider
 import net.corda.httprpc.server.impl.security.provider.credentials.tokens.BearerTokenAuthenticationCredentials
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.function.Supplier
 import javax.security.auth.login.FailedLoginException
 
@@ -18,7 +18,7 @@ internal open class JwtAuthenticationProvider(
 ) : BearerTokenAuthenticationProvider() {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun doAuthenticate(credential: BearerTokenAuthenticationCredentials): AuthorizingSubject {

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/security/provider/credentials/DefaultCredentialResolver.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/security/provider/credentials/DefaultCredentialResolver.kt
@@ -4,14 +4,14 @@ import io.javalin.core.util.Header.AUTHORIZATION
 import net.corda.httprpc.server.impl.context.ClientRequestContext
 import net.corda.httprpc.server.impl.security.provider.credentials.tokens.BearerTokenAuthenticationCredentials
 import net.corda.httprpc.server.impl.security.provider.credentials.tokens.UsernamePasswordAuthenticationCredentials
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import net.corda.v5.base.util.trace
 import javax.security.auth.login.FailedLoginException
 
 internal class DefaultCredentialResolver : CredentialResolver {
     companion object {
         private val TOKEN_PATTERN = "^Bearer (?<token>[a-zA-Z0-9-._~+/]+=*)$".toRegex()
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun resolve(context: ClientRequestContext): AuthenticationCredentials? {

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebSocketRouteAdaptor.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/WebSocketRouteAdaptor.kt
@@ -18,7 +18,7 @@ import net.corda.httprpc.server.impl.context.ContextUtils.retrieveParameters
 import net.corda.httprpc.server.impl.security.RestAuthenticationProvider
 import net.corda.httprpc.server.impl.security.provider.credentials.DefaultCredentialResolver
 import net.corda.httprpc.ws.DuplexChannel
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import org.eclipse.jetty.websocket.api.CloseStatus
 import org.eclipse.jetty.websocket.api.StatusCode.POLICY_VIOLATION
 
@@ -41,7 +41,7 @@ internal class WebSocketRouteAdaptor(
 ) : WsMessageHandler, WsCloseHandler, WsConnectHandler, WsErrorHandler, AutoCloseable {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val channelsBySessionId = ConcurrentHashMap<SessionId, DuplexChannel>()

--- a/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/deferred/DeferredWebSocketCloserService.kt
+++ b/libs/http-rpc/rest-server-impl/src/main/kotlin/net/corda/httprpc/server/impl/websocket/deferred/DeferredWebSocketCloserService.kt
@@ -4,7 +4,7 @@ import io.javalin.websocket.WsContext
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import net.corda.httprpc.server.impl.websocket.WebSocketCloserService
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import org.apache.commons.lang3.concurrent.BasicThreadFactory
 import org.eclipse.jetty.websocket.api.CloseStatus
 
@@ -14,7 +14,7 @@ import org.eclipse.jetty.websocket.api.CloseStatus
 class DeferredWebSocketCloserService : WebSocketCloserService {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val deferredWebsocketClosePool = Executors.newScheduledThreadPool(1,

--- a/libs/http-rpc/rest-server/src/main/kotlin/net/corda/httprpc/server/config/impl/RestServerObjectSettingsProvider.kt
+++ b/libs/http-rpc/rest-server/src/main/kotlin/net/corda/httprpc/server/config/impl/RestServerObjectSettingsProvider.kt
@@ -3,7 +3,7 @@ package net.corda.httprpc.server.config.impl
 import net.corda.httprpc.server.config.RestServerSettingsProvider
 import net.corda.httprpc.server.config.SsoSettingsProvider
 import net.corda.httprpc.server.config.models.RestServerSettings
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
 class RestServerObjectSettingsProvider(
@@ -11,7 +11,7 @@ class RestServerObjectSettingsProvider(
     private val devMode: Boolean
 ) : RestServerSettingsProvider {
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val ssoSettingsProvider: SsoSettingsProvider? by lazy {

--- a/libs/http-rpc/rest-stubs-impl/src/main/kotlin/net/corda/httprpc/endpoints/impl/HelloRestResourceImpl.kt
+++ b/libs/http-rpc/rest-stubs-impl/src/main/kotlin/net/corda/httprpc/endpoints/impl/HelloRestResourceImpl.kt
@@ -6,7 +6,7 @@ import net.corda.httprpc.RestResource
 import net.corda.httprpc.annotations.HttpPOST
 import net.corda.httprpc.annotations.RestQueryParameter
 import net.corda.httprpc.security.CURRENT_REST_CONTEXT
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import org.osgi.service.component.annotations.Component
 
 @HttpRestResource(name = "Hello Rest API", description = "The Hello Rest API is used to test interactions via the " +
@@ -26,7 +26,7 @@ interface HelloRestResource : RestResource {
 class HelloRestResourceImpl : HelloRestResource, PluggableRestResource<HelloRestResource>, RestResource {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val targetInterface = HelloRestResource::class.java

--- a/libs/http-rpc/rest-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpointImpl.kt
+++ b/libs/http-rpc/rest-test-common/src/main/kotlin/net/corda/httprpc/test/ObjectsInJsonEndpointImpl.kt
@@ -2,12 +2,12 @@ package net.corda.httprpc.test
 
 import net.corda.httprpc.JsonObject
 import net.corda.httprpc.PluggableRestResource
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class ObjectsInJsonEndpointImpl : ObjectsInJsonEndpoint, PluggableRestResource<ObjectsInJsonEndpoint> {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val protocolVersion: Int = 1

--- a/libs/http-rpc/rest-test-common/src/main/kotlin/net/corda/httprpc/test/TestHealthCheckAPIImpl.kt
+++ b/libs/http-rpc/rest-test-common/src/main/kotlin/net/corda/httprpc/test/TestHealthCheckAPIImpl.kt
@@ -3,8 +3,8 @@ package net.corda.httprpc.test
 import net.corda.httprpc.PluggableRestResource
 import net.corda.httprpc.ws.DuplexChannel
 import net.corda.lifecycle.Lifecycle
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 class TestHealthCheckAPIImpl : TestHealthCheckAPI, PluggableRestResource<TestHealthCheckAPI>, Lifecycle {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val targetInterface: Class<TestHealthCheckAPI>

--- a/libs/http-rpc/rest-test-common/src/main/kotlin/net/corda/httprpc/test/utils/TestURLStreamHandlerFactory.kt
+++ b/libs/http-rpc/rest-test-common/src/main/kotlin/net/corda/httprpc/test/utils/TestURLStreamHandlerFactory.kt
@@ -1,6 +1,6 @@
 package net.corda.httprpc.test.utils
 
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.io.Closeable
 import java.io.InputStream
@@ -14,7 +14,7 @@ import java.util.Hashtable
 internal class TestURLStreamHandlerFactory(content: Map<String, String>) : URLStreamHandlerFactory, Closeable {
     companion object {
         const val PROTOCOL = "mock"
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @Suppress("TooGenericExceptionThrown")
         private fun forceSetURLStreamHandlerFactory(factory: URLStreamHandlerFactory?) {

--- a/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapFactoryImpl.kt
+++ b/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapFactoryImpl.kt
@@ -3,13 +3,13 @@ package net.corda.layeredpropertymap.impl
 import net.corda.layeredpropertymap.CustomPropertyConverter
 import net.corda.layeredpropertymap.LayeredPropertyMapFactory
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.ComponentContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality
 import org.osgi.service.component.annotations.ReferencePolicy
+import org.slf4j.LoggerFactory
 
 @Component(
     service = [ LayeredPropertyMapFactory::class ],
@@ -27,7 +27,7 @@ class LayeredPropertyMapFactoryImpl @Activate constructor(
 ) : LayeredPropertyMapFactory {
     companion object {
         const val CUSTOM_CONVERTERS_REFERENCE_NAME = "customConverters"
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suppress("unchecked_cast", "SameParameterValue")

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
@@ -1,9 +1,5 @@
 package net.corda.lifecycle.impl
 
-import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 import net.corda.lifecycle.CustomEvent
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.LifecycleCoordinator
@@ -20,10 +16,14 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.TimerEvent
 import net.corda.lifecycle.impl.registry.LifecycleRegistryCoordinatorAccess
 import net.corda.lifecycle.registry.LifecycleRegistryException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.util.uncheckedCast
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 
 /**
@@ -55,7 +55,7 @@ class LifecycleCoordinatorImpl(
 ) : LifecycleCoordinatorInternal {
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
@@ -1,7 +1,5 @@
 package net.corda.lifecycle.impl
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ScheduledFuture
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.ErrorEvent
 import net.corda.lifecycle.LifecycleCoordinator
@@ -15,9 +13,11 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.TimerEvent
 import net.corda.lifecycle.impl.registry.LifecycleRegistryCoordinatorAccess
 import net.corda.lifecycle.registry.LifecycleRegistryException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledFuture
 
 /**
  * Perform processing of lifecycle events.
@@ -39,7 +39,7 @@ internal class LifecycleProcessor(
 ) {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         internal const val STARTED_REASON = "Component has been started"
         internal const val STOPPED_REASON = "Component has been stopped"

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/Registration.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/Registration.kt
@@ -1,14 +1,14 @@
 package net.corda.lifecycle.impl
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 import net.corda.lifecycle.CustomEvent
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.RegistrationStatusChangeEvent
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * A registration of a parent coordinator to a set of underlying child coordinators.
@@ -30,7 +30,7 @@ internal class Registration(
 ) : RegistrationHandle {
 
     private  companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinatorStatusMap = ConcurrentHashMap(coordinators.associateWith { LifecycleStatus.DOWN })

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImpl.kt
@@ -6,10 +6,10 @@ import net.corda.lifecycle.impl.LifecycleCoordinatorInternal
 import net.corda.lifecycle.registry.CoordinatorStatus
 import net.corda.lifecycle.registry.LifecycleRegistry
 import net.corda.lifecycle.registry.LifecycleRegistryException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
@@ -25,7 +25,7 @@ class LifecycleRegistryImpl : LifecycleRegistry, LifecycleRegistryCoordinatorAcc
     private companion object {
         private const val NEW_COORDINATOR_REASON = "Coordinator has just been created"
 
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val coordinators: MutableMap<LifecycleCoordinatorName, LifecycleCoordinatorInternal> =

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -3,7 +3,6 @@ package net.corda.membership.lib
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.membership.lib.notary.MemberNotaryDetails
 import net.corda.utilities.NetworkHostAndPort
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.parse
 import net.corda.v5.base.util.parseList
 import net.corda.v5.base.util.parseOrNull
@@ -14,13 +13,14 @@ import net.corda.v5.crypto.calculateHash
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
+import org.slf4j.LoggerFactory
 import java.net.URL
 import java.security.PublicKey
 import java.time.Instant
 
 class MemberInfoExtension {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         /** Key name for ledger keys property. */
         const val LEDGER_KEYS = "corda.ledger.keys"

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImpl.kt
@@ -18,12 +18,12 @@ import net.corda.membership.lib.grouppolicy.GroupPolicyParser
 import net.corda.membership.lib.grouppolicy.MemberGroupPolicy
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [GroupPolicyParser::class])
 class GroupPolicyParserImpl @Activate constructor(
@@ -31,7 +31,7 @@ class GroupPolicyParserImpl @Activate constructor(
     val memberInfoFactory: MemberInfoFactory
 ) : GroupPolicyParser {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val EMPTY_GROUP_POLICY = "GroupPolicy file is empty."
         const val NULL_GROUP_POLICY = "GroupPolicy file is null."
         const val FAILED_PARSING = "GroupPolicy file is incorrectly formatted and parsing failed."

--- a/libs/membership/schema-validation/src/main/kotlin/net/corda/membership/lib/schema/validation/impl/MembershipSchemaValidatorImpl.kt
+++ b/libs/membership/schema-validation/src/main/kotlin/net/corda/membership/lib/schema/validation/impl/MembershipSchemaValidatorImpl.kt
@@ -11,8 +11,8 @@ import net.corda.membership.lib.schema.validation.MembershipSchemaValidator
 import net.corda.schema.membership.MembershipSchema
 import net.corda.schema.membership.provider.MembershipSchemaException
 import net.corda.schema.membership.provider.MembershipSchemaProvider
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.versioning.Version
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.net.URI
 
@@ -21,7 +21,7 @@ class MembershipSchemaValidatorImpl(
 ) : MembershipSchemaValidator {
     private companion object {
         private val REGISTERED_SCHEMES = listOf("https", "http")
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val VALIDATION_ERROR = "Exception when validating membership schema."
     }
 

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/MessageBusConfigResolver.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/MessageBusConfigResolver.kt
@@ -17,9 +17,9 @@ import net.corda.schema.configuration.MessagingConfig.Bus.DB_PROPERTIES
 import net.corda.schema.configuration.MessagingConfig.Bus.JDBC_PASS
 import net.corda.schema.configuration.MessagingConfig.Bus.JDBC_URL
 import net.corda.schema.configuration.MessagingConfig.Bus.JDBC_USER
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.framework.FrameworkUtil
+import org.slf4j.LoggerFactory
 
 /**
  * Resolve a DB bus configuration against the enforced and default configurations provided by the library.
@@ -27,7 +27,7 @@ import org.osgi.framework.FrameworkUtil
 internal class MessageBusConfigResolver(private val smartConfigFactory: SmartConfigFactory) {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val ENFORCED_CONFIG_FILE = "messaging-enforced.conf"
         private const val DEFAULT_CONFIG_FILE = "messaging-defaults.conf"

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
@@ -36,7 +36,7 @@ class DBAccess(
     private val autoCreate = true
 
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         internal val ATOMIC_TRANSACTION = TransactionRecordEntry("Atomic Transaction", TransactionState.COMMITTED)
     }
 

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/EntityManagerFactoryHolder.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/EntityManagerFactoryHolder.kt
@@ -6,12 +6,12 @@ import net.corda.messagebus.db.datamodel.TopicRecordEntry
 import net.corda.messagebus.db.datamodel.TransactionRecordEntry
 import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManagerFactory
 
 /**
@@ -25,7 +25,7 @@ class EntityManagerFactoryHolder @Activate constructor(
     private val entityManagerFactoryFactory: EntityManagerFactoryFactory,
 ) {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var emf: EntityManagerFactory? = null

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/CordaTransactionalDBProducerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/CordaTransactionalDBProducerImpl.kt
@@ -16,7 +16,7 @@ import net.corda.messagebus.db.util.WriteOffsets
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.UUID
 import kotlin.math.abs
 
 class CordaTransactionalDBProducerImpl(
@@ -26,7 +26,7 @@ class CordaTransactionalDBProducerImpl(
 ) : CordaProducer {
 
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val _transaction = ThreadLocal<TransactionRecordEntry>()

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroDeserializerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroDeserializerImpl.kt
@@ -2,7 +2,7 @@ package net.corda.messagebus.db.serialization
 
 import net.corda.data.CordaAvroDeserializer
 import net.corda.schema.registry.AvroSchemaRegistry
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.util.function.Consumer
 
@@ -13,7 +13,7 @@ class CordaDBAvroDeserializerImpl<T : Any>(
 ) : CordaAvroDeserializer<T> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun deserialize(data: ByteArray): T? {

--- a/libs/messaging/db-topic-admin-impl/src/integrationTest/kotlin/net/corda/libs/messaging/topic/DBTopicUtilIntegrationTest.kt
+++ b/libs/messaging/db-topic-admin-impl/src/integrationTest/kotlin/net/corda/libs/messaging/topic/DBTopicUtilIntegrationTest.kt
@@ -10,21 +10,21 @@ import net.corda.messagebus.db.datamodel.TopicEntry
 import net.corda.messagebus.db.datamodel.TopicRecordEntry
 import net.corda.messagebus.db.datamodel.TransactionRecordEntry
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
-import net.corda.v5.base.util.contextLogger
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.StringWriter
-import java.util.*
+import java.util.UUID
 import javax.persistence.EntityManagerFactory
 
 
 class DBTopicUtilIntegrationTest {
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val entityManagerFactoryFactory = EntityManagerFactoryFactoryImpl()
         private val lbm = LiquibaseSchemaMigratorImpl()

--- a/libs/messaging/db-topic-admin-impl/src/main/kotlin/net/corda/libs/messaging/topic/DBTopicUtils.kt
+++ b/libs/messaging/db-topic-admin-impl/src/main/kotlin/net/corda/libs/messaging/topic/DBTopicUtils.kt
@@ -6,8 +6,8 @@ import com.typesafe.config.ConfigFactory
 import net.corda.libs.messaging.topic.utils.TopicUtils
 import net.corda.messagebus.db.datamodel.TopicEntry
 import net.corda.orm.utils.transaction
-import net.corda.v5.base.util.contextLogger
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import javax.persistence.EntityManagerFactory
 
 /**
@@ -20,7 +20,7 @@ class DBTopicUtils(
 ) : TopicUtils {
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createTopics(topicsTemplate: Config) {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/KafkaConfigMergerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/KafkaConfigMergerImpl.kt
@@ -8,15 +8,15 @@ import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.BootConfig.BOOT_KAFKA_COMMON
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_PROPERTIES_COMMON
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 
 @Component(service = [BusConfigMerger::class])
 class KafkaConfigMergerImpl : BusConfigMerger {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun getMessagingConfig(bootConfig: SmartConfig, messagingConfig: SmartConfig?): SmartConfig {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolver.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolver.kt
@@ -9,10 +9,10 @@ import net.corda.messaging.api.exception.CordaMessageAPIConfigException
 import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.schema.configuration.MessagingConfig.Bus.KAFKA_PROPERTIES
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.framework.FrameworkUtil
-import java.util.*
+import org.slf4j.LoggerFactory
+import java.util.Properties
 
 /**
  * Resolve a Kafka bus configuration against the enforced and default configurations provided by the library.
@@ -20,7 +20,7 @@ import java.util.*
 internal class MessageBusConfigResolver(private val smartConfigFactory: SmartConfigFactory) {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val ENFORCED_CONFIG_FILE = "kafka-messaging-enforced.conf"
         private const val DEFAULT_CONFIG_FILE = "kafka-messaging-defaults.conf"

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -12,7 +12,6 @@ import net.corda.messagebus.kafka.utils.toTopicPartition
 import net.corda.messagebus.kafka.utils.toTopicPartitions
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
-import net.corda.v5.base.util.contextLogger
 import org.apache.kafka.clients.consumer.CommitFailedException
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata
@@ -30,6 +29,7 @@ import org.apache.kafka.common.errors.InterruptException
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.errors.WakeupException
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 /**
@@ -43,7 +43,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
 ) : CordaConsumer<K, V> {
 
     companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun close() {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/builder/CordaKafkaConsumerBuilderImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/builder/CordaKafkaConsumerBuilderImpl.kt
@@ -11,7 +11,6 @@ import net.corda.messagebus.kafka.serialization.CordaAvroDeserializerImpl
 import net.corda.messagebus.kafka.utils.KafkaRetryUtils.executeKafkaActionWithRetry
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.utilities.classload.OsgiDelegatedClassLoader
-import net.corda.v5.base.util.contextLogger
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.osgi.framework.FrameworkUtil
@@ -19,7 +18,8 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
-import java.util.*
+import org.slf4j.LoggerFactory
+import java.util.Properties
 
 /**
  * Generate a Kafka Consumer.
@@ -31,7 +31,7 @@ class CordaKafkaConsumerBuilderImpl @Activate constructor(
 ) : CordaConsumerBuilder {
 
     companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun <K : Any, V : Any> createConsumer(

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImpl.kt
@@ -10,7 +10,6 @@ import net.corda.messagebus.kafka.utils.toKafkaRecords
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset
-import net.corda.v5.base.util.contextLogger
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.Callback
@@ -27,6 +26,7 @@ import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.errors.UnsupportedForMessageFormatException
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /**
  * Wrapper for the CordaKafkaProducer.
@@ -48,7 +48,7 @@ class CordaKafkaProducerImpl(
     }
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private fun CordaProducer.Callback.toKafkaCallback(): Callback {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
@@ -11,14 +11,14 @@ import net.corda.messagebus.kafka.utils.KafkaRetryUtils.executeKafkaActionWithRe
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.utilities.classload.OsgiDelegatedClassLoader
-import net.corda.v5.base.util.contextLogger
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
-import java.util.*
+import org.slf4j.LoggerFactory
+import java.util.Properties
 
 /**
  * Builder for a Kafka Producer.
@@ -34,7 +34,7 @@ class KafkaCordaProducerBuilderImpl @Activate constructor(
 ) : CordaProducerBuilder {
 
     companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createProducer(producerConfig: ProducerConfig, messageBusConfig: SmartConfig): CordaProducer {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
@@ -2,9 +2,9 @@ package net.corda.messagebus.kafka.serialization
 
 import net.corda.data.CordaAvroDeserializer
 import net.corda.schema.registry.AvroSchemaRegistry
-import net.corda.v5.base.util.contextLogger
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.util.function.Consumer
 
@@ -16,7 +16,7 @@ class CordaAvroDeserializerImpl<T : Any>(
 
     private companion object {
         val stringDeserializer = StringDeserializer()
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun deserialize(data: ByteArray): T? {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroSerializerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroSerializerImpl.kt
@@ -2,10 +2,10 @@ package net.corda.messagebus.kafka.serialization
 
 import net.corda.data.CordaAvroSerializer
 import net.corda.schema.registry.AvroSchemaRegistry
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.uncheckedCast
 import org.apache.kafka.common.serialization.Serializer
 import org.apache.kafka.common.serialization.StringSerializer
+import org.slf4j.LoggerFactory
 
 class CordaAvroSerializerImpl<T : Any>(
     private val schemaRegistry: AvroSchemaRegistry
@@ -13,7 +13,7 @@ class CordaAvroSerializerImpl<T : Any>(
 
     companion object {
         private val stringSerializer = StringSerializer()
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun serialize(data: T): ByteArray? {

--- a/libs/messaging/kafka-topic-admin-impl/src/main/kotlin/net/corda/libs/messaging/topic/KafkaTopicUtils.kt
+++ b/libs/messaging/kafka-topic-admin-impl/src/main/kotlin/net/corda/libs/messaging/topic/KafkaTopicUtils.kt
@@ -4,13 +4,13 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import net.corda.libs.messaging.topic.utils.TopicUtils
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.errors.TopicExistsException
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ExecutionException
 
 /**
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutionException
 class KafkaTopicUtils(private val adminClient: AdminClient) : TopicUtils {
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createTopics(topicsTemplate: Config) {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/MessagingConfigResolver.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/MessagingConfigResolver.kt
@@ -8,8 +8,8 @@ import net.corda.messaging.api.exception.CordaMessageAPIConfigException
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.constants.SubscriptionType
-import net.corda.v5.base.util.contextLogger
 import org.osgi.framework.FrameworkUtil
+import org.slf4j.LoggerFactory
 
 /**
  * Class to resolve configuration for the messaging layer.
@@ -17,7 +17,7 @@ import org.osgi.framework.FrameworkUtil
 internal class MessagingConfigResolver(private val smartConfigFactory: SmartConfigFactory) {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         // Defaults could be provided externally using the schema instead. However, at the time of writing this isn't
         // integrated, so the default fallback mechanism is left as a compromise.

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaPublisherImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaPublisherImpl.kt
@@ -1,8 +1,6 @@
 package net.corda.messaging.publisher
 
 import net.corda.messagebus.api.configuration.ProducerConfig
-import java.nio.ByteBuffer
-import java.util.concurrent.CompletableFuture
 import net.corda.messagebus.api.producer.CordaProducer
 import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messagebus.api.producer.builder.CordaProducerBuilder
@@ -14,9 +12,11 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.config.ResolvedPublisherConfig
 import net.corda.messaging.utils.toCordaProducerRecord
 import net.corda.messaging.utils.toCordaProducerRecords
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
 
 /**
  * Publisher will use a [CordaProducer] to communicate with the message bus. Failed producers are closed and recreated.
@@ -33,7 +33,7 @@ internal class CordaPublisherImpl(
 ) : Publisher {
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var cordaProducer = cordaProducerBuilder.createProducer(producerConfig, config.messageBusConfig)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -1,9 +1,5 @@
 package net.corda.messaging.publisher
 
-import java.nio.ByteBuffer
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.ExceptionEnvelope
@@ -35,9 +31,13 @@ import net.corda.messaging.subscription.consumer.listener.RPCConsumerRebalanceLi
 import net.corda.messaging.utils.FutureTracker
 import net.corda.metrics.CordaMetrics
 import net.corda.schema.Schemas.Companion.getRPCResponseTopic
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
 
 @Suppress("LongParameterList")
 internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
@@ -50,7 +50,7 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
 ) : RPCSender<REQUEST, RESPONSE>, RPCSubscription<REQUEST, RESPONSE> {
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var threadLooper =

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImplTest.kt
@@ -15,7 +15,6 @@ import net.corda.messaging.constants.SubscriptionType
 import net.corda.messaging.createResolvedSubscriptionConfig
 import net.corda.messaging.subscription.factory.MapFactory
 import net.corda.test.util.waitWhile
-import net.corda.v5.base.util.loggerFor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -33,6 +32,7 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
@@ -60,7 +60,7 @@ class CompactedSubscriptionImplTest {
     private val lifeCycleCoordinatorMockHelper = LifeCycleCoordinatorMockHelper()
 
     private open class TestProcessor : CompactedProcessor<String, String> {
-        private val log = loggerFor<TestProcessor>()
+        private val log = LoggerFactory.getLogger(this::class.java)
 
         override val keyClass: Class<String>
             get() = String::class.java

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/RPCSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/RPCSubscriptionImplTest.kt
@@ -23,7 +23,6 @@ import net.corda.messaging.constants.SubscriptionType
 import net.corda.messaging.createResolvedSubscriptionConfig
 import net.corda.test.util.waitWhile
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -41,6 +40,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
@@ -420,7 +420,7 @@ class RPCSubscriptionImplTest {
 
     private class TestProcessor(val responseStatus: ResponseStatus) :
         RPCResponderProcessor<HoldingIdentity, HoldingIdentity> {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         var failNext = false
         val incomingRecords = mutableListOf<HoldingIdentity>()

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDocumentReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDocumentReader.kt
@@ -6,9 +6,9 @@ import net.corda.libs.packaging.core.CpkIdentifier
 import net.corda.libs.packaging.core.CpkType
 import net.corda.libs.packaging.core.exception.DependencyMetadataException
 import net.corda.libs.packaging.core.exception.LibraryMetadataException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
+import org.slf4j.LoggerFactory
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.NodeList
@@ -28,7 +28,7 @@ import javax.xml.validation.SchemaFactory
 
 class CpkDocumentReader {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val SAME_SIGNER_PLACEHOLDER = SecureHash("NONE", byteArrayOf(0))
 
         private const val CORDA_CPK_V1 = "corda-cpk-1.0.xsd"

--- a/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RpcRbacEntitiesTest.kt
+++ b/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RpcRbacEntitiesTest.kt
@@ -12,7 +12,6 @@ import net.corda.orm.utils.use
 import net.corda.permissions.model.RbacEntities
 import net.corda.permissions.model.User
 import net.corda.test.util.LoggingUtils.emphasise
-import net.corda.v5.base.util.contextLogger
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -21,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.framework.FrameworkUtil
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.io.StringWriter
 import java.time.Instant
 import java.util.UUID
@@ -29,7 +29,7 @@ import javax.persistence.EntityManagerFactory
 @ExtendWith(ServiceExtension::class)
 class RpcRbacEntitiesTest {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         @InjectService
         lateinit var entityManagerFactoryFactory: EntityManagerFactoryFactory

--- a/libs/permissions/permission-manager-impl/src/integrationTest/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationServicePerfTest.kt
+++ b/libs/permissions/permission-manager-impl/src/integrationTest/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationServicePerfTest.kt
@@ -4,25 +4,23 @@ import net.corda.data.permissions.ChangeDetails
 import net.corda.data.permissions.User
 import net.corda.libs.permissions.management.cache.PermissionManagementCache
 import net.corda.permissions.password.impl.PasswordServiceImpl
-import net.corda.v5.base.util.contextLogger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.slf4j.LoggerFactory
 import java.security.SecureRandom
 import java.time.Instant
-
 import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Collectors
 
 class RbacBasicAuthenticationServicePerfTest {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val userLogons: List<String> = (1..10).map { "user$it" }
         const val repsCount = 1_000
         const val PERF_THRESHOLD_MS = 10_000L

--- a/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationService.kt
+++ b/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationService.kt
@@ -4,8 +4,8 @@ import net.corda.libs.permissions.management.cache.PermissionManagementCache
 import net.corda.libs.permissions.manager.BasicAuthenticationService
 import net.corda.permissions.password.PasswordHash
 import net.corda.permissions.password.PasswordService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicReference
 
 class RbacBasicAuthenticationService(
@@ -14,7 +14,7 @@ class RbacBasicAuthenticationService(
 ) : BasicAuthenticationService {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val repeatedLogonsCache = RepeatedLogonsCache()

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/PermissionStorageReaderImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/PermissionStorageReaderImpl.kt
@@ -23,8 +23,8 @@ import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_GROUP_TOPIC
 import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_ROLE_TOPIC
 import net.corda.schema.Schemas.RPC.Companion.RPC_PERM_USER_TOPIC
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicReference
 import net.corda.data.permissions.Group as AvroGroup
 import net.corda.data.permissions.Permission as AvroPermission
@@ -42,7 +42,7 @@ class PermissionStorageReaderImpl(
 ) : PermissionStorageReader {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var stopped = false

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImpl.kt
@@ -1,17 +1,17 @@
 package net.corda.libs.permissions.storage.reader.impl.summary
 
 import net.corda.libs.permissions.storage.common.converter.toAvroPermissionSummary
-import net.corda.data.permissions.summary.UserPermissionSummary as AvroUserPermissionSummary
 import net.corda.libs.permissions.storage.reader.repository.UserLogin
 import net.corda.libs.permissions.storage.reader.summary.InternalUserPermissionSummary
 import net.corda.libs.permissions.storage.reader.summary.PermissionSummaryReconciler
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import net.corda.data.permissions.summary.UserPermissionSummary as AvroUserPermissionSummary
 
 class PermissionSummaryReconcilerImpl : PermissionSummaryReconciler {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun getSummariesForReconciliation(

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.libs.permissions.storage.writer.impl
 
-import java.util.concurrent.CompletableFuture
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.permissions.Permission
 import net.corda.data.permissions.management.PermissionManagementRequest
@@ -11,15 +10,16 @@ import net.corda.data.permissions.management.permission.CreatePermissionRequest
 import net.corda.data.permissions.management.role.AddPermissionToRoleRequest
 import net.corda.data.permissions.management.role.CreateRoleRequest
 import net.corda.data.permissions.management.role.RemovePermissionFromRoleRequest
-import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.AddRoleToUserRequest
+import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.RemoveRoleFromUserRequest
 import net.corda.libs.permissions.storage.reader.PermissionStorageReader
 import net.corda.libs.permissions.storage.writer.PermissionStorageWriterProcessor
 import net.corda.libs.permissions.storage.writer.impl.permission.PermissionWriter
 import net.corda.libs.permissions.storage.writer.impl.role.RoleWriter
 import net.corda.libs.permissions.storage.writer.impl.user.UserWriter
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CompletableFuture
 import java.util.function.Supplier
 
 class PermissionStorageWriterProcessorImpl(
@@ -30,7 +30,7 @@ class PermissionStorageWriterProcessorImpl(
 ) : PermissionStorageWriterProcessor {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suppress("ComplexMethod")

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/permission/impl/PermissionWriterImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/permission/impl/PermissionWriterImpl.kt
@@ -1,19 +1,19 @@
 package net.corda.libs.permissions.storage.writer.impl.permission.impl
 
-import java.time.Instant
-import java.util.UUID
-import javax.persistence.EntityManagerFactory
 import net.corda.data.permissions.management.permission.CreatePermissionRequest
-import net.corda.libs.permissions.storage.common.converter.toDbModelPermissionType
 import net.corda.libs.permissions.storage.common.converter.toAvroPermission
+import net.corda.libs.permissions.storage.common.converter.toDbModelPermissionType
 import net.corda.libs.permissions.storage.writer.impl.permission.PermissionWriter
 import net.corda.libs.permissions.storage.writer.impl.validation.EntityValidationUtil
 import net.corda.orm.utils.transaction
 import net.corda.permissions.model.ChangeAudit
-import net.corda.permissions.model.RPCPermissionOperation
 import net.corda.permissions.model.Permission
-import net.corda.v5.base.util.contextLogger
+import net.corda.permissions.model.RPCPermissionOperation
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+import javax.persistence.EntityManagerFactory
 import net.corda.data.permissions.Permission as AvroPermission
 
 class PermissionWriterImpl(
@@ -21,7 +21,7 @@ class PermissionWriterImpl(
 ) : PermissionWriter {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createPermission(request: CreatePermissionRequest, requestUserId: String, virtualNodeId: String?): AvroPermission {

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/role/impl/RoleWriterImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/role/impl/RoleWriterImpl.kt
@@ -1,9 +1,6 @@
 package net.corda.libs.permissions.storage.writer.impl.role.impl
 
 import net.corda.data.permissions.management.role.AddPermissionToRoleRequest
-import java.time.Instant
-import java.util.UUID
-import javax.persistence.EntityManagerFactory
 import net.corda.data.permissions.management.role.CreateRoleRequest
 import net.corda.data.permissions.management.role.RemovePermissionFromRoleRequest
 import net.corda.libs.permissions.storage.common.converter.toAvroRole
@@ -15,8 +12,11 @@ import net.corda.permissions.model.Permission
 import net.corda.permissions.model.RPCPermissionOperation
 import net.corda.permissions.model.Role
 import net.corda.permissions.model.RolePermissionAssociation
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+import javax.persistence.EntityManagerFactory
 import net.corda.data.permissions.Role as AvroRole
 
 class RoleWriterImpl(
@@ -24,7 +24,7 @@ class RoleWriterImpl(
 ) : RoleWriter {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createRole(request: CreateRoleRequest, requestUserId: String): AvroRole {

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
@@ -1,9 +1,5 @@
 package net.corda.libs.permissions.storage.writer.impl.user.impl
 
-import java.time.Instant
-import java.util.UUID
-import javax.persistence.EntityManager
-import javax.persistence.EntityManagerFactory
 import net.corda.data.permissions.management.user.AddRoleToUserRequest
 import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.RemoveRoleFromUserRequest
@@ -17,8 +13,12 @@ import net.corda.permissions.model.RPCPermissionOperation
 import net.corda.permissions.model.Role
 import net.corda.permissions.model.RoleUserAssociation
 import net.corda.permissions.model.User
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
 import net.corda.data.permissions.User as AvroUser
 
 class UserWriterImpl(
@@ -26,7 +26,7 @@ class UserWriterImpl(
 ) : UserWriter {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun createUser(request: CreateUserRequest, requestUserId: String): AvroUser {

--- a/libs/permissions/permission-validation-impl/src/main/kotlin/net/corda/libs/permission/impl/PermissionValidatorImpl.kt
+++ b/libs/permissions/permission-validation-impl/src/main/kotlin/net/corda/libs/permission/impl/PermissionValidatorImpl.kt
@@ -1,19 +1,19 @@
 package net.corda.libs.permission.impl
 
 import net.corda.data.permissions.summary.UserPermissionSummary
-import net.corda.data.permissions.PermissionType as AvroPermissionType
 import net.corda.libs.permission.PermissionValidator
 import net.corda.libs.permissions.validation.cache.PermissionValidationCache
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicReference
+import net.corda.data.permissions.PermissionType as AvroPermissionType
 
 class PermissionValidatorImpl(
     private val permissionValidationCacheRef: AtomicReference<PermissionValidationCache?>
 ) : PermissionValidator {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var running = false

--- a/libs/sandbox-internal/sandbox-cpk-two/src/main/kotlin/com/example/sandbox/cpk2/ServicesTwoFlow.kt
+++ b/libs/sandbox-internal/sandbox-cpk-two/src/main/kotlin/com/example/sandbox/cpk2/ServicesTwoFlow.kt
@@ -2,10 +2,10 @@ package com.example.sandbox.cpk2
 
 import com.example.sandbox.library.SandboxQuery
 import net.corda.v5.application.flows.SubFlow
-import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /** Returns services visible to this sandbox. */
 @Suppress("unused")
@@ -14,7 +14,7 @@ class ServicesTwoFlow @Activate constructor(
     @Reference(target = "(component.name=sandbox.query)")
     private val sandboxQuery: SandboxQuery
 ) : SubFlow<List<Class<out Any>>> {
-    private val logger = loggerFor<ServicesTwoFlow>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     override fun call() = sandboxQuery.getAllServiceClasses()
 }

--- a/libs/sandbox-internal/sandbox-fragment-cpk/src/main/kotlin/com/example/fragment/ExampleFlow.kt
+++ b/libs/sandbox-internal/sandbox-fragment-cpk/src/main/kotlin/com/example/fragment/ExampleFlow.kt
@@ -1,15 +1,15 @@
 package com.example.fragment
 
 import net.corda.v5.application.flows.SubFlow
-import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import java.util.Properties
 
 @Suppress("unused")
 @Component(name = "sandbox.fragment.flow")
 class ExampleFlow @Activate constructor(): SubFlow<String> {
-    private val logger = loggerFor<ExampleFlow>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
         logger.info("Activated")

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -10,9 +10,9 @@ import net.corda.sandbox.internal.classtag.StaticTag
 import net.corda.sandbox.internal.sandbox.CpkSandbox
 import net.corda.sandbox.internal.sandbox.Sandbox
 import net.corda.sandbox.internal.utilities.BundleUtils
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.framework.Bundle
+import org.slf4j.LoggerFactory
 import java.util.Collections.unmodifiableMap
 
 /**
@@ -31,7 +31,7 @@ internal class SandboxGroupImpl(
 ) : SandboxGroupInternal {
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val metadata: Map<Bundle, CpkMetadata> = unmodifiableMap(cpkSandboxes.associate { cpk ->

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -12,7 +12,6 @@ import net.corda.sandbox.internal.sandbox.CpkSandboxImpl
 import net.corda.sandbox.internal.sandbox.Sandbox
 import net.corda.sandbox.internal.sandbox.SandboxImpl
 import net.corda.sandbox.internal.utilities.BundleUtils
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -24,6 +23,7 @@ import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.security.AccessController.doPrivileged
 import java.security.DigestInputStream
@@ -62,7 +62,7 @@ internal class SandboxServiceImpl @Activate constructor(
     // Bundles that failed to uninstall when a sandbox group was unloaded.
     private val zombieBundles = mutableSetOf<Bundle>()
 
-    private val logger = loggerFor<SandboxServiceImpl>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     override fun createPublicSandbox(publicBundles: Iterable<Bundle>, privateBundles: Iterable<Bundle>) {
         if (publicSandboxes.isNotEmpty()) {

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
@@ -1,8 +1,8 @@
 package net.corda.sandbox.internal.sandbox
 
 import net.corda.sandbox.SandboxException
-import net.corda.v5.base.util.loggerFor
 import org.osgi.framework.Bundle
+import org.slf4j.LoggerFactory
 import java.util.Collections.unmodifiableSet
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -17,7 +17,7 @@ internal open class SandboxImpl(
     final override val publicBundles: Set<Bundle>,
     final override val privateBundles: Set<Bundle>
 ) : Sandbox {
-    private val logger = loggerFor<SandboxImpl>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     // The other sandboxes whose services, bundles and events this sandbox can receive.
     // We use the sandboxes' IDs, rather than the sandboxes, to allow unloaded sandboxes to be garbage-collected.

--- a/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
+++ b/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
@@ -6,10 +6,9 @@ import net.corda.data.Fingerprint
 import net.corda.data.SchemaLoadException
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.uncheckedCast
 import net.corda.v5.base.types.toHexString
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import net.corda.v5.base.util.uncheckedCast
 import org.apache.avro.Schema
 import org.apache.avro.SchemaNormalization
 import org.apache.avro.io.DecoderFactory
@@ -19,6 +18,7 @@ import org.apache.avro.specific.SpecificDatumReader
 import org.apache.avro.specific.SpecificDatumWriter
 import org.apache.avro.specific.SpecificRecord
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentHashMap
@@ -63,7 +63,7 @@ class AvroSchemaRegistryImpl(
     }
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/libs/serialization/serialization-amqp/detekt-baseline.xml
+++ b/libs/serialization/serialization-amqp/detekt-baseline.xml
@@ -2362,7 +2362,7 @@
     <ID>UnusedPrivateMember:EvolutionObjectBuilderRenamedPropertyTests.kt$EvolutionObjectBuilderRenamedPropertyTests$private val yTestValue = 4113687</ID>
     <ID>UnusedPrivateMember:PrivatePropertyTests.kt$PrivatePropertyTests.Outer$private val i: Inner</ID>
     <ID>UnusedPrivateMember:ThrowableEvolutionTests.kt$ThrowableEvolutionTests$private val toBeRemovedValue = "Remove"</ID>
-    <ID>UnusedPrivateMember:TypeLoader.kt$ClassTypeLoader.Companion$private val logger = contextLogger()</ID>
+    <ID>UnusedPrivateMember:TypeLoader.kt$ClassTypeLoader.Companion$private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)</ID>
     <ID>UseCheckOrError:Envelope.kt$Envelope.Companion$throw IllegalStateException("Was expecting a list")</ID>
     <ID>UseCheckOrError:EvolutionSerializerFactory.kt$DefaultEvolutionSerializerFactory$throw IllegalStateException("Unknown primitive type '$primitiveType'")</ID>
     <ID>UseCheckOrError:LocalTypeInformation.kt$LocalTypeInformation.ACollection$throw IllegalStateException("Cannot parameterise $this")</ID>

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/CustomSerializerRegistry.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/CustomSerializerRegistry.kt
@@ -11,12 +11,12 @@ import net.corda.serialization.InternalDirectSerializer
 import net.corda.serialization.InternalProxySerializer
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaThrowable
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.serialization.SerializationCustomSerializer
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.framework.FrameworkUtil
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 import java.security.AccessControlContext
@@ -112,7 +112,7 @@ class CachingCustomSerializerRegistry(
     ) : this(descriptorBasedSerializerRegistry, emptySet(), sandboxGroup)
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val customSerializerNames: List<String>

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
@@ -10,13 +10,13 @@ import net.corda.serialization.EncodingAllowList
 import net.corda.serialization.SerializationContext
 import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.types.ByteSequence
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.serialization.SerializedBytes
 import org.apache.qpid.proton.amqp.Binary
 import org.apache.qpid.proton.amqp.DescribedType
 import org.apache.qpid.proton.amqp.UnsignedInteger
 import org.apache.qpid.proton.codec.Data
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.io.NotSerializableException
 import java.lang.reflect.ParameterizedType
@@ -37,7 +37,7 @@ class DeserializationInput constructor(
     private val serializerFactory: SerializerFactory
 ) {
     private val objectHistory: MutableList<Any> = mutableListOf()
-    private val logger = loggerFor<DeserializationInput>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     companion object {
         @VisibleForTesting

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/LocalSerializerFactory.kt
@@ -1,13 +1,13 @@
 package net.corda.internal.serialization.amqp
 
-import net.corda.internal.serialization.amqp.standard.EnumSerializer
-import net.corda.internal.serialization.amqp.standard.CollectionSerializer
-import net.corda.internal.serialization.amqp.standard.MapSerializer
-import net.corda.internal.serialization.amqp.standard.checkSupportedMapType
-import net.corda.internal.serialization.amqp.standard.PrimArraySerializer
 import net.corda.internal.serialization.amqp.standard.ArraySerializer
-import net.corda.internal.serialization.amqp.standard.SingletonSerializer
+import net.corda.internal.serialization.amqp.standard.CollectionSerializer
+import net.corda.internal.serialization.amqp.standard.EnumSerializer
+import net.corda.internal.serialization.amqp.standard.MapSerializer
 import net.corda.internal.serialization.amqp.standard.ObjectSerializer
+import net.corda.internal.serialization.amqp.standard.PrimArraySerializer
+import net.corda.internal.serialization.amqp.standard.SingletonSerializer
+import net.corda.internal.serialization.amqp.standard.checkSupportedMapType
 import net.corda.internal.serialization.model.DefaultCacheProvider
 import net.corda.internal.serialization.model.FingerPrinter
 import net.corda.internal.serialization.model.LocalTypeInformation
@@ -17,10 +17,10 @@ import net.corda.internal.serialization.model.TypeIdentifier.Parameterised
 import net.corda.sandbox.SandboxException
 import net.corda.sandbox.SandboxGroup
 import net.corda.utilities.reflection.kotlinObjectInstance
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.apache.qpid.proton.amqp.Symbol
+import org.slf4j.LoggerFactory
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.util.Optional
@@ -116,7 +116,7 @@ class DefaultLocalSerializerFactory(
     : LocalSerializerFactory {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val customSerializerNames: List<String>

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/RemoteSerializerFactory.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/RemoteSerializerFactory.kt
@@ -6,9 +6,9 @@ import net.corda.internal.serialization.model.RemoteTypeInformation
 import net.corda.internal.serialization.model.TypeDescriptor
 import net.corda.internal.serialization.model.TypeLoader
 import net.corda.sandbox.SandboxGroup
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
 import net.corda.v5.serialization.MissingSerializerException
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 import java.util.Collections.singletonList
 
@@ -68,7 +68,7 @@ class DefaultRemoteSerializerFactory(
 ) : RemoteSerializerFactory {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun get(

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
@@ -5,9 +5,9 @@ import net.corda.internal.serialization.SectionId
 import net.corda.internal.serialization.byteArrayOutput
 import net.corda.internal.serialization.model.TypeIdentifier
 import net.corda.serialization.SerializationContext
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.serialization.SerializedBytes
 import org.apache.qpid.proton.codec.Data
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 import java.io.OutputStream
 import java.lang.reflect.Type
@@ -30,7 +30,7 @@ open class SerializationOutput constructor(
         internal val serializerFactory: LocalSerializerFactory
 ) {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val objectHistory: MutableMap<Any, Int> = IdentityHashMap()

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ClassSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ClassSerializer.kt
@@ -6,8 +6,8 @@ import net.corda.serialization.InternalDirectSerializer
 import net.corda.serialization.InternalDirectSerializer.ReadObject
 import net.corda.serialization.InternalDirectSerializer.WriteObject
 import net.corda.serialization.SerializationContext
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.trace
+import org.slf4j.LoggerFactory
 
 /**
  * A serializer for [Class] writes the fully-qualified class name.
@@ -17,7 +17,7 @@ class ClassSerializer : InternalDirectSerializer<Class<*>> {
     override val withInheritance: Boolean get() = false
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun writeObject(obj: Class<*>, writer: WriteObject, context: SerializationContext)  {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
@@ -1,7 +1,7 @@
 package net.corda.internal.serialization.amqp.custom
 
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
 import net.corda.internal.serialization.amqp.GetterReader
+import net.corda.internal.serialization.amqp.LocalSerializerFactory
 import net.corda.internal.serialization.amqp.currentSandboxGroup
 import net.corda.internal.serialization.model.LocalConstructorInformation
 import net.corda.internal.serialization.model.LocalTypeInformation
@@ -9,7 +9,7 @@ import net.corda.serialization.InternalProxySerializer
 import net.corda.serialization.SerializationContext
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.exceptions.CordaThrowable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 import java.util.Locale
 
@@ -23,7 +23,7 @@ class ThrowableSerializer(
     override val revealSubclasses: Boolean get() = true
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private fun String.capitalise(): String {
             return replaceFirstChar { c ->

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -1,30 +1,29 @@
 package net.corda.internal.serialization.amqp.standard
 
-import net.corda.internal.serialization.model.resolveAgainst
-import net.corda.internal.serialization.amqp.LocalSerializerFactory
+import net.corda.internal.serialization.amqp.AMQPNotSerializableException
 import net.corda.internal.serialization.amqp.AMQPSerializer
+import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers
+import net.corda.internal.serialization.amqp.Descriptor
+import net.corda.internal.serialization.amqp.DeserializationInput
+import net.corda.internal.serialization.amqp.LocalSerializerFactory
+import net.corda.internal.serialization.amqp.Metadata
+import net.corda.internal.serialization.amqp.RestrictedType
+import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.SerializationSchemas
+import net.corda.internal.serialization.amqp.TypeNotation
+import net.corda.internal.serialization.amqp.asClass
 import net.corda.internal.serialization.amqp.componentType
 import net.corda.internal.serialization.amqp.isArray
-import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers
-import net.corda.internal.serialization.amqp.asClass
-import net.corda.internal.serialization.amqp.TypeNotation
-import net.corda.internal.serialization.amqp.RestrictedType
-import net.corda.internal.serialization.amqp.Descriptor
-import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.redescribe
 import net.corda.internal.serialization.amqp.withDescribed
 import net.corda.internal.serialization.amqp.withList
-import net.corda.internal.serialization.amqp.SerializationSchemas
-import net.corda.internal.serialization.amqp.Metadata
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.redescribe
-import net.corda.internal.serialization.amqp.AMQPNotSerializableException
+import net.corda.internal.serialization.model.resolveAgainst
 import net.corda.serialization.SerializationContext
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
+import org.slf4j.LoggerFactory
 import java.lang.reflect.Type
 
 /**
@@ -32,8 +31,9 @@ import java.lang.reflect.Type
  */
 open class ArraySerializer(override val type: Type, factory: LocalSerializerFactory) : AMQPSerializer<Any> {
     companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         fun make(type: Type, factory: LocalSerializerFactory) : AMQPSerializer<Any> {
-            contextLogger().debug { "Making array serializer, typename=${type.typeName}" }
+            logger.debug { "Making array serializer, typename=${type.typeName}" }
             return when (type) {
                 Array<Char>::class.java -> CharArraySerializer(factory)
                 else -> ArraySerializer(type, factory)
@@ -41,7 +41,7 @@ open class ArraySerializer(override val type: Type, factory: LocalSerializerFact
         }
     }
 
-    private val logger = loggerFor<ArraySerializer>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     // because this might be an array of array of primitives (to any recursive depth) and
     // because we care that the lowest type is unboxed we can't rely on the inbuilt type

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
@@ -2,7 +2,7 @@ package net.corda.internal.serialization.model
 
 import net.corda.internal.serialization.amqp.Metadata
 import net.corda.sandbox.SandboxGroup
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 import java.lang.reflect.Type
 
@@ -29,7 +29,7 @@ interface TypeLoader {
 class ClassTypeLoader: TypeLoader {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val cache = DefaultCacheProvider.createCache<TypeIdentifier, Type>()

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
@@ -1,8 +1,6 @@
 package net.corda.internal.serialization.model
 
 import com.google.common.hash.Hashing
-import net.corda.v5.base.util.contextLogger
-import net.corda.v5.base.util.toBase64
 import net.corda.internal.serialization.amqp.CustomSerializerRegistry
 import net.corda.internal.serialization.amqp.asClass
 import net.corda.internal.serialization.amqp.ifThrowsAppend
@@ -10,6 +8,8 @@ import net.corda.internal.serialization.model.TypeIdentifier.ArrayOf
 import net.corda.internal.serialization.model.TypeIdentifier.Parameterised
 import net.corda.internal.serialization.model.TypeIdentifier.UnknownType
 import net.corda.sandbox.SandboxGroup
+import net.corda.v5.base.util.toBase64
+import org.slf4j.LoggerFactory
 import java.lang.reflect.ParameterizedType
 
 /**
@@ -66,7 +66,7 @@ internal class FingerprintWriter(debugEnabled: Boolean = false) {
         private const val NOT_NULLABLE_HASH: String = "Nullable = false"
         private const val ANY_TYPE_HASH: String = "Any type = true"
 
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val debugBuffer: StringBuilder? = if (debugEnabled) StringBuilder() else null

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
@@ -22,9 +22,9 @@ import net.corda.kryoserialization.serializers.LinkedHashMapEntrySerializer
 import net.corda.kryoserialization.serializers.LinkedHashMapIteratorSerializer
 import net.corda.kryoserialization.serializers.LinkedListItrSerializer
 import net.corda.kryoserialization.serializers.LoggerSerializer
+import net.corda.kryoserialization.serializers.NonSerializableSerializer
 import net.corda.kryoserialization.serializers.ThrowableSerializer
 import net.corda.kryoserialization.serializers.X509CertificateSerializer
-import net.corda.kryoserialization.serializers.NonSerializableSerializer
 import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.utilities.LazyMappedList
 import org.apache.avro.specific.SpecificRecord

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/KryoCheckpointSerializer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/KryoCheckpointSerializer.kt
@@ -1,17 +1,17 @@
 package net.corda.kryoserialization
 
 import com.esotericsoftware.kryo.Kryo
-import java.io.ByteArrayInputStream
 import net.corda.serialization.checkpoint.CheckpointSerializer
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.uncheckedCast
+import org.slf4j.LoggerFactory
+import java.io.ByteArrayInputStream
 
 class KryoCheckpointSerializer(
     private val kryo: Kryo,
 ) : CheckpointSerializer {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun <T : Any> deserialize(

--- a/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
+++ b/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
@@ -6,7 +6,7 @@ import net.corda.data.chunking.UploadStatus
 import net.corda.data.chunking.UploadStatusKey
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * Receives [UploadStatus] messages on a compacted queue from the db-processor / [net.corda.chunking.db.impl.ChunkWriteToDbProcessor]
@@ -16,7 +16,7 @@ import net.corda.v5.base.util.contextLogger
 @Suppress("UNUSED")
 class UploadStatusProcessor : CompactedProcessor<UploadStatusKey, UploadStatus> {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val emptyExceptionEnvelope = ExceptionEnvelope("", "")
     }
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
@@ -1,9 +1,9 @@
 package com.r3.corda.notary.plugin.nonvalidating.client
 
-import com.r3.corda.notary.plugin.common.NotaryException
-import com.r3.corda.notary.plugin.common.generateRequestSignature
 import com.r3.corda.notary.plugin.common.NotarisationRequest
 import com.r3.corda.notary.plugin.common.NotarisationResponse
+import com.r3.corda.notary.plugin.common.NotaryException
+import com.r3.corda.notary.plugin.common.generateRequestSignature
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarisationPayload
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.SigningService
@@ -14,12 +14,12 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.annotations.VisibleForTesting
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import org.slf4j.LoggerFactory
 
 /**
  * The client that is used for the non-validating notary logic. This class is very simple and uses the basic
@@ -33,7 +33,7 @@ class NonValidatingNotaryClientFlowImpl(
 ) : PluggableNotaryClientFlow {
 
     private companion object {
-        val log = loggerFor<NonValidatingNotaryClientFlowImpl>()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -1,10 +1,10 @@
 package com.r3.corda.notary.plugin.nonvalidating.server
 
-import com.r3.corda.notary.plugin.common.toNotarisationResponse
-import com.r3.corda.notary.plugin.common.validateRequestSignature
 import com.r3.corda.notary.plugin.common.NotarisationRequest
 import com.r3.corda.notary.plugin.common.NotarisationResponse
 import com.r3.corda.notary.plugin.common.NotaryErrorGeneralImpl
+import com.r3.corda.notary.plugin.common.toNotarisationResponse
+import com.r3.corda.notary.plugin.common.validateRequestSignature
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarisationPayload
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
 import net.corda.v5.application.flows.CordaInject
@@ -16,7 +16,6 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.util.debug
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.StateAndRef
@@ -25,7 +24,7 @@ import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredData
 import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
 import net.corda.v5.ledger.utxo.uniqueness.client.LedgerUniquenessCheckerClientService
 import org.slf4j.Logger
-import kotlin.IllegalStateException
+import org.slf4j.LoggerFactory
 
 /**
  * The server-side implementation of the non-validating notary logic.
@@ -36,7 +35,7 @@ import kotlin.IllegalStateException
 class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
     private companion object {
-        val logger: Logger = loggerFor<NonValidatingNotaryServerFlowImpl>()
+        val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -64,7 +64,6 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.test.util.TestRandom
 import net.corda.test.util.eventually
 import net.corda.test.util.identity.createTestHoldingIdentity
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
@@ -87,6 +86,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 import java.time.Duration
 import java.time.Instant
@@ -97,7 +97,7 @@ import javax.persistence.EntityManagerFactory
 @ExtendWith(ServiceExtension::class, DBSetup::class)
 class CryptoProcessorTests {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val CLIENT_ID = makeClientId<CryptoProcessorTests>()
 

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestDependenciesTracker.kt
@@ -12,8 +12,8 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.registry.LifecycleRegistry
 import net.corda.utilities.concurrent.getOrThrow
-import net.corda.v5.base.util.contextLogger
 import org.junit.jupiter.api.Assertions
+import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
@@ -23,7 +23,7 @@ class TestDependenciesTracker(
     private val dependencies: Set<LifecycleCoordinatorName>
 ) : Lifecycle {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var registrationHandle: RegistrationHandle? = null

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -33,11 +33,11 @@ import net.corda.orm.JpaEntitiesRegistry
 import net.corda.processors.crypto.CryptoProcessor
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicInteger
 
 @Suppress("LongParameterList")
@@ -79,7 +79,7 @@ class CryptoProcessorImpl @Activate constructor(
     private val vnodeInfo: VirtualNodeInfoReadService
 ) : CryptoProcessor {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     init {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -49,7 +49,6 @@ import net.corda.reconciliation.ReconcilerFactory
 import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.write.db.VirtualNodeInfoWriteService
@@ -57,6 +56,7 @@ import net.corda.virtualnode.write.db.VirtualNodeWriteService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("Unused", "LongParameterList")
 @Component(service = [DBProcessor::class])
@@ -138,7 +138,7 @@ class DBProcessorImpl @Activate constructor(
     }
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
@@ -8,7 +8,7 @@ import net.corda.reconciliation.Reconciler
 import net.corda.reconciliation.ReconcilerFactory
 import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.ReconcilerWriter
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 class ConfigReconciler(
@@ -19,7 +19,7 @@ class ConfigReconciler(
     private val reconcilerWriter: ReconcilerWriter<String, Configuration>
 ) : ReconcilerWrapper {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val dependencies = setOf(
             LifecycleCoordinatorName.forComponent<DbConnectionManager>()
         )

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
@@ -9,7 +9,7 @@ import net.corda.reconciliation.Reconciler
 import net.corda.reconciliation.ReconcilerFactory
 import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.ReconcilerWriter
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 class CpiReconciler(
@@ -20,7 +20,7 @@ class CpiReconciler(
     private val reconcilerWriter: ReconcilerWriter<CpiIdentifier, CpiMetadata>
 ) : ReconcilerWrapper {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val dependencies = setOf(
             LifecycleCoordinatorName.forComponent<DbConnectionManager>()
         )

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
@@ -16,11 +16,11 @@ import net.corda.reconciliation.ReconcilerWriter
 import net.corda.reconciliation.VersionedRecord
 import net.corda.utilities.VisibleForTesting
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.membership.GroupParameters
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
 import java.util.stream.Stream
 import kotlin.concurrent.withLock
@@ -42,7 +42,7 @@ class GroupParametersReconciler(
     private val kafkaReconcilerReader: ReconcilerReader<HoldingIdentity, GroupParameters>,
 ) : ReconcilerWrapper {
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val dependencies = setOf(
             LifecycleCoordinatorName.forComponent<DbConnectionManager>(),
             LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
@@ -7,9 +7,9 @@ import net.corda.reconciliation.Reconciler
 import net.corda.reconciliation.ReconcilerFactory
 import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.ReconcilerWriter
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 class VirtualNodeReconciler(
@@ -20,7 +20,7 @@ class VirtualNodeReconciler(
     private val reconcilerWriter: ReconcilerWriter<HoldingIdentity, VirtualNodeInfo>
 ) : ReconcilerWrapper {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val dependencies = setOf(
             LifecycleCoordinatorName.forComponent<DbConnectionManager>()
         )

--- a/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
+++ b/processors/flow-processor/src/main/kotlin/net/corda/processors/flow/internal/FlowProcessorImpl.kt
@@ -21,13 +21,13 @@ import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.processors.flow.FlowProcessor
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.session.mapper.service.FlowMapperService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList", "Unused")
 @Component(service = [FlowProcessor::class])
@@ -59,7 +59,7 @@ class FlowProcessorImpl @Activate constructor(
 ) : FlowProcessor {
 
     private companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/processors/gateway-processor/src/main/kotlin/net/corda/processors/p2p/gateway/internal/GatewayProcessorImpl.kt
+++ b/processors/gateway-processor/src/main/kotlin/net/corda/processors/p2p/gateway/internal/GatewayProcessorImpl.kt
@@ -18,10 +18,10 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.gateway.Gateway
 import net.corda.processors.p2p.gateway.GatewayProcessor
 import net.corda.schema.registry.AvroSchemaRegistry
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList", "Unused")
 @Component(service = [GatewayProcessor::class])
@@ -43,7 +43,7 @@ class GatewayProcessorImpl @Activate constructor(
 ) : GatewayProcessor {
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lifecycleCoordinator = coordinatorFactory.createCoordinator<GatewayProcessorImpl>(::eventHandler)

--- a/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/internal/LinkManagerProcessorImpl.kt
+++ b/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/internal/LinkManagerProcessorImpl.kt
@@ -24,13 +24,13 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.linkmanager.LinkManager
 import net.corda.processors.p2p.linkmanager.LinkManagerProcessor
 import net.corda.schema.configuration.MessagingConfig.Subscription.POLL_TIMEOUT
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList", "Unused")
 @Component(service = [LinkManagerProcessor::class])
@@ -62,7 +62,7 @@ class LinkManagerProcessorImpl @Activate constructor(
 ) : LinkManagerProcessor {
 
     private companion object {
-        val log: Logger = contextLogger()
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var registration: RegistrationHandle? = null

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestDependenciesTracker.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestDependenciesTracker.kt
@@ -12,8 +12,8 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.registry.LifecycleRegistry
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.contextLogger
 import org.junit.jupiter.api.Assertions
+import org.slf4j.LoggerFactory
 import java.time.Duration
 
 class TestDependenciesTracker(
@@ -23,7 +23,7 @@ class TestDependenciesTracker(
     private val dependencies: Set<LifecycleCoordinatorName>
 ) : Lifecycle {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Volatile

--- a/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/MemberProcessorImpl.kt
+++ b/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/MemberProcessorImpl.kt
@@ -24,11 +24,11 @@ import net.corda.membership.service.MemberOpsService
 import net.corda.membership.synchronisation.SynchronisationProxy
 import net.corda.processors.member.MemberProcessor
 import net.corda.processors.member.internal.lifecycle.MemberProcessorLifecycleHandler
-import net.corda.v5.base.util.contextLogger
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("LongParameterList")
 @Component(service = [MemberProcessor::class])
@@ -76,7 +76,7 @@ class MemberProcessorImpl @Activate constructor(
 ) : MemberProcessor {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/lifecycle/MemberProcessorLifecycleHandler.kt
+++ b/processors/member-processor/src/main/kotlin/net/corda/processors/member/internal/lifecycle/MemberProcessorLifecycleHandler.kt
@@ -8,14 +8,14 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.processors.member.internal.BootConfigEvent
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 
 class MemberProcessorLifecycleHandler(
     private val configurationReadService: ConfigurationReadService
 ) : LifecycleEventHandler {
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun processEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {

--- a/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
+++ b/processors/rpc-processor/src/integrationTest/kotlin/net/corda/processors/rpc/OpenApiCompatibilityTest.kt
@@ -25,12 +25,12 @@ import net.corda.membership.httprpc.v1.MemberRegistrationRestResource
 import net.corda.membership.httprpc.v1.NetworkRestResource
 import net.corda.processors.rpc.diff.diff
 import net.corda.utilities.NetworkHostAndPort
-import net.corda.v5.base.util.contextLogger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URI
 import java.net.http.HttpClient
@@ -41,7 +41,7 @@ import java.net.http.HttpResponse
 class OpenApiCompatibilityTest {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val importantRpcOps = setOf(
             CertificatesRestResource::class.java, // P2P

--- a/processors/rpc-processor/src/main/kotlin/net/corda/processors/rpc/internal/RPCProcessorImpl.kt
+++ b/processors/rpc-processor/src/main/kotlin/net/corda/processors/rpc/internal/RPCProcessorImpl.kt
@@ -27,12 +27,12 @@ import net.corda.membership.read.GroupParametersReaderService
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.processors.rpc.RPCProcessor
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /** The processor for a `RPCWorker`. */
 @Component(service = [RPCProcessor::class])
@@ -79,7 +79,7 @@ class RPCProcessorImpl @Activate constructor(
 ) : RPCProcessor {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val CLIENT_ID_RPC_PROCESSOR = "rpc.processor"
     }

--- a/processors/uniqueness-processor/src/main/kotlin/net/corda/processors/uniqueness/internal/UniquenessProcessorImpl.kt
+++ b/processors/uniqueness-processor/src/main/kotlin/net/corda/processors/uniqueness/internal/UniquenessProcessorImpl.kt
@@ -10,10 +10,10 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.processors.uniqueness.UniquenessProcessor
 import net.corda.uniqueness.checker.UniquenessChecker
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * Uniqueness processor implementation.
@@ -27,7 +27,7 @@ class UniquenessProcessorImpl @Activate constructor(
 ) : UniquenessProcessor {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/processors/verification-processor/src/main/kotlin/net/corda/processors/verification/internal/VerificationProcessorImpl.kt
+++ b/processors/verification-processor/src/main/kotlin/net/corda/processors/verification/internal/VerificationProcessorImpl.kt
@@ -12,11 +12,11 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.processors.verification.VerificationProcessor
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Suppress("Unused")
 @Component(service = [VerificationProcessor::class])
@@ -30,7 +30,7 @@ class VerificationProcessorImpl @Activate constructor(
 ) : VerificationProcessor {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dependentComponents = DependentComponents.of(

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
@@ -1,12 +1,12 @@
 package net.cordacon.example.doorcode
 
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.InitiatingFlow
-import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
@@ -16,11 +16,11 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 
 /**
@@ -30,7 +30,7 @@ import java.security.PublicKey
 class DoorCodeChangeFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -89,7 +89,7 @@ class DoorCodeChangeFlow : ClientStartableFlow {
 class DoorCodeChangeResponderFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/AbsenceCallResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/AbsenceCallResponderFlow.kt
@@ -6,13 +6,13 @@ import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 @InitiatedBy("absence-call")
 class AbsenceCallResponderFlow: ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallFlow.kt
@@ -1,11 +1,11 @@
 package net.cordacon.example.rollcall
 
 import net.corda.v5.application.crypto.SigningService
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
@@ -14,12 +14,12 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.cordacon.example.rollcall.utils.BaseScriptMaker
 import net.cordacon.example.rollcall.utils.ScriptMaker
 import net.cordacon.example.rollcall.utils.findStudents
+import org.slf4j.LoggerFactory
 
 
 @InitiatingFlow("roll-call")
@@ -30,7 +30,7 @@ class RollCallFlow(val scriptMaker: ScriptMaker = BaseScriptMaker()): ClientStar
 
     private companion object {
         private const val RETRIES: Int = 2
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallResponderFlow.kt
@@ -6,13 +6,13 @@ import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 @InitiatedBy("roll-call")
 class RollCallResponderFlow: ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
@@ -9,8 +9,8 @@ import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SignatureSpec
+import org.slf4j.LoggerFactory
 import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -21,7 +21,7 @@ import javax.persistence.Table
 class TruancyResponderFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
@@ -6,7 +6,7 @@ import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 @InitiatingFlow("truancy-record")
 class TruancySubFlow(
@@ -15,7 +15,7 @@ class TruancySubFlow(
     ) : SubFlow<String> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
 

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedInstanceNodeBase.kt
@@ -9,11 +9,11 @@ import net.corda.simulator.runtime.flows.FlowManager
 import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.messaging.SimFiber
 import net.corda.simulator.runtime.messaging.SimFlowContextProperties
-import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.ClientStartableFlow
+import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * See [SimulatedInstanceNode].
@@ -40,7 +40,7 @@ class SimulatedInstanceNodeBase(
     }
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun callFlow(input: RequestData): String {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedNodeBase.kt
@@ -4,13 +4,13 @@ import net.corda.simulator.SimulatedNode
 import net.corda.simulator.crypto.HsmCategory
 import net.corda.simulator.runtime.messaging.SimFiber
 import net.corda.v5.application.persistence.PersistenceService
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 
 abstract class SimulatedNodeBase : SimulatedNode {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     protected abstract val fiber: SimFiber

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatedVirtualNodeBase.kt
@@ -11,7 +11,7 @@ import net.corda.simulator.runtime.flows.FlowServicesInjector
 import net.corda.simulator.runtime.messaging.SimFiber
 import net.corda.simulator.runtime.messaging.SimFlowContextProperties
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 /**
  * The base class for simulated virtual nodes.
@@ -30,7 +30,7 @@ class SimulatedVirtualNodeBase(
 ) : SimulatedNodeBase(), SimulatedVirtualNode {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val member : MemberX500Name = holdingIdentity.member

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/SimulatorDelegateBase.kt
@@ -16,7 +16,7 @@ import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 
@@ -38,7 +38,7 @@ class SimulatorDelegateBase  (
 ) : SimulatedCordaNetwork {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val flowFactory: FlowFactory = BaseFlowFactory()

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/BaseFlowManager.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/BaseFlowManager.kt
@@ -1,12 +1,12 @@
 package net.corda.simulator.runtime.flows
 
 import net.corda.simulator.runtime.utils.accessField
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.messaging.FlowMessaging
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.Closeable
 
 /**
@@ -15,7 +15,7 @@ import java.io.Closeable
 class BaseFlowManager : FlowManager {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun call(requestData: RestRequestBody, flow: ClientStartableFlow) : String {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjector.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/DefaultServicesInjector.kt
@@ -23,8 +23,8 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
+import org.slf4j.LoggerFactory
 
 /**
  * Injector for default services for Simulator.
@@ -32,7 +32,7 @@ import net.corda.v5.ledger.consensual.ConsensualLedgerService
 @Suppress("TooManyFunctions")
 class DefaultServicesInjector(private val configuration: SimulatorConfiguration) : FlowServicesInjector {
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
@@ -9,7 +9,7 @@ import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 /**
@@ -40,7 +40,7 @@ class InjectingFlowEngine(
 
     private val userContextProperties = copyFlowContextProperties(userContextProperties)
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val flowId: UUID

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistry.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseFlowRegistry.kt
@@ -3,7 +3,7 @@ package net.corda.simulator.runtime.messaging
 import net.corda.v5.application.flows.Flow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 class BaseFlowRegistry: FlowRegistry {
@@ -13,7 +13,7 @@ class BaseFlowRegistry: FlowRegistry {
     private val nodeResponderInstances = ConcurrentHashMap<MemberX500Name, ConcurrentHashMap<String, ResponderFlow>>()
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun registerResponderClass(

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
@@ -9,7 +9,7 @@ import net.corda.v5.application.messaging.FlowContextPropertiesBuilder
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.io.Closeable
 import kotlin.concurrent.thread
 
@@ -47,7 +47,7 @@ class ConcurrentFlowMessaging(
     private val openedSessions = mutableListOf<SessionPair>()
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/InitiatorFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/InitiatorFlowSession.kt
@@ -2,7 +2,7 @@ package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.exceptions.ResponderFlowException
 import net.corda.v5.application.messaging.FlowSession
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
@@ -27,7 +27,7 @@ class BaseInitiatorFlowSession(
 ) : BlockingQueueFlowSession(flowDetails, from, to, flowContextProperties), InitiatorFlowSession {
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var responderSessionClosed: Boolean = false

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/persistence/DbPersistenceService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/persistence/DbPersistenceService.kt
@@ -7,7 +7,6 @@ import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.application.persistence.PagedQuery
 import net.corda.v5.application.persistence.ParameterizedQuery
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import org.hibernate.Session
 import org.hibernate.cfg.AvailableSettings.DIALECT
 import org.hibernate.cfg.AvailableSettings.JPA_JDBC_DRIVER
@@ -16,6 +15,7 @@ import org.hibernate.cfg.AvailableSettings.JPA_JDBC_URL
 import org.hibernate.cfg.AvailableSettings.JPA_JDBC_USER
 import org.hibernate.dialect.HSQLDialect
 import org.hibernate.jpa.HibernatePersistenceProvider
+import org.slf4j.LoggerFactory
 import java.sql.Connection
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
@@ -32,7 +32,7 @@ class DbPersistenceService(member : MemberX500Name) : CloseablePersistenceServic
     private val emf : EntityManagerFactory = createEntityManagerFactory(member)
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         fun createEntityManagerFactory(member: MemberX500Name): EntityManagerFactory {
             log.info("Creating EntityManagerFactory")
             val emf = HibernatePersistenceProvider()

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
@@ -2,9 +2,9 @@ package net.corda.simulator.runtime.signing
 
 import net.corda.simulator.runtime.serialization.SimpleJsonMarshallingService
 import net.corda.v5.application.crypto.SigningService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 
 /**
@@ -18,7 +18,7 @@ class SimWithJsonSigningService(private val keyStore: SimKeyStore) : SigningServ
     private val jsonMarshallingService = SimpleJsonMarshallingService()
 
     companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     /**

--- a/testing/apps/test-app/src/main/kotlin/net/corda/sample/testapp/TestApplication.kt
+++ b/testing/apps/test-app/src/main/kotlin/net/corda/sample/testapp/TestApplication.kt
@@ -2,11 +2,12 @@ package net.corda.sample.testapp
 
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
-import net.corda.v5.base.util.contextLogger
+import net.corda.sample.testapp.TestApplication.Companion.SHUTDOWN_DELAY
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 /**
  * This class is the entry point of the didactic application showing how to run an *Application* from a bootable JAR.
@@ -24,7 +25,7 @@ class TestApplication @Activate constructor(
 
     private companion object {
 
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         /**
          * Time in ms before the application shutdown itself.

--- a/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/CalculatorFlow.kt
+++ b/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/CalculatorFlow.kt
@@ -1,18 +1,18 @@
 package net.cordapp.testing.calculator
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class CalculatorFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/OutputFormattingFlow.kt
+++ b/testing/cpbs/calculator/src/main/kotlin/net/cordapp/testing/calculator/OutputFormattingFlow.kt
@@ -3,12 +3,12 @@ package net.cordapp.testing.calculator
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class OutputFormattingFlow(private val result: Int) : SubFlow<String> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
+++ b/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
@@ -1,11 +1,11 @@
 package net.cordapp.demo.consensual
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.InitiatingFlow
-import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
@@ -13,9 +13,9 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
 import net.cordapp.demo.consensual.contract.TestConsensualState
+import org.slf4j.LoggerFactory
 
 /**
  * Example consensual flow.
@@ -27,7 +27,7 @@ class ConsensualDemoFlow : ClientStartableFlow {
     data class InputMessage(val input: String, val members: List<String>)
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -92,7 +92,7 @@ class ConsensualDemoFlow : ClientStartableFlow {
 class ConsensualResponderFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/FindTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/FindTransactionFlow.kt
@@ -1,15 +1,15 @@
 package net.cordapp.demo.utxo
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.cordapp.demo.utxo.contract.TestUtxoState
+import org.slf4j.LoggerFactory
 
 data class FindTransactionParameters(val transactionId: String)
 
@@ -44,7 +44,7 @@ data class FindTransactionResponse(
 class FindTransactionFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
@@ -1,11 +1,11 @@
 package net.cordapp.demo.utxo
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.InitiatingFlow
-import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
@@ -14,7 +14,6 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.messaging.receive
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.BelongsToContract
@@ -24,6 +23,7 @@ import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -48,7 +48,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
     class TestCommand : Command
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -251,7 +251,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
 class UtxoBackchainResolutionDemoResponderFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
@@ -1,11 +1,11 @@
 package net.cordapp.demo.utxo
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.InitiatingFlow
-import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
@@ -13,13 +13,13 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.days
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.cordapp.demo.utxo.contract.TestUtxoState
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 /**
@@ -34,7 +34,7 @@ class UtxoDemoFlow : ClientStartableFlow {
     class TestCommand : Command
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -106,7 +106,7 @@ class UtxoDemoFlow : ClientStartableFlow {
 class UtxoResponderFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/UtxoDemoTokenStateObserver.kt
+++ b/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/UtxoDemoTokenStateObserver.kt
@@ -1,6 +1,5 @@
 package net.cordapp.demo.utxo.contract
 
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
@@ -10,11 +9,7 @@ import net.corda.v5.ledger.utxo.observer.UtxoTokenPoolKey
 import java.math.BigDecimal
 
 class UtxoDemoTokenStateObserver : UtxoLedgerTokenStateObserver<TestUtxoState> {
-
-    private companion object {
-        val log = loggerFor<UtxoDemoTokenStateObserver>()
-    }
-
+    
     override val stateType = TestUtxoState::class.java
 
     override fun onCommit(state: TestUtxoState): UtxoToken {

--- a/testing/cpbs/mandelbrot/src/main/kotlin/net/cordapp/demo/mandelbrot/CalculateBlockFlow.kt
+++ b/testing/cpbs/mandelbrot/src/main/kotlin/net/cordapp/demo/mandelbrot/CalculateBlockFlow.kt
@@ -1,17 +1,17 @@
 package net.cordapp.demo.mandelbrot
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class CalculateBlockFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         val colourPalette = Array(255) { IntArray(3) { 0 } }.apply {
             this[0] = intArrayOf(0, 0, 0)

--- a/testing/cpbs/sandbox-scr-cpk/src/main/kotlin/com/example/sandbox/scr/UnauthorisedComponent.kt
+++ b/testing/cpbs/sandbox-scr-cpk/src/main/kotlin/com/example/sandbox/scr/UnauthorisedComponent.kt
@@ -1,11 +1,11 @@
 package com.example.sandbox.scr
 
 import net.corda.v5.application.flows.SubFlow
-import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.runtime.ServiceComponentRuntime
+import org.slf4j.LoggerFactory
 
 @Suppress("unused")
 @Component(name = "unauthorised.scr.flow")
@@ -14,7 +14,8 @@ class UnauthorisedComponent @Activate constructor(
     private val scr: ServiceComponentRuntime
 ) : SubFlow<List<String>> {
     init {
-        loggerFor<UnauthorisedComponent>().info("Activated!")
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        logger.info("Activated!")
     }
 
     override fun call(): List<String> {

--- a/testing/cpbs/sandbox-security-manager-one/src/main/kotlin/com/example/securitymanager/one/flows/FlowEngineFlow.kt
+++ b/testing/cpbs/sandbox-security-manager-one/src/main/kotlin/com/example/securitymanager/one/flows/FlowEngineFlow.kt
@@ -3,14 +3,14 @@ package com.example.securitymanager.one.flows
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.loggerFor
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 
 @Component
 class FlowEngineFlow @Activate constructor(private val context: BundleContext): SubFlow<String> {
-    private val logger = loggerFor<FlowEngineFlow>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     @Suspendable
     override fun call(): String {

--- a/testing/cpbs/test-cordapp-for-cache-testing/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/ReturnAStringFlow.kt
+++ b/testing/cpbs/test-cordapp-for-cache-testing/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/ReturnAStringFlow.kt
@@ -1,14 +1,14 @@
 package net.cordapp.testing.smoketests.virtualnode
 
-import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.ClientStartableFlow
+import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class ReturnAStringFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/testing/cpbs/test-cordapp-for-cache-testing/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
+++ b/testing/cpbs/test-cordapp-for-cache-testing/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
@@ -1,22 +1,22 @@
 package net.cordapp.testing.smoketests.virtualnode
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
 import net.cordapp.testing.bundles.fish.Fish
 import net.cordapp.testing.bundles.fish.Owner
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 @Suppress("unused")
 class SimplePersistenceCheckFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/test-cordapp-without-changelogs/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/NoChangelogFlow.kt
+++ b/testing/cpbs/test-cordapp-without-changelogs/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/NoChangelogFlow.kt
@@ -3,12 +3,12 @@ package net.cordapp.testing.smoketests.virtualnode
 import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class NoChangelogFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/InheritanceTestFlows.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/InheritanceTestFlows.kt
@@ -1,15 +1,15 @@
 package net.cordapp.testing.smoketests.flow
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.membership.MemberInfo
+import org.slf4j.LoggerFactory
 
 interface MemberResolver {
     fun findMember(memberX500Name: String): MemberInfo?
@@ -18,7 +18,7 @@ interface MemberResolver {
 @Suppress("unused")
 abstract class AbstractFlow : ClientStartableFlow, MemberResolver {
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     abstract fun buildOutput(memberInfo: MemberInfo?): String

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -3,11 +3,11 @@ package net.cordapp.testing.smoketests.flow
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
 import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.crypto.SigningService
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.marshalling.parse
@@ -19,7 +19,6 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.serialization.deserialize
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
@@ -31,6 +30,7 @@ import net.cordapp.testing.smoketests.flow.messages.JsonSerializationInput
 import net.cordapp.testing.smoketests.flow.messages.JsonSerializationOutput
 import net.cordapp.testing.smoketests.flow.messages.RpcSmokeTestInput
 import net.cordapp.testing.smoketests.flow.messages.RpcSmokeTestOutput
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 
@@ -39,7 +39,7 @@ import java.util.UUID
 class RpcSmokeTestFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val commandMap: Map<String, (RpcSmokeTestInput) -> String> = mapOf(

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
@@ -13,8 +13,8 @@ import net.corda.v5.application.messaging.receive
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.cordapp.testing.testflows.MyClass
+import org.slf4j.LoggerFactory
 
 @InitiatingFlow(protocol = "SendReceiveAllProtocol")
 class SendReceiveAllMessagingFlow(
@@ -22,7 +22,7 @@ class SendReceiveAllMessagingFlow(
 ) : SubFlow<String> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -100,7 +100,7 @@ class SendReceiveAllMessagingFlow(
 class SendReceiveAllInitiatedFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SubFlowSmokeTestFlows.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SubFlowSmokeTestFlows.kt
@@ -12,8 +12,8 @@ import net.corda.v5.application.messaging.receive
 import net.corda.v5.application.messaging.sendAndReceive
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.cordapp.testing.smoketests.flow.messages.InitiatedSmokeTestMessage
+import org.slf4j.LoggerFactory
 
 @InitiatingFlow("subflow-protocol")
 class InitiatingSubFlowSmokeTestFlow(
@@ -23,7 +23,7 @@ class InitiatingSubFlowSmokeTestFlow(
 ) : SubFlow<InitiatedSmokeTestMessage> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -51,7 +51,7 @@ class InlineSubFlowSmokeTestFlow(
 ) : SubFlow<InitiatedSmokeTestMessage> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable
@@ -71,7 +71,7 @@ class InlineSubFlowSmokeTestFlow(
 class InitiatingSubFlowResponderSmokeTestFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/ReturnAStringFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/ReturnAStringFlow.kt
@@ -1,14 +1,14 @@
 package net.cordapp.testing.smoketests.virtualnode
 
-import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.ClientStartableFlow
+import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 
 class ReturnAStringFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
@@ -1,14 +1,14 @@
 package net.cordapp.testing.smoketests.virtualnode
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
 import net.cordapp.testing.bundles.dogs.Dog
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 
@@ -16,7 +16,7 @@ import java.util.UUID
 class SimplePersistenceCheckFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/MessagingFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/MessagingFlow.kt
@@ -1,12 +1,12 @@
 package net.cordapp.testing.testflows
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.InitiatingFlow
-import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
@@ -18,14 +18,14 @@ import net.corda.v5.application.messaging.sendAndReceive
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.cordapp.testing.testflows.messages.MessageFlowInput
+import org.slf4j.LoggerFactory
 
 @InitiatingFlow(protocol = "flowDevProtocol")
 class MessagingFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -79,7 +79,7 @@ class MessagingFlow : ClientStartableFlow {
 class MessagingInitiatedFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -123,7 +123,7 @@ class MessagingInitiatedFlow : ResponderFlow {
 class InlineSubFlow(private val session: FlowSession) : SubFlow<Unit> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable
@@ -139,7 +139,7 @@ class InlineSubFlow(private val session: FlowSession) : SubFlow<Unit> {
 class InitiatingSubFlow(private val counterparty: MemberX500Name) : SubFlow<Unit> {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject
@@ -160,7 +160,7 @@ class InitiatingSubFlow(private val counterparty: MemberX500Name) : SubFlow<Unit
 class InitiatingSubFlowInitiatedFlow : ResponderFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -1,18 +1,17 @@
 package net.cordapp.testing.testflows
 
 import com.r3.corda.notary.plugin.nonvalidating.client.NonValidatingNotaryClientFlowImpl
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.marshalling.parseList
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.util.hours
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.containsAny
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.common.Party
@@ -23,6 +22,7 @@ import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import org.slf4j.LoggerFactory
 import java.security.PublicKey
 import java.time.Instant
 
@@ -63,7 +63,7 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
     lateinit var jsonMarshallingService: JsonMarshallingService
 
     private companion object {
-        val log = loggerFor<NonValidatingNotaryTestFlow>()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/PersistenceFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/PersistenceFlow.kt
@@ -1,18 +1,18 @@
 package net.cordapp.testing.testflows
 
-import java.time.Instant
-import java.util.UUID
-import net.cordapp.testing.bundles.dogs.Dog
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.util.contextLogger
+import net.cordapp.testing.bundles.dogs.Dog
 import net.cordapp.testing.testflows.messages.TestFlowInput
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
 
 /**
  * The PersistenceFlow exercises various basic db interactions in a flow.
@@ -21,7 +21,7 @@ import net.cordapp.testing.testflows.messages.TestFlowInput
 class PersistenceFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/TestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/TestFlow.kt
@@ -1,17 +1,17 @@
 package net.cordapp.testing.testflows
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.cordapp.testing.testflows.messages.TestFlowInput
 import net.cordapp.testing.testflows.messages.TestFlowOutput
+import org.slf4j.LoggerFactory
 
 /**
  * The Test Flow exercises various basic features of a flow, this flow
@@ -21,7 +21,7 @@ import net.cordapp.testing.testflows.messages.TestFlowOutput
 class TestFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/ledger/TokenSelectionFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/ledger/TokenSelectionFlow.kt
@@ -1,25 +1,25 @@
 package net.cordapp.testing.testflows.ledger
 
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.RestRequestBody
-import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.getRequestBodyAs
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.token.selection.TokenClaim
 import net.corda.v5.ledger.utxo.token.selection.TokenClaimCriteria
 import net.corda.v5.ledger.utxo.token.selection.TokenSelection
 import net.cordapp.testing.testflows.messages.TokenSelectionRequest
 import net.cordapp.testing.testflows.messages.TokenSelectionResponse
+import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 
 class TokenSelectionFlow : ClientStartableFlow {
 
     private companion object {
-        val log = contextLogger()
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpi-info-read-service-fake/src/main/kotlin/net/corda/cpiinfo/read/fake/CpiInfoReadServiceFake.kt
+++ b/testing/cpi-info-read-service-fake/src/main/kotlin/net/corda/cpiinfo/read/fake/CpiInfoReadServiceFake.kt
@@ -13,11 +13,11 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.reconciliation.VersionedRecord
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 @ServiceRanking(Int.MAX_VALUE)
@@ -35,7 +35,7 @@ class CpiInfoReadServiceFake internal constructor(
     ) : this(emptyList(), emptyList(), coordinatorFactory)
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val cpiData = cpiMetadatas.associateBy { it.cpiId }.toMutableMap()

--- a/testing/flow/dummy-link-manager/src/main/kotlin/net/corda/flow/dummy/link/DummyLinkManagerService.kt
+++ b/testing/flow/dummy-link-manager/src/main/kotlin/net/corda/flow/dummy/link/DummyLinkManagerService.kt
@@ -2,6 +2,7 @@ package net.corda.flow.dummy.link
 
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.data.p2p.app.AppMessage
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinator
@@ -17,15 +18,14 @@ import net.corda.lifecycle.createCoordinator
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.data.p2p.app.AppMessage
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
-import net.corda.v5.base.util.contextLogger
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 @Component(service = [DummyLinkManagerService::class], immediate = true)
 class DummyLinkManagerService @Activate constructor(
@@ -38,7 +38,7 @@ class DummyLinkManagerService @Activate constructor(
 ) : Lifecycle {
 
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val CONSUMER_GROUP = "DummyLinkManagerConsumer"
     }
 

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestEventLogProcessor.kt
@@ -1,11 +1,11 @@
 package net.corda.messaging.integration.processors
 
-import java.util.concurrent.CountDownLatch
 import net.corda.data.demo.DemoRecord
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CountDownLatch
 
 class TestEventLogProcessor(
     private val latch: CountDownLatch? = null, private val outputTopic: String? = null, val id: String? = null
@@ -16,7 +16,7 @@ class TestEventLogProcessor(
         get() = DemoRecord::class.java
 
     private companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun onNext(events: List<EventLogRecord<String, DemoRecord>>): List<Record<*, *>> {

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestStateEventProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestStateEventProcessor.kt
@@ -6,7 +6,7 @@ import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.processor.StateAndEventProcessor.Response
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CountDownLatch
 
 class TestStateEventProcessor(
@@ -21,7 +21,7 @@ class TestStateEventProcessor(
             DemoRecord> {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val keyClass: Class<String>

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
@@ -44,7 +44,6 @@ import net.corda.messaging.integration.processors.TestStateEventProcessor
 import net.corda.messaging.integration.processors.TestStateEventProcessorStrings
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.millis
 import net.corda.v5.base.util.seconds
 import org.junit.jupiter.api.Assertions
@@ -57,6 +56,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -67,7 +67,7 @@ class StateAndEventSubscriptionIntegrationTest {
     private lateinit var publisher: Publisher
 
     private companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val CLIENT_ID = "integrationTestEventPublisher"
         const val EVENTSTATE_OUTPUT2 = "EventStateOutputTopic2"

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/CordaPublisher.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/CordaPublisher.kt
@@ -5,8 +5,8 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.emulation.topic.service.TopicService
-import net.corda.v5.base.util.contextLogger
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -20,7 +20,7 @@ class CordaPublisher(
 ) : Publisher {
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val clientId = config.clientId

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/compacted/InMemoryCompactedSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/compacted/InMemoryCompactedSubscription.kt
@@ -9,9 +9,9 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.emulation.topic.model.Consumption
 import net.corda.messaging.emulation.topic.model.RecordMetadata
 import net.corda.messaging.emulation.topic.service.TopicService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -27,7 +27,7 @@ class InMemoryCompactedSubscription<K : Any, V : Any>(
     private val knownValues = ConcurrentHashMap<K, V>()
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     internal val topicName = subscriptionConfig.eventTopic

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/durable/DurableSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/durable/DurableSubscription.kt
@@ -10,8 +10,8 @@ import net.corda.messaging.api.subscription.listener.PartitionAssignmentListener
 import net.corda.messaging.emulation.topic.model.Consumption
 import net.corda.messaging.emulation.topic.model.RecordMetadata
 import net.corda.messaging.emulation.topic.service.TopicService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -25,7 +25,7 @@ internal class DurableSubscription<K : Any, V : Any>(
     private val instanceId: Int
 ) : Subscription<K, V> {
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lifecycleCoordinator = lifecycleCoordinatorFactory.createCoordinator(

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/eventlog/EventLogSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/eventlog/EventLogSubscription.kt
@@ -9,9 +9,9 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.listener.PartitionAssignmentListener
 import net.corda.messaging.emulation.topic.model.Consumption
 import net.corda.messaging.emulation.topic.service.TopicService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -35,7 +35,7 @@ class EventLogSubscription<K : Any, V : Any>(
 ) : Subscription<K, V> {
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var currentConsumer: Consumption? = null

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/pubsub/PubSubSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/pubsub/PubSubSubscription.kt
@@ -9,9 +9,9 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.emulation.topic.model.Consumption
 import net.corda.messaging.emulation.topic.model.RecordMetadata
 import net.corda.messaging.emulation.topic.service.TopicService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -33,7 +33,7 @@ class PubSubSubscription<K : Any, V : Any>(
 ) : Subscription<K, V> {
 
     companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lifecycleCoordinator = lifecycleCoordinatorFactory.createCoordinator(

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/stateandevent/InMemoryStateAndEventSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/stateandevent/InMemoryStateAndEventSubscription.kt
@@ -8,8 +8,8 @@ import net.corda.messaging.api.subscription.StateAndEventSubscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
 import net.corda.messaging.emulation.topic.service.TopicService
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
+import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -25,7 +25,7 @@ class InMemoryStateAndEventSubscription<K : Any, S : Any, E : Any>(
     StateAndEventSubscription<K, S, E> {
 
     companion object {
-        private val log = contextLogger()
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     internal val stateSubscriptionConfig = subscriptionConfig.copy(

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/ConsumptionLoop.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/ConsumptionLoop.kt
@@ -1,7 +1,7 @@
 package net.corda.messaging.emulation.topic.model
 
-import net.corda.v5.base.util.contextLogger
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.read
 
@@ -11,7 +11,7 @@ internal class ConsumptionLoop(
 ) : Runnable {
 
     companion object {
-        private val logger: Logger = contextLogger()
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     private val partitionToLastReadOffset = ConcurrentHashMap<Partition, Long>()
 

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Partition.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Partition.kt
@@ -1,9 +1,9 @@
 package net.corda.messaging.emulation.topic.model
 
 import net.corda.messaging.api.records.Record
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
-import java.util.*
+import org.slf4j.LoggerFactory
+import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
@@ -14,7 +14,7 @@ internal class Partition(
     val topicName: String,
 ) {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     val lock = ReentrantReadWriteLock()

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
@@ -1,10 +1,5 @@
 package net.corda.db.persistence.testkit.components.impl
 
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
-import javax.persistence.EntityManager
-import javax.persistence.EntityManagerFactory
-import javax.sql.DataSource
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.core.CloseableDataSource
 import net.corda.db.core.DbPrivilege
@@ -15,13 +10,18 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.orm.DbEntityManagerConfiguration
 import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.orm.JpaEntitiesSet
-import net.corda.v5.base.util.loggerFor
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import javax.sql.DataSource
 
 private data class NamedDataSource(val id: UUID, val name: String, val dataSource: CloseableDataSource)
 
@@ -33,7 +33,7 @@ class DbConnectionManagerImpl @Activate constructor(
     private val emff: EntityManagerFactoryFactory,
     bundleContext: BundleContext
 ) : DbConnectionManager, DataSourceAdmin {
-    private val logger = loggerFor<DbConnectionManagerImpl>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     private val dataSources = ConcurrentHashMap<UUID, NamedDataSource>()
     private var smartConfig: SmartConfig? = null

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -12,7 +12,7 @@ import net.corda.orm.DbEntityManagerConfiguration
 import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.orm.JpaEntitiesSet
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
-import net.corda.v5.base.util.contextLogger
+import org.slf4j.LoggerFactory
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
@@ -29,7 +29,7 @@ class FakeDbConnectionManager(
     private val emff: EntityManagerFactoryFactory = EntityManagerFactoryFactoryImpl()
 ): DbConnectionManager, DbConnectionOps, DataSourceFactory {
     private companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private data class NamedDataSources(val id: UUID, val name: String, val dataSource: CloseableDataSource)

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
@@ -1,17 +1,17 @@
 package net.corda.testing.sandboxes.testkit.impl
 
-import java.time.Duration
-import java.util.concurrent.CompletableFuture
 import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheControl
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.testing.sandboxes.SandboxSetup
-import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
 
 @Suppress("unused")
 @Component(service = [ SandboxGroupContextComponent::class ])
@@ -20,7 +20,7 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     @Reference
     private val sandboxGroupContextService: SandboxGroupContextService
 ) : SandboxGroupContextComponent, SandboxGroupContextService by sandboxGroupContextService {
-    private val logger = loggerFor<SandboxGroupContextComponentImpl>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     override val isRunning: Boolean = true
 

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
@@ -7,11 +7,11 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.reconciliation.VersionedRecord
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
-import net.corda.v5.base.util.loggerFor
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 @Suppress("unused")
@@ -21,7 +21,7 @@ class CpiInfoServiceImpl @Activate constructor(
     @Reference
     private val loader: CpiLoader
 ): CpiInfoReadService {
-    private val logger = loggerFor<CpiInfoServiceImpl>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     override val lifecycleCoordinatorName = LifecycleCoordinatorName.forComponent<CpiInfoReadService>()
 

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
@@ -1,15 +1,14 @@
 package net.corda.testing.sandboxes.impl
 
 import net.corda.cpk.read.CpkReadService
+import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.libs.packaging.Cpi
-import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.testutils.cpb.packaging.v2.TestCpbReaderV2
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.SecureHash
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
@@ -17,6 +16,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.ConfigurationPolicy.REQUIRE
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file.Paths
@@ -34,7 +34,7 @@ class CpkReadServiceImpl @Activate constructor(
     bundleContext: BundleContext,
     properties: Map<String, Any?>
 ) : CpkReadService, CpiLoader {
-    private val logger = loggerFor<CpkReadService>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     private val cpkDir = (properties[CpiLoader.BASE_DIRECTORY_KEY] as? String)?.let { Paths.get(it) }
         ?: throw IllegalStateException("Base directory not configured")

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -5,19 +5,19 @@ import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.read.NotaryVirtualNodeLookup
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.loggerFor
 import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 
 @Suppress("unused")
 @Component
 @ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
-    private val logger = loggerFor<MembershipGroupReaderProvider>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     override fun getGroupReader(holdingIdentity: HoldingIdentity): MembershipGroupReader {
         return MembershipGroupReaderImpl(holdingIdentity)

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -5,7 +5,6 @@ import net.corda.sandbox.SandboxCreationService
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.impl.SandboxSetupImpl.Companion.INSTALLER_NAME
-import net.corda.v5.base.util.loggerFor
 import org.osgi.framework.BundleContext
 import org.osgi.service.cm.ConfigurationAdmin
 import org.osgi.service.component.ComponentContext
@@ -15,6 +14,7 @@ import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL
 import org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC
+import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.util.Collections.unmodifiableSet
 import java.util.Deque
@@ -68,7 +68,7 @@ class SandboxSetupImpl @Activate constructor(
             "slf4j.api"
         ))
 
-        private val logger = loggerFor<SandboxSetup>()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val cleanups: Deque<AutoCloseable> = LinkedList()

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
@@ -1,16 +1,14 @@
 package net.corda.testing.sandboxes.impl
 
-import net.corda.libs.packaging.core.CpiIdentifier
-import java.util.concurrent.ConcurrentHashMap
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.reconciliation.VersionedRecord
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.VirtualNodeLoader
-import net.corda.v5.base.util.loggerFor
-import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoListener
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -18,8 +16,10 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 
 @Suppress("unused")
@@ -32,7 +32,7 @@ class VirtualNodeLoaderImpl @Activate constructor(
     private val virtualNodeInfoMap = ConcurrentHashMap<HoldingIdentity, VirtualNodeInfo>()
     private val resourcesLookup = mutableMapOf<CpiIdentifier, String>()
     private val cpiResources = mutableMapOf<String, Cpi>()
-    private val logger = loggerFor<VirtualNodeLoader>()
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     override val isRunning: Boolean
         get() = true

--- a/testing/uniqueness/backing-store-fake/src/main/kotlin/net/corda/uniqueness/backingstore/impl/fake/BackingStoreImplFake.kt
+++ b/testing/uniqueness/backing-store-fake/src/main/kotlin/net/corda/uniqueness/backingstore/impl/fake/BackingStoreImplFake.kt
@@ -16,12 +16,11 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.uniqueness.backingstore.BackingStore
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateDetailsImpl
-import net.corda.uniqueness.datamodel.internal.UniquenessCheckTransactionDetailsInternal
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckRequestInternal
+import net.corda.uniqueness.datamodel.internal.UniquenessCheckTransactionDetailsInternal
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateDetails
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
@@ -29,6 +28,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
 import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @ServiceRanking(Int.MAX_VALUE)
 @Component(service = [BackingStore::class])
@@ -39,7 +39,7 @@ open class BackingStoreImplFake @Activate constructor(
 ) : BackingStore {
 
     private companion object {
-        private val log: Logger = contextLogger()
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lifecycleCoordinator: LifecycleCoordinator = coordinatorFactory

--- a/testing/virtual-node-info-read-service-fake/src/main/kotlin/net/corda/virtualnode/read/fake/VirtualNodeInfoReadServiceFake.kt
+++ b/testing/virtual-node-info-read-service-fake/src/main/kotlin/net/corda/virtualnode/read/fake/VirtualNodeInfoReadServiceFake.kt
@@ -10,9 +10,8 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.reconciliation.VersionedRecord
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.util.contextLogger
-import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoListener
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -21,6 +20,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.stream.Stream
 
@@ -40,7 +40,7 @@ class VirtualNodeInfoReadServiceFake internal constructor(
     ) : this(emptyMap(), emptyList(), coordinatorFactory)
 
     companion object {
-        val logger = contextLogger()
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val file = File("virtual-node-info-read-service-fake.yaml")
     }

--- a/tools/crypto-tck/src/main/kotlin/net/corda/crypto/tck/impl/CryptoTCKImpl.kt
+++ b/tools/crypto-tck/src/main/kotlin/net/corda/crypto/tck/impl/CryptoTCKImpl.kt
@@ -7,7 +7,6 @@ import net.corda.crypto.tck.ExecutionBuilder
 import net.corda.crypto.tck.ExecutionOptions
 import net.corda.crypto.tck.impl.compliance.CryptoServiceCompliance
 import net.corda.crypto.tck.impl.compliance.SessionInactivityCompliance
-import net.corda.v5.base.util.contextLogger
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.engine.JupiterTestEngine
 import org.junit.platform.engine.discovery.DiscoverySelectors
@@ -24,6 +23,7 @@ import org.opentest4j.TestAbortedException
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 import java.io.PrintWriter
 
 @Component(service = [CryptoTCK::class], immediate = true)
@@ -32,7 +32,7 @@ class CryptoTCKImpl @Activate constructor(
     override val schemeMetadata: CipherSchemeMetadata
 ) : CryptoTCK {
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val version: String by lazy(LazyThreadSafetyMode.PUBLICATION) {

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/TopicPlugin.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/TopicPlugin.kt
@@ -9,7 +9,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
 import java.io.FileInputStream
-import java.util.*
+import java.util.Properties
 
 class TopicPlugin(wrapper: PluginWrapper) : Plugin(wrapper) {
 


### PR DESCRIPTION
Removed use of `contextLogger` and `loggerFor` as they should not be in the API lib.

API change: https://github.com/corda/corda-api/pull/813