### PR TITLE
CORE-10503 Make query parameter optional while fetching preauth tokens

### DIFF
--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/httprpc/v1/MGMRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/httprpc/v1/MGMRestResource.kt
@@ -148,7 +148,7 @@ interface MGMRestResource : RestResource {
         ownerX500Name: String? = null,
         @RestQueryParameter(required = false)
         preAuthTokenId: String? = null,
-        @RestQueryParameter(required = false)
+        @RestQueryParameter(required = false, default = "false")
         viewInactive: Boolean = false
     ): Collection<PreAuthToken>
 


### PR DESCRIPTION
Fixes issue where the GET endpoint for preauth tokens fails without the `viewInactive` query parameter.