### PR TITLE
CORE-9741 Move encryption config in Helm overrides

### DIFF
--- a/charts/corda/templates/_helpers.tpl
+++ b/charts/corda/templates/_helpers.tpl
@@ -697,29 +697,27 @@ Kafka SASL init container
 {{- end }}
 
 {{/*
-DB SALT and Passphrase environment variable
-NOTE: some of then naming here is incorrect.
-      These variables have nothing to do with the DB or DB Worker, but are common for all worker types.
+SALT and PASSPHRASE environment variables for decrypting configuration.
 */}}
 {{- define "corda.configSaltAndPassphraseEnv" -}}
 - name: SALT
   valueFrom:
     secretKeyRef:
-      {{- if .Values.workers.db.salt.valueFrom.secretKeyRef.name }}
-      name: {{ .Values.workers.db.salt.valueFrom.secretKeyRef.name | quote }}
-      key: {{ required "Must specify workers.db.salt.valueFrom.secretKeyRef.key" .Values.workers.db.salt.valueFrom.secretKeyRef.key | quote }}
+      {{- if .Values.config.encryption.salt.valueFrom.secretKeyRef.name }}
+      name: {{ .Values.config.encryption.salt.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required "Must specify config.encryption.salt.valueFrom.secretKeyRef.key" .Values.config.encryption.salt.valueFrom.secretKeyRef.key | quote }}
       {{- else }}
-      name: {{ (printf "%s-db-worker" (include "corda.fullname" .)) | quote }}
+      name: {{ (printf "%s-config" (include "corda.fullname" .)) | quote }}
       key: "salt"
       {{- end }}
 - name: PASSPHRASE
   valueFrom:
     secretKeyRef:
-      {{- if .Values.workers.db.passphrase.valueFrom.secretKeyRef.name }}
-      name: {{ .Values.workers.db.passphrase.valueFrom.secretKeyRef.name | quote }}
-      key: {{ required "Must specify workers.db.passphrase.valueFrom.secretKeyRef.key" .Values.workers.db.passphrase.valueFrom.secretKeyRef.key | quote }}
+      {{- if .Values.config.encryption.passphrase.valueFrom.secretKeyRef.name }}
+      name: {{ .Values.config.encryption.passphrase.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required "Must specify config.encryption.passphrase.valueFrom.secretKeyRef.key" .Values.workers.db.passphrase.valueFrom.secretKeyRef.key | quote }}
       {{- else }}
-      name: {{ (printf "%s-db-worker" (include "corda.fullname" .)) | quote }}
+      name: {{ (printf "%s-config" (include "corda.fullname" .)) | quote }}
       key: "passphrase" 
       {{- end }}
 {{- end }}

--- a/charts/corda/templates/config-secret.yaml
+++ b/charts/corda/templates/config-secret.yaml
@@ -1,7 +1,7 @@
-{{- if or ( not .Values.workers.db.salt.valueFrom.secretKeyRef.name) ( not .Values.workers.db.passphrase.valueFrom.secretKeyRef.name) }}
+{{- if or ( not .Values.config.encryption.salt.valueFrom.secretKeyRef.name) ( not .Values.config.encryption.passphrase.valueFrom.secretKeyRef.name) }}
 apiVersion: v1
 kind: Secret
-{{- $name := printf "%s-db-worker" (include "corda.fullname" .) }}
+{{- $name := printf "%s-config" (include "corda.fullname" .) }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $name }}
 metadata:
   annotations:
@@ -13,9 +13,9 @@ metadata:
     {{- include "corda.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if (not .Values.workers.db.salt.valueFrom.secretKeyRef.name) }}
-{{- if .Values.workers.db.salt.value }}
-  salt: {{ .Values.workers.db.salt.value }}
+{{- if (not .Values.config.encryption.salt.valueFrom.secretKeyRef.name) }}
+{{- if .Values.config.encryption.salt.value }}
+  salt: {{ .Values.config.encryption.salt.value }}
 {{- else }}
 {{- if $existingSecret }}
   salt: {{ index $existingSecret.data "salt" }}
@@ -24,9 +24,9 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if (not .Values.workers.db.passphrase.valueFrom.secretKeyRef.name) }}
-{{- if .Values.workers.db.passphrase.value }}
-  passphrase: {{ .Values.workers.db.passphrase.value }}
+{{- if (not .Values.config.encryption.passphrase.valueFrom.secretKeyRef.name) }}
+{{- if .Values.config.encryption.passphrase.value }}
+  passphrase: {{ .Values.config.encryption.passphrase.value }}
 {{- else }}
 {{- if $existingSecret }}
   passphrase: {{ index $existingSecret.data "passphrase" }}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1027,8 +1027,6 @@
                                 "profiling": {
                                     "enabled": false
                                 },
