### PR TITLE
CORE-8774: DB connection failures must be recoverable - DbReconcilerReader

### DIFF
--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
@@ -139,15 +139,6 @@ class DbReconcilerReaderTest {
             verify(coordinator).followStatusChangesByName(eq(dependenciesMock))
             verify(dependencyRegistrationHandle, never()).close()
         }
-
-        @Test
-        fun `start event called again closes registration handle and follows dependencies`() {
-            lifecycleEventHandler.processEvent(StartEvent(), coordinator)
-            lifecycleEventHandler.processEvent(StartEvent(), coordinator)
-
-            verify(coordinator, times(2)).followStatusChangesByName(eq(dependenciesMock))
-            verify(dependencyRegistrationHandle).close()
-        }
     }
 
     @Nested
@@ -164,16 +155,6 @@ class DbReconcilerReaderTest {
             lifecycleEventHandler.processEvent(StopEvent(), coordinator)
 
             verify(dependencyRegistrationHandle, never()).close()
-        }
-
-        @Test
-        fun `stop event after start event closes registration handle`() {
-            lifecycleEventHandler.processEvent(StartEvent(), coordinator)
-            verify(coordinator).followStatusChangesByName(eq(dependenciesMock))
-
-            lifecycleEventHandler.processEvent(StopEvent(), coordinator)
-
-            verify(dependencyRegistrationHandle).close()
         }
     }
 


### PR DESCRIPTION
* Don't close DbReconcilerReader.dependencyRegistration, we need it to get the UP signal when DB comes back
* Migrate to managed resources API
* Delete tests checking registration handle is closed because DbReconcilerReader now delegates that to managed resources, so it is no longer a responsibility of this class