### PR TITLE
CORE-10473 lower the chunk size for cpi upload so it does not accidentally trigger message bus chunking

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.SoftAssertions
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -37,7 +36,6 @@ class ClusterBootstrapTest {
     private val client = HttpClient.newBuilder().build()
 
     @Test
-    @Disabled
     fun checkCluster() {
         runBlocking(Dispatchers.Default) {
             val softly = SoftAssertions()

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
@@ -1,15 +1,5 @@
 package net.corda.applications.workers.smoketest
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.SoftAssertions
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
-import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.net.URI
 import java.net.http.HttpClient
@@ -17,6 +7,17 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.time.Instant
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.slf4j.LoggerFactory
 
 @Order(2)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
@@ -36,6 +37,7 @@ class ClusterBootstrapTest {
     private val client = HttpClient.newBuilder().build()
 
     @Test
+    @Disabled
     fun checkCluster() {
         runBlocking(Dispatchers.Default) {
             val softly = SoftAssertions()

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseChunkPersistenceTest.kt
@@ -10,6 +10,7 @@ import javax.persistence.EntityManagerFactory
 import javax.persistence.NoResultException
 import javax.persistence.NonUniqueResultException
 import net.corda.chunking.ChunkWriterFactory
+import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 import net.corda.chunking.RequestId
 import net.corda.chunking.datamodel.ChunkEntity
 import net.corda.chunking.datamodel.ChunkingEntities
@@ -142,7 +143,7 @@ internal class DatabaseChunkPersistenceTest {
             .withFailMessage("The test string should not be a multiple of $divisor so that we have a final odd sized chunk ")
             .isNotEqualTo(mockCpkContent.length)
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterFactory.create(chunkSize + 10240).apply {
+        val writer = ChunkWriterFactory.create(chunkSize + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD).apply {
             onChunk { chunks.add(it) }
         }
         // end of setup...

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/RecreateBinaryTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/RecreateBinaryTest.kt
@@ -1,8 +1,14 @@
 package net.corda.chunking.db.impl.tests
 
 import com.google.common.jimfs.Jimfs
+import java.nio.file.FileSystem
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.UUID
 import net.corda.chunking.ChunkReaderFactoryImpl
 import net.corda.chunking.ChunkWriterFactory
+import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 import net.corda.chunking.datamodel.ChunkingEntities
 import net.corda.chunking.db.impl.persistence.database.DatabaseChunkPersistence
 import net.corda.data.chunking.Chunk
@@ -18,11 +24,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.nio.file.FileSystem
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardOpenOption
-import java.util.UUID
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RecreateBinaryTest {
@@ -81,7 +82,7 @@ class RecreateBinaryTest {
         val chunkSize = loremIpsum.length / divisor
 
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterFactory.create(chunkSize + 10240).apply {
+        val writer = ChunkWriterFactory.create(chunkSize + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD).apply {
             onChunk { chunks.add(it) }
         }
         // end of setup...

--- a/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
@@ -162,10 +162,10 @@ class CpkWriteServiceImplTest {
         val configChangedEvent = ConfigChangedEvent(
             setOf(ConfigKeys.MESSAGING_CONFIG, ConfigKeys.RECONCILIATION_CONFIG),
             mapOf(
-                ConfigKeys.MESSAGING_CONFIG to mock {
-                    on { getInt(MessagingConfig.MAX_ALLOWED_MSG_SIZE) }.doReturn((10240 * 2) + 32)
+                ConfigKeys.MESSAGING_CONFIG to mock() {
+                    on { getInt(MessagingConfig.MAX_ALLOWED_MSG_SIZE) }.doReturn(10240 + 32)
                 },
-                ConfigKeys.RECONCILIATION_CONFIG to mock {
+                ConfigKeys.RECONCILIATION_CONFIG to mock() {
                     on { getLong(RECONCILIATION_CPK_WRITE_INTERVAL_MS) }.doReturn(1)
                 }
             )

--- a/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
@@ -2,6 +2,7 @@ package net.corda.cpk.write.impl
 
 import java.nio.ByteBuffer
 import java.security.MessageDigest
+import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpk.write.impl.services.db.CpkChecksumToData
@@ -163,7 +164,7 @@ class CpkWriteServiceImplTest {
             setOf(ConfigKeys.MESSAGING_CONFIG, ConfigKeys.RECONCILIATION_CONFIG),
             mapOf(
                 ConfigKeys.MESSAGING_CONFIG to mock() {
-                    on { getInt(MessagingConfig.MAX_ALLOWED_MSG_SIZE) }.doReturn(10240 + 32)
+                    on { getInt(MessagingConfig.MAX_ALLOWED_MSG_SIZE) }.doReturn(APP_LEVEL_CHUNK_MESSAGE_OVERHEAD + 32)
                 },
                 ConfigKeys.RECONCILIATION_CONFIG to mock() {
                     on { getLong(RECONCILIATION_CPK_WRITE_INTERVAL_MS) }.doReturn(1)

--- a/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
+++ b/components/virtual-node/cpk-write-service-impl/src/test/kotlin/net/corda/cpk/write/impl/CpkWriteServiceImplTest.kt
@@ -162,10 +162,10 @@ class CpkWriteServiceImplTest {
         val configChangedEvent = ConfigChangedEvent(
             setOf(ConfigKeys.MESSAGING_CONFIG, ConfigKeys.RECONCILIATION_CONFIG),
             mapOf(
-                ConfigKeys.MESSAGING_CONFIG to mock() {
-                    on { getInt(MessagingConfig.MAX_ALLOWED_MSG_SIZE) }.doReturn(10240 + 32)
+                ConfigKeys.MESSAGING_CONFIG to mock {
+                    on { getInt(MessagingConfig.MAX_ALLOWED_MSG_SIZE) }.doReturn((10240 * 2) + 32)
                 },
-                ConfigKeys.RECONCILIATION_CONFIG to mock() {
+                ConfigKeys.RECONCILIATION_CONFIG to mock {
                     on { getLong(RECONCILIATION_CPK_WRITE_INTERVAL_MS) }.doReturn(1)
                 }
             )

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/Constants.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/Constants.kt
@@ -4,7 +4,10 @@ class Constants {
     companion object {
         const val KB = 1024
         const val MB = 1024 * KB
+        //Max size of a record
         const val CORDA_MESSAGE_OVERHEAD = 10 * KB
+        //Max size of a Chunk, this allows extra overhead for generated chunks to avoid message bus level automatic chunking
+        const val APP_LEVEL_CHUNK_MESSAGE_OVERHEAD = CORDA_MESSAGE_OVERHEAD * 2
         // This value should match the liquibase table value in `corda-api`
         const val MAX_DB_CHUNK_SIZE = 8 * MB
         const val SECURE_HASH_VALIDATION_ERROR = "Checksums do not match, one or more of the chunks may be corrupt"

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/Constants.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/Constants.kt
@@ -4,10 +4,10 @@ class Constants {
     companion object {
         const val KB = 1024
         const val MB = 1024 * KB
-        //Max size of a record
-        const val CORDA_MESSAGE_OVERHEAD = 10 * KB
-        //Max size of a Chunk, this allows extra overhead for generated chunks to avoid message bus level automatic chunking
-        const val APP_LEVEL_CHUNK_MESSAGE_OVERHEAD = CORDA_MESSAGE_OVERHEAD * 2
+        //Additional overhead when checking max size of a record
+        const val CORDA_RECORD_OVERHEAD = 10 * KB
+        //Additional overhead when checking max size of a chunk. This allows extra overhead to avoid message bus chunking
+        const val APP_LEVEL_CHUNK_MESSAGE_OVERHEAD = CORDA_RECORD_OVERHEAD * 2
         // This value should match the liquibase table value in `corda-api`
         const val MAX_DB_CHUNK_SIZE = 8 * MB
         const val SECURE_HASH_VALIDATION_ERROR = "Checksums do not match, one or more of the chunks may be corrupt"

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkWriterImpl.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkWriterImpl.kt
@@ -8,7 +8,7 @@ import net.corda.chunking.Checksum
 import net.corda.chunking.ChunkBuilderService
 import net.corda.chunking.ChunkWriteCallback
 import net.corda.chunking.ChunkWriter
-import net.corda.chunking.Constants.Companion.CORDA_MESSAGE_OVERHEAD
+import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.v5.base.exceptions.CordaRuntimeException
@@ -36,7 +36,7 @@ internal class ChunkWriterImpl(
 
     // chunk size must be smaller than the max allowed message size to allow a buffer for the rest of the message.
     //add extra overhead to avoid message bus level chunking
-    val chunkSize = maxAllowedMessageSize - (CORDA_MESSAGE_OVERHEAD*2)
+    val chunkSize = maxAllowedMessageSize - APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 
     override fun write(fileName: String, inputStream: InputStream): ChunkWriter.Request {
         if (chunkWriteCallback == null) {

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkWriterImpl.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkWriterImpl.kt
@@ -35,7 +35,8 @@ internal class ChunkWriterImpl(
     var chunkWriteCallback: ChunkWriteCallback? = null
 
     // chunk size must be smaller than the max allowed message size to allow a buffer for the rest of the message.
-    val chunkSize = maxAllowedMessageSize - CORDA_MESSAGE_OVERHEAD
+    //add extra overhead to avoid message bus level chunking
+    val chunkSize = maxAllowedMessageSize - (CORDA_MESSAGE_OVERHEAD*2)
 
     override fun write(fileName: String, inputStream: InputStream): ChunkWriter.Request {
         if (chunkWriteCallback == null) {

--- a/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkReadingTest.kt
+++ b/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkReadingTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 class ChunkReadingTest {
     private lateinit var fs: FileSystem
 
+    private val extraSpace = CORDA_MESSAGE_OVERHEAD * 2
     private val chunkReaderFactory = ChunkReaderFactoryImpl
     private val chunkBuilderService = ChunkBuilderServiceImpl()
 
@@ -81,7 +82,7 @@ class ChunkReadingTest {
 
         val chunkCount = 5
 
-        val writer = ChunkWriterImpl(32 + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(32 + extraSpace, chunkBuilderService).apply {
             // guaranteed to be in order in this test
             onChunk(chunks::add)
         }
@@ -103,7 +104,7 @@ class ChunkReadingTest {
     @Test
     fun `can read out of order chunks`() {
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterImpl(32 + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(32 + extraSpace, chunkBuilderService).apply {
             onChunk(chunks::add)
         }
 
@@ -146,7 +147,7 @@ class ChunkReadingTest {
     @Test
     fun `can read overlapping files with out of order chunks`() {
         val chunks = mutableListOf<Chunk>()
-        val chunkSize = 32 + CORDA_MESSAGE_OVERHEAD //bytes
+        val chunkSize = 32 + extraSpace //bytes
         val writer = ChunkWriterImpl(chunkSize, chunkBuilderService).apply {
             onChunk(chunks::add)
         }
@@ -197,7 +198,7 @@ class ChunkReadingTest {
         }
 
         val divisor = 10
-        val chunkSize = (loremIpsum.length / divisor) + CORDA_MESSAGE_OVERHEAD
+        val chunkSize = (loremIpsum.length / divisor) + extraSpace
         assertThat(chunkSize * 10)
             .withFailMessage("The test string should not be a multiple of $divisor so that we have a final odd sized chunk ")
             .isNotEqualTo(loremIpsum.length)
@@ -245,7 +246,7 @@ class ChunkReadingTest {
         val path = createEmptyFile(0)
         val ourFileName = randomFileName()
         val chunks = mutableListOf<Chunk>()
-        val chunkSize = 32 + CORDA_MESSAGE_OVERHEAD //bytes
+        val chunkSize = 32 + extraSpace * 2 //bytes
         val writer = ChunkWriterImpl(chunkSize, chunkBuilderService).apply {
             onChunk(chunks::add)
         }

--- a/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkReadingTest.kt
+++ b/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkReadingTest.kt
@@ -7,7 +7,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.util.UUID
-import net.corda.chunking.Constants.Companion.CORDA_MESSAGE_OVERHEAD
+import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 import net.corda.chunking.Constants.Companion.MB
 import net.corda.chunking.impl.ChunkBuilderServiceImpl
 import net.corda.chunking.impl.ChunkReaderImpl
@@ -81,7 +81,7 @@ class ChunkReadingTest {
 
         val chunkCount = 5
 
-        val writer = ChunkWriterImpl(32 + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(32 + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD, chunkBuilderService).apply {
             // guaranteed to be in order in this test
             onChunk(chunks::add)
         }
@@ -103,7 +103,7 @@ class ChunkReadingTest {
     @Test
     fun `can read out of order chunks`() {
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterImpl(32 + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(32 + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD, chunkBuilderService).apply {
             onChunk(chunks::add)
         }
 
@@ -146,7 +146,7 @@ class ChunkReadingTest {
     @Test
     fun `can read overlapping files with out of order chunks`() {
         val chunks = mutableListOf<Chunk>()
-        val chunkSize = 32 + CORDA_MESSAGE_OVERHEAD //bytes
+        val chunkSize = 32 + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD //bytes
         val writer = ChunkWriterImpl(chunkSize, chunkBuilderService).apply {
             onChunk(chunks::add)
         }
@@ -197,7 +197,7 @@ class ChunkReadingTest {
         }
 
         val divisor = 10
-        val chunkSize = (loremIpsum.length / divisor) + CORDA_MESSAGE_OVERHEAD
+        val chunkSize = (loremIpsum.length / divisor) + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
         assertThat(chunkSize * 10)
             .withFailMessage("The test string should not be a multiple of $divisor so that we have a final odd sized chunk ")
             .isNotEqualTo(loremIpsum.length)
@@ -245,7 +245,7 @@ class ChunkReadingTest {
         val path = createEmptyFile(0)
         val ourFileName = randomFileName()
         val chunks = mutableListOf<Chunk>()
-        val chunkSize = 32 + CORDA_MESSAGE_OVERHEAD //bytes
+        val chunkSize = 32 + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD //bytes
         val writer = ChunkWriterImpl(chunkSize, chunkBuilderService).apply {
             onChunk(chunks::add)
         }

--- a/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkReadingTest.kt
+++ b/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkReadingTest.kt
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test
 class ChunkReadingTest {
     private lateinit var fs: FileSystem
 
-    private val extraSpace = CORDA_MESSAGE_OVERHEAD * 2
     private val chunkReaderFactory = ChunkReaderFactoryImpl
     private val chunkBuilderService = ChunkBuilderServiceImpl()
 
@@ -82,7 +81,7 @@ class ChunkReadingTest {
 
         val chunkCount = 5
 
-        val writer = ChunkWriterImpl(32 + extraSpace, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(32 + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
             // guaranteed to be in order in this test
             onChunk(chunks::add)
         }
@@ -104,7 +103,7 @@ class ChunkReadingTest {
     @Test
     fun `can read out of order chunks`() {
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterImpl(32 + extraSpace, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(32 + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
             onChunk(chunks::add)
         }
 
@@ -147,7 +146,7 @@ class ChunkReadingTest {
     @Test
     fun `can read overlapping files with out of order chunks`() {
         val chunks = mutableListOf<Chunk>()
-        val chunkSize = 32 + extraSpace //bytes
+        val chunkSize = 32 + CORDA_MESSAGE_OVERHEAD //bytes
         val writer = ChunkWriterImpl(chunkSize, chunkBuilderService).apply {
             onChunk(chunks::add)
         }
@@ -198,7 +197,7 @@ class ChunkReadingTest {
         }
 
         val divisor = 10
-        val chunkSize = (loremIpsum.length / divisor) + extraSpace
+        val chunkSize = (loremIpsum.length / divisor) + CORDA_MESSAGE_OVERHEAD
         assertThat(chunkSize * 10)
             .withFailMessage("The test string should not be a multiple of $divisor so that we have a final odd sized chunk ")
             .isNotEqualTo(loremIpsum.length)
@@ -246,7 +245,7 @@ class ChunkReadingTest {
         val path = createEmptyFile(0)
         val ourFileName = randomFileName()
         val chunks = mutableListOf<Chunk>()
-        val chunkSize = 32 + extraSpace * 2 //bytes
+        val chunkSize = 32 + CORDA_MESSAGE_OVERHEAD //bytes
         val writer = ChunkWriterImpl(chunkSize, chunkBuilderService).apply {
             onChunk(chunks::add)
         }

--- a/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
+++ b/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 class ChunkWritingTest {
     lateinit var fs: FileSystem
 
+    private val extraSpace = CORDA_MESSAGE_OVERHEAD * 2
     private val chunkBuilderService: ChunkBuilderService = ChunkBuilderServiceImpl()
 
     @BeforeEach
@@ -102,7 +103,7 @@ class ChunkWritingTest {
     fun `ensure chunks are trimmed to minimum size`() {
         val chunkSize = 32 * KB
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterImpl(chunkSize + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(chunkSize + extraSpace, chunkBuilderService).apply {
             onChunk { chunks.add(it) }
         }
 

--- a/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
+++ b/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
@@ -7,7 +7,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.util.UUID
-import net.corda.chunking.Constants.Companion.CORDA_MESSAGE_OVERHEAD
+import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 import net.corda.chunking.Constants.Companion.KB
 import net.corda.chunking.Constants.Companion.MB
 import net.corda.chunking.impl.ChunkBuilderServiceImpl
@@ -102,7 +102,7 @@ class ChunkWritingTest {
     fun `ensure chunks are trimmed to minimum size`() {
         val chunkSize = 32 * KB
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterImpl(chunkSize + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(chunkSize + APP_LEVEL_CHUNK_MESSAGE_OVERHEAD, chunkBuilderService).apply {
             onChunk { chunks.add(it) }
         }
 

--- a/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
+++ b/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test
 class ChunkWritingTest {
     lateinit var fs: FileSystem
 
-    private val extraSpace = CORDA_MESSAGE_OVERHEAD * 2
     private val chunkBuilderService: ChunkBuilderService = ChunkBuilderServiceImpl()
 
     @BeforeEach
@@ -103,7 +102,7 @@ class ChunkWritingTest {
     fun `ensure chunks are trimmed to minimum size`() {
         val chunkSize = 32 * KB
         val chunks = mutableListOf<Chunk>()
-        val writer = ChunkWriterImpl(chunkSize + extraSpace, chunkBuilderService).apply {
+        val writer = ChunkWriterImpl(chunkSize + CORDA_MESSAGE_OVERHEAD, chunkBuilderService).apply {
             onChunk { chunks.add(it) }
         }
 

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorSend.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorSend.kt
@@ -52,7 +52,7 @@ class SessionDataProcessorSend(
             }
             SessionStateType.CREATED, SessionStateType.CONFIRMED  -> {
                 val bytes = (payload.payload as ByteBuffer).array()
-                val chunks = chunkSerializer.generateChunksFromBytes(bytes)
+                val chunks = chunkSerializer.generateChunks(bytes)
                 val sendEventsState = sessionState.sendEventsState
                 if (chunks.isNotEmpty()) {
                     chunks.forEach {

--- a/libs/flows/session-manager-impl/src/test/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorSendTest.kt
+++ b/libs/flows/session-manager-impl/src/test/kotlin/net/corda/session/manager/impl/processor/SessionDataProcessorSendTest.kt
@@ -114,7 +114,7 @@ class SessionDataProcessorSendTest {
             SessionStateType.CONFIRMED, 0, mutableListOf(), 0, mutableListOf()
         )
 
-        whenever(chunkSerializerService.generateChunksFromBytes(any())).thenReturn(listOf(Chunk(), Chunk(), Chunk()))
+        whenever(chunkSerializerService.generateChunks(any())).thenReturn(listOf(Chunk(), Chunk(), Chunk()))
         val result = SessionDataProcessorSend("key", inputState, sessionEvent, Instant.now(), chunkSerializerService, payload).execute()
         assertThat(result).isNotNull
         assertThat(result.status).isEqualTo(SessionStateType.CONFIRMED)

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -98,9 +98,11 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         val recordsToReturn = mutableListOf<CordaConsumerRecord<K, V>>()
         polledRecords.groupBy { it.partition() }.forEach { (partition, records) ->
             val bufferedRecords = bufferedRecords[partition] ?: emptyList()
-            log.trace {
-                "Taking  ${bufferedRecords.size} buffered records from partition $partition and adding them to the polled records" +
-                        " of size ${records.size}"
+            if (bufferedRecords.isNotEmpty()) {
+                log.trace {
+                    "Taking  ${bufferedRecords.size} buffered records from partition $partition and adding them to the polled records" +
+                            " of size ${records.size}"
+                }
             }
             recordsToReturn.addAll(parseRecords(partition, bufferedRecords.plus(records)))
         }
@@ -141,13 +143,10 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
             val key = consumerRecord.key()
             if (key is ChunkKey && vClazz != Chunk::class.java && value is Chunk) {
                 log.trace {
-                    "read chunk offset ${consumerRecord.offset()} and chunkid ${value.requestId} and partNumber ${
-                        value
-                            .partNumber
-                    }"
+                    "Read chunk offset ${consumerRecord.offset()} and chunkId ${value.requestId} and partNumber ${value.partNumber}"
                 }
                 getCompleteRecord(key, value, consumerRecord, currentChunks)?.let {
-                    log.trace { "adding complete record with offset ${consumerRecord.offset()} and chunkid ${value.requestId}" }
+                    log.trace { "Adding complete record with offset ${consumerRecord.offset()} and chunkId ${value.requestId}" }
                     completeRecords.add(it)
                 }
             } else {
@@ -165,7 +164,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         }
 
         val readUpToOffset = bufferIncompleteAndGetReadToOffset(currentChunks, polledRecords, partition)
-        log.trace { "readUpToOffset: $readUpToOffset for partition $partition" }
+        log.trace { "ReadUpToOffset: $readUpToOffset for partition $partition" }
         return completeRecords.filter { it.offset < readUpToOffset }
     }
 
@@ -187,6 +186,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
 
         //chunk ordering is guaranteed as chunks are always committed via transactions
         return if (chunk.checksum != null) {
+            log.trace { "Found checksum for chunkId ${chunk.requestId} " }
             currentChunks.remove(chunk.requestId)
             chunkDeserializerService.assembleChunks(chunksRead.chunks)?.let {
                 CordaConsumerRecord(

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -47,7 +47,6 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
     private val consumer: Consumer<Any, Any>,
     private var defaultListener: CordaConsumerRebalanceListener? = null,
     private val chunkDeserializerService: ConsumerChunkDeserializerService<K, V>,
-    private val vClazz: Class<V>,
 ) : CordaConsumer<K, V> {
 
     private var currentAssignment = mutableSetOf<Int>()
@@ -141,7 +140,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         polledRecords.forEach { consumerRecord ->
             val value = consumerRecord.value()
             val key = consumerRecord.key()
-            if (key is ChunkKey && vClazz != Chunk::class.java && value is Chunk) {
+            if (key is ChunkKey && value is Chunk) {
                 log.trace {
                     "Read chunk offset ${consumerRecord.offset()} and chunkId ${value.requestId} and partNumber ${value.partNumber}"
                 }

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/builder/CordaKafkaConsumerBuilderImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/builder/CordaKafkaConsumerBuilderImpl.kt
@@ -58,7 +58,7 @@ class CordaKafkaConsumerBuilderImpl @Activate constructor(
                 val consumerChunkDeserializerService =
                     messagingChunkFactory.createConsumerChunkDeserializerService(keyDeserializer, valueDeserializer, onSerializationError)
                 val consumer = createKafkaConsumer(kafkaProperties, keyDeserializer, valueDeserializer)
-                CordaKafkaConsumerImpl(resolvedConfig, consumer, listener, consumerChunkDeserializerService, vClazz)
+                CordaKafkaConsumerImpl(resolvedConfig, consumer, listener, consumerChunkDeserializerService)
             },
             errorMessage = {
                 "MessageBusConsumerBuilder failed to create consumer for group ${consumerConfig.group}, " +

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -87,7 +87,6 @@ class CordaKafkaConsumerImplTest {
             consumerParam,
             listenerParam,
             chunkDeserializerService,
-            String::class.java,
         )
     }
 

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImplTest.kt
@@ -51,7 +51,7 @@ class CordaKafkaProducerImplTest {
     private val consumerChunkDeserializerService: ConsumerChunkDeserializerService<Any, Any> = mock()
     private val mockedCallback: CordaProducer.Callback = mock()
     private val cordaConsumer =
-        CordaKafkaConsumerImpl(consumerConfig, consumer, null, consumerChunkDeserializerService, Any::class.java)
+        CordaKafkaConsumerImpl(consumerConfig, consumer, null, consumerChunkDeserializerService)
     private lateinit var cordaKafkaProducer: CordaKafkaProducerImpl
 
     private val record: CordaProducerRecord<Any, Any> = CordaProducerRecord("topic", "key", "value")

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImpl.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 import net.corda.chunking.Checksum
 import net.corda.chunking.ChunkBuilderService
 import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
-import net.corda.chunking.Constants.Companion.CORDA_MESSAGE_OVERHEAD
+import net.corda.chunking.Constants.Companion.CORDA_RECORD_OVERHEAD
 import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.chunking.Chunk
@@ -33,7 +33,7 @@ class ChunkSerializerServiceImpl(
     }
 
     // chunk size must be smaller than the max allowed message size to allow a buffer for the rest of the message.
-    private val maxRecordSize = (maxAllowedMessageSize - CORDA_MESSAGE_OVERHEAD).toInt()
+    private val maxRecordSize = (maxAllowedMessageSize - CORDA_RECORD_OVERHEAD).toInt()
     private val maxChunkSize = (maxAllowedMessageSize - APP_LEVEL_CHUNK_MESSAGE_OVERHEAD).toInt()
 
     override fun generateChunks(anyObject: Any): List<Chunk> {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImpl.kt
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer
 import java.util.UUID
 import net.corda.chunking.Checksum
 import net.corda.chunking.ChunkBuilderService
+import net.corda.chunking.Constants.Companion.APP_LEVEL_CHUNK_MESSAGE_OVERHEAD
 import net.corda.chunking.Constants.Companion.CORDA_MESSAGE_OVERHEAD
 import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.data.CordaAvroSerializer
@@ -32,26 +33,26 @@ class ChunkSerializerServiceImpl(
     }
 
     // chunk size must be smaller than the max allowed message size to allow a buffer for the rest of the message.
-    private val maxBytesSize = (maxAllowedMessageSize - CORDA_MESSAGE_OVERHEAD).toInt()
-    private val chunkSize = maxBytesSize - CORDA_MESSAGE_OVERHEAD
+    private val maxRecordSize = (maxAllowedMessageSize - CORDA_MESSAGE_OVERHEAD).toInt()
+    private val maxChunkSize = (maxAllowedMessageSize - APP_LEVEL_CHUNK_MESSAGE_OVERHEAD).toInt()
 
-    override fun generateChunks(avroObject: Any): List<Chunk> {
-        logger.debug { "Generating chunks for object of type ${avroObject::class.java}" }
-        val bytes = tryToSerialize(avroObject)
-        if (bytes == null || bytes.size <= maxBytesSize) {
+    override fun generateChunks(anyObject: Any): List<Chunk> {
+        logger.debug { "Generating chunks for object of type ${anyObject::class.java}" }
+        val bytes = tryToSerialize(anyObject)
+        if (bytes == null || bytes.size <= maxChunkSize) {
             return emptyList()
         }
-        return generateChunksFromBytes(bytes)
+        return generateChunksFromBytes(bytes, maxChunkSize)
     }
 
     override fun generateChunkedRecords(producerRecord: CordaProducerRecord<*, *>): List<CordaProducerRecord<*, *>> {
         val serializedKey = tryToSerialize(producerRecord.key)
         val valueBytes = tryToSerialize(producerRecord.value)
-        if (serializedKey == null || valueBytes == null || valueBytes.size <= maxBytesSize) {
+        if (serializedKey == null || valueBytes == null || valueBytes.size <= maxRecordSize) {
             return emptyList()
         }
 
-        val chunksToKey = generateChunksFromBytes(valueBytes).associateBy {
+        val chunksToKey = generateChunksFromBytes(valueBytes, maxRecordSize).associateBy {
             ChunkKey.newBuilder()
                 .setPartNumber(it.partNumber)
                 .setRealKey(ByteBuffer.wrap(serializedKey))
@@ -62,12 +63,8 @@ class ChunkSerializerServiceImpl(
         return chunksToKey.map { CordaProducerRecord(producerRecord.topic, it.key, it.value) }
     }
 
-    override fun generateChunksFromBytes(bytes: ByteArray): List<Chunk> {
+    private fun generateChunksFromBytes(bytes: ByteArray, chunkSize: Int): List<Chunk> {
         val byteSize = bytes.size
-        if (byteSize <= maxBytesSize) {
-            logger.debug { "Failed to deserialize bytes or object is too small for chunking" }
-            return emptyList()
-        }
         val hash = platformDigestService.hash(bytes, DigestAlgorithmName(Checksum.ALGORITHM))
         var partNumber = INITIAL_PART_NUMBER
         val requestId = UUID.randomUUID().toString()

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImplTest.kt
@@ -22,7 +22,7 @@ import org.mockito.kotlin.whenever
 class ChunkSerializerServiceImplTest {
 
     private companion object {
-        const val chunkSize = 1024 * 50L
+        const val maxAllowedMsgSize = 1024 * 50L
         val someSmallBytes = ByteArray(1)
         val someLargeBytes = ByteArray(1024 * 120)
     }
@@ -41,7 +41,7 @@ class ChunkSerializerServiceImplTest {
         chunkBuilderService = mock()
         producerRecord = mock()
         platformDigestService = mock()
-        chunkSerializerService = ChunkSerializerServiceImpl(chunkSize, serializer, chunkBuilderService, platformDigestService)
+        chunkSerializerService = ChunkSerializerServiceImpl(maxAllowedMsgSize, serializer, chunkBuilderService, platformDigestService)
 
         var partNumber = 0
         doAnswer {
@@ -107,12 +107,12 @@ class ChunkSerializerServiceImplTest {
     }
 
     @Test
-    fun `generateChunks from corda producer record success and returns 5 chunks`() {
+    fun `generateChunks from corda producer record success and returns 4 chunks`() {
         val result = chunkSerializerService.generateChunkedRecords(producerRecord)
         assertThat(result).isNotEmpty
-        assertThat(result.size).isEqualTo(5)
+        assertThat(result.size).isEqualTo(4)
 
-        verify(chunkBuilderService, times(4)).buildChunk(any(), any(), any(), any(), anyOrNull(), anyOrNull())
+        verify(chunkBuilderService, times(3)).buildChunk(any(), any(), any(), any(), anyOrNull(), anyOrNull())
         verify(chunkBuilderService, times(1)).buildFinalChunk(any(), any(), any(), any(), anyOrNull(), anyOrNull())
     }
 }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/chunking/ChunkSerializerServiceImplTest.kt
@@ -115,20 +115,4 @@ class ChunkSerializerServiceImplTest {
         verify(chunkBuilderService, times(4)).buildChunk(any(), any(), any(), any(), anyOrNull(), anyOrNull())
         verify(chunkBuilderService, times(1)).buildFinalChunk(any(), any(), any(), any(), anyOrNull(), anyOrNull())
     }
-
-    @Test
-    fun `generateChunks from bytes too small so returns no chunks`() {
-        val result = chunkSerializerService.generateChunksFromBytes(someSmallBytes)
-        assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `generateChunks from bytes success and returns 3 chunks`() {
-        val result = chunkSerializerService.generateChunksFromBytes(someLargeBytes)
-        assertThat(result).isNotEmpty
-        assertThat(result.size).isEqualTo(5)
-
-        verify(chunkBuilderService, times(4)).buildChunk(any(), any(), any(), any(), anyOrNull(), anyOrNull())
-        verify(chunkBuilderService, times(1)).buildFinalChunk(any(), any(), any(), any(), anyOrNull(), anyOrNull())
-    }
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/chunking/ChunkSerializerService.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/chunking/ChunkSerializerService.kt
@@ -9,20 +9,12 @@ import net.corda.messagebus.api.producer.CordaProducerRecord
 interface ChunkSerializerService {
 
     /**
-     * Take a byte array and divide it into [Chunk]s
-     * @param bytes Any byte array
+     * Take any Avro object, String or ByteArray and divide it into [Chunk]s
+     * @param anyObject Object to chunk.
      * @return Returns the object broken up into chunks. Returns an empty list if the object was too small to be chunked or failed to be
      * serialized.
      */
-    fun generateChunksFromBytes(bytes: ByteArray): List<Chunk>
-
-    /**
-     * Take an Avro object and divide it into [Chunk]s
-     * @param avroObject Avro object to chunk.
-     * @return Returns the object broken up into chunks. Returns an empty list if the object was too small to be chunked or failed to be
-     * serialized.
-     */
-    fun generateChunks(avroObject: Any) : List<Chunk>
+    fun generateChunks(anyObject: Any) : List<Chunk>
 
     /**
      * Take a messaging [CordaProducerRecord] and divide it into chunks.

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
@@ -1,5 +1,6 @@
 package net.cordapp.testing.smoketests.flow
 
+import java.util.concurrent.ThreadLocalRandom
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.InitiatedBy
@@ -52,7 +53,7 @@ class SendReceiveAllMessagingFlow(
         flowMessaging.sendAll(MyClass("Serialize me please", 3), setOf(sessionOne, sessionTwo))
 
         //additional send via session to help verify init isn't sent again
-        val largeString = getLargeString(2200)
+        val largeString = getLargeString(1100)
         sessionOne.send(MyClass(largeString, 4))
         sessionTwo.send(MyClass("Serialize me please", 5))
 
@@ -103,7 +104,7 @@ class SendReceiveAllMessagingFlow(
     private fun getLargeString(kiloBytes: Int) : String {
         val stringBuilder = StringBuilder()
         for (i in 0..CHARS_PER_KB*kiloBytes) {
-            stringBuilder.append("A")
+            stringBuilder.append(ThreadLocalRandom.current().nextInt(0,9) )
         }
         return stringBuilder.toString()
     }

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
@@ -1,6 +1,5 @@
 package net.cordapp.testing.smoketests.flow
 
-import java.util.concurrent.ThreadLocalRandom
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.flows.InitiatedBy
@@ -53,7 +52,7 @@ class SendReceiveAllMessagingFlow(
         flowMessaging.sendAll(MyClass("Serialize me please", 3), setOf(sessionOne, sessionTwo))
 
         //additional send via session to help verify init isn't sent again
-        val largeString = getLargeString(1100)
+        val largeString = getLargeString(2200)
         sessionOne.send(MyClass(largeString, 4))
         sessionTwo.send(MyClass("Serialize me please", 5))
 
@@ -104,7 +103,7 @@ class SendReceiveAllMessagingFlow(
     private fun getLargeString(kiloBytes: Int) : String {
         val stringBuilder = StringBuilder()
         for (i in 0..CHARS_PER_KB*kiloBytes) {
-            stringBuilder.append(ThreadLocalRandom.current().nextInt(0,9) )
+            stringBuilder.append("A")
         }
         return stringBuilder.toString()
     }


### PR DESCRIPTION
reduce the chunking api to remove redundant api. 
Use different chunk size for message bus chunking versus app level chunking