### PR TITLE
CORE-9160: Ignore States 4 Partitions Not Synced

### DIFF
--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
@@ -46,7 +46,7 @@ class SessionEventExecutor(
         val eventPayload = sessionEvent.payload
 
         return if (eventPayload !is SessionError) {
-            log.error("Flow mapper received session event for session which does not exist. Session may have expired. Returning error to " +
+            log.warn("Flow mapper received session event for session which does not exist. Session may have expired. Returning error to " +
                     "counterparty. Key: $eventKey, Event: $sessionEvent")
             val sessionId = sessionEvent.sessionId
             FlowMapperResult(

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -68,8 +68,11 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
         }
 
         stateConsumer.poll(STATE_POLL_TIMEOUT).forEach { state ->
-            log.debug { "Updating state: $state" }
-            updateInMemoryState(state)
+            log.debug { "Processing state: $state" }
+            // Do not update in memory state unless we are syncing as we are already guaranteed to have the latest state
+            if (partitionsToSync.containsKey(state.partition)) {
+                updateInMemoryState(state)
+            }
         }
 
         if (syncPartitions && partitionsToSync.isNotEmpty()) {


### PR DESCRIPTION
When polling and updating states within the state and event message
pattern, do not update the in memory states for partitions that are not
currently marked as being synced.

- Add unit test.
- Reduce session not found log message level from 'ERROR' to 'WARN'.
