### PR TITLE
CORE-7036 Prevent AMQP serialization of transaction builders

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionBuilderSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionBuilderSerializer.kt
@@ -1,0 +1,41 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp
+
+import net.corda.ledger.utxo.flow.impl.transaction.filtered.UtxoFilteredTransactionBuilderInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByVerification
+import net.corda.serialization.BaseProxySerializer
+import net.corda.serialization.InternalCustomSerializer
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionBuilder
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+
+@Component(
+    service = [InternalCustomSerializer::class, UsedByFlow::class],
+    property = [CORDA_UNINJECTABLE_SERVICE],
+    scope = PROTOTYPE
+)
+class UtxoFilteredTransactionBuilderSerializer :
+    BaseProxySerializer<UtxoFilteredTransactionBuilderInternal, UtxoFilteredTransactionBuilderProxy>(),
+    UsedByFlow, UsedByVerification {
+
+    override val type = UtxoFilteredTransactionBuilderInternal::class.java
+
+    override val proxyType = UtxoFilteredTransactionBuilderProxy::class.java
+
+    override val withInheritance = true
+
+    override fun toProxy(obj: UtxoFilteredTransactionBuilderInternal): UtxoFilteredTransactionBuilderProxy {
+        throw CordaRuntimeException("${UtxoFilteredTransactionBuilder::class.java.name} cannot be AMQP serialized and sent to peers")
+    }
+
+    override fun fromProxy(proxy: UtxoFilteredTransactionBuilderProxy): UtxoFilteredTransactionBuilderInternal {
+        throw CordaRuntimeException("${UtxoFilteredTransactionBuilder::class.java.name} cannot be AMQP serialized and received from peers")
+    }
+}
+
+/**
+ * Unused, needed to satisfy the serializer's methods.
+ */
+class UtxoFilteredTransactionBuilderProxy

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoTransactionBuilderSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoTransactionBuilderSerializer.kt
@@ -1,0 +1,41 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp
+
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByVerification
+import net.corda.serialization.BaseProxySerializer
+import net.corda.serialization.InternalCustomSerializer
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+
+@Component(
+    service = [InternalCustomSerializer::class, UsedByFlow::class],
+    property = [CORDA_UNINJECTABLE_SERVICE],
+    scope = PROTOTYPE
+)
+class UtxoTransactionBuilderSerializer :
+    BaseProxySerializer<UtxoTransactionBuilderInternal, UtxoTransactionBuilderProxy>(),
+    UsedByFlow, UsedByVerification {
+
+    override val type = UtxoTransactionBuilderInternal::class.java
+
+    override val proxyType = UtxoTransactionBuilderProxy::class.java
+
+    override val withInheritance = true
+
+    override fun toProxy(obj: UtxoTransactionBuilderInternal): UtxoTransactionBuilderProxy {
+        throw CordaRuntimeException("${UtxoTransactionBuilder::class.java.name} cannot be AMQP serialized and sent to peers")
+    }
+
+    override fun fromProxy(proxy: UtxoTransactionBuilderProxy): UtxoTransactionBuilderInternal {
+        throw CordaRuntimeException("${UtxoTransactionBuilder::class.java.name} cannot be AMQP serialized and received from peers")
+    }
+}
+
+/**
+ * Unused, needed to satisfy the serializer's methods.
+ */
+class UtxoTransactionBuilderProxy

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionBuilderSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionBuilderSerializerTest.kt
@@ -1,0 +1,24 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp
+
+import net.corda.ledger.utxo.flow.impl.transaction.filtered.UtxoFilteredTransactionBuilderImpl
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+class UtxoFilteredTransactionBuilderSerializerTest {
+
+    @Test
+    fun `cannot serialize utxo filtered transaction builder`() {
+        val builder = UtxoFilteredTransactionBuilderImpl(mock(), mock())
+        assertThatThrownBy { UtxoFilteredTransactionBuilderSerializer().toProxy(builder, mock()) }
+            .isInstanceOf(CordaRuntimeException::class.java)
+    }
+
+    @Test
+    fun `cannot deserialize utxo filtered transaction builder proxy`() {
+        assertThatThrownBy { UtxoFilteredTransactionBuilderSerializer().fromProxy(UtxoFilteredTransactionBuilderProxy(), mock()) }
+            .isInstanceOf(CordaRuntimeException::class.java)
+    }
+
+}

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoTransactionBuilderSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoTransactionBuilderSerializerTest.kt
@@ -1,0 +1,24 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp
+
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderImpl
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+class UtxoTransactionBuilderSerializerTest {
+
+    @Test
+    fun `cannot serialize utxo transaction builder`() {
+        val builder = UtxoTransactionBuilderImpl(mock())
+        assertThatThrownBy { UtxoTransactionBuilderSerializer().toProxy(builder, mock()) }
+            .isInstanceOf(CordaRuntimeException::class.java)
+    }
+
+    @Test
+    fun `cannot deserialize utxo transaction builder proxy`() {
+        assertThatThrownBy { UtxoTransactionBuilderSerializer().fromProxy(UtxoTransactionBuilderProxy(), mock()) }
+            .isInstanceOf(CordaRuntimeException::class.java)
+    }
+
+}


### PR DESCRIPTION
Make `UtxoTransactionBuilder` and `UtxoFilteredTransactionBuilder` unserializable by AMQP by adding custom serializers that throw exceptions.