### PR TITLE
CORE-9682 Prevent FlowStateManager from mutating initial state to all…

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
@@ -45,6 +45,8 @@ interface OutputAssertions {
 
     fun flowResumedWith(value: Any?)
 
+    fun flowResumedWithData(value: Map<String, ByteArray>)
+
     fun <T : Throwable> flowResumedWithError(exceptionClass: Class<T>)
 
     fun wakeUpEvent()

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -1,7 +1,5 @@
 package net.corda.flow.testing.context
 
-import net.bytebuddy.dynamic.scaffold.MethodGraph.Linked
-import net.corda.crypto.cipher.suite.schemes.all
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.flow.event.FlowEvent
@@ -176,7 +174,7 @@ class OutputAssertionsImpl(
             assertInstanceOf(FlowContinuation.Run::class.java, testRun.flowContinuation)
             val resumedWith = (testRun.flowContinuation as FlowContinuation.Run).value
 
-            if (resumedWith is LinkedHashMap<*, *>) {
+            if (resumedWith is Map<*, *>) {
                 assertEquals(value.keys, resumedWith.keys)
                 value.values.zip(resumedWith.values).forEach { pair ->
                     assertArrayEquals(pair.component1(), pair.component2() as ByteArray,

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/CloseSessionsAcceptanceTest.kt
@@ -616,7 +616,7 @@ class CloseSessionsAcceptanceTest : FlowServiceTestBase() {
             }
 
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
                 sessionCloseEvents(SESSION_ID_1, SESSION_ID_2)
                 sessionAckEvents()
             }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExternalEventAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExternalEventAcceptanceTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.osgi.framework.AdminPermission.CONTEXT
 import org.osgi.service.component.annotations.Component
 import org.osgi.test.junit5.service.ServiceExtension
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ReceiveAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ReceiveAcceptanceTest.kt
@@ -271,7 +271,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
             }
 
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
                 sessionAckEvents(SESSION_ID_2)
             }
         }
@@ -297,7 +297,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
                 sessionAckEvents(SESSION_ID_2)
             }
         }
@@ -356,7 +356,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
             }
 
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1))
                 wakeUpEvent()
             }
         }
@@ -550,7 +550,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
             }
 
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
                 sessionAckEvents(SESSION_ID_2)
             }
         }
@@ -579,7 +579,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
             }
 
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1))
                 sessionAckEvents(SESSION_ID_1)
             }
         }
@@ -650,7 +650,7 @@ class ReceiveAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_5))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_5))
             }
         }
     }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
@@ -179,7 +179,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
             }
 
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
                 sessionDataEvents(SESSION_ID_1 to DATA_MESSAGE_3, SESSION_ID_2 to DATA_MESSAGE_4)
                 sessionAckEvents()
             }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAndReceiveAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAndReceiveAcceptanceTest.kt
