### PR TITLE
CORE-10402 Make transaction builders mutable

### DIFF
--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImpl.kt
@@ -11,17 +11,20 @@ import java.util.Objects
 class ConsensualTransactionBuilderImpl(
     private val consensualSignedTransactionFactory: ConsensualSignedTransactionFactory,
     // cpi defines what type of signing/hashing is used (related to the digital signature signing and verification stuff)
-    override val states: List<ConsensualState> = emptyList(),
+    override val states: MutableList<ConsensualState> = mutableListOf(),
 ) : ConsensualTransactionBuilder {
 
     private var alreadySigned = false
 
-    override fun withStates(vararg states: ConsensualState): ConsensualTransactionBuilder =
-        copy(states = this.states + states)
+     override fun withStates(vararg states: ConsensualState): ConsensualTransactionBuilder {
+        this.states += states
+        return this
+    }
 
     @Suspendable
-    override fun toSignedTransaction(): ConsensualSignedTransaction =
-        sign()
+    override fun toSignedTransaction(): ConsensualSignedTransaction {
+        return sign()
+    }
 
     @Suspendable
     fun sign(): ConsensualSignedTransaction {
@@ -30,13 +33,6 @@ class ConsensualTransactionBuilderImpl(
         return consensualSignedTransactionFactory.create(this).also {
             alreadySigned = true
         }
-    }
-
-    private fun copy(states: List<ConsensualState> = this.states): ConsensualTransactionBuilderImpl {
-        return ConsensualTransactionBuilderImpl(
-            consensualSignedTransactionFactory,
-            states,
-        )
     }
 
     override fun equals(other: Any?): Boolean {

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
@@ -6,6 +6,7 @@ import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.ledger.consensual.testkit.ConsensualStateClassExample
 import net.corda.ledger.consensual.testkit.consensualStateExample
 import net.corda.v5.crypto.SecureHash
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -82,5 +83,14 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
             )
         )
         assertEquals(expectedCpkMetadata, metadata.getCpkMetadata())
+    }
+
+    @Test
+    fun `adding states mutates and returns the current builder`() {
+        val originalTransactionBuilder = consensualTransactionBuilder
+        val mutatedTransactionBuilder = consensualTransactionBuilder.withStates(consensualStateExample)
+        assertThat(mutatedTransactionBuilder.states).isEqualTo(listOf(consensualStateExample))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -18,16 +18,16 @@ import java.time.Instant
 import java.util.Objects
 
 @Suppress("TooManyFunctions")
-data class UtxoTransactionBuilderImpl(
+class UtxoTransactionBuilderImpl(
     private val utxoSignedTransactionFactory: UtxoSignedTransactionFactory,
-    override val notary: Party? = null,
-    override val timeWindow: TimeWindow? = null,
-    override val attachments: List<SecureHash> = emptyList(),
-    override val commands: List<Command> = emptyList(),
-    override val signatories: List<PublicKey> = emptyList(),
-    override val inputStateRefs: List<StateRef> = emptyList(),
-    override val referenceStateRefs: List<StateRef> = emptyList(),
-    override val outputStates: List<ContractStateAndEncumbranceTag> = emptyList()
+    override var notary: Party? = null,
+    override var timeWindow: TimeWindow? = null,
+    override val attachments: MutableList<SecureHash> = mutableListOf(),
+    override val commands: MutableList<Command> = mutableListOf(),
+    override val signatories: MutableList<PublicKey> = mutableListOf(),
+    override val inputStateRefs: MutableList<StateRef> = mutableListOf(),
+    override val referenceStateRefs: MutableList<StateRef> = mutableListOf(),
+    override val outputStates: MutableList<ContractStateAndEncumbranceTag> = mutableListOf()
 ) : UtxoTransactionBuilder, UtxoTransactionBuilderInternal {
 
     // TODO : Review implementation...
@@ -38,23 +38,28 @@ data class UtxoTransactionBuilderImpl(
     private var alreadySigned = false
 
     override fun addAttachment(attachmentId: SecureHash): UtxoTransactionBuilder {
-        return copy(attachments = attachments + attachmentId)
+        this.attachments += attachmentId
+        return this
     }
 
     override fun addCommand(command: Command): UtxoTransactionBuilder {
-        return copy(commands = commands + command)
+        this.commands += command
+        return this
     }
 
     override fun addSignatories(signatories: Iterable<PublicKey>): UtxoTransactionBuilder {
-        return copy(signatories = this.signatories + signatories)
+        this.signatories += signatories
+        return this
     }
 
     override fun addInputState(stateRef: StateRef): UtxoTransactionBuilder {
-        return copy(inputStateRefs = inputStateRefs + stateRef)
+        this.inputStateRefs += stateRef
+        return this
     }
 
     override fun addInputStates(stateRefs: Iterable<StateRef>): UtxoTransactionBuilder {
-        return copy(inputStateRefs = inputStateRefs + stateRefs)
+        this.inputStateRefs += stateRefs
+        return this
     }
 
     override fun addInputStates(vararg stateRefs: StateRef): UtxoTransactionBuilder {
@@ -62,11 +67,13 @@ data class UtxoTransactionBuilderImpl(
     }
 
     override fun addReferenceState(stateRef: StateRef): UtxoTransactionBuilder {
-        return copy(referenceStateRefs = referenceStateRefs + stateRef)
+        this.referenceStateRefs += stateRef
+        return this
     }
 
     override fun addReferenceStates(stateRefs: Iterable<StateRef>): UtxoTransactionBuilder {
-        return copy(referenceStateRefs = referenceStateRefs + stateRefs)
+        this.referenceStateRefs += stateRefs
+        return this
     }
 
     override fun addReferenceStates(vararg stateRefs: StateRef): UtxoTransactionBuilder {
@@ -74,11 +81,13 @@ data class UtxoTransactionBuilderImpl(
     }
 
     override fun addOutputState(contractState: ContractState): UtxoTransactionBuilder {
-        return copy(outputStates = outputStates + contractState.withEncumbrance(null))
+        this.outputStates += contractState.withEncumbrance(null)
+        return this
     }
 
     override fun addOutputStates(contractStates: Iterable<ContractState>): UtxoTransactionBuilder {
-        return copy(outputStates = outputStates + contractStates.map { it.withEncumbrance(null) })
+        this.outputStates += contractStates.map { it.withEncumbrance(null) }
+        return this
     }
 
     override fun addOutputStates(vararg contractStates: ContractState): UtxoTransactionBuilder {
@@ -89,7 +98,8 @@ data class UtxoTransactionBuilderImpl(
         tag: String,
         contractStates: Iterable<ContractState>
     ): UtxoTransactionBuilder {
-        return copy(outputStates = outputStates + contractStates.map { it.withEncumbrance(tag) })
+        this.outputStates += contractStates.map { it.withEncumbrance(tag) }
+        return this
     }
 
     override fun addEncumberedOutputStates(tag: String, vararg contractStates: ContractState): UtxoTransactionBuilder {
@@ -111,23 +121,27 @@ data class UtxoTransactionBuilderImpl(
     }
 
     override fun setNotary(notary: Party): UtxoTransactionBuilder {
-        return copy(notary = notary)
+        this.notary = notary
+        return this
     }
 
     override fun setTimeWindowUntil(until: Instant): UtxoTransactionBuilder {
-        return copy(timeWindow = TimeWindowUntilImpl(until))
+        this.timeWindow = TimeWindowUntilImpl(until)
+        return this
     }
 
     override fun setTimeWindowBetween(from: Instant, until: Instant): UtxoTransactionBuilder {
-        return copy(timeWindow = TimeWindowBetweenImpl(from, until))
+        this.timeWindow = TimeWindowBetweenImpl(from, until)
+        return this
     }
 
     @Suspendable
-    override fun toSignedTransaction(): UtxoSignedTransaction =
-        sign()
+    override fun toSignedTransaction(): UtxoSignedTransaction {
+        return sign()
+    }
 
     @Suspendable
-    fun sign(): UtxoSignedTransaction {
+    private fun sign(): UtxoSignedTransaction {
         check(!alreadySigned) { "The transaction cannot be signed twice." }
         UtxoTransactionBuilderVerifier(this).verify()
         return utxoSignedTransactionFactory.create(this, signatories).also {
@@ -144,6 +158,7 @@ data class UtxoTransactionBuilderImpl(
         return this === other
                 || other is UtxoTransactionBuilderImpl
                 && other.notary == notary
+                && other.timeWindow == timeWindow
                 && other.attachments == attachments
                 && other.commands == commands
                 && other.inputStateRefs == inputStateRefs

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -17,7 +17,7 @@ import java.security.PublicKey
 import java.time.Instant
 import java.util.Objects
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 class UtxoTransactionBuilderImpl(
     private val utxoSignedTransactionFactory: UtxoSignedTransactionFactory,
     override var notary: Party? = null,
@@ -30,11 +30,6 @@ class UtxoTransactionBuilderImpl(
     override val outputStates: MutableList<ContractStateAndEncumbranceTag> = mutableListOf()
 ) : UtxoTransactionBuilder, UtxoTransactionBuilderInternal {
 
-    // TODO : Review implementation...
-    // 1. Introduces mutability to what is effectively an immutable builder.
-    // 2. Calling toSignedTransaction is an idempotent call, but results in signed transactions with different privacy salt.
-    // 3. Probably won't be needed if we move to an implementation where the developer passes a transaction builder directly to finality.
-    // 4. Consider the same implementation for the consensual transaction builder.
     private var alreadySigned = false
 
     override fun addAttachment(attachmentId: SecureHash): UtxoTransactionBuilder {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -8,6 +8,7 @@ import net.corda.ledger.utxo.testkit.UtxoCommandExample
 import net.corda.ledger.utxo.testkit.UtxoStateClassExample
 import net.corda.ledger.utxo.testkit.getUtxoInvalidStateAndRef
 import net.corda.ledger.utxo.testkit.utxoNotaryExample
+import net.corda.ledger.utxo.testkit.utxoStateAndRefExample
 import net.corda.ledger.utxo.testkit.utxoStateExample
 import net.corda.ledger.utxo.testkit.utxoTimeWindowExample
 import net.corda.v5.crypto.SecureHash
@@ -19,7 +20,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import kotlin.test.assertIs
 
-internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
+class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
     @Test
     fun `can build a simple Transaction`() {
 
@@ -64,11 +65,9 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
         assertThat(tx.referenceStateRefs).isEmpty()
         assertEquals(utxoStateExample, tx.outputStateAndRefs.single().state.contractState)
         assertEquals(utxoNotaryExample, tx.notary)
-        assertEquals(utxoTimeWindowExample, tx.timeWindow,)
+        assertEquals(utxoTimeWindowExample, tx.timeWindow)
         assertEquals(publicKeyExample, tx.signatories.first())
     }
-
-    // TODO Add tests for verification failures.
 
     @Test
     fun `includes CPI and CPK information in metadata`() {
@@ -162,31 +161,178 @@ internal class UtxoTransactionBuilderImplTest: UtxoLedgerTest() {
             .toSignedTransaction()
 
         assertThat(tx.outputStateAndRefs).hasSize(7)
-        assertThat(tx.outputStateAndRefs[0].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 1")
-        assertThat(tx.outputStateAndRefs[0].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
+        assertThat(tx.outputStateAndRefs[0].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(tx.outputStateAndRefs[0].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[1].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 1")
-        assertThat(tx.outputStateAndRefs[1].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
+        assertThat(tx.outputStateAndRefs[1].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(tx.outputStateAndRefs[1].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(3)
 
         assertThat(tx.outputStateAndRefs[2].state.encumbrance).isNull()
 
-        assertThat(tx.outputStateAndRefs[3].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 2")
-        assertThat(tx.outputStateAndRefs[3].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
+        assertThat(tx.outputStateAndRefs[3].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 2")
+        assertThat(tx.outputStateAndRefs[3].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[4].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 2")
-        assertThat(tx.outputStateAndRefs[4].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
+        assertThat(tx.outputStateAndRefs[4].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 2")
+        assertThat(tx.outputStateAndRefs[4].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[5].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 2")
-        assertThat(tx.outputStateAndRefs[5].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
+        assertThat(tx.outputStateAndRefs[5].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 2")
+        assertThat(tx.outputStateAndRefs[5].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(3)
 
-        assertThat(tx.outputStateAndRefs[6].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 1")
-        assertThat(tx.outputStateAndRefs[6].state.encumbrance).isNotNull().extracting { it?.size }.isEqualTo(3)
+        assertThat(tx.outputStateAndRefs[6].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(tx.outputStateAndRefs[6].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(3)
+    }
 
+    @Test
+    fun `setting the notary mutates and returns the current builder`() {
+        val originalTransactionBuilder = utxoTransactionBuilder
+        val mutatedTransactionBuilder = utxoTransactionBuilder.setNotary(utxoNotaryExample)
+        assertThat(mutatedTransactionBuilder.notary).isEqualTo(utxoNotaryExample)
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `setting the time window mutates and returns the current builder`() {
+        val originalTransactionBuilder = utxoTransactionBuilder
+        val mutatedTransactionBuilder = utxoTransactionBuilder
+            .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).timeWindow).isEqualTo(utxoTimeWindowExample)
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `adding attachments mutates and returns the current builder`() {
+        val attachmentId = SecureHash("SHA-256", ByteArray(12))
+        val originalTransactionBuilder = utxoTransactionBuilder
+        val mutatedTransactionBuilder = utxoTransactionBuilder.addAttachment(attachmentId)
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).attachments).isEqualTo(listOf(attachmentId))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `adding commands mutates and returns the current builder`() {
+        val command = UtxoCommandExample()
+        val originalTransactionBuilder = utxoTransactionBuilder
+        val mutatedTransactionBuilder = utxoTransactionBuilder.addCommand(command)
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).commands).isEqualTo(listOf(command))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `adding signatories mutates and returns the current builder`() {
+        val signatories = listOf(publicKeyExample)
+        val originalTransactionBuilder = utxoTransactionBuilder
+        val mutatedTransactionBuilder = utxoTransactionBuilder.addSignatories(signatories)
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).signatories).isEqualTo(signatories)
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `adding input states mutates and returns the current builder`() {
+        val inputState = utxoStateAndRefExample.ref
+        val originalTransactionBuilder = utxoTransactionBuilder
+
+        val mutatedTransactionBuilder = utxoTransactionBuilder.addInputState(inputState)
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).inputStateRefs).isEqualTo(listOf(inputState))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+
+        val mutatedTransactionBuilder2 = utxoTransactionBuilder.addInputStates(listOf(inputState))
+        assertThat((mutatedTransactionBuilder2 as UtxoTransactionBuilderInternal).inputStateRefs).isEqualTo(listOf(inputState, inputState))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder2)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+
+        val mutatedTransactionBuilder3 = utxoTransactionBuilder.addInputStates(inputState)
+        assertThat((mutatedTransactionBuilder3 as UtxoTransactionBuilderInternal).inputStateRefs)
+            .isEqualTo(listOf(inputState, inputState, inputState))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder3)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `adding reference states mutates and returns the current builder`() {
+        val referenceState = utxoStateAndRefExample.ref
+        val originalTransactionBuilder = utxoTransactionBuilder
+
+        val mutatedTransactionBuilder = utxoTransactionBuilder.addReferenceState(referenceState)
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).referenceStateRefs).isEqualTo(listOf(referenceState))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+
+        val mutatedTransactionBuilder2 = utxoTransactionBuilder.addReferenceStates(listOf(referenceState))
+        assertThat((mutatedTransactionBuilder2 as UtxoTransactionBuilderInternal).referenceStateRefs)
+            .isEqualTo(listOf(referenceState, referenceState))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder2)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+
+        val mutatedTransactionBuilder3 = utxoTransactionBuilder.addReferenceStates(referenceState)
+        assertThat((mutatedTransactionBuilder3 as UtxoTransactionBuilderInternal).referenceStateRefs)
+            .isEqualTo(listOf(referenceState, referenceState, referenceState))
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder3)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `adding output states mutates and returns the current builder`() {
+        val originalTransactionBuilder = utxoTransactionBuilder
+
+        val mutatedTransactionBuilder = utxoTransactionBuilder.addOutputState(utxoStateExample)
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).outputStates).isEqualTo(
+            listOf(
+                ContractStateAndEncumbranceTag(utxoStateExample, null)
+            )
+        )
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+
+        val mutatedTransactionBuilder2 = utxoTransactionBuilder.addOutputStates(listOf(utxoStateExample))
+        assertThat((mutatedTransactionBuilder2 as UtxoTransactionBuilderInternal).outputStates).isEqualTo(
+            listOf(
+                ContractStateAndEncumbranceTag(utxoStateExample, null),
+                ContractStateAndEncumbranceTag(utxoStateExample, null)
+            )
+        )
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder2)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+
+        val mutatedTransactionBuilder3 = utxoTransactionBuilder.addOutputStates(utxoStateExample)
+        assertThat((mutatedTransactionBuilder3 as UtxoTransactionBuilderInternal).outputStates).isEqualTo(
+            listOf(
+                ContractStateAndEncumbranceTag(utxoStateExample, null),
+                ContractStateAndEncumbranceTag(utxoStateExample, null),
+                ContractStateAndEncumbranceTag(utxoStateExample, null)
+            )
+        )
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder3)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+    }
+
+    @Test
+    fun `adding output states with an encumbrance group mutates and returns the current builder`() {
+        val tag = "tag"
+        val originalTransactionBuilder = utxoTransactionBuilder
+
+        val mutatedTransactionBuilder = utxoTransactionBuilder.addEncumberedOutputStates(tag, listOf(utxoStateExample))
+        assertThat((mutatedTransactionBuilder as UtxoTransactionBuilderInternal).outputStates).isEqualTo(
+            listOf(
+                ContractStateAndEncumbranceTag(utxoStateExample, tag)
+            )
+        )
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
+
+        val mutatedTransactionBuilder2 = utxoTransactionBuilder.addEncumberedOutputStates(tag, utxoStateExample)
+        assertThat((mutatedTransactionBuilder2 as UtxoTransactionBuilderInternal).outputStates).isEqualTo(
+            listOf(
+                ContractStateAndEncumbranceTag(utxoStateExample, tag),
+                ContractStateAndEncumbranceTag(utxoStateExample, tag)
+            )
+        )
+        assertThat(mutatedTransactionBuilder).isEqualTo(originalTransactionBuilder)
+        assertThat(System.identityHashCode(mutatedTransactionBuilder2)).isEqualTo(System.identityHashCode(originalTransactionBuilder))
     }
 }


### PR DESCRIPTION
Confusion around mutability of transaction builders was raised multiple times which suggested we took the wrong approach of returning copies each time.

We now mutate the existing instance and return it each time.