### PR TITLE
CORE-9807: Fix Status Transition in RPCSubscription

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListener.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListener.kt
@@ -20,21 +20,24 @@ class RPCConsumerRebalanceListener<RESPONSE>(
     private val partitions = mutableListOf<CordaTopicPartition>()
 
     override fun onPartitionsRevoked(partitions: Collection<CordaTopicPartition>) {
+        super.onPartitionsRevoked(partitions)
+
         tracker.removePartitions(partitions.toList())
         this.partitions.removeAll(partitions)
-        if (this.partitions.isEmpty()){
+        if (this.partitions.isEmpty()) {
             lifecycleStatusUpdater.updateLifecycleStatus(LifecycleStatus.DOWN)
         }
-        super.onPartitionsRevoked(partitions)
     }
 
     override fun onPartitionsAssigned(partitions: Collection<CordaTopicPartition>) {
-        if (this.partitions.isEmpty()){
+        super.onPartitionsAssigned(partitions)
+
+        if (this.partitions.isEmpty() && partitions.isNotEmpty()) {
             lifecycleStatusUpdater.updateLifecycleStatus(LifecycleStatus.UP)
         }
         tracker.addPartitions(partitions.toList())
         this.partitions.addAll(partitions)
-        super.onPartitionsAssigned(partitions)
+
     }
 
     fun getPartitions(): List<CordaTopicPartition> {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/FutureTracker.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/FutureTracker.kt
@@ -55,5 +55,4 @@ class FutureTracker<RESPONSE> {
             futuresInPartitionMap.remove(partition.partition)
         }
     }
-
 }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListenerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListenerTest.kt
@@ -4,12 +4,24 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messaging.subscription.LifecycleStatusUpdater
 import net.corda.messaging.utils.FutureTracker
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 
 class RPCConsumerRebalanceListenerTest {
+    private lateinit var lifecycleStatusUpdater: LifecycleStatusUpdater
+    private lateinit var listener : RPCConsumerRebalanceListener<String>
+    private val firstTopicPartition = CordaTopicPartition("test", 0)
+    private val secondTopicPartition = CordaTopicPartition("test", 1)
+
+    @BeforeEach
+    fun setup() {
+        lifecycleStatusUpdater = mock()
+        listener = RPCConsumerRebalanceListener<String>("", "", FutureTracker(), lifecycleStatusUpdater)
+    }
 
     @Test
     fun `Test up and down status changes are triggered correctly`() {
@@ -21,5 +33,26 @@ class RPCConsumerRebalanceListenerTest {
 
         listener.onPartitionsRevoked(mutableListOf(CordaTopicPartition("test", 0)))
         verify(lifecycleStatusUpdater, times(1)).updateLifecycleStatus(LifecycleStatus.DOWN)
+    }
+
+    @Test
+    fun `sets status to DOWN when there are no partitions assigned`() {
+        listener.onPartitionsAssigned(mutableListOf(firstTopicPartition, secondTopicPartition))
+        verify(lifecycleStatusUpdater, times(1)).updateLifecycleStatus(LifecycleStatus.UP)
+
+        listener.onPartitionsRevoked(mutableListOf(firstTopicPartition))
+        verify(lifecycleStatusUpdater, never()).updateLifecycleStatus(LifecycleStatus.DOWN)
+
+        listener.onPartitionsRevoked(mutableListOf(secondTopicPartition))
+        verify(lifecycleStatusUpdater, times(1)).updateLifecycleStatus(LifecycleStatus.DOWN)
+    }
+
+    @Test
+    fun `sets status to UP when there is at least one partitions assigned`() {
+        listener.onPartitionsAssigned(mutableListOf())
+        verify(lifecycleStatusUpdater, never()).updateLifecycleStatus(LifecycleStatus.UP)
+
+        listener.onPartitionsAssigned(mutableListOf(firstTopicPartition))
+        verify(lifecycleStatusUpdater, times(1)).updateLifecycleStatus(LifecycleStatus.UP)
     }
 }


### PR DESCRIPTION
The listener sets the subscription status as 'DOWN' whenever there are
no partitions assigned and back to 'UP' again within
'onPartitionsAssigned' callback. The latter, however, is always invoked
when the cooperative rebalance algorithm is used (it might receive an
empty list of partitions or not), so it should set the status as 'UP'
if and only if the current set of assigned partitions is empty and the
received list of partitions is not, otherwise it might wrongly
transition the subscription to 'UP' even though it should have stayed
as 'DOWN'.
