### PR TITLE
CORE-9786: Use SandboxGroup Id for "corda.sandbox" property value.

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.testing.fakes
 
 import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import net.corda.flow.pipeline.FlowEventContext
 import net.corda.flow.pipeline.sandbox.SandboxDependencyInjector
@@ -47,7 +48,7 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
         virtualNodeContext: VirtualNodeContext,
         initializer: SandboxGroupContextInitializer
     ): SandboxGroupContext {
-        return FakeSandboxGroupContext(virtualNodeContext, FakeSandboxGroup(mapOf()), initiatingToInitiatedFlowsMap)
+        return FakeSandboxGroupContext(virtualNodeContext, FakeSandboxGroup(UUID.randomUUID(), mapOf()), initiatingToInitiatedFlowsMap)
     }
 
     override fun registerMetadataServices(
@@ -160,7 +161,7 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
         }
     }
 
-    class FakeSandboxGroup(override val metadata: Map<Bundle, CpkMetadata>) : SandboxGroup {
+    class FakeSandboxGroup(override val id: UUID, override val metadata: Map<Bundle, CpkMetadata>) : SandboxGroup {
         override fun loadClassFromMainBundles(className: String): Class<*> {
             TODO("Not yet implemented")
         }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -56,6 +56,7 @@ import java.util.Hashtable
 import java.util.LinkedList
 import java.util.SortedMap
 import java.util.TreeMap
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 typealias SatisfiedServiceReferences = Map<String, SortedMap<ServiceReference<*>, Any>>
@@ -97,12 +98,9 @@ class SandboxGroupContextServiceImpl @Activate constructor(
         private val systemFilter = FrameworkUtil.createFilter(CORDA_SYSTEM_FILTER)
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
-        private val sandboxServiceProperties = Hashtable<String, Any?>().apply {
-            put(CORDA_SANDBOX, true)
-        }
-
-        private fun ServiceReference<*>.copyPropertiesForSandbox(): Hashtable<String, Any?> {
-            return Hashtable(sandboxServiceProperties).also { props ->
+        private fun ServiceReference<*>.copyPropertiesForSandbox(sandboxId: UUID): Hashtable<String, Any?> {
+            return Hashtable<String, Any?>().also { props ->
+                props[CORDA_SANDBOX] = sandboxId
                 propertyKeys.forEach { key ->
                     props[key] = getProperty(key)
                 }
@@ -196,7 +194,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                 val sandboxGroupContext = SandboxGroupContextImpl(vnc, sandboxGroup)
 
                 // Register common OSGi services for use within this sandbox.
-                val commonServiceRegistrations = registerCommonServices(vnc, sandboxGroup.metadata.keys)?.let {
+                val commonServiceRegistrations = registerCommonServices(sandboxGroupContext)?.let {
                     sandboxGroupContext.putObjectByKey(SANDBOX_SINGLETONS, it.first)
                     it.second
                 }
@@ -204,6 +202,9 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                 // Run the caller's initializer.
                 val initializerAutoCloseable =
                     initializer.initializeSandboxGroupContext(vnc.holdingIdentity, sandboxGroupContext)
+
+                logger.debug("Created {} sandbox {} for holding identity={}",
+                    vnc.sandboxGroupType, sandboxGroup.id, vnc.holdingIdentity)
 
                 // Wrapped SandboxGroupContext, specifically to set closeable and forward on all other calls.
 
@@ -224,9 +225,12 @@ class SandboxGroupContextServiceImpl @Activate constructor(
         }
     }
 
-    private fun registerCommonServices(vnc: VirtualNodeContext, bundles: Iterable<Bundle>): Pair<Set<*>, Collection<AutoCloseable>>? {
+    private fun registerCommonServices(sandboxGroupContext: SandboxGroupContext): Pair<Set<*>, Collection<AutoCloseable>>? {
+        val sandboxGroup = sandboxGroupContext.sandboxGroup
+        val bundles = sandboxGroup.metadata.keys
         val targetContext = bundles.firstOrNull()?.bundleContext ?: return null
-        return createSandboxServiceContext(vnc, bundles).registerInjectables(targetContext)
+        return createSandboxServiceContext(sandboxGroup.id, sandboxGroupContext.virtualNodeContext, bundles)
+            .registerInjectables(targetContext)
     }
 
     /**
@@ -250,7 +254,11 @@ class SandboxGroupContextServiceImpl @Activate constructor(
      * Identify which of these services should be registered with the OSGi framework.
      */
     @Suppress("ComplexMethod")
-    private fun createSandboxServiceContext(vnc: VirtualNodeContext, bundles: Iterable<Bundle>): SandboxServiceContext {
+    private fun createSandboxServiceContext(
+        sandboxId: UUID,
+        vnc: VirtualNodeContext,
+        bundles: Iterable<Bundle>
+    ): SandboxServiceContext {
         val injectables = mutableMapOf<ServiceReference<*>, ServiceDefinition>()
         val serviceIndex = mutableMapOf<String, MutableSet<ServiceReference<*>>>()
 
@@ -309,7 +317,13 @@ class SandboxGroupContextServiceImpl @Activate constructor(
             serviceIndex[markerName] = emptyImmutableSet
         }
 
-        return SandboxServiceContext(bundleContext, serviceComponentRuntime, serviceIndex, injectables)
+        return SandboxServiceContext(
+            sandboxId = sandboxId,
+            sourceContext = bundleContext,
+            serviceComponentRuntime,
+            serviceIndex,
+            injectables
+        )
     }
 
     override fun registerMetadataServices(
@@ -318,8 +332,8 @@ class SandboxGroupContextServiceImpl @Activate constructor(
         isMetadataService: (Class<*>) -> Boolean,
         serviceMarkerType: Class<*>
     ): AutoCloseable {
-        val groupMetadata = sandboxGroupContext.sandboxGroup.metadata
-        val services = groupMetadata.flatMap { (mainBundle, cpkMetadata) ->
+        val group = sandboxGroupContext.sandboxGroup
+        val services = group.metadata.flatMap { (mainBundle, cpkMetadata) ->
             // Fetch metadata classes provided by each CPK main bundle.
             serviceNames(cpkMetadata).mapNotNull { serviceName ->
                 mainBundle.loadMetadataService(serviceName, isMetadataService)
@@ -327,7 +341,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
         }
 
         // Register each metadata service as an OSGi service for its host main bundle.
-        val (instances, registrations) = registerMetadataServices(serviceMarkerType.name, services)
+        val (instances, registrations) = registerMetadataServices(group.id, serviceMarkerType.name, services)
         (sandboxGroupContext as? MutableSandboxGroupContext)?.putObjectByKey(serviceMarkerType.name, instances)
         return AutoCloseable {
             registrations.forEach { registration ->
@@ -337,6 +351,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
     }
 
     private fun registerMetadataServices(
+        sandboxId: UUID,
         serviceMarkerTypeName: String,
         services: Iterable<Pair<Class<*>, Bundle>>
     ): Pair<Set<Any>, Deque<AutoCloseable>> {
@@ -358,7 +373,9 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                 val registration = serviceBundle.bundleContext.registerService(
                     serviceInterfaces.toTypedArray(),
                     serviceObj,
-                    sandboxServiceProperties
+                    Hashtable<String, Any?>().also { props ->
+                        props[CORDA_SANDBOX] = sandboxId
+                    }
                 )
 
                 logger.info("Registered Metadata Service [{}] for bundle [{}][{}]",
@@ -440,6 +457,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
      * likely require several other - possible non-injectable - services as parameters
      * too. The algorithm is therefore a bit tricky.
      *
+     * @property sandboxId unique identifier for our sandbox instance.
      * @property sourceContext the [BundleContext] of [SandboxGroupContextComponentImpl].
      * @property serviceComponentRuntime a reference to OSGi's [ServiceComponentRuntime].
      * @property injectables the services we know we still need to create.
@@ -465,6 +483,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
      * anything new.
      */
     private class SandboxServiceContext(
+        private val sandboxId: UUID,
         private val sourceContext: BundleContext,
         private val serviceComponentRuntime: ServiceComponentRuntime,
         private val serviceIndex: Map<String, MutableSet<ServiceReference<*>>>,
@@ -596,7 +615,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                 val serviceRegistration = targetContext.registerService(
                     serviceClassNames.toTypedArray(),
                     serviceObj,
-                    serviceFactory.serviceReference.copyPropertiesForSandbox()
+                    serviceFactory.serviceReference.copyPropertiesForSandbox(sandboxId)
                 )
                 if (logger.isDebugEnabled) {
                     logger.debug("Registered sandbox service {}[{}] for bundle [{}][{}]",

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -16,16 +16,19 @@ import org.slf4j.LoggerFactory
 import java.util.Collections.unmodifiableSortedMap
 import java.util.SortedMap
 import java.util.TreeMap
+import java.util.UUID
 
 /**
  * An implementation of the [SandboxGroup] interface.
  *
- * @param cpkSandboxes The CPK sandboxes in this sandbox group.
+ * @property id Unique identifier for this sandbox group.
+ * @property cpkSandboxes The CPK sandboxes in this sandbox group.
  * @param publicSandboxes An iterable containing all existing public sandboxes.
  * @param classTagFactory Used to generate class tags.
  * @param bundleUtils The utils that all OSGi activity is delegated to for testing purposes.
  */
 internal class SandboxGroupImpl(
+    override val id: UUID,
     override val cpkSandboxes: Collection<CpkSandbox>,
     private val publicSandboxes: Iterable<Sandbox>,
     private val classTagFactory: ClassTagFactory,

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -247,7 +247,13 @@ internal class SandboxServiceImpl @Activate constructor(
             startBundles(bundles)
         }
 
-        val sandboxGroup = SandboxGroupImpl(newSandboxes, publicSandboxes, ClassTagFactoryImpl(), bundleUtils)
+        val sandboxGroup = SandboxGroupImpl(
+            id = UUID.randomUUID(),
+            cpkSandboxes = newSandboxes,
+            publicSandboxes,
+            ClassTagFactoryImpl(),
+            bundleUtils
+        )
 
         bundles.forEach { bundle ->
             bundleIdToSandboxGroup[bundle.bundleId] = sandboxGroup

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
@@ -69,7 +69,7 @@ class SandboxGroupImplTests {
     private val publicSandbox = SandboxImpl(randomUUID(), setOf(mockPublicBundle), setOf(mockPublicLibraryBundle))
 
     private val sandboxGroupImpl = SandboxGroupImpl(
-        setOf(cpkSandbox), setOf(publicSandbox), DummyClassTagFactory(cpkSandbox.cpkMetadata), mockBundleUtils
+        randomUUID(), setOf(cpkSandbox), setOf(publicSandbox), DummyClassTagFactory(cpkSandbox.cpkMetadata), mockBundleUtils
     )
 
     @Test

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxGroup.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxGroup.kt
@@ -1,5 +1,6 @@
 package net.corda.sandbox
 
+import java.util.UUID
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.framework.Bundle
@@ -7,9 +8,12 @@ import org.osgi.framework.Bundle
 /**
  * A group of sandboxes with visibility of one another.
  *
- * @property cpks The CPKs this sandbox group is constructed from.
+ * @property id A unique identifier for this [SandboxGroup].
+ * @property metadata [CpkMetadata] for each CPK's "main" bundle.
  */
 interface SandboxGroup: SingletonSerializeAsToken {
+    val id: UUID
+
     val metadata: Map<Bundle, CpkMetadata>
 
     /**

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/serialization/BaseSerializationService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/serialization/BaseSerializationService.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.serialization
 
+import java.util.UUID
 import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.impl.serialization.PublicKeySerializer
@@ -55,7 +56,7 @@ class BaseSerializationService(
                 objectReferencesEnabled = false,
                 useCase = SerializationContext.UseCase.Testing,
                 encoding = null,
-                sandboxGroup = SimSandboxGroup()
+                sandboxGroup = SimSandboxGroup(UUID.randomUUID())
             )
             val factory = buildDefaultFactoryNoEvolution(
                 registerMoreSerializers,
@@ -69,6 +70,7 @@ class BaseSerializationService(
         }
 
         private class SimSandboxGroup(
+            override val id: UUID,
             private val classLoader: ClassLoader = ClassLoader.getSystemClassLoader()
         ) : SandboxGroup {
 

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
@@ -2,6 +2,7 @@
 
 package net.corda.internal.serialization.amqp.helper
 
+import java.util.UUID
 import java.util.function.Supplier
 import net.corda.internal.serialization.SerializationContextImpl
 import net.corda.internal.serialization.amqp.SerializerFactory
@@ -14,7 +15,10 @@ import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.serialization.SerializationContext
 import org.osgi.framework.Bundle
 
-private class MockSandboxGroup(private val classLoader: ClassLoader = ClassLoader.getSystemClassLoader()) : SandboxGroup {
+private class MockSandboxGroup(
+    override val id: UUID,
+    private val classLoader: ClassLoader = ClassLoader.getSystemClassLoader()
+) : SandboxGroup {
     override val metadata: Map<Bundle, CpkMetadata> = emptyMap()
 
     override fun loadClassFromMainBundles(className: String): Class<*> =
@@ -36,7 +40,7 @@ val testSerializationContext = SerializationContextImpl(
     objectReferencesEnabled = false,
     useCase = SerializationContext.UseCase.Testing,
     encoding = null,
-    sandboxGroup = MockSandboxGroup()
+    sandboxGroup = MockSandboxGroup(UUID.randomUUID())
 )
 
 /**


### PR DESCRIPTION
Replace `corda.sandbox=true` sandbox service property with `corda.sandbox=<sandbox group id>`. Our OSGi sandbox resolving hooks _should_ ensure that a given sandbox can only "see" services registered for its own `SandboxGroup` instance. `SandboxDependencyInjectorFactoryImpl` can now use the `corda.sanbox` property to check that this is true.