### PR TITLE
CORE-10198: Upgrade to Kotlin 1.8.10.

### DIFF
--- a/applications/examples/sandbox-app/build.gradle
+++ b/applications/examples/sandbox-app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation project(":libs:packaging:packaging")
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-application'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     implementation project(':testing:sandboxes')

--- a/applications/examples/sandbox-app/example-cpi/build.gradle
+++ b/applications/examples/sandbox-app/example-cpi/build.gradle
@@ -21,7 +21,7 @@ cordapp {
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-crypto-extensions'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/applications/tools/p2p-test/app-simulator/build.gradle
+++ b/applications/tools/p2p-test/app-simulator/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-avro-schema:$cordaApiVersion"
     implementation "net.corda:corda-config-schema:$cordaApiVersion"
     implementation "net.corda:corda-topic-schema:$cordaApiVersion"

--- a/applications/tools/p2p-test/dump-topic/build.gradle
+++ b/applications/tools/p2p-test/dump-topic/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "info.picocli:picocli:$picocliVersion"
     implementation "org.apache.avro:avro:$avroVersion"
     implementation project(":libs:configuration:configuration-core")

--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-config-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -61,7 +61,7 @@ kotlin {
 
 dependencies {
     // NO CORDA DEPENDENCIES!!
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.2"
 
     // Avoid having the schema names and keys scattered across projects

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import static org.gradle.api.JavaVersion.VERSION_11
 import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
 
 buildscript {
     configurations.classpath {
@@ -62,16 +64,15 @@ allprojects {
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-        kotlinOptions {
+        compilerOptions {
             allWarningsAsErrors = true
-            languageVersion = '1.7'
-            apiVersion = '1.7'
-            jvmTarget = javaVersion
+            languageVersion = KOTLIN_1_8
+            apiVersion = KOTLIN_1_8
+            jvmTarget = JVM_11
             javaParameters = true   // Useful for reflection.
-            freeCompilerArgs += [
-                "-java-parameters",
+            freeCompilerArgs.addAll([
                 "-Xjvm-default=all"
-            ]
+            ])
         }
     }
 
@@ -283,8 +284,8 @@ allprojects {
 void configureKotlinForOSGi(Configuration configuration) {
     configuration.resolutionStrategy {
         dependencySubstitution {
-            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') with module("net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion")
-            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk7') with module("net.corda.kotlin:kotlin-stdlib-jdk7-osgi:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk7') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
             substitute module('org.jetbrains.kotlin:kotlin-stdlib-common') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
             substitute module('org.jetbrains.kotlin:kotlin-stdlib') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
             substitute module('org.jetbrains.kotlin:kotlin-reflect') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -19,8 +19,8 @@ plugins {
 def applyDependencySubstitution = { Configuration conf ->
     conf.resolutionStrategy.dependencySubstitution {
         //Replace Kotlin stdlib
-        substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') using module("net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion")
-        substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk7') using module("net.corda.kotlin:kotlin-stdlib-jdk7-osgi:$kotlinVersion")
+        substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') using module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
+        substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk7') using module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
         substitute module('org.jetbrains.kotlin:kotlin-stdlib-common') using module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
         substitute module('org.jetbrains.kotlin:kotlin-stdlib') using module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
         substitute module('org.jetbrains.kotlin:kotlin-reflect') using module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")

--- a/buildSrc/src/main/groovy/corda.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda.common-library.gradle
@@ -29,6 +29,7 @@ configurations {
 }
 
 dependencies {
+    compileOnly "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"

--- a/components/chunking/chunk-db-write-impl/build.gradle
+++ b/components/chunking/chunk-db-write-impl/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'javax.persistence:javax.persistence-api'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"
     implementation 'net.corda:corda-config-schema'

--- a/components/chunking/chunk-db-write/build.gradle
+++ b/components/chunking/chunk-db-write/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-base'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(':components:virtual-node:cpi-info-write-service')
 }

--- a/components/chunking/chunk-read-service-impl/build.gradle
+++ b/components/chunking/chunk-read-service-impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'

--- a/components/chunking/chunk-read-service/build.gradle
+++ b/components/chunking/chunk-read-service/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'javax.persistence:javax.persistence-api'
 
     api project(":libs:configuration:configuration-core")

--- a/components/configuration/configuration-read-service-impl/build.gradle
+++ b/components/configuration/configuration-read-service-impl/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'

--- a/components/configuration/configuration-read-service/build.gradle
+++ b/components/configuration/configuration-read-service/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(":components:reconciliation:reconciliation")
     api project(":libs:configuration:configuration-core")

--- a/components/configuration/configuration-rpcops-service-impl/build.gradle
+++ b/components/configuration/configuration-rpcops-service-impl/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/components/configuration/configuration-write-service-impl/build.gradle
+++ b/components/configuration/configuration-write-service-impl/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-db-schema'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/components/configuration/configuration-write-service/build.gradle
+++ b/components/configuration/configuration-write-service/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(":components:reconciliation:reconciliation")
 }

--- a/components/crypto/crypto-client-hsm-impl/build.gradle
+++ b/components/crypto/crypto-client-hsm-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "net.corda:corda-config-schema"

--- a/components/crypto/crypto-client-hsm/build.gradle
+++ b/components/crypto/crypto-client-hsm/build.gradle
@@ -8,7 +8,7 @@ description 'Crypto components clients'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     api "net.corda:corda-avro-schema"

--- a/components/crypto/crypto-client-impl/build.gradle
+++ b/components/crypto/crypto-client-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "net.corda:corda-config-schema"

--- a/components/crypto/crypto-client/build.gradle
+++ b/components/crypto/crypto-client/build.gradle
@@ -8,7 +8,7 @@ description 'Crypto components clients'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(':libs:crypto:crypto-core')
 

--- a/components/crypto/crypto-component-core-impl/build.gradle
+++ b/components/crypto/crypto-component-core-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "net.corda:corda-base"

--- a/components/crypto/crypto-component-test-utils/build.gradle
+++ b/components/crypto/crypto-component-test-utils/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "net.corda:corda-config-schema"

--- a/components/crypto/crypto-hes-core-impl/build.gradle
+++ b/components/crypto/crypto-hes-core-impl/build.gradle
@@ -8,7 +8,7 @@ description 'Crypto Hybrid Encryption Scheme core implementation'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation project(":libs:crypto:crypto-core")

--- a/components/crypto/crypto-hes-impl/build.gradle
+++ b/components/crypto/crypto-hes-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     api project(":components:crypto:crypto-hes-core-impl")

--- a/components/crypto/crypto-hes/build.gradle
+++ b/components/crypto/crypto-hes/build.gradle
@@ -8,7 +8,7 @@ description 'Crypto Hybrid Encryption Scheme API'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     api project(':libs:crypto:cipher-suite')

--- a/components/crypto/crypto-persistence-impl/build.gradle
+++ b/components/crypto/crypto-persistence-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"

--- a/components/crypto/crypto-persistence-model/build.gradle
+++ b/components/crypto/crypto-persistence-model/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     api "javax.persistence:javax.persistence-api"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation 'net.corda:corda-db-schema'

--- a/components/crypto/crypto-persistence/build.gradle
+++ b/components/crypto/crypto-persistence/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     api 'javax.persistence:javax.persistence-api'
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"

--- a/components/crypto/crypto-service-impl/build.gradle
+++ b/components/crypto/crypto-service-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"

--- a/components/crypto/crypto-softhsm-impl/build.gradle
+++ b/components/crypto/crypto-softhsm-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"

--- a/components/db/db-connection-manager-impl/build.gradle
+++ b/components/db/db-connection-manager-impl/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-db-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/components/db/db-connection-manager/build.gradle
+++ b/components/db/db-connection-manager/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-db-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:configuration:configuration-validation')
     implementation project(":libs:virtual-node:virtual-node-info")
 

--- a/components/domino-logic/build.gradle
+++ b/components/domino-logic/build.gradle
@@ -7,7 +7,7 @@ description 'Domino logic'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:configuration:configuration-core")

--- a/components/flow/flow-mapper-service/build.gradle
+++ b/components/flow/flow-mapper-service/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-topic-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/components/flow/flow-p2p-filter-service/build.gradle
+++ b/components/flow/flow-p2p-filter-service/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-topic-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/components/flow/flow-rpcops-service-impl/build.gradle
+++ b/components/flow/flow-rpcops-service-impl/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'
     implementation 'net.corda:corda-rbac-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation "com.google.guava:guava:$guavaVersion"
     implementation "org.apache.commons:commons-lang3:$commonsLangVersion"

--- a/components/flow/flow-rpcops-service/build.gradle
+++ b/components/flow/flow-rpcops-service/build.gradle
@@ -14,6 +14,6 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 }

--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'net.corda:corda-ledger-common'
     implementation project(":libs:packaging:packaging")
     implementation "net.corda:corda-topic-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"

--- a/components/kafka-topic-admin/build.gradle
+++ b/components/kafka-topic-admin/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation project(':libs:messaging:topic-admin')
 }

--- a/components/ledger/ledger-persistence/build.gradle
+++ b/components/ledger/ledger-persistence/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'net.corda:corda-ledger-consensual'
     implementation 'net.corda:corda-ledger-utxo'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':libs:ledger:ledger-utxo-data')

--- a/components/ledger/ledger-persistence/testing-datamodel/build.gradle
+++ b/components/ledger/ledger-persistence/testing-datamodel/build.gradle
@@ -16,6 +16,6 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided 'net.corda:corda-base'
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'javax.persistence:javax.persistence-api'
 }

--- a/components/ledger/ledger-utxo-token-cache/build.gradle
+++ b/components/ledger/ledger-utxo-token-cache/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation "net.corda:corda-config-schema"
     implementation project(":libs:packaging:packaging")
     implementation "net.corda:corda-topic-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/components/ledger/ledger-verification/build.gradle
+++ b/components/ledger/ledger-verification/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'net.corda:corda-ledger-common'
     implementation 'net.corda:corda-ledger-utxo'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     implementation project(':components:configuration:configuration-read-service')

--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:p2p-crypto")
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle:lifecycle")

--- a/components/membership/certificates-service/build.gradle
+++ b/components/membership/certificates-service/build.gradle
@@ -7,7 +7,7 @@ description 'Member Certificates service'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(':libs:virtual-node:virtual-node-info')
     implementation project(':libs:lifecycle:lifecycle')

--- a/components/membership/group-params-writer-service-impl/build.gradle
+++ b/components/membership/group-params-writer-service-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-membership'

--- a/components/membership/group-params-writer-service/build.gradle
+++ b/components/membership/group-params-writer-service/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     api project(':components:reconciliation:reconciliation')
     api project(':libs:virtual-node:virtual-node-info')
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-membership'
 }

--- a/components/membership/group-policy-configuration-validation-impl/build.gradle
+++ b/components/membership/group-policy-configuration-validation-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation project(':libs:configuration:configuration-core')
     implementation project(':libs:membership:membership-common')

--- a/components/membership/group-policy-configuration-validation/build.gradle
+++ b/components/membership/group-policy-configuration-validation/build.gradle
@@ -11,6 +11,6 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     api project(':libs:lifecycle:lifecycle')
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
 }

--- a/components/membership/group-policy-impl/build.gradle
+++ b/components/membership/group-policy-impl/build.gradle
@@ -8,7 +8,7 @@ description 'Group policy provider component implementation'
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'

--- a/components/membership/group-policy/build.gradle
+++ b/components/membership/group-policy/build.gradle
@@ -8,7 +8,7 @@ description 'Group policy provider component'
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 

--- a/components/membership/locally-hosted-identities-service-impl/build.gradle
+++ b/components/membership/locally-hosted-identities-service-impl/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"

--- a/components/membership/locally-hosted-identities-service/build.gradle
+++ b/components/membership/locally-hosted-identities-service/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:virtual-node:virtual-node-info')

--- a/components/membership/members-client-certificate-publisher-service-impl/build.gradle
+++ b/components/membership/members-client-certificate-publisher-service-impl/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"

--- a/components/membership/members-client-certificate-publisher-service/build.gradle
+++ b/components/membership/members-client-certificate-publisher-service/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(':libs:lifecycle:lifecycle')
 }

--- a/components/membership/membership-client-impl/build.gradle
+++ b/components/membership/membership-client-impl/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-topic-schema"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testImplementation project(":libs:crypto:crypto-impl")
     testImplementation project(":libs:membership:membership-impl")

--- a/components/membership/membership-client/build.gradle
+++ b/components/membership/membership-client/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:membership:membership-common")

--- a/components/membership/membership-group-read-impl/build.gradle
+++ b/components/membership/membership-group-read-impl/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-membership"
     implementation "net.corda:corda-topic-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api"
 
     integrationTestImplementation project(":testing:db-message-bus-testkit")

--- a/components/membership/membership-group-read/build.gradle
+++ b/components/membership/membership-group-read/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     api platform("net.corda:corda-api:$cordaApiVersion")
     api 'net.corda:corda-membership'
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(":libs:membership:membership-common")
     api project(':components:reconciliation:reconciliation')

--- a/components/membership/membership-http-rpc-impl/build.gradle
+++ b/components/membership/membership-http-rpc-impl/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-membership"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "commons-validator:commons-validator:$commonsVersion"
 

--- a/components/membership/membership-http-rpc/build.gradle
+++ b/components/membership/membership-http-rpc/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(":libs:rest:rest")
 }

--- a/components/membership/membership-p2p-impl/build.gradle
+++ b/components/membership/membership-p2p-impl/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'

--- a/components/membership/membership-p2p/build.gradle
+++ b/components/membership/membership-p2p/build.gradle
@@ -8,7 +8,7 @@ description 'Membership P2P message handling'
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":libs:lifecycle:lifecycle")

--- a/components/membership/membership-persistence-client-impl/build.gradle
+++ b/components/membership/membership-persistence-client-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'

--- a/components/membership/membership-persistence-client/build.gradle
+++ b/components/membership/membership-persistence-client/build.gradle
@@ -7,7 +7,7 @@ description 'Membership persistence client'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     api 'net.corda:corda-membership'

--- a/components/membership/membership-persistence-service-impl/build.gradle
+++ b/components/membership/membership-persistence-service-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'

--- a/components/membership/membership-persistence-service/build.gradle
+++ b/components/membership/membership-persistence-service/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(':libs:lifecycle:lifecycle')
 }

--- a/components/membership/mtls-mgm-allowed-list-reader-writer-impl/build.gradle
+++ b/components/membership/mtls-mgm-allowed-list-reader-writer-impl/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"

--- a/components/membership/mtls-mgm-allowed-list-reader-writer/build.gradle
+++ b/components/membership/mtls-mgm-allowed-list-reader-writer/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     api platform("net.corda:corda-api:$cordaApiVersion")
     api 'net.corda:corda-membership'
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(':components:reconciliation:reconciliation')
     implementation project(":libs:lifecycle:lifecycle")

--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-membership"
     implementation "net.corda:corda-topic-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testImplementation project(":libs:lifecycle:lifecycle-test-impl")
 

--- a/components/membership/registration/build.gradle
+++ b/components/membership/registration/build.gradle
@@ -7,7 +7,7 @@ description 'Member group registration API'
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":libs:lifecycle:lifecycle")
 

