### PR TITLE
CORE-9520 Member API endpoint to inspect group parameters

### DIFF
--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MemberLookupRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MemberLookupRestResourceImpl.kt
@@ -176,10 +176,11 @@ class MemberLookupRestResourceImpl @Activate constructor(
                 holdingIdentityShortHash
             ) { "Could not find holding identity '$holdingIdentityShortHash' associated with member." }.holdingIdentity
 
-            return with(membershipGroupReaderProvider.getGroupReader(holdingIdentity)) {
-                groupParameters?.toMap()
-            } ?: throw ResourceNotFoundException("Could not find group parameters for holding identity " +
-                        "'$holdingIdentityShortHash'.")
+            return membershipGroupReaderProvider
+                .getGroupReader(holdingIdentity)
+                .groupParameters
+                ?.toMap() ?: throw ResourceNotFoundException("Could not find group parameters for holding identity " +
+                    "'$holdingIdentityShortHash'.")
         }
 
         private fun GroupParameters.toMap() = entries.associate { it.key to it.value }

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
@@ -382,11 +382,16 @@ class MemberLookupRestResourceTest {
 
         @Test
         fun `viewGroupParameters correctly returns group parameters as JSON string`() {
+            val expectedGroupParamsMap = mapOf(
+                MPV_KEY to "1",
+                EPOCH_KEY to "1",
+                MODIFIED_TIME_KEY to clock.instant().toString(),
+            )
+
             val result = memberLookupRestResource.viewGroupParameters(HOLDING_IDENTITY_STRING)
-            assertThat(result)
-                .contains("\"${MPV_KEY}\":\"1\"")
-                .contains("\"${EPOCH_KEY}\":\"1\"")
-                .contains("\"${MODIFIED_TIME_KEY}\":\"${clock.instant()}\"")
+
+            assertThat(result.size).isEqualTo(3)
+            assertThat(result.entries).isEqualTo(expectedGroupParamsMap.entries)
         }
     }
 }

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
@@ -43,12 +43,10 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -57,7 +55,6 @@ import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.time.Instant
 import java.util.UUID
-import kotlin.test.assertFailsWith
 
 class MemberLookupRestResourceTest {
     companion object {
@@ -225,16 +222,16 @@ class MemberLookupRestResourceTest {
     @Test
     fun `starting and stopping the service succeeds`() {
         memberLookupRestResource.start()
-        assertTrue(memberLookupRestResource.isRunning)
+        assertThat(memberLookupRestResource.isRunning).isTrue
         memberLookupRestResource.stop()
-        assertFalse(memberLookupRestResource.isRunning)
+        assertThat(memberLookupRestResource.isRunning).isFalse
     }
 
     @Test
     fun `exception should be thrown when service is not running`() {
         val ex =
-            assertFailsWith<ServiceUnavailableException> { memberLookupRestResource.lookup(BAD_HOLDING_IDENTITY.value) }
-        assertTrue(ex.message.contains("MemberLookupRestResourceImpl"))
+            assertThrows<ServiceUnavailableException> { memberLookupRestResource.lookup(BAD_HOLDING_IDENTITY.value) }
+        assertThat(ex).hasMessageContaining("MemberLookupRestResourceImpl")
     }
 
     @Nested
@@ -249,71 +246,71 @@ class MemberLookupRestResourceTest {
         @Test
         fun `unfiltered lookup returns a list of all active members and their contexts`() {
             val result = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING)
-            assertEquals(2, result.members.size)
-            assertEquals(RestMemberInfoList(memberInfoList.map {
+            assertThat(result.members.size).isEqualTo(2)
+            assertThat(result).isEqualTo(RestMemberInfoList(memberInfoList.map {
                 RestMemberInfo(it.memberProvidedContext.entries.associate { it.key to it.value },
                     it.mgmProvidedContext.entries.associate { it.key to it.value })
-            }), result)
+            }))
         }
 
         @Test
         fun `lookup filtered by common name (CN) is case-insensitive and returns a list of members and their contexts`() {
             val result1 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, commonName = "bob")
-            assertEquals(1, result1.members.size)
-            assertEquals(bobRestResult, result1)
+            assertThat(result1.members.size).isEqualTo(1)
+            assertThat(result1).isEqualTo(bobRestResult)
             val result2 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, commonName = "BOB")
-            assertEquals(1, result2.members.size)
-            assertEquals(bobRestResult, result2)
+            assertThat(result2.members.size).isEqualTo(1)
+            assertThat(result2).isEqualTo(bobRestResult)
         }
 
         @Test
         fun `lookup filtered by organization (O) is case-insensitive and returns a list of members and their contexts`() {
             val result1 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, organization = "ALICE")
-            assertEquals(1, result1.members.size)
-            assertEquals(aliceRestResult, result1)
+            assertThat(result1.members.size).isEqualTo(1)
+            assertThat(result1).isEqualTo(aliceRestResult)
             val result2 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, organization = "alice")
