### PR TITLE
NOTICK: Sort each sandbox's CPK bundles by ascending bundle ID.

### DIFF
--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -13,7 +13,9 @@ import net.corda.sandbox.internal.utilities.BundleUtils
 import net.corda.v5.base.util.debug
 import org.osgi.framework.Bundle
 import org.slf4j.LoggerFactory
-import java.util.Collections.unmodifiableMap
+import java.util.Collections.unmodifiableSortedMap
+import java.util.SortedMap
+import java.util.TreeMap
 
 /**
  * An implementation of the [SandboxGroup] interface.
@@ -30,11 +32,11 @@ internal class SandboxGroupImpl(
     private val bundleUtils: BundleUtils
 ) : SandboxGroupInternal {
 
-    companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    private companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    override val metadata: Map<Bundle, CpkMetadata> = unmodifiableMap(cpkSandboxes.associate { cpk ->
+    override val metadata: SortedMap<Bundle, CpkMetadata> = unmodifiableSortedMap(cpkSandboxes.associateTo(TreeMap()) { cpk ->
         cpk.mainBundle to cpk.cpkMetadata
     })
 


### PR DESCRIPTION
Store the sandbox group's CPK bundles inside a `SortedMap` to ensure that their iteration order is stable. This potentially removes a source of non-deterministic behaviour in the sandbox code.