--- a/components/membership/synchronisation-impl/build.gradle
+++ b/components/membership/synchronisation-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-topic-schema"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation project(":components:configuration:configuration-read-service")

--- a/components/membership/synchronisation/build.gradle
+++ b/components/membership/synchronisation/build.gradle
@@ -7,7 +7,7 @@ description 'Membership data distribution and synchronisation API'
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":libs:lifecycle:lifecycle")
 

--- a/components/permissions/permission-management-cache-service/build.gradle
+++ b/components/permissions/permission-management-cache-service/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-topic-schema"
     implementation "net.corda:corda-avro-schema"
     implementation 'net.corda:corda-base'

--- a/components/permissions/permission-management-service/build.gradle
+++ b/components/permissions/permission-management-service/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     implementation project(":libs:lifecycle:lifecycle")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"

--- a/components/permissions/permission-rpc-ops-impl/build.gradle
+++ b/components/permissions/permission-rpc-ops-impl/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     implementation project(":libs:lifecycle:lifecycle")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"

--- a/components/permissions/permission-storage-reader-service/build.gradle
+++ b/components/permissions/permission-storage-reader-service/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation project(':libs:permissions:permission-storage-common')
     implementation project(":libs:utilities")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "javax.persistence:javax.persistence-api"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/components/permissions/permission-storage-writer-service/build.gradle
