### PR TITLE
CORE-9797: CertificatesClient 503 on Repartition

### DIFF
--- a/components/membership/membership-http-rpc-impl/build.gradle
+++ b/components/membership/membership-http-rpc-impl/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation project(":components:virtual-node:virtual-node-info-read-service-rpc-extensions")
     implementation project(':components:configuration:configuration-read-service')
     implementation project(":libs:crypto:crypto-core")
+    implementation project(":libs:messaging:messaging")
     implementation project(":libs:http-rpc:rest")
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(':libs:membership:certificates-common')

--- a/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-http-rpc-impl/src/main/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImpl.kt
@@ -106,7 +106,7 @@ class CertificatesRestResourceImpl @Activate constructor(
                 tenantId = tenantId,
                 ids = listOf(keyId)
             )
-        }!!.firstOrNull() ?: throw ResourceNotFoundException("Can not find any key with ID $keyId for $tenantId")
+        }.firstOrNull() ?: throw ResourceNotFoundException("Can not find any key with ID $keyId for $tenantId")
         val publicKey = keyEncodingService.decodePublicKey(key.publicKey.array())
 
         val extensionsGenerator = ExtensionsGenerator()
@@ -222,7 +222,7 @@ class CertificatesRestResourceImpl @Activate constructor(
                 usageType,
                 holdingIdentityShortHash,
             )
-        }!!.toList()
+        }.toList()
     }
 
     override fun getCertificateChain(usage: String, holdingIdentityId: String?, alias: String): String {
@@ -293,8 +293,8 @@ class CertificatesRestResourceImpl @Activate constructor(
 
     private fun<T> tryWithExceptionHandling(
         operation: String,
-        block: () -> T?
-    ): T? {
+        block: () -> T
+    ): T {
         try {
             return block()
         } catch (repartitionException: CordaRPCAPIPartitionException) {

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImplTest.kt
@@ -5,10 +5,12 @@ import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.certificates.CertificateUsage
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.httprpc.HttpFileUpload
+import net.corda.httprpc.ResponseCode
 import net.corda.httprpc.exception.BadRequestException
 import net.corda.httprpc.exception.InternalServerException
 import net.corda.httprpc.exception.InvalidInputDataException
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.exception.ServiceUnavailableException
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleEventHandler
@@ -17,6 +19,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.membership.certificate.client.CertificatesClient
 import net.corda.membership.certificates.CertificateUsageUtils.publicName
 import net.corda.membership.httprpc.v1.CertificatesRestResource.Companion.SIGNATURE_SPEC
+import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
@@ -162,6 +165,24 @@ class CertificatesRestResourceImplTest {
                     null,
                 )
             }
+        }
+
+        @Test
+        fun `it throws ServiceUnavailableException when repartition event happens while trying to retrieve key`() {
+            whenever(cryptoOpsClient.lookup(any(), any())).doThrow(CordaRPCAPIPartitionException("repartition event"))
+
+            val details = assertThrows<ServiceUnavailableException> {
+                certificatesOps.generateCsr(
+                    holdingIdentityShortHash,
+                    keyId,
+                    x500Name,
+                    null,
+                    null,
+                )
+            }
+
+            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
+            assertThat(details.message).isEqualTo("Could not find key with ID keyId for id: Repartition Event!")
         }
 
         @Test
@@ -389,6 +410,23 @@ class CertificatesRestResourceImplTest {
                 "$certificateText\n$certificateText\n$certificateText"
             )
         }
+
+        @Test
+        fun `repartition event during operation throws ServiceUnavailableException`() {
+            val certificateText = ClassLoader.getSystemResource("r3.pem").readText()
+            val certificate = mock<HttpFileUpload> {
+                on { content } doReturn certificateText.byteInputStream()
+            }
+            whenever(certificatesClient.importCertificates(CertificateUsage.P2P_TLS, null, "alias", certificateText))
+                .doThrow(CordaRPCAPIPartitionException("repartition event"))
+
+            val details = assertThrows<ServiceUnavailableException> {
+                certificatesOps.importCertificateChain("p2p-tls", null, "alias", listOf(certificate))
+            }
+
+            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
+            assertThat(details.message).isEqualTo("Could not import certificate: Repartition Event!")
+        }
     }
 
     @Nested
@@ -450,6 +488,21 @@ class CertificatesRestResourceImplTest {
                     "012301230123",
                 )
             }
+        }
+
+        @Test
+        fun `it throws an exception if repartition event occurs while waiting for response`() {
+            whenever(certificatesClient.getCertificateAliases(any(), any())).doThrow(CordaRPCAPIPartitionException("repartition"))
+
+            val details = assertThrows<ServiceUnavailableException> {
+                certificatesOps.getCertificateAliases(
+                    CertificateUsage.RPC_API_TLS.publicName,
+                    "012301230123",
+                )
+            }
+
+            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
+            assertThat(details.message).isEqualTo("Could not get certificate aliases: Repartition Event!")
         }
     }
 
@@ -530,6 +583,24 @@ class CertificatesRestResourceImplTest {
                     "alias",
                 )
             }
+        }
+
+
+        @Test
+        fun `it throws an exception if repartition event occurs while waiting for response`() {
+            whenever(certificatesClient.retrieveCertificates(null, CertificateUsage.P2P_SESSION, "alias"))
+                .doThrow(CordaRPCAPIPartitionException("repartition"))
+
+            val details = assertThrows<ServiceUnavailableException> {
+                certificatesOps.getCertificateChain(
+                    CertificateUsage.P2P_SESSION.publicName,
+                    null,
+                    "alias",
+                )
+            }
+
+            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
+            assertThat(details.message).isEqualTo("Could not get certificate chain: Repartition Event!")
         }
     }
 }

--- a/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-http-rpc-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/CertificatesRestResourceImplTest.kt
@@ -5,7 +5,6 @@ import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.certificates.CertificateUsage
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.httprpc.HttpFileUpload
-import net.corda.httprpc.ResponseCode
 import net.corda.httprpc.exception.BadRequestException
 import net.corda.httprpc.exception.InternalServerException
 import net.corda.httprpc.exception.InvalidInputDataException
@@ -181,7 +180,6 @@ class CertificatesRestResourceImplTest {
                 )
             }
 
-            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
             assertThat(details.message).isEqualTo("Could not find key with ID keyId for id: Repartition Event!")
         }
 
@@ -424,7 +422,6 @@ class CertificatesRestResourceImplTest {
                 certificatesOps.importCertificateChain("p2p-tls", null, "alias", listOf(certificate))
             }
 
-            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
             assertThat(details.message).isEqualTo("Could not import certificate: Repartition Event!")
         }
     }
@@ -501,7 +498,6 @@ class CertificatesRestResourceImplTest {
                 )
             }
 
-            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
             assertThat(details.message).isEqualTo("Could not get certificate aliases: Repartition Event!")
         }
     }
@@ -599,7 +595,6 @@ class CertificatesRestResourceImplTest {
                 )
             }
 
-            assertThat(details.responseCode).isEqualTo(ResponseCode.SERVICE_UNAVAILABLE)
             assertThat(details.message).isEqualTo("Could not get certificate chain: Repartition Event!")
         }
     }


### PR DESCRIPTION
If a rebalance operation occurs while waiting for an RPC response, the
internal future is cancelled with 'CordaRPCAPIPartitionException' and
the end user receives and HTTP 500 without further information.
Return HTTP Code 503 (service unavailable) instead.
