### PR TITLE
NOTICK: Allow Overriding Defaults

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CpiLoader.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CpiLoader.kt
@@ -72,9 +72,9 @@ object CpiLoader {
                 groupPolicyFileName = groupPolicyPath.toString()
                 outputFileName = cpiPath.toString()
                 signingOptions = SigningOptions().apply {
-                    keyAlias = signOptions.keyAlias
-                    keyStoreFileName = signOptions.keyStore
+                    keyStoreFileName = keyStorePath.toString()
                     keyStorePass = signOptions.keyStorePassword
+                    keyAlias = signOptions.keyAlias
                 }
             }.run()
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/GroupPolicyUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/GroupPolicyUtils.kt
@@ -2,14 +2,15 @@ package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.databind.ObjectMapper
 
-private fun createCertificate() = CpiLoader::class.java.classLoader.getResource("certificate.pem")!!
+private fun createCertificate(certificateResource: String) = CpiLoader::class.java.classLoader.getResource(certificateResource)!!
     .readText()
     .replace("\r", "")
     .replace("\n", System.lineSeparator())
 
 fun getDefaultStaticNetworkGroupPolicy(
     groupId: String,
-    staticMemberNames: List<String>
+    staticMemberNames: List<String>,
+    certificateResource : String = "certificate.pem"
 ): String {
     val groupPolicy = mapOf(
         "fileFormatVersion" to 1,
@@ -33,11 +34,11 @@ fun getDefaultStaticNetworkGroupPolicy(
         ),
         "p2pParameters" to mapOf(
             "sessionTrustRoots" to listOf(
-                createCertificate(),
-                createCertificate()
+                createCertificate(certificateResource),
+                createCertificate(certificateResource)
             ),
             "tlsTrustRoots" to listOf(
-                createCertificate()
+                createCertificate(certificateResource)
             ),
             "sessionPki" to "Standard",
             "tlsPki" to "Standard",

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/Utils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/Utils.kt
@@ -26,7 +26,7 @@ const val CODE_SIGNER_CERT = "/cordadevcodesign.pem"
 const val TEST_NOTARY_CPI_NAME = "test-notary-server-cordapp"
 const val TEST_NOTARY_CPB_LOCATION = "/META-INF/notary-plugin-non-validating-server.cpb"
 
-val CLUSTER_URI = URI(System.getProperty("rpcHost"))
+val CLUSTER_URI = URI(System.getProperty("rpcHost", "NONE"))
 
 // BUG:  Not sure if we should be requiring clients to use a method similar to this because we
 // return a full hash (64 chars?) but the same API only accepts the first 12 chars.


### PR DESCRIPTION
Allow overriding internal default values so testing utilities can be
used regardless of the environment variables, certificates and
resources configured by consumers.