+++ b/components/permissions/permission-storage-writer-service/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation project(':libs:permissions:permission-storage-writer')
     implementation project(":libs:utilities")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'javax.persistence:javax.persistence-api'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/components/permissions/permission-validation-cache-service/build.gradle
+++ b/components/permissions/permission-validation-cache-service/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-topic-schema"
     implementation "net.corda:corda-avro-schema"
     implementation 'net.corda:corda-base'

--- a/components/permissions/permission-validation-service/build.gradle
+++ b/components/permissions/permission-validation-service/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle:lifecycle")

--- a/components/persistence/entity-processor-service-impl/build.gradle
+++ b/components/persistence/entity-processor-service-impl/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'net.corda:corda-application'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(':testing:db-testkit')

--- a/components/persistence/persistence-service-common/build.gradle
+++ b/components/persistence/persistence-service-common/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation project(":libs:messaging:messaging")
     implementation project(':libs:virtual-node:sandbox-group-context')
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     runtimeOnly project(":libs:crypto:crypto-serialization-impl")
 

--- a/components/rbac-security-manager-service/build.gradle
+++ b/components/rbac-security-manager-service/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation project(':components:permissions:permission-management-service')
     implementation project(':libs:rest:rbac-security-manager')

--- a/components/reconciliation/reconciliation-impl/build.gradle
+++ b/components/reconciliation/reconciliation-impl/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "net.corda:corda-base"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(":libs:lifecycle:lifecycle-impl")
     implementation project(':libs:lifecycle:registry')

--- a/components/reconciliation/reconciliation/build.gradle
+++ b/components/reconciliation/reconciliation/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(':libs:lifecycle:lifecycle')
 }

--- a/components/rest-gateway-comp/build.gradle
+++ b/components/rest-gateway-comp/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"

--- a/components/security-manager/build.gradle
+++ b/components/security-manager/build.gradle
@@ -17,7 +17,7 @@ configurations {
 }
 
 dependencies {
-    api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:osgi.core"

--- a/components/uniqueness/backing-store-impl/build.gradle
+++ b/components/uniqueness/backing-store-impl/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     api project(':libs:lifecycle:lifecycle')
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-crypto"
     implementation "net.corda:corda-db-schema"

--- a/components/uniqueness/backing-store/build.gradle
+++ b/components/uniqueness/backing-store/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':libs:uniqueness:common')
     api project(":libs:virtual-node:virtual-node-info")
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-application'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"

--- a/components/uniqueness/uniqueness-checker-client-service-impl/build.gradle
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-ledger-utxo'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(':components:crypto:crypto-client')
     implementation project(':components:ledger:ledger-common-flow-api')

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/build.gradle
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     integrationTestImplementation 'net.corda:corda-base'
     integrationTestImplementation 'net.corda:corda-config-schema'
     integrationTestImplementation 'net.corda:corda-topic-schema'
-    integrationTestImplementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    integrationTestImplementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     integrationTestImplementation "org.assertj:assertj-core:$assertjVersion"
     integrationTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     integrationTestImplementation 'org.slf4j:slf4j-api'

--- a/components/uniqueness/uniqueness-checker-impl/build.gradle
+++ b/components/uniqueness/uniqueness-checker-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"

--- a/components/uniqueness/uniqueness-checker/build.gradle
+++ b/components/uniqueness/uniqueness-checker/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     api project(':libs:lifecycle:lifecycle')
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"
     implementation platform("net.corda:corda-api:$cordaApiVersion")

--- a/components/virtual-node/cpi-upload-rpcops-service/build.gradle
+++ b/components/virtual-node/cpi-upload-rpcops-service/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-crypto'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-avro-schema"
     implementation 'net.corda:corda-topic-schema'
     implementation project(":libs:packaging:packaging")

--- a/components/virtual-node/sandbox-amqp/build.gradle
+++ b/components/virtual-node/sandbox-amqp/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-application'
     implementation 'net.corda:corda-serialization'
     implementation project(':libs:serialization:serialization-amqp')

--- a/components/virtual-node/sandbox-crypto/build.gradle
+++ b/components/virtual-node/sandbox-crypto/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:virtual-node:sandbox-group-context')
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -64,8 +64,6 @@ class SandboxGroupContextComponentImpl @Activate constructor(
                 "net.corda.base",
                 "net.corda.crypto",
                 "net.corda.crypto-extensions",
-                "net.corda.kotlin-stdlib-jdk7.osgi-bundle",
-                "net.corda.kotlin-stdlib-jdk8.osgi-bundle",
                 "net.corda.ledger-common",
                 "net.corda.ledger-consensual",
                 "net.corda.ledger-utxo",

--- a/components/virtual-node/sandbox-json/build.gradle
+++ b/components/virtual-node/sandbox-json/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-application'
     implementation project(':libs:serialization:json-serializers')
     implementation project(':libs:virtual-node:sandbox-group-context')

--- a/components/virtual-node/virtual-node-info-read-service-rpc-extensions/build.gradle
+++ b/components/virtual-node/virtual-node-info-read-service-rpc-extensions/build.gradle
@@ -8,7 +8,7 @@ description "Virtual Node Info Service RPC Extensions"
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(':libs:rest:rest')
     implementation project(":libs:virtual-node:virtual-node-info")

--- a/components/virtual-node/virtual-node-management-sender/build.gradle
+++ b/components/virtual-node/virtual-node-management-sender/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     // External
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     // Project
     implementation project(':components:configuration:configuration-read-service')

--- a/components/virtual-node/virtual-node-rpcops-maintenance-impl/build.gradle
+++ b/components/virtual-node/virtual-node-rpcops-maintenance-impl/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/components/virtual-node/virtual-node-rpcops-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-membership'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/components/virtual-node/virtual-node-write-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-write-service-impl/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'net.corda:corda-db-schema'
     implementation 'net.corda:corda-membership'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation project(":libs:crypto:crypto-impl")

--- a/components/virtual-node/virtual-node-write-service/build.gradle
+++ b/components/virtual-node/virtual-node-write-service/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-base'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(":components:reconciliation:reconciliation")
     api project(':libs:virtual-node:virtual-node-info')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # General repository setup properties
 artifactoryContextUrl=https://software.r3.com/artifactory
 kotlin.code.style=official
-kotlinVersion=1.7.21
+kotlinVersion=1.8.10
 kotlin.stdlib.default.dependency=false
 kotlinMetadataVersion = 0.6.0
 
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.636-beta+
+cordaApiVersion=5.0.0.637-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/application/addon-osgi-test/build.gradle
+++ b/libs/application/addon-osgi-test/build.gradle
@@ -5,6 +5,7 @@ plugins {
 description 'Add-on OSGi tests'
 
 dependencies {
+    compileOnly 'org.jetbrains:annotations'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     compileOnly 'org.osgi:osgi.annotation'
@@ -17,7 +18,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-config-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testRuntimeOnly 'org.osgi:osgi.core'
 }

--- a/libs/application/addon/build.gradle
+++ b/libs/application/addon/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")

--- a/libs/application/application-impl/build.gradle
+++ b/libs/application/application-impl/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation project(":libs:virtual-node:sandbox-group-context")
     api project(":libs:serialization:json-serializers")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation 'org.slf4j:slf4j-api'
 

--- a/libs/application/banner/build.gradle
+++ b/libs/application/banner/build.gradle
@@ -12,6 +12,6 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 }

--- a/libs/cache/cache-caffeine/build.gradle
+++ b/libs/cache/cache-caffeine/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(":libs:utilities")
     implementation 'net.corda:corda-base'
     api "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/libs/chunking/chunking-core/build.gradle
+++ b/libs/chunking/chunking-core/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
     api "net.corda:corda-crypto"
 

--- a/libs/chunking/chunking-datamodel/build.gradle
+++ b/libs/chunking/chunking-datamodel/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-db-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:db:db-core')
 
     integrationTestImplementation project(':libs:chunking:chunking-core')

--- a/libs/configuration/configuration-core/build.gradle
+++ b/libs/configuration/configuration-core/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-config-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(":libs:crypto:crypto-core")
 

--- a/libs/configuration/configuration-datamodel/build.gradle
+++ b/libs/configuration/configuration-datamodel/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-db-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:db:db-core')
 
     integrationTestImplementation project(':libs:db:db-admin')

--- a/libs/configuration/configuration-endpoints/build.gradle
+++ b/libs/configuration/configuration-endpoints/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     api project(':libs:rest:rest')
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
 }

