### PR TITLE
CORE-5084 Add values-prereqs.yaml for corda-dev-prereqs

### DIFF
--- a/values-prereqs.yaml
+++ b/values-prereqs.yaml
@@ -1,18 +1,10 @@
-# Override file suitable for local deployment of the Corda Helm chart against version 0.1.0 of the corda-dev prereqs Helm chart.
-#
-# First use `./gradlew publishOSGiImage --parallel` to create local docker images
-# Then deploy using:
-#
-#  helm upgrade --install corda -n corda \
-#  charts/corda \
-#  --values values.yaml \
-#  --values debug.yaml \
-#  --wait
+# Override file suitable for local deployment of the Corda Helm chart against version 0.2.0 of the corda-dev-prereqs Helm chart.
 #
 # See `debug.yaml` for debug settings.
 #
 # NOTE: The below assumes you deploy Kafka and the PostgreSQL database in the same namespace, so that domain names containing just the service name are resolved (i.e. prereqs-postgresql instead of prereqs-postgresql.<namespace>)
 #       If that is not the case, you might need to add the namespace as a suffix.
+
 imagePullPolicy: "IfNotPresent"
 image:
   registry: "corda-os-docker-dev.software.r3.com"
@@ -29,32 +21,32 @@ bootstrap:
   kafka:
     replicas: 1
 
+db:
+  cluster:
+    host: "prereqs-postgres"
+    username:
+      value: "corda"
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: "prereqs-postgres"
+          key: "corda-password"
 kafka:
   bootstrapServers: "prereqs-kafka:9092"
   sasl:
     enabled: true
+    mechanism: "PLAIN"
     username:
-      value: "user"
+      value: "admin"
     password:
       valueFrom:
         secretKeyRef:
-          name: "prereqs-kafka-jaas"
-          key: "client-passwords"
+          name: "prereqs-kafka"
+          key: "admin-password"
   tls:
     enabled: true
     truststore:
       valueFrom:
         secretKeyRef:
-          name: "prereqs-kafka-0-tls"
+          name: "prereqs-kafka"
           key: "ca.crt"
-
-db:
-  cluster:
-    host: "prereqs-postgresql"
-    password:
-      valueFrom:
-        secretKeyRef:
-          name: "prereqs-postgresql"
-          key: "password"
-    username:
-      value: "user"


### PR DESCRIPTION
Decided to leave the existing `values.yaml` and add a new `value-prereqs.yaml` for the new `corda-dev-prereqs` chart.