### PR TITLE
NOTICK: Configure Quasar for :libs:messaging in a single place.

### DIFF
--- a/libs/messaging/messaging-impl/build.gradle
+++ b/libs/messaging/messaging-impl/build.gradle
@@ -8,7 +8,6 @@ description 'Message Patterns Impl'
 dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation project(":libs:chunking:chunking-core")
     implementation project(":libs:crypto:cipher-suite")

--- a/libs/messaging/messaging-impl/src/main/java/net/corda/messaging/package-info.java
+++ b/libs/messaging/messaging-impl/src/main/java/net/corda/messaging/package-info.java
@@ -1,4 +1,0 @@
-@QuasarIgnoreAllPackages
-package net.corda.messaging;
-
-import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;

--- a/libs/messaging/messaging/src/main/java/net/corda/messaging/package-info.java
+++ b/libs/messaging/messaging/src/main/java/net/corda/messaging/package-info.java
@@ -1,4 +1,4 @@
 @QuasarIgnoreSubPackages
-package net.corda.messaging.api;
+package net.corda.messaging;
 
 import co.paralleluniverse.quasar.annotations.QuasarIgnoreSubPackages;


### PR DESCRIPTION
Configure Quasar to ignore all messaging packages via its API bundle.