### PR TITLE
NOTICK - Add code owners entries for platform network team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,11 +29,13 @@ CODEOWNERS         @corda/blt @corda/corda5-team-leads
 /applications/workers/release/member-worker/                    @corda/corda-platform-network-team
 /processors/link-manager-processor/                             @corda/corda-platform-network-team
 /processors/gateway-processor/                                  @corda/corda-platform-network-team
-/processors/link-manager-processor/                             @corda/corda-platform-network-team
+/processors/member-processor/                                   @corda/corda-platform-network-team
 /components/gateway/                                            @corda/corda-platform-network-team
 /components/link-manager/                                       @corda/corda-platform-network-team
 /components/membership/                                         @corda/corda-platform-network-team
 /libs/membership/                                               @corda/corda-platform-network-team
 /libs/p2p-crypto/                                               @corda/corda-platform-network-team
+/libs/layered-property-map/                                     @corda/corda-platform-network-team
 /tools/plugins/mgm/                                             @corda/corda-platform-network-team
+/tools/plugins/network/                                         @corda/corda-platform-network-team
 /applications/tools/p2p-test/                                   @corda/corda-platform-network-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,18 @@ CODEOWNERS         @corda/blt @corda/corda5-team-leads
 
 # Corda Helm chart for cluster management team
 /charts/corda/                                @corda/cluster-management
+
+# Modules to be audited by the Network team
+/applications/workers/release/p2p-gateway-worker/               @corda/corda-platform-network-team
+/applications/workers/release/p2p-link-manager-worker/          @corda/corda-platform-network-team
+/applications/workers/release/member-worker/                    @corda/corda-platform-network-team
+/processors/link-manager-processor/                             @corda/corda-platform-network-team
+/processors/gateway-processor/                                  @corda/corda-platform-network-team
+/processors/link-manager-processor/                             @corda/corda-platform-network-team
+/components/gateway/                                            @corda/corda-platform-network-team
+/components/link-manager/                                       @corda/corda-platform-network-team
+/components/membership/                                         @corda/corda-platform-network-team
+/libs/membership/                                               @corda/corda-platform-network-team
+/libs/p2p-crypto/                                               @corda/corda-platform-network-team
+/tools/plugins/mgm/                                             @corda/corda-platform-network-team
+/applications/tools/p2p-test/                                   @corda/corda-platform-network-team


### PR DESCRIPTION
Adding some entries in the CODEOWNERS file to ensure the platform network team is notified & can review any changes in the areas of the codebase that consist of the network layer.