### PR TITLE
NOTICK: Avoid thread context classloader when searching for serialization encoders.

### DIFF
--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -1,6 +1,7 @@
 package net.corda.serialization.amqp.test
 
 import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
+import net.corda.internal.serialization.CordaSerializationEncoding.SNAPPY
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.IllegalCustomSerializerException
 import net.corda.internal.serialization.amqp.ObjectAndEnvelope
@@ -51,7 +52,7 @@ import java.util.concurrent.TimeUnit
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class AMQPwithOSGiSerializationTests {
-    private val testSerializationContext = AMQP_STORAGE_CONTEXT
+    private val testSerializationContext = AMQP_STORAGE_CONTEXT.withEncoding(SNAPPY)
 
     @RegisterExtension
     private val lifecycle = EachTestLifecycle()

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
@@ -50,7 +50,7 @@ enum class CordaSerializationEncoding(private val encoderType: EncoderType) : Se
          */
         private val encoderService: EncoderService by lazy(LazyThreadSafetyMode.PUBLICATION) {
             // This has to be lazy initialized or a function rather than a value due to initialization order.
-            ServiceLoader.load(EncoderService::class.java).toList().firstOrNull()
+            ServiceLoader.load(EncoderService::class.java, this::class.java.classLoader).toList().firstOrNull()
                     ?: throw NullPointerException("Could not get serialization encoder service")
         }
 


### PR DESCRIPTION
Given a choice, we should always specify which classloader Java should be using. Left to its own devices, `ServiceLoader` will consult the thread context classloader, which is weird. Enabling `SNAPPY` encoding for all AMQP OSGi tests should test that we can still find its encoder from within an OSGi framework.

We use Aries SPI-Fly to ensure `ServiceLoader` behaves correctly inside an OSGi framework.