### PR TITLE
CORE-9550 Add caching for full key ids in `SigningKeyStoreImpl`

### DIFF
--- a/components/crypto/crypto-persistence-impl/build.gradle
+++ b/components/crypto/crypto-persistence-impl/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
     testImplementation project(":components:crypto:crypto-component-test-utils")

--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeyStoreImpl.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeyStoreImpl.kt
@@ -298,8 +298,9 @@ class SigningKeyStoreImpl @Activate constructor(
                         it.value
                     }
                     .filterTo(mutableSetOf()) {
-                        // TODO Clashed keys on short ids should be identified and removed from `requestedFullKeyIds` so we don't look them up in DB
-                        //  since short key ids can't clash per tenant, i.e. there can't be a different key with same short key id
+                        // TODO Clashed keys on short ids should be identified and removed from `requestedFullKeyIds` so we
+                        //  don't look them up in DB since short key ids can't clash per tenant,
+                        //  i.e. there can't be a different key with same short key id
                         SecureHash.parse(it.fullId) in requestedFullKeyIds
                     }
 

--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeyStoreImpl.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeyStoreImpl.kt
@@ -311,7 +311,7 @@ class SigningKeyStoreImpl @Activate constructor(
             } else {
                 val notFound =
                     requestedFullKeyIds - cachedKeysByFullId.mapTo(mutableSetOf()) { SecureHash.parse(it.fullId) }
-                // We look for keys by their full key ids so not risking a clash here
+                // We look for keys in DB by their full key ids so not risking a clash here
                 val fetchedKeys =
                     entityManagerFactory(tenantId).use { em ->
                         signingKeysRepository.findKeysByFullIds(em, tenantId, notFound)

--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeyStoreImpl.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeyStoreImpl.kt
@@ -274,10 +274,7 @@ class SigningKeyStoreImpl @Activate constructor(
                     entityManagerFactory(tenantId).use { em ->
                         signingKeysRepository.findKeysByIds(em, tenantId, notFound)
                     }
-                    // TODO below distinct is not needed. We are guarded by PK
-                    .distinctBy {
-                    it.id
-                }
+
                 fetchedKeys.forEach {
                     cache.put(CacheKey(tenantId, ShortHash.of(it.id)), it)
                 }

--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeysRepository.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeysRepository.kt
@@ -1,0 +1,34 @@
+package net.corda.crypto.persistence.impl
+
+import net.corda.crypto.persistence.SigningCachedKey
+import net.corda.crypto.persistence.db.model.SigningKeyEntity
+import net.corda.v5.crypto.SecureHash
+import net.corda.virtualnode.ShortHash
+import javax.persistence.EntityManager
+
+// Adding interface so it can be mocked in tests
+interface SigningKeysRepository {
+    fun findKeysByIds(
+        entityManager: EntityManager,
+        tenantId: String,
+        keyIds: Set<ShortHash>
+    ): Collection<SigningCachedKey>
+
+    fun findKeysByFullIds(
+        entityManager: EntityManager,
+        tenantId: String,
+        fullKeyIds: Set<SecureHash>
+    ): Collection<SigningCachedKey>
+
+    fun findKeyByFullId(
+        entityManager: EntityManager,
+        tenantId: String,
+        fullKeyId: SecureHash
+    ): SigningCachedKey?
+
+    fun findByAliases(
+        entityManager: EntityManager,
+        tenantId: String,
+        aliases: Collection<String>
+    ): Collection<SigningKeyEntity>
+}

--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeysRepositoryImpl.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeysRepositoryImpl.kt
@@ -1,0 +1,87 @@
+package net.corda.crypto.persistence.impl
+
+import net.corda.crypto.persistence.SigningCachedKey
+import net.corda.crypto.persistence.SigningKeyStatus
+import net.corda.crypto.persistence.db.model.SigningKeyEntity
+import net.corda.v5.crypto.SecureHash
+import net.corda.virtualnode.ShortHash
+import javax.persistence.EntityManager
+
+object SigningKeysRepositoryImpl : SigningKeysRepository {
+
+    override fun findKeysByIds(
+        entityManager: EntityManager,
+        tenantId: String,
+        keyIds: Set<ShortHash>
+    ): Collection<SigningCachedKey> {
+        val keyIdsStrings = keyIds.map { it.value }
+        return entityManager.createQuery(
+            "FROM SigningKeyEntity WHERE tenantId=:tenantId AND keyId IN(:keyIds)",
+            SigningKeyEntity::class.java
+        ).setParameter("tenantId", tenantId)
+            .setParameter("keyIds", keyIdsStrings)
+            .resultList.map { it.toSigningCachedKey() }
+    }
+
+    override fun findKeysByFullIds(
+        entityManager: EntityManager,
+        tenantId: String,
+        fullKeyIds: Set<SecureHash>
+    ): Collection<SigningCachedKey> {
+        val fullKeyIdsStrings = fullKeyIds.map { it.toString() }
+        return entityManager.createQuery(
+            "FROM ${SigningKeyEntity::class.java.simpleName} " +
+                    "WHERE tenantId=:tenantId " +
+                    "AND fullKeyId IN(:fullKeyIds) " +
+                    "ORDER BY timestamp",
+            SigningKeyEntity::class.java
+        ).setParameter("tenantId", tenantId)
+            .setParameter("fullKeyIds", fullKeyIdsStrings)
+            .resultList.map { it.toSigningCachedKey() }
+    }
+
+    override fun findKeyByFullId(
+        entityManager: EntityManager,
+        tenantId: String,
+        fullKeyId: SecureHash
+    ): SigningCachedKey? =
+        entityManager.createQuery(
+            "FROM ${SigningKeyEntity::class.java.simpleName} " +
+                    "WHERE tenantId=:tenantId " +
+                    "AND fullKeyId=:fullKeyId",
+            SigningKeyEntity::class.java
+        ).setParameter("tenantId", tenantId)
+            .setParameter("fullKeyId", fullKeyId.toString())
+            .resultList.singleOrNull()?.toSigningCachedKey()
+
+    override fun findByAliases(
+        entityManager: EntityManager,
+        tenantId: String,
+        aliases: Collection<String>
+    ): Collection<SigningKeyEntity> =
+        entityManager.createQuery(
+            "FROM SigningKeyEntity WHERE tenantId=:tenantId AND alias IN(:aliases)",
+            SigningKeyEntity::class.java
+        ).setParameter("tenantId", tenantId)
+            .setParameter("aliases", aliases)
+            .resultList
+}
+
+fun SigningKeyEntity.toSigningCachedKey(): SigningCachedKey =
+    SigningCachedKey(
+        id = keyId,
+        fullId = fullKeyId,
+        tenantId = tenantId,
+        category = category,
+        alias = alias,
+        hsmAlias = hsmAlias,
+        publicKey = publicKey,
+        keyMaterial = keyMaterial,
+        schemeCodeName = schemeCodeName,
+        masterKeyAlias = masterKeyAlias,
+        externalId = externalId,
+        encodingVersion = encodingVersion,
+        timestamp = timestamp,
+        hsmId = hsmId,
+        status = SigningKeyStatus.valueOf(status.name)
+    )

--- a/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
+++ b/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
@@ -45,7 +45,6 @@ class SigningKeyStoreUnitTest {
                                 whenever(it.getLong("expireAfterAccessMins")).thenReturn(5L)
                                 whenever(it.getLong("maximumSize")).thenReturn(3)
                             }
-//                            whenever(it.getConfig("cache")).thenReturn(cacheConfig)
 
                             val signingServiceConfig = mock<SmartConfig>().also {
                                 whenever(it.getConfig("cache")).thenReturn(cacheConfig)
@@ -138,10 +137,6 @@ class SigningKeyStoreUnitTest {
 
         val fullKeyId1 = SecureHash.parse("SHA-256:BBC12345678911111111111111")
         val shortKeyId1 = ShortHash.of(fullKeyId1)
-        val cachedKey1 = mock<SigningCachedKey>().also {
-            whenever(it.fullId).thenReturn(fullKeyId1.toString())
-        }
-        println(cachedKey1)
 
         val signingKeyIds = setOf(fullKeyId0, fullKeyId1).mapTo(mutableSetOf()) { ShortHash.of(it) }
         val cachedKeys = mapOf(

--- a/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
+++ b/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
@@ -1,0 +1,328 @@
+package net.corda.crypto.persistence.impl.tests
+
+import com.github.benmanes.caffeine.cache.Cache
+import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
+import net.corda.cipher.suite.impl.PlatformDigestServiceImpl
+import net.corda.configuration.read.ConfigChangedEvent
+import net.corda.crypto.config.impl.CryptoSigningServiceConfig
+import net.corda.crypto.config.impl.signingService
+import net.corda.crypto.config.impl.toCryptoConfig
+import net.corda.crypto.persistence.CryptoConnectionsFactory
+import net.corda.crypto.persistence.SigningCachedKey
+import net.corda.crypto.persistence.impl.SigningKeyStoreImpl
+import net.corda.crypto.persistence.impl.SigningKeyStoreImpl.Impl.CacheKey
+import net.corda.crypto.persistence.impl.SigningKeysRepository
+import net.corda.libs.configuration.SmartConfig
+import net.corda.schema.configuration.ConfigKeys
+import net.corda.v5.crypto.SecureHash
+import net.corda.virtualnode.ShortHash
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// TODO This is to be renamed to SigningKeyStoreTest once `SigningKeyStoreTests` gets ported/ removed
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SigningKeyStoreUnitTest {
+
+    val signingServiceConfig = ConfigChangedEvent(
+        mock(),
+        run {
+            mapOf(
+                ConfigKeys.CRYPTO_CONFIG to
+                        mock<SmartConfig>().also {
+                            val cacheConfig = mock<SmartConfig>().also {
+                                whenever(it.getLong("expireAfterAccessMins")).thenReturn(5L)
+                                whenever(it.getLong("maximumSize")).thenReturn(3)
+                            }
+//                            whenever(it.getConfig("cache")).thenReturn(cacheConfig)
+
+                            val signingServiceConfig = mock<SmartConfig>().also {
+                                whenever(it.getConfig("cache")).thenReturn(cacheConfig)
+                            }
+
+                            whenever(it.getConfig("signingService")).thenReturn(signingServiceConfig)
+                        }
+            )
+        }
+    ).config.toCryptoConfig().signingService()
+
+    val tenantId = "123"
+
+    val cipherSchemeMetadataImpl = CipherSchemeMetadataImpl()
+    lateinit var connectionsFactory: CryptoConnectionsFactory
+
+    lateinit var signingKeysRepository: SigningKeysRepository
+    lateinit var signingKeyStore: SigningKeyStoreImpl.Impl
+
+    fun setUpSigningKeyStore(cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey>) {
+        signingKeyStore =
+            SigningKeyStoreImpl.Impl(
+                signingServiceConfig,
+                mock(),
+                cipherSchemeMetadataImpl,
+                connectionsFactory,
+                PlatformDigestServiceImpl(cipherSchemeMetadataImpl),
+                signingKeysRepository,
+                cacheFactory
+            )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        signingKeysRepository = mock()
+        // resetting this state for verify
+        connectionsFactory = mock<CryptoConnectionsFactory>().also {
+            val entityManagerFactory = mock<EntityManagerFactory>().also {
+                val entityManager = mock<EntityManager>()
+                whenever(it.createEntityManager()).thenReturn(entityManager)
+            }
+            whenever(it.getEntityManagerFactory(tenantId)).thenReturn(entityManagerFactory)
+        }
+    }
+
+    @Test
+    fun `lookupByKeyIds returns requested keys from cache if all requested keys are in cache`() {
+        // Remember key ids cannot clash for same tenant so short keys of testing keys need to be different
+        val fullKeyId0 = SecureHash.parse("SHA-256:ABC12345678911111111111111")
+        val shortKeyId0 = ShortHash.of(fullKeyId0)
+        val cachedKey0 = mock<SigningCachedKey>().also {
+            whenever(it.fullId).thenReturn(fullKeyId0.toString())
+        }
+
+        val fullKeyId1 = SecureHash.parse("SHA-256:BBC12345678911111111111111")
+        val shortKeyId1 = ShortHash.of(fullKeyId1)
+        val cachedKey1 = mock<SigningCachedKey>().also {
+            whenever(it.fullId).thenReturn(fullKeyId1.toString())
+        }
+
+        val signingKeyIds = setOf(fullKeyId0, fullKeyId1).mapTo(mutableSetOf()) { ShortHash.of(it) }
+        val cachedKeys = mapOf(
+            CacheKey(tenantId, shortKeyId0) to cachedKey0,
+            CacheKey(tenantId, shortKeyId1) to cachedKey1
+        )
+
+        val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
+            mock<Cache<CacheKey, SigningCachedKey>>().also {
+                whenever(
+                    it.getAllPresent(eq(signingKeyIds.mapTo(mutableSetOf()) { CacheKey(tenantId, it) }))).thenReturn(cachedKeys)
+            }
+        }
+        setUpSigningKeyStore(cacheFactory)
+        assertEquals(
+            setOf(fullKeyId0, fullKeyId1).map { it.toString() }.toSet(),
+            signingKeyStore.lookupByKeyIds(tenantId, setOf(shortKeyId0, shortKeyId1)).map { it.fullId }.toSet()
+        )
+        // verify it didn't go to the database
+        verify(connectionsFactory, times(0)).getEntityManagerFactory(any())
+    }
+
+    @Test
+    fun `lookupByKeyIds returns requested keys from cache and from database if they are not cached`() {
+        val fullKeyId0 = SecureHash.parse("SHA-256:ABC12345678911111111111111")
+        val shortKeyId0 = ShortHash.of(fullKeyId0)
+        val cachedKey0 = mock<SigningCachedKey>().also {
+            whenever(it.id).thenReturn(shortKeyId0.toString())
+            whenever(it.fullId).thenReturn(fullKeyId0.toString())
+        }
+
+        val fullKeyId1 = SecureHash.parse("SHA-256:BBC12345678911111111111111")
+        val shortKeyId1 = ShortHash.of(fullKeyId1)
+        val cachedKey1 = mock<SigningCachedKey>().also {
+            whenever(it.fullId).thenReturn(fullKeyId1.toString())
+        }
+        println(cachedKey1)
+
+        val signingKeyIds = setOf(fullKeyId0, fullKeyId1).mapTo(mutableSetOf()) { ShortHash.of(it) }
+        val cachedKeys = mapOf(
+            CacheKey(tenantId, shortKeyId0) to cachedKey0
+        )
+
+        val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
+            mock<Cache<CacheKey, SigningCachedKey>>().also {
+                whenever(
+                    it.getAllPresent(eq(signingKeyIds.mapTo(mutableSetOf()) { CacheKey(tenantId, it) }))).thenReturn(cachedKeys)
+            }
+        }
+
+        val keysCaptor = argumentCaptor<Set<ShortHash>>()
+        signingKeysRepository.run {
+            val dbFetchedKey = mock<SigningCachedKey>().also { whenever(it.id).thenReturn(shortKeyId1.value) }
+            whenever(this.findKeysByIds(any(), eq(tenantId), keysCaptor.capture())).thenReturn(setOf(dbFetchedKey))
+        }
+
+        setUpSigningKeyStore(cacheFactory)
+        val lookedUpByKeyIdsKeys = signingKeyStore.lookupByKeyIds(tenantId, setOf(shortKeyId0, shortKeyId1))
+
+        val expectedNotFoundInCache = setOf(shortKeyId1)
+        assertEquals(expectedNotFoundInCache, keysCaptor.firstValue)
+        assertEquals(setOf(shortKeyId0.value, shortKeyId1.value), lookedUpByKeyIdsKeys.mapTo(mutableSetOf()) { it.id })
+        verify(connectionsFactory, times(1)).getEntityManagerFactory(any())
+    }
+
+    @Test
+    fun `lookupByFullKeyIds returns requested keys from cache if all requested keys are in cache`() {
+        // Remember key ids cannot clash for same tenant so short keys of testing keys need to be different
+        val fullKeyId0 = SecureHash.parse("SHA-256:ABC12345678911111111111111")
+        val shortKeyId0 = ShortHash.of(fullKeyId0)
+
+        val fullKeyId1 = SecureHash.parse("SHA-256:BBC12345678911111111111111")
+        val shortKeyId1 = ShortHash.of(fullKeyId1)
+
+        val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
+            val cachedKey0 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId0.toString()) }
+            val cachedKey1 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId1.toString()) }
+            val cachedKeys = mapOf(
+                CacheKey(tenantId, shortKeyId0) to cachedKey0,
+                CacheKey(tenantId, shortKeyId1) to cachedKey1
+            )
+            mock<Cache<CacheKey, SigningCachedKey>>().also {
+                val cacheKeyIds = setOf(shortKeyId0, shortKeyId1).mapTo(mutableSetOf()) { CacheKey(tenantId, it) }
+                whenever(it.getAllPresent(eq(cacheKeyIds))).thenReturn(cachedKeys)
+            }
+        }
+
+        setUpSigningKeyStore(cacheFactory)
+        assertEquals(
+            setOf(fullKeyId0, fullKeyId1).map { it.toString() }.toSet(),
+            signingKeyStore.lookupByFullKeyIds(tenantId, setOf(fullKeyId0, fullKeyId1)).map { it.fullId }.toSet()
+        )
+        // verify it didn't go to the database
+        verify(connectionsFactory, times(0)).getEntityManagerFactory(any())
+    }
+
+    @Test
+    fun `lookupByFullKeyIds returns requested keys from cache and from database if they are not cached`() {
+        val fullKeyId0 = SecureHash.parse("SHA-256:ABC12345678911111111111111")
+        val shortKeyId0 = ShortHash.of(fullKeyId0)
+        val fullKeyId1 = SecureHash.parse("SHA-256:BBC12345678911111111111111")
+        val shortKeyId1 = ShortHash.of(fullKeyId1)
+
+        val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
+            mock<Cache<CacheKey, SigningCachedKey>>().also {
+                val cachedKey0 = mock<SigningCachedKey>().also {
+                    whenever(it.id).thenReturn(shortKeyId0.toString())
+                    whenever(it.fullId).thenReturn(fullKeyId0.toString())
+                }
+                val cachedKeys = mapOf(
+                    CacheKey(tenantId, shortKeyId0) to cachedKey0
+                )
+
+                val cacheKeyIds = setOf(shortKeyId0, shortKeyId1).mapTo(mutableSetOf()) { CacheKey(tenantId, it) }
+                whenever(
+                    it.getAllPresent(eq(cacheKeyIds))).thenReturn(cachedKeys)
+            }
+        }
+
+        val keysCaptor = argumentCaptor<Set<SecureHash>>()
+        signingKeysRepository.run {
+            val dbFetchedKey = mock<SigningCachedKey>().also {
+                whenever(it.id).thenReturn(shortKeyId1.value)
+                whenever(it.fullId).thenReturn(fullKeyId1.toString())
+            }
+            whenever(this.findKeysByFullIds(any(), eq(tenantId), keysCaptor.capture())).thenReturn(setOf(dbFetchedKey))
+        }
+
+        setUpSigningKeyStore(cacheFactory)
+        val lookedUpByFullKeyIdsKeys = signingKeyStore.lookupByFullKeyIds(tenantId, setOf(fullKeyId0, fullKeyId1))
+
+        val expectedNotFoundInCache = setOf(fullKeyId1)
+        assertEquals(expectedNotFoundInCache, keysCaptor.firstValue)
+        assertEquals(setOf(fullKeyId0.toString(), fullKeyId1.toString()), lookedUpByFullKeyIdsKeys.mapTo(mutableSetOf()) { it.fullId })
+        verify(connectionsFactory, times(1)).getEntityManagerFactory(any())
+    }
+
+    @Test
+    fun `lookupByFullKeyIds will not return clashed keys on short key id`() {
+        val fullKeyId = SecureHash.parse("SHA-256:ABC12345678911111111111111")
+        val shortKeyId = ShortHash.of(fullKeyId)
+        val requestedFullKeyId = SecureHash.parse("SHA-256:ABC12345678911111111111112")
+        val requestedShortKeyId = ShortHash.of(requestedFullKeyId)
+
+        val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
+            mock<Cache<CacheKey, SigningCachedKey>>().also {
+                val cachedKey = mock<SigningCachedKey>().also {
+                    whenever(it.id).thenReturn(shortKeyId.toString())
+                    whenever(it.fullId).thenReturn(fullKeyId.toString())
+                }
+                val cachedKeys = mapOf(
+                    CacheKey(tenantId, shortKeyId) to cachedKey
+                )
+
+                val cacheKeyIds = setOf(shortKeyId, requestedShortKeyId).mapTo(mutableSetOf()) { CacheKey(tenantId, it) }
+                whenever(it.getAllPresent(eq(cacheKeyIds))).thenReturn(cachedKeys)
+            }
+        }
+
+        val keysCaptor = argumentCaptor<Set<SecureHash>>()
+        signingKeysRepository.run {
+            whenever(this.findKeysByFullIds(any(), eq(tenantId), keysCaptor.capture())).thenReturn(setOf())
+        }
+
+        setUpSigningKeyStore(cacheFactory)
+        val lookedUpByFullKeyIdsKeys = signingKeyStore.lookupByFullKeyIds(tenantId, setOf(requestedFullKeyId))
+
+        // TODO This currently goes to look for clashed on short key id keys up in DB, it should be changed so that id doesn't as
+        //  we can't have clashed short key ids per tenant
+        val keysLookedUpInDb = setOf(requestedFullKeyId)
+        assertEquals(keysLookedUpInDb, keysCaptor.firstValue)
+        assertEquals(setOf(), lookedUpByFullKeyIdsKeys.mapTo(mutableSetOf()) { it.fullId })
+        verify(connectionsFactory, times(1)).getEntityManagerFactory(any())
+    }
+
+    @Test
+    fun `lookupByFullKeyId returns requested key from cache if cached`() {
+        val fullKeyId = SecureHash.parse("SHA-256:ABC12345678911111111111111")
+        val shortKeyId = ShortHash.of(fullKeyId)
+
+        val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
+            mock<Cache<CacheKey, SigningCachedKey>>().also {
+                val cachedKey = mock<SigningCachedKey>().also {
+                    whenever(it.id).thenReturn(shortKeyId.toString())
+                    whenever(it.fullId).thenReturn(fullKeyId.toString())
+                }
+                whenever(it.get(eq(CacheKey(tenantId, shortKeyId)), any())).thenReturn(cachedKey)
+            }
+        }
+
+        setUpSigningKeyStore(cacheFactory)
+        val lookedUpByFullKeyIdKey = signingKeyStore.lookupByFullKeyId(tenantId, fullKeyId)
+
+        assertEquals(fullKeyId.toString(), lookedUpByFullKeyIdKey!!.fullId)
+        verify(connectionsFactory, times(0)).getEntityManagerFactory(any())
+    }
+
+
+    @Test
+    fun `lookupByFullKeyId will not return clashed keys on short key id`() {
+        val fullKeyId = SecureHash.parse("SHA-256:ABC12345678911111111111111")
+        val shortKeyId = ShortHash.of(fullKeyId)
+        val requestedFullKeyId = SecureHash.parse("SHA-256:ABC12345678911111111111112")
+
+        val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
+            mock<Cache<CacheKey, SigningCachedKey>>().also {
+                val cachedKey = mock<SigningCachedKey>().also {
+                    whenever(it.id).thenReturn(shortKeyId.toString())
+                    whenever(it.fullId).thenReturn(fullKeyId.toString())
+                }
+                whenever(it.get(eq(CacheKey(tenantId, shortKeyId)), any())).thenReturn(cachedKey)
+            }
+        }
+
+        setUpSigningKeyStore(cacheFactory)
+        val lookedUpByFullKeyIdKey = signingKeyStore.lookupByFullKeyId(tenantId, requestedFullKeyId)
+
+        assertNull(lookedUpByFullKeyIdKey)
+        verify(connectionsFactory, times(0)).getEntityManagerFactory(any())
+    }
+}

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/PublicKeyUtils.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/PublicKeyUtils.kt
@@ -26,6 +26,9 @@ fun fullPublicKeyIdFromBytes(publicKey: ByteArray, digestService: PlatformDigest
 fun PublicKey.fullId(keyEncodingService: KeyEncodingService, digestService: PlatformDigestService): String =
     fullPublicKeyIdFromBytes(keyEncodingService.encodeAsByteArray(this), digestService)
 
+fun PublicKey.fullIdHash(keyEncodingService: KeyEncodingService, digestService: PlatformDigestService): SecureHash =
+    digestService.hash(keyEncodingService.encodeAsByteArray(this), DigestAlgorithmName.SHA2_256)
+
 // TODO Remove the followings, only adding now for convenience
 fun fullPublicKeyIdFromBytes(publicKey: ByteArray): String =
     SecureHash(DigestAlgorithmName.SHA2_256.name, publicKey.sha256Bytes()).toString()


### PR DESCRIPTION
- extracts out persistence code in repository pattern/ interface so it can be mocked out
- adds caching for full key ids in `SigningKeyStoreImpl`