### PR TITLE
CORE-7252 ReconcilerImpl `stop` method calls both `stop` and `close` on the lifecycle coordinator

### DIFF
--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerImpl.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerImpl.kt
@@ -45,6 +45,5 @@ internal class ReconcilerImpl<K : Any, V : Any>(
 
     override fun stop() {
         coordinator.stop()
-        coordinator.close()
     }
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -258,7 +258,7 @@ class DBProcessorImpl @Activate constructor(
     }
 
     private fun onStopEvent() {
-        reconcilers.close()
+        reconcilers.stop()
     }
 
     data class BootConfigEvent(val config: SmartConfig) : LifecycleEvent

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/Reconcilers.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/Reconcilers.kt
@@ -33,7 +33,7 @@ import net.corda.virtualnode.write.db.VirtualNodeInfoWriteService
  * Container component that holds the reconilcation objects.
  */
 @Suppress("LongParameterList")
-class Reconcilers constructor(
+class Reconcilers(
     coordinatorFactory: LifecycleCoordinatorFactory,
     dbConnectionManager: DbConnectionManager,
     virtualNodeInfoWriteService: VirtualNodeInfoWriteService,
@@ -49,7 +49,7 @@ class Reconcilers constructor(
     jpaEntitiesRegistry: JpaEntitiesRegistry,
     groupParametersFactory: GroupParametersFactory,
     allowedCertificatesReaderWriterService: AllowedCertificatesReaderWriterService,
-) : AutoCloseable {
+) {
     private val cpiReconciler = CpiReconciler(
         coordinatorFactory,
         dbConnectionManager,
@@ -93,12 +93,12 @@ class Reconcilers constructor(
         allowedCertificatesReaderWriterService,
     )
 
-    override fun close() {
-        cpiReconciler.close()
-        vnodeReconciler.close()
-        configReconciler.close()
-        groupParametersReconciler.close()
-        mgmAllowedCertificateSubjectsReconciler.close()
+    fun stop() {
+        cpiReconciler.stop()
+        vnodeReconciler.stop()
+        configReconciler.stop()
+        groupParametersReconciler.stop()
+        mgmAllowedCertificateSubjectsReconciler.stop()
     }
 
     /**

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
@@ -32,7 +32,7 @@ class ConfigReconciler(
         Stream.of(ClusterReconciliationContext(dbConnectionManager))
     }
 
-    override fun close() {
+    override fun stop() {
         dbReconciler?.stop()
         dbReconciler = null
         reconciler?.stop()

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconciler.kt
@@ -33,7 +33,7 @@ class CpiReconciler(
         Stream.of(ClusterReconciliationContext(dbConnectionManager))
     }
 
-    override fun close() {
+    override fun stop() {
         dbReconciler?.stop()
         dbReconciler = null
         reconciler?.stop()

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconciler.kt
@@ -68,7 +68,7 @@ class GroupParametersReconciler(
     @VisibleForTesting
     internal var reconciler: Reconciler? = null
 
-    override fun close() {
+    override fun stop() {
         lock.withLock {
             dbReconcilerReader?.stop()
             dbReconcilerReader = null

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconciler.kt
@@ -101,7 +101,7 @@ internal class MgmAllowedCertificateSubjectsReconciler(
             }
     }
 
-    override fun close() {
+    override fun stop() {
         dbReconcilerReader?.stop()
         dbReconcilerReader = null
         reconciler?.stop()

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconcilerWrapper.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconcilerWrapper.kt
@@ -3,7 +3,7 @@ package net.corda.processors.db.internal.reconcile.db
 /**
  * Any subclasses are assumed to be "reconcilers" that run periodically.
  */
-interface ReconcilerWrapper : AutoCloseable {
+interface ReconcilerWrapper {
     /**
      * Set the interval between reconciliations.
      *
@@ -12,4 +12,6 @@ interface ReconcilerWrapper : AutoCloseable {
      * If this method has never been called no reconciliation will take place.
      */
     fun updateInterval(intervalMillis: Long)
+
+    fun stop()
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeReconciler.kt
@@ -33,7 +33,7 @@ class VirtualNodeReconciler(
         Stream.of(ClusterReconciliationContext(dbConnectionManager))
     }
 
-    override fun close() {
+    override fun stop() {
         dbReconciler?.stop()
         dbReconciler = null
         reconciler?.stop()

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
@@ -119,17 +119,17 @@ class MgmAllowedCertificateSubjectsReconcilerTest {
     }
 
     @Test
-    fun `close will close the reconciler`() {
+    fun `stop will stop the reconciler`() {
         mgmAllowedCertificateSubjectsReconciler.updateInterval(10)
 
-        mgmAllowedCertificateSubjectsReconciler.close()
+        mgmAllowedCertificateSubjectsReconciler.stop()
 
         verify(reconciler).stop()
     }
 
     @Test
-    fun `close will not close the reconciler is not started`() {
-        mgmAllowedCertificateSubjectsReconciler.close()
+    fun `stop will not stop the reconciler is not started`() {
+        mgmAllowedCertificateSubjectsReconciler.stop()
 
         verify(reconciler, never()).stop()
     }


### PR DESCRIPTION
- removes erroneous `close` on coordinator
- changes some `close`s to `stop`s to conceptually align with reconcilers being stopped and not closed, i.e. they could be re-used if we wanted to