--- a/libs/configuration/configuration-merger/build.gradle
+++ b/libs/configuration/configuration-merger/build.gradle
@@ -17,6 +17,6 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(':libs:messaging:message-bus')
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 }

--- a/libs/configuration/configuration-osgi-test/build.gradle
+++ b/libs/configuration/configuration-osgi-test/build.gradle
@@ -5,6 +5,7 @@ plugins {
 description 'Configuration OSGi tests'
 
 dependencies {
+    compileOnly 'org.jetbrains:annotations'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     compileOnly 'org.osgi:osgi.annotation'
@@ -13,7 +14,7 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testRuntimeOnly 'org.osgi:osgi.core'
 }

--- a/libs/configuration/configuration-schema/p2p/build.gradle
+++ b/libs/configuration/configuration-schema/p2p/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 }

--- a/libs/configuration/configuration-validation/build.gradle
+++ b/libs/configuration/configuration-validation/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:configuration:configuration-core")
 
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"

--- a/libs/crypto/certificate-generation/build.gradle
+++ b/libs/crypto/certificate-generation/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-crypto'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:crypto:cipher-suite')
 }

--- a/libs/crypto/cipher-suite-impl/build.gradle
+++ b/libs/crypto/cipher-suite-impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-application'
 

--- a/libs/crypto/cipher-suite/build.gradle
+++ b/libs/crypto/cipher-suite/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     api platform("net.corda:corda-api:$cordaApiVersion")

--- a/libs/crypto/crypto-config-impl/build.gradle
+++ b/libs/crypto/crypto-config-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "net.corda:corda-config-schema"

--- a/libs/crypto/crypto-core/build.gradle
+++ b/libs/crypto/crypto-core/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     api project(':libs:crypto:cipher-suite')

--- a/libs/crypto/crypto-flow/build.gradle
+++ b/libs/crypto/crypto-flow/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "net.corda:corda-avro-schema"

--- a/libs/crypto/crypto-impl/build.gradle
+++ b/libs/crypto/crypto-impl/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-serialization"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
 
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"

--- a/libs/crypto/crypto-serialization-impl/build.gradle
+++ b/libs/crypto/crypto-serialization-impl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     api project(':libs:crypto:cipher-suite')

--- a/libs/crypto/crypto-utils/build.gradle
+++ b/libs/crypto/crypto-utils/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
 

--- a/libs/crypto/delegated-signing/build.gradle
+++ b/libs/crypto/delegated-signing/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-crypto"
 

--- a/libs/crypto/merkle-impl/build.gradle
+++ b/libs/crypto/merkle-impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api 'net.corda:corda-serialization'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-application"
     implementation "net.corda:corda-crypto"
     implementation project(':libs:crypto:cipher-suite')

