### PR TITLE
CORE-10183: add logging and set multi arch false in benchmarking script

### DIFF
--- a/build-benchmark.sh
+++ b/build-benchmark.sh
@@ -1,6 +1,5 @@
 # The purpose of this script it so run a number of build benchmark tests. The results of these tests will be sent
 # to Gradle Enterprise so that we can analyse them.
-#
 MAX_WORKERS=4
 TAG_BENCHMARK="build-benchmark"    # Gradle build scan label prefix - should remain stable
 TAG_EXP="${TAG_BENCHMARK}-0001"    # Gradle build scan label suffix - can be incremented in case we want another set of benchmarks, for example to compare a before/after change
@@ -18,19 +17,21 @@ gradle_run() {
  ./gradlew -Dscan.tag.${TAG_BENCHMARK} -Dscan.tag.${TAG_EXP} -Dscan.tag.${TAG_EXP} -Dscan.tag.${TAG_BENCHMARK_ID} -Dscan.tag.$1 --parallel --max-workers=${MAX_WORKERS} $2
 }
 
+set -x
+
 ./gradlew --stop
 
 echo "Using ${MAX_WORKERS} workers"
 
 echo "Building without cache"
 gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache clean"
-gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache publishOSGiImage"
-gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache publishOSGiImage"
+gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
+gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
 
 echo "Building with cache"
 gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache clean"
-gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache publishOSGiImage"
-gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_INCREMENTAL}" "--build-cache publishOSGiImage"
+gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
+gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_INCREMENTAL}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
 
 echo "(Incremental) Detekt without cache"
 gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache detekt"

--- a/build-benchmark.sh
+++ b/build-benchmark.sh
@@ -1,5 +1,6 @@
 # The purpose of this script it so run a number of build benchmark tests. The results of these tests will be sent
 # to Gradle Enterprise so that we can analyse them.
+#
 MAX_WORKERS=4
 TAG_BENCHMARK="build-benchmark"    # Gradle build scan label prefix - should remain stable
 TAG_EXP="${TAG_BENCHMARK}-0001"    # Gradle build scan label suffix - can be incremented in case we want another set of benchmarks, for example to compare a before/after change


### PR DESCRIPTION
Slight tweaks to the existing benchmark script.

`set -x` to output what gradle command is being run in a given stage, useful for debugging on the server or locally 
add `-PmultiArchSupport=false` to `publishOSGiImage` call as when setting up benchmarking job on jenkins we don't want to push these untested images to the remote only the local docker daemon to gather this data in Gradle Enterprise , However, Jib does not support pushing multi-architecture images to a local docker daemon only a remote registry, so this needs to be explicitly set to false here.

When executing this command locally, this is implicitly false this change is only to enable successful Jenkins execution of this script.

A separate piece of work will set up a Jenkins job relate to executing this to populate benchmark data in Gradle Ent for later analysis 