### PR TITLE
CORE-10332,CORE-10333: Update for Java base and application modules.

### DIFF
--- a/components/crypto/crypto-client-hsm-impl/src/test/kotlin/net/corda/crypto/client/hsm/impl/HSMRegistrationClientComponentTests.kt
+++ b/components/crypto/crypto-client-hsm-impl/src/test/kotlin/net/corda/crypto/client/hsm/impl/HSMRegistrationClientComponentTests.kt
@@ -23,7 +23,7 @@ import net.corda.lifecycle.test.impl.TestLifecycleCoordinatorFactoryImpl
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.exceptions.CryptoException
 import net.corda.v5.crypto.sha256Bytes
 import org.assertj.core.api.Assertions.assertThat
@@ -63,7 +63,7 @@ class HSMRegistrationClientComponentTests {
 
     @BeforeEach
     fun setup() {
-        knownTenantId = UUID.randomUUID().toString().toByteArray().sha256Bytes().toHex().take(12)
+        knownTenantId = toHex(UUID.randomUUID().toString().toByteArray().sha256Bytes()).take(12)
         coordinatorFactory = TestLifecycleCoordinatorFactoryImpl()
         sender = TestRPCSender(coordinatorFactory)
         publisherFactory = mock {

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -31,8 +31,8 @@ import net.corda.data.crypto.wire.ops.rpc.queries.SupportedSchemesRpcQuery
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.utilities.concurrent.getOrThrow
+import net.corda.v5.base.util.EncodingUtils.toBase58
 import net.corda.v5.base.util.debug
-import net.corda.v5.base.util.toBase58
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.KEY_LOOKUP_INPUT_ITEMS_LIMIT
 import net.corda.v5.crypto.SignatureSpec
@@ -240,7 +240,7 @@ class CryptoOpsClientImpl(
     ): CryptoSignatureWithKey {
         logger.debug {
             "Sending '${SignRpcCommand::class.java.simpleName}'(tenant=${tenantId}," +
-                    "publicKey=${publicKey.array().sha256Bytes().toBase58().take(12)}..)"
+                    "publicKey=${toBase58(publicKey.array().sha256Bytes()).take(12)}..)"
         }
         val request = createRequest(
             tenantId,

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -48,7 +48,7 @@ import net.corda.lifecycle.test.impl.TestLifecycleCoordinatorFactoryImpl
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.KEY_LOOKUP_INPUT_ITEMS_LIMIT
@@ -100,7 +100,7 @@ class CryptoOpsClientComponentTests {
 
     @BeforeEach
     fun setup() {
-        knownTenantId = UUID.randomUUID().toString().toByteArray().sha256Bytes().toHex().take(12)
+        knownTenantId = toHex(UUID.randomUUID().toString().toByteArray().sha256Bytes()).take(12)
         knownAlias = UUID.randomUUID().toString()
         knownOperationContext = mapOf(
             UUID.randomUUID().toString() to UUID.randomUUID().toString()

--- a/components/crypto/crypto-hes-impl/src/test/kotlin/net/corda/crypto/hes/impl/HybridEncryptionSchemeTests.kt
+++ b/components/crypto/crypto-hes-impl/src/test/kotlin/net/corda/crypto/hes/impl/HybridEncryptionSchemeTests.kt
@@ -10,7 +10,7 @@ import net.corda.crypto.hes.impl.infra.TestCryptoOpsClient
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.test.impl.TestLifecycleCoordinatorFactoryImpl
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.ECDSA_SECP256K1_CODE_NAME
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SM2_CODE_NAME
@@ -43,7 +43,7 @@ class HybridEncryptionSchemeTests {
         @BeforeAll
         @JvmStatic
         fun setup() {
-            tenantId = UUID.randomUUID().toString().toByteArray().sha256Bytes().toHex().take(12)
+            tenantId = toHex(UUID.randomUUID().toString().toByteArray().sha256Bytes()).take(12)
             coordinatorFactory = TestLifecycleCoordinatorFactoryImpl()
             schemeMetadata = CipherSchemeMetadataImpl()
             ecdhKeySchemes = listOf(

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
@@ -46,7 +46,7 @@ import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
 import net.corda.schema.configuration.BootConfig
 import net.corda.test.util.eventually
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.EDDSA_ED25519_CODE_NAME
 import net.corda.v5.crypto.X25519_CODE_NAME
@@ -192,7 +192,7 @@ class PersistenceTests {
                 hsmId = hsmId,
                 timestamp = Instant.now(),
                 masterKeyAlias = if (masterKeyPolicy == MasterKeyPolicy.UNIQUE) {
-                    UUID.randomUUID().toString().toByteArray().toHex().take(30)
+                    toHex(UUID.randomUUID().toString().toByteArray()).take(30)
                 } else {
                     null
                 }
@@ -399,7 +399,7 @@ class PersistenceTests {
             tenantId = tenantId,
             hsmId = hsmId,
             timestamp = Instant.now(),
-            masterKeyAlias = UUID.randomUUID().toString().toByteArray().toHex().take(30)
+            masterKeyAlias = toHex(UUID.randomUUID().toString().toByteArray()).take(30)
         )
         cryptoDbEmf().transaction { em ->
             em.persist(association)
@@ -437,7 +437,7 @@ class PersistenceTests {
             tenantId = tenantId,
             hsmId = hsmId,
             timestamp = Instant.now(),
-            masterKeyAlias = UUID.randomUUID().toString().toByteArray().toHex().take(30)
+            masterKeyAlias = toHex(UUID.randomUUID().toString().toByteArray()).take(30)
         )
         cryptoDbEmf().transaction { em ->
             em.persist(association1)
@@ -447,7 +447,7 @@ class PersistenceTests {
             tenantId = tenantId,
             hsmId = hsmId,
             timestamp = Instant.now(),
-            masterKeyAlias = UUID.randomUUID().toString().toByteArray().toHex().take(30)
+            masterKeyAlias = toHex(UUID.randomUUID().toString().toByteArray()).take(30)
         )
         assertThrows(PersistenceException::class.java) {
             cryptoDbEmf().transaction { em ->

--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/HSMStoreImpl.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/HSMStoreImpl.kt
@@ -14,7 +14,7 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -148,7 +148,7 @@ class HSMStoreImpl @Activate constructor(
         }
 
         private fun generateRandomShortAlias() =
-            UUID.randomUUID().toString().toByteArray().toHex().take(12)
+            toHex(UUID.randomUUID().toString().toByteArray()).take(12)
 
         private fun HSMCategoryAssociationEntity.toHSMAssociation() = HSMAssociationInfo(
             id,

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
@@ -20,7 +20,7 @@ import net.corda.data.crypto.wire.hsm.registration.queries.AssignedHSMQuery
 import net.corda.data.crypto.wire.ops.rpc.commands.GenerateWrappingKeyRpcCommand
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.sha256Bytes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -44,7 +44,7 @@ import kotlin.test.assertTrue
 
 class HSMRegistrationBusProcessorTests {
     companion object {
-        private val tenantId = UUID.randomUUID().toString().toByteArray().sha256Bytes().toHex().take(12)
+        private val tenantId = toHex(UUID.randomUUID().toString().toByteArray().sha256Bytes()).take(12)
 
         private val configEvent = ConfigChangedEvent(
             setOf(ConfigKeys.CRYPTO_CONFIG),

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestHSMStore.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestHSMStore.kt
@@ -10,7 +10,7 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
@@ -100,7 +100,7 @@ class TestHSMStore(
     }
 
     private fun generateRandomShortAlias() =
-        UUID.randomUUID().toString().toByteArray().toHex().take(12)
+        toHex(UUID.randomUUID().toString().toByteArray()).take(12)
 
     private fun HSMCategoryAssociationEntity.toHSMAssociation() = HSMAssociationInfo(
         id,

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlow.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlow.kt
@@ -7,7 +7,7 @@ import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
 
-@InitiatingFlow("protocol")
+@InitiatingFlow(protocol = "protocol")
 class FakeFlow: ClientStartableFlow {
 
     override fun call(requestBody: RestRequestBody): String {
@@ -15,7 +15,7 @@ class FakeFlow: ClientStartableFlow {
     }
 }
 
-@InitiatedBy("protocol")
+@InitiatedBy(protocol = "protocol")
 class FakeInitiatedFlow: ResponderFlow {
 
     override fun call(session: FlowSession) {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFactory.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFactory.kt
@@ -31,11 +31,11 @@ class FakeFlowFactory : FlowFactory {
     }
 
     private class FakeFlowSession : FlowSession {
-        override val counterparty: MemberX500Name
-            get() = TODO("Not yet implemented")
+        override fun getCounterparty(): MemberX500Name
+            = TODO("Not yet implemented")
 
-        override val contextProperties: FlowContextProperties
-            get() = TODO("Not yet implemented")
+        override fun getContextProperties(): FlowContextProperties
+            = TODO("Not yet implemented")
 
         override fun <R : Any> sendAndReceive(receiveType: Class<R>, payload: Any): R {
             TODO("Not yet implemented")

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeRestRequestBody.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeRestRequestBody.kt
@@ -8,7 +8,7 @@ class FakeRestRequestBody: RestRequestBody {
         return ""
     }
 
-    override fun <T> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
+    override fun <T : Any> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
         TODO("Not yet implemented")
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/FlowEngineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/FlowEngineImpl.kt
@@ -27,14 +27,14 @@ class FlowEngineImpl @Activate constructor(
     private val flowFiberService: FlowFiberService
 ) : FlowEngine, UsedByFlow, SingletonSerializeAsToken {
 
-    override val flowId: UUID
-        get() = flowFiberService.getExecutingFiber().flowId
+    override fun getFlowId(): UUID
+        = flowFiberService.getExecutingFiber().flowId
 
-    override val virtualNodeName: MemberX500Name
-        get() = flowFiberService.getExecutingFiber().getExecutionContext().memberX500Name
+    override fun getVirtualNodeName(): MemberX500Name
+        = flowFiberService.getExecutingFiber().getExecutionContext().memberX500Name
 
-    override val flowContextProperties: FlowContextProperties
-        get() = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.flowContext
+    override fun getFlowContextProperties(): FlowContextProperties
+        = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.flowContext
 
     @Suspendable
     override fun <R> subFlow(subFlow: SubFlow<R>): R {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/NotaryLookupImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/NotaryLookupImpl.kt
@@ -18,8 +18,8 @@ class NotaryLookupImpl @Activate constructor(
     @Reference(service = FlowFiberService::class)
     private val flowFiberService: FlowFiberService,
 ) : NotaryLookup, UsedByFlow, SingletonSerializeAsToken {
-    @Suspendable
     override val notaryServices: Collection<NotaryInfo>
+        @Suspendable
         get() = notaries ?: emptyList()
 
     @Suspendable
@@ -35,11 +35,11 @@ class NotaryLookupImpl @Activate constructor(
         }
     }
 
-    @Suspendable
     private val groupReader
+        @Suspendable
         get() = flowFiberService.getExecutingFiber().getExecutionContext().membershipGroupReader
 
-    @Suspendable
     private val notaries
+        @Suspendable
         get() = groupReader.groupParameters?.notaries
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/FlowSessionImpl.kt
@@ -15,9 +15,9 @@ import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import org.slf4j.LoggerFactory
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class FlowSessionImpl(
-    override val counterparty: MemberX500Name,
+    private val counterparty: MemberX500Name,
     private val sourceSessionId: String,
     private val flowFiberService: FlowFiberService,
     private val serializationService: SerializationServiceInternal,
@@ -29,7 +29,9 @@ class FlowSessionImpl(
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    override val contextProperties: FlowContextProperties = flowContext
+    override fun getCounterparty(): MemberX500Name = counterparty
+
+    override fun getContextProperties(): FlowContextProperties = flowContext
 
     enum class Direction {
         INITIATING_SIDE,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/RestRequestBodyImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/RestRequestBodyImpl.kt
@@ -18,16 +18,16 @@ class RestRequestBodyImpl(private val fiberService: FlowFiberService) : RestRequ
             ?: throw IllegalStateException("Failed to find the start args for Rest started flow")
     }
 
-    override fun <T> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
-        return marshallingService.parse(getRequestBody(), clazz)
+    override fun <T : Any> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
+        return marshallingService.parse(requestBody, clazz)
     }
 
     override fun <T> getRequestBodyAsList(marshallingService: MarshallingService, clazz: Class<T>): List<T> {
-        return marshallingService.parseList(getRequestBody(), clazz)
+        return marshallingService.parseList(requestBody, clazz)
     }
 
     override fun toString(): String {
         // Truncate the JSON object to ensure that we don't try and write too much data into logs.
-        return "RestRequestBody(input=${getRequestBody().take(MAX_STRING_LENGTH)})"
+        return "RestRequestBody(input=${requestBody.take(MAX_STRING_LENGTH)})"
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStackBasedContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStackBasedContext.kt
@@ -6,7 +6,7 @@ import net.corda.flow.state.ContextPlatformProperties
 import net.corda.flow.state.FlowContext
 import net.corda.flow.utils.KeyValueStore
 import net.corda.serialization.checkpoint.NonSerializable
-import net.corda.v5.application.flows.FlowContextProperties.Companion.CORDA_RESERVED_PREFIX
+import net.corda.v5.application.flows.FlowContextProperties.CORDA_RESERVED_PREFIX
 
 /**
  * [FlowStackBasedContext] is the core means of interacting with flow context internally in Corda. It is stack based

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/MutableFlatSerializableContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/MutableFlatSerializableContext.kt
@@ -2,7 +2,7 @@ package net.corda.flow.state.impl
 
 import net.corda.flow.state.ContextPlatformProperties
 import net.corda.flow.state.FlowContext
-import net.corda.v5.application.flows.FlowContextProperties.Companion.CORDA_RESERVED_PREFIX
+import net.corda.v5.application.flows.FlowContextProperties.CORDA_RESERVED_PREFIX
 
 /**
  * A [FlatSerializableContext] which supports put operations.

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/PersistenceServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/PersistenceServiceImplTest.kt
@@ -41,7 +41,7 @@ class PersistenceServiceImplTest {
         persistenceService =
             PersistenceServiceImpl(externalEventExecutor, pagedQueryFactory, serializationService)
 
-        whenever(serializationService.serialize(any())).thenReturn(serializedBytes)
+        whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
         whenever(serializedBytes.bytes).thenReturn(byteBuffer.array())
         whenever(
             externalEventExecutor.execute(
@@ -55,20 +55,20 @@ class PersistenceServiceImplTest {
     fun `persist executes successfully`() {
         persistenceService.persist(TestObject())
 
-        verify(serializationService).serialize(any())
+        verify(serializationService).serialize(any<TestObject>())
         assertThat(argumentCaptor.firstValue).isEqualTo(PersistExternalEventFactory::class.java)
     }
 
     @Test
     fun `bulk persist executes successfully`() {
         persistenceService.persist(listOf(TestObject(), TestObject()))
-        verify(serializationService, times(2)).serialize(any())
+        verify(serializationService, times(2)).serialize(any<TestObject>())
         assertThat(argumentCaptor.firstValue).isEqualTo(PersistExternalEventFactory::class.java)
     }
 
     @Test
     fun `bulk persist with no input entities does nothing`() {
-        persistenceService.persist(emptyList())
+        persistenceService.persist(emptyList<Any>())
         verify(externalEventExecutor, never()).execute(any<Class<ExternalEventFactory<Any, Any, Any>>>(), any())
         verify(serializationService, never()).deserialize<TestObject>(any<ByteArray>(), any())
         verify(serializationService, never()).serialize<TestObject>(any())
@@ -115,7 +115,7 @@ class PersistenceServiceImplTest {
 
     @Test
     fun `bulk merge with no input entities does nothing`() {
-        persistenceService.merge(emptyList())
+        persistenceService.merge(emptyList<Any>())
         verify(externalEventExecutor, never()).execute(any<Class<ExternalEventFactory<Any, Any, Any>>>(), any())
         verify(serializationService, never()).deserialize<TestObject>(any<ByteArray>(), any())
         verify(serializationService, never()).serialize<TestObject>(any())
@@ -133,7 +133,7 @@ class PersistenceServiceImplTest {
         persistenceService.remove(TestObject())
 
         verify(serializationService, times(0)).deserialize<TestObject>(any<ByteArray>(), any())
-        verify(serializationService).serialize<TestObject>(any())
+        verify(serializationService).serialize(any<TestObject>())
         assertThat(argumentCaptor.firstValue).isEqualTo(RemoveExternalEventFactory::class.java)
     }
 
@@ -155,7 +155,7 @@ class PersistenceServiceImplTest {
 
     @Test
     fun `bulk remove with no input entities does nothing`() {
-        persistenceService.remove(emptyList())
+        persistenceService.remove(emptyList<Any>())
         verify(externalEventExecutor, never()).execute(any<Class<ExternalEventFactory<Any, Any, Any>>>(), any())
         verify(serializationService, never()).deserialize<TestObject>(any<ByteArray>(), any())
         verify(serializationService, never()).serialize<TestObject>(any())
@@ -195,7 +195,7 @@ class PersistenceServiceImplTest {
 
     @Test
     fun `bulk find with no input primary keys does nothing`() {
-        persistenceService.merge(emptyList())
+        persistenceService.merge(emptyList<Any>())
         verify(externalEventExecutor, never()).execute(any<Class<ExternalEventFactory<Any, Any, Any>>>(), any())
         verify(serializationService, never()).deserialize<TestObject>(any<ByteArray>(), any())
         verify(serializationService, never()).serialize<TestObject>(any())

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/ClientStartedFlowTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/ClientStartedFlowTest.kt
@@ -24,7 +24,7 @@ class ClientStartedFlowTest {
             return REQUEST_BODY
         }
 
-        override fun <T> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
+        override fun <T : Any> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
             TODO("Not yet implemented")
         }
 
@@ -35,7 +35,7 @@ class ClientStartedFlowTest {
 
     private class TestFlow : ClientStartableFlow {
         override fun call(requestBody: RestRequestBody): String {
-            return requestBody.getRequestBody()
+            return requestBody.requestBody
         }
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/SerializationServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/SerializationServiceImplTest.kt
@@ -35,7 +35,7 @@ class SerializationServiceImplTest {
     fun setup() {
         whenever(currentSandboxGroupContext.get()).thenReturn(sandboxGroupContext)
         whenever(sandboxGroupContext.get(AMQP_SERIALIZATION_SERVICE, SerializationService::class.java)).thenReturn(serializationService)
-        whenever(serializationService.serialize(any())).thenReturn(serializedBytes)
+        whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
     }
 
     @Test

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
@@ -56,12 +56,7 @@ class FlowSessionManagerImplTest {
         const val CPI_ID = "cpi id"
         const val INITIATING_FLOW_NAME = "Initiating flow"
         private const val PROTOCOL = "protocol"
-        val X500_NAME = MemberX500Name(
-            commonName = "Alice",
-            organization = "Alice Corp",
-            locality = "LDN",
-            country = "GB"
-        )
+        val X500_NAME = MemberX500Name("Alice", "Alice Corp", "LDN", "GB")
         val HOLDING_IDENTITY = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group id")
         val COUNTERPARTY_HOLDING_IDENTITY = HoldingIdentity(X500_NAME.toString(), "group id")
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
@@ -749,7 +749,7 @@ class FlowCheckpointImplTest {
     }
 }
 
-@InitiatingFlow("valid-example")
+@InitiatingFlow(protocol = "valid-example")
 class InitiatingFlowExample : SubFlow<Unit> {
     override fun call() {
     }

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -68,7 +68,7 @@ import net.corda.test.util.lifecycle.usingLifecycle
 import net.corda.utilities.concurrent.getOrThrow
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.seconds
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIterable
 import org.bouncycastle.jce.PrincipalUtil
@@ -109,7 +109,7 @@ import java.net.http.HttpRequest as JavaHttpRequest
 
 class GatewayIntegrationTest : TestBase() {
     private companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val GROUP_ID = "Group - 1"
 
         const val aliceX500name = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
@@ -351,7 +351,7 @@ class GatewayIntegrationTest : TestBase() {
             val port = getOpenPort()
             val serverAddress = URI.create("https://www.alice.net:$port")
             val bigMessage = ByteArray(10_000_000)
-            val linkInMessage = LinkInMessage(authenticatedP2PMessage(bigMessage.toHex()))
+            val linkInMessage = LinkInMessage(authenticatedP2PMessage(toHex(bigMessage)))
             val gatewayMessage = GatewayMessage("msg-id", linkInMessage.payload)
             Gateway(
                 createConfigurationServiceFor(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpRequest.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpRequest.kt
@@ -1,6 +1,6 @@
 package net.corda.p2p.gateway.messaging.http
 
-import net.corda.v5.base.util.toBase64
+import net.corda.v5.base.util.EncodingUtils.toBase64
 import java.net.SocketAddress
 
 class HttpRequest(
@@ -10,6 +10,6 @@ class HttpRequest(
 ) {
 
     override fun toString(): String {
-        return "Source: $source\ndestination: $destination\npayload: ${payload.toBase64()}"
+        return "Source: $source\ndestination: $destination\npayload: ${toBase64(payload)}"
     }
 }

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpResponse.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HttpResponse.kt
@@ -1,7 +1,7 @@
 package net.corda.p2p.gateway.messaging.http
 
 import io.netty.handler.codec.http.HttpResponseStatus
-import net.corda.v5.base.util.toBase64
+import net.corda.v5.base.util.EncodingUtils.toBase64
 import java.net.SocketAddress
 
 class HttpResponse(
@@ -12,6 +12,6 @@ class HttpResponse(
 ) {
 
     override fun toString(): String {
-        return "Status: $statusCode\nsource: $source\ndestination: $destination\npayload: ${payload.toBase64()}"
+        return "Status: $statusCode\nsource: $source\ndestination: $destination\npayload: ${toBase64(payload)}"
     }
 }

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/SniCalculator.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/SniCalculator.kt
@@ -1,12 +1,12 @@
 package net.corda.p2p.gateway.messaging.http
 
 import java.security.MessageDigest
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.net.URI
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import org.apache.commons.validator.routines.InetAddressValidator
 import org.bouncycastle.asn1.x500.AttributeTypeAndValue
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 object SniCalculator {
 
@@ -24,7 +24,7 @@ object SniCalculator {
         val x500NameSorted = X500Name(x500Name).rdNs.flatMap { it.typesAndValues.asList() }.sortedBy { it.type.toString() }.groupBy(
             AttributeTypeAndValue::getType, AttributeTypeAndValue::getValue)
             .mapValues { it.value[0].toString() }.map { it }.joinToString(", ")
-        return sha256Hash(x500NameSorted.toByteArray()).toHex().take(HASH_TRUNCATION_SIZE)
+        return toHex(sha256Hash(x500NameSorted.toByteArray())).take(HASH_TRUNCATION_SIZE)
             .lowercase() + CLASSIC_CORDA_SNI_SUFFIX
     }
 

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -151,10 +151,10 @@ class TransactionSignatureServiceImpl @Activate constructor(
         val signedData = SignableData(signedHash, signatureWithMetadata.metadata)
 
         return digitalSignatureVerificationService.verify(
-            publicKey = signatureWithMetadata.by,
-            signatureSpec = signatureSpec,
-            signatureData = signatureWithMetadata.signature.bytes,
-            clearData = serializationService.serialize(signedData).bytes
+            signatureWithMetadata.by,
+            signatureSpec,
+            signatureWithMetadata.signature.bytes,
+            serializationService.serialize(signedData).bytes
         )
     }
 

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/persistence/ConsensualLedgerPersistenceServiceImplTest.kt
@@ -46,7 +46,7 @@ class ConsensualLedgerPersistenceServiceImplTest {
                 externalEventExecutor, serializationService, transactionSignatureService
         )
 
-        whenever(serializationService.serialize(any())).thenReturn(serializedBytes)
+        whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
         whenever(
             externalEventExecutor.execute(
                 argumentCaptor.capture(),
@@ -70,7 +70,7 @@ class ConsensualLedgerPersistenceServiceImplTest {
             )
         ).isEqualTo(listOf(expectedObj))
 
-        verify(serializationService).serialize(any())
+        verify(serializationService).serialize(any<Any>())
         verify(serializationService).deserialize<CordaPackageSummaryImpl>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(PersistTransactionExternalEventFactory::class.java)
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -56,7 +56,7 @@ class UtxoLedgerPersistenceServiceImplTest {
             utxoSignedTransactionFactory
         )
 
-        whenever(serializationService.serialize(any())).thenReturn(serializedBytes)
+        whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
         whenever(
             externalEventExecutor.execute(
                 argumentCaptor.capture(),
@@ -80,7 +80,7 @@ class UtxoLedgerPersistenceServiceImplTest {
             )
         ).isEqualTo(listOf(expectedObj))
 
-        verify(serializationService).serialize(any())
+        verify(serializationService).serialize(any<Any>())
         verify(serializationService).deserialize<CordaPackageSummaryImpl>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(PersistTransactionExternalEventFactory::class.java)
     }
@@ -176,7 +176,7 @@ class UtxoLedgerPersistenceServiceImplTest {
 
         test(transaction, packageSummary)
 
-        verify(serializationService).serialize(any())
+        verify(serializationService).serialize(any<Any>())
         verify(serializationService).deserialize<Pair<String?, List<CordaPackageSummary>>>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(PersistTransactionIfDoesNotExistExternalEventFactory::class.java)
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImplTest.kt
@@ -41,7 +41,7 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
             serializationService
         )
 
-        whenever(serializationService.serialize(any())).thenReturn(serializedBytes)
+        whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
     }
 
     @Test
@@ -69,7 +69,7 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
             verificationService.verify(transaction)
         }
 
-        verify(serializationService).serialize(any())
+        verify(serializationService).serialize(any<Any>())
         assertThat(argumentCaptor.firstValue).isEqualTo(TransactionVerificationExternalEventFactory::class.java)
     }
 
@@ -105,7 +105,7 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
         assertThat(exception.originalExceptionClassName).isEqualTo(expectedObj.errorType)
         assertThat(exception.status).isEqualTo(expectedObj.status)
 
-        verify(serializationService).serialize(any())
+        verify(serializationService).serialize(any<Any>())
         assertThat(argumentCaptor.firstValue).isEqualTo(TransactionVerificationExternalEventFactory::class.java)
     }
 }

--- a/components/ledger/notary-worker-selection-impl/src/test/kotlin/net/corda/ledger/notary/worker/selection/impl/NotaryVirtualNodeSelectorServiceImplTest.kt
+++ b/components/ledger/notary-worker-selection-impl/src/test/kotlin/net/corda/ledger/notary/worker/selection/impl/NotaryVirtualNodeSelectorServiceImplTest.kt
@@ -23,7 +23,7 @@ class NotaryVirtualNodeSelectorServiceImplTest {
         )
 
         private val secondNotaryServiceIdentity = Party(
-            MemberX500Name.Companion.parse("O=MySecondNotaryService, L=London, C=GB"),
+            MemberX500Name.parse("O=MySecondNotaryService, L=London, C=GB"),
             mock()
         )
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -57,10 +57,10 @@ import net.corda.schema.Schemas.P2P.Companion.SESSION_OUT_PARTITIONS
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.MockTimeFacilitiesProvider
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.util.EncodingUtils.toBase64
 import net.corda.v5.base.util.days
 import net.corda.v5.base.util.millis
 import net.corda.v5.base.util.minutes
-import net.corda.v5.base.util.toBase64
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.PublicKeyHash
 import net.corda.v5.crypto.SignatureSpec
@@ -574,7 +574,7 @@ class SessionManagerTest {
 
         assertThat(responseMessage).isNull()
         loggingInterceptor.assertSingleWarning("Received ${InitiatorHelloMessage::class.java.simpleName} with sessionId ${sessionId}. " +
-                "The received public key hash (${initiatorKeyHash.toBase64()}) corresponding " +
+                "The received public key hash (${toBase64(initiatorKeyHash)}) corresponding " +
                 "to one of the sender's holding identities is not in the members map. The message was discarded.")
     }
 
@@ -946,7 +946,7 @@ class SessionManagerTest {
 
         assertThat(responseMessage).isNull()
         loggingInterceptor.assertSingleWarning("Received ${InitiatorHandshakeMessage::class.java.simpleName} with sessionId " +
-                "${sessionId}. The received public key hash (${initiatorPublicKeyHash.toBase64()}) corresponding " +
+                "${sessionId}. The received public key hash (${toBase64(initiatorPublicKeyHash)}) corresponding " +
                 "to one of the sender's holding identities is not in the members map. The message was discarded.")
     }
 
@@ -1058,7 +1058,7 @@ class SessionManagerTest {
 
         assertThat(responseMessage).isNull()
         loggingInterceptor.assertSingleWarningContains("Received ${InitiatorHandshakeMessage::class.java.simpleName} with sessionId " +
-                "${sessionId}. The received public key hash (${responderPublicKeyHash.toBase64()}) corresponding " +
+                "${sessionId}. The received public key hash (${toBase64(responderPublicKeyHash)}) corresponding " +
                 "to one of our holding identities is not in the members map. The message was discarded.")
     }
 

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/ServiceNotReadyException.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/ServiceNotReadyException.kt
@@ -2,4 +2,4 @@ package net.corda.membership.client
 
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
-class ServiceNotReadyException(cause: Exception) : CordaRuntimeException(cause.message, cause = cause)
+class ServiceNotReadyException(cause: Exception) : CordaRuntimeException(cause.message, cause)

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
@@ -241,7 +241,7 @@ class MembershipPackageFactoryTest {
         return mock {
             on { mgmProvidedContext } doReturn mgmContext
             on { memberProvidedContext } doReturn memberContext
-            on { name } doReturn MemberX500Name.Companion.parse("C=GB,L=London,O=$memberName")
+            on { name } doReturn MemberX500Name.parse("C=GB,L=London,O=$memberName")
         }
     }
 }

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerFactoryTest.kt
@@ -24,7 +24,7 @@ class SignerFactoryTest {
         }
         val mgm = mock<MemberInfo> {
             on { memberProvidedContext } doReturn memberContext
-            on { name } doReturn MemberX500Name.Companion.parse("C=GB,L=London,O=mgm")
+            on { name } doReturn MemberX500Name.parse("C=GB,L=London,O=mgm")
             on { sessionInitiationKey } doReturn publicKey
         }
 

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -303,7 +303,7 @@ class MGMRestResourceImpl internal constructor(
             subject: String
         ) {
             verifyMutualTlsIsRunning()
-            val subjectName = MemberX500Name.parse("subject", subject)
+            val subjectName = parseX500Name("subject", subject)
             handleCommonErrors(holdingIdentityShortHash) {
                 mgmResourceClient.mutualTlsAllowClientCertificate(it, subjectName)
             }
@@ -311,7 +311,7 @@ class MGMRestResourceImpl internal constructor(
 
         override fun mutualTlsDisallowClientCertificate(holdingIdentityShortHash: String, subject: String) {
             verifyMutualTlsIsRunning()
-            val subjectName = MemberX500Name.parse("subject", subject)
+            val subjectName = parseX500Name("subject", subject)
             handleCommonErrors(holdingIdentityShortHash) {
                 mgmResourceClient.mutualTlsDisallowClientCertificate(it, subjectName)
             }
@@ -331,7 +331,7 @@ class MGMRestResourceImpl internal constructor(
             val ttlAsInstant = request.ttl?.let { ttl ->
                 clock.instant() + ttl
             }
-            val x500Name = MemberX500Name.parse("ownerX500Name", request.ownerX500Name)
+            val x500Name = parseX500Name("ownerX500Name", request.ownerX500Name)
             return handleCommonErrors(holdingIdentityShortHash) { shortHash ->
                 mgmResourceClient.generatePreAuthToken(
                     shortHash,
@@ -349,7 +349,7 @@ class MGMRestResourceImpl internal constructor(
             viewInactive: Boolean
         ): Collection<PreAuthToken> {
             val ownerX500 = ownerX500Name?.let {
-                MemberX500Name.parse("ownerX500Name", it)
+                parseX500Name("ownerX500Name", it)
             }
             val tokenId = preAuthTokenId?.let {
                 parsePreAuthTokenId(it)
@@ -468,9 +468,9 @@ class MGMRestResourceImpl internal constructor(
             }
         }
 
-        private fun MemberX500Name.Companion.parse(keyName: String, x500Name: String): MemberX500Name {
+        private fun parseX500Name(keyName: String, x500Name: String): MemberX500Name {
             return try {
-                parse(x500Name)
+                MemberX500Name.parse(x500Name)
             } catch (e: IllegalArgumentException) {
                 throw InvalidInputDataException(
                     details = mapOf(keyName to x500Name),

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MGMRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MGMRestResourceTest.kt
@@ -400,7 +400,7 @@ class MGMRestResourceTest {
 
             verify(mgmResourceClient).mutualTlsAllowClientCertificate(
                 HOLDING_IDENTITY_ID.shortHash(),
-                MemberX500Name.Companion.parse(subject),
+                MemberX500Name.parse(subject),
             )
         }
     }
@@ -456,7 +456,7 @@ class MGMRestResourceTest {
 
             verify(mgmResourceClient).mutualTlsDisallowClientCertificate(
                 HOLDING_IDENTITY_ID.shortHash(),
-                MemberX500Name.Companion.parse(subject),
+                MemberX500Name.parse(subject),
             )
         }
     }

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/FakeFlowEngineImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/FakeFlowEngineImpl.kt
@@ -12,12 +12,12 @@ import java.util.UUID
 
 @Component(service = [FlowEngine::class, UsedByFlow::class], scope = PROTOTYPE)
 class FakeFlowEngineImpl : FlowEngine, UsedByFlow, SingletonSerializeAsToken {
-    override val flowId: UUID
-        get() = throw UnsupportedOperationException("VICTORY IS MINE!")
-    override val virtualNodeName: MemberX500Name
-        get() = throw UnsupportedOperationException("VICTORY IS MINE!")
-    override val flowContextProperties: FlowContextProperties
-        get() = throw UnsupportedOperationException("VICTORY IS MINE!")
+    override fun getFlowId(): UUID
+        = throw UnsupportedOperationException("VICTORY IS MINE!")
+    override fun getVirtualNodeName(): MemberX500Name
+        = throw UnsupportedOperationException("VICTORY IS MINE!")
+    override fun getFlowContextProperties(): FlowContextProperties
+        = throw UnsupportedOperationException("VICTORY IS MINE!")
 
     override fun <R> subFlow(subFlow: SubFlow<R>): R {
         throw UnsupportedOperationException("VICTORY IS MINE!")

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -55,8 +55,8 @@ internal class SandboxGroupContextCacheImpl private constructor(
      *
      * @return number of contexts to be closed.
      */
-    @VisibleForTesting
     internal val evictedContextsToBeClosed: Int
+        @VisibleForTesting
         get() {
             purgeExpiryQueue()
             return toBeClosed.size

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -15,7 +15,6 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.core.CloseableDataSource
 import net.corda.db.core.DbPrivilege
-import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.virtualnode.common.exception.CpiNotFoundException
 import net.corda.libs.virtualnode.common.exception.VirtualNodeAlreadyExistsException
 import net.corda.libs.virtualnode.datamodel.repository.HoldingIdentityRepository
@@ -59,13 +58,11 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
-import java.sql.Connection
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
-import javax.persistence.EntityTransaction
 
 /** Tests of [VirtualNodeWriterProcessor]. */
 class VirtualNodeWriterProcessorTests {
@@ -133,28 +130,28 @@ class VirtualNodeWriterProcessorTests {
             "update_actor"
         )
 
-    private val em = mock<EntityManager>() {
-        on { transaction }.doReturn(mock<EntityTransaction>())
+    private val em = mock<EntityManager> {
+        on { transaction }.doReturn(mock())
     }
 
-    private val emf = mock<EntityManagerFactory>() {
+    private val emf = mock<EntityManagerFactory> {
         on { createEntityManager() }.doReturn(em)
     }
 
-    private val dataSource = mock<CloseableDataSource>() {
-        on { connection }.doReturn(mock<Connection>())
+    private val dataSource = mock<CloseableDataSource> {
+        on { connection }.doReturn(mock())
     }
 
-    private val connectionManager = mock<DbConnectionManager>() {
+    private val connectionManager = mock<DbConnectionManager> {
         on { getDataSource(any()) }.doReturn(dataSource)
         on { getClusterEntityManagerFactory() }.doReturn(emf)
         on { putConnection(any(), any(), any(), any(), any(), any()) }.doReturn(UUID.fromString(connectionId))
     }
 
-    private val dbConnection = mock<DbConnectionImpl>() {
+    private val dbConnection = mock<DbConnectionImpl> {
         on { name }.doReturn("connection")
         on { privilege }.doReturn(DbPrivilege.DDL)
-        on { config }.doReturn(mock<SmartConfig>())
+        on { config }.doReturn(mock())
         on { description }.doReturn("description")
         on { getUser() }.doReturn("user")
         on { getPassword() }.doReturn("password")
@@ -183,7 +180,7 @@ class VirtualNodeWriterProcessorTests {
         whenever(dbType).thenReturn(VirtualNodeDbType.UNIQUENESS)
     }
 
-    private val vNodeFactory = mock<VirtualNodeDbFactory>() {
+    private val vNodeFactory = mock<VirtualNodeDbFactory> {
         on { createVNodeDbs(any(), any()) }.doReturn(
             mapOf(
                 VirtualNodeDbType.VAULT to vaultDb,
@@ -193,7 +190,7 @@ class VirtualNodeWriterProcessorTests {
         )
     }
 
-    private val vNodeRepo = mock<VirtualNodeEntityRepository>() {
+    private val vNodeRepo = mock<VirtualNodeEntityRepository> {
         on { getCpiMetadataByChecksum(any()) }.doReturn(cpiMetaData)
     }
     private val mgmMemberContextKey = "member-context-key"
@@ -243,8 +240,8 @@ class VirtualNodeWriterProcessorTests {
         return respFuture.get()
     }
 
-    private fun virtualNodeRepositoryMock(): VirtualNodeRepository = mock<VirtualNodeRepository>()
-    private fun holdingIdentityRepositoryMock(): HoldingIdentityRepository = mock<HoldingIdentityRepository>()
+    private fun virtualNodeRepositoryMock(): VirtualNodeRepository = mock()
+    private fun holdingIdentityRepositoryMock(): HoldingIdentityRepository = mock()
 
     @Test
     fun `publishes correct virtual node info to Kafka`() {
@@ -353,7 +350,7 @@ class VirtualNodeWriterProcessorTests {
     @Test
     fun `skips MGM member info publishing to Kafka without error if MGM information is not present in group policy`() {
         val publisher = getPublisher()
-        val vNodeRepo = mock<VirtualNodeEntityRepository>() {
+        val vNodeRepo = mock<VirtualNodeEntityRepository> {
             on { getCpiMetadataByChecksum(any()) }.doReturn(cpiMetaData)
         }
         val processor = VirtualNodeWriterProcessor(
@@ -724,7 +721,7 @@ class VirtualNodeWriterProcessorTests {
         val entityRepository = mock<VirtualNodeEntityRepository>().apply {
             whenever(getCpiMetadataByChecksum(any())).thenReturn(cpiMetaData)
         }
-        val vnodeRepo = mock<VirtualNodeRepository>() {
+        val vnodeRepo = mock<VirtualNodeRepository> {
             on { find(any(), any()) }.doReturn(mock())
         }
         val processor = VirtualNodeWriterProcessor(
@@ -750,14 +747,14 @@ class VirtualNodeWriterProcessorTests {
             ""
         )
 
-        val entityRepository = mock<VirtualNodeEntityRepository>() {
+        val entityRepository = mock<VirtualNodeEntityRepository> {
             on { getCpiMetadataByChecksum(any()) }.doReturn(cpiMetaData)
         }
 
-        val holdingIdentityRepository = mock<HoldingIdentityRepository>() {
-            on { find(any(), any()) }.doReturn(mock<HoldingIdentity>())
+        val holdingIdentityRepository = mock<HoldingIdentityRepository> {
+            on { find(any(), any()) }.doReturn(mock())
         }
-        val vnodeRepo = mock<VirtualNodeRepository>() {
+        val vnodeRepo = mock<VirtualNodeRepository> {
             on { find(any(), any()) }.doReturn(null)
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.642-beta+
+cordaApiVersion=5.0.0.643-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoServiceUtils.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoServiceUtils.kt
@@ -2,7 +2,7 @@
 
 package net.corda.crypto.cipher.suite
 
-import net.corda.v5.base.types.toHexString
+import net.corda.v5.base.types.ByteArrays
 import net.corda.v5.crypto.HMAC_SHA256_ALGORITHM
 import net.corda.v5.crypto.hmac
 
@@ -66,6 +66,6 @@ fun computeHSMAlias(
     return (tenantId + alias)
         .encodeToByteArray()
         .hmac(secret, HMAC_SHA256_ALGORITHM)
-        .toHexString()
+        .let(ByteArrays::toHexString)
         .take(take)
 }

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CompositeKeyImpl.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CompositeKeyImpl.kt
@@ -1,7 +1,7 @@
 package net.corda.crypto.impl
 
 import net.corda.crypto.core.OID_COMPOSITE_KEY_IDENTIFIER
-import net.corda.v5.base.types.sequence
+import net.corda.v5.base.types.ByteArrays.sequence
 import net.corda.v5.base.util.exactAdd
 import net.corda.v5.crypto.COMPOSITE_KEY_CHILDREN_LIMIT
 import net.corda.v5.crypto.CompositeKey
@@ -37,7 +37,7 @@ class CompositeKeyImpl(val threshold: Int, childrenUnsorted: List<CompositeKeyNo
         // will improve efficiency, because keys with bigger "weights" are the first to be checked and thus the
         // threshold requirement might be met earlier without requiring a full [children] scan.
         private val descWeightComparator =
-            compareBy<CompositeKeyNodeAndWeight>({ -it.weight }, { it.node.encoded.sequence() })
+            compareBy<CompositeKeyNodeAndWeight>({ -it.weight }, { sequence(it.node.encoded) })
 
         fun createFromKeys(keys: List<PublicKey>, threshold: Int?) =
             create(keys.map { CompositeKeyNodeAndWeight(it, 1) }, threshold)

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/WireUtilsTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/WireUtilsTests.kt
@@ -7,7 +7,7 @@ import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureParameterSpec
 import net.corda.data.crypto.wire.CryptoSignatureSpec
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
@@ -84,7 +84,7 @@ class WireUtilsTests {
 
     @Test
     fun `Should create wire request context for a given caller`() {
-        val tenantId = UUID.randomUUID().toString().toByteArray().sha256Bytes().toHex().take(12)
+        val tenantId = toHex(UUID.randomUUID().toString().toByteArray().sha256Bytes()).take(12)
         val other = KeyValuePairList(
             listOf(
                 KeyValuePair("key1", "value1")

--- a/libs/crypto/crypto-utils/src/main/kotlin/net/corda/crypto/utils/CertificateUtils.kt
+++ b/libs/crypto/crypto-utils/src/main/kotlin/net/corda/crypto/utils/CertificateUtils.kt
@@ -1,6 +1,6 @@
 package net.corda.crypto.utils
 
-import net.corda.v5.base.util.toHex
+import net.corda.v5.base.util.EncodingUtils.toHex
 import org.bouncycastle.asn1.ASN1IA5String
 import org.bouncycastle.asn1.ASN1InputStream
 import org.bouncycastle.asn1.DEROctetString
@@ -12,17 +12,17 @@ import org.bouncycastle.asn1.x509.GeneralName
 import org.bouncycastle.asn1.x509.GeneralNames
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier
 import org.bouncycastle.cert.X509CertificateHolder
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayInputStream
 import java.security.KeyStore
 import java.security.KeyStoreException
+import java.security.cert.Certificate
 import java.security.cert.CertificateException
 import java.security.cert.CertificateFactory
-import org.slf4j.LoggerFactory
 import java.security.cert.CertPathValidatorException
-import java.security.cert.Certificate
 import java.security.cert.PKIXRevocationChecker
 import java.security.cert.X509Certificate
-import java.util.*
+import java.util.LinkedList
 
 private const val KEY_STORE_TYPE = "PKCS12"
 typealias PemCertificate = String
@@ -108,12 +108,12 @@ fun certPathToString(certPath: Array<out X509Certificate?>?): String {
         val subject = bcCert.subject.toString()
         val issuer = bcCert.issuer.toString()
         val keyIdentifier = try {
-            SubjectKeyIdentifier.getInstance(bcCert.getExtension(Extension.subjectKeyIdentifier).parsedValue).keyIdentifier.toHex()
+            toHex(SubjectKeyIdentifier.getInstance(bcCert.getExtension(Extension.subjectKeyIdentifier).parsedValue).keyIdentifier)
         } catch (ex: Exception) {
             "null"
         }
         val authorityKeyIdentifier = try {
-            AuthorityKeyIdentifier.getInstance(bcCert.getExtension(Extension.authorityKeyIdentifier).parsedValue).keyIdentifier.toHex()
+            toHex(AuthorityKeyIdentifier.getInstance(bcCert.getExtension(Extension.authorityKeyIdentifier).parsedValue).keyIdentifier)
         } catch (ex: Exception) {
             "null"
         }

--- a/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapImpl.kt
+++ b/libs/layered-property-map/src/main/kotlin/net/corda/layeredpropertymap/impl/LayeredPropertyMapImpl.kt
@@ -18,16 +18,15 @@ class LayeredPropertyMapImpl(
 
     private val cache = ConcurrentHashMap<Pair<String, Class<*>>, CachedValue>()
 
-    override operator fun get(key: String): String? = properties[key]
+    override fun get(key: String): String? = properties[key]
 
-    override val entries: Set<Map.Entry<String, String?>>
-        get() = properties.entries
+    override fun getEntries(): Set<Map.Entry<String, String?>> = properties.entries
 
     /**
      * Function for reading and parsing the String values to actual objects.
      */
     @Suppress("UNCHECKED_CAST")
-    override fun <T> parse(key: String, clazz: Class<out T>): T {
+    override fun <T : Any> parse(key: String, clazz: Class<out T>): T {
         require(key.isNotBlank()) {
             "The key cannot be blank string."
         }

--- a/libs/layered-property-map/src/test/kotlin/net/corda/layeredpropertymap/LayeredPropertyMapTest.kt
+++ b/libs/layered-property-map/src/test/kotlin/net/corda/layeredpropertymap/LayeredPropertyMapTest.kt
@@ -4,8 +4,8 @@ import net.corda.layeredpropertymap.impl.LayeredPropertyMapImpl
 import net.corda.layeredpropertymap.impl.PropertyConverter
 import net.corda.test.util.createTestCase
 import net.corda.v5.base.exceptions.ValueNotFoundException
+import net.corda.v5.base.types.ByteArrays.toHexString
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.base.types.toHexString
 import net.corda.v5.base.util.parse
 import net.corda.v5.base.util.parseList
 import net.corda.v5.base.util.parseOrNull
@@ -74,10 +74,10 @@ class LayeredPropertyMapTest {
                 "corda.endpoints.1.protocolVersion" to "2",
                 "listWithNull.0" to "42",
                 "listWithNull.1" to null,
-                "singlePublicKeyHash" to "single".toByteArray().sha256Bytes().toHexString(),
-                "setPublicKeyHash.0" to "set0".toByteArray().sha256Bytes().toHexString(),
-                "setPublicKeyHash.1" to "set1".toByteArray().sha256Bytes().toHexString(),
-                "setPublicKeyHash.2" to "set2".toByteArray().sha256Bytes().toHexString(),
+                "singlePublicKeyHash" to toHexString("single".toByteArray().sha256Bytes()),
+                "setPublicKeyHash.0" to toHexString("set0".toByteArray().sha256Bytes()),
+                "setPublicKeyHash.1" to toHexString("set1".toByteArray().sha256Bytes()),
+                "setPublicKeyHash.2" to toHexString("set2".toByteArray().sha256Bytes()),
             ),
             PropertyConverter(
                 mapOf(
@@ -95,13 +95,13 @@ class LayeredPropertyMapTest {
         val single1 = propertyMap.parse<PublicKeyHash>("singlePublicKeyHash")
         val single2 = propertyMap.parseOrNull<PublicKeyHash>("singlePublicKeyHash")
         assertEquals(single1, single2)
-        assertEquals("single".toByteArray().sha256Bytes().toHexString(), single1.value)
+        assertEquals(toHexString("single".toByteArray().sha256Bytes()), single1.value)
         val set = propertyMap.parseSet<PublicKeyHash>("setPublicKeyHash")
         assertEquals(3, set.size)
         val setContents = set.map { it.value }
-        assertTrue(setContents.contains("set0".toByteArray().sha256Bytes().toHexString()))
-        assertTrue(setContents.contains("set1".toByteArray().sha256Bytes().toHexString()))
-        assertTrue(setContents.contains("set2".toByteArray().sha256Bytes().toHexString()))
+        assertTrue(setContents.contains(toHexString("set0".toByteArray().sha256Bytes())))
+        assertTrue(setContents.contains(toHexString("set1".toByteArray().sha256Bytes())))
+        assertTrue(setContents.contains(toHexString("set2".toByteArray().sha256Bytes())))
     }
 
     @Test

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
@@ -16,7 +16,7 @@ import net.corda.messaging.config.ResolvedSubscriptionConfig
 import net.corda.messaging.subscription.consumer.listener.PubSubConsumerRebalanceListener
 import net.corda.messaging.utils.toRecord
 import net.corda.metrics.CordaMetrics
-import net.corda.v5.base.types.toHexString
+import net.corda.v5.base.types.ByteArrays.toHexString
 import net.corda.v5.base.util.debug
 import org.slf4j.LoggerFactory
 
@@ -172,6 +172,6 @@ internal class PubSubSubscriptionImpl<K : Any, V : Any>(
     }
 
     private fun logFailedDeserialize(data: ByteArray) {
-        log.error("Failed to deserialize a record on ${config.topic}: (${data.toHexString()}")
+        log.error("Failed to deserialize a record on ${config.topic}: (${toHexString(data)}")
     }
 }

--- a/libs/rest/json-serialization/src/test/kotlin/net/corda/common/json/serialization/JsonSerializationTest.kt
+++ b/libs/rest/json-serialization/src/test/kotlin/net/corda/common/json/serialization/JsonSerializationTest.kt
@@ -18,7 +18,7 @@ class JsonSerializationTest{
         val df = SimpleDateFormat("dd-MM-yyyy hh:mm")
         df.timeZone = TimeZone.getTimeZone("UTC")
         val date: Date = df.parse("01-01-1970 01:00")
-        val event = Event("party", date.toInstant(), MemberX500Name.Companion.parse("O=Alice, L=London, C=GB"))
+        val event = Event("party", date.toInstant(), MemberX500Name.parse("O=Alice, L=London, C=GB"))
 
         val expectedSerializedEvent = """{"name":"party","date":"1970-01-01T01:00:00Z","memberX500Name":"O=Alice, L=London, C=GB"}"""
 

--- a/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
+++ b/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
@@ -6,7 +6,7 @@ import net.corda.data.Fingerprint
 import net.corda.data.SchemaLoadException
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.toHexString
+import net.corda.v5.base.types.ByteArrays.toHexString
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.uncheckedCast
 import org.apache.avro.Schema
@@ -109,7 +109,7 @@ class AvroSchemaRegistryImpl(
         ?: throw CordaRuntimeException("Could not find fingerprint for class ${clazz.name}")
 
     private fun getSchema(fingerprint: Fingerprint) = schemasByFingerprint[fingerprint]
-        ?: throw CordaRuntimeException("Could not find schema for fingerprint ${fingerprint.bytes().toHexString()}")
+        ?: throw CordaRuntimeException("Could not find schema for fingerprint ${toHexString(fingerprint.bytes())}")
 
     private fun <T : Any> getRecordData(clazz: Class<T>) = recordDataByFingerprint[getFingerprint(clazz)]
         ?: throw CordaRuntimeException("Could not record data for class: $clazz")
@@ -218,7 +218,7 @@ class AvroSchemaRegistryImpl(
     }
 
     override fun <T : Any> deserialize(bytes: ByteBuffer, offset: Int, length: Int, clazz: Class<T>, reusable: T?): T {
-        log.trace("Deserializing from: ${bytes.array().toHexString()}")
+        log.trace("Deserializing from: ${toHexString(bytes.array())}")
         val envelope = decodeAvroEnvelope(bytes.array())
         if (envelope.magic != MAGIC) {
             throw CordaRuntimeException("Incorrect Header detected.  Cannot deserialize message.")

--- a/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
+++ b/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
@@ -7,8 +7,8 @@ import net.corda.data.test.EvolvedMessage
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.parseAsHex
-import net.corda.v5.base.types.toHexString
+import net.corda.v5.base.types.ByteArrays.parseAsHex
+import net.corda.v5.base.types.ByteArrays.toHexString
 import org.apache.avro.Schema
 import org.apache.avro.SchemaNormalization
 import org.apache.avro.generic.GenericContainer
@@ -39,9 +39,9 @@ internal class AvroSchemaRegistryImplTest {
         registry.initialiseSchemas(avroGeneratedMessages)
         val encoded = registry.serialize(secureHash)
 
-        val encodedString = encoded.array().toHexString()
+        val encodedString = toHexString(encoded.array())
         assertThat(encodedString.contains(MAGIC.toString()))
-        assertThat(encodedString.contains(expectedSchemaFingerprint.toHexString()))
+        assertThat(encodedString.contains(toHexString(expectedSchemaFingerprint)))
 
         val decoded = registry.deserialize<SecureHash>(encoded)
         assertThat(secureHash).isEqualTo(decoded)
@@ -58,9 +58,9 @@ internal class AvroSchemaRegistryImplTest {
         registry.initialiseSchemas(avroGeneratedMessages)
         val encoded = registry.serialize(secureHash)
 
-        val encodedString = encoded.array().toHexString()
+        val encodedString = toHexString(encoded.array())
         assertThat(encodedString.contains(MAGIC.toString()))
-        assertThat(encodedString.contains(expectedSchemaFingerprint.toHexString()))
+        assertThat(encodedString.contains(toHexString(expectedSchemaFingerprint)))
 
         val reuse = SecureHash("reuse", ByteBuffer.wrap("3".toByteArray()))
         assertThat(secureHash).isNotEqualTo(reuse)
@@ -79,9 +79,9 @@ internal class AvroSchemaRegistryImplTest {
         serializingRegistry.initialiseSchemas(avroGeneratedMessages)
         val encoded = serializingRegistry.serialize(secureHash)
 
-        val encodedString = encoded.array().toHexString()
+        val encodedString = toHexString(encoded.array())
         assertThat(encodedString.contains(MAGIC.toString()))
-        assertThat(encodedString.contains(expectedSchemaFingerprint.toHexString()))
+        assertThat(encodedString.contains(toHexString(expectedSchemaFingerprint)))
 
         val deserializingRegistry = AvroSchemaRegistryImpl(
             options = AvroSchemaRegistryImpl.Options(
@@ -147,9 +147,9 @@ internal class AvroSchemaRegistryImplTest {
 
         val encoded = registry.serialize(nonAvroMessage)
 
-        val encodedString = encoded.array().toHexString()
+        val encodedString = toHexString(encoded.array())
         assertThat(encodedString.contains(MAGIC.toString()))
-        assertThat(encodedString.contains(expectedSchemaFingerprint.toHexString()))
+        assertThat(encodedString.contains(toHexString(expectedSchemaFingerprint)))
 
         val decoded = registry.deserialize<TestMessage>(encoded)
         assertThat(nonAvroMessage).isEqualTo(decoded)
@@ -170,7 +170,7 @@ internal class AvroSchemaRegistryImplTest {
         // val evolvedMessage = EvolvedMessage(5)
         // {"flags": 5}
         val encodedMessage = "636F726461010000DA291C049362E1AC80C927626090F4ECB88A0F881673325C2C994CBBA108C48400020A"
-        val encoded = encodedMessage.parseAsHex()
+        val encoded = parseAsHex(encodedMessage)
 
         registry.addSchemaOnly(previousSchema)
 
@@ -209,7 +209,7 @@ internal class AvroSchemaRegistryImplTest {
 
         val dummy = EvolvedMessage(0, "")
 
-        val encoded = ByteBuffer.wrap(evolvedMessage.parseAsHex())
+        val encoded = ByteBuffer.wrap(parseAsHex(evolvedMessage))
 
         val decoded = registry.deserialize(encoded, dummy)
         assertThat(decoded.flags).isEqualTo(5)
@@ -228,9 +228,9 @@ internal class AvroSchemaRegistryImplTest {
         repeat(1_000_000) {
             val encoded = registry.serialize(secureHash)
 
-            val encodedString = encoded.array().toHexString()
+            val encodedString = toHexString(encoded.array())
             assertThat(encodedString.contains(MAGIC.toString()))
-            assertThat(encodedString.contains(expectedSchemaFingerprint.toHexString()))
+            assertThat(encodedString.contains(toHexString(expectedSchemaFingerprint)))
 
             val decoded = registry.deserialize(encoded, reusable)
             assertThat(secureHash).isEqualTo(decoded)

--- a/libs/serialization/json-serializers/src/main/kotlin/net/corda/common/json/serializers/MemberX500NameSerialization.kt
+++ b/libs/serialization/json-serializers/src/main/kotlin/net/corda/common/json/serializers/MemberX500NameSerialization.kt
@@ -1,5 +1,7 @@
 package net.corda.common.json.serializers
 
+import java.io.IOException
+import java.io.UncheckedIOException
 import net.corda.v5.application.marshalling.json.JsonDeserializer
 import net.corda.v5.application.marshalling.json.JsonNodeReader
 import net.corda.v5.application.marshalling.json.JsonSerializer
@@ -28,5 +30,11 @@ class MemberX500NameDeserializer : JsonDeserializer<MemberX500Name> {
  */
 @Component
 class MemberX500NameSerializer : JsonSerializer<MemberX500Name> {
-    override fun serialize(item: MemberX500Name, jsonWriter: JsonWriter) = jsonWriter.writeString(item.toString())
+    override fun serialize(item: MemberX500Name, jsonWriter: JsonWriter) {
+        return try {
+            jsonWriter.writeString(item.toString())
+        } catch (e: IOException) {
+            throw UncheckedIOException(e)
+        }
+    }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationFormat.kt
@@ -16,7 +16,7 @@ import java.util.ServiceLoader
 class CordaSerializationMagic(bytes: ByteArray) : OpaqueBytes(bytes) {
     private val bufferView = slice()
     fun consume(data: ByteSequence): ByteBuffer? {
-        return if (data.slice(start = 0, end = size) == bufferView) data.slice(size) else null
+        return if (data.slice(0, size) == bufferView) data.slice(size) else null
     }
 }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationScheme.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationScheme.kt
@@ -87,7 +87,7 @@ open class SerializationFactoryImpl(
 
     private fun schemeFor(byteSequence: ByteSequence, target: SerializationContext.UseCase): Pair<SerializationScheme, CordaSerializationMagic> {
         // truncate sequence to at most magicSize, and make sure it's a copy to avoid holding onto large ByteArrays
-        val magic = CordaSerializationMagic(byteSequence.slice(start = 0, end = magicSize).copyBytes())
+        val magic = CordaSerializationMagic(byteSequence.slice(0, magicSize).copyBytes())
         val lookupKey = magic to target
         // ConcurrentHashMap.get() is lock free, but computeIfAbsent is not, even if the key is in the map already.
         return (

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
@@ -4,7 +4,7 @@ import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.serialization.SerializationContext
 import net.corda.v5.application.serialization.SerializationService
-import net.corda.v5.base.types.sequence
+import net.corda.v5.base.types.ByteArrays.sequence
 import net.corda.v5.serialization.SerializedBytes
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import java.security.AccessController
@@ -40,7 +40,7 @@ class SerializationServiceImpl(
     override fun <T : Any> deserialize(bytes: ByteArray, clazz: Class<T>): T {
         return try {
             AccessController.doPrivileged(PrivilegedExceptionAction {
-                deserializationInput.deserialize(bytes.sequence(), clazz, context)
+                deserializationInput.deserialize(sequence(bytes), clazz, context)
             })
         } catch (e: PrivilegedActionException) {
             throw e.exception

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeModellingFingerPrinter.kt
@@ -8,7 +8,7 @@ import net.corda.internal.serialization.model.TypeIdentifier.ArrayOf
 import net.corda.internal.serialization.model.TypeIdentifier.Parameterised
 import net.corda.internal.serialization.model.TypeIdentifier.UnknownType
 import net.corda.sandbox.SandboxGroup
-import net.corda.v5.base.util.toBase64
+import net.corda.v5.base.util.EncodingUtils.toBase64
 import org.slf4j.LoggerFactory
 import java.lang.reflect.ParameterizedType
 
@@ -88,7 +88,7 @@ internal class FingerprintWriter(debugEnabled: Boolean = false) {
     }
 
     val fingerprint: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        val fingerprint = hasher.hash().asBytes().toBase64()
+        val fingerprint = toBase64(hasher.hash().asBytes())
         if (debugBuffer != null) logger.info("$fingerprint from $debugBuffer")
         fingerprint
     }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionObjectBuilderRenamedPropertyTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolutionObjectBuilderRenamedPropertyTests.kt
@@ -76,7 +76,7 @@ class EvolutionObjectBuilderRenamedPropertyTests {
     @TestBelongsToContract(TemplateContract::class)
     @CordaSerializable
     data class TemplateState(val cordappVersion: Int, val data: String, val y: String?, override val participants: List<TestParty> = listOf()) : TestContractState {
-        @DeprecatedConstructorForDeserialization(1)
+        @DeprecatedConstructorForDeserialization(version = 1)
         constructor(
             cordappVersion: Int,
             data: String,

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolvabilityTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/EvolvabilityTests.kt
@@ -231,7 +231,7 @@ class EvolvabilityTests {
         @Suppress("UNUSED")
         @CordaSerializable
         data class CC(val a: Int, val b: String) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             constructor (a: Int) : this(a, "hello")
         }
 
@@ -258,7 +258,7 @@ class EvolvabilityTests {
         @Suppress("UNUSED")
         @CordaSerializable
         data class CC(val z: Int, val y: Int, val a: String) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             constructor (z: Int, y: Int) : this(z, y, "10")
         }
 
@@ -350,7 +350,7 @@ class EvolvabilityTests {
         data class CC(val a: Int, val b: Int, val c: String, val d: String) {
             // ensure none of the original parameters align with the initial
             // construction order
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             constructor (c: String, a: Int, b: Int) : this(a, b, c, "wibble")
         }
 
@@ -384,7 +384,7 @@ class EvolvabilityTests {
             // ensure none of the original parameters align with the initial
             // construction order
             @Suppress("UNUSED")
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             constructor (c: String, a: Int) : this(a, c, "wibble")
         }
 
@@ -429,13 +429,13 @@ class EvolvabilityTests {
         @Suppress("UNUSED")
         @CordaSerializable
         data class C(val e: Int, val c: Int, val b: Int, val a: Int, val d: Int) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             constructor (b: Int, a: Int) : this(-1, -1, b, a, -1)
 
-            @DeprecatedConstructorForDeserialization(2)
+            @DeprecatedConstructorForDeserialization(version = 2)
             constructor (a: Int, c: Int, b: Int) : this(-1, c, b, a, -1)
 
-            @DeprecatedConstructorForDeserialization(3)
+            @DeprecatedConstructorForDeserialization(version = 3)
             constructor (a: Int, b: Int, c: Int, d: Int) : this(-1, c, b, a, d)
         }
 
@@ -553,16 +553,16 @@ class EvolvabilityTests {
         @Suppress("UNUSED")
         @CordaSerializable
         data class C(val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             constructor (b: Int, c: Int) : this(b, c, -1, -1, -1, -1)
 
-            @DeprecatedConstructorForDeserialization(2)
+            @DeprecatedConstructorForDeserialization(version = 2)
             constructor (b: Int, c: Int, d: Int) : this(b, c, d, -1, -1, -1)
 
-            @DeprecatedConstructorForDeserialization(3)
+            @DeprecatedConstructorForDeserialization(version = 3)
             constructor (b: Int, c: Int, d: Int, e: Int) : this(b, c, d, e, -1, -1)
 
-            @DeprecatedConstructorForDeserialization(4)
+            @DeprecatedConstructorForDeserialization(version = 4)
             constructor (b: Int, c: Int, d: Int, e: Int, f: Int) : this(b, c, d, e, f, -1)
         }
 
@@ -686,7 +686,7 @@ class EvolvabilityTests {
 
         @CordaSerializable
         data class CC(val a: Int?, val b: Int) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             @Suppress("unused")
             constructor(a: Int) : this(a, 42)
         }
@@ -711,7 +711,7 @@ class EvolvabilityTests {
 
         @CordaSerializable
         data class CC(val a: Int, val b: Int) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             @Suppress("unused")
             constructor(a: Int?) : this(a ?: -1, 42)
         }
@@ -736,7 +736,7 @@ class EvolvabilityTests {
 
         @CordaSerializable
         data class CC(val data: String, val b: String) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             @Suppress("unused")
             constructor(data: String, a: Int?) : this(data, a?.toString() ?: "<not provided>")
         }
@@ -761,7 +761,7 @@ class EvolvabilityTests {
 
         @CordaSerializable
         data class CC(val data: String) {
-            @DeprecatedConstructorForDeserialization(1)
+            @DeprecatedConstructorForDeserialization(version = 1)
             @Suppress("unused")
             constructor(data: String, a: Int?) : this(data + (a?.toString() ?: "<not provided>"))
         }

--- a/libs/serialization/serialization-internal/src/main/kotlin/net/corda/serialization/SerializationHelpers.kt
+++ b/libs/serialization/serialization-internal/src/main/kotlin/net/corda/serialization/SerializationHelpers.kt
@@ -1,7 +1,7 @@
 package net.corda.serialization
 
+import net.corda.v5.base.types.ByteArrays.sequence
 import net.corda.v5.base.types.ByteSequence
-import net.corda.v5.base.types.sequence
 import net.corda.v5.serialization.SerializedBytes
 import java.sql.Blob
 
@@ -36,7 +36,7 @@ inline fun <reified T : Any> SerializedBytes<T>.deserialize(serializationFactory
 inline fun <reified T : Any> ByteArray.deserialize(serializationFactory: SerializationFactory,
                                                    context: SerializationContext): T {
     require(isNotEmpty()) { "Empty bytes" }
-    return this.sequence().deserialize(serializationFactory, context)
+    return sequence(this).deserialize(serializationFactory, context)
 }
 
 /**

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckErrorsImpl.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckErrorsImpl.kt
@@ -9,29 +9,44 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckErrorTimeWindowO
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateDetails
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
 import java.time.Instant
+import java.util.Collections.unmodifiableList
 
 data class UniquenessCheckErrorInputStateConflictImpl(
-    override val conflictingStates: List<UniquenessCheckStateDetails>
-) : UniquenessCheckErrorInputStateConflict
+    private val conflictingStates: List<UniquenessCheckStateDetails>
+) : UniquenessCheckErrorInputStateConflict {
+    override fun getConflictingStates() = conflictingStates
+}
 
 data class UniquenessCheckErrorInputStateUnknownImpl(
-    override val unknownStates: List<UniquenessCheckStateRef>
-) : UniquenessCheckErrorInputStateUnknown
+    private val unknownStates: List<UniquenessCheckStateRef>
+) : UniquenessCheckErrorInputStateUnknown {
+    override fun getUnknownStates() = unknownStates
+}
 
 data class UniquenessCheckErrorReferenceStateConflictImpl(
-    override val conflictingStates: List<UniquenessCheckStateDetails>
-) : UniquenessCheckErrorReferenceStateConflict
+    private val conflictingStates: List<UniquenessCheckStateDetails>
+) : UniquenessCheckErrorReferenceStateConflict {
+    override fun getConflictingStates(): List<UniquenessCheckStateDetails> = unmodifiableList(conflictingStates)
+}
 
 data class UniquenessCheckErrorReferenceStateUnknownImpl(
-    override val unknownStates: List<UniquenessCheckStateRef>
-) : UniquenessCheckErrorReferenceStateUnknown
+    private val unknownStates: List<UniquenessCheckStateRef>
+) : UniquenessCheckErrorReferenceStateUnknown {
+    override fun getUnknownStates(): List<UniquenessCheckStateRef> = unmodifiableList(unknownStates)
+}
 
 data class UniquenessCheckErrorTimeWindowOutOfBoundsImpl(
-    override val evaluationTimestamp: Instant,
-    override val timeWindowLowerBound: Instant?,
-    override val timeWindowUpperBound: Instant
-) : UniquenessCheckErrorTimeWindowOutOfBounds
+    private val evaluationTimestamp: Instant,
+    private val timeWindowLowerBound: Instant?,
+    private val timeWindowUpperBound: Instant
+) : UniquenessCheckErrorTimeWindowOutOfBounds {
+    override fun getEvaluationTimestamp() = evaluationTimestamp
+    override fun getTimeWindowLowerBound() = timeWindowLowerBound
+    override fun getTimeWindowUpperBound() = timeWindowUpperBound
+}
 
 data class UniquenessCheckErrorMalformedRequestImpl(
-    override val errorText: String
-) : UniquenessCheckErrorMalformedRequest
+    private val errorText: String
+) : UniquenessCheckErrorMalformedRequest {
+    override fun getErrorText() = errorText
+}

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckResultsImpl.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckResultsImpl.kt
@@ -6,10 +6,15 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResultSuccess
 import java.time.Instant
 
 data class UniquenessCheckResultSuccessImpl(
-    override val resultTimestamp: Instant
-) : UniquenessCheckResultSuccess
+    private val resultTimestamp: Instant
+) : UniquenessCheckResultSuccess {
+    override fun getResultTimestamp() = resultTimestamp
+}
 
 data class UniquenessCheckResultFailureImpl(
-    override val resultTimestamp: Instant,
-    override val error: UniquenessCheckError
-) : UniquenessCheckResultFailure
+    private val resultTimestamp: Instant,
+    private val error: UniquenessCheckError
+) : UniquenessCheckResultFailure {
+    override fun getResultTimestamp() = resultTimestamp
+    override fun getError() = error
+}

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckStateDetailsImpl.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckStateDetailsImpl.kt
@@ -5,6 +5,9 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
 import net.corda.v5.crypto.SecureHash
 
 data class UniquenessCheckStateDetailsImpl(
-    override val stateRef: UniquenessCheckStateRef,
-    override val consumingTxId: SecureHash?
-) : UniquenessCheckStateDetails
+    private val stateRef: UniquenessCheckStateRef,
+    private val consumingTxId: SecureHash?
+) : UniquenessCheckStateDetails {
+    override fun getStateRef() = stateRef
+    override fun getConsumingTxId() = consumingTxId
+}

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckStateRefImpl.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckStateRefImpl.kt
@@ -4,8 +4,10 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
 import net.corda.v5.crypto.SecureHash
 
 data class UniquenessCheckStateRefImpl(
-    override val txHash: SecureHash,
-    override val stateIndex: Int
+    private val txHash: SecureHash,
+    private val stateIndex: Int
 ) : UniquenessCheckStateRef {
+    override fun getTxHash() = txHash
+    override fun getStateIndex() = stateIndex
     override fun toString() = "${txHash}:${stateIndex}"
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -179,7 +179,7 @@ class VirtualNodeRepositoryTest {
     @Test
     fun `put throws when Holding Identity does not exist`() {
         val hi = HoldingIdentity(
-            MemberX500Name.Companion.parse("C=GB,L=London,O=Test"),
+            MemberX500Name.parse("C=GB,L=London,O=Test"),
             "group"
         )
         val cpiId = CpiIdentifier("cpi ${UUID.randomUUID()}", "1.0", TestRandom.secureHash())

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
@@ -145,7 +145,7 @@ class NonValidatingNotaryClientFlowImplTest {
                 on { myInfo() } doReturn mockMemberInfo
             },
             mock {
-                on { serialize(any()) } doReturn SerializedBytes("ABC".toByteArray())
+                on { serialize(any<Any>()) } doReturn SerializedBytes("ABC".toByteArray())
             },
             mock {
                 on { sign(any(), any(), any()) } doReturn mockRequestSignature

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -419,7 +419,7 @@ class NonValidatingNotaryServerFlowImplTest {
 
         // 5. Serialization service has no part in this testing so just returning a dummy
         val mockSerializationService = mock<SerializationService> {
-            on { serialize(any()) } doReturn SerializedBytes("ABC".toByteArray())
+            on { serialize(any<Any>()) } doReturn SerializedBytes("ABC".toByteArray())
         }
 
         val server = NonValidatingNotaryServerFlowImpl(

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/doorcode/DoorCodeChangeFlow.kt
@@ -26,7 +26,7 @@ import java.security.PublicKey
 /**
  * A flow to ensure that everyone living in a building gets the new door code before it's changed.
  */
-@InitiatingFlow("door-code")
+@InitiatingFlow(protocol = "door-code")
 class DoorCodeChangeFlow : ClientStartableFlow {
 
     private companion object {
@@ -85,7 +85,7 @@ class DoorCodeChangeFlow : ClientStartableFlow {
     }
 }
 
-@InitiatedBy("door-code")
+@InitiatedBy(protocol = "door-code")
 class DoorCodeChangeResponderFlow : ResponderFlow {
 
     private companion object {

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/AbsenceCallResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/AbsenceCallResponderFlow.kt
@@ -8,7 +8,7 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import org.slf4j.LoggerFactory
 
-@InitiatedBy("absence-call")
+@InitiatedBy(protocol = "absence-call")
 class AbsenceCallResponderFlow: ResponderFlow {
 
     private companion object {

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/AbsenceSubFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/AbsenceSubFlow.kt
@@ -7,7 +7,7 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 
-@InitiatingFlow("absence-call")
+@InitiatingFlow(protocol = "absence-call")
 class AbsenceSubFlow(private val counterparty: MemberX500Name) : SubFlow<String> {
 
     @CordaInject

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallFlow.kt
@@ -22,7 +22,7 @@ import net.cordacon.example.rollcall.utils.findStudents
 import org.slf4j.LoggerFactory
 
 
-@InitiatingFlow("roll-call")
+@InitiatingFlow(protocol = "roll-call")
 class RollCallFlow(val scriptMaker: ScriptMaker = BaseScriptMaker()): ClientStartableFlow {
 
     private data class SessionAndRecipient(val flowSession: FlowSession, val receipient : MemberX500Name)

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/RollCallResponderFlow.kt
@@ -8,7 +8,7 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import org.slf4j.LoggerFactory
 
-@InitiatedBy("roll-call")
+@InitiatedBy(protocol = "roll-call")
 class RollCallResponderFlow: ResponderFlow {
 
     private companion object {

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
@@ -17,7 +17,7 @@ import javax.persistence.Entity
 import javax.persistence.Id
 import javax.persistence.Table
 
-@InitiatedBy("truancy-record")
+@InitiatedBy(protocol = "truancy-record")
 class TruancyResponderFlow : ResponderFlow {
 
     private companion object {

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancySubFlow.kt
@@ -8,14 +8,14 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 import org.slf4j.LoggerFactory
 
-@InitiatingFlow("truancy-record")
+@InitiatingFlow(protocol = "truancy-record")
 class TruancySubFlow(
         private val truancyOffice: MemberX500Name,
         private val truancyRecord: TruancyRecord
     ) : SubFlow<String> {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
 

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SessionManagementTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SessionManagementTest.kt
@@ -27,7 +27,7 @@ class SessionManagementTest {
         val bob = createMember("Bob")
         val charlie =createMember("Charlie")
 
-        @InitiatingFlow("send-receive")
+        @InitiatingFlow(protocol = "send-receive")
         class InitiatingSendingFlow: ClientStartableFlow {
             @CordaInject
             private lateinit var flowMessaging: FlowMessaging
@@ -40,7 +40,7 @@ class SessionManagementTest {
             }
         }
 
-        @InitiatedBy("send-receive")
+        @InitiatedBy(protocol = "send-receive")
         class ReceivingAndSendingOnFlow: ResponderFlow {
             @CordaInject
             private lateinit var flowEngine: FlowEngine
@@ -53,7 +53,7 @@ class SessionManagementTest {
             }
         }
 
-        @InitiatingFlow("receive-send")
+        @InitiatingFlow(protocol = "receive-send")
         class SendingOnSubFlow: SubFlow<String> {
             @CordaInject
             private lateinit var flowMessaging: FlowMessaging

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithResponder.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithResponder.kt
@@ -59,7 +59,7 @@ class FlowContextPropertiesInitiator : ClientStartableFlow{
     }
 }
 
-@InitiatedBy("flow-context-2")
+@InitiatedBy(protocol = "flow-context-2")
 class FlowContextPropertiesResponder : ResponderFlow {
     @CordaInject
     lateinit var flowEngine: FlowEngine

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithSubFlow.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/runtime/flows/FlowContextPropertiesWithSubFlow.kt
@@ -93,7 +93,7 @@ class FlowContextPropertiesSubFlow2 : SubFlow<FlowContextProperties> {
     }
 }
 
-@InitiatedBy("flow-context-2")
+@InitiatedBy(protocol = "flow-context-2")
 class FlowContextPropertiesSubFlowResponder : ResponderFlow {
     @CordaInject
     lateinit var flowEngine: FlowEngine

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/RPCRequestDataWrapper.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/RPCRequestDataWrapper.kt
@@ -24,10 +24,10 @@ data class RPCRequestDataWrapper(
     override fun toRPCRequestData() : RestRequestBody {
         return object : RestRequestBody {
             override fun getRequestBody(): String {
-                return requestBody
+                return this@RPCRequestDataWrapper.requestBody
             }
 
-            override fun <T> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
+            override fun <T : Any> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {
                 return marshallingService.parse(requestBody, clazz)
             }
 

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/flows/InjectingFlowEngine.kt
@@ -21,7 +21,7 @@ import java.util.UUID
  * @param configuration The configuration of the instance of Simulator.
  * @param virtualNodeName The name of the virtual node owner.
  * @param fiber A simulated fiber through which responders should be registered.
- * @param contextProperties The [FlowContextProperties] for the flow.
+ * @param userContextProperties The [FlowContextProperties] for the flow.
  * @param injector An injector which will initialize the services in the subFlow.
  * @param flowChecker A flow checker.
  *
@@ -30,7 +30,7 @@ import java.util.UUID
 @Suppress("LongParameterList")
 class InjectingFlowEngine(
     private val configuration: SimulatorConfiguration,
-    override val virtualNodeName: MemberX500Name,
+    private val virtualNodeName: MemberX500Name,
     private val fiber: SimFiber,
     userContextProperties: FlowContextProperties,
     private val injector: FlowServicesInjector = DefaultServicesInjector(configuration),
@@ -40,14 +40,14 @@ class InjectingFlowEngine(
 
     private val userContextProperties = copyFlowContextProperties(userContextProperties)
     companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    override val flowId: UUID
-        get() = TODO("Not yet implemented")
+    override fun getVirtualNodeName(): MemberX500Name = virtualNodeName
 
-    override val flowContextProperties: FlowContextProperties
-        get() = userContextProperties
+    override fun getFlowId(): UUID = TODO("Not yet implemented")
+
+    override fun getFlowContextProperties(): FlowContextProperties = userContextProperties
 
     override fun <R> subFlow(subFlow: SubFlow<R>): R {
         log.info("Running subflow ${SubFlow::class.java} for \"$virtualNodeName\"")

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
@@ -43,14 +43,14 @@ abstract class BlockingQueueFlowSession(
     /**
      * Not implemented.
      */
-    override val contextProperties: FlowContextProperties
-        get() = flowContextProperties.toImmutableContext()
+    override fun getContextProperties(): FlowContextProperties
+        = flowContextProperties.toImmutableContext()
 
     /**
      * Returns the counterparty with whom this session has been opened.
      */
-    override val counterparty: MemberX500Name
-        get() = flowDetails.member
+    override fun getCounterparty(): MemberX500Name
+        = flowDetails.member
 
     /**
      * Waits to receive a payload from the counterparty, polling to check for any detected errors on the

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/persistence/DbPersistenceService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/persistence/DbPersistenceService.kt
@@ -138,7 +138,7 @@ class DbPersistenceService(member : MemberX500Name) : CloseablePersistenceServic
             private val context: QueryContext = QueryContext(
                 0,
                 Int.MAX_VALUE,
-                mapOf<String, Any>()
+                mapOf()
             )
         ) : ParameterizedQuery<T> {
             override fun execute(): List<T> {
@@ -215,14 +215,14 @@ class DbPersistenceService(member : MemberX500Name) : CloseablePersistenceServic
         }
     }
 
-    override fun <T : Any> find(entityClass: Class<T>, primaryKeys: List<Any>): List<T> {
+    override fun <T : Any> find(entityClass: Class<T>, primaryKeys: List<*>): List<T> {
         return emf.guard {
             primaryKeys.map { pk -> it.find(entityClass, pk) }
         }
     }
 
     override fun <T : Any> findAll(entityClass: Class<T>): PagedQuery<T> {
-        return PagedQueryBase<T>(emf, entityClass)
+        return PagedQueryBase(emf, entityClass)
     }
 
     override fun <T : Any> merge(entity: T): T? {
@@ -243,14 +243,14 @@ class DbPersistenceService(member : MemberX500Name) : CloseablePersistenceServic
         }
     }
 
-    override fun persist(entities: List<Any>) {
+    override fun persist(entities: List<*>) {
         emf.transaction { em ->
             entities.forEach { em.persist(it) }
         }
     }
 
     override fun <T : Any> query(queryName: String, entityClass: Class<T>): ParameterizedQuery<T> {
-        return ParameterizedQueryBase<T>(emf, queryName, entityClass)
+        return ParameterizedQueryBase(emf, queryName, entityClass)
     }
 
     override fun remove(entity: Any) {
@@ -265,7 +265,7 @@ class DbPersistenceService(member : MemberX500Name) : CloseablePersistenceServic
         }
     }
 
-    override fun remove(entities: List<Any>) {
+    override fun remove(entities: List<*>) {
         emf.transaction {
             entities.forEach { entity ->
                 it.remove(if (it.contains(entity)) { entity } else { it.merge(entity) })

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/HelloFlow.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/HelloFlow.kt
@@ -17,7 +17,7 @@ import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
 
-@InitiatingFlow("hello")
+@InitiatingFlow(protocol = "hello")
 class HelloFlow : ClientStartableFlow {
 
     @CordaInject

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/PingAckFlow.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/PingAckFlow.kt
@@ -13,7 +13,7 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 
-@InitiatingFlow("ping-ack")
+@InitiatingFlow(protocol = "ping-ack")
 class PingAckFlow : ClientStartableFlow {
 
     @CordaInject
@@ -31,7 +31,7 @@ class PingAckFlow : ClientStartableFlow {
     }
 }
 
-@InitiatedBy("ping-ack")
+@InitiatedBy(protocol = "ping-ack")
 class PingAckResponderFlow : ResponderFlow {
     @Suspendable
     override fun call(session: FlowSession) {

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/ValidStartingFlow.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/ValidStartingFlow.kt
@@ -5,7 +5,7 @@ import net.corda.v5.application.flows.RestRequestBody
 import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.base.annotations.Suspendable
 
-@InitiatingFlow("valid")
+@InitiatingFlow(protocol = "valid")
 class ValidStartingFlow : ClientStartableFlow {
     @Suspendable
     override fun call(requestBody: RestRequestBody): String {

--- a/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
+++ b/testing/cpbs/ledger-consensual-demo-app/src/main/kotlin/net/cordapp/demo/consensual/ConsensualDemoFlow.kt
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory
  * TODO expand description
  */
 
-@InitiatingFlow("consensual-flow-protocol")
+@InitiatingFlow(protocol = "consensual-flow-protocol")
 class ConsensualDemoFlow : ClientStartableFlow {
     data class InputMessage(val input: String, val members: List<String>)
 
@@ -88,7 +88,7 @@ class ConsensualDemoFlow : ClientStartableFlow {
     }
 }
 
-@InitiatedBy("consensual-flow-protocol")
+@InitiatedBy(protocol = "consensual-flow-protocol")
 class ConsensualResponderFlow : ResponderFlow {
 
     private companion object {

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
@@ -28,7 +28,7 @@ import java.security.PublicKey
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-@InitiatingFlow("utxo-backchain-resolution-protocol")
+@InitiatingFlow(protocol = "utxo-backchain-resolution-protocol")
 class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
     data class InputMessage(val input: String, val members: List<String>)
 
@@ -247,7 +247,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
     }
 }
 
-@InitiatedBy("utxo-backchain-resolution-protocol")
+@InitiatedBy(protocol = "utxo-backchain-resolution-protocol")
 class UtxoBackchainResolutionDemoResponderFlow : ResponderFlow {
 
     private companion object {

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
@@ -21,7 +21,7 @@ import net.cordapp.demo.utxo.contract.TestUtxoState
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
-@InitiatingFlow("utxo-evolve-protocol")
+@InitiatingFlow(protocol = "utxo-evolve-protocol")
 class UtxoDemoEvolveFlow : ClientStartableFlow {
 
     data class EvolveMessage(val update: String, val transactionId: String, val index: Int)
@@ -104,7 +104,7 @@ class UtxoDemoEvolveFlow : ClientStartableFlow {
 }
 
 
-@InitiatedBy("utxo-evolve-protocol")
+@InitiatedBy(protocol = "utxo-evolve-protocol")
 class UtxoEvolveResponderFlow : ResponderFlow {
 
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
@@ -27,7 +27,7 @@ import java.time.Instant
  * TODO expand description
  */
 
-@InitiatingFlow("utxo-flow-protocol")
+@InitiatingFlow(protocol = "utxo-flow-protocol")
 class UtxoDemoFlow : ClientStartableFlow {
     data class InputMessage(val input: String, val members: List<String>, val notary: String)
 
@@ -101,7 +101,7 @@ class UtxoDemoFlow : ClientStartableFlow {
     }
 }
 
-@InitiatedBy("utxo-flow-protocol")
+@InitiatedBy(protocol = "utxo-flow-protocol")
 class UtxoResponderFlow : ResponderFlow {
 
     private companion object {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SubFlowSmokeTestFlows.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SubFlowSmokeTestFlows.kt
@@ -15,7 +15,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.cordapp.testing.smoketests.flow.messages.InitiatedSmokeTestMessage
 import org.slf4j.LoggerFactory
 
-@InitiatingFlow("subflow-protocol")
+@InitiatingFlow(protocol = "subflow-protocol")
 class InitiatingSubFlowSmokeTestFlow(
     private val x500Name: MemberX500Name,
     private val initiateSessionInInitiatingFlow: Boolean,
@@ -51,7 +51,7 @@ class InlineSubFlowSmokeTestFlow(
 ) : SubFlow<InitiatedSmokeTestMessage> {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable
@@ -67,7 +67,7 @@ class InlineSubFlowSmokeTestFlow(
     }
 }
 
-@InitiatedBy("subflow-protocol")
+@InitiatedBy(protocol = "subflow-protocol")
 class InitiatingSubFlowResponderSmokeTestFlow : ResponderFlow {
 
     private companion object {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/BrokenProtocolFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/BrokenProtocolFlow.kt
@@ -21,12 +21,7 @@ class BrokenProtocolFlow : ClientStartableFlow {
     @Suspendable
     override fun call(requestBody: RestRequestBody): String {
         val session = messaging.initiateFlow(
-            MemberX500Name(
-                commonName = "Alice",
-                organization = "Alice Corp",
-                locality = "LDN",
-                country = "GB"
-            )
+            MemberX500Name("Alice", "Alice Corp", "LDN", "GB")
         )
         session.sendAndReceive<MyClass>(MyClass("Serialize me please", 1))
         return ""

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/PersistenceFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/PersistenceFlow.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 class PersistenceFlow : ClientStartableFlow {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoardMember.kt
@@ -4,7 +4,7 @@ import kong.unirest.Unirest
 import kong.unirest.json.JSONArray
 import kong.unirest.json.JSONObject
 import net.corda.cli.plugins.packaging.CreateCpiV2
-import net.corda.v5.base.util.toBase64
+import net.corda.v5.base.util.EncodingUtils.toBase64
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.File
@@ -176,7 +176,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
         }
         return digest
             .digest()
-            .toBase64()
+            .let(::toBase64)
             .replace('/', '.')
             .replace('+', '-')
             .replace('=', '_')


### PR DESCRIPTION
Updates required now that `:base` and `:application` are _mostly_  Java APIs.

This cannot be completely seamless because Java has no concept of Kotlin properties, but _"Them's the breaks!"_.

Notable changes:
- Migration of `EncodingUtils` to a set of `static` functions.
- Annotation parameters must now be specified by name, e.g. `@InitiatingFlow(protocol = 1)`
- Function parameters cannot be specified by name.
- Annotations such as `@Suspendable` or `@VisibleForTesting` must be applied to property getters and setters rather than to the property itself, e.g.
```kotlin
val thingy: String
    @Suspendable
    get() = thingyValue
```
or
```kotlin
@get:Suspendable
val thingy: String = thingyValue
```