### PR TITLE
CORE-9880 - adding operation in progress to virtual node info

### DIFF
--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -398,6 +398,7 @@ internal class VirtualNodeRestResourceImpl @Activate constructor(
             flowStartOperationalStatus,
             flowOperationalStatus,
             vaultDbOperationalStatus,
+            operationInProgress
         )
 
     private fun net.corda.libs.packaging.core.CpiIdentifier.toEndpointType(): CpiIdentifier =

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/MgmGroupMismatchException.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/MgmGroupMismatchException.kt
@@ -1,6 +1,0 @@
-package net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception
-
-import net.corda.v5.base.exceptions.CordaRuntimeException
-
-class MgmGroupMismatchException(currentMgmGroupId: String, incorrectMgmGroupId: String) :
-    CordaRuntimeException("Expected MGM GroupId $currentMgmGroupId but was $incorrectMgmGroupId in CPI.")

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/MigrationsFailedException.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/MigrationsFailedException.kt
@@ -1,0 +1,6 @@
+package net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception
+
+import java.lang.Exception
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class MigrationsFailedException(val reason: String, val exception: Exception) : CordaRuntimeException(reason, exception)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/VirtualNodeStateException.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/VirtualNodeStateException.kt
@@ -1,5 +1,0 @@
-package net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception
-
-import net.corda.v5.base.exceptions.CordaRuntimeException
-
-class VirtualNodeStateException(message: String) : CordaRuntimeException(message)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/VirtualNodeUpgradeRejectedException.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/VirtualNodeUpgradeRejectedException.kt
@@ -1,0 +1,5 @@
+package net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class VirtualNodeUpgradeRejectedException(val reason: String, val requestId: String) : CordaRuntimeException("$reason (request $requestId)")

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -122,6 +122,7 @@ class VirtualNodeWriterProcessorTests {
             OperationalStatus.ACTIVE.name,
             OperationalStatus.ACTIVE.name,
             OperationalStatus.ACTIVE.name,
+            null,
             -1,
             clock.instant()
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.634-beta+
+cordaApiVersion=5.0.0.635-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -24,6 +24,7 @@ import java.time.Instant
 import java.util.*
 import javax.persistence.EntityManagerFactory
 import kotlin.random.Random
+import net.corda.libs.virtualnode.datamodel.entities.OperationType
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VirtualNodeEntitiesIntegrationTest {
@@ -131,6 +132,7 @@ class VirtualNodeEntitiesIntegrationTest {
             "req-$rand",
             "some-data",
             VirtualNodeOperationState.IN_PROGRESS,
+            OperationType.UPGRADE,
             Instant.now()
         )
         val vnodeEntity = VNodeTestUtils.newVNode(entityManagerFactory, name, version, hash, virtualNodeOperationEntity)

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -250,11 +250,7 @@ class VirtualNodeRepositoryTest {
         assertThat(upgradeVirtualNodeInfo.cpiIdentifier.signerSummaryHash).isEqualTo(signerSummaryHash)
 
         val foundEntity = entityManagerFactory.createEntityManager().transaction {
-            val query = "from ${VirtualNodeEntity::class.java.simpleName} vnode JOIN FETCH vnode.operationInProgress " +
-                    "where vnode.holdingIdentityId = :holdingIdentity"
-            it.createQuery(query, VirtualNodeEntity::class.java)
-                .setParameter("holdingIdentity", holdingIdentityShortHash)
-                .singleResult
+            it.find(VirtualNodeEntity::class.java, holdingIdentityShortHash)
         }
 
         assertThat(foundEntity).isNotNull

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -33,6 +33,7 @@ import kotlin.streams.toList
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationState
+import net.corda.libs.virtualnode.datamodel.entities.OperationType
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class VirtualNodeRepositoryTest {
@@ -275,7 +276,8 @@ class VirtualNodeRepositoryTest {
         val operationId = UUID.randomUUID().toString()
         val requestId = UUID.randomUUID().toString()
 
-        val operation = VirtualNodeOperationEntity(operationId, requestId, "data", VirtualNodeOperationState.IN_PROGRESS, Instant.now())
+        val operation = VirtualNodeOperationEntity(operationId, requestId, "data", VirtualNodeOperationState.IN_PROGRESS,
+            OperationType.UPGRADE, Instant.now())
         val vnode = VNodeTestUtils.newVNode(entityManagerFactory, testName, "v1", signerSummaryHash.toString(), operation)
 
         entityManagerFactory.createEntityManager().transaction {

--- a/libs/virtual-node/virtual-node-datamodel/src/main/java/net/corda/libs/virtualnode/datamodel/dto/package-info.java
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/java/net/corda/libs/virtualnode/datamodel/dto/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.libs.virtualnode.datamodel.dto;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/dto/VirtualNodeOperationType.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/dto/VirtualNodeOperationType.kt
@@ -1,0 +1,5 @@
+package net.corda.libs.virtualnode.datamodel.dto
+
+enum class VirtualNodeOperationType {
+    CREATE, UPGRADE
+}

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -140,6 +140,7 @@ internal class VirtualNodeEntity(
             flowStartOperationalStatus,
             flowOperationalStatus,
             vaultDbOperationalStatus,
+            operationInProgress?.id,
             entityVersion,
             insertTimestamp!!,
             isDeleted

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -15,7 +15,6 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Enumerated
 import javax.persistence.EnumType
-import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.MapsId
@@ -97,7 +96,7 @@ internal class VirtualNodeEntity(
     @Column(name = "vault_db_operational_status", nullable = false)
     var vaultDbOperationalStatus: OperationalStatus = OperationalStatus.ACTIVE,
 
-    @OneToOne(cascade = [CascadeType.PERSIST, CascadeType.MERGE], fetch = FetchType.LAZY)
+    @OneToOne(cascade = [CascadeType.PERSIST, CascadeType.MERGE])
     @JoinColumn(name = "operation_in_progress")
     var operationInProgress: VirtualNodeOperationEntity? = null,
 
@@ -140,7 +139,7 @@ internal class VirtualNodeEntity(
             flowStartOperationalStatus,
             flowOperationalStatus,
             vaultDbOperationalStatus,
-            operationInProgress?.id,
+            operationInProgress?.requestId,
             entityVersion,
             insertTimestamp!!,
             isDeleted

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
@@ -65,7 +65,7 @@ internal class VirtualNodeOperationEntity(
 }
 
 enum class VirtualNodeOperationState {
-    IN_PROGRESS, COMPLETED, ABORTED, VALIDATION_FAILED
+    IN_PROGRESS, COMPLETED, ABORTED, VALIDATION_FAILED, MIGRATIONS_FAILED
 }
 
 enum class OperationType {

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
@@ -10,6 +10,7 @@ import javax.persistence.Id
 import javax.persistence.Table
 import javax.persistence.Version
 import net.corda.db.schema.DbSchema.CONFIG
+import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
 
 @Entity
 @Table(name = "virtual_node_operation", schema = CONFIG)
@@ -29,6 +30,10 @@ internal class VirtualNodeOperationEntity(
     @Column(name = "state", nullable = false)
     var state: VirtualNodeOperationState,
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "operation_type", nullable = false)
+    var operationType: OperationType,
+
     @Column(name = "request_timestamp")
     var requestTimestamp: Instant,
 
@@ -37,6 +42,9 @@ internal class VirtualNodeOperationEntity(
 
     @Column(name = "heartbeat_timestamp")
     var heartbeatTimestamp: Instant? = null,
+
+    @Column(name = "errors")
+    var errors: String? = null,
 
     @Version
     @Column(name = "entity_version", nullable = false)
@@ -58,4 +66,14 @@ internal class VirtualNodeOperationEntity(
 
 enum class VirtualNodeOperationState {
     IN_PROGRESS, COMPLETED, ABORTED, VALIDATION_FAILED
+}
+
+enum class OperationType {
+    CREATE, UPGRADE;
+
+    companion object {
+        fun from(operationType: VirtualNodeOperationType): OperationType {
+            return valueOf(operationType.name)
+        }
+    }
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeOperationEntity.kt
@@ -57,5 +57,5 @@ internal class VirtualNodeOperationEntity(
 }
 
 enum class VirtualNodeOperationState {
-    IN_PROGRESS, COMPLETED, ABORTED
+    IN_PROGRESS, COMPLETED, ABORTED, VALIDATION_FAILED
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -77,5 +77,19 @@ interface VirtualNodeRepository {
         reason: String,
         operationType: VirtualNodeOperationType
     )
+
+    /**
+     * Update a virtual node operation with failure details caused by failure to run migrations.
+     */
+    @Suppress("LongParameterList")
+    fun failedMigrationsOperation(
+        entityManager: EntityManager,
+        holdingIdentityShortHash: String,
+        requestId: String,
+        serializedRequest: String,
+        requestTimestamp: Instant,
+        reason: String,
+        operationType: VirtualNodeOperationType
+    )
 }
 

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -62,5 +62,16 @@ interface VirtualNodeRepository {
         entityManager: EntityManager,
         holdingIdentityShortHash: String
     ): VirtualNodeInfo
+
+    /**
+     * Create a virtual node operation holding the details of a rejected request.
+     */
+    fun rejectedOperation(
+        entityManager: EntityManager,
+        holdingIdentityShortHash: String,
+        requestId: String,
+        requestTimestamp: Instant,
+        reason: String
+    )
 }
 

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -8,6 +8,7 @@ import net.corda.virtualnode.VirtualNodeInfo
 import java.util.UUID
 import java.util.stream.Stream
 import javax.persistence.EntityManager
+import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
 
 /**
  * Interface for CRUD operations for a virtual node.
@@ -66,12 +67,15 @@ interface VirtualNodeRepository {
     /**
      * Create a virtual node operation holding the details of a rejected request.
      */
+    @Suppress("LongParameterList")
     fun rejectedOperation(
         entityManager: EntityManager,
         holdingIdentityShortHash: String,
         requestId: String,
+        serializedRequest: String,
         requestTimestamp: Instant,
-        reason: String
+        reason: String,
+        operationType: VirtualNodeOperationType
     )
 }
 

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -164,6 +164,24 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
             .toVirtualNodeInfo()
     }
 
+    override fun rejectedOperation(
+        entityManager: EntityManager,
+        holdingIdentityShortHash: String,
+        requestId: String,
+        requestTimestamp: Instant,
+        reason: String
+    ) {
+        entityManager.persist(
+            VirtualNodeOperationEntity(
+                UUID.randomUUID().toString(),
+                requestId,
+                reason,
+                VirtualNodeOperationState.VALIDATION_FAILED,
+                requestTimestamp
+            )
+        )
+    }
+
     private fun findEntity(entityManager: EntityManager, holdingIdentityShortHash: String): VirtualNodeEntity? {
         val queryBuilder = with(entityManager.criteriaBuilder!!) {
             val queryBuilder = createQuery(VirtualNodeEntity::class.java)!!

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -14,8 +14,10 @@ import net.corda.virtualnode.VirtualNodeInfo
 import java.util.UUID
 import java.util.stream.Stream
 import javax.persistence.EntityManager
+import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationState
+import net.corda.libs.virtualnode.datamodel.entities.OperationType
 
 class VirtualNodeRepositoryImpl : VirtualNodeRepository {
     /**
@@ -143,6 +145,7 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
             requestId,
             serializedRequest,
             VirtualNodeOperationState.IN_PROGRESS,
+            OperationType.UPGRADE,
             requestTimestamp
         )
         val updatedVirtualNode = entityManager.merge(virtualNode)
@@ -168,16 +171,20 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
         entityManager: EntityManager,
         holdingIdentityShortHash: String,
         requestId: String,
+        serializedRequest: String,
         requestTimestamp: Instant,
-        reason: String
+        reason: String,
+        operationType: VirtualNodeOperationType
     ) {
         entityManager.persist(
             VirtualNodeOperationEntity(
                 UUID.randomUUID().toString(),
                 requestId,
-                reason,
+                serializedRequest,
                 VirtualNodeOperationState.VALIDATION_FAILED,
-                requestTimestamp
+                OperationType.from(operationType),
+                requestTimestamp,
+                errors = reason
             )
         )
     }

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodeInfo.kt
@@ -20,7 +20,11 @@ import net.corda.virtualnode.OperationalStatus
  * @param uniquenessDdlConnectionId Uniqueness DB DDL connection ID.
  * @param uniquenessDmlConnectionId Uniqueness DB DML connection ID.
  * @param hsmConnectionId HSM connection ID.
- * @param state The state of the virtual node.
+ * @param flowP2pOperationalStatus operational status of the virtual node.
+ * @param flowStartOperationalStatus operational status of the virtual node.
+ * @param flowOperationalStatus operational status of the virtual node.
+ * @param vaultDbOperationalStatus operational status of the virtual node.
+ * @param operationInProgress ID of any ongoing operation on this virtual node.
  */
 data class VirtualNodeInfo(
     val holdingIdentity: HoldingIdentity,
@@ -36,4 +40,5 @@ data class VirtualNodeInfo(
     val flowStartOperationalStatus: OperationalStatus,
     val flowOperationalStatus: OperationalStatus,
     val vaultDbOperationalStatus: OperationalStatus,
+    val operationInProgress: String? = null
 )

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -40,7 +40,7 @@ data class VirtualNodeInfo(
     val flowOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
     /** Current state of the virtual node instance */
     val vaultDbOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
-    /** Populated when an operation is in progress on this virtual node */
+    /** The requestId of an operation that is in progress on this virtual node. Null if no operation is in progress */
     val operationInProgress: String? = null,
     /** Version of this vnode */
     val version: Int = -1,

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -40,6 +40,8 @@ data class VirtualNodeInfo(
     val flowOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
     /** Current state of the virtual node instance */
     val vaultDbOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
+    /** Populated when an operation is in progress on this virtual node */
+    val operationInProgress: String? = null,
     /** Version of this vnode */
     val version: Int = -1,
     /** Creation timestamp */
@@ -71,6 +73,7 @@ fun VirtualNodeInfo.toAvro(): VirtualNodeInfoAvro =
             flowStartOperationalStatus.toString(),
             flowOperationalStatus.toString(),
             vaultDbOperationalStatus.toString(),
+            operationInProgress,
             version,
             timestamp
         )
@@ -92,6 +95,7 @@ fun VirtualNodeInfoAvro.toCorda(): VirtualNodeInfo {
         OperationalStatus.valueOf(flowStartOperationalStatus),
         OperationalStatus.valueOf(flowOperationalStatus),
         OperationalStatus.valueOf(vaultDbOperationalStatus),
+        operationInProgress,
         version,
         timestamp,
         false

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -4712,6 +4712,11 @@
             "nullable" : true,
             "example" : "string"
           },
+          "operationInProgress" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
           "uniquenessDdlConnectionId" : {
             "type" : "string",
             "nullable" : true,

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -3732,7 +3732,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -3871,7 +3870,6 @@
       },
       "GenerateCsrWrapperRequest" : {
         "required" : [ "x500Name" ],
-        "type" : "object",
         "properties" : {
           "contextMap" : {
             "type" : "object",
@@ -4157,7 +4155,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4201,7 +4198,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4238,7 +4234,6 @@
             "example" : "string"
           },
           "status" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "REVOKED",
             "enum" : [ "AVAILABLE", "REVOKED", "CONSUMED", "AUTO_INVALIDATED" ]
@@ -4344,7 +4339,6 @@
             "example" : "2022-06-24T10:15:30Z"
           },
           "registrationStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "SENT_TO_MGM",
             "enum" : [ "NEW", "SENT_TO_MGM", "RECEIVED_BY_MGM", "PENDING_MEMBER_VERIFICATION", "PENDING_APPROVAL_FLOW", "PENDING_MANUAL_APPROVAL", "PENDING_AUTO_APPROVAL", "DECLINED", "INVALID", "APPROVED" ]
@@ -4687,19 +4681,16 @@
             "example" : "string"
           },
           "flowOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowP2pOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowStartOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
@@ -4728,7 +4719,6 @@
             "example" : "string"
           },
           "vaultDbOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]


### PR DESCRIPTION
Corresponding corda-api change: https://github.com/corda/corda-api/pull/834

Expand the following examples:
<details>
<summary>Virtual node validation failed (mgm groupId was different):</summary>
**VirtualNode**

| holding\_identity\_id | cpi\_name | cpi\_version | cpi\_signer\_summary\_hash | flow\_p2p\_operational\_status | flow\_start\_operational\_status | flow\_operational\_status | vault\_db\_operational\_status | vault\_ddl\_connection\_id | vault\_dml\_connection\_id | crypto\_ddl\_connection\_id | crypto\_dml\_connection\_id | uniqueness\_ddl\_connection\_id | uniqueness\_dml\_connection\_id | operation\_in\_progress | entity\_version | is\_deleted | insert\_ts |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 23583727B08F | upgrade-testing-cordapp\_bad917c9-0120-4fca-8c69-3717b2135a93 | v1 | SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903 | INACTIVE | INACTIVE | INACTIVE | INACTIVE | 7161a73c-2a2c-4a57-bdaa-c6ff16ca205b | 433688b3-98e3-45f1-a16c-357820a370b5 | 7161a73c-2a2c-4a57-bdaa-c6ff16ca205b | 7b42afb5-2600-44a4-b436-f5c00922b3b2 | 5c18d35e-8808-4590-b11b-ce923d9717e0 | 36d55a9b-f317-4a65-a9b6-f94bcd5e218e | null | 1 | false | 2023-02-04 00:12:42.689995 |

- Notice the operationInProgress is null, no operation started because it failed validation.

**VirtualNodeOperation**

| id | request\_id | data | request\_timestamp | latest\_update\_timestamp | heartbeat\_timestamp | state | operation\_type | errors | entity\_version |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1ea9835a-16f3-4ac1-a111-539747798c0a | 23583727B08FC7F983AD2CCDC17AE4F37CF0 | {"virtualNodeShortHash": "23583727B08F", "cpiFileChecksum": "C17AE4F37CF0D2415064043F78272B1EC5D027CFAE2C2A0D199C2B0890CE7F12", "actor": "admin"} | 2023-02-04 00:12:45.179000 | 2023-02-04 00:12:46.197799 | null | VALIDATION\_FAILED | UPGRADE | Expected MGM GroupId 7c5d6948-e17b-44e7-9d1c-fa4a3f667cad but was 6d3d6948-e17b-44e7-9d1c-fa4a3f667cad in CPI | 0 |

- Notice the operation entity was persisted with VALIDATION_FAILED, the "errors" column has the reason.

</details>


</details>

<details>
<summary> Failed while running the migrations </summary>

| holding\_identity\_id | cpi\_name | cpi\_version | cpi\_signer\_summary\_hash | flow\_p2p\_operational\_status | flow\_start\_operational\_status | flow\_operational\_status | vault\_db\_operational\_status | vault\_ddl\_connection\_id | vault\_dml\_connection\_id | crypto\_ddl\_connection\_id | crypto\_dml\_connection\_id | uniqueness\_ddl\_connection\_id | uniqueness\_dml\_connection\_id | operation\_in\_progress | entity\_version | is\_deleted | insert\_ts |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 652D48FE2B83 | upgrade-testing-cordapp\_a9d9bbfd-edb4-4921-830d-c24cf6a246ea | v2 | SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903 | INACTIVE | INACTIVE | INACTIVE | INACTIVE | 6504f8fb-ff08-47a8-96a0-1efdfea9be69 | 1af453aa-63c5-40ae-9ad2-c67d67fe2c2a | 6504f8fb-ff08-47a8-96a0-1efdfea9be69 | f6e59179-ac27-4a56-9855-7d8beadd1679 | e10eb5af-7a35-4e6b-a338-4a98da14c95f | 3a9c8716-8159-4489-b236-da3ec175dbd7 | 0387588c-5b6e-43b9-81bf-0839a5f9679a | 2 | false | 2023-02-04 00:26:32.996407 |

- Notice there is an operation in progress, let's have a look at that operation:

| id | request\_id | data | request\_timestamp | latest\_update\_timestamp | heartbeat\_timestamp | state | operation\_type | errors | entity\_version |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 0387588c-5b6e-43b9-81bf-0839a5f9679a | 652D48FE2B83A9795982C9527FAAE4D9A637 | {"virtualNodeShortHash": "652D48FE2B83", "cpiFileChecksum": "7FAAE4D9A6375DB8F19BAF7418A02FCC67B9897B68EE9B9283A47F3C55210B13", "actor": "admin"} | 2023-02-04 00:26:36.065000 | 2023-02-04 00:26:36.807652 | null | MIGRATIONS\_FAILED | UPGRADE | liquibase.exception.SetupException: liquibase.exception.SetupException: Error parsing line 7 column 42 of migration/v2/dogs-migration-v1.0.xml: cvc-complex-type.3.2.2: Attribute 'wrongProperty' is not allowed to appear in element 'createTable'. | 1 |

- We've picked out the exception from liquibase, we used an incorrect attribute on the createTable.
- Notice it has MIGRATIONS_FAILED.

</details>


<details>
<summary>Completed successfully:</summary>

| holding\_identity\_id | cpi\_name | cpi\_version | cpi\_signer\_summary\_hash | flow\_p2p\_operational\_status | flow\_start\_operational\_status | flow\_operational\_status | vault\_db\_operational\_status | vault\_ddl\_connection\_id | vault\_dml\_connection\_id | crypto\_ddl\_connection\_id | crypto\_dml\_connection\_id | uniqueness\_ddl\_connection\_id | uniqueness\_dml\_connection\_id | operation\_in\_progress | entity\_version | is\_deleted | insert\_ts |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 05AA3DA51441 | upgrade-testing-cordapp\_6934568f-46e8-42cd-baa4-32b26ee87fdf | v2 | SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903 | INACTIVE | INACTIVE | INACTIVE | INACTIVE | def323b8-27ad-4baa-b31b-f1d60f67b3da | 86aff855-26a5-4c6c-93a7-74fdb39b0c26 | def323b8-27ad-4baa-b31b-f1d60f67b3da | 781177da-2421-4b68-b2a3-4dbb6b910e96 | 33d2f416-f98e-4ea2-8d49-815a9d95ca51 | 9561df23-dc06-4a9b-ba7e-eff760d08cf7 | null | 3 | false | 2023-02-04 00:31:42.520799 |

- No operation in progress any more.

| id | request\_id | data | request\_timestamp | latest\_update\_timestamp | heartbeat\_timestamp | state | operation\_type | errors | entity\_version |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| e8886612-3a03-4877-ad07-e4864d8685fe | 05AA3DA5144117505192385E5593ACE4C8DF | {"virtualNodeShortHash": "05AA3DA51441", "cpiFileChecksum": "5593ACE4C8DFA04309D61F8435CD51BEC70AC5366A4E7A59DEEC56DBBD3A1DAF", "actor": "admin"} | 2023-02-04 00:31:45.705000 | 2023-02-04 00:31:46.197931 | null | COMPLETED | UPGRADE | null | 1 |


- The operation entity remains, it can be queried using the status endpoint, it shows the upgrade completed, plus the request information and actor.


</details>

- GET virtual node endpoint returns the operationInProgress, it is the requestId, which can then be used in the status endpoint (TBD).
- We've added some validations on operation being in progress, and some exception handling to write the failed operations.