### PR TITLE
NOTICK: Declare LazyThreadSafetyMode for lazy properties.

### DIFF
--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
@@ -13,6 +13,7 @@ import net.corda.kotlin.reflect.types.jvmSuperClasses
 import net.corda.kotlin.reflect.types.toSignature
 import java.lang.reflect.Method
 import java.util.Collections.unmodifiableMap
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.reflect.KCallable
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -270,7 +271,7 @@ sealed class KotlinClassImpl<T : Any> constructor(
         klazz: KClass<T>,
         kClassPool: KClassPool
     ): KotlinClassImpl<T>(clazz, klazz, kClassPool) {
-        private val jMembers by lazy {
+        private val jMembers by lazy(PUBLICATION) {
             JavaMembers(clazz, allSuperKotlinClasses)
         }
 

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinMembers.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinMembers.kt
@@ -24,6 +24,7 @@ import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.function.Function
 import java.util.function.Supplier
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 import kotlin.reflect.KCallable
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty1
@@ -36,13 +37,13 @@ class KotlinMembers<T : Any>(
     private val jvmSuperKotlinClasses: Supplier<List<KotlinClassImpl<*>>>,
     private val allSuperKotlinClasses: Supplier<List<KotlinClassImpl<*>>>
 ) {
-    private val declaredMemberMethods: Map<MemberSignature, Method> by lazy(clazz::declaredMemberMethods)
-    private val declaredMemberFields: Map<JvmFieldSignature, Field> by lazy(clazz::declaredMemberFields)
+    private val declaredMemberMethods: Map<MemberSignature, Method> by lazy(PUBLICATION, clazz::declaredMemberMethods)
+    private val declaredMemberFields: Map<JvmFieldSignature, Field> by lazy(PUBLICATION, clazz::declaredMemberFields)
 
     private val declaredMemberPopulator: Populator
         get() = Populator(declaredMemberMethods::get, declaredMemberFields::get)
 
-    val properties: Collection<KProperty1<T, *>> by lazy {
+    val properties: Collection<KProperty1<T, *>> by lazy(PUBLICATION) {
         @Suppress("unchecked_cast")
         clazz.computeMembers(
             ::declaredProperties,
@@ -53,7 +54,7 @@ class KotlinMembers<T : Any>(
         } as Collection<KProperty1<T, *>>
     }
 
-    val functions: Collection<KFunction<*>> by lazy {
+    val functions: Collection<KFunction<*>> by lazy(PUBLICATION) {
         clazz.computeMembers(
             ::declaredFunctions,
             KotlinClassImpl<*>::declaredMemberFunctions,
@@ -63,7 +64,7 @@ class KotlinMembers<T : Any>(
         }
     }
 
-    val extensionProperties: Collection<KProperty2<T, *, *>> by lazy {
+    val extensionProperties: Collection<KProperty2<T, *, *>> by lazy(PUBLICATION) {
         @Suppress("unchecked_cast")
         clazz.computeMembers(
             ::declaredExtensionProperties,
@@ -74,7 +75,7 @@ class KotlinMembers<T : Any>(
         } as Collection<KProperty2<T, *, *>>
     }
 
-    val extensionFunctions: Collection<KFunction<*>> by lazy {
+    val extensionFunctions: Collection<KFunction<*>> by lazy(PUBLICATION) {
         clazz.computeMembers(
             ::declaredExtensionFunctions,
             KotlinClassImpl<*>::declaredMemberExtensionFunctions,
@@ -119,28 +120,28 @@ class KotlinMembers<T : Any>(
         return associateByTo(allMembers, keyMapper::apply).values
     }
 
-    val declaredProperties: List<KProperty1<T, *>> by lazy {
+    val declaredProperties: List<KProperty1<T, *>> by lazy(PUBLICATION) {
         kmProperties
             .filterNot(::isExtension)
             .map<KmProperty, KotlinProperty1<T, Any?>> { prop -> clazz.createKotlinProperty1(prop) }
             .map(declaredMemberPopulator::forProperty)
     }
 
-    val declaredFunctions: List<KFunction<*>> by lazy {
+    val declaredFunctions: List<KFunction<*>> by lazy(PUBLICATION) {
         kmFunctions
             .filterNot(::isExtension)
             .map<KmFunction, KotlinFunction<Any?>> { func -> KotlinFunction(func, clazz) }
             .map(declaredMemberPopulator::forFunction)
     }
 
-    val declaredExtensionProperties: List<KProperty2<T, *, *>> by lazy {
+    val declaredExtensionProperties: List<KProperty2<T, *, *>> by lazy(PUBLICATION) {
         kmProperties
             .filter(::isExtension)
             .map<KmProperty, KotlinProperty2<T, Any?, Any?>> { prop -> clazz.createKotlinProperty2(prop) }
             .map(declaredMemberPopulator::forProperty)
     }
 
-    val declaredExtensionFunctions: List<KFunction<*>> by lazy {
+    val declaredExtensionFunctions: List<KFunction<*>> by lazy(PUBLICATION) {
         kmFunctions
             .filter(::isExtension)
             .map<KmFunction, KotlinFunction<Any?>> { func -> KotlinFunction(func, clazz) }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
@@ -48,7 +48,7 @@ enum class CordaSerializationEncoding(private val encoderType: EncoderType) : Se
         /**
          * Gets the [EncoderService] via jvm [ServiceLoader]
          */
-        private val encoderService: EncoderService by lazy {
+        private val encoderService: EncoderService by lazy(LazyThreadSafetyMode.PUBLICATION) {
             // This has to be lazy initialized or a function rather than a value due to initialization order.
             ServiceLoader.load(EncoderService::class.java).toList().firstOrNull()
                     ?: throw NullPointerException("Could not get serialization encoder service")

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/ComposableTypePropertySerializer.kt
@@ -176,10 +176,10 @@ class DescribedTypeReadStrategy(name: String,
 class DescribedTypeWriteStrategy(private val name: String,
                                  private val propertyInformation: LocalPropertyInformation,
                                  private val reader: GetterReader,
-                                 private val serializerProvider: () -> AMQPSerializer<Any>) : PropertyWriteStrategy {
+                                 serializerProvider: () -> AMQPSerializer<Any>) : PropertyWriteStrategy {
 
     // Lazy to avoid getting into infinite loops when there are cycles.
-    private val serializer by lazy { serializerProvider() }
+    private val serializer by lazy(LazyThreadSafetyMode.PUBLICATION, serializerProvider)
 
     private val nameForDebug get() = "$name(${propertyInformation.type.typeIdentifier.prettyPrint(false)})"
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -25,6 +25,7 @@ import org.apache.qpid.proton.amqp.Symbol
 import org.apache.qpid.proton.codec.Data
 import org.slf4j.LoggerFactory
 import java.lang.reflect.Type
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 /**
  * Serialization / deserialization of arrays.
@@ -71,14 +72,14 @@ open class ArraySerializer(override val type: Type, factory: LocalSerializerFact
         }
     }
 
-    override val typeDescriptor: Symbol by lazy {
+    override val typeDescriptor: Symbol by lazy(PUBLICATION) {
         factory.createDescriptor(type)
     }
 
-    internal val elementType: Type by lazy { type.componentType().resolveAgainst(type) }
-    internal open val typeName by lazy { calcTypeName(type) }
+    internal val elementType: Type by lazy(PUBLICATION) { type.componentType().resolveAgainst(type) }
+    internal open val typeName by lazy(PUBLICATION) { calcTypeName(type) }
 
-    internal val typeNotation: TypeNotation by lazy {
+    internal val typeNotation: TypeNotation by lazy(PUBLICATION) {
         RestrictedType(typeName, null, emptyList(), "list", Descriptor(typeDescriptor), emptyList())
     }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CollectionSerializer.kt
@@ -36,7 +36,7 @@ class CollectionSerializer(private val declaredType: ParameterizedType, factory:
     AMQPSerializer<Any> {
     override val type: Type = declaredType
 
-    override val typeDescriptor: Symbol by lazy {
+    override val typeDescriptor: Symbol by lazy(LazyThreadSafetyMode.PUBLICATION) {
         factory.createDescriptor(type)
     }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CorDappCustomSerializer.kt
@@ -83,7 +83,7 @@ class CorDappCustomSerializer(
         proxyType = types[PROXY_TYPE]
     }
 
-    private val proxySerializer: ObjectSerializer by lazy {
+    private val proxySerializer: ObjectSerializer by lazy(LazyThreadSafetyMode.PUBLICATION) {
         ObjectSerializer.make(factory.getTypeInformation(proxyType), factory)
     }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CustomSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CustomSerializer.kt
@@ -192,7 +192,7 @@ abstract class CustomSerializer<T : Any> : AMQPSerializer<T>, SerializerFor {
         serializer: InternalProxySerializer<T, P>,
         factory: SerializerFactory
     ) : CustomSerializerImpl<T>(serializer) {
-        private val proxySerializer: ObjectSerializer by lazy {
+        private val proxySerializer: ObjectSerializer by lazy(LazyThreadSafetyMode.PUBLICATION) {
             ObjectSerializer.make(factory.getTypeInformation(serializer.proxyType), factory)
         }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/RemoteTypeInformation.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/RemoteTypeInformation.kt
@@ -82,7 +82,7 @@ sealed class RemoteTypeInformation {
      * The [RemoteTypeInformation] emitted if we hit a cycle while traversing the graph of related types.
      */
     data class Cycle(override val typeIdentifier: TypeIdentifier) : RemoteTypeInformation() {
-        override val typeDescriptor by lazy { follow.typeDescriptor }
+        override val typeDescriptor by lazy(LazyThreadSafetyMode.PUBLICATION) { follow.typeDescriptor }
         lateinit var follow: RemoteTypeInformation
 
         override fun equals(other: Any?): Boolean = other is Cycle && other.typeIdentifier == typeIdentifier

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
@@ -87,7 +87,7 @@ internal class FingerprintWriter(debugEnabled: Boolean = false) {
         hasher = hasher.putUnencodedChars(chars)
     }
 
-    val fingerprint: String by lazy {
+    val fingerprint: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
         val fingerprint = hasher.hash().asBytes().toBase64()
         if (debugBuffer != null) logger.info("$fingerprint from $debugBuffer")
         fingerprint

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeSimpleTypesTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DeserializeSimpleTypesTests.kt
@@ -56,7 +56,6 @@ class DeserializeSimpleTypesTests {
         assertEquals('আ', deserializedC.c)
     }
 
-    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     @Test
 	fun testCharacter() {
         @CordaSerializable
@@ -100,7 +99,6 @@ class DeserializeSimpleTypesTests {
         assertEquals(ia.ia[2], deserializedIA.ia[2])
     }
 
-    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     @Test
 	fun testArrayOfInteger() {
         @CordaSerializable

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/InMemoryEntityManagerConfiguration.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/InMemoryEntityManagerConfiguration.kt
@@ -4,9 +4,12 @@ import net.corda.db.core.CloseableDataSource
 import net.corda.db.core.InMemoryDataSourceFactory
 import net.corda.orm.DdlManage
 import net.corda.orm.EntityManagerConfiguration
+import kotlin.LazyThreadSafetyMode.SYNCHRONIZED
 
 open class InMemoryEntityManagerConfiguration(dbName: String) : EntityManagerConfiguration {
-    override val dataSource: CloseableDataSource by lazy {
+    override val dataSource: CloseableDataSource by lazy(SYNCHRONIZED) {
+        // SYNCHRONIZED because we have no opportunity to close any extra
+        // candidates that could be created via PUBLICATION mode.
         InMemoryDataSourceFactory().create(dbName)
     }
 


### PR DESCRIPTION
Declare explicit "thread-safety" mode for Kotlin `lazy` properties. (The default mode is [documented](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/lazy.html) as being `SYNCHRONIZED`.)

This PR mostly just targets AMQP serialization and the `kotlin-reflection` library.