-            assertEquals(1, result2.members.size)
-            assertEquals(aliceRestResult, result2)
+            assertThat(result2.members.size).isEqualTo(1)
+            assertThat(result2).isEqualTo(aliceRestResult)
         }
 
         @Test
         fun `lookup filtered by organization unit (OU) is case-insensitive and returns a list of members and their contexts`() {
             val result1 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, organizationUnit = "unit2")
-            assertEquals(1, result1.members.size)
-            assertEquals(bobRestResult, result1)
+            assertThat(result1.members.size).isEqualTo(1)
+            assertThat(result1).isEqualTo(bobRestResult)
             val result2 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, organizationUnit = "UNIT2")
-            assertEquals(1, result2.members.size)
-            assertEquals(bobRestResult, result2)
+            assertThat(result2.members.size).isEqualTo(1)
+            assertThat(result2).isEqualTo(bobRestResult)
         }
 
         @Test
         fun `lookup filtered by locality (L) is case-insensitive and returns a list of members and their contexts`() {
             val result1 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, locality = "london")
-            assertEquals(1, result1.members.size)
-            assertEquals(aliceRestResult, result1)
+            assertThat(result1.members.size).isEqualTo(1)
+            assertThat(result1).isEqualTo(aliceRestResult)
             val result2 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, locality = "LONDON")
-            assertEquals(1, result2.members.size)
-            assertEquals(aliceRestResult, result2)
+            assertThat(result2.members.size).isEqualTo(1)
+            assertThat(result2).isEqualTo(aliceRestResult)
         }
 
         @Test
         fun `lookup filtered by state (ST) is case-insensitive and returns a list of members and their contexts`() {
             val result1 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, state = "state2")
-            assertEquals(1, result1.members.size)
-            assertEquals(bobRestResult, result1)
+            assertThat(result1.members.size).isEqualTo(1)
+            assertThat(result1).isEqualTo(bobRestResult)
             val result2 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, state = "state2")
-            assertEquals(1, result2.members.size)
-            assertEquals(bobRestResult, result2)
+            assertThat(result2.members.size).isEqualTo(1)
+            assertThat(result2).isEqualTo(bobRestResult)
         }
 
         @Test
         fun `lookup filtered by country (C) is case-insensitive and returns a list of members and their contexts`() {
             val result1 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, country = "gb")
-            assertEquals(1, result1.members.size)
-            assertEquals(aliceRestResult, result1)
+            assertThat(result1.members.size).isEqualTo(1)
+            assertThat(result1).isEqualTo(aliceRestResult)
             val result2 = memberLookupRestResource.lookup(HOLDING_IDENTITY_STRING, country = "GB")
-            assertEquals(1, result2.members.size)
-            assertEquals(aliceRestResult, result2)
+            assertThat(result2.members.size).isEqualTo(1)
+            assertThat(result2).isEqualTo(aliceRestResult)
         }
 
         @Test
@@ -327,8 +324,8 @@ class MemberLookupRestResourceTest {
                 "state2",
                 "ie"
             )
-            assertEquals(1, result1.members.size)
-            assertEquals(bobRestResult, result1)
+            assertThat(result1.members.size).isEqualTo(1)
+            assertThat(result1).isEqualTo(bobRestResult)
             val result2 = memberLookupRestResource.lookup(
                 HOLDING_IDENTITY_STRING,
                 "BOB",
@@ -338,15 +335,15 @@ class MemberLookupRestResourceTest {
                 "STATE2",
                 "IE"
             )
-            assertEquals(1, result2.members.size)
-            assertEquals(bobRestResult, result2)
+            assertThat(result2.members.size).isEqualTo(1)
+            assertThat(result2).isEqualTo(bobRestResult)
         }
 
         @Test
         fun `lookup should fail when non-existent holding identity is used`() {
             val ex =
-                assertFailsWith<ResourceNotFoundException> { memberLookupRestResource.lookup(BAD_HOLDING_IDENTITY.value) }
-            assertTrue(ex.message.contains("holding identity"))
+                assertThrows<ResourceNotFoundException> { memberLookupRestResource.lookup(BAD_HOLDING_IDENTITY.value) }
+            assertThat(ex).hasMessageContaining("Could not find holding identity")
         }
     }
 
