### PR TITLE
CORE-9428 Update transaction to INVALID in unrecoverable cases.

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
@@ -106,7 +106,7 @@ class ConsensualLedgerTests {
     }
 
     @Test
-    fun `Consensual Ledger - creating a transaction that fails custom verification causes finality to fail`() {
+    fun `Consensual Ledger - creating a transaction that fails custom validation causes finality to fail`() {
         val consensualFlowRequestId = startRpcFlow(
             aliceHoldingId,
             mapOf("input" to "fail", "members" to listOf(bobX500, charlieX500)),

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
@@ -101,6 +101,7 @@ class ConsensualFinalityFlow(
         return transaction to signaturesReceivedFromSessions
     }
 
+    @Suspendable
     private fun verifyAllReceivedSignatures(
         transaction: ConsensualSignedTransactionInternal,
         signaturesReceivedFromSessions: Map<FlowSession, List<DigitalSignatureAndMetadata>>

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
@@ -38,6 +38,7 @@ class ConsensualFinalityFlow(
 
     @Suspendable
     override fun call(): ConsensualSignedTransaction {
+        verifyExistingSignatures(initialTransaction)
         verifyTransaction(initialTransaction)
         persistUnverifiedTransaction()
         val (transaction, signaturesReceivedFromSessions) = receiveSignaturesAndAddToTransaction()

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlow.kt
@@ -40,7 +40,10 @@ class ConsensualFinalityFlow(
     override fun call(): ConsensualSignedTransaction {
         verifyExistingSignatures(initialTransaction)
         verifyTransaction(initialTransaction)
+
+        // Initial verifications passed, the transaction can be saved in the database.
         persistUnverifiedTransaction()
+
         val (transaction, signaturesReceivedFromSessions) = receiveSignaturesAndAddToTransaction()
         verifyAllReceivedSignatures(transaction, signaturesReceivedFromSessions)
         persistTransactionWithCounterpartySignatures(transaction)

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
@@ -31,7 +31,9 @@ class ConsensualReceiveFinalityFlow(
         val initialTransaction = session.receive<ConsensualSignedTransactionInternal>()
         val transactionId = initialTransaction.id
 
-        verifyExistingSignatures(initialTransaction)
+        verifyExistingSignatures(initialTransaction){
+            session.send(Payload.Failure<List<DigitalSignatureAndMetadata>>(it))
+        }
         verifyTransaction(initialTransaction)
 
         var transaction = if (validateTransaction(initialTransaction)) {
@@ -60,15 +62,6 @@ class ConsensualReceiveFinalityFlow(
         log.debug { "Recorded transaction with all parties' signatures $transactionId" }
 
         return transaction
-    }
-
-    @Suspendable
-    private fun verifyExistingSignatures(initialTransaction: ConsensualSignedTransactionInternal) {
-        initialTransaction.signatures.forEach {
-            verifySignature(initialTransaction, it) { message ->
-                session.send(Payload.Failure<List<DigitalSignatureAndMetadata>>(message))
-            }
-        }
     }
 
     @Suspendable

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
@@ -2,20 +2,18 @@ package net.corda.ledger.consensual.flow.impl.flows.finality
 
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
-import net.corda.ledger.consensual.flow.impl.persistence.ConsensualLedgerPersistenceService
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
 import net.corda.sandbox.CordaSystemFlow
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
-import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.messaging.receive
-import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionValidator
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 @CordaSystemFlow
@@ -25,14 +23,8 @@ class ConsensualReceiveFinalityFlow(
 ) : ConsensualFinalityBase() {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
-
-    @CordaInject
-    lateinit var persistenceService: ConsensualLedgerPersistenceService
-
-    @CordaInject
-    lateinit var serializationService: SerializationService
 
     @Suspendable
     override fun call(): ConsensualSignedTransaction {
@@ -50,6 +42,7 @@ class ConsensualReceiveFinalityFlow(
             session.send(payload)
             transaction
         } else {
+            log.warn("Failed to validate transaction: ${initialTransaction.id}")
             persistInvalidTransaction(initialTransaction)
             val payload = Payload.Failure<List<DigitalSignatureAndMetadata>>(
                 "Transaction validation failed for transaction $transactionId when signature was requested"
@@ -61,7 +54,7 @@ class ConsensualReceiveFinalityFlow(
         transaction = receiveSignaturesAndAddToTransaction(transaction)
 
         log.debug { "Verifying signatures of transaction: $transactionId" }
-        transaction.verifySignatures()
+        verifyAllReceivedSignatures(transaction)
 
         persistenceService.persist(transaction, TransactionStatus.VERIFIED)
         log.debug { "Recorded transaction with all parties' signatures $transactionId" }
@@ -106,13 +99,6 @@ class ConsensualReceiveFinalityFlow(
     }
 
     @Suspendable
-    private fun persistInvalidTransaction(transaction: ConsensualSignedTransactionInternal) {
-        log.warn("Failed to validate transaction: ${transaction.id}")
-        persistenceService.persist(transaction, TransactionStatus.INVALID)
-        log.debug { "Recorded transaction as invalid: ${transaction.id}" }
-    }
-
-    @Suspendable
     private fun receiveSignaturesAndAddToTransaction(
         transaction: ConsensualSignedTransactionInternal
     ): ConsensualSignedTransactionInternal {
@@ -126,5 +112,15 @@ class ConsensualReceiveFinalityFlow(
             }
 
         return signedTransaction
+    }
+
+    private fun verifyAllReceivedSignatures(transaction: ConsensualSignedTransactionInternal) {
+        log.debug { "Verifying signatures of transaction: ${transaction.id}" }
+        try {
+            transaction.verifySignatures()
+        } catch (e: Exception) {
+            persistInvalidTransaction(transaction)
+            throw e
+        }
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
@@ -107,6 +107,7 @@ class ConsensualReceiveFinalityFlow(
         return signedTransaction
     }
 
+    @Suspendable
     private fun verifyAllReceivedSignatures(transaction: ConsensualSignedTransactionInternal) {
         log.debug { "Verifying signatures of transaction: ${transaction.id}" }
         try {

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlow.kt
@@ -31,9 +31,7 @@ class ConsensualReceiveFinalityFlow(
         val initialTransaction = session.receive<ConsensualSignedTransactionInternal>()
         val transactionId = initialTransaction.id
 
-        verifyExistingSignatures(initialTransaction){
-            session.send(Payload.Failure<List<DigitalSignatureAndMetadata>>(it))
-        }
+        verifyExistingSignatures(initialTransaction, session)
         verifyTransaction(initialTransaction)
 
         var transaction = if (validateTransaction(initialTransaction)) {

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
@@ -129,18 +129,18 @@ class ConsensualFinalityFlowTest {
     }
 
     @Test
-    fun `called with a transaction initially without signatures throws and does not persist anything`() {
+    fun `called with a transaction initially without signatures throws and persists as invalid`() {
         whenever(signedTransaction.signatures).thenReturn(listOf())
         assertThatThrownBy { callFinalityFlow(signedTransaction, listOf(sessionAlice, sessionBob)) }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("Received initial transaction without signatures.")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
     }
 
     @Test
-    fun `called with a transaction initially with invalid signature throws and does not persist anything`() {
+    fun `called with a transaction initially with invalid signature throws and persists as invalid`() {
         whenever(transactionSignatureService.verifySignature(any(), any())).thenThrow(
             CryptoSignatureException("Verifying signature failed!!")
         )
@@ -149,11 +149,11 @@ class ConsensualFinalityFlowTest {
             .hasMessageContaining("Verifying signature failed!!")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
     }
 
     @Test
-    fun `called with an invalid transaction initially throws and does not persist anything`() {
+    fun `called with an invalid transaction initially throws and persists as invalid`() {
         whenever(ledgerTransaction.states).thenReturn(
             listOf(
                 ConsensualStateClassExample(
@@ -169,7 +169,7 @@ class ConsensualFinalityFlowTest {
             .hasMessageContaining("State verification failed")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
     }
 
     @Test

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
@@ -102,19 +102,19 @@ class ConsensualReceiveFinalityFlowTest {
     }
 
     @Test
-    fun `receiving a transaction initially without signatures throws and does not persist anything`() {
+    fun `receiving a transaction initially without signatures throws and persists as invalid`() {
         whenever(signedTransaction.signatures).thenReturn(listOf())
         assertThatThrownBy { callReceiveFinalityFlow() }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("Received initial transaction without signatures.")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
         verify(session).send(any<Payload.Failure<List<DigitalSignatureAndMetadata>>>())
     }
 
     @Test
-    fun `receiving a transaction initially with invalid signature throws and does not persist anything`() {
+    fun `receiving a transaction initially with invalid signature throws and persists as invalid`() {
         whenever(transactionSignatureService.verifySignature(any(), any())).thenThrow(
             CryptoSignatureException("Verifying signature failed!!")
         )
@@ -123,12 +123,12 @@ class ConsensualReceiveFinalityFlowTest {
             .hasMessageContaining("Verifying signature failed!!")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
         verify(session).send(any<Payload.Failure<List<DigitalSignatureAndMetadata>>>())
     }
 
     @Test
-    fun `receiving an invalid transaction initially throws and does not persist anything`() {
+    fun `receiving an invalid transaction initially throws and persists as invalid`() {
         whenever(ledgerTransaction.states).thenReturn(listOf(ConsensualStateClassExample("throw", listOf(
             publicKeyExample))))
 
@@ -137,7 +137,7 @@ class ConsensualReceiveFinalityFlowTest {
             .hasMessageContaining("State verification failed")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
     }
 
     @Test

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation project(':libs:serialization:serialization-internal')
     implementation project(':libs:virtual-node:sandbox-group-context')
     implementation project(':components:virtual-node:sandbox-notary')
+    implementation project(':notary-plugins:notary-plugin-common')
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
@@ -130,4 +130,20 @@ abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
         log.debug { "Recorded transaction as invalid: ${transaction.id}" }
     }
 
+    @Suspendable
+    protected fun verifyExistingSignatures(
+        initialTransaction: UtxoSignedTransactionInternal,
+        onFailure: ((message: String) -> Unit)? = null
+    ) {
+        if (initialTransaction.signatures.isEmpty()){
+            val message = "Received initial transaction without signatures."
+            log.warn(message)
+            if (onFailure != null)
+                onFailure(message)
+            throw CordaRuntimeException(message)
+        }
+        initialTransaction.signatures.forEach {
+            verifySignature(initialTransaction, it, onFailure)
+        }
+    }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -110,6 +110,7 @@ class UtxoFinalityFlow(
         return transaction to signaturesReceivedFromSessions
     }
 
+    @Suspendable
     private fun verifyAllReceivedSignatures(
         transaction: UtxoSignedTransactionInternal,
         signaturesReceivedFromSessions: Map<FlowSession, List<DigitalSignatureAndMetadata>>

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -43,7 +43,10 @@ class UtxoFinalityFlow(
         log.trace("Starting finality flow for transaction: $transactionId")
         verifyExistingSignatures(initialTransaction)
         verifyTransaction(initialTransaction)
+
+        // Initial verifications passed, the transaction can be saved in the database.
         persistUnverifiedTransaction()
+
         sendTransactionAndBackchainToCounterparties()
         val (transaction, signaturesReceivedFromSessions) = receiveSignaturesAndAddToTransaction()
         verifyAllReceivedSignatures(transaction, signaturesReceivedFromSessions)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -42,6 +42,7 @@ class UtxoFinalityFlow(
     @Suspendable
     override fun call(): UtxoSignedTransaction {
         log.trace("Starting finality flow for transaction: $transactionId")
+        verifyExistingSignatures(initialTransaction)
         verifyTransaction(initialTransaction)
         persistUnverifiedTransaction()
         sendTransactionAndBackchainToCounterparties()

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality
 
+import com.r3.corda.notary.plugin.common.NotaryException
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
@@ -16,7 +17,6 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
-import net.corda.v5.ledger.notary.plugin.core.NotaryError
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import org.slf4j.LoggerFactory
 
@@ -182,7 +182,7 @@ class UtxoFinalityFlow(
         val notarySignatures = try {
             flowEngine.subFlow(notarizationFlow)
         } catch (e: CordaRuntimeException) {
-            val (message, failureReason) = if (NotaryError::class.java.isAssignableFrom(e.javaClass)) {
+            val (message, failureReason) = if (NotaryException::class.java.isAssignableFrom(e.javaClass)) {
                 persistInvalidTransaction(transaction)
                 "Notarization failed permanently with ${e.message}." to FinalityNotarizationFailureType.UNRECOVERABLE
             } else {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -19,7 +19,6 @@ import net.corda.v5.base.util.trace
 import net.corda.v5.ledger.notary.plugin.core.NotaryError
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import org.slf4j.LoggerFactory
-import kotlin.reflect.full.isSubclassOf
 
 @CordaSystemFlow
 class UtxoFinalityFlow(
@@ -183,7 +182,7 @@ class UtxoFinalityFlow(
         val notarySignatures = try {
             flowEngine.subFlow(notarizationFlow)
         } catch (e: CordaRuntimeException) {
-            val (message, failureReason) = if (e::class.isSubclassOf(NotaryError::class)){
+            val (message, failureReason) = if (NotaryError::class.java.isAssignableFrom(e.javaClass)) {
                 persistInvalidTransaction(transaction)
                 "Notarization failed permanently with ${e.message}." to FinalityNotarizationFailureType.UNRECOVERABLE
             } else {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -87,12 +87,16 @@ class UtxoFinalityFlow(
 
         var transaction = initialTransaction
         val signaturesReceivedFromSessions = signaturesPayloads.map { (session, signaturesPayload) ->
-            val signatures = signaturesPayload.getOrThrow { failure ->
-                val message = "Failed to receive signatures from ${session.counterparty} for transaction " +
-                        "$transactionId with message: ${failure.message}"
-                log.warn(message)
-                persistInvalidTransaction(initialTransaction)
-                CordaRuntimeException(message)
+
+            val signatures = when (signaturesPayload) {
+                is Payload.Success -> signaturesPayload.value
+                is Payload.Failure<*> -> {
+                    val message = "Failed to receive signatures from ${session.counterparty} for transaction " +
+                            "$transactionId with message: ${signaturesPayload.message}"
+                    log.warn(message)
+                    persistInvalidTransaction(initialTransaction)
+                    throw CordaRuntimeException(message)
+                }
             }
 
             log.debug { "Received ${signatures.size} signature(s) from ${session.counterparty} for transaction $transactionId" }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -182,7 +182,7 @@ class UtxoFinalityFlow(
         val notarySignatures = try {
             flowEngine.subFlow(notarizationFlow)
         } catch (e: CordaRuntimeException) {
-            val (message, failureReason) = if (NotaryException::class.java.isAssignableFrom(e.javaClass)) {
+            val (message, failureReason) = if (e is NotaryException) {
                 persistInvalidTransaction(transaction)
                 "Notarization failed permanently with ${e.message}." to FinalityNotarizationFailureType.UNRECOVERABLE
             } else {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
@@ -108,6 +108,7 @@ class UtxoReceiveFinalityFlow(
         return signedTransaction
     }
 
+    @Suspendable
     private fun verifyAllReceivedSignatures(transaction: UtxoSignedTransactionInternal) {
         log.debug { "Verifying signatures of transaction: ${transaction.id}" }
         try {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
@@ -31,9 +31,7 @@ class UtxoReceiveFinalityFlow(
     override fun call(): UtxoSignedTransaction {
         val initialTransaction = receiveTransactionAndBackchain()
         val transactionId = initialTransaction.id
-        verifyExistingSignatures(initialTransaction){
-            session.send(Payload.Failure<List<DigitalSignatureAndMetadata>>(it))
-        }
+        verifyExistingSignatures(initialTransaction, session)
         verifyTransaction(initialTransaction)
         var transaction = if (validateTransaction(initialTransaction)) {
             log.trace { "Successfully validated transaction: $transactionId" }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
@@ -178,18 +178,18 @@ class UtxoFinalityFlowTest {
     }
 
     @Test
-    fun `called with a transaction initially without signatures throws and does not persist anything`() {
+    fun `called with a transaction initially without signatures throws and persists as invalid`() {
         whenever(initialTx.signatures).thenReturn(listOf())
         assertThatThrownBy { callFinalityFlow(initialTx, listOf(sessionAlice, sessionBob)) }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("Received initial transaction without signatures.")
 
         verify(initialTx, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any(), any())
+        verify(persistenceService).persist(initialTx, TransactionStatus.INVALID)
     }
 
     @Test
-    fun `called with a transaction initially with invalid signature throws and does not persist anything`() {
+    fun `called with a transaction initially with invalid signature throws and persists as invalid`() {
         whenever(transactionSignatureService.verifySignature(any(), any())).thenThrow(
             CryptoSignatureException("Verifying signature failed!!")
         )
@@ -198,11 +198,11 @@ class UtxoFinalityFlowTest {
             .hasMessageContaining("Verifying signature failed!!")
 
         verify(initialTx, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any(), any())
+        verify(persistenceService).persist(initialTx, TransactionStatus.INVALID)
     }
 
     @Test
-    fun `called with an invalid transaction initially throws and does not persist anything`() {
+    fun `called with an invalid transaction initially throws and persists as invalid`() {
         whenever(transactionVerificationService.verify(any())).thenThrow(
             TransactionVerificationException(
                 TX_ID, "Verification error", null)
@@ -212,7 +212,7 @@ class UtxoFinalityFlowTest {
             .hasMessageContaining("Verification error")
 
         verify(initialTx, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any(), any())
+        verify(persistenceService).persist(initialTx, TransactionStatus.INVALID)
     }
 
     @Test

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlowTest.kt
@@ -135,19 +135,19 @@ class UtxoReceiveFinalityFlowTest {
     }
 
     @Test
-    fun `receiving a transaction initially without signatures throws and does not persist anything`() {
+    fun `receiving a transaction initially without signatures throws and persists as invalid`() {
         whenever(signedTransaction.signatures).thenReturn(listOf())
         assertThatThrownBy { callReceiveFinalityFlow() }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("Received initial transaction without signatures.")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
         verify(session).send(any<Payload.Failure<List<DigitalSignatureAndMetadata>>>())
     }
 
     @Test
-    fun `receiving a transaction initially with invalid signature throws and does not persist anything`() {
+    fun `receiving a transaction initially with invalid signature throws and persists as invalid`() {
         whenever(transactionSignatureService.verifySignature(any(), any())).thenThrow(
             CryptoSignatureException("Verifying signature failed!!")
         )
@@ -156,19 +156,19 @@ class UtxoReceiveFinalityFlowTest {
             .hasMessageContaining("Verifying signature failed!!")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
         verify(session).send(any<Payload.Failure<List<DigitalSignatureAndMetadata>>>())
     }
 
     @Test
-    fun `receiving an invalid transaction initially throws and does not persist anything`() {
+    fun `receiving an invalid transaction initially throws and persists as invalid`() {
         whenever(transactionVerificationService.verify(any())).thenThrow(TransactionVerificationException(ID, "Verification error", null))
         assertThatThrownBy { callReceiveFinalityFlow() }
             .isInstanceOf(TransactionVerificationException::class.java)
             .hasMessageContaining("Verification error")
 
         verify(signedTransaction, never()).addMissingSignatures()
-        verify(persistenceService, never()).persist(any(), any(), any())
+        verify(persistenceService).persist(signedTransaction, TransactionStatus.INVALID)
     }
 
     @Test

--- a/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualStateClassExample.kt
+++ b/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualStateClassExample.kt
@@ -1,6 +1,5 @@
 package net.corda.ledger.consensual.testkit
 
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.common.transaction.TransactionVerificationException
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction

--- a/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualStateClassExample.kt
+++ b/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualStateClassExample.kt
@@ -1,5 +1,7 @@
 package net.corda.ledger.consensual.testkit
 
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.common.transaction.TransactionVerificationException
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import java.security.PublicKey
@@ -9,7 +11,12 @@ class ConsensualStateClassExample(
     val testField: String,
     override val participants: List<PublicKey>
 ) : ConsensualState {
-    override fun verify(ledgerTransaction: ConsensualLedgerTransaction) {}
+    override fun verify(ledgerTransaction: ConsensualLedgerTransaction) {
+        if (testField == "throw") {
+            throw TransactionVerificationException(ledgerTransaction.id, "State verification failed", null)
+        }
+    }
+
     override fun equals(other: Any?): Boolean =
         (this === other) || (
             (other is ConsensualStateClassExample) &&


### PR DESCRIPTION
Update transactions to Invalid in the Finality flow if they encounter an unrecoverable error.
Add checks against the signatures of the initial transaction on both sides.
And unit test to cover these.