### PR TITLE
CORE-10088: Treat CLOSING as Confirmed Session Status

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionConfirmationWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionConfirmationWaitingForHandler.kt
@@ -62,7 +62,11 @@ class SessionConfirmationWaitingForHandler @Activate constructor(
     }
 
     private fun areAllSessionsConfirmed(checkpoint: FlowCheckpoint, waitingFor: SessionConfirmation): Boolean {
-        return flowSessionManager.doAllSessionsHaveStatus(checkpoint, waitingFor.sessionIds, SessionStateType.CONFIRMED)
+        return flowSessionManager.doAllSessionsHaveStatusIn(
+            checkpoint,
+            waitingFor.sessionIds,
+            listOf(SessionStateType.CONFIRMED, SessionStateType.CLOSING)
+        )
     }
 
     private fun waitingForSessionsToClose(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/FlowSessionManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/FlowSessionManager.kt
@@ -149,6 +149,23 @@ interface FlowSessionManager {
     ): List<SessionState>
 
     /**
+     * Do all the specified sessions have a [SessionStateType] included within [statuses]?
+     *
+     * @param checkpoint The flow's [FlowCheckpoint].
+     * @param sessionIds The session ids to check the status of.
+     * @param statuses The acceptable statuses the sessions can have.
+     *
+     * @return `true`, if all sessions have status included within [statuses], `false` otherwise.
+     *
+     * @throws [FlowSessionStateException] If a session does not exist within the flow's [FlowCheckpoint].
+     */
+    fun doAllSessionsHaveStatusIn(
+        checkpoint: FlowCheckpoint,
+        sessionIds: List<String>,
+        statuses: List<SessionStateType>
+    ): Boolean
+
+    /**
      * Are all the specified sessions have a [SessionStateType] of [status]?
      *
      * @param checkpoint The flow's [FlowCheckpoint].
@@ -159,7 +176,8 @@ interface FlowSessionManager {
      *
      * @throws [FlowSessionStateException] If a session does not exist within the flow's [FlowCheckpoint].
      */
-    fun doAllSessionsHaveStatus(checkpoint: FlowCheckpoint, sessionIds: List<String>, status: SessionStateType): Boolean
+    fun doAllSessionsHaveStatus(checkpoint: FlowCheckpoint, sessionIds: List<String>, status: SessionStateType) =
+        doAllSessionsHaveStatusIn(checkpoint, sessionIds, listOf(status))
 
     /**
      * Get the states whose next ordered message is a SessionClose.

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -164,12 +164,14 @@ class FlowSessionManagerImpl @Activate constructor(
             .filter { sessionState -> sessionState.status == status }
     }
 
-    override fun doAllSessionsHaveStatus(
+    override fun doAllSessionsHaveStatusIn(
         checkpoint: FlowCheckpoint,
         sessionIds: List<String>,
-        status: SessionStateType
+        statuses: List<SessionStateType>
     ): Boolean {
-        return getSessionsWithStatus(checkpoint, sessionIds, status).size == sessionIds.size
+        return sessionIds
+            .map { sessionId -> getAndRequireSession(checkpoint, sessionId) }
+            .count { sessionState -> statuses.contains(sessionState.status) } == sessionIds.size
     }
 
     private enum class Operation { SENDING, RECEIVING }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionConfirmationWaitingForHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionConfirmationWaitingForHandlerTest.kt
@@ -53,8 +53,8 @@ class SessionConfirmationWaitingForHandlerTest {
     }
 
     @Test
-    fun `When the session being waited for is confirmed while waiting for a session confirmation (Initiate) returns a FlowContinuation#Run`() {
-        whenever(flowSessionManager.doAllSessionsHaveStatus(checkpoint, listOf(SESSION_ID), SessionStateType.CONFIRMED)).thenReturn(true)
+    fun `When the session being waited for is confirmed or closing while waiting for a session confirmation (Initiate) returns a FlowContinuation#Run`() {
+        whenever(flowSessionManager.doAllSessionsHaveStatusIn(checkpoint, listOf(SESSION_ID), listOf(SessionStateType.CONFIRMED, SessionStateType.CLOSING))).thenReturn(true)
         val inputContext = buildFlowEventContext(
             checkpoint = checkpoint,
             inputEventPayload = SessionEvent().apply {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
@@ -495,69 +495,69 @@ class FlowSessionManagerImplTest {
     }
 
     @Test
-    fun `doAllSessionsHaveStatus returns true if all sessions have the passed in status`() {
-        sessionState.status = SessionStateType.CLOSED
-        anotherSessionState.status = SessionStateType.CLOSED
+    fun `doAllSessionsHaveStatusIn returns true if all sessions have the passed in statuses`() {
+        sessionState.status = SessionStateType.CONFIRMED
+        anotherSessionState.status = SessionStateType.CLOSING
 
         assertTrue(
-            flowSessionManager.doAllSessionsHaveStatus(
+            flowSessionManager.doAllSessionsHaveStatusIn(
                 checkpoint,
                 listOf(SESSION_ID, ANOTHER_SESSION_ID),
-                SessionStateType.CLOSED
+                listOf(SessionStateType.CLOSING, SessionStateType.CONFIRMED)
             )
         )
     }
 
     @Test
-    fun `doAllSessionsHaveStatus returns false if any session does not have the passed in status`() {
+    fun `doAllSessionsHaveStatusIn returns false if any session does not have the passed in statuses`() {
         sessionState.status = SessionStateType.CLOSED
         anotherSessionState.status = SessionStateType.CONFIRMED
 
         assertFalse(
-            flowSessionManager.doAllSessionsHaveStatus(
+            flowSessionManager.doAllSessionsHaveStatusIn(
                 checkpoint,
                 listOf(SESSION_ID, ANOTHER_SESSION_ID),
-                SessionStateType.CLOSED
+                listOf(SessionStateType.CLOSED)
             )
         )
     }
 
     @Test
-    fun `doAllSessionsHaveStatus returns false if all sessions do not have the passed in status`() {
+    fun `doAllSessionsHaveStatusIn returns false if none of the sessions have the passed in statuses`() {
         sessionState.status = SessionStateType.CLOSING
         anotherSessionState.status = SessionStateType.CONFIRMED
 
         assertFalse(
-            flowSessionManager.doAllSessionsHaveStatus(
+            flowSessionManager.doAllSessionsHaveStatusIn(
                 checkpoint,
                 listOf(SESSION_ID, ANOTHER_SESSION_ID),
-                SessionStateType.CLOSED
+                listOf(SessionStateType.CLOSED)
             )
         )
     }
 
     @Test
-    fun `doAllSessionsHaveStatus throws an exception if a session does not exist`() {
+    fun `doAllSessionsHaveStatusIn throws an exception if a session does not exist`() {
         sessionState.status = SessionStateType.CLOSING
 
         whenever(checkpoint.getSessionState(ANOTHER_SESSION_ID)).thenReturn(null)
 
         assertThrows<FlowSessionStateException> {
-            flowSessionManager.doAllSessionsHaveStatus(
+            flowSessionManager.doAllSessionsHaveStatusIn(
                 checkpoint,
                 listOf(SESSION_ID, ANOTHER_SESSION_ID),
-                SessionStateType.CLOSED
+                listOf(SessionStateType.CLOSED)
             )
         }
     }
 
     @Test
-    fun `doAllSessionsHaveStatus returns true there are no sessions`() {
+    fun `doAllSessionsHaveStatusIn returns true there are no sessions`() {
         assertTrue(
-            flowSessionManager.doAllSessionsHaveStatus(
+            flowSessionManager.doAllSessionsHaveStatusIn(
                 checkpoint,
                 emptyList(),
-                SessionStateType.CLOSED
+                listOf(SessionStateType.CLOSED)
             )
         )
     }


### PR DESCRIPTION
Sessions in 'CLOSING' status are already confirmed by definition, so
the aforementioned status should be included in the list of options
when deciding whether the flow should keep waiting for sessions or not.
