### PR TITLE
CORE-10198: Fix compileAll task for Kotlin 1.8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,8 @@ allprojects {
         description = "Compiles all the Kotlin and Java classes, including all of the test classes."
         group = "verification"
 
-        task.dependsOn tasks.withType(AbstractCompile)
+        task.dependsOn tasks.withType(AbstractCompile),
+            tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
     }
 
     repositories {


### PR DESCRIPTION
As of Kotlin 1.8, the `KotlinCompile` task no longer extends `AbstractCompile`.