### PR TITLE
CORE-9630 Finality takes a transaction builder

### DIFF
--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImpl.kt
@@ -3,7 +3,6 @@ package net.corda.ledger.consensual.flow.impl
 import net.corda.ledger.consensual.flow.impl.flows.finality.ConsensualFinalityFlow
 import net.corda.ledger.consensual.flow.impl.flows.finality.ConsensualReceiveFinalityFlow
 import net.corda.ledger.consensual.flow.impl.persistence.ConsensualLedgerPersistenceService
-import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualTransactionBuilderImpl
 import net.corda.ledger.consensual.flow.impl.transaction.factory.ConsensualSignedTransactionFactory
 import net.corda.sandbox.type.UsedByFlow
@@ -14,16 +13,13 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
-import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionValidator
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
+import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionValidator
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
-import java.security.AccessController
-import java.security.PrivilegedActionException
-import java.security.PrivilegedExceptionAction
 
 @Component(service = [ConsensualLedgerService::class, UsedByFlow::class], scope = PROTOTYPE)
 class ConsensualLedgerServiceImpl @Activate constructor(

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImpl.kt
@@ -55,21 +55,10 @@ class ConsensualLedgerServiceImpl @Activate constructor(
 
     @Suspendable
     override fun finalize(
-        signedTransaction: ConsensualSignedTransaction,
+        transactionBuilder: ConsensualTransactionBuilder,
         sessions: List<FlowSession>
     ): ConsensualSignedTransaction {
-        /*
-        Need [doPrivileged] due to [contextLogger] being used in the flow's constructor.
-        Creating the executing the SubFlow must be independent otherwise the security manager causes issues with Quasar.
-        */
-        val consensualFinalityFlow = try {
-            AccessController.doPrivileged(PrivilegedExceptionAction {
-                ConsensualFinalityFlow(signedTransaction as ConsensualSignedTransactionInternal, sessions)
-            })
-        } catch (e: PrivilegedActionException) {
-            throw e.exception
-        }
-        return flowEngine.subFlow(consensualFinalityFlow)
+        return flowEngine.subFlow(ConsensualFinalityFlow(transactionBuilder, sessions))
     }
 
     @Suspendable
@@ -77,13 +66,6 @@ class ConsensualLedgerServiceImpl @Activate constructor(
         session: FlowSession,
         validator: ConsensualTransactionValidator
     ): ConsensualSignedTransaction {
-        val consensualReceiveFinalityFlow = try {
-            AccessController.doPrivileged(PrivilegedExceptionAction {
-                ConsensualReceiveFinalityFlow(session, validator)
-            })
-        } catch (e: PrivilegedActionException) {
-            throw e.exception
-        }
-        return flowEngine.subFlow(consensualReceiveFinalityFlow)
+        return flowEngine.subFlow(ConsensualReceiveFinalityFlow(session, validator))
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImpl.kt
@@ -4,17 +4,13 @@ import net.corda.ledger.consensual.flow.impl.transaction.factory.ConsensualSigne
 import net.corda.ledger.consensual.flow.impl.transaction.verifier.ConsensualTransactionBuilderVerifier
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.consensual.ConsensualState
-import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
 import java.util.Objects
 
 class ConsensualTransactionBuilderImpl(
     private val consensualSignedTransactionFactory: ConsensualSignedTransactionFactory,
-    // cpi defines what type of signing/hashing is used (related to the digital signature signing and verification stuff)
     override val states: MutableList<ConsensualState> = mutableListOf(),
 ) : ConsensualTransactionBuilder, ConsensualTransactionBuilderInternal {
-
-    private var alreadySigned = false
 
      override fun withStates(vararg states: ConsensualState): ConsensualTransactionBuilder {
         this.states += states
@@ -23,11 +19,8 @@ class ConsensualTransactionBuilderImpl(
 
     @Suspendable
     override fun toSignedTransaction(): ConsensualSignedTransactionInternal {
-        check(!alreadySigned) { "A transaction cannot be signed twice." }
         ConsensualTransactionBuilderVerifier(this).verify()
-        return consensualSignedTransactionFactory.create(this).also {
-            alreadySigned = true
-        }
+        return consensualSignedTransactionFactory.create(this)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImpl.kt
@@ -12,7 +12,7 @@ class ConsensualTransactionBuilderImpl(
     private val consensualSignedTransactionFactory: ConsensualSignedTransactionFactory,
     // cpi defines what type of signing/hashing is used (related to the digital signature signing and verification stuff)
     override val states: MutableList<ConsensualState> = mutableListOf(),
-) : ConsensualTransactionBuilder {
+) : ConsensualTransactionBuilder, ConsensualTransactionBuilderInternal {
 
     private var alreadySigned = false
 
@@ -22,12 +22,7 @@ class ConsensualTransactionBuilderImpl(
     }
 
     @Suspendable
-    override fun toSignedTransaction(): ConsensualSignedTransaction {
-        return sign()
-    }
-
-    @Suspendable
-    fun sign(): ConsensualSignedTransaction {
+    override fun toSignedTransaction(): ConsensualSignedTransactionInternal {
         check(!alreadySigned) { "A transaction cannot be signed twice." }
         ConsensualTransactionBuilderVerifier(this).verify()
         return consensualSignedTransactionFactory.create(this).also {

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderInternal.kt
@@ -1,0 +1,27 @@
+package net.corda.ledger.consensual.flow.impl.transaction
+
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
+import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
+
+/**
+ * Internal representation of [ConsensualTransactionBuilder] for methods we don't want used publicly.
+ */
+interface ConsensualTransactionBuilderInternal : ConsensualTransactionBuilder {
+
+    /**
+     * Verifies the content of the [ConsensualTransactionBuilder] and
+     * signs the transaction with any required signatories that belong to the current node.
+     *
+     * Calling this function once consumes the [ConsensualTransactionBuilder], so it cannot be used again.
+     * Therefore, if you want to build two transactions you need two builders.
+     *
+     * @return Returns a [ConsensualSignedTransactionInternal] with signatures for any required signatories that belong to the current node.
+     *
+     * @throws IllegalStateException when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
+     * @throws TransactionNoAvailableKeysException if none of the required keys are available to sign the transaction.
+     */
+    @Suspendable
+    fun toSignedTransaction(): ConsensualSignedTransactionInternal
+}

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactory.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactory.kt
@@ -1,19 +1,19 @@
 package net.corda.ledger.consensual.flow.impl.transaction.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
 
 interface ConsensualSignedTransactionFactory {
     @Suspendable
     fun create(
         consensualTransactionBuilder: ConsensualTransactionBuilder,
-    ): ConsensualSignedTransaction
+    ): ConsensualSignedTransactionInternal
 
     fun create(
         wireTransaction: WireTransaction,
         signaturesWithMetaData: List<DigitalSignatureAndMetadata>
-    ): ConsensualSignedTransaction
+    ): ConsensualSignedTransactionInternal
 }

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -9,6 +9,7 @@ import net.corda.ledger.consensual.data.transaction.ConsensualComponentGroup
 import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionImpl
 import net.corda.ledger.consensual.data.transaction.TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
+import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionInternal
 import net.corda.ledger.consensual.flow.impl.transaction.verifier.ConsensualLedgerTransactionVerifier
 import net.corda.ledger.consensual.flow.impl.transaction.verifier.verifyMetadata
 import net.corda.sandbox.type.UsedByFlow
@@ -19,7 +20,6 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
-import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
@@ -56,7 +56,7 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
     @Suspendable
     override fun create(
         consensualTransactionBuilder: ConsensualTransactionBuilder
-    ): ConsensualSignedTransaction {
+    ): ConsensualSignedTransactionInternal {
         val metadata: TransactionMetadata = transactionMetadataFactory.create(consensualMetadata())
         verifyMetadata(metadata)
         val metadataBytes = serializeMetadata(metadata)
@@ -84,7 +84,7 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
     override fun create(
         wireTransaction: WireTransaction,
         signaturesWithMetaData: List<DigitalSignatureAndMetadata>
-    ): ConsensualSignedTransaction {
+    ): ConsensualSignedTransactionInternal {
         return ConsensualSignedTransactionImpl(
             serializationService,
             transactionSignatureService,

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/ConsensualLedgerServiceImplTest.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.consensual.flow.impl
 
+import net.corda.ledger.consensual.flow.impl.transaction.ConsensualTransactionBuilderInternal
 import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.ledger.consensual.testkit.consensualStateExample
 import net.corda.v5.crypto.SecureHash
@@ -20,6 +21,7 @@ class ConsensualLedgerServiceImplTest: ConsensualLedgerTest() {
         val transactionBuilder = consensualLedgerService.getTransactionBuilder()
         val signedTransaction = transactionBuilder
             .withStates(consensualStateExample)
+            .let { it as ConsensualTransactionBuilderInternal }
             .toSignedTransaction()
         assertIs<ConsensualSignedTransaction>(signedTransaction)
         assertIs<SecureHash>(signedTransaction.id)

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/ConsensualFinalityFlowTest.kt
@@ -40,6 +40,7 @@ import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.time.Instant
 
+@Suppress("MaxLineLength")
 class ConsensualFinalityFlowTest {
 
     private companion object {

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualLedgerTransactionImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualLedgerTransactionImplTest.kt
@@ -19,6 +19,7 @@ class ConsensualLedgerTransactionImplTest: ConsensualLedgerTest() {
         val signedTransaction = ConsensualTransactionBuilderImpl(
             consensualSignedTransactionFactory)
             .withStates(consensualStateExample)
+            .let { it as ConsensualTransactionBuilderInternal }
             .toSignedTransaction()
         val ledgerTransaction = signedTransaction.toLedgerTransaction()
         assertTrue(abs(ledgerTransaction.timestamp.toEpochMilli() / 1000 - testTimestamp.toEpochMilli() / 1000) < 5)

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
@@ -17,6 +17,7 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
     fun `can build a simple Transaction`() {
         val tx = consensualTransactionBuilder
             .withStates(consensualStateExample)
+            .let { it as ConsensualTransactionBuilderInternal }
             .toSignedTransaction()
         assertIs<SecureHash>(tx.id)
     }
@@ -27,7 +28,7 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
             val builder = consensualTransactionBuilder
                 .withStates(consensualStateExample)
 
-            builder.toSignedTransaction()
+            (builder as ConsensualTransactionBuilderInternal).toSignedTransaction()
             builder.toSignedTransaction()
         }
     }
@@ -46,6 +47,7 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
             consensualTransactionBuilder
                 .withStates(consensualStateExample)
                 .withStates(ConsensualStateClassExample("test", emptyList()))
+                .let { it as ConsensualTransactionBuilderInternal }
                 .toSignedTransaction()
         }
         assertEquals("All consensual states must have participants.", exception.message)
@@ -55,7 +57,8 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
     fun `includes CPI and CPK information in metadata`() {
         val tx = consensualTransactionBuilder
             .withStates(consensualStateExample)
-            .toSignedTransaction() as ConsensualSignedTransactionImpl
+            .let { it as ConsensualTransactionBuilderInternal }
+            .toSignedTransaction()
 
         val metadata = tx.wireTransaction.metadata
         assertEquals(1, metadata.getLedgerVersion())

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
@@ -23,17 +23,6 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
     }
 
     @Test
-    fun `can't sign twice`() {
-        assertThrows(IllegalStateException::class.java) {
-            val builder = consensualTransactionBuilder
-                .withStates(consensualStateExample)
-
-            (builder as ConsensualTransactionBuilderInternal).toSignedTransaction()
-            builder.toSignedTransaction()
-        }
-    }
-
-    @Test
     fun `cannot build Transaction without Consensual States`() {
         val exception = assertThrows(IllegalStateException::class.java) {
             consensualTransactionBuilder.toSignedTransaction()

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -84,21 +84,10 @@ class UtxoLedgerServiceImpl @Activate constructor(
 
     @Suspendable
     override fun finalize(
-        signedTransaction: UtxoSignedTransaction,
+        transactionBuilder: UtxoTransactionBuilder,
         sessions: List<FlowSession>
     ): UtxoSignedTransaction {
-        /*
-        Need [doPrivileged] due to [contextLogger] being used in the flow's constructor.
-        Creating the executing the SubFlow must be independent otherwise the security manager causes issues with Quasar.
-        */
-        val utxoFinalityFlow = try {
-            AccessController.doPrivileged(PrivilegedExceptionAction {
-                UtxoFinalityFlow(signedTransaction as UtxoSignedTransactionInternal, sessions)
-            })
-        } catch (e: PrivilegedActionException) {
-            throw e.exception
-        }
-        return flowEngine.subFlow(utxoFinalityFlow)
+        return flowEngine.subFlow(UtxoFinalityFlow(transactionBuilder, sessions))
     }
 
     @Suspendable
@@ -106,13 +95,6 @@ class UtxoLedgerServiceImpl @Activate constructor(
         session: FlowSession,
         validator: UtxoTransactionValidator
     ): UtxoSignedTransaction {
-        val utxoReceiveFinalityFlow = try {
-            AccessController.doPrivileged(PrivilegedExceptionAction {
-                UtxoReceiveFinalityFlow(session, validator)
-            })
-        } catch (e: PrivilegedActionException) {
-            throw e.exception
-        }
-        return flowEngine.subFlow(utxoReceiveFinalityFlow)
+        return flowEngine.subFlow(UtxoReceiveFinalityFlow(session, validator))
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -29,9 +29,6 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
-import java.security.AccessController
-import java.security.PrivilegedActionException
-import java.security.PrivilegedExceptionAction
 
 @Component(service = [UtxoLedgerService::class, UsedByFlow::class], scope = PROTOTYPE)
 class UtxoLedgerServiceImpl @Activate constructor(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityBase.kt
@@ -97,9 +97,10 @@ abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
             // If the notary service key (composite key) is provided we need to make sure it contains the key the
             // transaction was signed with. This means it was signed with one of the notary VNodes (worker).
             if (!transaction.notary.owningKey.containsAny(listOf(signature.by))) {
-                throw CordaRuntimeException("Notary's signature has not been created by the transaction's notary. " +
-                    "Notary's public key: ${transaction.notary.owningKey} " +
-                    "Notary signature's key: ${signature.by}"
+                throw CordaRuntimeException(
+                    "Notary's signature has not been created by the transaction's notary. " +
+                            "Notary's public key: ${transaction.notary.owningKey} " +
+                            "Notary signature's key: ${signature.by}"
                 )
             }
             transactionSignatureService.verifySignature(transaction, signature)
@@ -107,7 +108,7 @@ abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
                 "Successfully verified signature($signature) by notary ${transaction.notary} for transaction ${transaction.id}"
             }
         } catch (e: Exception) {
-            val message ="Failed to verify transaction's signature($signature) by notary ${transaction.notary} for " +
+            val message = "Failed to verify transaction's signature($signature) by notary ${transaction.notary} for " +
                     "transaction ${transaction.id}. Message: ${e.message}"
             log.warn(message)
             persistInvalidTransaction(transaction)
@@ -120,7 +121,8 @@ abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
     protected fun verifyTransaction(signedTransaction: UtxoSignedTransaction) {
         try {
             transactionVerificationService.verify(signedTransaction.toLedgerTransaction())
-        } catch(e: Exception){
+        } catch (e: Exception) {
+            log.warn("Failed to verify platform checks and contract code for transaction ${signedTransaction.id}")
             persistInvalidTransaction(signedTransaction)
             throw e
         }
@@ -137,7 +139,7 @@ abstract class UtxoFinalityBase : SubFlow<UtxoSignedTransaction> {
         initialTransaction: UtxoSignedTransactionInternal,
         sessionToNotify: FlowSession? = null
     ) {
-        if (initialTransaction.signatures.isEmpty()){
+        if (initialTransaction.signatures.isEmpty()) {
             val message = "Received initial transaction without signatures."
             log.warn(message)
             persistInvalidTransaction(initialTransaction)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -131,12 +131,7 @@ class UtxoTransactionBuilderImpl(
     }
 
     @Suspendable
-    override fun toSignedTransaction(): UtxoSignedTransaction {
-        return sign()
-    }
-
-    @Suspendable
-    private fun sign(): UtxoSignedTransaction {
+    override fun toSignedTransaction(): UtxoSignedTransactionInternal {
         check(!alreadySigned) { "The transaction cannot be signed twice." }
         UtxoTransactionBuilderVerifier(this).verify()
         return utxoSignedTransactionFactory.create(this, signatories).also {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -30,8 +30,6 @@ class UtxoTransactionBuilderImpl(
     override val outputStates: MutableList<ContractStateAndEncumbranceTag> = mutableListOf()
 ) : UtxoTransactionBuilder, UtxoTransactionBuilderInternal {
 
-    private var alreadySigned = false
-
     override fun addAttachment(attachmentId: SecureHash): UtxoTransactionBuilder {
         this.attachments += attachmentId
         return this
@@ -132,11 +130,8 @@ class UtxoTransactionBuilderImpl(
 
     @Suspendable
     override fun toSignedTransaction(): UtxoSignedTransactionInternal {
-        check(!alreadySigned) { "The transaction cannot be signed twice." }
         UtxoTransactionBuilderVerifier(this).verify()
-        return utxoSignedTransactionFactory.create(this, signatories).also {
-            alreadySigned = true
-        }
+        return utxoSignedTransactionFactory.create(this, signatories)
     }
 
     private fun ContractState.withEncumbrance(tag: String?): ContractStateAndEncumbranceTag {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -11,7 +11,6 @@ import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.TimeWindow
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import java.security.PublicKey
 import java.time.Instant

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -6,7 +6,6 @@ import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysExceptio
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.TimeWindow
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import java.security.PublicKey
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -26,7 +26,7 @@ interface UtxoTransactionBuilderInternal : UtxoTransactionBuilder {
      * Calling this function once consumes the [UtxoTransactionBuilder], so it cannot be used again.
      * Therefore, if you want to build two transactions you need two builders.
      *
-     * @return Returns a [UtxoSignedTransaction] with signatures for any required signatories that belong to the current node.
+     * @return Returns a [UtxoSignedTransactionInternal] with signatures for any required signatories that belong to the current node.
      *
      * @throws IllegalStateException when called a second time on the same object to prevent
      *      unintentional duplicate transactions.

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -1,9 +1,12 @@
 package net.corda.ledger.utxo.flow.impl.transaction
 
+import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.TimeWindow
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import java.security.PublicKey
 
@@ -15,4 +18,20 @@ interface UtxoTransactionBuilderInternal : UtxoTransactionBuilder {
     val inputStateRefs: List<StateRef>
     val referenceStateRefs: List<StateRef>
     val outputStates: List<ContractStateAndEncumbranceTag>
+
+    /**
+     * Verifies the content of the [UtxoTransactionBuilder] and
+     * signs the transaction with any required signatories that belong to the current node.
+     *
+     * Calling this function once consumes the [UtxoTransactionBuilder], so it cannot be used again.
+     * Therefore, if you want to build two transactions you need two builders.
+     *
+     * @return Returns a [UtxoSignedTransaction] with signatures for any required signatories that belong to the current node.
+     *
+     * @throws IllegalStateException when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
+     * @throws TransactionNoAvailableKeysException if none of the required keys are available to sign the transaction.
+     */
+    @Suspendable
+    fun toSignedTransaction(): UtxoSignedTransactionInternal
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactory.kt
@@ -1,10 +1,10 @@
 package net.corda.ledger.utxo.flow.impl.transaction.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import java.security.PublicKey
 
 interface UtxoSignedTransactionFactory {
@@ -12,10 +12,10 @@ interface UtxoSignedTransactionFactory {
     fun create(
         utxoTransactionBuilder: UtxoTransactionBuilderInternal,
         signatories: Iterable<PublicKey>
-    ): UtxoSignedTransaction
+    ): UtxoSignedTransactionInternal
 
     fun create(
         wireTransaction: WireTransaction,
         signaturesWithMetaData: List<DigitalSignatureAndMetadata>
-    ): UtxoSignedTransaction
+    ): UtxoSignedTransactionInternal
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -4,13 +4,13 @@ import net.corda.common.json.validation.JsonValidator
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
-import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.ledger.common.flow.transaction.factory.TransactionMetadataFactory
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionMetadata
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
@@ -23,7 +23,7 @@ import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -62,7 +62,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
     override fun create(
         utxoTransactionBuilder: UtxoTransactionBuilderInternal,
         signatories: Iterable<PublicKey>
-    ): UtxoSignedTransaction {
+    ): UtxoSignedTransactionInternal {
         val metadata = transactionMetadataFactory.create(utxoMetadata())
 
         verifyMetadata(metadata)
@@ -90,7 +90,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
     override fun create(
         wireTransaction: WireTransaction,
         signaturesWithMetaData: List<DigitalSignatureAndMetadata>
-    ): UtxoSignedTransaction = UtxoSignedTransactionImpl(
+    ): UtxoSignedTransactionInternal = UtxoSignedTransactionImpl(
         serializationService,
         transactionSignatureService,
         utxoLedgerTransactionFactory,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl
 
 import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.ledger.utxo.test.UtxoLedgerTest
 import net.corda.ledger.utxo.testkit.UtxoCommandExample
 import net.corda.ledger.utxo.testkit.UtxoStateClassExample
@@ -50,6 +51,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(command)
             .addAttachment(attachment)
+            .let { it as UtxoTransactionBuilderInternal }
             .toSignedTransaction()
 
         assertIs<UtxoSignedTransaction>(signedTransaction)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoLedgerTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoLedgerTransactionImplTest.kt
@@ -48,6 +48,7 @@ internal class UtxoLedgerTransactionImplTest: UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(command)
             .addAttachment(attachment)
+            .let { it as UtxoTransactionBuilderInternal }
             .toSignedTransaction()
         ledgerTransaction = signedTransaction.toLedgerTransaction()
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
@@ -34,7 +34,8 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
             .addOutputState(utxoStateExample)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
-            .toSignedTransaction() as UtxoSignedTransactionInternal
+            .let { it as UtxoTransactionBuilderInternal }
+            .toSignedTransaction()
 
     }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -41,6 +41,7 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
+            .let { it as UtxoTransactionBuilderInternal }
             .toSignedTransaction()
         assertIs<SecureHash>(tx.id)
         assertEquals(inputStateRef, tx.inputStateRefs.single())
@@ -59,6 +60,7 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
             .addOutputState(utxoStateExample)
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
+            .let { it as UtxoTransactionBuilderInternal }
             .toSignedTransaction()
         assertIs<SecureHash>(tx.id)
         assertThat(tx.inputStateRefs).isEmpty()
@@ -78,6 +80,7 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
+            .let { it as UtxoTransactionBuilderInternal }
             .toSignedTransaction() as UtxoSignedTransactionImpl
 
         val metadata = tx.wireTransaction.metadata
@@ -119,7 +122,7 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
                 .addCommand(UtxoCommandExample())
                 .addAttachment(SecureHash("SHA-256", ByteArray(12)))
 
-            builder.toSignedTransaction()
+            (builder as UtxoTransactionBuilderInternal).toSignedTransaction()
             builder.toSignedTransaction()
         }
     }
@@ -158,6 +161,7 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
+            .let { it as UtxoTransactionBuilderInternal }
             .toSignedTransaction()
 
         assertThat(tx.outputStateAndRefs).hasSize(7)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -14,7 +14,6 @@ import net.corda.ledger.utxo.testkit.utxoTimeWindowExample
 import net.corda.v5.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -112,22 +112,6 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
     }
 
     @Test
-    fun `can't sign twice`() {
-        assertThrows(IllegalStateException::class.java) {
-            val builder = utxoTransactionBuilder
-                .setNotary(utxoNotaryExample)
-                .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
-                .addOutputState(utxoStateExample)
-                .addSignatories(listOf(publicKeyExample))
-                .addCommand(UtxoCommandExample())
-                .addAttachment(SecureHash("SHA-256", ByteArray(12)))
-
-            (builder as UtxoTransactionBuilderInternal).toSignedTransaction()
-            builder.toSignedTransaction()
-        }
-    }
-
-    @Test
     fun `Calculate encumbrance groups correctly`() {
         val inputStateAndRef = getUtxoInvalidStateAndRef()
         val inputStateRef = inputStateAndRef.ref

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializerTest.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp
 
 import net.corda.internal.serialization.amqp.helper.TestSerializationService
 import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.ledger.utxo.test.UtxoLedgerTest
 import net.corda.ledger.utxo.testkit.UtxoCommandExample
 import net.corda.ledger.utxo.testkit.UtxoStateClassExample
@@ -59,6 +60,7 @@ class UtxoSignedTransactionSerializerTest : UtxoLedgerTest() {
             .addSignatories(listOf(publicKeyExample))
             .addCommand(UtxoCommandExample())
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
+            .let { it as UtxoTransactionBuilderInternal }
             .toSignedTransaction()
 
         val bytes = serializationService.serialize(signedTx)
@@ -67,15 +69,11 @@ class UtxoSignedTransactionSerializerTest : UtxoLedgerTest() {
         assertThat(deserialized).isEqualTo(signedTx)
         assertThat(deserialized.outputStateAndRefs).hasSize(3)
 
-        assertThat(deserialized.outputStateAndRefs[0].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 1")
-        assertThat(deserialized.outputStateAndRefs[0].state.encumbrance).isNotNull().extracting { it?.size }
-            .isEqualTo(2)
+        assertThat(deserialized.outputStateAndRefs[0].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(deserialized.outputStateAndRefs[0].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(2)
 
-        assertThat(deserialized.outputStateAndRefs[1].state.encumbrance).isNotNull().extracting { it?.tag }
-            .isEqualTo("encumbrance 1")
-        assertThat(deserialized.outputStateAndRefs[1].state.encumbrance).isNotNull().extracting { it?.size }
-            .isEqualTo(2)
+        assertThat(deserialized.outputStateAndRefs[1].state.encumbrance).isNotNull.extracting { it?.tag }.isEqualTo("encumbrance 1")
+        assertThat(deserialized.outputStateAndRefs[1].state.encumbrance).isNotNull.extracting { it?.size }.isEqualTo(2)
 
         assertThat(deserialized.outputStateAndRefs[2].state.encumbrance).isNull()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.647-beta+
+cordaApiVersion=5.0.0.649-alpha-1676626679323
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
`UtxoLedgerService.finalize` and `ConsensualLedgerService.finalize` both
now take in their respective transaction builders instead of signed
transactions.

The respective finality flows now sign the builders.

`toSignedTransaction` has been made internal and removed from the API.

The "cant sign twice" code has been removed from the builders because
we control the signing of them, making the code redundant (as it was there
to help developers).