### PR TITLE
NOTICK: bump gradle ent versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.jpa' apply false
     id 'io.gitlab.arturbosch.detekt' apply false
     id 'biz.aQute.bnd.builder' apply false
-    id "org.gradle.test-retry" apply false
     id 'com.adarshr.test-logger' version '3.2.0' apply false
     id 'io.snyk.gradle.plugin.snykplugin'
     id 'idea'
@@ -56,7 +55,6 @@ allprojects {
     }
 
     apply plugin: 'org.jetbrains.kotlin.jvm'
-    apply plugin: "org.gradle.test-retry" 
 
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -146,7 +146,6 @@ kotlin.build.report.output=file,build_scan
 
 gradleEnterpriseVersion = 3.12.2
 gradleDataPlugin = 1.8.2
-gradleTestRetryPluginVersion = 1.5.1
 org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
 #snyk version

--- a/gradle.properties
+++ b/gradle.properties
@@ -144,9 +144,9 @@ profilerVersion=2022.3
 # Kotlin build
 kotlin.build.report.output=file,build_scan
 
-gradleEnterpriseVersion = 3.11.4
+gradleEnterpriseVersion = 3.12.2
 gradleDataPlugin = 1.8.2
-gradleTestRetryPluginVersion = 1.5.0
+gradleTestRetryPluginVersion = 1.5.1
 org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
 #snyk version

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,6 @@ pluginManagement {
         id 'net.corda.plugins.cordapp-cpb2' version cordaGradlePluginsVersion
         id 'io.gitlab.arturbosch.detekt' version detektPluginVersion
         id 'com.github.ben-manes.versions' version dependencyCheckVersion
-        id "org.gradle.test-retry" version gradleTestRetryPluginVersion
         id "com.jfrog.artifactory" version artifactoryPluginVersion
         id 'io.snyk.gradle.plugin.snykplugin' version snykVersion
         id 'org.jetbrains.dokka' version dokkaVersion


### PR DESCRIPTION
Bump various plugins related to Gradle Ent - [release notes ](https://plugins.gradle.org/plugin/com.gradle.enterprise/3.12)

Note test retry plugin was removed due to the following from release notes (they are now bundled together) 

`- [NEW] Test Retry: Test retry functionality provided by the Test-Retry Gradle plugin is integrated
`