### PR TITLE
CORE-7146 metadata sync, constraints and tests

### DIFF
--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl
+import net.corda.ledger.consensual.flow.impl.transaction.verifier.verifyMetadata
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
@@ -27,10 +28,7 @@ class ConsensualSignedTransactionImpl(
         require(signatures.isNotEmpty()) {
             "Tried to instantiate a ${ConsensualSignedTransactionImpl::class.java.simpleName} without any signatures "
         }
-        require(wireTransaction.metadata.getLedgerModel() == ConsensualLedgerTransactionImpl::class.java.name) {
-            "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
-                    "'${wireTransaction.metadata.getLedgerModel()}' != '${ConsensualLedgerTransactionImpl::class.java.name}'"
-        }
+        verifyMetadata(wireTransaction.metadata)
     }
 
     override val id: SecureHash

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -27,7 +27,10 @@ class ConsensualSignedTransactionImpl(
         require(signatures.isNotEmpty()) {
             "Tried to instantiate a ${ConsensualSignedTransactionImpl::class.java.simpleName} without any signatures "
         }
-        // TODO(CORE-7237 Check WireTx's metadata's ledger type and allow only the matching ones.)
+        require(wireTransaction.metadata.getLedgerModel() == ConsensualLedgerTransactionImpl::class.java.canonicalName) {
+            "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
+                    "'${wireTransaction.metadata.getLedgerModel()}' != '${ConsensualLedgerTransactionImpl::class.java.canonicalName}'"
+        }
     }
 
     override val id: SecureHash

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -27,9 +27,9 @@ class ConsensualSignedTransactionImpl(
         require(signatures.isNotEmpty()) {
             "Tried to instantiate a ${ConsensualSignedTransactionImpl::class.java.simpleName} without any signatures "
         }
-        require(wireTransaction.metadata.getLedgerModel() == ConsensualLedgerTransactionImpl::class.java.canonicalName) {
+        require(wireTransaction.metadata.getLedgerModel() == ConsensualLedgerTransactionImpl::class.java.name) {
             "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
-                    "'${wireTransaction.metadata.getLedgerModel()}' != '${ConsensualLedgerTransactionImpl::class.java.canonicalName}'"
+                    "'${wireTransaction.metadata.getLedgerModel()}' != '${ConsensualLedgerTransactionImpl::class.java.name}'"
         }
     }
 

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -94,7 +94,7 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
     }
 
     private fun consensualMetadata() = mapOf(
-        TransactionMetadataImpl.LEDGER_MODEL_KEY to ConsensualLedgerTransactionImpl::class.java.canonicalName,
+        TransactionMetadataImpl.LEDGER_MODEL_KEY to ConsensualLedgerTransactionImpl::class.java.name,
         TransactionMetadataImpl.LEDGER_VERSION_KEY to TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION,
         TransactionMetadataImpl.NUMBER_OF_COMPONENT_GROUPS to ConsensualComponentGroup.values().size
     )

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/verifier/ConsensualTransactionMetadataVerifier.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/verifier/ConsensualTransactionMetadataVerifier.kt
@@ -4,9 +4,9 @@ import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionI
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
 fun verifyMetadata(transactionMetadata: TransactionMetadata) {
-    check(transactionMetadata.getLedgerModel() == ConsensualLedgerTransactionImpl::class.java.canonicalName) {
+    check(transactionMetadata.getLedgerModel() == ConsensualLedgerTransactionImpl::class.java.name) {
         "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
-                "'${transactionMetadata.getLedgerModel()}' != '${ConsensualLedgerTransactionImpl::class.java.canonicalName}'"
+                "'${transactionMetadata.getLedgerModel()}' != '${ConsensualLedgerTransactionImpl::class.java.name}'"
     }
     check(transactionMetadata.getTransactionSubtype() == null) {
         "The transaction subtype in the metadata of the transaction should be empty for Consensual Transactions."

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/verifier/ConsensualTransactionMetadataVerifier.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/verifier/ConsensualTransactionMetadataVerifier.kt
@@ -1,9 +1,14 @@
 package net.corda.ledger.consensual.flow.impl.transaction.verifier
 
+import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
-@Suppress("UNUSED", "UNUSED_PARAMETER")
-fun verifyMetadata(metadata: TransactionMetadata) {
-    // TODO(CORE-5982 more verifications)
-    // TODO(CORE-5982 ? metadata verifications: nulls, order of CPKs, at least one CPK?)) Maybe from json schema?
+fun verifyMetadata(transactionMetadata: TransactionMetadata) {
+    check(transactionMetadata.getLedgerModel() == ConsensualLedgerTransactionImpl::class.java.canonicalName) {
+        "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
+                "'${transactionMetadata.getLedgerModel()}' != '${ConsensualLedgerTransactionImpl::class.java.canonicalName}'"
+    }
+    check(transactionMetadata.getTransactionSubtype() == null) {
+        "The transaction subtype in the metadata of the transaction should be empty for Consensual Transactions."
+    }
 }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
@@ -94,7 +94,7 @@ class ConsensualFinalityFlowTest {
         whenever(updatedSignedTransaction.id).thenReturn(TX_ID)
         whenever(updatedSignedTransaction.addSignature(any())).thenReturn(updatedSignedTransaction)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)
-        whenever(transactionMetadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.canonicalName)
+        whenever(transactionMetadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.name)
 
         whenever(ledgerTransaction.id).thenReturn(TX_ID)
         whenever(ledgerTransaction.states).thenReturn(listOf(consensualStateExample))

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
@@ -6,6 +6,7 @@ import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl
 import net.corda.ledger.consensual.flow.impl.persistence.ConsensualLedgerPersistenceService
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
 import net.corda.ledger.consensual.testkit.ConsensualStateClassExample
@@ -93,6 +94,7 @@ class ConsensualFinalityFlowTest {
         whenever(updatedSignedTransaction.id).thenReturn(TX_ID)
         whenever(updatedSignedTransaction.addSignature(any())).thenReturn(updatedSignedTransaction)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)
+        whenever(transactionMetadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.canonicalName)
 
         whenever(ledgerTransaction.id).thenReturn(TX_ID)
         whenever(ledgerTransaction.states).thenReturn(listOf(consensualStateExample))

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
@@ -76,7 +76,7 @@ class ConsensualReceiveFinalityFlowTest {
 
         whenever(signedTransaction.id).thenReturn(ID)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)
-        whenever(transactionMetadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.canonicalName)
+        whenever(transactionMetadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.name)
         whenever(signedTransaction.wireTransaction).thenReturn(wireTransaction)
         whenever(signedTransaction.toLedgerTransaction()).thenReturn(ledgerTransaction)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransaction to listOf(signature1, signature2))

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualReceiveFinalityFlowTest.kt
@@ -76,6 +76,7 @@ class ConsensualReceiveFinalityFlowTest {
 
         whenever(signedTransaction.id).thenReturn(ID)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)
+        whenever(transactionMetadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.canonicalName)
         whenever(signedTransaction.wireTransaction).thenReturn(wireTransaction)
         whenever(signedTransaction.toLedgerTransaction()).thenReturn(ledgerTransaction)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransaction to listOf(signature1, signature2))

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
@@ -5,6 +5,7 @@ import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.AbstractConsensualLedgerExternalEventFactory
 import net.corda.ledger.consensual.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
@@ -14,6 +15,7 @@ import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransac
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.serialization.SerializedBytes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -77,7 +79,11 @@ class ConsensualLedgerPersistenceServiceImplTest {
 
     @Test
     fun `find executes successfully`() {
+        val metadata = mock<TransactionMetadata>()
+        whenever(metadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.canonicalName)
         val wireTransaction = mock<WireTransaction>()
+        whenever(wireTransaction.metadata).thenReturn(metadata)
+
         val signatures = listOf(mock<DigitalSignatureAndMetadata>())
         val expectedObj = ConsensualSignedTransactionImpl(
             serializationService,

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
@@ -80,7 +80,7 @@ class ConsensualLedgerPersistenceServiceImplTest {
     @Test
     fun `find executes successfully`() {
         val metadata = mock<TransactionMetadata>()
-        whenever(metadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.canonicalName)
+        whenever(metadata.getLedgerModel()).thenReturn(ConsensualLedgerTransactionImpl::class.java.name)
         val wireTransaction = mock<WireTransaction>()
         whenever(wireTransaction.metadata).thenReturn(metadata)
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -2,10 +2,10 @@ package net.corda.ledger.utxo.flow.impl.transaction
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
-import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
+import net.corda.ledger.utxo.transaction.verifier.verifyMetadata
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
@@ -33,10 +33,7 @@ data class UtxoSignedTransactionImpl(
 
     init {
         require(signatures.isNotEmpty()) { "Tried to instantiate a ${javaClass.simpleName} without any signatures." }
-        require(wireTransaction.metadata.getLedgerModel() == UtxoLedgerTransactionImpl::class.java.name) {
-            "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
-                    "'${wireTransaction.metadata.getLedgerModel()}' != '${UtxoLedgerTransactionImpl::class.java.name}'"
-        }
+        verifyMetadata(wireTransaction.metadata)
     }
 
     private val wrappedWireTransaction = WrappedUtxoWireTransaction(wireTransaction, serializationService)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
@@ -32,7 +33,10 @@ data class UtxoSignedTransactionImpl(
 
     init {
         require(signatures.isNotEmpty()) { "Tried to instantiate a ${javaClass.simpleName} without any signatures." }
-        // TODO(CORE-7237 Check WireTx's metadata's ledger type and allow only the matching ones.)
+        require(wireTransaction.metadata.getLedgerModel() == UtxoLedgerTransactionImpl::class.java.canonicalName) {
+            "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
+                    "'${wireTransaction.metadata.getLedgerModel()}' != '${UtxoLedgerTransactionImpl::class.java.canonicalName}'"
+        }
     }
 
     private val wrappedWireTransaction = WrappedUtxoWireTransaction(wireTransaction, serializationService)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -33,9 +33,9 @@ data class UtxoSignedTransactionImpl(
 
     init {
         require(signatures.isNotEmpty()) { "Tried to instantiate a ${javaClass.simpleName} without any signatures." }
-        require(wireTransaction.metadata.getLedgerModel() == UtxoLedgerTransactionImpl::class.java.canonicalName) {
+        require(wireTransaction.metadata.getLedgerModel() == UtxoLedgerTransactionImpl::class.java.name) {
             "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
-                    "'${wireTransaction.metadata.getLedgerModel()}' != '${UtxoLedgerTransactionImpl::class.java.canonicalName}'"
+                    "'${wireTransaction.metadata.getLedgerModel()}' != '${UtxoLedgerTransactionImpl::class.java.name}'"
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -99,7 +99,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
     )
 
     private fun utxoMetadata() = mapOf(
-        TransactionMetadataImpl.LEDGER_MODEL_KEY to UtxoLedgerTransactionImpl::class.java.canonicalName,
+        TransactionMetadataImpl.LEDGER_MODEL_KEY to UtxoLedgerTransactionImpl::class.java.name,
         TransactionMetadataImpl.LEDGER_VERSION_KEY to UtxoTransactionMetadata.LEDGER_VERSION,
         TransactionMetadataImpl.TRANSACTION_SUBTYPE_KEY to UtxoTransactionMetadata.TransactionSubtype.GENERAL,
         TransactionMetadataImpl.NUMBER_OF_COMPONENT_GROUPS to UtxoComponentGroup.values().size

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
@@ -7,7 +7,6 @@ import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesExce
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.notary.plugin.factory.PluggableNotaryClientFlowFactory
-import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowTest.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesExce
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.notary.plugin.factory.PluggableNotaryClientFlowFactory
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -138,7 +138,7 @@ class UtxoLedgerPersistenceServiceImplTest {
     @Test
     fun `find executes successfully`() {
         val metadata = mock<TransactionMetadata>()
-        whenever(metadata.getLedgerModel()).thenReturn(UtxoLedgerTransactionImpl::class.java.canonicalName)
+        whenever(metadata.getLedgerModel()).thenReturn(UtxoLedgerTransactionImpl::class.java.name)
         val wireTransaction = mock<WireTransaction>()
         whenever(wireTransaction.componentGroupLists).thenReturn(List(UtxoComponentGroup.values().size) { listOf() })
         whenever(wireTransaction.metadata).thenReturn(metadata)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -139,6 +139,7 @@ class UtxoLedgerPersistenceServiceImplTest {
     fun `find executes successfully`() {
         val metadata = mock<TransactionMetadata>()
         whenever(metadata.getLedgerModel()).thenReturn(UtxoLedgerTransactionImpl::class.java.name)
+        whenever(metadata.getTransactionSubtype()).thenReturn("GENERAL")
         val wireTransaction = mock<WireTransaction>()
         whenever(wireTransaction.componentGroupLists).thenReturn(List(UtxoComponentGroup.values().size) { listOf() })
         whenever(wireTransaction.metadata).thenReturn(metadata)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.AbstractUtxoLedgerExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
@@ -19,6 +20,7 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.serialization.SerializedBytes
 import org.assertj.core.api.Assertions.assertThat
@@ -135,8 +137,11 @@ class UtxoLedgerPersistenceServiceImplTest {
 
     @Test
     fun `find executes successfully`() {
+        val metadata = mock<TransactionMetadata>()
+        whenever(metadata.getLedgerModel()).thenReturn(UtxoLedgerTransactionImpl::class.java.canonicalName)
         val wireTransaction = mock<WireTransaction>()
         whenever(wireTransaction.componentGroupLists).thenReturn(List(UtxoComponentGroup.values().size) { listOf() })
+        whenever(wireTransaction.metadata).thenReturn(metadata)
 
         val signatures = listOf(mock<DigitalSignatureAndMetadata>())
         val expectedObj = UtxoSignedTransactionImpl(

--- a/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
@@ -16,6 +16,7 @@ import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.ledger.common.testkit.createExample
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionContainer
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.ledger.utxo.verification.CordaPackageSummary
 import net.corda.ledger.utxo.verification.TransactionVerificationRequest
@@ -263,7 +264,9 @@ class VerificationRequestProcessorTest {
                 emptyList(),
                 listOf(outputState),
                 listOf(command)
-            )
+            ),
+            ledgerModel = UtxoLedgerTransactionImpl::class.java.canonicalName,
+            transactionSubType = "GENERAL"
         )
         val inputStateAndRefs: List<StateAndRef<*>> = listOf()
         val referenceStateAndRefs: List<StateAndRef<*>> = listOf()

--- a/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
@@ -265,7 +265,7 @@ class VerificationRequestProcessorTest {
                 listOf(outputState),
                 listOf(command)
             ),
-            ledgerModel = UtxoLedgerTransactionImpl::class.java.canonicalName,
+            ledgerModel = UtxoLedgerTransactionImpl::class.java.name,
             transactionSubType = "GENERAL"
         )
         val inputStateAndRefs: List<StateAndRef<*>> = listOf()

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.643-beta+
+cordaApiVersion=5.0.0.644-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
@@ -91,7 +91,7 @@ class TransactionMetadataImpl (private val properties: Map<String, Any>) : Trans
             version.toInt()
         } catch (e: NumberFormatException) {
             throw CordaRuntimeException(
-                "Transaction metadata representation error: JSON platform version should be an integer but could not be parsed: $version")
+                "Transaction metadata representation error: Platform version should be an integer but could not be parsed: $version")
         }
     }
 

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
@@ -83,4 +83,16 @@ class TransactionMetadataImpl (private val properties: Map<String, Any>) : Trans
                 "Transaction metadata representation error: JSON schema version should be an integer but could not be parsed: $version")
         }
     }
+
+    override fun getPlatformVersion(): Int {
+        val version = this[PLATFORM_VERSION_KEY].toString()
+
+        return try {
+            version.toInt()
+        } catch (e: NumberFormatException) {
+            throw CordaRuntimeException(
+                "Transaction metadata representation error: JSON platform version should be an integer but could not be parsed: $version")
+        }
+    }
+
 }

--- a/libs/ledger/ledger-common-data/src/main/resources/schema/transaction-metadata.json
+++ b/libs/ledger/ledger-common-data/src/main/resources/schema/transaction-metadata.json
@@ -2,14 +2,17 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.net/schema/transaction-metadata.json",
   "unevaluatedProperties": false,
+  "additionalProperties": false,
   "title": "Root",
   "type": "object",
   "required": [
-    "ledgerModel",
-    "ledgerVersion",
     "cpiMetadata",
     "cpkMetadata",
     "digestSettings",
+    "ledgerModel",
+    "ledgerVersion",
+    "numberOfComponentGroups",
+    "platformVersion",
     "schemaVersion"
   ],
   "properties": {
@@ -27,6 +30,10 @@
       "description": "Settings relating to the Merkle tree digest algorithms.",
       "type": "object",
       "required": [
+        "batchMerkleTreeDigestProviderName",
+        "batchMerkleTreeDigestAlgorithmName",
+        "batchMerkleTreeDigestOptionsLeafPrefixB64",
+        "batchMerkleTreeDigestOptionsNodePrefixB64",
         "rootMerkleTreeDigestProviderName",
         "rootMerkleTreeDigestAlgorithmName",
         "rootMerkleTreeDigestOptionsLeafPrefixB64",
@@ -153,8 +160,7 @@
     "cpiMetadata": {
       "title": "CPI metadata",
       "$ref": "#/definitions/package_metadata"
-    }
-    ,
+    },
     "cpkMetadata": {
       "title": "CPK metadata",
       "type": "array",
@@ -169,7 +175,15 @@
       "title": "Number of component groups",
       "description": "The number of component groups contained in the transaction",
       "type": "integer",
-      "default": 0
+      "default": 1
+    },
+    "platformVersion": {
+      "title": "Active platform version at the time of the creation of the transaction",
+      "type": "integer",
+      "default": "",
+      "examples": [
+        1
+      ]
     },
     "schemaVersion": {
       "title": "Metadata schema version",
@@ -178,31 +192,23 @@
       "examples": [
         1
       ]
+    },
+    "transactionSubtype": {
+      "title": "Transaction subtype",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        null,
+        "NOTARY_CHANGE",
+        "GENERAL"
+      ]
     }
   },
   "allOf": [
-    {
-      "if": {
-        "properties": {
-          "ledgerModel": {
-            "const": "net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl"
-          }
-        }
-      },
-      "then": {
-        "required": [ "transactionSubtype" ],
-        "properties": {
-          "transactionSubtype": {
-            "title": "Transaction subtype",
-            "type": "string",
-            "enum": [
-              "NOTARY_CHANGE",
-              "GENERAL"
-            ]
-          }
-        }
-      }
-    }
+    { "$ref": "#/definitions/if-consensual-ledger" },
+    { "$ref": "#/definitions/if-utxo-ledger" }
   ],
   "definitions": {
     "package_metadata": {
@@ -250,6 +256,50 @@
         }
       },
       "additionalProperties": false
+    },
+    "if-consensual-ledger": {
+      "if": {
+        "properties": {
+          "ledgerModel": {
+            "const": "net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "transactionSubtype": {
+            "title": "Transaction subtype",
+            "type": "null",
+            "enum": [
+              null
+            ]
+          }
+        }
+      }
+    },
+    "if-utxo-ledger": {
+      "if": {
+        "properties": {
+          "ledgerModel": {
+            "const": "net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "transactionSubtype": {
+            "title": "Transaction subtype",
+            "type": "string",
+            "enum": [
+              "NOTARY_CHANGE",
+              "GENERAL"
+            ]
+          }
+        },
+        "required": [
+          "transactionSubtype"
+        ]
+      }
     }
   }
 }

--- a/libs/ledger/ledger-common-data/src/main/resources/schema/transaction-metadata.json
+++ b/libs/ledger/ledger-common-data/src/main/resources/schema/transaction-metadata.json
@@ -162,7 +162,8 @@
       "items":{
         "title": "Items",
         "$ref": "#/definitions/package_metadata"
-      }
+      },
+      "minItems": 1
     },
     "numberOfComponentGroups": {
       "title": "Number of component groups",

--- a/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImplTest.kt
+++ b/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImplTest.kt
@@ -8,6 +8,7 @@ import net.corda.ledger.common.testkit.transactionMetadataExample
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
+@Suppress("MaxLineLength")
 class WireTransactionFactoryImplTest : CommonLedgerTest() {
     private val metadata = transactionMetadataExample(numberOfComponentGroups = 1)
     private val metadataJson = jsonMarshallingService.format(metadata)
@@ -68,7 +69,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageStartingWith("JSON validation failed due to: \$.ledgerModel: is missing but it is required")
+            .hasMessageMatching("JSON validation failed due to: \\$.*: is missing but it is required")
     }
 
     @Test
@@ -83,7 +84,22 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("JSON validation failed due to: \$.ledgerVersion: is missing but it is required")
+            .hasMessageStartingWith("JSON validation failed due to: \$.ledgerVersion: is missing but it is required")
+    }
+
+    @Test
+    fun `Creating a WireTransaction with unknown json metadata properties throws`() {
+        val mangledJson = canonicalJson.replaceFirst("{", "{\"aaa\":\"value\",")
+
+        assertThatThrownBy {
+            wireTransactionFactory.create(
+                listOf(
+                    listOf(mangledJson.toByteArray()),
+                ), privacySalt
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("JSON validation failed due to: \$.aaa: is not defined in the schema and the schema does not allow additional properties")
     }
 
     @Test
@@ -100,5 +116,106 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageStartingWith("JSON validation failed due to: \$.cpkMetadata: there must be a minimum of 1 items in the array")
     }
+
+    @Test
+    fun `Creating a WireTransaction with Consensual settings`() {
+        val metadata = transactionMetadataExample(numberOfComponentGroups = 1,
+            ledgerModel = "net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl",
+            transactionSubType = null)
+        val metadataJson = jsonMarshallingService.format(metadata)
+        val canonicalJson = jsonValidator.canonicalize(metadataJson)
+        wireTransactionFactory.create(
+            listOf(
+                listOf(canonicalJson.toByteArray()),
+            ), privacySalt
+        )
+    }
+
+    @Test
+    fun `Creating a WireTransaction with Consensual settings with transaction subtype throws`() {
+        val metadata = transactionMetadataExample(numberOfComponentGroups = 1,
+            ledgerModel = "net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl",
+            transactionSubType = "GENERAL")
+        val metadataJson = jsonMarshallingService.format(metadata)
+        val canonicalJson = jsonValidator.canonicalize(metadataJson)
+        assertThatThrownBy {
+            wireTransactionFactory.create(
+                listOf(
+                    listOf(canonicalJson.toByteArray()),
+                ), privacySalt
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageStartingWith("JSON validation failed due to: \$.transactionSubtype: does not have a value in the enumeration [null],\$.transactionSubtype: string found, null expected")
+    }
+
+    @Test
+    fun `Creating a WireTransaction with Utxo settings`() {
+        val metadata = transactionMetadataExample(numberOfComponentGroups = 1,
+            ledgerModel = "net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl",
+            transactionSubType = "GENERAL")
+        val metadataJson = jsonMarshallingService.format(metadata)
+        val canonicalJson = jsonValidator.canonicalize(metadataJson)
+        wireTransactionFactory.create(
+            listOf(
+                listOf(canonicalJson.toByteArray()),
+            ), privacySalt
+        )
+    }
+
+    @Test
+    fun `Creating a WireTransaction with Consensual settings without transaction subtype throws`() {
+        val metadata = transactionMetadataExample(numberOfComponentGroups = 1,
+            ledgerModel = "net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl",
+            transactionSubType = null)
+        val metadataJson = jsonMarshallingService.format(metadata)
+        val canonicalJson = jsonValidator.canonicalize(metadataJson)
+        assertThatThrownBy {
+            wireTransactionFactory.create(
+                listOf(
+                    listOf(canonicalJson.toByteArray()),
+                ), privacySalt
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("JSON validation failed due to: \$.transactionSubtype: does not have a value in the enumeration [NOTARY_CHANGE, GENERAL],\$.transactionSubtype: null found, string expected")
+    }
+
+    @Test
+    fun `Creating a WireTransaction with Consensual settings with unknown transaction subtype throws`() {
+        val metadata = transactionMetadataExample(numberOfComponentGroups = 1,
+            ledgerModel = "net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl",
+            transactionSubType = "UNKNOWN")
+        val metadataJson = jsonMarshallingService.format(metadata)
+        val canonicalJson = jsonValidator.canonicalize(metadataJson)
+        assertThatThrownBy {
+            wireTransactionFactory.create(
+                listOf(
+                    listOf(canonicalJson.toByteArray()),
+                ), privacySalt
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("JSON validation failed due to: \$.transactionSubtype: does not have a value in the enumeration [null, NOTARY_CHANGE, GENERAL],\$.transactionSubtype: does not have a value in the enumeration [NOTARY_CHANGE, GENERAL]")
+    }
+
+    @Test
+    fun `Creating a WireTransaction with unknown ledger model throws`() {
+        val metadata = transactionMetadataExample(numberOfComponentGroups = 1,
+            ledgerModel = "unknown"
+        )
+        val metadataJson = jsonMarshallingService.format(metadata)
+        val canonicalJson = jsonValidator.canonicalize(metadataJson)
+        assertThatThrownBy {
+            wireTransactionFactory.create(
+                listOf(
+                    listOf(canonicalJson.toByteArray()),
+                ), privacySalt
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("JSON validation failed due to: \$.ledgerModel: does not have a value in the enumeration [net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl, net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl]")
+    }
+
 
 }

--- a/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImplTest.kt
+++ b/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImplTest.kt
@@ -85,4 +85,20 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("JSON validation failed due to: \$.ledgerVersion: is missing but it is required")
     }
+
+    @Test
+    fun `Creating a WireTransaction without CPK metadata throws`() {
+        val metadata = transactionMetadataExample(numberOfComponentGroups = 1, cpkMetadata = emptyList())
+        val metadataJson = jsonMarshallingService.format(metadata)
+        assertThatThrownBy {
+            wireTransactionFactory.create(
+                listOf(
+                    listOf(metadataJson.toByteArray()),
+                ), privacySalt
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageStartingWith("JSON validation failed due to: \$.cpkMetadata: there must be a minimum of 1 items in the array")
+    }
+
 }

--- a/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImplTest.kt
+++ b/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImplTest.kt
@@ -56,7 +56,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("JSON validation failed due to: \$: unknown found, object expected")
+            .hasMessageStartingWith("JSON validation failed due to:")
     }
 
     @Test
@@ -69,7 +69,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageMatching("JSON validation failed due to: \\$.*: is missing but it is required")
+            .hasMessageContaining("is missing but it is required")
     }
 
     @Test
@@ -84,7 +84,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageStartingWith("JSON validation failed due to: \$.ledgerVersion: is missing but it is required")
+            .hasMessageContaining("ledgerVersion: is missing but it is required")
     }
 
     @Test
@@ -99,7 +99,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("JSON validation failed due to: \$.aaa: is not defined in the schema and the schema does not allow additional properties")
+            .hasMessageContaining("the schema does not allow additional properties")
     }
 
     @Test
@@ -114,7 +114,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageStartingWith("JSON validation failed due to: \$.cpkMetadata: there must be a minimum of 1 items in the array")
+            .hasMessageContaining("cpkMetadata: there must be a minimum of 1 items in the array")
     }
 
     @Test
@@ -146,7 +146,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageStartingWith("JSON validation failed due to: \$.transactionSubtype: does not have a value in the enumeration [null],\$.transactionSubtype: string found, null expected")
+            .hasMessageContaining("transactionSubtype: does not have a value in the enumeration")
     }
 
     @Test
@@ -178,7 +178,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("JSON validation failed due to: \$.transactionSubtype: does not have a value in the enumeration [NOTARY_CHANGE, GENERAL],\$.transactionSubtype: null found, string expected")
+            .hasMessageContaining("transactionSubtype: does not have a value in the enumeration")
     }
 
     @Test
@@ -196,7 +196,7 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("JSON validation failed due to: \$.transactionSubtype: does not have a value in the enumeration [null, NOTARY_CHANGE, GENERAL],\$.transactionSubtype: does not have a value in the enumeration [NOTARY_CHANGE, GENERAL]")
+            .hasMessageContaining("transactionSubtype: does not have a value in the enumeration")
     }
 
     @Test
@@ -214,8 +214,6 @@ class WireTransactionFactoryImplTest : CommonLedgerTest() {
             )
         }
             .isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("JSON validation failed due to: \$.ledgerModel: does not have a value in the enumeration [net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl, net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl]")
+            .hasMessageContaining("ledgerModel: does not have a value in the enumeration")
     }
-
-
 }

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionMetadataVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionMetadataVerifier.kt
@@ -4,9 +4,9 @@ import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
 fun verifyMetadata(transactionMetadata: TransactionMetadata) {
-    check(transactionMetadata.getLedgerModel() == UtxoLedgerTransactionImpl::class.java.canonicalName) {
+    check(transactionMetadata.getLedgerModel() == UtxoLedgerTransactionImpl::class.java.name) {
         "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
-                "'${transactionMetadata.getLedgerModel()}' != '${UtxoLedgerTransactionImpl::class.java.canonicalName}'"
+                "'${transactionMetadata.getLedgerModel()}' != '${UtxoLedgerTransactionImpl::class.java.name}'"
     }
     checkNotNull(transactionMetadata.getTransactionSubtype()) {
         "The transaction subtype in the metadata of the transaction should not be empty for Utxo Transactions."

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionMetadataVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionMetadataVerifier.kt
@@ -1,9 +1,14 @@
 package net.corda.ledger.utxo.transaction.verifier
 
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
-@Suppress("UNUSED_PARAMETER")
 fun verifyMetadata(transactionMetadata: TransactionMetadata) {
-    // TODO : CORE-7116 more verifications
-    // TODO : CORE-7116 ? metadata verifications: nulls, order of CPKs, at least one CPK?)) Maybe from json schema?
+    check(transactionMetadata.getLedgerModel() == UtxoLedgerTransactionImpl::class.java.canonicalName) {
+        "The ledger model in the metadata of the transaction does not match with the expectation of the ledger. " +
+                "'${transactionMetadata.getLedgerModel()}' != '${UtxoLedgerTransactionImpl::class.java.canonicalName}'"
+    }
+    checkNotNull(transactionMetadata.getTransactionSubtype()) {
+        "The transaction subtype in the metadata of the transaction should not be empty for Utxo Transactions."
+    }
 }

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.transaction.verifier
 
 import net.corda.ledger.utxo.data.state.StateAndRefImpl
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.testkit.utxoNotaryExample
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.Party
@@ -36,6 +37,9 @@ class UtxoLedgerTransactionVerifierTest {
 
     @BeforeEach
     fun beforeEach() {
+        whenever(metadata.getLedgerModel()).thenReturn(UtxoLedgerTransactionImpl::class.java.canonicalName)
+        whenever(metadata.getTransactionSubtype()).thenReturn("GENERAL")
+
         whenever(transaction.id).thenReturn(SecureHash("SHA", byteArrayOf(1, 1, 1, 1)))
         whenever(transaction.signatories).thenReturn(listOf(signatory))
         whenever(transaction.inputStateRefs).thenReturn(listOf(stateRef))

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -37,7 +37,7 @@ class UtxoLedgerTransactionVerifierTest {
 
     @BeforeEach
     fun beforeEach() {
-        whenever(metadata.getLedgerModel()).thenReturn(UtxoLedgerTransactionImpl::class.java.canonicalName)
+        whenever(metadata.getLedgerModel()).thenReturn(UtxoLedgerTransactionImpl::class.java.name)
         whenever(metadata.getTransactionSubtype()).thenReturn("GENERAL")
 
         whenever(transaction.id).thenReturn(SecureHash("SHA", byteArrayOf(1, 1, 1, 1)))

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/CpkPackageSummaryListExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/CpkPackageSummaryListExample.kt
@@ -2,23 +2,11 @@ package net.corda.ledger.common.testkit
 
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 
-fun cpkPackageSummaryListExample(seed: String? = "123CBA") = listOf(
+fun cpkPackageSummaryListExample(seed: String? = "123CBA") = List(3) {
     CordaPackageSummaryImpl(
-        "$seed-cpk1",
-        "signerSummaryHash1",
-        "1.0",
-        "$seed-fileChecksum1"
-    ),
-    CordaPackageSummaryImpl(
-        "$seed-cpk2",
-        "signerSummaryHash2",
-        "2.0",
-        "$seed-fileChecksum2"
-    ),
-    CordaPackageSummaryImpl(
-        "$seed-cpk3",
-        "signerSummaryHash3",
-        "3.0",
-        "$seed-fileChecksum3"
+        "$seed-cpk$it",
+        "signerSummaryHash$it",
+        "$it.0",
+        "$seed-fileChecksum$it"
     )
-)
+}

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/TransactionMetadataExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/TransactionMetadataExample.kt
@@ -9,18 +9,26 @@ fun transactionMetadataExample(
     cpiMetadata: CordaPackageSummaryImpl = cpiPackageSummaryExample,
     cpkPackageSeed: String? = null,
     cpkMetadata: List<CordaPackageSummaryImpl> = cpkPackageSummaryListExample(cpkPackageSeed),
-    numberOfComponentGroups: Int
+    numberOfComponentGroups: Int,
+    ledgerModel: String = "net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl",
+    transactionSubType: String? = null
 ): TransactionMetadata {
+    val transactionSubTypePart = if (transactionSubType == null) {
+        emptyMap()
+    } else {
+        mapOf(TransactionMetadataImpl.TRANSACTION_SUBTYPE_KEY to transactionSubType)
+    }
     return TransactionMetadataImpl(
         mapOf(
-            TransactionMetadataImpl.LEDGER_MODEL_KEY to "net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl",
+            TransactionMetadataImpl.LEDGER_MODEL_KEY to ledgerModel,
             TransactionMetadataImpl.LEDGER_VERSION_KEY to 1,
             TransactionMetadataImpl.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,
             TransactionMetadataImpl.PLATFORM_VERSION_KEY to 123,
             TransactionMetadataImpl.CPI_METADATA_KEY to cpiMetadata,
             TransactionMetadataImpl.CPK_METADATA_KEY to cpkMetadata,
             TransactionMetadataImpl.SCHEMA_VERSION_KEY to TransactionMetadataImpl.SCHEMA_VERSION,
-            TransactionMetadataImpl.NUMBER_OF_COMPONENT_GROUPS to numberOfComponentGroups
-        )
+            TransactionMetadataImpl.NUMBER_OF_COMPONENT_GROUPS to numberOfComponentGroups,
+
+            ) + transactionSubTypePart
     )
 }

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/TransactionMetadataExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/TransactionMetadataExample.kt
@@ -5,6 +5,7 @@ import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
+@Suppress("LongParameterList")
 fun transactionMetadataExample(
     cpiMetadata: CordaPackageSummaryImpl = cpiPackageSummaryExample,
     cpkPackageSeed: String? = null,

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/WireTransactionExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/WireTransactionExample.kt
@@ -12,9 +12,16 @@ import java.time.Instant
 fun WireTransactionFactory.createExample(
     jsonMarshallingService: JsonMarshallingService,
     jsonValidator: JsonValidator,
-    componentGroups: List<List<ByteArray>> = defaultComponentGroups
+    componentGroups: List<List<ByteArray>> = defaultComponentGroups,
+    ledgerModel: String = "net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl",
+    transactionSubType: String? = null
 ): WireTransaction {
-    val metadata = transactionMetadataExample(numberOfComponentGroups = componentGroups.size + 1)
+    val metadata =
+        transactionMetadataExample(
+            numberOfComponentGroups = componentGroups.size + 1,
+            ledgerModel = ledgerModel,
+            transactionSubType = transactionSubType
+        )
     val metadataJson = jsonMarshallingService.format(metadata)
     val canonicalJson = jsonValidator.canonicalize(metadataJson)
 

--- a/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualTransactionMetadataExample.kt
+++ b/testing/ledger/ledger-consensual-testkit/src/main/kotlin/net/corda/ledger/consensual/testkit/ConsensualTransactionMetadataExample.kt
@@ -9,7 +9,7 @@ import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionI
 import net.corda.ledger.consensual.data.transaction.TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION
 
 fun consensualTransactionMetadataExample(cpkPackageSeed: String? = null) = TransactionMetadataImpl(mapOf(
-    TransactionMetadataImpl.LEDGER_MODEL_KEY to ConsensualLedgerTransactionImpl::class.java.canonicalName,
+    TransactionMetadataImpl.LEDGER_MODEL_KEY to ConsensualLedgerTransactionImpl::class.java.name,
     TransactionMetadataImpl.LEDGER_VERSION_KEY to TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION,
     TransactionMetadataImpl.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,
     TransactionMetadataImpl.PLATFORM_VERSION_KEY to 123,

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
@@ -29,7 +29,7 @@ fun UtxoSignedTransactionFactory.createExample(
         jsonMarshallingService,
         jsonValidator,
         componentGroups,
-        ledgerModel = UtxoLedgerTransactionImpl::class.java.canonicalName,
+        ledgerModel = UtxoLedgerTransactionImpl::class.java.name,
         transactionSubType = "GENERAL"
     )
     return create(wireTransaction, listOf(getSignatureWithMetadataExample()))

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
@@ -9,6 +9,7 @@ import net.corda.ledger.common.testkit.defaultComponentGroups
 import net.corda.ledger.common.testkit.getWireTransactionExample
 import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
@@ -24,7 +25,13 @@ fun UtxoSignedTransactionFactory.createExample(
     componentGroups: List<List<ByteArray>> = defaultComponentGroups +
             List(UtxoComponentGroup.values().size - defaultComponentGroups.size) { emptyList() }
 ):UtxoSignedTransaction {
-    val wireTransaction = wireTransactionFactory.createExample(jsonMarshallingService, jsonValidator, componentGroups)
+    val wireTransaction = wireTransactionFactory.createExample(
+        jsonMarshallingService,
+        jsonValidator,
+        componentGroups,
+        ledgerModel = UtxoLedgerTransactionImpl::class.java.canonicalName,
+        transactionSubType = "GENERAL"
+    )
     return create(wireTransaction, listOf(getSignatureWithMetadataExample()))
 }
 

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoTransactionMetadataExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoTransactionMetadataExample.kt
@@ -9,7 +9,7 @@ import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionMetadata
 
 fun utxoTransactionMetadataExample(cpkPackageSeed: String? = null) = TransactionMetadataImpl(mapOf(
-    TransactionMetadataImpl.LEDGER_MODEL_KEY to UtxoLedgerTransactionImpl::class.java.canonicalName,
+    TransactionMetadataImpl.LEDGER_MODEL_KEY to UtxoLedgerTransactionImpl::class.java.name,
     TransactionMetadataImpl.LEDGER_VERSION_KEY to UtxoTransactionMetadata.LEDGER_VERSION,
     TransactionMetadataImpl.TRANSACTION_SUBTYPE_KEY to UtxoTransactionMetadata.TransactionSubtype.GENERAL,
     TransactionMetadataImpl.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,


### PR DESCRIPTION
CORE-7237 Test WireTransaction's ledger model when creating Signed Transaction from them.
CORE-7146 Test the same and transactionSubtype in metadata verification steps too.
CORE-7146 Add platform version to TransactionMetadataImpl
CORE-7146 Update transaction-metadata.json with missing fields and constraints. And add a few tests against it.


Amend tests accordingly.

API: https://github.com/corda/corda-api/pull/858