### PR TITLE
CORE-9379 Verification Sandbox accepts only contract CPKs

### DIFF
--- a/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
@@ -131,11 +131,11 @@ class VerificationRequestProcessorTest {
         val virtualNodeInfo = virtualNodeService.load(TEST_CPB)
         val holdingIdentity = virtualNodeInfo.holdingIdentity
         val cpksMetadata = cpiInfoReadService.get(virtualNodeInfo.cpiIdentifier)!!.cpksMetadata.filter { it.isContractCpk() }
-        val cpkFileChecksums = cpksMetadata.mapTo(HashSet()) { it.fileChecksum }
+        val cpkSummaries = cpksMetadata.map { it.toCpkSummary() }
         val verificationSandboxService = virtualNodeService.verificationSandboxService
-        val sandbox = verificationSandboxService.get(holdingIdentity, cpkFileChecksums)
+        val sandbox = verificationSandboxService.get(holdingIdentity, cpkSummaries)
         val transaction = createTestTransaction(sandbox, isValid = true)
-        val request = createRequest(sandbox, holdingIdentity, transaction, cpksMetadata.map { it.toCpkSummary() })
+        val request = createRequest(sandbox, holdingIdentity, transaction, cpkSummaries)
 
         // Create request processor
         val processor = VerificationRequestProcessor(
@@ -165,11 +165,11 @@ class VerificationRequestProcessorTest {
         val virtualNodeInfo = virtualNodeService.load(TEST_CPB)
         val holdingIdentity = virtualNodeInfo.holdingIdentity
         val cpksMetadata = cpiInfoReadService.get(virtualNodeInfo.cpiIdentifier)!!.cpksMetadata.filter { it.isContractCpk() }
-        val cpkFileChecksums = cpksMetadata.mapTo(HashSet()) { it.fileChecksum }
+        val cpkSummaries = cpksMetadata.map { it.toCpkSummary() }
         val verificationSandboxService = virtualNodeService.verificationSandboxService
-        val sandbox = verificationSandboxService.get(holdingIdentity, cpkFileChecksums)
+        val sandbox = verificationSandboxService.get(holdingIdentity, cpkSummaries)
         val transaction = createTestTransaction(sandbox, isValid = false)
-        val request = createRequest(sandbox, holdingIdentity, transaction, cpksMetadata.map { it.toCpkSummary() })
+        val request = createRequest(sandbox, holdingIdentity, transaction, cpkSummaries)
 
         // Create request processor
         val processor = VerificationRequestProcessor(
@@ -203,9 +203,9 @@ class VerificationRequestProcessorTest {
         val virtualNodeInfo = virtualNodeService.load(TEST_CPB)
         val holdingIdentity = virtualNodeInfo.holdingIdentity
         val cpksMetadata = cpiInfoReadService.get(virtualNodeInfo.cpiIdentifier)!!.cpksMetadata.filter { it.isContractCpk() }
-        val cpkFileChecksums = cpksMetadata.mapTo(HashSet()) { it.fileChecksum }
+        val cpkSummaries = cpksMetadata.map { it.toCpkSummary() }
         val verificationSandboxService = virtualNodeService.verificationSandboxService
-        val sandbox = verificationSandboxService.get(holdingIdentity, cpkFileChecksums)
+        val sandbox = verificationSandboxService.get(holdingIdentity, cpkSummaries)
         val transaction = createTestTransaction(sandbox, isValid = true)
         val request = createRequest(sandbox, holdingIdentity, transaction, listOf(NON_EXISTING_CPK))
 

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/sandbox/VerificationSandboxService.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/sandbox/VerificationSandboxService.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.verification.sandbox
 
+import net.corda.ledger.utxo.verification.CordaPackageSummary
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 
 interface VerificationSandboxService {
@@ -12,5 +12,5 @@ interface VerificationSandboxService {
      *
      * @throws [CordaRuntimeException] if not found
      */
-    fun get(holdingIdentity: HoldingIdentity, cpkFileChecksums: Set<SecureHash>): SandboxGroupContext
+    fun get(holdingIdentity: HoldingIdentity, cpks: List<CordaPackageSummary>): SandboxGroupContext
 }

--- a/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
@@ -11,7 +11,6 @@ import net.corda.ledger.verification.processor.VerificationRequestHandler
 import net.corda.ledger.verification.sandbox.VerificationSandboxService
 import net.corda.messaging.api.records.Record
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -24,6 +23,8 @@ class VerificationRequestProcessorTest {
     private companion object {
         const val ALICE_X500 = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
         val ALICE_X500_HOLDING_ID = HoldingIdentity(ALICE_X500, "group1")
+        const val CPK_NAME = "test.cpk"
+        const val CPK_VERSION = "1.0"
         const val CPK_CHECKSUM = "SHA-256:1212121212121212"
         const val SIGNER_SUMMARY_HASH = "SHA-256:3434343434343434"
     }
@@ -32,7 +33,7 @@ class VerificationRequestProcessorTest {
     private val verificationRequestHandler = mock<VerificationRequestHandler>()
     private val responseFactory = mock<ExternalEventResponseFactory>()
     private val cordaHoldingIdentity = ALICE_X500_HOLDING_ID.toCorda()
-    private val cpkChecksums = setOf(SecureHash.parse(CPK_CHECKSUM))
+    private val cpkSummaries = listOf(CordaPackageSummary(CPK_NAME, CPK_VERSION, SIGNER_SUMMARY_HASH, CPK_CHECKSUM))
     private val sandbox = mock<SandboxGroupContext>()
 
     private val verificationRequestProcessor = VerificationRequestProcessor(
@@ -43,7 +44,7 @@ class VerificationRequestProcessorTest {
 
     @BeforeEach
     fun setup() {
-        whenever(verificationSandboxService.get(cordaHoldingIdentity, cpkChecksums)).thenReturn(sandbox)
+        whenever(verificationSandboxService.get(cordaHoldingIdentity, cpkSummaries)).thenReturn(sandbox)
     }
 
     @Test

--- a/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
@@ -102,7 +102,7 @@ class VerificationRequestProcessorTest {
             flowExternalEventContext = ExternalEventContext(requestId, "f1", KeyValuePairList())
             holdingIdentity = ALICE_X500_HOLDING_ID
             cpkMetadata = listOf(
-                CordaPackageSummary("cpk1", "1.0", SIGNER_SUMMARY_HASH, CPK_CHECKSUM)
+                CordaPackageSummary(CPK_NAME, CPK_VERSION, SIGNER_SUMMARY_HASH, CPK_CHECKSUM)
             )
         }
 }

--- a/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/NotAllowedCpkException.kt
+++ b/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/NotAllowedCpkException.kt
@@ -1,0 +1,7 @@
+package net.corda.flow.external.events.responses.exceptions
+
+/**
+ * Used to indicate that a CPK is not allowed. This can happen if CPK is workflow CPK and is being loaded into sandbox
+ * that only allows contract CPKs.
+ */
+class NotAllowedCpkException(message: String, cause: Throwable? = null) : Exception(message, cause)


### PR DESCRIPTION
Checking that CPKs for Verification Sandbox are contract CPKs. Exception `NotAllowedCpkException` is thrown in case there is a non-contract CPK found.