### PR TITLE
CORE-10198: Upgrade Kotlin Metadata library 0.5 -> 0.6.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ artifactoryContextUrl=https://software.r3.com/artifactory
 kotlin.code.style=official
 kotlinVersion=1.7.21
 kotlin.stdlib.default.dependency=false
-kotlinMetadataVersion = 0.5.0
+kotlinMetadataVersion = 0.6.0
 
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
@@ -3,7 +3,6 @@ package net.corda.kotlin.reflect.impl
 
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmPackage
-import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
 import net.corda.kotlin.reflect.KotlinClass
 import net.corda.kotlin.reflect.types.KFunctionInternal
@@ -377,16 +376,7 @@ private fun <T : Any> Metadata.forKotlinType(
     klazz: KClass<T>,
     pool: KClassPool
 ): KotlinClassImpl<T> {
-    val header = KotlinClassHeader(
-        kind,
-        metadataVersion,
-        data1,
-        data2,
-        extraString,
-        packageName,
-        extraInt
-    )
-    return when (val km = KotlinClassMetadata.read(header)) {
+    return when (val km = KotlinClassMetadata.read(this)) {
         is KotlinClassMetadata.Class -> KotlinClassImpl.KmClassType(clazz, klazz, pool, km.toKmClass())
         is KotlinClassMetadata.FileFacade -> KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.toKmPackage())
         is KotlinClassMetadata.MultiFileClassPart -> KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.toKmPackage())

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinFunction.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinFunction.kt
@@ -10,6 +10,7 @@ import kotlinx.metadata.jvm.lambdaClassOriginName
 import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Method
 import java.util.Objects
+import kotlin.contracts.ExperimentalContracts
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
@@ -74,6 +75,7 @@ class KotlinFunction<V> private constructor(
                 kmf.versionRequirements += kmFunction.versionRequirements
                 kmf.typeParameters += kmFunction.typeParameters
                 kmf.returnType = kmFunction.returnType
+                @OptIn(ExperimentalContracts::class)
                 kmf.contract = kmFunction.contract
 
                 // Copy values from JvmFunctionExtension.


### PR DESCRIPTION
Upgrade the Kotlin Metadata library, which underpins our OSGi Kotlin reflection support.

This is a precursor to upgrading Corda to Kotlin 1.8.10, although does not actually _require_ Kotlin 1.8.10.