--- a/libs/datasync/build.gradle
+++ b/libs/datasync/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-avro-schema'
 }

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -14,7 +14,7 @@ ext {
 description 'Database Admin API'
 
 dependencies {
-    api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     compileOnly "org.osgi:osgi.annotation"

--- a/libs/db/db-core/build.gradle
+++ b/libs/db/db-core/build.gradle
@@ -6,7 +6,7 @@ plugins {
 description 'Database Core Library'
 
 dependencies {
-    api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     compileOnly 'org.osgi:osgi.core'

--- a/libs/db/db-orm/build.gradle
+++ b/libs/db/db-orm/build.gradle
@@ -6,7 +6,7 @@ plugins {
 description 'Database ORM API'
 
 dependencies {
-    api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation project(":libs:db:db-core")

--- a/libs/db/osgi-integration-tests/build.gradle
+++ b/libs/db/osgi-integration-tests/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:osgi.core"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    compileOnly 'org.jetbrains:annotations'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api "javax.persistence:javax.persistence-api"
 

--- a/libs/flows/external-event-responses-impl/build.gradle
+++ b/libs/flows/external-event-responses-impl/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-topic-schema"

--- a/libs/flows/external-event-responses/build.gradle
+++ b/libs/flows/external-event-responses/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
 

--- a/libs/flows/flow-api/build.gradle
+++ b/libs/flows/flow-api/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-application"
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"

--- a/libs/flows/flow-mapper-impl/build.gradle
+++ b/libs/flows/flow-mapper-impl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation project(":libs:flows:session-manager")
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"

--- a/libs/flows/flow-mapper/build.gradle
+++ b/libs/flows/flow-mapper/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(":libs:messaging:messaging")
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
 }

--- a/libs/flows/session-manager-impl/build.gradle
+++ b/libs/flows/session-manager-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"

--- a/libs/flows/session-manager/build.gradle
+++ b/libs/flows/session-manager/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation project(':libs:configuration:configuration-core')
     implementation project(":libs:messaging:messaging")
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
 }

--- a/libs/flows/utils/build.gradle
+++ b/libs/flows/utils/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     api "net.corda:corda-avro-schema"
 }

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -24,13 +24,14 @@ configurations {
 }
 
 dependencies {
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadataVersion"
     compileOnly "org.ow2.asm:asm:$asmVersion"
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
+    testCompileOnly "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
     testRuntimeOnly "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadataVersion"

--- a/libs/kotlin-reflection/kotlin-reflection-test-api/build.gradle
+++ b/libs/kotlin-reflection/kotlin-reflection-test-api/build.gradle
@@ -5,6 +5,6 @@ plugins {
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 }

--- a/libs/kotlin-reflection/kotlin-reflection-test-example/build.gradle
+++ b/libs/kotlin-reflection/kotlin-reflection-test-example/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api project(':libs:kotlin-reflection:kotlin-reflection-test-api')
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 }

--- a/libs/layered-property-map/build.gradle
+++ b/libs/layered-property-map/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     api "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-serialization"

--- a/libs/layered-property-map/layered-property-map-test-converter/build.gradle
+++ b/libs/layered-property-map/layered-property-map-test-converter/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
 
     implementation project(":libs:layered-property-map")

--- a/libs/lifecycle/lifecycle-impl/build.gradle
+++ b/libs/lifecycle/lifecycle-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.google.guava:guava:$guavaVersion"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation 'org.slf4j:slf4j-api'
 

--- a/libs/lifecycle/lifecycle-test-impl/build.gradle
+++ b/libs/lifecycle/lifecycle-test-impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(":libs:lifecycle:registry")
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.assertj:assertj-core:$assertjVersion"
     implementation "org.mockito:mockito-core:$mockitoVersion"
     implementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/lifecycle/lifecycle/build.gradle
+++ b/libs/lifecycle/lifecycle/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation 'org.slf4j:slf4j-api'
 

--- a/libs/lifecycle/registry/build.gradle
+++ b/libs/lifecycle/registry/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation 'org.slf4j:slf4j-api'
     implementation project(":libs:lifecycle:lifecycle")

--- a/libs/membership/certificates-common/build.gradle
+++ b/libs/membership/certificates-common/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "net.corda:corda-base"
     api "net.corda:corda-avro-schema"

--- a/libs/membership/certificates-datamodel/build.gradle
+++ b/libs/membership/certificates-datamodel/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     api 'javax.persistence:javax.persistence-api'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-db-schema'
 }

--- a/libs/membership/membership-common/build.gradle
+++ b/libs/membership/membership-common/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "net.corda:corda-base"
     implementation 'net.corda:corda-config-schema'

--- a/libs/membership/membership-datamodel/build.gradle
+++ b/libs/membership/membership-datamodel/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     api "javax.persistence:javax.persistence-api"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation 'net.corda:corda-base'

--- a/libs/membership/membership-impl/build.gradle
+++ b/libs/membership/membership-impl/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-membership"
     implementation 'net.corda:corda-serialization'
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testImplementation project(":libs:crypto:crypto-impl")
     testImplementation project(":testing:layered-property-map-testkit")

--- a/libs/membership/schema-validation/build.gradle
+++ b/libs/membership/schema-validation/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     api "net.corda:corda-membership-schema"
 

--- a/libs/messaging/db-message-bus-datamodel/build.gradle
+++ b/libs/messaging/db-message-bus-datamodel/build.gradle
@@ -7,7 +7,7 @@ description 'Database Message Bus Datamodel'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:osgi.annotation'
 

--- a/libs/messaging/db-message-bus-impl/build.gradle
+++ b/libs/messaging/db-message-bus-impl/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "net.corda:corda-config-schema"
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-db-schema'
 
     api "javax.persistence:javax.persistence-api"

--- a/libs/messaging/db-topic-admin-impl/build.gradle
+++ b/libs/messaging/db-topic-admin-impl/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "net.corda:corda-base"

--- a/libs/messaging/kafka-message-bus-impl/build.gradle
+++ b/libs/messaging/kafka-message-bus-impl/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"

--- a/libs/messaging/kafka-topic-admin-impl/build.gradle
+++ b/libs/messaging/kafka-topic-admin-impl/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
     implementation "net.corda:corda-base"

--- a/libs/messaging/message-bus/build.gradle
+++ b/libs/messaging/message-bus/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "net.corda:corda-base"
     implementation project(":libs:configuration:configuration-core")

--- a/libs/messaging/messaging-impl/build.gradle
+++ b/libs/messaging/messaging-impl/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-topic-schema'
     implementation 'net.corda:corda-config-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 

--- a/libs/messaging/messaging/build.gradle
+++ b/libs/messaging/messaging/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"

--- a/libs/messaging/topic-admin/build.gradle
+++ b/libs/messaging/topic-admin/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 }

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     api ("io.micrometer:micrometer-core:$micrometerVersion") {

--- a/libs/p2p-crypto/build.gradle
+++ b/libs/p2p-crypto/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-crypto"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:crypto:crypto-utils")
 
     api "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"

--- a/libs/packaging/packaging-core/build.gradle
+++ b/libs/packaging/packaging-core/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     api platform("net.corda:corda-api:$cordaApiVersion")
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api 'net.corda:corda-avro-schema'
     api 'net.corda:corda-crypto'
 

--- a/libs/packaging/packaging-verify/build.gradle
+++ b/libs/packaging/packaging-verify/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Packaging Verify'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api platform("net.corda:corda-api:$cordaApiVersion")
 

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     api 'net.corda:corda-base'
     api 'net.corda:corda-crypto'
     api 'net.corda:corda-crypto-extensions'
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(':libs:utilities')
     implementation project(":libs:packaging:packaging-core")

--- a/libs/packaging/packaging/test/contract-cpk/build.gradle
+++ b/libs/packaging/packaging/test/contract-cpk/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
 
     cordaProvided 'net.corda:corda-application'
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/permissions/permission-cache-common/build.gradle
+++ b/libs/permissions/permission-cache-common/build.gradle
@@ -7,7 +7,7 @@ description 'Common module for sharing dependencies between cache implementation
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'

--- a/libs/permissions/permission-common/build.gradle
+++ b/libs/permissions/permission-common/build.gradle
@@ -7,7 +7,7 @@ description 'Common Permission Module'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'

--- a/libs/permissions/permission-datamodel/build.gradle
+++ b/libs/permissions/permission-datamodel/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Permission data model'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-db-schema'
     implementation project(":libs:db:db-orm")

--- a/libs/permissions/permission-endpoint/build.gradle
+++ b/libs/permissions/permission-endpoint/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-rbac-schema"
 

--- a/libs/permissions/permission-management-cache-impl/build.gradle
+++ b/libs/permissions/permission-management-cache-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-avro-schema"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:messaging")

--- a/libs/permissions/permission-management-cache/build.gradle
+++ b/libs/permissions/permission-management-cache/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     api "net.corda:corda-avro-schema"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(":libs:lifecycle:lifecycle")
     api project(":libs:permissions:permission-cache-common")

--- a/libs/permissions/permission-manager-impl/build.gradle
+++ b/libs/permissions/permission-manager-impl/build.gradle
@@ -8,7 +8,7 @@ description 'Permission Manager Implementation'
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-base"

--- a/libs/permissions/permission-manager/build.gradle
+++ b/libs/permissions/permission-manager/build.gradle
@@ -8,7 +8,7 @@ description 'Permission Manager'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     api "net.corda:corda-avro-schema"
     implementation "net.corda:corda-base"

--- a/libs/permissions/permission-password/build.gradle
+++ b/libs/permissions/permission-password/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(":libs:crypto:crypto-core")
     implementation "org.apache.commons:commons-text:$commonsTextVersion"

--- a/libs/permissions/permission-storage-common/build.gradle
+++ b/libs/permissions/permission-storage-common/build.gradle
@@ -7,7 +7,7 @@ description 'Common Permission Storage Utilities'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-avro-schema"

--- a/libs/permissions/permission-storage-reader-impl/build.gradle
+++ b/libs/permissions/permission-storage-reader-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-topic-schema"

--- a/libs/permissions/permission-storage-reader/build.gradle
+++ b/libs/permissions/permission-storage-reader/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     api project(":libs:permissions:permission-management-cache")
     api project(":libs:permissions:permission-validation-cache")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api "javax.persistence:javax.persistence-api"
 
     implementation project(":libs:lifecycle:lifecycle")

--- a/libs/permissions/permission-storage-writer-impl/build.gradle
+++ b/libs/permissions/permission-storage-writer-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-avro-schema"
 