-                                "salt": "password",
-                                "passphrase": "password",
                                 "resources": {
                                     "requests": {
                                         "cpu": "1",
@@ -1413,8 +1411,6 @@
                     "profiling": {
                         "enabled": false
                     },
-                    "salt": "",
-                    "passphrase": "",
                     "resources": {
                         "requests": {
                             "cpu": "1",

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -890,6 +890,33 @@
                 }
             }
         },
+        "config": {
+            "type": "object",
+            "title": "config service configuration",
+            "required": [
+                "encryption"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "encryption": {
+                    "type": "object",
+                    "title": "configuration for encryption of configuration",
+                    "required": [
+                        "salt",
+                        "passphrase"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "salt": {
+                            "$ref": "#/$defs/config"
+                        },
+                        "passphrase": {
+                            "$ref": "#/$defs/config"
+                        }
+                    }
+                }
+            }
+        },
         "workers": {
             "type": "object",
             "default": {},
@@ -981,12 +1008,6 @@
                                             ]
                                         }
                                     }
-                                },
-                                "salt": {
-                                    "$ref": "#/$defs/config"
-                                },
-                                "passphrase": {
-                                    "$ref": "#/$defs/config"
                                 }
                             },
                             "examples": [{

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -326,6 +326,35 @@ bootstrap:
   serviceAccount:
     name: ""
 
+# config service configuration
+config:
+  # the configuration for encryption of configuration
+  encryption:
+    # the salt configuration for encryption of configuration
+    salt:
+      # -- the salt for encryption of configuration, defaults to a value randomly-generated on install
+      value: ""
+      # the salt secret configuration; if name is specified, used in preference to config.encryption.salt.value
+      valueFrom:
+        # the salt secret key reference
+        secretKeyRef:
+          # -- the name of the secret containing the salt for encryption of configuration; if specified, used in preference to config.encryption.salt.value
+          name: ""
+          # -- the key in the secret containing the salt for encryption of configuration
+          key: ""
+    # the passphrase configuration for encryption of configuration
+    passphrase:
+      # -- the passphrase for encryption of configuration, defaults to a value randomly-generated on install
+      value: ""
+      # the passphrase secret configuration; if name is specified, used in preference to config.encryption.passphrase.value
+      valueFrom:
+        # the passphrase secret key reference
+        secretKeyRef:
+          # -- the name of the secret containing the passphrase for encryption of configuration; if specified, used in preference to config.encryption.passphrase.value
+          name: ""
+          # -- the key in the secret containing the passphrase for encryption of configuration
+          key: ""
+
 # worker configuration
 workers:
   # crypto worker configuration
@@ -429,30 +458,6 @@ workers:
     profiling:
       # -- run DB worker with profiling enabled
       enabled: false
-    # the salt configuration 
-    salt: 
-      # -- the salt, defaults to a value randomly-generated on install
-      value: ""
-      # the salt secret configuration; used in preference to value if name is set
-      valueFrom:
-        # the salt secret key reference
-        secretKeyRef:
-          # -- the salt secret name
-          name: ""
-          # -- the salt secret key
-          key: ""
-    # passphrase configuration
-    passphrase: 
-      # -- the passphrase, defaults to a value randomly-generated on install
-      value: ""
-      # the passphrase secret configuration
-      valueFrom:
-        # the passphrase secret key reference
-        secretKeyRef:
-          # -- the passphrase secret name
-          name: ""
-          # -- the passphrase secret key
-          key: ""
 
     # resource limits and requests configuration for the DB worker containers.
     resources:


### PR DESCRIPTION
Moves workers.db.salt/passphrase to config.encryption.salt/passphrase as these values are not specific to the DB worker. Also renames the secret that is used to store the values  from *-db-worker to *-config.