### PR TITLE
NOTICK: Replace boolean expression with assertAll to provide better failure information

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -32,6 +32,8 @@ import net.corda.applications.workers.smoketest.VNODE_UPGRADE_TEST_CPI_NAME
 import net.corda.applications.workers.smoketest.VNODE_UPGRADE_TEST_CPI_V1
 import net.corda.applications.workers.smoketest.VNODE_UPGRADE_TEST_CPI_V2
 import net.corda.e2etest.utilities.getFlowStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertAll
 
 /**
  * Any 'unordered' tests are run *last*
@@ -428,10 +430,38 @@ class VirtualNodeRpcTest {
                         val vNodeInfo = it.toJson()["virtualNodes"].single { virtualNode ->
                             virtualNode["holdingIdentity"]["shortHash"].textValue() == vnodeId
                         }
-                        vNodeInfo["flowP2pOperationalStatus"].textValue() == expectedOperationalStatuses &&
-                                vNodeInfo["flowStartOperationalStatus"].textValue() == expectedOperationalStatuses &&
-                                vNodeInfo["flowOperationalStatus"].textValue() == expectedOperationalStatuses &&
-                                vNodeInfo["vaultDbOperationalStatus"].textValue() == expectedOperationalStatuses
+                        assertAll(
+                            {
+                                assertEquals(
+                                    expectedOperationalStatuses,
+                                    vNodeInfo["flowP2pOperationalStatus"].textValue(),
+                                    "flowP2pOperationalStatus"
+                                )
+                            },
+                            {
+                                assertEquals(
+                                    expectedOperationalStatuses,
+                                    vNodeInfo["flowStartOperationalStatus"].textValue(),
+                                    "flowStartOperationalStatus"
+                                )
+                            },
+                            {
+                                assertEquals(
+                                    expectedOperationalStatuses,
+                                    vNodeInfo["flowOperationalStatus"].textValue(),
+                                    "flowOperationalStatus"
+                                )
+                            },
+                            {
+                                assertEquals(
+                                    expectedOperationalStatuses,
+                                    vNodeInfo["vaultDbOperationalStatus"].textValue(),
+                                    "vaultDbOperationalStatus"
+                                )
+                            }
+                        )
+                        true
+
                     } else {
                         false
                     }


### PR DESCRIPTION
Changes the error from this:
```
org.opentest4j.AssertionFailedError: Retried https://localhost:8888/api/v1/virtualnode and failed with status code = 200 and body =
{"virtualNodes":[{"holdingIdentity":{"x500Name":"CN=Bob-86d40c61-3944-4db0-9f88-f372f617f234, OU=Application, O=R3, L=London, C=GB","groupId":"7c5d6948-e17b-44e7-9d1c-fa4a3f667cad","shortHash":"FB7468552EB1","fullHash":"FB7468552EB1EACD1488F8F1D113349F580C88BB36F0053269B28634214AE813"},"cpiIdentifier":{"cpiName":"upgrade-testing-cordapp_86d40c61-3944-4db0-9f88-f372f617f234","cpiVersion":"v2","signerSummaryHash":"SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903"},"vaultDdlConnectionId":"34f06208-4ccc-4ef4-8be0-6e07b8476cf2","vaultDmlConnectionId":"c3bae43b-ef2b-4167-90f7-18b4364252f9","cryptoDdlConnectionId":"34f06208-4ccc-4ef4-8be0-6e07b8476cf2","cryptoDmlConnectionId":"52b687f7-1dc1-4b5d-84a5-8f7a649123d9","uniquenessDdlConnectionId":"c44e9b44-965c-4ca6-b5de-8fb73be1ba06","uniquenessDmlConnectionId":"4b5321bf-dbeb-4980-a157-9fc95ae2a055","hsmConnectionId":"null","flowP2pOperationalStatus":"INACTIVE","flowStartOperationalStatus":"INACTIVE","flowOperationalStatus":"INACTIVE","vaultDbOperationalStatus":"INACTIVE","operationInProgress":"FB7468552EB1245EE98EE0E7EAE6DCCB8C49"},{"holdingIdentity":{"x500Name":"CN=Alice-86d40c61-3944-4db0-9f88-f372f617f234, OU=Application, O=R3, L=London, C=GB","groupId":"7c5d6948-e17b-44e7-9d1c-fa4a3f667cad","shortHash":"3186E851FE96","fullHash":"3186E851FE968F7FB540083C48295A8BA01D62364234CEADF0EAFB49184840D8"},"cpiIdentifier":{"cpiName":"test-cordapp_86d40c61-3944-4db0-9f88-f372f617f234","cpiVersion":"1.0.0.0-SNAPSHOT","signerSummaryHash":"SHA-256:CDFF8A944383063AB86AFE61488208CCCC84149911F85BE4F0CACCF399CA9903"},"vaultDdlConnectionId":"fc26c7f8-bba7-40f3-9856-44806cc08334","vaultDmlConnectionId":"8f11a99f-33b8-488f-9262-1c2396998cc5","cryptoDdlConnectionId":"fc26c7f8-bba7-40f3-9856-44806cc08334","cryptoDmlConnectionId":"f73e97f8-beb2-4bd3-8cb8-61800755b7d5","uniquenessDdlConnectionId":"431eac95-94af-49ca-a4e7-8dbefe33282c","uniquenessDmlConnectionId":"5581abce-22c4-4509-baaf-3da013802ada","hsmConnectionId":"null","flowP2pOperationalStatus":"ACTIVE","flowStartOperationalStatus":"ACTIVE","flowOperationalStatus":"ACTIVE","vaultDbOperationalStatus":"ACTIVE","operationInProgress":null}]}
```

To this:

```
org.gradle.internal.exceptions.DefaultMultiCauseException: Multiple Failures (4 failures)
	org.opentest4j.AssertionFailedError: flowP2pOperationalStatus ==> expected: <ACTIVE> but was: <INACTIVE>
	org.opentest4j.AssertionFailedError: flowStartOperationalStatus ==> expected: <ACTIVE> but was: <INACTIVE>
	org.opentest4j.AssertionFailedError: flowOperationalStatus ==> expected: <ACTIVE> but was: <INACTIVE>
	org.opentest4j.AssertionFailedError: vaultDbOperationalStatus ==> expected: <ACTIVE> but was: <INACTIVE>
```