### PR TITLE
CORE-8029 Modified 'libs/json-serialization' README to replace RPC with REST

### DIFF
--- a/libs/http-rpc/json-serialization/README.md
+++ b/libs/http-rpc/json-serialization/README.md
@@ -1,3 +1,3 @@
-# HTTP RPC Json Serialization
+# REST JSON Serialization
 
 This module contains helper methods for JSON marshalling of commonly used Corda data structures.


### PR DESCRIPTION
This PR satisfies [CORE-8029 ](https://r3-cev.atlassian.net/browse/CORE-8029)as part of the [CORE-7040](https://r3-cev.atlassian.net/browse/CORE-8029) epic; just a straightforward .README change.

[CORE-7040]: https://r3-cev.atlassian.net/browse/CORE-7040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