### PR TITLE
CORE-9889 Intermittent `CordaRPCAPISenderException` in flow worker and crypto worker interaction

### DIFF
--- a/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/DependentComponents.kt
+++ b/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/DependentComponents.kt
@@ -77,19 +77,23 @@ class DependentComponents private constructor(private val map: Map<LifecycleCoor
         return with(map, component,componentType, instanceId)
     }
 
-    private var registration: RegistrationHandle? = null
+    val registration: RegistrationHandle
+        get() = _registration
+            ?: throw IllegalStateException("Not started ${DependentComponents::class.java.simpleName}")
+
+    private var _registration: RegistrationHandle? = null
 
     val coordinatorNames: Set<LifecycleCoordinatorName> = map.keys
 
     fun stopAll() {
         map.values.forEach { it.stop() }
-        registration?.close()
-        registration = null
+        _registration?.close()
+        _registration = null
     }
 
     fun registerAndStartAll(coordinator: LifecycleCoordinator) {
-        registration?.close()
-        registration = coordinator.followStatusChangesByName(map.keys)
+        _registration?.close()
+        _registration = coordinator.followStatusChangesByName(map.keys)
         map.values.forEach { it.start() }
     }
 }

--- a/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/DependentComponents.kt
+++ b/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/DependentComponents.kt
@@ -77,23 +77,19 @@ class DependentComponents private constructor(private val map: Map<LifecycleCoor
         return with(map, component,componentType, instanceId)
     }
 
-    val registration: RegistrationHandle
-        get() = _registration
-            ?: throw IllegalStateException("Not started ${DependentComponents::class.java.simpleName}")
-
-    private var _registration: RegistrationHandle? = null
+    var registration: RegistrationHandle? = null
 
     val coordinatorNames: Set<LifecycleCoordinatorName> = map.keys
 
     fun stopAll() {
         map.values.forEach { it.stop() }
-        _registration?.close()
-        _registration = null
+        registration?.close()
+        registration = null
     }
 
     fun registerAndStartAll(coordinator: LifecycleCoordinator) {
-        _registration?.close()
-        _registration = coordinator.followStatusChangesByName(map.keys)
+        registration?.close()
+        registration = coordinator.followStatusChangesByName(map.keys)
         map.values.forEach { it.start() }
     }
 }

