### PR TITLE
CORE-9044: Flow REST endpoint validation on flow_start_operational_status

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -693,7 +693,7 @@ class VirtualNodeRpcTest {
 
     @Test
     @Order(113)
-    fun `can upgrading a virtual node's CPI when it is in maintenance`() {
+    fun `can upgrade a virtual node's CPI when it is in maintenance`() {
         cluster {
             endpoint(CLUSTER_URI, USERNAME, PASSWORD)
 
@@ -702,6 +702,8 @@ class VirtualNodeRpcTest {
             val cpiV2 = getCpiChecksum(upgradeTestingCpiName, "v2")
             triggerVirtualNodeUpgrade(bobHoldingId, cpiV2)
             eventuallyAssertVirtualNodeHasCpi(bobHoldingId, upgradeTestingCpiName, "v2")
+
+            eventuallyUpdateVirtualNodeState(bobHoldingId, "active", "ACTIVE")
 
             runReturnAStringFlow("upgrade-test-v2", bobHoldingId)
             runSimplePersistenceCheckFlow("Could persist dog", bobHoldingId)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -31,6 +31,7 @@ import net.corda.applications.workers.smoketest.TEST_CPB_WITHOUT_CHANGELOGS_LOCA
 import net.corda.applications.workers.smoketest.VNODE_UPGRADE_TEST_CPI_NAME
 import net.corda.applications.workers.smoketest.VNODE_UPGRADE_TEST_CPI_V1
 import net.corda.applications.workers.smoketest.VNODE_UPGRADE_TEST_CPI_V2
+import net.corda.e2etest.utilities.getFlowStatus
 
 /**
  * Any 'unordered' tests are run *last*
@@ -408,7 +409,8 @@ class VirtualNodeRpcTest {
 
             val className = "net.cordapp.testing.smoketests.virtualnode.ReturnAStringFlow"
             val requestId = startRpcFlow(aliceHoldingId, emptyMap(), className, 503)
-            awaitRpcFlowFinished(aliceHoldingId, requestId, 404)
+            getFlowStatus(aliceHoldingId, requestId, 404)
+
 
             eventuallyUpdateVirtualNodeState(vnodeId, oldState, "ACTIVE")
         }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -405,6 +405,11 @@ class VirtualNodeRpcTest {
             val newState = "maintenance"
 
             eventuallyUpdateVirtualNodeState(vnodeId, newState, "INACTIVE")
+
+            val className = "net.cordapp.testing.smoketests.virtualnode.ReturnAStringFlow"
+            val requestId = startRpcFlow(aliceHoldingId, emptyMap(), className, 503)
+            awaitRpcFlowFinished(aliceHoldingId, requestId, 404)
+
             eventuallyUpdateVirtualNodeState(vnodeId, oldState, "ACTIVE")
         }
     }

--- a/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rpcops-service-impl/src/main/kotlin/net/corda/flow/rpcops/impl/v1/FlowRestResourceImpl.kt
@@ -115,7 +115,7 @@ class FlowRestResourceImpl @Activate constructor(
         val vNode = getVirtualNode(holdingIdentityShortHash)
 
         if (vNode.flowStartOperationalStatus == OperationalStatus.INACTIVE.name) {
-            throw ServiceUnavailableException("Cannot start flow. Virtual node ${vNode.holdingIdentity.x500Name} is in maintenance mode.")
+            throw ServiceUnavailableException("Cannot start flow. Virtual node $holdingIdentityShortHash is in maintenance mode.")
         }
 
         val clientRequestId = startFlow.clientRequestId

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -75,7 +75,7 @@ fun startRpcFlow(holdingId: String, args: Map<String, Any>, flowName: String, ex
     }
 }
 
-fun awaitRpcFlowFinished(holdingId: String, requestId: String): FlowStatus {
+fun awaitRpcFlowFinished(holdingId: String, requestId: String, expectedCode: Int = 200): FlowStatus {
     return cluster {
         endpoint(
             CLUSTER_URI,
@@ -89,9 +89,13 @@ fun awaitRpcFlowFinished(holdingId: String, requestId: String): FlowStatus {
                 //CORE-6118 - tmp increase this timeout to a large number to allow tests to pass while slow flow sessions are investigated
                 timeout(Duration.ofMinutes(6))
                 condition {
-                    it.code == 200 &&
-                            (it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||
-                                    it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_FAILED)
+                    if (expectedCode == 200) {
+                        it.code == 200 &&
+                                (it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||
+                                        it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_FAILED)
+                    } else {
+                        it.code == expectedCode
+                    }
                 }
             }.body, FlowStatus::class.java
         )


### PR DESCRIPTION
Adds validation to check flow_start_operational_status for a virtual node in FlowRestResourceImpl. Throws a ServiceUnavailableException if the node is in maintenance mode. 