--- a/libs/permissions/permission-storage-writer/build.gradle
+++ b/libs/permissions/permission-storage-writer/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     implementation project(":libs:messaging:messaging")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "javax.persistence:javax.persistence-api"
 
     implementation project(":libs:lifecycle:lifecycle")

--- a/libs/permissions/permission-validation-cache-impl/build.gradle
+++ b/libs/permissions/permission-validation-cache-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-avro-schema"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:messaging")

--- a/libs/permissions/permission-validation-cache/build.gradle
+++ b/libs/permissions/permission-validation-cache/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     api "net.corda:corda-avro-schema"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api project(":libs:lifecycle:lifecycle")
     api project(":libs:permissions:permission-cache-common")

--- a/libs/permissions/permission-validation-impl/build.gradle
+++ b/libs/permissions/permission-validation-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 
     implementation project(":libs:configuration:configuration-core")

--- a/libs/permissions/permission-validation/build.gradle
+++ b/libs/permissions/permission-validation/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 
     implementation project(":libs:lifecycle:lifecycle")

--- a/libs/platform-info/build.gradle
+++ b/libs/platform-info/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion") {

--- a/libs/rest/rbac-security-manager/build.gradle
+++ b/libs/rest/rbac-security-manager/build.gradle
@@ -8,7 +8,7 @@ description 'Implementation of the Security Manager that integrates with Role Ba
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
 

--- a/libs/rest/rest-client/build.gradle
+++ b/libs/rest/rest-client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-application"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
     implementation "net.corda:corda-crypto"
 

--- a/libs/rest/rest-common/build.gradle
+++ b/libs/rest/rest-common/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-application"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/libs/rest/rest-security-read/build.gradle
+++ b/libs/rest/rest-security-read/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"
     api project(":libs:lifecycle:lifecycle")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api project(":libs:rest:rest-common")
 }

--- a/libs/rest/rest-server/build.gradle
+++ b/libs/rest/rest-server/build.gradle
@@ -7,7 +7,7 @@ description 'Corda REST Server'
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(':libs:rest:rest')
     implementation project(":libs:rest:rest-tools")

--- a/libs/rest/rest-test-common/build.gradle
+++ b/libs/rest/rest-test-common/build.gradle
@@ -9,7 +9,7 @@ description 'Corda REST Test Common'
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-serialization"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"

--- a/libs/rest/rest-tools/build.gradle
+++ b/libs/rest/rest-tools/build.gradle
@@ -8,7 +8,7 @@ description 'Corda REST tools'
 
 dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation project(':libs:rest:rest')
     implementation project(':libs:rest:rest-common')

--- a/libs/rest/rest/build.gradle
+++ b/libs/rest/rest/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     implementation "net.corda:corda-base"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/rest/ssl-cert-read/build.gradle
+++ b/libs/rest/ssl-cert-read/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     api project(":libs:lifecycle:lifecycle")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/sandbox-hooks/build.gradle
+++ b/libs/sandbox-hooks/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly "org.osgi:osgi.core"
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 

--- a/libs/sandbox-internal/build.gradle
+++ b/libs/sandbox-internal/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:osgi.core"
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":libs:packaging:packaging")

--- a/libs/sandbox-internal/sandbox-cpk-library/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-library/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     compileOnly "org.osgi:osgi.core"
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api"
 }

--- a/libs/sandbox-internal/sandbox-cpk-one/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-one/build.gradle
@@ -19,8 +19,9 @@ dependencies {
     cpb project(':libs:sandbox-internal:sandbox-cpk-two')
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:sandbox-internal:sandbox-cpk-library')
+    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.osgi:osgi.core'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/libs/sandbox-internal/sandbox-cpk-three/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-three/build.gradle
@@ -18,8 +18,9 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:sandbox-internal:sandbox-cpk-library')
+    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.osgi:osgi.core'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/libs/sandbox-internal/sandbox-cpk-two/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-two/build.gradle
@@ -19,7 +19,8 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     implementation project(':libs:sandbox-internal:sandbox-cpk-library')
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
+    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.osgi:osgi.core'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/libs/sandbox-internal/sandbox-fragment-cpk/build.gradle
+++ b/libs/sandbox-internal/sandbox-fragment-cpk/build.gradle
@@ -17,6 +17,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided 'org.osgi:org.osgi.service.component.annotations'
+    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-base'
     implementation project('fragment')

--- a/libs/sandbox/build.gradle
+++ b/libs/sandbox/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
     api platform("net.corda:corda-api:$cordaApiVersion")
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api project(":libs:packaging:packaging")
     api 'net.corda:corda-serialization'
 

--- a/libs/schema-registry/schema-registry-impl/build.gradle
+++ b/libs/schema-registry/schema-registry-impl/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
 
     implementation "org.apache.avro:avro:$avroVersion"

--- a/libs/schema-registry/schema-registry/build.gradle
+++ b/libs/schema-registry/schema-registry/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api "org.apache.avro:avro:$avroVersion"
 }