@@ -361,15 +358,15 @@ class MemberLookupRestResourceTest {
 
         @Test
         fun `viewGroupParameters should fail when non-existent holding identity is used`() {
-            val ex = assertFailsWith<ResourceNotFoundException> {
+            val ex = assertThrows<ResourceNotFoundException> {
                 memberLookupRestResource.viewGroupParameters(BAD_HOLDING_IDENTITY.value)
             }
-            assertTrue(ex.message.contains("Could not find holding identity"))
+            assertThat(ex).hasMessageContaining("Could not find holding identity")
         }
 
         @Test
         fun `viewGroupParameters fails with bad request if short hash is invalid`() {
-            assertFailsWith<BadRequestException> {
+            assertThrows<BadRequestException> {
                 memberLookupRestResource.viewGroupParameters("INVALID_SHORT_HASH")
             }
         }
@@ -377,10 +374,10 @@ class MemberLookupRestResourceTest {
         @Test
         fun `viewGroupParameters fails when reader returns null`() {
             whenever(groupReader.groupParameters).doReturn(null)
-            val ex = assertFailsWith<ResourceNotFoundException> {
+            val ex = assertThrows<ResourceNotFoundException> {
                 memberLookupRestResource.viewGroupParameters(HOLDING_IDENTITY_STRING)
             }
-            assertTrue(ex.message.contains("Could not find group parameters"))
+            assertThat(ex).hasMessageContaining("Could not find group parameters")
         }
 
         @Test

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/httprpc/v1/MemberLookupRestResourceTest.kt
@@ -390,8 +390,7 @@ class MemberLookupRestResourceTest {
 
             val result = memberLookupRestResource.viewGroupParameters(HOLDING_IDENTITY_STRING)
 
-            assertThat(result.size).isEqualTo(3)
-            assertThat(result.entries).isEqualTo(expectedGroupParamsMap.entries)
+            assertThat(result).containsExactlyEntriesOf(expectedGroupParamsMap)
         }
     }
 }

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/httprpc/v1/MemberLookupRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/httprpc/v1/MemberLookupRestResource.kt
@@ -86,4 +86,29 @@ interface MemberLookupRestResource : RestResource {
         )
         country: String? = null
     ): RestMemberInfoList
+
+    /**
+     * The [viewGroupParameters] method allows you to inspect the group parameters of the membership group, as
+     * visible to the member represented by [holdingIdentityShortHash].
+     *
+     * Example usage:
+     * ```
+     * memberLookupOps.viewGroupParameters(holdingIdentityShortHash = "58B6030FABDD")
+     * ```
+     *
+     * @param holdingIdentityShortHash Holding identity ID of the requesting member, which uniquely identifies the member
+     * and its group.
+     *
+     * @return The group parameters of the membership group in JSON [String] format.
+     */
+    @HttpGET(
+        path = "{holdingIdentityShortHash}/group-parameters",
+        description = "This method retrieves the group parameters of the membership group.",
+        responseDescription = "The group parameters of the membership group as a string in JSON format"
+    )
+    fun viewGroupParameters(
+        @RestPathParameter(description = "Holding identity ID of the requesting member. The result contains group " +
+                "parameters visible to this member.")
+        holdingIdentityShortHash: String
+    ): String
 }

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/httprpc/v1/MemberLookupRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/httprpc/v1/MemberLookupRestResource.kt
@@ -99,16 +99,16 @@ interface MemberLookupRestResource : RestResource {
      * @param holdingIdentityShortHash Holding identity ID of the requesting member, which uniquely identifies the member
      * and its group.
      *
-     * @return The group parameters of the membership group in JSON [String] format.
+     * @return The group parameters of the membership group as a [Map].
      */
     @HttpGET(
         path = "{holdingIdentityShortHash}/group-parameters",
         description = "This method retrieves the group parameters of the membership group.",
-        responseDescription = "The group parameters of the membership group as a string in JSON format"
+        responseDescription = "The group parameters of the membership group as a map"
     )
     fun viewGroupParameters(
         @RestPathParameter(description = "Holding identity ID of the requesting member. The result contains group " +
                 "parameters visible to this member.")
         holdingIdentityShortHash: String
-    ): String
+    ): Map<String, String>
 }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -1812,13 +1812,17 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "The group parameters of the membership group as a string in JSON format",
+            "description" : "The group parameters of the membership group as a map",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "type" : "string",
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string",
+                    "example" : "string"
+                  },
                   "nullable" : false,
-                  "example" : "string"
+                  "example" : "No example available for this type"
                 }
               }
             }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -1793,6 +1793,45 @@
         }
       }
     },
+    "/members/{holdingidentityshorthash}/group-parameters" : {
+      "get" : {
+        "tags" : [ "Member Lookup API" ],
+        "description" : "This method retrieves the group parameters of the membership group.",
+        "operationId" : "get_members__holdingidentityshorthash__group_parameters",
+        "parameters" : [ {
+          "name" : "holdingidentityshorthash",
+          "in" : "path",
+          "description" : "Holding identity ID of the requesting member. The result contains group parameters visible to this member.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "Holding identity ID of the requesting member. The result contains group parameters visible to this member.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The group parameters of the membership group as a string in JSON format",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "nullable" : false,
+                  "example" : "string"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
     "/membership/getprotocolversion" : {
       "get" : {
         "tags" : [ "Member Registration API" ],


### PR DESCRIPTION
Adds a REST endpoint on the Member Lookup API to retrieve group parameters.

To retrieve group parameters:
```
curl --insecure -u admin:admin $API_URL/members/$HOLDING_ID/group-parameters
```

Note: This PR has also been tested manually.
<img width="1788" alt="Screenshot 2023-02-20 at 17 43 47" src="https://user-images.githubusercontent.com/17948697/220173268-15fe6e4d-2d0d-4821-84c3-462d131bb3e0.png">
