### PR TITLE
CORE-9816: PermissionEndpoint 503 on Repartition

### DIFF
--- a/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionManagementHandler.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/common/PermissionManagementHandler.kt
@@ -6,6 +6,7 @@ import net.corda.httprpc.exception.InternalServerException
 import net.corda.httprpc.exception.InvalidInputDataException
 import net.corda.httprpc.exception.ResourceAlreadyExistsException
 import net.corda.httprpc.exception.ResourceNotFoundException
+import net.corda.httprpc.exception.ServiceUnavailableException
 import java.util.concurrent.TimeoutException
 import net.corda.libs.permissions.common.exception.EntityAlreadyExistsException
 import net.corda.libs.permissions.common.exception.EntityAssociationAlreadyExistsException
@@ -14,6 +15,7 @@ import net.corda.libs.permissions.common.exception.EntityNotFoundException
 import net.corda.libs.permissions.manager.PermissionManager
 import net.corda.libs.permissions.manager.exception.UnexpectedPermissionResponseException
 import net.corda.libs.permissions.manager.exception.RemotePermissionManagementException
+import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import org.slf4j.Logger
@@ -49,6 +51,10 @@ fun <T : Any?> withPermissionManager(
                 details = buildExceptionCauseDetails(e.exceptionType, e.message ?: "Remote permission management error occurred.")
             )
         }
+
+    } catch (e: CordaRPCAPIPartitionException) {
+        logger.warn("Error waiting for permission management response.", e)
+        throw ServiceUnavailableException("Error waiting for permission management response: Repartition Event!")
 
     } catch (e: CordaRPCAPISenderException) {
         logger.warn("Error during sending of permission management request.", e)

--- a/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/common/PermissionManagementHandlerTest.kt
+++ b/components/permissions/permission-rpc-ops-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/common/PermissionManagementHandlerTest.kt
@@ -2,9 +2,11 @@ package net.corda.libs.permissions.endpoints.common
 
 import java.util.concurrent.TimeoutException
 import net.corda.httprpc.exception.InternalServerException
+import net.corda.httprpc.exception.ServiceUnavailableException
 import net.corda.libs.permissions.manager.PermissionManager
 import net.corda.libs.permissions.manager.exception.RemotePermissionManagementException
 import net.corda.libs.permissions.manager.exception.UnexpectedPermissionResponseException
+import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -102,6 +104,19 @@ internal class PermissionManagementHandlerTest {
         assertEquals(2, e.details.size)
         assertEquals(UnexpectedPermissionResponseException::class.java.name, e.details["cause"])
         assertEquals("unexpected exception", e.details["reason"])
+    }
+
+    @Test
+    fun `test CordaRPCAPIPartitionException returns ServiceUnavailableException`() {
+
+        val e = assertThrows<ServiceUnavailableException> {
+            withPermissionManager(permissionManager, logger){
+                throw CordaRPCAPIPartitionException("Repartition event.")
+            }
+        }
+
+        assertEquals("Error waiting for permission management response: Repartition Event!", e.message)
+        assertEquals(0, e.details.size)
     }
 
     @Test


### PR DESCRIPTION
If a rebalance operation occurs while waiting for an RPC response, the
internal future is cancelled with 'CordaRPCAPIPartitionException' and
the end user receives and HTTP 500 without further information.
Return HTTP Code 503 (service unavailable) instead.