--- a/libs/serialization/json-validator/build.gradle
+++ b/libs/serialization/json-validator/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation project(':libs:sandbox-types')
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-serialization'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "io.github.erdtman:java-json-canonicalization:$jsonCanonicalizerVersion"
     implementation("com.networknt:json-schema-validator:$networkntJsonSchemaVersion"){
         // Exclude transitive dependency on vulnerable version of jackson

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation project(path: ':libs:serialization:serialization-encoding', configuration: 'bundle')
     implementation project(":libs:utilities")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.google.guava:guava:$guavaVersion"
     implementation "org.apache.qpid:proton-j:$protonjVersion"
     implementation 'org.slf4j:slf4j-api'

--- a/libs/serialization/serialization-amqp/cpk-evolution-newer/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-evolution-newer/build.gradle
@@ -20,7 +20,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-evolution-older/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-evolution-older/build.gradle
@@ -20,7 +20,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-four/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-four/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     cordapp project(":libs:serialization:serialization-amqp:cpk-three")
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-library/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-library/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     compileOnly "org.osgi:osgi.core"
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/serialization/serialization-amqp/cpk-one/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-one/build.gradle
@@ -19,7 +19,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-platform-type-custom-serializer/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-platform-type-custom-serializer/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
     cordaProvided "net.corda:corda-serialization"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-swap-original/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-swap-original/build.gradle
@@ -19,7 +19,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-swap-replacement/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-swap-replacement/build.gradle
@@ -19,7 +19,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-three/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-three/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     cordapp project(":libs:serialization:serialization-amqp:cpk-one")
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-two/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-two/build.gradle
@@ -19,7 +19,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/cpk-using-lib/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-using-lib/build.gradle
@@ -19,7 +19,7 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided "net.corda:corda-base"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:serialization:serialization-amqp:cpk-library")
 }
 

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -48,10 +48,14 @@ import java.nio.file.StandardCopyOption
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-@Timeout(value = 30, unit = TimeUnit.SECONDS)
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class AMQPwithOSGiSerializationTests {
+    private companion object {
+        private const val TIMEOUT_MILLIS = 10000L
+    }
+
     private val testSerializationContext = AMQP_STORAGE_CONTEXT.withEncoding(SNAPPY)
 
     @RegisterExtension
@@ -59,12 +63,12 @@ class AMQPwithOSGiSerializationTests {
 
     private lateinit var sandboxFactory: SandboxFactory
 
-    @InjectService(timeout = 1000)
+    @InjectService(timeout = TIMEOUT_MILLIS)
     lateinit var securityManagerService: SecurityManagerService
 
     @BeforeAll
     fun setUp(
-        @InjectService(timeout = 1000)
+        @InjectService(timeout = TIMEOUT_MILLIS)
         sandboxSetup: SandboxSetup,
         @InjectBundleContext
         bundleContext: BundleContext,
@@ -74,7 +78,7 @@ class AMQPwithOSGiSerializationTests {
         applyPolicyFile("security-deny-platform-serializers.policy")
         sandboxSetup.configure(bundleContext, testDirectory)
         lifecycle.accept(sandboxSetup) { setup ->
-            sandboxFactory = setup.fetchService(timeout = 1500)
+            sandboxFactory = setup.fetchService(timeout = TIMEOUT_MILLIS)
         }
     }
 

--- a/libs/serialization/serialization-checkpoint-api/build.gradle
+++ b/libs/serialization/serialization-checkpoint-api/build.gradle
@@ -8,10 +8,7 @@ description 'Corda Checkpoint Serialization API'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
-
-    api "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
-    api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'

--- a/libs/serialization/serialization-encoding/build.gradle
+++ b/libs/serialization/serialization-encoding/build.gradle
@@ -18,13 +18,14 @@ configurations {
 }
 
 dependencies {
+    compileOnly 'org.jetbrains:annotations'
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
     compileOnly "org.iq80.snappy:snappy:$snappyVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 }
 

--- a/libs/serialization/serialization-internal/build.gradle
+++ b/libs/serialization/serialization-internal/build.gradle
@@ -13,7 +13,7 @@ description 'Corda Serialization Internal API'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     api platform("net.corda:corda-api:$cordaApiVersion")
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api 'net.corda:corda-serialization'
     api 'net.corda:corda-base'
 }

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
     implementation "com.esotericsoftware:kryo:$kryoVersion"
     implementation project(path: ':libs:serialization:kryo-serializers', configuration: 'bundle')
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api"
     
     implementation project(":libs:sandbox")

--- a/libs/serialization/serialization-kryo/cpks/serializable-cpk-one/build.gradle
+++ b/libs/serialization/serialization-kryo/cpks/serializable-cpk-one/build.gradle
@@ -23,5 +23,5 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/serialization/serialization-kryo/cpks/serializable-cpk-two/build.gradle
+++ b/libs/serialization/serialization-kryo/cpks/serializable-cpk-two/build.gradle
@@ -23,5 +23,5 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/uniqueness/common/build.gradle
+++ b/libs/uniqueness/common/build.gradle
@@ -8,7 +8,7 @@ description 'Uniqueness library'
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"
     implementation 'net.corda:corda-crypto'

--- a/libs/uniqueness/jpa-backing-store-datamodel/build.gradle
+++ b/libs/uniqueness/jpa-backing-store-datamodel/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-db-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:db:db-core')
     implementation project(':libs:uniqueness:common')
 

--- a/libs/utilities/build.gradle
+++ b/libs/utilities/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     // Concluded this is the one acceptable dependency in addition to kotlin.
     implementation 'org.slf4j:slf4j-api'
 

--- a/libs/virtual-node/cpi-datamodel/build.gradle
+++ b/libs/virtual-node/cpi-datamodel/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-db-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:db:db-core')
     implementation project(':libs:packaging:packaging-core')
 

--- a/libs/virtual-node/cpi-upload-endpoints/build.gradle
+++ b/libs/virtual-node/cpi-upload-endpoints/build.gradle
@@ -12,5 +12,5 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-avro-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/virtual-node/cpi-upload-manager-impl/build.gradle
+++ b/libs/virtual-node/cpi-upload-manager-impl/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-topic-schema"
     implementation 'net.corda:corda-crypto'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
 }

--- a/libs/virtual-node/cpi-upload-manager/build.gradle
+++ b/libs/virtual-node/cpi-upload-manager/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-crypto'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/virtual-node/virtual-node-common/build.gradle
+++ b/libs/virtual-node/virtual-node-common/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/virtual-node/virtual-node-datamodel/build.gradle
+++ b/libs/virtual-node/virtual-node-datamodel/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'javax.persistence:javax.persistence-api'
     implementation 'net.corda:corda-db-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':libs:db:db-core')
     implementation project(':libs:db:db-orm')
     implementation project(':libs:virtual-node:virtual-node-info')

--- a/libs/virtual-node/virtual-node-endpoints-maintenance/build.gradle
+++ b/libs/virtual-node/virtual-node-endpoints-maintenance/build.gradle
@@ -14,5 +14,5 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-avro-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/virtual-node/virtual-node-endpoints/build.gradle
+++ b/libs/virtual-node/virtual-node-endpoints/build.gradle
@@ -15,5 +15,5 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-avro-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/notary-plugins/notary-plugin-common/build.gradle
+++ b/notary-plugins/notary-plugin-common/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     cordaProvided "net.corda:corda-application"
     cordaProvided "net.corda:corda-notary-plugin"
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     cordaProvided project(':libs:crypto:cipher-suite')
 }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-api/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-api/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-notary-plugin'
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'org.slf4j:slf4j-api'
 
     cordapp project(":notary-plugins:notary-plugin-common")

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-notary-plugin'
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'org.slf4j:slf4j-api'
 
     // Common package pulled in as transitive dependency through API

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-notary-plugin'
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     cordaProvided "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     cordaProvided "org.osgi:osgi.core"

--- a/processors/crypto-processor/build.gradle
+++ b/processors/crypto-processor/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:osgi.annotation"
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation "net.corda:corda-avro-schema"

--- a/processors/flow-processor/build.gradle
+++ b/processors/flow-processor/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'

--- a/processors/gateway-processor/build.gradle
+++ b/processors/gateway-processor/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(':components:configuration:configuration-read-service')
     implementation project(":components:crypto:crypto-client")

--- a/processors/link-manager-processor/build.gradle
+++ b/processors/link-manager-processor/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'

--- a/processors/member-processor/build.gradle
+++ b/processors/member-processor/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(':components:membership:locally-hosted-identities-service')
     implementation project(':components:membership:members-client-certificate-publisher-service')
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(':libs:configuration:configuration-core')
 

--- a/processors/verification-processor/build.gradle
+++ b/processors/verification-processor/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'

--- a/simulator/api/build.gradle
+++ b/simulator/api/build.gradle
@@ -10,7 +10,7 @@ ext {
 
 dependencies {
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-application:$cordaApiVersion"
 
     runtimeOnly project(':simulator:runtime')

--- a/simulator/example-app/build.gradle
+++ b/simulator/example-app/build.gradle
@@ -10,7 +10,7 @@ version = "$cordaApiVersion"
 
 dependencies {
 
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided 'net.corda:corda-base'
     cordaProvided 'net.corda:corda-application'

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     api "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
     api "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-application:$cordaApiVersion"
     implementation "net.corda:corda-ledger-consensual"
 

--- a/testing/apps/test-app/build.gradle
+++ b/testing/apps/test-app/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     compileOnly 'org.slf4j:slf4j-api'
     compileOnly project(':osgi-framework-api')
 

--- a/testing/cpbs/crypto-custom-digest-one-consumer/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-one-consumer/build.gradle
@@ -19,7 +19,8 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains:annotations'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-crypto'
     cordaProvided 'net.corda:corda-crypto-extensions'

--- a/testing/cpbs/crypto-custom-digest-one-cpk/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-one-cpk/build.gradle
@@ -18,7 +18,7 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided project(':libs:crypto:cipher-suite')
     cordaProvided 'net.corda:corda-crypto'
     cordaProvided 'net.corda:corda-crypto-extensions'

--- a/testing/cpbs/crypto-custom-digest-two-consumer/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-two-consumer/build.gradle
@@ -19,7 +19,8 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains:annotations'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-crypto'
     cordaProvided 'net.corda:corda-crypto-extensions'

--- a/testing/cpbs/crypto-custom-digest-two-cpk/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-two-cpk/build.gradle
@@ -18,7 +18,7 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided project(':libs:crypto:cipher-suite')
     cordaProvided 'net.corda:corda-crypto'
     cordaProvided 'net.corda:corda-crypto-extensions'

--- a/testing/cpbs/sandbox-scr-cpk/build.gradle
+++ b/testing/cpbs/sandbox-scr-cpk/build.gradle
@@ -19,6 +19,7 @@ cordapp {
 dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     cordaProvided "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
+    cordaProvided 'org.jetbrains:annotations'
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided 'net.corda:corda-application'
     cordaProvided "org.osgi:osgi.core"

--- a/testing/cpbs/sandbox-security-manager-one/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-one/build.gradle
@@ -22,7 +22,8 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     cordaProvided 'org.osgi:osgi.core'
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains:annotations'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'
     cordapp project(':testing:cpbs:sandbox-security-manager-two')

--- a/testing/cpbs/sandbox-security-manager-two/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-two/build.gradle
@@ -20,7 +20,8 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    cordaProvided "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    cordaProvided 'org.jetbrains:annotations'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'
 }

--- a/testing/cpbs/sandbox-singletons-cpk/build.gradle
+++ b/testing/cpbs/sandbox-singletons-cpk/build.gradle
@@ -20,7 +20,8 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains:annotations'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided project(':testing:sandboxes:test-api')
     cordaProvided 'net.corda:corda-application'
 }

--- a/testing/cpbs/split-packages/split-packages-one/build.gradle
+++ b/testing/cpbs/split-packages/split-packages-one/build.gradle
@@ -14,6 +14,6 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project('library-one')
 }

--- a/testing/cpbs/split-packages/split-packages-one/library-one/build.gradle
+++ b/testing/cpbs/split-packages/split-packages-one/library-one/build.gradle
@@ -7,6 +7,6 @@ group 'com.example.split'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 }

--- a/testing/cpbs/split-packages/split-packages-two/build.gradle
+++ b/testing/cpbs/split-packages/split-packages-two/build.gradle
@@ -14,6 +14,6 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project('library-two')
 }

