### PR TITLE
NOTICK Extend test app and smoke tests for UTXO ledger

### DIFF
--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/PeekTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/PeekTransactionFlow.kt
@@ -1,0 +1,78 @@
+package net.cordapp.demo.utxo
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.marshalling.JsonMarshallingService
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.util.loggerFor
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.utxo.UtxoLedgerService
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+
+data class PeekTransactionParameters(val transactionId: String)
+
+
+data class PeekTransactionResponse(
+    val inputs: List<TestUtxoStateResult>,
+    val outputs: List<TestUtxoStateResult>,
+    val errorMessage: String?
+)
+
+class PeekTransactionFlow : RPCStartableFlow {
+
+    private companion object {
+        val log = loggerFor<PeekTransactionFlow>()
+    }
+
+    @CordaInject
+    lateinit var ledgerService: UtxoLedgerService
+
+    @CordaInject
+    lateinit var marshallingService: JsonMarshallingService
+
+    @Suspendable
+    override fun call(requestBody: RPCRequestData): String {
+        log.info("Utxo peek transaction flow starting...")
+        val requestObject =
+            requestBody.getRequestBodyAs(marshallingService, PeekTransactionParameters::class.java)
+
+        val txId = requestObject.transactionId
+
+        log.info("Utxo finding transaction $txId")
+        val ledgerTransaction = ledgerService.findLedgerTransaction(SecureHash.parse(txId))
+
+
+        val resultString = marshallingService.format(extractStates(ledgerTransaction))
+
+        log.info("Utxo finding transaction $txId's result: $resultString")
+        return resultString
+    }
+
+    @Suspendable
+    private fun extractStates(ledgerTransaction: UtxoLedgerTransaction?): PeekTransactionResponse {
+        if (ledgerTransaction == null ){
+            return PeekTransactionResponse(emptyList(), emptyList(),
+            "Failed to load transaction.")
+        }
+        val inputStates =
+            try {
+                ledgerTransaction.getInputStateAndRefs(UtxoDemoFlow.TestUtxoState::class.java)
+                    .map { it.state.contractState.toResult() }
+            } catch (e: Exception){
+                return PeekTransactionResponse(inputs = emptyList(), outputs = emptyList(),
+                    "Failed to load inputs: ${e.message}" )
+            }
+
+        val outputStates =
+            try {
+                ledgerTransaction.getOutputStateAndRefs(UtxoDemoFlow.TestUtxoState::class.java)
+                    .map { it.state.contractState.toResult() }
+            } catch (e: Exception){
+                return PeekTransactionResponse(inputs = emptyList(), outputs = emptyList(),
+                    "Failed to load outputs: ${e.message}" )
+            }
+
+        return PeekTransactionResponse(inputStates, outputStates, null)
+    }
+}

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/PeekTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/PeekTransactionFlow.kt
@@ -39,13 +39,13 @@ class PeekTransactionFlow : RPCStartableFlow {
 
         val txId = requestObject.transactionId
 
-        log.info("Utxo finding transaction $txId")
+        log.info("Utxo finding transaction $txId for taking a peek")
         val ledgerTransaction = ledgerService.findLedgerTransaction(SecureHash.parse(txId))
 
 
         val resultString = marshallingService.format(extractStates(ledgerTransaction))
 
-        log.info("Utxo finding transaction $txId's result: $resultString")
+        log.info("Utxo transaction $txId peeking result: $resultString")
         return resultString
     }
 

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
@@ -1,0 +1,132 @@
+package net.cordapp.demo.utxo
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.RPCStartableFlow
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.getRequestBodyAs
+import net.corda.v5.application.marshalling.JsonMarshallingService
+import net.corda.v5.application.membership.MemberLookup
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.base.util.contextLogger
+import net.corda.v5.base.util.days
+import net.corda.v5.base.util.loggerFor
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.utxo.UtxoLedgerService
+import java.time.Instant
+
+@InitiatingFlow("utxo-evolve-protocol")
+class UtxoDemoEvolveFlow : RPCStartableFlow {
+
+    data class EvolveMessage(val update: String, val transactionId: String, val index: Int)
+    data class EvolveResponse( val transactionId: String?, val errorMessage: String?)
+
+    class EvolveFlowError(message: String): Exception(message)
+
+    @CordaInject
+    lateinit var flowMessaging: FlowMessaging
+
+    @CordaInject
+    lateinit var utxoLedgerService: UtxoLedgerService
+
+    @CordaInject
+    lateinit var jsonMarshallingService: JsonMarshallingService
+
+    @CordaInject
+    lateinit var memberLookup: MemberLookup
+
+    private val log = loggerFor<UtxoDemoEvolveFlow>()
+
+    override fun call(requestBody: RPCRequestData): String {
+        log.info("Utxo flow demo starting...")
+        val response = try {
+            val request = requestBody.getRequestBodyAs<EvolveMessage>(jsonMarshallingService)
+
+            val inputTx = utxoLedgerService.findLedgerTransaction(SecureHash.parse(request.transactionId)) ?:
+                throw EvolveFlowError( "Failed to find transaction ${request.transactionId}")
+
+            val prevStates = inputTx.outputStateAndRefs
+            if (prevStates.size <= request.index)
+                throw EvolveFlowError( "Invalid state index ${request.index} - transaction " +
+                        "${request.transactionId} only has ${prevStates.size + 1} outputs.")
+
+            val input = prevStates[request.index]
+            val inputState = input.state.contractState as? UtxoDemoFlow.TestUtxoState ?:
+                throw EvolveFlowError( "State ${prevStates[request.index].ref} is not of type TestUtxoState")
+
+            val output =
+                UtxoDemoFlow.TestUtxoState(
+                    request.update,
+                    inputState.participants,
+                    inputState.participantNames)
+
+
+            val myInfo = memberLookup.myInfo()
+            val members = output.participantNames.map { x500 ->
+                requireNotNull(memberLookup.lookup(MemberX500Name.parse(x500))) {
+                    "Member $x500 does not exist in the membership group"
+                }
+            }
+
+            @Suppress("DEPRECATION")
+            val signedTransaction = utxoLedgerService.getTransactionBuilder()
+                .addCommand(UtxoDemoFlow.TestCommand())
+                .addOutputState(output)
+                .addInputState(input.ref)
+                .setNotary(input.state.notary)
+                .setTimeWindowUntil(Instant.now().plusMillis(1.days.toMillis()))
+                .addSignatories(output.participants)
+                .toSignedTransaction(myInfo.ledgerKeys.first())
+
+            val sessions = members.map { flowMessaging.initiateFlow(it.name) }
+
+            val finalizedSignedTransaction = utxoLedgerService.finalize(
+                    signedTransaction,
+                    sessions
+                )
+
+            val transactionId = finalizedSignedTransaction.id.toString()
+            EvolveResponse(transactionId, null).also {
+                log.info("Success! Response: $it")
+            }
+        }
+        catch (e: Exception){
+            EvolveResponse(null,"Flow failed: ${e.message}")
+        }
+
+        return jsonMarshallingService.format(response)
+    }
+}
+
+@InitiatedBy("utxo-evolve-protocol")
+class UtxoEvolveResponderFlow : ResponderFlow {
+
+    private companion object {
+        val log = contextLogger()
+    }
+
+    @CordaInject
+    lateinit var utxoLedgerService: UtxoLedgerService
+
+    @Suspendable
+    override fun call(session: FlowSession) {
+        try {
+            val finalizedSignedTransaction = utxoLedgerService.receiveFinality(session) { ledgerTransaction ->
+                val state = ledgerTransaction.outputContractStates.first() as UtxoDemoFlow.TestUtxoState
+                if (state.testField == "fail") {
+                    log.info("Failed to verify the transaction - ${ledgerTransaction.id}")
+                    throw IllegalStateException("Failed verification")
+                }
+                log.info("Verified the transaction- ${ledgerTransaction.id}")
+            }
+            log.info("Finished responder flow - ${finalizedSignedTransaction.id}")
+        } catch (e: Exception) {
+            log.warn("Exceptionally finished responder flow", e)
+        }
+    }
+}

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
@@ -42,6 +42,7 @@ class UtxoDemoEvolveFlow : RPCStartableFlow {
 
     private val log = loggerFor<UtxoDemoEvolveFlow>()
 
+    @Suspendable
     override fun call(requestBody: RPCRequestData): String {
         log.info("Utxo flow demo starting...")
         val response = try {

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
@@ -43,7 +43,8 @@ class UtxoDemoFlow : RPCStartableFlow {
     @BelongsToContract(TestContract::class)
     class TestUtxoState(
         val testField: String,
-        override val participants: List<PublicKey>
+        override val participants: List<PublicKey>,
+        val participantNames: List<String>
     ) : ContractState
 
     class TestCommand : Command
@@ -81,7 +82,8 @@ class UtxoDemoFlow : RPCStartableFlow {
             }
             val testUtxoState = TestUtxoState(
                 request.input,
-                members.map { it.ledgerKeys.first() } + myInfo.ledgerKeys.first()
+                members.map { it.ledgerKeys.first() } + myInfo.ledgerKeys.first(),
+                request.members + listOf(myInfo.name.toString())
             )
 
             val notary = notaryLookup.notaryServices.single()

--- a/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestFindTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestFindTransactionFlow.kt
@@ -48,7 +48,7 @@ class TestFindTransactionFlow {
         val keyGenerator = KeyPairGenerator.getInstance("EC")
 
         val participantKey = keyGenerator.generateKeyPair().public
-        val testState = UtxoDemoFlow.TestUtxoState("text", listOf(participantKey) )
+        val testState = UtxoDemoFlow.TestUtxoState("text", listOf(participantKey), listOf("") )
 
         val ledgerTx = mock<UtxoLedgerTransaction>().apply {
             whenever(id).thenReturn(txIdGood)

--- a/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
@@ -1,0 +1,94 @@
+package net.cordapp.demo.utxo
+
+import net.corda.application.impl.services.json.JsonMarshallingServiceImpl
+import net.corda.v5.application.flows.RPCRequestData
+import net.corda.v5.application.flows.getRequestBodyAs
+import net.corda.v5.application.marshalling.parse
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.utxo.StateAndRef
+import net.corda.v5.ledger.utxo.StateRef
+import net.corda.v5.ledger.utxo.TransactionState
+import net.corda.v5.ledger.utxo.UtxoLedgerService
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.security.KeyPairGenerator
+
+class TestPeekTransactionFlow {
+    class TestFindTransactionFlow {
+        private val jsonMarshallingService = JsonMarshallingServiceImpl()
+
+        @Test
+        fun missingTransactionReturnsError() {
+            val flow = PeekTransactionFlow()
+
+            val txIdBad = SecureHash("SHA256", "Fail!".toByteArray())
+            val ledgerService = mock<UtxoLedgerService>()
+            whenever(ledgerService.findLedgerTransaction(txIdBad)).thenReturn(null)
+
+            flow.marshallingService = jsonMarshallingService
+            flow.ledgerService = ledgerService
+
+            val badRequest = mock<RPCRequestData>()
+            val body = PeekTransactionParameters(txIdBad.toString())
+            whenever(badRequest.getRequestBodyAs<PeekTransactionParameters>(jsonMarshallingService)).thenReturn(body)
+
+            val result = flow.call(badRequest)
+            val resObj = jsonMarshallingService.parse<PeekTransactionResponse>(result)
+            Assertions.assertThat(resObj.inputs).isEmpty()
+            Assertions.assertThat(resObj.outputs).isEmpty()
+            Assertions.assertThat(resObj.errorMessage)
+                .isEqualTo("Failed to load transaction.")
+        }
+
+        @Test
+        fun canReturnExampleFlowStates() {
+            val flow = PeekTransactionFlow()
+
+
+            val txIdGood = SecureHash("SHA256", "12345".toByteArray())
+
+            val keyGenerator = KeyPairGenerator.getInstance("EC")
+
+            val participantKey = keyGenerator.generateKeyPair().public
+            val testState = UtxoDemoFlow.TestUtxoState("text", listOf(participantKey))
+            val testContractState = mock<TransactionState<UtxoDemoFlow.TestUtxoState>>().apply {
+                whenever(this.contractState).thenReturn(testState)
+            }
+
+            val testStateAndRef = mock<StateAndRef<UtxoDemoFlow.TestUtxoState>>().apply {
+                whenever(ref).thenReturn(StateRef(txIdGood, 0))
+                whenever(state).thenReturn(testContractState )
+            }
+
+
+            val ledgerTx = mock<UtxoLedgerTransaction>().apply {
+                whenever(id).thenReturn(txIdGood)
+                whenever(getOutputStateAndRefs(UtxoDemoFlow.TestUtxoState::class.java))
+                    .thenReturn(listOf(testStateAndRef))
+                whenever(signatories).thenReturn(listOf(testState.participants.first()))
+            }
+
+            val ledgerService = mock<UtxoLedgerService>()
+            whenever(ledgerService.findLedgerTransaction(txIdGood)).thenReturn(ledgerTx)
+
+            flow.marshallingService = jsonMarshallingService
+            flow.ledgerService = ledgerService
+
+            val goodRequest = mock<RPCRequestData>()
+            val body = PeekTransactionParameters(txIdGood.toString())
+            whenever(goodRequest.getRequestBodyAs<PeekTransactionParameters>(jsonMarshallingService)).thenReturn(body)
+
+            val result = flow.call(goodRequest)
+            println(result)
+            val resObj = jsonMarshallingService.parse<PeekTransactionResponse>(result)
+            Assertions.assertThat(resObj.inputs).isEmpty()
+            Assertions.assertThat(resObj.outputs).hasSize(1)
+            Assertions.assertThat(resObj.outputs.first().testField).isEqualTo("text")
+            Assertions.assertThat(resObj.errorMessage).isNull()
+        }
+
+    }
+}

--- a/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
@@ -53,7 +53,7 @@ class TestPeekTransactionFlow {
             val keyGenerator = KeyPairGenerator.getInstance("EC")
 
             val participantKey = keyGenerator.generateKeyPair().public
-            val testState = UtxoDemoFlow.TestUtxoState("text", listOf(participantKey))
+            val testState = UtxoDemoFlow.TestUtxoState("text", listOf(participantKey), listOf(""))
             val testContractState = mock<TransactionState<UtxoDemoFlow.TestUtxoState>>().apply {
                 whenever(this.contractState).thenReturn(testState)
             }

--- a/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
@@ -82,7 +82,6 @@ class TestPeekTransactionFlow {
             whenever(goodRequest.getRequestBodyAs<PeekTransactionParameters>(jsonMarshallingService)).thenReturn(body)
 
             val result = flow.call(goodRequest)
-            println(result)
             val resObj = jsonMarshallingService.parse<PeekTransactionResponse>(result)
             Assertions.assertThat(resObj.inputs).isEmpty()
             Assertions.assertThat(resObj.outputs).hasSize(1)


### PR DESCRIPTION
Extend the UTXO demo app to incude:
- evolving a state (consuming states)
- loading inputs and outputs from a LedgerTransaction

Also extend the UTXO ledger smoketest to exercise all that logic.