--- a/processors/crypto-processor/build.gradle
+++ b/processors/crypto-processor/build.gradle
@@ -86,4 +86,7 @@ dependencies {
     integrationTestRuntimeOnly "org.hibernate:hibernate-core:$hibernateVersion"
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
+
+    testImplementation project(":libs:lifecycle:lifecycle-test-impl")
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -162,7 +162,9 @@ class CryptoProcessorImpl @Activate constructor(
                     if (event.registration == dependentComponents.registration) {
                         // The lifecycle bootstrapping has been done in two phases in an attempt to make sure
                         // RPC sender created for FLOW_OPS_MESSAGE_TOPIC (through `CryptoOpsClientImpl`) will
-                        // happen after RPC subscription for that topic is created first (through `CryptoOpsBusServiceImpl`)
+                        // happen after the creation of the RPC subscription for that topic (through `CryptoOpsBusServiceImpl`).
+                        // Coordination is happening here/ at this level as there is no dependency between `CryptoOpsClientImpl` and
+                        // `CryptoOpsBusServiceImpl`.
                         // We used to get: "CordaRPCAPISenderException: No partitions for topic crypto.ops.rpc.resp. Couldn't send."
                         if (cryptoOpsClientAndDependentComponents.registration == null) {
                             logger.debug {

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -105,13 +105,13 @@ class CryptoProcessorImpl @Activate constructor(
         ::vnodeInfo
     )
 
+    @VisibleForTesting
+    val lifecycleCoordinator = coordinatorFactory.createCoordinator<CryptoProcessor>(dependentComponents, ::eventHandler)
+
     private val cryptoOpsClientAndDependentComponents = DependentComponents.of(
         ::cryptoOpsClient,
         ::cryptoFlowOpsBusService
     )
-
-    @VisibleForTesting
-    val lifecycleCoordinator = coordinatorFactory.createCoordinator<CryptoProcessor>(dependentComponents, ::eventHandler)
 
     @Volatile
     private var hsmAssociated: Boolean = false

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -177,10 +177,11 @@ class CryptoProcessorImpl @Activate constructor(
                             coordinator.postEvent(AssociateHSM())
                         }
                     } else {
-                        throw IllegalArgumentException(
+                        logger.error(
                             "Unexpected registration for received ${RegistrationStatusChangeEvent::class.java.simpleName}: "
                                     + "${event.registration}"
                         )
+                        setStatus(LifecycleStatus.ERROR, coordinator)
                     }
                 } else {
                     dependenciesUp = false

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -167,18 +167,14 @@ class CryptoProcessorImpl @Activate constructor(
                         // `CryptoOpsBusServiceImpl`.
                         // We used to get: "CordaRPCAPISenderException: No partitions for topic crypto.ops.rpc.resp. Couldn't send."
                         if (cryptoOpsClientAndDependentComponents.registration == null) {
-                            logger.debug {
-                                "Dependent components are UP. Now registering and starting " +
-                                        "crypto ops client and its dependent components"
-                            }
+                            logger.debug { "Dependent components are UP" }
                             cryptoOpsClientAndDependentComponents.registerAndStartAll(coordinator)
                         } else {
-                            logger.debug {
-                                "Dependent components are UP. Crypto ops client and its dependent components are already UP"
-                            }
+                            logger.debug { "Dependent components are UP. Crypto ops client and its dependent components are already UP" }
                             coordinator.postEvent(AllDependenciesAreUp)
                         }
                     } else if (event.registration == cryptoOpsClientAndDependentComponents.registration) {
+                        logger.debug { "Registering and starting crypto ops client and its dependent components" }
                         coordinator.postEvent(AllDependenciesAreUp)
                     } else {
                         logger.error(

--- a/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
+++ b/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
@@ -115,16 +115,14 @@ class CryptoProcessorImplTest {
     fun `dependentComponents going DOWN brings crypto processor DOWN`() {
         dependentComponents.forEach(lifecycleTest::bringDependencyDown)
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
-        lifecycleTest.verifyIsUp<CryptoOpsClient>()
-        lifecycleTest.verifyIsUp<CryptoFlowOpsBusService>()
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::verifyIsUp)
     }
 
     @Test
     @Order(25)
     fun `dependentComponents going back UP brings crypto processor back UP`() {
         dependentComponents.forEach(lifecycleTest::bringDependencyUp)
-        lifecycleTest.verifyIsUp<CryptoOpsClient>()
-        lifecycleTest.verifyIsUp<CryptoFlowOpsBusService>()
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::verifyIsUp)
         assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
     }
 }

--- a/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
+++ b/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
@@ -1,0 +1,128 @@
+package net.corda.processors.crypto.internal
+
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.crypto.client.CryptoOpsClient
+import net.corda.crypto.persistence.CryptoConnectionsFactory
+import net.corda.crypto.persistence.HSMStore
+import net.corda.crypto.persistence.SigningKeyStore
+import net.corda.crypto.persistence.WrappingKeyStore
+import net.corda.crypto.service.CryptoFlowOpsBusService
+import net.corda.crypto.service.CryptoOpsBusService
+import net.corda.crypto.service.CryptoServiceFactory
+import net.corda.crypto.service.HSMRegistrationBusService
+import net.corda.crypto.service.HSMService
+import net.corda.crypto.service.SigningServiceFactory
+import net.corda.crypto.softhsm.SoftCryptoServiceProvider
+import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.test.impl.LifecycleTest
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.api.TestMethodOrder
+import org.mockito.kotlin.mock
+
+@TestInstance(Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class CryptoProcessorImplTest {
+
+    lateinit var cryptoProcessor: CryptoProcessorImpl
+
+    val dependentComponents = setOf(
+        LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+        LifecycleCoordinatorName.forComponent<CryptoConnectionsFactory>(),
+        LifecycleCoordinatorName.forComponent<WrappingKeyStore>(),
+        LifecycleCoordinatorName.forComponent<SigningKeyStore>(),
+        LifecycleCoordinatorName.forComponent<HSMStore>(),
+        LifecycleCoordinatorName.forComponent<SigningServiceFactory>(),
+        LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+        LifecycleCoordinatorName.forComponent<CryptoOpsBusService>(),
+        LifecycleCoordinatorName.forComponent<SoftCryptoServiceProvider>(),
+        LifecycleCoordinatorName.forComponent<CryptoServiceFactory>(),
+        LifecycleCoordinatorName.forComponent<HSMService>(),
+        LifecycleCoordinatorName.forComponent<HSMRegistrationBusService>(),
+        LifecycleCoordinatorName.forComponent<DbConnectionManager>(),
+        LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()
+    )
+    val cryptoOpsClientAndDependentComponents = setOf(
+        LifecycleCoordinatorName.forComponent<CryptoOpsClient>(),
+        LifecycleCoordinatorName.forComponent<CryptoFlowOpsBusService>()
+    )
+
+    val lifecycleTest = LifecycleTest {
+        cryptoProcessor =
+            CryptoProcessorImpl(
+                coordinatorFactory,
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock(),
+                mock()
+            )
+        // We need to test `CryptoProcessorImpl` lifecycle bootstrapping. `CryptoProcessorImpl` is not a
+        // `Lifecycle` so test it by grabbing its lifecycle coordinator.
+        cryptoProcessor.lifecycleCoordinator
+    }.also { lifecycleTest ->
+        (dependentComponents + cryptoOpsClientAndDependentComponents).forEach {
+            lifecycleTest.addDependency(it)
+        }
+    }
+
+    init {
+        cryptoProcessor.start(mock())
+    }
+
+    @Test
+    @Order(5)
+    fun `fresh lifecycle bootstrapping brings crypto processor UP`() {
+        dependentComponents.forEach(lifecycleTest::bringDependencyUp)
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyUp)
+        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
+    }
+
+    @Test
+    @Order(10)
+    fun `cryptoOpsClientAndDependentComponents going DOWN brings crypto processor DOWN`() {
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyDown)
+        assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
+    }
+
+    @Test
+    @Order(15)
+    fun `cryptoOpsClientAndDependentComponents going back UP brings crypto processor back UP`() {
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyUp)
+        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
+    }
+
+    @Test
+    @Order(20)
+    fun `dependentComponents going DOWN brings crypto processor DOWN`() {
+        dependentComponents.forEach(lifecycleTest::bringDependencyDown)
+        assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
+    }
+
+    @Test
+    @Order(25)
+    fun `dependentComponents going back UP brings crypto processor back UP`() {
+        dependentComponents.forEach(lifecycleTest::bringDependencyUp)
+        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
+        lifecycleTest.verifyIsUp<CryptoOpsClient>()
+        lifecycleTest.verifyIsUp<CryptoFlowOpsBusService>()
+    }
+}

--- a/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
+++ b/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
@@ -125,10 +125,6 @@ class CryptoProcessorImplTest {
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
         cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyUp)
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
-
-        // dependentComponents going back UP should now bring crypto processor back UP
-        dependentComponents.forEach(lifecycleTest::bringDependencyUp)
-        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
     }
 
     @Test
@@ -139,9 +135,5 @@ class CryptoProcessorImplTest {
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
         dependentComponents.forEach(lifecycleTest::bringDependencyUp)
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
-
-        // cryptoOpsClientAndDependentComponents going back UP should now bring crypto processor back UP
-        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyUp)
-        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
     }
 }

