### PR TITLE
NOTICK Remove unneeded separate tracking of DB manager bootstrapping

### DIFF
--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -205,7 +205,7 @@ class DBProcessorImpl @Activate constructor(
         when (event) {
             is StartEvent -> onStartEvent()
             is RegistrationStatusChangeEvent -> onRegistrationStatusChangeEvent(event, coordinator)
-            is ConfigChangedEvent -> reconcilers.onConfigChanged(event)
+            is ConfigChangedEvent -> onConfigChangedEvent(event)
             is BootConfigEvent -> onBootConfigEvent(event)
             is StopEvent -> onStopEvent()
             else -> log.error("Unexpected event $event!")
@@ -246,6 +246,13 @@ class DBProcessorImpl @Activate constructor(
             )
         }
         coordinator.updateStatus(event.status)
+    }
+
+    private fun onConfigChangedEvent(
+        event: ConfigChangedEvent,
+    ) {
+        // Creates and starts the rest of the reconcilers
+        reconcilers.onConfigChanged(event)
     }
 
     private fun onStartEvent() {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -187,8 +187,6 @@ class DBProcessorImpl @Activate constructor(
         allowedCertificatesReaderWriterService,
     )
 
-    private var instanceId: Int? = null
-
     override fun start(bootConfig: SmartConfig) {
         log.info("DB processor starting.")
         lifecycleCoordinator.start()
@@ -216,7 +214,7 @@ class DBProcessorImpl @Activate constructor(
 
     private fun onBootConfigEvent(event: BootConfigEvent) {
         val bootstrapConfig = event.config
-        instanceId = bootstrapConfig.getInt(INSTANCE_ID)
+        val instanceId = bootstrapConfig.getInt(INSTANCE_ID)
 
         log.info("Bootstrapping DB connection Manager")
         dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB_PARAMS))


### PR DESCRIPTION
- removes unneeded separated tracking of DB manager in `DBProcessorImpl` which used to support old code and is now removed
- uses managed resources coordinator API