### PR TITLE
CORE-8881 Maintain the allowed set of TLS certificate subjects

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
@@ -39,7 +39,7 @@ class DynamicCertificateSubjectStore(
     )
 
     fun subjectAllowed(subject: CertificateSubject): Boolean {
-        return certificateSubjects[subject] != null
+        return certificateSubjects.containsKey(subject)
     }
 
     private fun addSource(subject: CertificateSubject, source: String) {
@@ -49,11 +49,9 @@ class DynamicCertificateSubjectStore(
     }
 
     private fun removeSource(subject: CertificateSubject, source: String) {
-        certificateSubjects.compute(subject) { _, sources ->
-            sources?.remove(source)
-            if (sources?.isNotEmpty() == true) {
-                sources
-            } else {
+        certificateSubjects.computeIfPresent(subject) { _, sources ->
+            sources.remove(source)
+            sources.ifEmpty {
                 null
             }
         }

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
@@ -1,0 +1,89 @@
+package net.corda.p2p.gateway.messaging.mtls
+
+import net.corda.data.p2p.mtls.gateway.ClientCertificateSubjects
+import net.corda.libs.configuration.SmartConfig
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
+import net.corda.lifecycle.domino.logic.util.SubscriptionDominoTile
+import net.corda.messaging.api.processor.CompactedProcessor
+import net.corda.messaging.api.records.Record
+import net.corda.messaging.api.subscription.config.SubscriptionConfig
+import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.schema.Schemas
+import java.util.concurrent.ConcurrentHashMap
+
+class DynamicCertificateSubjectStore(
+    lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    subscriptionFactory: SubscriptionFactory,
+    messagingConfiguration: SmartConfig,
+): LifecycleWithDominoTile {
+    private companion object {
+        const val CONSUMER_GROUP_ID = "gateway_certificates_allowed_client_subjects_reader"
+    }
+
+    private val subscriptionConfig = SubscriptionConfig(CONSUMER_GROUP_ID, Schemas.P2P.GATEWAY_ALLOWED_CLIENT_CERTIFICATE_SUBJECTS)
+    private val certificateSubjects = ConcurrentHashMap<CertificateSubject, MutableSet<String>>()
+    private val subscription = {
+        subscriptionFactory.createCompactedSubscription(
+            subscriptionConfig,
+            Processor(),
+            messagingConfiguration
+        )
+    }
+    override val dominoTile = SubscriptionDominoTile(
+        lifecycleCoordinatorFactory,
+        subscription,
+        subscriptionConfig,
+        emptyList(),
+        emptyList(),
+    )
+
+    fun subjectAllowed(subject: CertificateSubject): Boolean {
+        return certificateSubjects[subject] != null
+    }
+
+    private fun addSource(subject: CertificateSubject, source: String) {
+        certificateSubjects.compute(subject) { _, sources ->
+            sources?.apply { add(source) } ?: mutableSetOf(source)
+        }
+    }
+
+    private fun removeSource(subject: CertificateSubject, source: String) {
+        certificateSubjects.compute(subject) { _, sources ->
+            sources?.remove(source)
+            if (sources?.isNotEmpty() == true) {
+                sources
+            } else {
+                null
+            }
+        }
+    }
+
+    private inner class Processor : CompactedProcessor<String, ClientCertificateSubjects> {
+        override val keyClass = String::class.java
+        override val valueClass = ClientCertificateSubjects::class.java
+
+        override fun onNext(
+            newRecord: Record<String, ClientCertificateSubjects>,
+            oldValue: ClientCertificateSubjects?,
+            currentData: Map<String, ClientCertificateSubjects>
+        ) {
+            val newCertificateSubject = newRecord.value?.subject
+            val oldCertificateSubjects = oldValue?.subject
+            val source = newRecord.key
+            if (newCertificateSubject != null) {
+                addSource(newCertificateSubject, source)
+            } else if (oldCertificateSubjects != null) {
+                removeSource(oldCertificateSubjects, source)
+            }
+        }
+
+        override fun onSnapshot(currentData: Map<String, ClientCertificateSubjects>) {
+            currentData.forEach { (source, value) ->
+                addSource(value.subject, source)
+            }
+        }
+    }
+}
+
+typealias CertificateSubject = String

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
@@ -12,7 +12,7 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
 import java.util.concurrent.ConcurrentHashMap
 
-class DynamicCertificateSubjectStore(
+internal class DynamicCertificateSubjectStore(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
     messagingConfiguration: SmartConfig,

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-class DynamicCertificateSubjectStoreTest {
+internal class DynamicCertificateSubjectStoreTest {
     private companion object {
         const val TOPIC = "Topic"
         const val KEY_1 = "key1"

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-internal class DynamicCertificateSubjectStoreTest {
+class DynamicCertificateSubjectStoreTest {
     private companion object {
         const val TOPIC = "Topic"
         const val KEY_1 = "key1"

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
@@ -1,0 +1,87 @@
+package net.corda.p2p.gateway.messaging.mtls
+
+import net.corda.data.p2p.mtls.gateway.ClientCertificateSubjects
+import net.corda.libs.configuration.SmartConfig
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.domino.logic.util.SubscriptionDominoTile
+import net.corda.messaging.api.processor.CompactedProcessor
+import net.corda.messaging.api.records.Record
+import net.corda.messaging.api.subscription.CompactedSubscription
+import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class DynamicCertificateSubjectStoreTest {
+    private companion object {
+        const val TOPIC = "Topic"
+        const val KEY_1 = "key1"
+        const val KEY_2 = "key2"
+        const val SUBJECT_1 = "Subject 1"
+        const val SUBJECT_2 = "Subject 2"
+    }
+    private val lifecycleCoordinatorFactory = mock<LifecycleCoordinatorFactory>()
+    private val nodeConfiguration = mock<SmartConfig>()
+    private val subscription = mock<CompactedSubscription<String, ClientCertificateSubjects>>()
+
+    private val processor = argumentCaptor<CompactedProcessor<String, ClientCertificateSubjects>>()
+    private val subscriptionFactory = mock<SubscriptionFactory> {
+        on { createCompactedSubscription(any(), processor.capture(), eq(nodeConfiguration)) } doReturn subscription
+    }
+    private val subscriptionDominoTile = Mockito.mockConstruction(SubscriptionDominoTile::class.java) { mock, context ->
+        whenever(mock.coordinatorName).doReturn(LifecycleCoordinatorName("", ""))
+        @Suppress("UNCHECKED_CAST")
+        (context.arguments()[1] as (() -> CompactedSubscription<String, ClientCertificateSubjects>)).invoke()
+    }
+    private val dynamicCertificateSubjectStore =
+        DynamicCertificateSubjectStore(lifecycleCoordinatorFactory, subscriptionFactory, nodeConfiguration)
+
+    @AfterEach
+    fun cleanUp() {
+        subscriptionDominoTile.close()
+    }
+
+    @Test
+    fun `onSnapshot adds subjects to the store`() {
+        processor.firstValue.onSnapshot(mapOf(KEY_1 to ClientCertificateSubjects(SUBJECT_1), KEY_2 to ClientCertificateSubjects(SUBJECT_2)))
+
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed(SUBJECT_1)).isTrue
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed(SUBJECT_2)).isTrue
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed("Not a Subject")).isFalse
+    }
+
+    @Test
+    fun `onNext adds subjects to the store`() {
+        processor.firstValue.onNext(Record(TOPIC, KEY_1, ClientCertificateSubjects(SUBJECT_1)), null, emptyMap())
+        processor.firstValue.onNext(Record(TOPIC, KEY_2, ClientCertificateSubjects(SUBJECT_2)), null, emptyMap())
+
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed(SUBJECT_1)).isTrue
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed(SUBJECT_2)).isTrue
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed("Not a Subject")).isFalse
+    }
+
+    @Test
+    fun `onNext removes subjects from the store after a tombstone record for every key`() {
+        processor.firstValue.onNext(Record(TOPIC, KEY_1, ClientCertificateSubjects(SUBJECT_1)), null, emptyMap())
+        processor.firstValue.onNext(Record(TOPIC, KEY_2, ClientCertificateSubjects(SUBJECT_1)), null, emptyMap())
+
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed(SUBJECT_1)).isTrue
+
+        processor.firstValue.onNext(Record(TOPIC, KEY_1, null), ClientCertificateSubjects(SUBJECT_1), emptyMap())
+
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed(SUBJECT_1)).isTrue
+
+        processor.firstValue.onNext(Record(TOPIC, KEY_2, null), ClientCertificateSubjects(SUBJECT_1), emptyMap())
+
+        assertThat(dynamicCertificateSubjectStore.subjectAllowed(SUBJECT_1)).isFalse
+    }
+
+}


### PR DESCRIPTION
Read the certificate subjects published by the Link Manager inside the gateway. Merge them from the 3 sources into a single source from which we can do a lookup by certificate subject.