### PR TITLE
CORE-8973: Mutual TLS e2e tests

### DIFF
--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/MultiClusterDynamicNetworkTest.kt
@@ -7,7 +7,7 @@ import net.corda.applications.workers.rpc.utils.E2eClusterFactory
 import net.corda.applications.workers.rpc.utils.E2eClusterMember
 import net.corda.applications.workers.rpc.utils.allowClientCertificates
 import net.corda.applications.workers.rpc.utils.assertAllMembersAreInMemberList
-import net.corda.applications.workers.rpc.utils.sslConfiguration
+import net.corda.applications.workers.rpc.utils.setSslConfiguration
 import net.corda.applications.workers.rpc.utils.generateGroupPolicy
 import net.corda.applications.workers.rpc.utils.getGroupId
 import net.corda.applications.workers.rpc.utils.onboardMembers
@@ -78,13 +78,13 @@ class MultiClusterDynamicNetworkTest {
     private fun onboardMultiClusterGroup(mutualTls: Boolean): String {
         val mgm = clusterC.members[0]
 
-        clusterC.sslConfiguration(mutualTls)
+        clusterC.setSslConfiguration(mutualTls)
         clusterC.onboardMgm(mgm, tempDir, mutualTls = mutualTls)
 
         val memberGroupPolicy = clusterC.generateGroupPolicy(mgm.holdingId)
 
         memberClusters.forEach { cordaCluster ->
-            cordaCluster.sslConfiguration(mutualTls)
+            cordaCluster.setSslConfiguration(mutualTls)
             cordaCluster.onboardMembers(mgm, memberGroupPolicy, tempDir) { certificatePem ->
                 if (mutualTls) {
                     clusterC.allowClientCertificates(certificatePem, mgm)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/MultiClusterDynamicNetworkTest.kt
@@ -5,14 +5,16 @@ import net.corda.applications.workers.rpc.utils.E2eClusterBConfig
 import net.corda.applications.workers.rpc.utils.E2eClusterCConfig
 import net.corda.applications.workers.rpc.utils.E2eClusterFactory
 import net.corda.applications.workers.rpc.utils.E2eClusterMember
+import net.corda.applications.workers.rpc.utils.allowClientCertificates
 import net.corda.applications.workers.rpc.utils.assertAllMembersAreInMemberList
-import net.corda.applications.workers.rpc.utils.disableGatewayCLRChecks
+import net.corda.applications.workers.rpc.utils.sslConfiguration
 import net.corda.applications.workers.rpc.utils.generateGroupPolicy
 import net.corda.applications.workers.rpc.utils.getGroupId
 import net.corda.applications.workers.rpc.utils.onboardMembers
 import net.corda.applications.workers.rpc.utils.onboardMgm
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -60,24 +62,34 @@ class MultiClusterDynamicNetworkTest {
     }
 
     @Test
-    fun `Create mgm and allow members to join the group`() {
-        onboardMultiClusterGroup()
+    fun `Create mgm and allow members to join the group - one way TLS`() {
+        onboardMultiClusterGroup(false)
+    }
+
+    @Test
+    @Disabled("Disable mutual TLS test as both TLS modes can't run at the same time on the same cluster")
+    fun `Create mgm and allow members to join the group - mutual TLS`() {
+        onboardMultiClusterGroup(true)
     }
 
     /**
      * Onboard group and return group ID.
      */
-    private fun onboardMultiClusterGroup(): String {
+    private fun onboardMultiClusterGroup(mutualTls: Boolean): String {
         val mgm = clusterC.members[0]
 
-        clusterC.disableGatewayCLRChecks()
-        clusterC.onboardMgm(mgm, tempDir)
+        clusterC.sslConfiguration(mutualTls)
+        clusterC.onboardMgm(mgm, tempDir, mutualTls = mutualTls)
 
         val memberGroupPolicy = clusterC.generateGroupPolicy(mgm.holdingId)
 
         memberClusters.forEach { cordaCluster ->
-            cordaCluster.disableGatewayCLRChecks()
-            cordaCluster.onboardMembers(mgm, memberGroupPolicy, tempDir)
+            cordaCluster.sslConfiguration(mutualTls)
+            cordaCluster.onboardMembers(mgm, memberGroupPolicy, tempDir) { certificatePem ->
+                if (mutualTls) {
+                    clusterC.allowClientCertificates(certificatePem, mgm)
+                }
+            }
         }
 
         // Assert all members can see each other in their member lists.

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/SessionCertificateTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/SessionCertificateTest.kt
@@ -6,7 +6,7 @@ import net.corda.applications.workers.rpc.utils.E2eClusterCConfig
 import net.corda.applications.workers.rpc.utils.E2eClusterFactory
 import net.corda.applications.workers.rpc.utils.E2eClusterMember
 import net.corda.applications.workers.rpc.utils.assertAllMembersAreInMemberList
-import net.corda.applications.workers.rpc.utils.disableGatewayCLRChecks
+import net.corda.applications.workers.rpc.utils.sslConfiguration
 import net.corda.applications.workers.rpc.utils.disableLinkManagerCLRChecks
 import net.corda.applications.workers.rpc.utils.generateGroupPolicy
 import net.corda.applications.workers.rpc.utils.getGroupId
@@ -68,14 +68,14 @@ class SessionCertificateTest {
     private fun onboardMultiClusterGroup(): String {
         val mgm = clusterC.members[0]
 
-        clusterC.disableGatewayCLRChecks()
+        clusterC.sslConfiguration(false)
         clusterC.disableLinkManagerCLRChecks()
         clusterC.onboardMgm(mgm, tempDir, useSessionCertificate = true)
 
         val memberGroupPolicy = clusterC.generateGroupPolicy(mgm.holdingId)
 
         memberClusters.forEach { cordaCluster ->
-            cordaCluster.disableGatewayCLRChecks()
+            cordaCluster.sslConfiguration(false)
             cordaCluster.disableLinkManagerCLRChecks()
             cordaCluster.onboardMembers(mgm, memberGroupPolicy, tempDir, useSessionCertificate = true)
         }

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/SessionCertificateTest.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/SessionCertificateTest.kt
@@ -6,7 +6,7 @@ import net.corda.applications.workers.rpc.utils.E2eClusterCConfig
 import net.corda.applications.workers.rpc.utils.E2eClusterFactory
 import net.corda.applications.workers.rpc.utils.E2eClusterMember
 import net.corda.applications.workers.rpc.utils.assertAllMembersAreInMemberList
-import net.corda.applications.workers.rpc.utils.sslConfiguration
+import net.corda.applications.workers.rpc.utils.setSslConfiguration
 import net.corda.applications.workers.rpc.utils.disableLinkManagerCLRChecks
 import net.corda.applications.workers.rpc.utils.generateGroupPolicy
 import net.corda.applications.workers.rpc.utils.getGroupId
@@ -68,14 +68,14 @@ class SessionCertificateTest {
     private fun onboardMultiClusterGroup(): String {
         val mgm = clusterC.members[0]
 
-        clusterC.sslConfiguration(false)
+        clusterC.setSslConfiguration(false)
         clusterC.disableLinkManagerCLRChecks()
         clusterC.onboardMgm(mgm, tempDir, useSessionCertificate = true)
 
         val memberGroupPolicy = clusterC.generateGroupPolicy(mgm.holdingId)
 
         memberClusters.forEach { cordaCluster ->
-            cordaCluster.sslConfiguration(false)
+            cordaCluster.setSslConfiguration(false)
             cordaCluster.disableLinkManagerCLRChecks()
             cordaCluster.onboardMembers(mgm, memberGroupPolicy, tempDir, useSessionCertificate = true)
         }

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/ClusterTestUtils.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/ClusterTestUtils.kt
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.Assertions.fail
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 import java.util.UUID
 
 const val GATEWAY_CONFIG = "corda.p2p.gateway"
@@ -44,7 +46,12 @@ const val HSM_CAT_PRE_AUTH = "PRE_AUTH"
 const val HSM_CAT_LEDGER = "LEDGER"
 const val HSM_CAT_TLS = "TLS"
 
-private data class TestJsonObject(override val escapedJson: String = "") : JsonObject
+private class TestJsonObject(data: Map<String, Any?>) : JsonObject {
+    val json = ObjectMapper()
+    override val escapedJson by lazy {
+        json.writeValueAsString(data)
+    }
+}
 
 fun E2eCluster.uploadCpi(
     groupPolicy: ByteArray,
@@ -281,27 +288,43 @@ fun E2eCluster.setUpNetworkIdentity(
     }
 }
 
-fun E2eCluster.disableGatewayCLRChecks() {
-    val sslConfig = "sslConfig"
-    val revocationCheck = "revocationCheck"
-    val mode = "mode"
-    val modeOff = "OFF"
+fun E2eCluster.allowClientCertificates(certificatePem: String, mgm: E2eClusterMember) {
+    val subject = CertificateFactory.getInstance("X.509")
+        .generateCertificates(certificatePem.byteInputStream())
+        .filterIsInstance<X509Certificate>()
+        .first()
+        .subjectX500Principal
+    clusterHttpClientFor(MGMRestResource::class.java).use { restClient ->
+        restClient.start().proxy.mutualTlsAllowClientCertificate(
+            holdingIdentityShortHash = mgm.holdingId,
+            subject = subject.toString()
+        )
+    }
+}
+
+fun E2eCluster.sslConfiguration(mutualTls: Boolean) {
+    val tlsType = if (mutualTls) {
+        "MUTUAL"
+    } else {
+        "ONE_WAY"
+    }
+    val config = mapOf(
+        "sslConfig" to mapOf(
+            "revocationCheck" to mapOf("mode" to "OFF"),
+            "tlsType" to tlsType
+        )
+    )
     clusterHttpClientFor(ConfigRestResource::class.java).use { client ->
         val proxy = client.start().proxy
         val configResponse = proxy.get(GATEWAY_CONFIG)
-        val config = ObjectMapper().readTree(
-            configResponse.configWithDefaults
-        )
-        if (modeOff != config[sslConfig][revocationCheck][mode].asText()) {
-            proxy.updateConfig(
-                UpdateConfigParameters(
-                    GATEWAY_CONFIG,
-                    configResponse.version,
-                    TestJsonObject("{ \"$sslConfig\": { \"$revocationCheck\": { \"$mode\": \"$modeOff\" }  } }"),
-                    ConfigSchemaVersion(1, 0)
-                )
+        proxy.updateConfig(
+            UpdateConfigParameters(
+                GATEWAY_CONFIG,
+                configResponse.version,
+                TestJsonObject(config),
+                ConfigSchemaVersion(1, 0)
             )
-        }
+        )
     }
 }
 
@@ -320,7 +343,13 @@ fun E2eCluster.disableLinkManagerCLRChecks() {
                 UpdateConfigParameters(
                     LINK_MANAGER_CONFIG,
                     configResponse.version,
-                    TestJsonObject("{ \"$revocationCheck\": { \"$mode\": \"$modeOff\" } }"),
+                    TestJsonObject(
+                        mapOf(
+                            revocationCheck to mapOf(
+                                mode to modeOff
+                            )
+                        )
+                    ),
                     ConfigSchemaVersion(1, 0)
                 )
             )
@@ -337,6 +366,7 @@ fun E2eCluster.onboardMembers(
     memberGroupPolicy: String,
     tempDir: Path,
     useSessionCertificate: Boolean = false,
+    certificateUploaded: (String) -> Unit = {},
 ): List<E2eClusterMember> {
     val holdingIds = mutableListOf<E2eClusterMember>()
     val memberCpiChecksum = uploadCpi(memberGroupPolicy.toByteArray(), tempDir)
@@ -351,6 +381,7 @@ fun E2eCluster.onboardMembers(
             val memberTlsCsr = generateCsr(member, memberTlsKeyId)
             val memberTlsCert = getCa().generateCert(memberTlsCsr)
             uploadTlsCertificate(memberTlsCert)
+            certificateUploaded(memberTlsCert)
         }
 
         val memberSessionKeyId = generateKeyPairIfNotExists(member.holdingId, HSM_CAT_SESSION)
@@ -395,6 +426,7 @@ fun E2eCluster.onboardMgm(
     mgm: E2eClusterMember,
     tempDir: Path,
     useSessionCertificate: Boolean = false,
+    mutualTls: Boolean = false,
 ) {
     val cpiChecksum = uploadCpi(createMGMGroupPolicyJson(), tempDir, true)
     createVirtualNode(mgm, cpiChecksum)
@@ -403,6 +435,11 @@ fun E2eCluster.onboardMgm(
 
     val mgmSessionKeyId = generateKeyPairIfNotExists(mgm.holdingId, HSM_CAT_SESSION)
     val mgmECDHKeyId = generateKeyPairIfNotExists(mgm.holdingId, HSM_CAT_PRE_AUTH)
+    val tlsType = if (mutualTls) {
+        "Mutual"
+    } else {
+        "OneWay"
+    }
 
     val mgmRegistrationContext = if (useSessionCertificate) {
         val mgmSessionCsr = generateCsr(mgm, mgmSessionKeyId, mgm.holdingId, addHostToSubjectAlternativeNames = false)
@@ -413,14 +450,16 @@ fun E2eCluster.onboardMgm(
             sessionKeyId = mgmSessionKeyId,
             ecdhKeyId = mgmECDHKeyId,
             p2pUrl = p2pUrl,
-            sessionPkiMode = "Standard"
+            sessionPkiMode = "Standard",
+            tlsType = tlsType,
         )
     } else {
         createMgmRegistrationContext(
             caTrustRoot = getCa().caCertificate.toPem(),
             sessionKeyId = mgmSessionKeyId,
             ecdhKeyId = mgmECDHKeyId,
-            p2pUrl = p2pUrl
+            p2pUrl = p2pUrl,
+            tlsType = tlsType,
         )
     }
 

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/ClusterTestUtils.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/ClusterTestUtils.kt
@@ -302,7 +302,7 @@ fun E2eCluster.allowClientCertificates(certificatePem: String, mgm: E2eClusterMe
     }
 }
 
-fun E2eCluster.sslConfiguration(mutualTls: Boolean) {
+fun E2eCluster.setSslConfiguration(mutualTls: Boolean) {
     val tlsType = if (mutualTls) {
         "MUTUAL"
     } else {
@@ -366,7 +366,7 @@ fun E2eCluster.onboardMembers(
     memberGroupPolicy: String,
     tempDir: Path,
     useSessionCertificate: Boolean = false,
-    certificateUploaded: (String) -> Unit = {},
+    certificateUploadedCallback: (String) -> Unit = {},
 ): List<E2eClusterMember> {
     val holdingIds = mutableListOf<E2eClusterMember>()
     val memberCpiChecksum = uploadCpi(memberGroupPolicy.toByteArray(), tempDir)
@@ -381,7 +381,7 @@ fun E2eCluster.onboardMembers(
             val memberTlsCsr = generateCsr(member, memberTlsKeyId)
             val memberTlsCert = getCa().generateCert(memberTlsCsr)
             uploadTlsCertificate(memberTlsCert)
-            certificateUploaded(memberTlsCert)
+            certificateUploadedCallback(memberTlsCert)
         }
 
         val memberSessionKeyId = generateKeyPairIfNotExists(member.holdingId, HSM_CAT_SESSION)

--- a/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/MembershipTestUtils.kt
+++ b/applications/workers/release/rpc-worker/src/e2eTest/kotlin/net/corda/applications/workers/rpc/utils/MembershipTestUtils.kt
@@ -79,7 +79,8 @@ fun createMgmRegistrationContext(
     sessionKeyId: String,
     ecdhKeyId: String,
     p2pUrl: String,
-    sessionPkiMode: String = "NoPKI"
+    sessionPkiMode: String = "NoPKI",
+    tlsType: String = "OneWay",
 ) = mapOf(
     "corda.session.key.id" to sessionKeyId,
     "corda.ecdh.key.id" to ecdhKeyId,
@@ -89,7 +90,7 @@ fun createMgmRegistrationContext(
             to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
     "corda.group.protocol.p2p.mode" to "Authenticated_Encryption",
     "corda.group.key.session.policy" to "Distinct",
-    "corda.group.tls.type" to "OneWay",
+    "corda.group.tls.type" to tlsType,
     "corda.group.pki.session" to sessionPkiMode,
     "corda.group.pki.tls" to "Standard",
     "corda.group.tls.version" to "1.3",


### PR DESCRIPTION
Tested by enabling the test and running:
```bash

cd ~/corda-runtime-os/
applications/tools/p2p-test/app-simulator/scripts/deploy.sh yift-cluster-a yift-cluster-b yift-cluster-c


kubectl port-forward --namespace yift-cluster-a deployment/corda-rpc-worker 8881:8888 &
kubectl port-forward --namespace yift-cluster-a deployment/corda-rpc-worker 8882:8888 &
kubectl port-forward --namespace yift-cluster-a deployment/corda-rpc-worker 8883:8888 &

export E2E_CLUSTER_A_RPC_HOST=localhost
export E2E_CLUSTER_A_RPC_PORT=8881
export E2E_CLUSTER_B_RPC_HOST=localhost
export E2E_CLUSTER_B_RPC_PORT=8882
export E2E_CLUSTER_C_RPC_HOST=localhost
export E2E_CLUSTER_C_RPC_PORT=8883

export E2E_CLUSTER_A_P2P_HOST=corda-p2p-gateway-worker.yift-cluster-a
export E2E_CLUSTER_A_P2P_PORT=8080
export E2E_CLUSTER_B_P2P_HOST=corda-p2p-gateway-worker.yift-cluster-b
export E2E_CLUSTER_B_P2P_PORT=8080
export E2E_CLUSTER_C_P2P_HOST=corda-p2p-gateway-worker.yift-cluster-c
export E2E_CLUSTER_C_P2P_PORT=8080

export E2E_CLUSTER_A_RPC_PASSWORD=admin
export E2E_CLUSTER_B_RPC_PASSWORD=admin
export E2E_CLUSTER_C_RPC_PASSWORD=admin

./gradlew --stop

./gradlew :applications:workers:release:rpc-worker:e2eTest --tests "net.corda.applications.workers.rpc.MultiClusterDynamicNetworkTest" --no-daemon
```