--- a/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
+++ b/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
@@ -98,31 +98,50 @@ class CryptoProcessorImplTest {
 
     @Test
     @Order(10)
-    fun `cryptoOpsClientAndDependentComponents going DOWN brings crypto processor DOWN`() {
+    fun `cryptoOpsClientAndDependentComponents going UP while dependentComponents are UP brings crypto processor back UP`() {
         cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyDown)
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
-    }
-
-    @Test
-    @Order(15)
-    fun `cryptoOpsClientAndDependentComponents going back UP brings crypto processor back UP`() {
         cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyUp)
         assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
     }
 
     @Test
-    @Order(20)
-    fun `dependentComponents going DOWN brings crypto processor DOWN`() {
+    @Order(15)
+    fun `dependentComponents going UP while cryptoOpsClientAndDependentComponents are UP brings crypto processor back UP`() {
         dependentComponents.forEach(lifecycleTest::bringDependencyDown)
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::verifyIsUp)
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
         cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::verifyIsUp)
+        dependentComponents.forEach(lifecycleTest::bringDependencyUp)
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::verifyIsUp)
+        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
     }
 
     @Test
-    @Order(25)
-    fun `dependentComponents going back UP brings crypto processor back UP`() {
+    @Order(20)
+    fun `cryptoOpsClientAndDependentComponents going UP while dependentComponents are DOWN should keep processor DOWN`() {
+        dependentComponents.forEach(lifecycleTest::bringDependencyDown)
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyDown)
+        assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyUp)
+        assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
+
+        // dependentComponents going back UP should now bring crypto processor back UP
         dependentComponents.forEach(lifecycleTest::bringDependencyUp)
-        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::verifyIsUp)
+        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
+    }
+
+    @Test
+    @Order(20)
+    fun `dependentComponents going UP while cryptoOpsClientAndDependentComponents are DOWN should keep processor DOWN`() {
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyDown)
+        dependentComponents.forEach(lifecycleTest::bringDependencyDown)
+        assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
+        dependentComponents.forEach(lifecycleTest::bringDependencyUp)
+        assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
+
+        // cryptoOpsClientAndDependentComponents going back UP should now bring crypto processor back UP
+        cryptoOpsClientAndDependentComponents.forEach(lifecycleTest::bringDependencyUp)
         assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
     }
 }

