### PR TITLE
CORE-8733 Intermittent `CordaRPCAPISenderException` in crypto worker

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryImpl.kt
@@ -23,9 +23,9 @@ import net.corda.crypto.config.impl.toConfigurationSecrets
 import net.corda.crypto.config.impl.toCryptoConfig
 import net.corda.crypto.core.InvalidParamsException
 import net.corda.crypto.impl.decorators.CryptoServiceDecorator
+import net.corda.crypto.persistence.HSMStore
 import net.corda.crypto.service.CryptoServiceFactory
 import net.corda.crypto.service.CryptoServiceRef
-import net.corda.crypto.service.HSMService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -56,8 +56,8 @@ class CryptoServiceFactoryImpl @Activate constructor(
     coordinatorFactory: LifecycleCoordinatorFactory,
     @Reference(service = ConfigurationReadService::class)
     configurationReadService: ConfigurationReadService,
-    @Reference(service = HSMService::class)
-    private val hsmService: HSMService,
+    @Reference(service = HSMStore::class)
+    private val hsmStore: HSMStore,
     @Reference(service = CryptoServiceProvider::class)
     private val cryptoServiceProvider: CryptoServiceProvider<*>
 ) : AbstractConfigurableComponent<CryptoServiceFactoryImpl.Impl>(
@@ -67,7 +67,7 @@ class CryptoServiceFactoryImpl @Activate constructor(
     upstream = DependenciesTracker.Default(
         setOf(
             LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
-            LifecycleCoordinatorName.forComponent<HSMService>()
+            LifecycleCoordinatorName.forComponent<HSMStore>()
         ) + ((cryptoServiceProvider as? LifecycleNameProvider)?.lifecycleNameAsSet() ?: emptySet())
     ),
     configKeys = setOf(CRYPTO_CONFIG)
@@ -90,7 +90,7 @@ class CryptoServiceFactoryImpl @Activate constructor(
     override fun createActiveImpl(event: ConfigChangedEvent): Impl = Impl(
         bootConfig = bootConfig ?: throw IllegalStateException("The bootstrap configuration haven't been received yet."),
         event = event,
-        hsmService = hsmService,
+        hsmStore = hsmStore,
         cryptoServiceProvider = cryptoServiceProvider as CryptoServiceProvider<Any>
     )
 
@@ -109,14 +109,13 @@ class CryptoServiceFactoryImpl @Activate constructor(
     class Impl(
         bootConfig: SmartConfig,
         event: ConfigChangedEvent,
-        private val hsmService: HSMService,
+        private val hsmStore: HSMStore,
         private val cryptoServiceProvider: CryptoServiceProvider<Any>
     ) : DownstreamAlwaysUpAbstractImpl() {
 
         private val hsmId: String
 
         private val cryptoConfig: SmartConfig
-
         private val hsmConfig: CryptoHSMConfig
 
         init {
@@ -149,7 +148,7 @@ class CryptoServiceFactoryImpl @Activate constructor(
 
         fun findInstance(tenantId: String, category: String): CryptoServiceRef {
             logger.debug { "Getting the crypto service for tenantId '$tenantId', category '$category'." }
-            val association = hsmService.findAssignedHSM(tenantId, category)
+            val association = hsmStore.findTenantAssociation(tenantId, category)
                 ?: throw InvalidParamsException("The tenant '$tenantId' is not configured for category '$category'.")
             if(association.hsmId != hsmId) {
                 throw InvalidParamsException(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/HSMServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/HSMServiceImpl.kt
@@ -146,17 +146,15 @@ class HSMServiceImpl @Activate constructor(
                 }
 
                 val signingService = signingServiceFactory.getInstance()
-                executor.executeWithRetry {
-                    signingService
-                        .createWrappingKey(
-                            hsmId = association.hsmId,
-                            failIfExists = false,
-                            masterKeyAlias = association.masterKeyAlias!!,
-                            context = mapOf(
-                                CRYPTO_TENANT_ID to association.tenantId
-                            )
-                    )
-                }
+                signingService
+                    .createWrappingKey(
+                        hsmId = association.hsmId,
+                        failIfExists = false,
+                        masterKeyAlias = association.masterKeyAlias!!,
+                        context = mapOf(
+                            CRYPTO_TENANT_ID to association.tenantId
+                        )
+                )
             }
         }
 

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/HSMServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/HSMServiceImpl.kt
@@ -3,7 +3,6 @@ package net.corda.crypto.service.impl
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.CRYPTO_TENANT_ID
-import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.component.impl.AbstractConfigurableComponent
 import net.corda.crypto.component.impl.DependenciesTracker
 import net.corda.crypto.config.impl.MasterKeyPolicy
@@ -16,6 +15,7 @@ import net.corda.crypto.impl.retrying.BackoffStrategy
 import net.corda.crypto.impl.retrying.CryptoRetryingExecutor
 import net.corda.crypto.persistence.HSMStore
 import net.corda.crypto.service.HSMService
+import net.corda.crypto.service.SigningServiceFactory
 import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -34,8 +34,8 @@ class HSMServiceImpl @Activate constructor(
     configurationReadService: ConfigurationReadService,
     @Reference(service = HSMStore::class)
     private val store: HSMStore,
-    @Reference(service = CryptoOpsClient::class)
-    private val cryptoOpsClient: CryptoOpsClient
+    @Reference(service = SigningServiceFactory::class)
+    private val signingServiceFactory: SigningServiceFactory
 ) : AbstractConfigurableComponent<HSMServiceImpl.Impl>(
     coordinatorFactory = coordinatorFactory,
     myName = LifecycleCoordinatorName.forComponent<HSMService>(),
@@ -44,13 +44,12 @@ class HSMServiceImpl @Activate constructor(
         setOf(
             LifecycleCoordinatorName.forComponent<HSMStore>(),
             LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
-            LifecycleCoordinatorName.forComponent<CryptoOpsClient>()
         )
     ),
     configKeys = setOf(CRYPTO_CONFIG)
 ), HSMService {
     override fun createActiveImpl(event: ConfigChangedEvent): Impl =
-        Impl(logger, event, store, cryptoOpsClient)
+        Impl(logger, event, store, signingServiceFactory)
 
     override fun assignHSM(tenantId: String, category: String, context: Map<String, String>): HSMAssociationInfo =
         impl.assignHSM(tenantId, category, context)
@@ -65,7 +64,7 @@ class HSMServiceImpl @Activate constructor(
         private val logger: Logger,
         event: ConfigChangedEvent,
         private val store: HSMStore,
-        private val cryptoOpsClient: CryptoOpsClient
+        private val signingServiceFactory: SigningServiceFactory
     ) : DownstreamAlwaysUpAbstractImpl() {
         companion object {
             private fun Map<String, String>.isPreferredPrivateKeyPolicy(policy: String): Boolean =
@@ -145,14 +144,17 @@ class HSMServiceImpl @Activate constructor(
                 require(!association.masterKeyAlias.isNullOrBlank()) {
                     "The master key alias is not specified."
                 }
+
+                val signingService = signingServiceFactory.getInstance()
                 executor.executeWithRetry {
-                    cryptoOpsClient.createWrappingKey(
-                        hsmId = association.hsmId,
-                        failIfExists = false,
-                        masterKeyAlias = association.masterKeyAlias!!,
-                        context = mapOf(
-                            CRYPTO_TENANT_ID to association.tenantId
-                        )
+                    signingService
+                        .createWrappingKey(
+                            hsmId = association.hsmId,
+                            failIfExists = false,
+                            masterKeyAlias = association.masterKeyAlias!!,
+                            context = mapOf(
+                                CRYPTO_TENANT_ID to association.tenantId
+                            )
                     )
                 }
             }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryTests.kt
@@ -33,7 +33,7 @@ class CryptoServiceFactoryTests {
         component = CryptoServiceFactoryImpl(
             factory.coordinatorFactory,
             factory.configurationReadService,
-            factory.hsmService,
+            factory.hsmStore,
             object : CryptoServiceProvider<SoftCryptoServiceConfig> {
                 override val name: String = CryptoConsts.SOFT_HSM_SERVICE_NAME
                 override val configType: Class<SoftCryptoServiceConfig> = SoftCryptoServiceConfig::class.java

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/HSMServiceLifecycleTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/HSMServiceLifecycleTests.kt
@@ -23,7 +23,7 @@ class HSMServiceLifecycleTests {
             factory.coordinatorFactory,
             factory.configurationReadService,
             factory.hsmStore,
-            factory.opsProxyClient
+            factory.signingServiceFactory
         )
     }
 

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
@@ -28,6 +28,7 @@ import net.corda.crypto.service.SigningService
 import net.corda.crypto.service.SigningServiceFactory
 import net.corda.crypto.service.impl.CryptoServiceFactoryImpl
 import net.corda.crypto.service.impl.HSMServiceImpl
+import net.corda.crypto.service.impl.SigningServiceFactoryImpl
 import net.corda.crypto.service.impl.SigningServiceImpl
 import net.corda.crypto.softhsm.SoftCryptoServiceConfig
 import net.corda.crypto.softhsm.impl.DefaultSoftPrivateKeyWrapping
@@ -41,8 +42,6 @@ import net.corda.lifecycle.test.impl.TestLifecycleCoordinatorFactoryImpl
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.test.util.eventually
 import net.corda.v5.crypto.SignatureSpec
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.assertEquals
 
@@ -183,8 +182,13 @@ class TestServicesFactory {
         )
     }
 
-    val signingServiceFactory: SigningServiceFactory = mock<SigningServiceFactory>().also {
-        whenever(it.getInstance()).thenReturn(signingService)
+    val signingServiceFactory: SigningServiceFactory by lazy {
+        SigningServiceFactoryImpl(
+            coordinatorFactory,
+            schemeMetadata,
+            signingKeyStore,
+            cryptoServiceFactory
+        )
     }
 
     val hsmService: HSMServiceImpl by lazy {

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
@@ -188,7 +188,12 @@ class TestServicesFactory {
             schemeMetadata,
             signingKeyStore,
             cryptoServiceFactory
-        )
+        ).also {
+            it.start()
+            eventually {
+                assertEquals(LifecycleStatus.UP, it.lifecycleCoordinator.status)
+            }
+        }
     }
 
     val hsmService: HSMServiceImpl by lazy {

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -169,7 +169,6 @@ class CryptoProcessorImpl @Activate constructor(
                     if (hsmAssociated) {
                         setStatus(LifecycleStatus.UP, coordinator)
                     } else {
-                        logger.info("Assigning SOFT HSMs")
                         val failed = temporaryAssociateClusterWithSoftHSM()
                         if (failed.isNotEmpty()) {
                             if(tmpAssignmentFailureCounter.getAndIncrement() <= 5) {

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -142,13 +142,13 @@ class CryptoProcessorImpl @Activate constructor(
             is BootConfigEvent -> {
                 val bootstrapConfig = event.config
 
-                logger.info("Crypto processor bootstrapping {}", configurationReadService::class.simpleName)
+                logger.info("Bootstrapping {}", configurationReadService::class.simpleName)
                 configurationReadService.bootstrapConfig(bootstrapConfig)
 
-                logger.info("Crypto processor bootstrapping {}", dbConnectionManager::class.simpleName)
+                logger.info("Bootstrapping {}", dbConnectionManager::class.simpleName)
                 dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB_PARAMS))
 
-                logger.info("Crypto processor bootstrapping {}", cryptoServiceFactory::class.simpleName)
+                logger.info("Bootstrapping {}", cryptoServiceFactory::class.simpleName)
                 cryptoServiceFactory.bootstrapConfig(bootstrapConfig.getConfig(BOOT_CRYPTO))
             }
             is RegistrationStatusChangeEvent -> {

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -139,6 +139,18 @@ class CryptoProcessorImpl @Activate constructor(
             is StopEvent -> {
                 // Nothing to do
             }
+            is BootConfigEvent -> {
+                val bootstrapConfig = event.config
+
+                logger.info("Crypto processor bootstrapping {}", configurationReadService::class.simpleName)
+                configurationReadService.bootstrapConfig(bootstrapConfig)
+
+                logger.info("Crypto processor bootstrapping {}", dbConnectionManager::class.simpleName)
+                dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB_PARAMS))
+
+                logger.info("Crypto processor bootstrapping {}", cryptoServiceFactory::class.simpleName)
+                cryptoServiceFactory.bootstrapConfig(bootstrapConfig.getConfig(BOOT_CRYPTO))
+            }
             is RegistrationStatusChangeEvent -> {
                 if (event.status == LifecycleStatus.UP) {
                     dependenciesUp = true
@@ -151,18 +163,6 @@ class CryptoProcessorImpl @Activate constructor(
                     dependenciesUp = false
                     setStatus(event.status, coordinator)
                 }
-            }
-            is BootConfigEvent -> {
-                val bootstrapConfig = event.config
-
-                logger.info("Crypto processor bootstrapping {}", configurationReadService::class.simpleName)
-                configurationReadService.bootstrapConfig(bootstrapConfig)
-
-                logger.info("Crypto processor bootstrapping {}", dbConnectionManager::class.simpleName)
-                dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB_PARAMS))
-
-                logger.info("Crypto processor bootstrapping {}", cryptoServiceFactory::class.simpleName)
-                cryptoServiceFactory.bootstrapConfig(bootstrapConfig.getConfig(BOOT_CRYPTO))
             }
             is AssociateHSM -> {
                 if(dependenciesUp) {

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -153,14 +153,16 @@ class CryptoProcessorImpl @Activate constructor(
                 }
             }
             is BootConfigEvent -> {
+                val bootstrapConfig = event.config
+
                 logger.info("Crypto processor bootstrapping {}", configurationReadService::class.simpleName)
-                configurationReadService.bootstrapConfig(event.config)
+                configurationReadService.bootstrapConfig(bootstrapConfig)
 
                 logger.info("Crypto processor bootstrapping {}", dbConnectionManager::class.simpleName)
-                dbConnectionManager.bootstrap(event.config.getConfig(BOOT_DB_PARAMS))
+                dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB_PARAMS))
 
                 logger.info("Crypto processor bootstrapping {}", cryptoServiceFactory::class.simpleName)
-                cryptoServiceFactory.bootstrapConfig(event.config.getConfig(BOOT_CRYPTO))
+                cryptoServiceFactory.bootstrapConfig(bootstrapConfig.getConfig(BOOT_CRYPTO))
             }
             is AssociateHSM -> {
                 if(dependenciesUp) {


### PR DESCRIPTION
On crypto-worker start-up we would quite often get:

```
15:57:29.621 [lifecycle-coordinator-0] ERROR net.corda.crypto.client.impl.CryptoOpsClientImpl {} - Failed executing net.corda.data.crypto.wire.ops.rpc.commands.GenerateWrappingKeyRpcCommand for tenant crypto 
net.corda.messaging.api.exception.CordaRPCAPISenderException: No partitions for topic crypto.ops.rpc.resp. Couldn't send. 
	at net.corda.messaging.publisher.CordaRPCSenderImpl.sendRequest(CordaRPCSenderImpl.kt:230) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientImpl.execute(CryptoOpsClientImpl.kt:359) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientImpl.execute$default(CryptoOpsClientImpl.kt:352) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientImpl.createWrappingKey(CryptoOpsClientImpl.kt:279) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientComponent.createWrappingKey(CryptoOpsClientComponent.kt:173) ~[?:?] 
	at net.corda.crypto.service.impl.HSMServiceImpl$Impl$ensureWrappingKey$2.invoke(HSMServiceImpl.kt:149) ~[?:?] 
	at net.corda.crypto.service.impl.HSMServiceImpl$Impl$ensureWrappingKey$2.invoke(HSMServiceImpl.kt:148) ~[?:?] 
	at net.corda.crypto.impl.retrying.CryptoRetryingExecutor.execute(CryptoRetryingExecutor.kt:81) ~[?:?] 
	at net.corda.crypto.impl.retrying.CryptoRetryingExecutor.executeWithRetry(CryptoRetryingExecutor.kt:39) ~[?:?] 
	at net.corda.crypto.service.impl.HSMServiceImpl$Impl.ensureWrappingKey(HSMServiceImpl.kt:148) ~[?:?] 
	at net.corda.crypto.service.impl.HSMServiceImpl$Impl.assignSoftHSM(HSMServiceImpl.kt:125) ~[?:?] 
	at net.corda.crypto.service.impl.HSMServiceImpl.assignSoftHSM(HSMServiceImpl.kt:59) ~[?:?] 
	at net.corda.processors.crypto.internal.CryptoProcessorImpl.tryAssignSoftHSM(CryptoProcessorImpl.kt:223) ~[?:?] 
	at net.corda.processors.crypto.internal.CryptoProcessorImpl.temporaryAssociateClusterWithSoftHSM(CryptoProcessorImpl.kt:206) ~[?:?]
```

This was happening because `HSMServiceImpl` was using `CryptoOpsClient` to create wrapping key for no obvious reason as `HSMServiceImpl` is meant to be used within crypto worker and `CryptoOpsClient` creates requests over Kafka for crypto worker.

There was a race between, `CryptoOpsClientImpl` creating a `RPCSender` and its complement `RPCSubscription` created by `CryptoOpsBusServiceImpl`. If `RPCSender` would happen earlier it would find no partitions yet and would fail. 

So instead inject the underlying service which takes care of create wrapping key request which is `SigningServiceFactory`.

- replaces with underlying `SigningServiceFactory` service needed for create wrapping key operation instead of using `CryptoOpsClient` to go over Kafka to crypto worker while already inside the crypto worker.
- replaces with `HSMStore` where `HSMServiceImpl` was just delegating to `HSMStore` to break circular dependency.

**How I reproduced it/ tested it was resolved:**
_ I was able to reproduce it by killing the crypto worker pod on a local kubernetes cluster and witness the error in the crypto worker logs. After the change the issue stopped happening.