@@ -88,7 +88,7 @@ class SendAndReceiveAcceptanceTest : FlowServiceTestBase() {
             }
 
             expectOutputForFlow(FLOW_ID1) {
-                flowResumedWith(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
+                flowResumedWithData(mapOf(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2))
                 sessionDataEvents(SESSION_ID_1 to DATA_MESSAGE_3, SESSION_ID_2 to DATA_MESSAGE_4)
                 sessionAckEvents()
             }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFinishedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFinishedAcceptanceTest.kt
@@ -5,14 +5,12 @@ import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.event.session.SessionAck
 import net.corda.data.flow.event.session.SessionClose
 import net.corda.data.flow.event.session.SessionData
-import net.corda.data.flow.state.checkpoint.FlowStackItem
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.flow.testing.context.StepSetup
 import net.corda.flow.testing.context.flowResumedWithError
 import net.corda.flow.testing.context.initiateSingleFlow
 import net.corda.flow.testing.context.initiateTwoFlows
-import net.corda.flow.utils.mutableKeyValuePairList
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStateManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStateManager.kt
@@ -20,7 +20,7 @@ class FlowStateManager(private val initialState: FlowState) {
 
     private var state = FlowState.newBuilder(initialState).build()
 
-    private var sessionMap = validateAndCreateSessionMap(initialState.sessions)
+    private var sessionMap = validateAndCreateSessionMap(state.sessions)
 
     var stack = FlowStackImpl(state.flowStackItems)
 
@@ -72,7 +72,7 @@ class FlowStateManager(private val initialState: FlowState) {
     fun rollback() {
         state = FlowState.newBuilder(initialState).build()
         sessionMap = validateAndCreateSessionMap(state.sessions)
-        stack = FlowStackImpl(initialState.flowStackItems)
+        stack = FlowStackImpl(state.flowStackItems)
         flowContext = FlowStackBasedContext(stack)
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowStateManagerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowStateManagerTest.kt
@@ -1,0 +1,104 @@
+package net.corda.flow.state
+
+import net.corda.data.flow.FlowKey
+import net.corda.data.flow.FlowStartContext
+import net.corda.data.flow.state.checkpoint.FlowStackItem
+import net.corda.data.flow.state.checkpoint.FlowState
+import net.corda.data.flow.state.external.ExternalEventState
+import net.corda.data.flow.state.session.SessionState
+import net.corda.data.flow.state.waiting.WaitingFor
+import net.corda.data.flow.state.waiting.Wakeup
+import net.corda.data.identity.HoldingIdentity
+import net.corda.flow.BOB_X500_HOLDING_IDENTITY
+import net.corda.flow.FLOW_ID_1
+import net.corda.flow.state.impl.FlowStateManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertIterableEquals
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+
+class FlowStateManagerTest {
+    @Suppress("LongParameterList")
+    private fun createFlowState(
+        key: FlowKey = FlowKey(FLOW_ID_1, BOB_X500_HOLDING_IDENTITY),
+        holdingIdentity: HoldingIdentity = BOB_X500_HOLDING_IDENTITY,
+        stackItems: List<FlowStackItem> = listOf(),
+        sessionStates: List<SessionState> = listOf(),
+        newFiber: ByteBuffer = ByteBuffer.wrap(byteArrayOf()),
+        suspendedOn: String = "foo",
+        waitingFor: WaitingFor = WaitingFor(Wakeup()),
+        suspendCount: Int = 0,
+        externalEventState: ExternalEventState? = null
+    ): FlowState {
+
+        val startContext = FlowStartContext().apply {
+            statusKey = key
+            identity = holdingIdentity
+        }
+
+        return FlowState().apply {
+            flowStartContext = startContext
+            flowStackItems = stackItems.toMutableList()
+            sessions = sessionStates.toMutableList()
+            fiber = newFiber
+            this.suspendedOn = suspendedOn
+            this.waitingFor = waitingFor
+            this.suspendCount = suspendCount
+            this.externalEventState = externalEventState
+        }
+    }
+
+    @Test
+    fun `Rollback successfully restores sessions to initial state adding additional sessions`() {
+        val initialSessions = listOf(SessionState().apply {
+            sessionId = "foo"
+        })
+
+        val flowState = createFlowState(sessionStates = initialSessions)
+        val sut = FlowStateManager(flowState)
+
+        assertIterableEquals(initialSessions, sut.sessions)
+
+        val newSession = SessionState().apply { sessionId = "bar" }
+        sut.putSessionState(newSession)
+
+        assertIterableEquals(initialSessions + newSession, sut.sessions)
+
+        sut.rollback()
+        assertIterableEquals(initialSessions, sut.sessions)
+    }
+
+    @Test
+    fun `Rollback successfully restores sessions to initial state after modifying existing session`() {
+        val flowState = createFlowState(sessionStates = listOf(
+            SessionState().apply { sessionId = "foo" }
+        ))
+
+        val sut = FlowStateManager(flowState)
+
+        sut.getSessionState("foo").apply { this?.sessionId = "bar" }
+
+        assertIterableEquals(
+            listOf(SessionState().apply {sessionId = "bar"}),
+            sut.sessions
+        )
+
+        sut.rollback()
+
+        assertIterableEquals(
+            listOf(SessionState().apply {sessionId = "foo"}),
+            sut.sessions
+        )
+    }
+
+    @Test
+    fun `Valid FlowState successfully converted to avro`() {
+        val flowState = createFlowState(sessionStates = listOf(
+            SessionState().apply {sessionId = "foo"}
+        ))
+
+        val sut = FlowStateManager(flowState)
+
+        assertEquals(flowState, sut.toAvro())
+    }
+}


### PR DESCRIPTION
## Description
This PR satisfies [CORE-9682](https://r3-cev.atlassian.net/browse/CORE-9682) which was created to address the incorrect handling of transient exceptions thrown within the FlowEventProcessor.

## Root cause
This was due to the implementation of the `FlowStateManager`. This class is passed an `initialState: FlowState` when it's instantiated which we use as the source of truth for the original state, however the `sessions` attribute of this object was being passed through by reference, causing the original object to be mutated if any modifications were made to it. This overwrote the true initial value `sessions`, causing the rollback to return us to an inconsistent state.
## Fix
To fix this, we ensure that we create a deep copy of `initialState` when instantiating and rolling back the `FlowStateManager` object, thus preserving the original state.
## Testing
Unit tests were created for the `FlowStateManager` class, and a failing test was written which reproduced the issue described. After implementing the fix, these tests all now pass as expected.

**Update**: Upon releasing this PR initially, it was discovered that the acceptance tests were failing. This was due to the implementation of the utility function `flowResumedWith(Any?)` being unable to correctly compare ByteArrays. To fix this, I added a `flowResumedWithData(Map<String, ByteArray>)` which handles cases matching a <SessionId: Data> call.

To increase our confidence that this handles the original problem, we should monitor gradle enterprise to ensure that this type of error drops off after the changes have been merged.

[CORE-9682]: https://r3-cev.atlassian.net/browse/CORE-9682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