### PR TITLE
CORE-8764 Prevent Internal Server Error In Keys REST Resource

### DIFF
--- a/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/CryptoOpsClient.kt
+++ b/components/crypto/crypto-client/src/main/kotlin/net/corda/crypto/client/CryptoOpsClient.kt
@@ -58,7 +58,7 @@ interface CryptoOpsClient : Lifecycle {
      * @param scheme the key's scheme code name describing which type of the key to generate.
      * @param context the optional key/value operation context.
      * @throws [KeyAlreadyExistsException] if a key with the provided alias already exists for the tenant.
-     * @throws [InvalidParamsException] If the tenant is not configured for the given category.
+     * @throws [InvalidParamsException] If the tenant is not configured for the given category or if the key's scheme is invalid.
      *
      * @return The public part of the pair.
      */
@@ -81,7 +81,7 @@ interface CryptoOpsClient : Lifecycle {
      * @param scheme the key's scheme code name describing which type of the key to generate.
      * @param context the optional key/value operation context.
      * @throws [KeyAlreadyExistsException] if a key with the provided alias already exists for the tenant.
-     * @throws [InvalidParamsException] If the tenant is not configured for the given category.
+     * @throws [InvalidParamsException] If the tenant is not configured for the given category or if the key's scheme is invalid.
      *
      * @return The public part of the pair.
      */
@@ -103,6 +103,7 @@ interface CryptoOpsClient : Lifecycle {
      * @param category The key category, such as ACCOUNTS, CI, etc.
      * @param scheme the key's scheme code name describing which type of the key to generate.
      * @param context the optional key/value operation context.
+     * @throws [InvalidParamsException] If the key's scheme is invalid.
      *
      * @return The [PublicKey] of the generated [KeyPair].
      */
@@ -122,6 +123,7 @@ interface CryptoOpsClient : Lifecycle {
      * @param externalId an id associated with the key, the service doesn't use any semantic beyond association.
      * @param scheme the key's scheme code name describing which type of the key to generate.
      * @param context the optional key/value operation context.
+     * @throws [InvalidParamsException] If the key's scheme is invalid.
      *
      * @return The [PublicKey] of the generated [KeyPair].
      */

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -12,6 +12,7 @@ import net.corda.crypto.core.CryptoConsts.Categories.LEDGER
 import net.corda.crypto.core.CryptoConsts.Categories.SESSION_INIT
 import net.corda.crypto.core.CryptoConsts.SOFT_HSM_ID
 import net.corda.crypto.core.CryptoConsts.SigningKeyFilters.ALIAS_FILTER
+import net.corda.crypto.core.InvalidParamsException
 import net.corda.crypto.core.KeyAlreadyExistsException
 import net.corda.crypto.core.publicKeyIdFromBytes
 import net.corda.crypto.impl.toWire
@@ -206,6 +207,14 @@ class CryptoOpsBusProcessorTests {
         testSigning(publicKey, data)
     }
 
+    @Test
+    fun `generate key should throw InvalidParamsException if invalid scheme name`() {
+        // generate
+        val exception = assertFailsWith<ExecutionException> {
+            process<CryptoPublicKey>(GenerateKeyPairCommand(LEDGER, newAlias(), null, "InvalidSchema", basicContext))
+        }
+        assertThat(exception.cause).isInstanceOf(InvalidParamsException::class.java)
+    }
 
     @Test
     fun `Second attempt to generate key with same alias should throw KeyAlreadyExistsException`() {
@@ -292,6 +301,16 @@ class CryptoOpsBusProcessorTests {
         assertEquals(externalId, info.externalId)
         // signing
         testSigning(publicKey, data)
+    }
+
+    @Test
+    fun `generate fresh key pair should throw InvalidParamsException if invalid scheme name`() {
+        // generate
+        val externalId = UUID.randomUUID().toString()
+        val exception = assertFailsWith<ExecutionException> {
+            process<CryptoPublicKey>(GenerateFreshKeyRpcCommand(CI, externalId, "InvalidSchema", basicContext))
+        }
+        assertThat(exception.cause).isInstanceOf(InvalidParamsException::class.java)
     }
 
     @Test


### PR DESCRIPTION
Catch `IllegalArgumentException` and throw `InvalidParamsException` inside CryptoOpsBusProcessor, when looking up the key schema. This causes the keys REST API to now return a 400 instead of a 500. See https://github.com/corda/corda-runtime-os/pull/2356/.

Before:
```
curl --insecure -u admin:admin -X POST https://localhost:8890/api/v1/keys/DCC16A5AC6AA/alias/DCC16AAAC6AA-auth/category/PRE_AUTH/scheme/CORDA.ECDSA_SECP256A1
Handling connection for 8890
{
    "title": "Could not generate key pair for tenant DCC16A5AC6AA: Unrecognised scheme code name: CORDA.ECDSA_SECP256A1",
    "status": 500,
    "details": {}
}%
```

After:
```
curl --insecure -u admin:admin -X POST https://localhost:8890/api/v1/keys/7677D002A03D/alias/7677D002A03D-auth/category/PRE_AUTH/scheme/CORDA.ECDSA_SECP256A1
Handling connection for 8890
{
    "title": "Unrecognised scheme code name: CORDA.ECDSA_SECP256A1",
    "status": 400,
    "details": {}
}%
```