### PR TITLE
CORE-10286: squash WrappingKeyStore into CachingSoftWrappingKeyMap.kt

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -310,7 +310,7 @@ class CryptoOpsBusProcessorTests {
         assertEquals(context.items[0].value, operationContextMap[CTX_TRACKING])
         assertEquals(context.items[1].value, operationContextMap["reason"])
         assertEquals(tenantId, operationContextMap[CRYPTO_TENANT_ID])
-        assertThat(factory.wrappingKeyStore.keys).containsKey(masterKeyAlias)
+        assertThat(factory.cryptoConnectionsFactory.exists(masterKeyAlias)).isTrue()
     }
 
     @Test
@@ -329,6 +329,7 @@ class CryptoOpsBusProcessorTests {
         val otherKeyEnc = ByteBuffer.wrap(factory.schemeMetadata.encodeAsByteArray(otherKeyPair.public))
         val secret = process<CryptoDerivedSharedSecret>(DeriveSharedSecretCommand(keyEnc, otherKeyEnc, context))
         val operationContextMap = factory.recordedCryptoContexts[context.items[0].value]
+
         assertNotNull(operationContextMap)
         assertEquals(3, operationContextMap.size)
         assertEquals(context.items[0].value, operationContextMap[CTX_TRACKING])

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/InMemoryCryptoConnectionsFactory.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/InMemoryCryptoConnectionsFactory.kt
@@ -1,0 +1,68 @@
+package net.corda.crypto.service.impl.infra
+
+import net.corda.crypto.persistence.CryptoConnectionsFactory
+import net.corda.crypto.persistence.db.model.WrappingKeyEntity
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.util.concurrent.ConcurrentHashMap
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import javax.persistence.EntityTransaction
+
+
+/** An in-memory implementation of CryptoConnetionsFactory
+ *
+ * Doesn't need lifecycle, but can optionally participate in lifecycle for test purposes.
+ */
+class InMemoryCryptoConnectionsFactory(
+    val coordinatorFactory: LifecycleCoordinatorFactory? = null
+) : CryptoConnectionsFactory {
+    val keys: ConcurrentHashMap<String, WrappingKeyEntity> = ConcurrentHashMap()
+
+    val entityTransaction: EntityTransaction = mock()
+
+    val entityManager = mock<EntityManager> {
+        on { persist(any()) }.thenAnswer {
+            val wrappingKeyEntity = it.arguments.first() as WrappingKeyEntity
+            keys[wrappingKeyEntity.alias] = wrappingKeyEntity
+            null
+        }
+        on { find<Any>(any(), any()) }.thenAnswer {
+            val alias = it.arguments[1] as String
+            keys[alias]
+        }
+        on { transaction } doReturn entityTransaction
+    }
+
+    val emf = mock<EntityManagerFactory> {
+        on { createEntityManager() } doReturn entityManager
+    }
+
+    override fun getEntityManagerFactory(tenantId: String): EntityManagerFactory = emf
+
+    fun exists(alias: String): Boolean = keys.containsKey(alias)
+
+    val lifecycleCoordinator = coordinatorFactory?.createCoordinator(
+        LifecycleCoordinatorName.forComponent<CryptoConnectionsFactory>(),
+    ) { event, coordinator ->
+        if (event is StartEvent) {
+            coordinator.updateStatus(LifecycleStatus.UP)
+        }
+    }
+
+    override val isRunning: Boolean
+        get() = lifecycleCoordinator?.isRunning ?: true
+
+    override fun start() {
+        lifecycleCoordinator?.start()
+    }
+
+    override fun stop() {
+        lifecycleCoordinator?.stop()
+    }
+}

--- a/components/crypto/crypto-softhsm-impl/build.gradle
+++ b/components/crypto/crypto-softhsm-impl/build.gradle
@@ -21,11 +21,13 @@ dependencies {
     implementation project(":components:crypto:crypto-hes")
     implementation project(":components:crypto:crypto-hes-core-impl")
     implementation project(":components:crypto:crypto-persistence")
+    implementation project(":components:crypto:crypto-persistence-model")
     implementation project(":libs:cache:cache-caffeine")
     implementation project(":libs:configuration:configuration-core")
     implementation project(':libs:crypto:cipher-suite-impl')
     implementation project(':libs:crypto:crypto-core')
     implementation project(":libs:lifecycle:lifecycle")
+    implementation project(":libs:db:db-orm")
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation project(":components:crypto:crypto-component-test-utils")

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/CachingSoftWrappingKeyMap.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/CachingSoftWrappingKeyMap.kt
@@ -3,47 +3,64 @@ package net.corda.crypto.softhsm.impl
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.cache.caffeine.CacheFactoryImpl
+import net.corda.crypto.core.CryptoTenants
 import net.corda.crypto.core.aes.WrappingKey
-import net.corda.crypto.persistence.WrappingKeyInfo
-import net.corda.crypto.persistence.WrappingKeyStore
+import net.corda.crypto.persistence.CryptoConnectionsFactory
+import net.corda.crypto.persistence.db.model.WrappingKeyEntity
 import net.corda.crypto.softhsm.SoftCacheConfig
 import net.corda.crypto.softhsm.SoftWrappingKeyMap
 import net.corda.crypto.softhsm.WRAPPING_KEY_ENCODING_VERSION
+import net.corda.orm.utils.use
+import net.corda.orm.utils.transaction
+import java.time.Instant
 import java.util.concurrent.TimeUnit
+
+
+// TODO - rename to AliasWrappingKeyMap
 
 class CachingSoftWrappingKeyMap(
     config: SoftCacheConfig,
-    private val store: WrappingKeyStore,
-    private val master: WrappingKey
+    private val master: WrappingKey,
+    private val connectionsFactory: CryptoConnectionsFactory
 ) : SoftWrappingKeyMap {
     private val cache: Cache<String, WrappingKey> = CacheFactoryImpl().build(
         "HSM-Wrapping-Keys-Map",
         Caffeine.newBuilder()
             .expireAfterAccess(config.expireAfterAccessMins, TimeUnit.MINUTES)
-            .maximumSize(config.maximumSize))
+            .maximumSize(config.maximumSize)
+    )
+
+    private fun entityManagerFactory() = connectionsFactory.getEntityManagerFactory(CryptoTenants.CRYPTO)
+
+    private fun findWrappingKey(alias: String): WrappingKeyEntity? = entityManagerFactory().use { em ->
+        em.find(WrappingKeyEntity::class.java, alias)
+    }
 
     override fun getWrappingKey(alias: String): WrappingKey = cache.get(alias) {
-        val wrappingKeyInfo = store.findWrappingKey(alias)
-            ?: throw IllegalStateException("The $alias is not created yet.")
-        require(wrappingKeyInfo.encodingVersion == WRAPPING_KEY_ENCODING_VERSION) {
+        val key = findWrappingKey(alias) ?: throw IllegalStateException("$alias not found")
+        require(key.encodingVersion == WRAPPING_KEY_ENCODING_VERSION) {
             "Unknown wrapping key encoding. Expected to be $WRAPPING_KEY_ENCODING_VERSION"
         }
-        require(master.algorithm == wrappingKeyInfo.algorithmName) {
-            "Expected algorithm is ${master.algorithm} but was ${wrappingKeyInfo.algorithmName}"
+        require(master.algorithm == key.algorithmName) {
+            "Expected algorithm is ${master.algorithm} but was ${key.algorithmName}"
         }
-        master.unwrapWrappingKey(wrappingKeyInfo.keyMaterial)
+        master.unwrapWrappingKey(key.keyMaterial)
     }
 
     override fun putWrappingKey(alias: String, wrappingKey: WrappingKey) {
-        val wrappingKeyInfo = WrappingKeyInfo(
-            encodingVersion = WRAPPING_KEY_ENCODING_VERSION,
-            algorithmName = wrappingKey.algorithm,
-            keyMaterial = master.wrap(wrappingKey)
-        )
-        store.saveWrappingKey(alias, wrappingKeyInfo)
+        entityManagerFactory().transaction { em ->
+            em.persist(
+                WrappingKeyEntity(
+                    alias = alias,
+                    created = Instant.now(),
+                    encodingVersion = WRAPPING_KEY_ENCODING_VERSION,
+                    algorithmName = wrappingKey.algorithm,
+                    keyMaterial = master.wrap(wrappingKey)
+                )
+            )
+        }
         cache.put(alias, wrappingKey)
     }
 
-    override fun exists(alias: String): Boolean =
-        cache.getIfPresent(alias) != null || store.findWrappingKey(alias) != null
+    override fun exists(alias: String): Boolean = cache.getIfPresent(alias) != null || findWrappingKey(alias) != null
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
@@ -7,7 +7,7 @@ import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.crypto.component.impl.AbstractComponent
 import net.corda.crypto.component.impl.DependenciesTracker
 import net.corda.crypto.core.aes.WrappingKey
-import net.corda.crypto.persistence.WrappingKeyStore
+import net.corda.crypto.persistence.CryptoConnectionsFactory
 import net.corda.crypto.softhsm.CryptoServiceProvider
 import net.corda.crypto.softhsm.KEY_MAP_CACHING_NAME
 import net.corda.crypto.softhsm.KEY_MAP_TRANSIENT_NAME
@@ -45,14 +45,14 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
     private val schemeMetadata: CipherSchemeMetadata,
     @Reference(service = PlatformDigestService::class)
     private val digestService: PlatformDigestService,
-    @Reference(service = WrappingKeyStore::class)
-    private val store: WrappingKeyStore
+    @Reference(service = CryptoConnectionsFactory::class)
+    private val connectionsFactory: CryptoConnectionsFactory
 ) : AbstractComponent<SoftCryptoServiceProviderImpl.Impl>(
     coordinatorFactory = coordinatorFactory,
     myName = lifecycleCoordinatorName,
     upstream = DependenciesTracker.Default(
         setOf(
-            LifecycleCoordinatorName.forComponent<WrappingKeyStore>()
+            LifecycleCoordinatorName.forComponent<CryptoConnectionsFactory>()
         )
     )
 ), SoftCryptoServiceProvider {
@@ -61,7 +61,7 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
         private val lifecycleCoordinatorName = LifecycleCoordinatorName.forComponent<SoftCryptoServiceProvider>()
     }
 
-    override fun createActiveImpl(): Impl = Impl(schemeMetadata, digestService, store)
+    override fun createActiveImpl(): Impl = Impl(schemeMetadata, digestService, connectionsFactory)
 
     override fun getInstance(config: SmartConfig): CryptoService = impl.getInstance(config)
 
@@ -70,7 +70,7 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
     class Impl(
         private val schemeMetadata: CipherSchemeMetadata,
         private val digestService: PlatformDigestService,
-        private val store: WrappingKeyStore
+        private val connectionsFactory: CryptoConnectionsFactory
     ) : AbstractImpl {
 
         fun getInstance(config: SmartConfig): CryptoService {
@@ -111,7 +111,7 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
                 KEY_MAP_TRANSIENT_NAME -> SoftCacheConfig(0, 0)
                 else -> wrappingKeyMapCacheConfig
             }
-            return CachingSoftWrappingKeyMap(finalWrappingKeyMapCacheConfig, store, masterKey)
+            return CachingSoftWrappingKeyMap(finalWrappingKeyMapCacheConfig, masterKey, connectionsFactory)
         }
 
         // TODO - rework to use Config directly

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/CachingSoftWrappingKeyMapTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/CachingSoftWrappingKeyMapTests.kt
@@ -1,21 +1,24 @@
 package net.corda.crypto.softhsm.impl
 
 import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
-import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.core.aes.WrappingKey
-import net.corda.crypto.persistence.WrappingKeyInfo
-import net.corda.crypto.persistence.WrappingKeyStore
+import net.corda.crypto.persistence.CryptoConnectionsFactory
+import net.corda.crypto.persistence.db.model.WrappingKeyEntity
 import net.corda.crypto.softhsm.SoftCacheConfig
 import net.corda.crypto.softhsm.WRAPPING_KEY_ENCODING_VERSION
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
+import java.time.Instant
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import javax.persistence.EntityTransaction
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
@@ -26,34 +29,55 @@ import kotlin.test.assertTrue
  * testing as by default the eviction is scheduled on an executor, so it's not exactly deterministic.
  */
 class CachingSoftWrappingKeyMapTests {
-    companion object {
-        private lateinit var schemeMetadata: CipherSchemeMetadata
+    private val schemeMetadata = CipherSchemeMetadataImpl()
+    private val master = WrappingKey.generateWrappingKey(schemeMetadata)
+    private val expected1 = WrappingKey.generateWrappingKey(schemeMetadata)
+    private val expected2 = WrappingKey.generateWrappingKey(schemeMetadata)
 
-        @JvmStatic
-        @BeforeAll
-        fun setup() {
-            schemeMetadata = CipherSchemeMetadataImpl()
+    private val alias1 = "master-alias-1"
+    private val alias2 = "master-alias-2"
+
+    private val now = Instant.now()
+
+
+    private fun makeCachingSoftWrappingKeyMapWithMockedDatabase(entityManager: EntityManager): CachingSoftWrappingKeyMap {
+        val emf = mock<EntityManagerFactory> {
+            on { createEntityManager() } doReturn entityManager
         }
+        val connectionsFactory = mock<CryptoConnectionsFactory> {
+            on { getEntityManagerFactory(any()) } doReturn emf
+        }
+        val cut = CachingSoftWrappingKeyMap(
+            SoftCacheConfig(expireAfterAccessMins = 2, maximumSize = 3),
+            master,
+            connectionsFactory
+        )
+        return cut
     }
 
     @Test
     fun `getWrappingKey should cache requested key using alias as cache key`() {
-        val master = WrappingKey.generateWrappingKey(schemeMetadata)
-        val expected1 = WrappingKey.generateWrappingKey(schemeMetadata)
-        val expected2 = WrappingKey.generateWrappingKey(schemeMetadata)
-        val alias1 = "master-alias-1"
-        val alias2 = "master-alias-2"
-        val info1 = WrappingKeyInfo(WRAPPING_KEY_ENCODING_VERSION, expected1.algorithm, master.wrap(expected1))
-        val info2 = WrappingKeyInfo(WRAPPING_KEY_ENCODING_VERSION, expected2.algorithm, master.wrap(expected2))
-        val store = mock<WrappingKeyStore> {
-            on { findWrappingKey(alias1) } doReturn info1
-            on { findWrappingKey(alias2) } doReturn info2
+        val info1 =
+            WrappingKeyEntity(
+                alias1,
+                now,
+                WRAPPING_KEY_ENCODING_VERSION,
+                expected1.algorithm,
+                master.wrap(expected1)
+            ) // TODO renaame
+        val info2 =
+            WrappingKeyEntity(
+                alias2,
+                now,
+                WRAPPING_KEY_ENCODING_VERSION,
+                expected2.algorithm,
+                master.wrap(expected2)
+            ) // TODO renaame
+        val entityManager = mock<EntityManager> {
+            on { find(WrappingKeyEntity::class.java, alias1) } doReturn info1
+            on { find(WrappingKeyEntity::class.java, alias2) } doReturn info2
         }
-        val cut = CachingSoftWrappingKeyMap(
-            SoftCacheConfig(expireAfterAccessMins = 2, maximumSize = 3),
-            store,
-            master
-        )
+        val cut = makeCachingSoftWrappingKeyMapWithMockedDatabase(entityManager)
         val key11 = cut.getWrappingKey(alias1)
         assertEquals(expected1, key11)
         val key21 = cut.getWrappingKey(alias2)
@@ -65,117 +89,90 @@ class CachingSoftWrappingKeyMapTests {
         val key22 = cut.getWrappingKey(alias2)
         assertEquals(expected2, key22)
 
-        Mockito.verify(store, times(2)).findWrappingKey(any())
+        Mockito.verify(entityManager, times(1)).find(WrappingKeyEntity::class.java, alias1)
+        Mockito.verify(entityManager, times(1)).find(WrappingKeyEntity::class.java, alias2)
     }
 
     @Test
     fun `getWrappingKey should throw IllegalArgumentException when encoding version is not recognised`() {
-        val master = WrappingKey.generateWrappingKey(schemeMetadata)
-        val expected = WrappingKey.generateWrappingKey(schemeMetadata)
-        val alias = "master-alias-1"
-        val info = WrappingKeyInfo(
-            WRAPPING_KEY_ENCODING_VERSION + 1,
-            expected.algorithm,
-            master.wrap(expected)
-        )
-        val store = mock<WrappingKeyStore> {
-            on { findWrappingKey(alias) } doReturn info
+        val badVersion = WRAPPING_KEY_ENCODING_VERSION + 1
+        val entity1 = WrappingKeyEntity(alias1, now, badVersion, expected1.algorithm, master.wrap(expected1))
+        val entityManager = mock<EntityManager> {
+            on { find(WrappingKeyEntity::class.java, alias1) } doReturn entity1
         }
-        val cut = CachingSoftWrappingKeyMap(
-            SoftCacheConfig(expireAfterAccessMins = 2, maximumSize = 3),
-            store,
-            master
-        )
+        val cut = makeCachingSoftWrappingKeyMapWithMockedDatabase(entityManager)
         assertThrows<IllegalArgumentException> {
-            cut.getWrappingKey(alias)
+            cut.getWrappingKey(alias1)
         }
     }
 
     @Test
     fun `getWrappingKey should throw IllegalArgumentException when key algorithm does not match master key`() {
-        val master = WrappingKey.generateWrappingKey(schemeMetadata)
-        val expected = WrappingKey.generateWrappingKey(schemeMetadata)
-        val alias = "master-alias-1"
-        val info = WrappingKeyInfo(
+        val entity1 = WrappingKeyEntity(
+            alias1,
+            now,
             WRAPPING_KEY_ENCODING_VERSION,
-            expected.algorithm + "!",
-            master.wrap(expected)
+            expected1.algorithm + "!",
+            master.wrap(expected1)
         )
-        val store = mock<WrappingKeyStore> {
-            on { findWrappingKey(alias) } doReturn info
+
+        val entityManager = mock<EntityManager> {
+            on { find(WrappingKeyEntity::class.java, alias1) } doReturn entity1
         }
-        val cut = CachingSoftWrappingKeyMap(
-            SoftCacheConfig(expireAfterAccessMins = 2, maximumSize = 3),
-            store,
-            master
-        )
+        val cut = makeCachingSoftWrappingKeyMapWithMockedDatabase(entityManager)
         assertThrows<IllegalArgumentException> {
-            cut.getWrappingKey(alias)
+            cut.getWrappingKey(alias1)
         }
     }
 
     @Test
     fun `getWrappingKey should throw IllegalStateException when wrapping key is not found`() {
-        val master = WrappingKey.generateWrappingKey(schemeMetadata)
-        val alias = "master-alias-1"
-        val store = mock<WrappingKeyStore> {
-            on { findWrappingKey(alias) } doReturn null
+        val entityManager = mock<EntityManager> {
+            on { find(WrappingKeyEntity::class.java, alias1) } doReturn null
         }
-        val cut = CachingSoftWrappingKeyMap(
-            SoftCacheConfig(expireAfterAccessMins = 2, maximumSize = 3),
-            store,
-            master
-        )
+        val cut = makeCachingSoftWrappingKeyMapWithMockedDatabase(entityManager)
         assertThrows<IllegalStateException> {
-            cut.getWrappingKey(alias)
+            cut.getWrappingKey(alias1)
         }
     }
 
     @Test
     fun `putWrappingKey should put to cache using public key as cache key`() {
-        val master = WrappingKey.generateWrappingKey(schemeMetadata)
-        val expected = WrappingKey.generateWrappingKey(schemeMetadata)
-        val alias = "master-alias"
-        val info = WrappingKeyInfo(WRAPPING_KEY_ENCODING_VERSION, expected.algorithm, master.wrap(expected))
-        val store = mock<WrappingKeyStore> {
-            on { findWrappingKey(alias) } doReturn info
+        val entityTransaction: EntityTransaction = mock()
+        val entityManager = mock<EntityManager> {
+            on { transaction } doReturn entityTransaction
         }
-        val cut = CachingSoftWrappingKeyMap(
-            SoftCacheConfig(expireAfterAccessMins = 2, maximumSize = 3),
-            store,
-            master
-        )
-        cut.putWrappingKey(alias, expected)
-        val key = cut.getWrappingKey(alias)
-        assertEquals(expected, key)
-        Mockito.verify(store, times(1)).saveWrappingKey(any(), any())
-        Mockito.verify(store, never()).findWrappingKey(any())
+        val cut = makeCachingSoftWrappingKeyMapWithMockedDatabase(entityManager)
+        cut.putWrappingKey(alias1, expected1)
+        val key = cut.getWrappingKey(alias1)
+        assertEquals(expected1, key)
+        Mockito.verify(entityManager, times(1)).persist(any())
+        Mockito.verify(entityManager, never()).find(eq(WrappingKeyEntity::class.java), any())
     }
 
     @Test
     fun `exists should return true whenever key exist in cache or store and false otherwise`() {
-        val master = WrappingKey.generateWrappingKey(CipherSchemeMetadataImpl())
-        val expected1 = WrappingKey.generateWrappingKey(CipherSchemeMetadataImpl())
-        val expected2 = WrappingKey.generateWrappingKey(CipherSchemeMetadataImpl())
-        val alias1 = "master-alias-1"
-        val alias2 = "master-alias-2"
         val alias3 = "master-alias-3"
-        val info1 = WrappingKeyInfo(WRAPPING_KEY_ENCODING_VERSION, expected1.algorithm, master.wrap(expected1))
-        val info2 = WrappingKeyInfo(WRAPPING_KEY_ENCODING_VERSION, expected2.algorithm, master.wrap(expected2))
-        val store = mock<WrappingKeyStore> {
-            on { findWrappingKey(alias1) } doReturn info1
-            on { findWrappingKey(alias2) } doReturn info2
-            on { findWrappingKey(alias3) } doReturn null
+        val entity1 =
+            WrappingKeyEntity(alias1, now, WRAPPING_KEY_ENCODING_VERSION, expected1.algorithm, master.wrap(expected1))
+        val entity2 =
+            WrappingKeyEntity(alias2, now, WRAPPING_KEY_ENCODING_VERSION, expected2.algorithm, master.wrap(expected2))
+        val entityTransaction: EntityTransaction = mock()
+        val entityManager = mock<EntityManager> {
+            on { transaction } doReturn entityTransaction
+            on { find(WrappingKeyEntity::class.java, alias1) } doReturn entity1
+            on { find(WrappingKeyEntity::class.java, alias2) } doReturn entity2
+            on { find(WrappingKeyEntity::class.java, alias3) } doReturn null
         }
-        val cut = CachingSoftWrappingKeyMap(
-            SoftCacheConfig(expireAfterAccessMins = 2, maximumSize = 3),
-            store,
-            master
-        )
+        val cut = makeCachingSoftWrappingKeyMapWithMockedDatabase(entityManager)
         cut.putWrappingKey(alias1, expected1)
 
         assertTrue(cut.exists(alias1), "Should exist from cache")
+        Mockito.verify(entityManager, never()).find(eq(WrappingKeyEntity::class.java), any())
         assertTrue(cut.exists(alias2), "Should exist from store")
+        Mockito.verify(entityManager, times(1)).find(eq(WrappingKeyEntity::class.java), any())
         assertFalse(cut.exists(alias3), "Should not exist")
+        Mockito.verify(entityManager, times(2)).find(eq(WrappingKeyEntity::class.java), any())
+
     }
 }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/InMemoryCryptoConnectionsFactory.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/InMemoryCryptoConnectionsFactory.kt
@@ -1,0 +1,68 @@
+package net.corda.crypto.softhsm.impl
+
+import net.corda.crypto.persistence.CryptoConnectionsFactory
+import net.corda.crypto.persistence.db.model.WrappingKeyEntity
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.util.concurrent.ConcurrentHashMap
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import javax.persistence.EntityTransaction
+
+
+/** An in-memory implementation of CryptoConnetionsFactory
+ *
+ * Doesn't need lifecycle, but can optionally participate in lifecycle for test purposes.
+ */
+class InMemoryCryptoConnectionsFactory(
+    val coordinatorFactory: LifecycleCoordinatorFactory? = null
+) : CryptoConnectionsFactory {
+    val keys: ConcurrentHashMap<String, WrappingKeyEntity> = ConcurrentHashMap()
+
+    val entityTransaction: EntityTransaction = mock()
+
+    val entityManager = mock<EntityManager> {
+        on { persist(any()) }.thenAnswer {
+            val wrappingKeyEntity = it.arguments.first() as WrappingKeyEntity
+            keys[wrappingKeyEntity.alias] = wrappingKeyEntity
+            null
+        }
+        on { find<Any>(any(), any()) }.thenAnswer {
+            val alias = it.arguments[1] as String
+            keys[alias]
+        }
+        on { transaction } doReturn entityTransaction
+    }
+
+    val emf = mock<EntityManagerFactory> {
+        on { createEntityManager() } doReturn entityManager
+    }
+
+    override fun getEntityManagerFactory(tenantId: String): EntityManagerFactory = emf
+
+    fun exists(alias: String): Boolean = keys.containsKey(alias)
+
+    val lifecycleCoordinator = coordinatorFactory?.createCoordinator(
+        LifecycleCoordinatorName.forComponent<CryptoConnectionsFactory>(),
+    ) { event, coordinator ->
+        if (event is StartEvent) {
+            coordinator.updateStatus(LifecycleStatus.UP)
+        }
+    }
+
+    override val isRunning: Boolean
+        get() = lifecycleCoordinator?.isRunning ?: true
+
+    override fun start() {
+        lifecycleCoordinator?.start()
+    }
+
+    override fun stop() {
+        lifecycleCoordinator?.stop()
+    }
+}

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
@@ -4,6 +4,7 @@ import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.crypto.cipher.suite.CRYPTO_CATEGORY
 import net.corda.crypto.cipher.suite.CRYPTO_TENANT_ID
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.cipher.suite.CryptoServiceExtensions
 import net.corda.crypto.cipher.suite.KeyGenerationSpec
 import net.corda.crypto.cipher.suite.KeyMaterialSpec
 import net.corda.crypto.cipher.suite.SharedSecretWrappedSpec
@@ -20,6 +21,7 @@ import net.corda.v5.crypto.EDDSA_ED25519_CODE_NAME
 import net.corda.v5.crypto.OID_COMPOSITE_KEY
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.X25519_CODE_NAME
+import org.assertj.core.api.Assertions
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -281,5 +283,28 @@ class SoftCryptoServiceGeneralTests {
                 )
             )
         }
+    }
+
+    @Test
+    fun `SoftCryptoService should require wrapping key`() {
+        val cryptoService = SoftCryptoService(
+            mock(),
+            mock(),
+            schemeMetadata,
+            mock()
+        )
+        Assertions.assertThat(cryptoService.extensions).contains(CryptoServiceExtensions.REQUIRE_WRAPPING_KEY)
+    }
+
+
+    @Test
+    fun `SoftCryptoService should not support key deletion`() {
+        val cryptoService = SoftCryptoService(
+            mock(),
+            mock(),
+            schemeMetadata,
+            mock()
+        )
+        Assertions.assertThat(cryptoService.extensions).doesNotContain(CryptoServiceExtensions.DELETE_KEYS)
     }
 }


### PR DESCRIPTION

For now we do not eliminate WrappingKeyStore, since this PR is large enough already, and some of the tests for WrappingKeyStore cover the WrappingKeyEntity we still use.