--- a/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
+++ b/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
@@ -115,14 +115,16 @@ class CryptoProcessorImplTest {
     fun `dependentComponents going DOWN brings crypto processor DOWN`() {
         dependentComponents.forEach(lifecycleTest::bringDependencyDown)
         assertEquals(LifecycleStatus.DOWN, lifecycleTest.testClass.status)
+        lifecycleTest.verifyIsUp<CryptoOpsClient>()
+        lifecycleTest.verifyIsUp<CryptoFlowOpsBusService>()
     }
 
     @Test
     @Order(25)
     fun `dependentComponents going back UP brings crypto processor back UP`() {
         dependentComponents.forEach(lifecycleTest::bringDependencyUp)
-        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
         lifecycleTest.verifyIsUp<CryptoOpsClient>()
         lifecycleTest.verifyIsUp<CryptoFlowOpsBusService>()
+        assertEquals(LifecycleStatus.UP, lifecycleTest.testClass.status)
     }
 }


### PR DESCRIPTION
There has been reported the following error which comes from the crypto worker:
```
15:58:19.451 [durable processing thread crypto.ops.flow-crypto.ops.flow] ERROR net.corda.crypto.service.impl.bus.CryptoFlowOpsBusProcessor {} - Failed to handle class net.corda.data.crypto.wire.ops.flow.commands.SignFlowCommand for tenant 654226B863F9 { requestId: f473552e-fd82-49dc-959a-4623241fa04e, key: 69b12a0e-24f1-4bc0-a40f-5341f395cd7b } 
net.corda.messaging.api.exception.CordaRPCAPISenderException: No partitions for topic crypto.ops.rpc.resp. Couldn't send. 
	at net.corda.messaging.publisher.CordaRPCSenderImpl.sendRequest(CordaRPCSenderImpl.kt:230) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientImpl.execute(CryptoOpsClientImpl.kt:359) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientImpl.execute$default(CryptoOpsClientImpl.kt:352) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientImpl.signProxy(CryptoOpsClientImpl.kt:254) ~[?:?] 
	at net.corda.crypto.client.impl.CryptoOpsClientComponent.signProxy(CryptoOpsClientComponent.kt:166) ~[?:?] 
	at net.corda.crypto.service.impl.bus.CryptoFlowOpsBusProcessor.handleRequest(CryptoFlowOpsBusProcessor.kt:119) ~[?:?] 
	at net.corda.crypto.service.impl.bus.CryptoFlowOpsBusProcessor.access$handleRequest(CryptoFlowOpsBusProcessor.kt:26) ~[?:?] 
	at net.corda.crypto.service.impl.bus.CryptoFlowOpsBusProcessor$onNext$response$1.invoke(CryptoFlowOpsBusProcessor.kt:75) ~[?:?]
```

Which is then propagated to the flow worker:
```
15:58:19.880 [single-threaded-scheduled-executor-1] WARN  net.corda.flow.fiber.FlowFiberImpl {client_id=654226B863F9-flow-159-1674489498733, external_event_id=f473552e-fd82-49dc-959a-4623241fa04e, flow_id=69b12a0e-24f1-4bc0-a40f-5341f395cd7b, vnode_id=654226B863F9} - Flow failed 
net.corda.v5.base.exceptions.CordaRuntimeException: No partitions for topic crypto.ops.rpc.resp. Couldn't send. 
	at net.corda.flow.fiber.FlowFiberImpl.suspend(FlowFiberImpl.kt:151) ~[?:?] 
	at net.corda.flow.external.events.impl.executor.ExternalEventExecutorImpl.execute(ExternalEventExecutorImpl.kt:30) ~[?:?] 
	at net.corda.flow.external.events.impl.executor.ExternalEventExecutorImpl.execute(ExternalEventExecutorImpl.kt:55) ~[?:?]
```

This seems to be happening from RPC sender being created (through `CryptoOpsClientImpl`) before the RPC subscription (through `CryptoOpsBusServiceImpl`) for `FLOW_OPS_MESSAGE_TOPIC`. But, there is no dependency between`CryptoOpsClientImpl` and `CryptoOpsBusServiceImpl`, so this change attempts to coordinate the two at `CryptoProcessorImpl` level.

- starts `CryptoOpsClientImpl` only after `CryptoOpsBusServiceImpl` is created, so that RPC Sender is being created RPC subscription for `FLOW_OPS_MESSAGE_TOPIC`.