--- a/testing/cpbs/split-packages/split-packages-two/library-two/build.gradle
+++ b/testing/cpbs/split-packages/split-packages-two/library-two/build.gradle
@@ -7,6 +7,6 @@ group 'com.example.split'
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 }

--- a/testing/cpbs/test-cordapp/build.gradle
+++ b/testing/cpbs/test-cordapp/build.gradle
@@ -14,6 +14,7 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
+    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-ledger-utxo'
     cordaProvided 'net.corda:corda-notary-plugin'

--- a/testing/crypto-testkit/build.gradle
+++ b/testing/crypto-testkit/build.gradle
@@ -8,7 +8,7 @@ description 'Crypto internal testkit'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation project(':libs:crypto:cipher-suite')

--- a/testing/db-message-bus-testkit/build.gradle
+++ b/testing/db-message-bus-testkit/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-db-schema'
     implementation 'net.corda:corda-config-schema'
     implementation project(":libs:messaging:db-message-bus-datamodel")

--- a/testing/db-testkit/build.gradle
+++ b/testing/db-testkit/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-config-schema'
     implementation "net.corda:corda-db-schema"
     implementation project(":testing:test-utilities")

--- a/testing/flow/dummy-link-manager/build.gradle
+++ b/testing/flow/dummy-link-manager/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-topic-schema"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "org.slf4j:slf4j-api:$slf4jVersion"

--- a/testing/flow/external-events/build.gradle
+++ b/testing/flow/external-events/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'net.corda:corda-avro-schema'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-topic-schema'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.assertj:assertj-core:$assertjVersion"
 
     implementation project(':libs:configuration:configuration-core')

--- a/testing/flow/flow-utilities/build.gradle
+++ b/testing/flow/flow-utilities/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-avro-schema:$cordaApiVersion"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }
 
 description 'Flow Test Utilities'

--- a/testing/kryo-serialization-testkit/build.gradle
+++ b/testing/kryo-serialization-testkit/build.gradle
@@ -7,7 +7,7 @@ description 'Kryo serialization test utilities'
 dependencies {
     implementation "org.osgi:osgi.core"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.esotericsoftware:kryo:$kryoVersion"
     implementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 

--- a/testing/layered-property-map-testkit/build.gradle
+++ b/testing/layered-property-map-testkit/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation 'org.osgi:osgi.core'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation project(":libs:layered-property-map")
 }

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -23,7 +23,7 @@ configurations {
 dependencies {
     integrationTestCompileOnly 'org.osgi:osgi.core'
     integrationTestCompileOnly 'org.osgi:org.osgi.service.component.annotations'
-    integrationTestImplementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    integrationTestImplementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     integrationTestImplementation project(":components:kafka-topic-admin")
 

--- a/testing/p2p/certificates/build.gradle
+++ b/testing/p2p/certificates/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/testing/p2p/inmemory-messaging-impl/build.gradle
+++ b/testing/p2p/inmemory-messaging-impl/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation 'net.corda:corda-config-schema'
     implementation "com.typesafe:config:$typeSafeConfigVersion"

--- a/testing/packaging-test-utilities/build.gradle
+++ b/testing/packaging-test-utilities/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Packaging Test - Build in memory CPI, CPB, and CPK for testin
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     api platform("net.corda:corda-api:$cordaApiVersion")
     api 'net.corda:corda-crypto'

--- a/testing/sandboxes/build.gradle
+++ b/testing/sandboxes/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     api "org.junit.jupiter:junit-jupiter-api:$junit5Version"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':components:membership:membership-group-read')
     implementation project(':components:virtual-node:cpi-info-read-service')
     implementation project(':components:virtual-node:virtual-node-info-read-service')

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -52,8 +52,6 @@ class SandboxSetupImpl @Activate constructor(
             "net.corda.base",
             "net.corda.crypto",
             "net.corda.crypto-extensions",
-            "net.corda.kotlin-stdlib-jdk7.osgi-bundle",
-            "net.corda.kotlin-stdlib-jdk8.osgi-bundle",
             "net.corda.ledger-consensual",
             "net.corda.ledger-utxo",
             "net.corda.membership",

--- a/testing/security-manager-utilities/build.gradle
+++ b/testing/security-manager-utilities/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.mockito:mockito-core:$mockitoVersion"
 
     implementation project(':components:security-manager')

--- a/testing/test-serialization/build.gradle
+++ b/testing/test-serialization/build.gradle
@@ -7,7 +7,7 @@ description 'Test serialization service'
 dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly "org.osgi:osgi.annotation"
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     api "net.corda:corda-application"

--- a/testing/test-utilities/build.gradle
+++ b/testing/test-utilities/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     api project(":libs:utilities")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.mockito:mockito-core:$mockitoVersion"
     implementation project(":libs:virtual-node:virtual-node-info")
     implementation project(":libs:lifecycle:lifecycle")

--- a/testing/uniqueness/backing-store-fake/build.gradle
+++ b/testing/uniqueness/backing-store-fake/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-crypto"
     implementation "net.corda:corda-ledger-utxo"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":components:uniqueness:backing-store")

--- a/testing/uniqueness/uniqueness-utilities/build.gradle
+++ b/testing/uniqueness/uniqueness-utilities/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     api "net.corda:corda-crypto"
 
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-application"


### PR DESCRIPTION
Kotlin 1.8 has dropped Java 6 support, and the `kotlin-osgi-bundle` now requires Java 8+. It  has therefore absorbed the `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` artifacts, which means we no longer need our home-grown `kotlin-stdlib-jdk7-osgi` and `kotlin-stdlib-jdk8-osgi` bundles.