### PR TITLE
CORE-8774: Make AllTestsLifecycle fields static

### DIFF
--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -231,6 +231,7 @@ class MembershipP2PIntegrationTest {
             }
         }
 
+        @JvmStatic
         @AfterAll
         fun tearDown() {
             p2pSender.close()

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SandboxSingletonsTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/SandboxSingletonsTest.kt
@@ -31,10 +31,11 @@ class SandboxSingletonsTest {
         private const val TIMEOUT_MILLIS = 10000L
         private const val CPB = "META-INF/sandbox-singletons-cpk.cpb"
         private const val MAP_PROVIDER_FLOW = "com.example.singletons.TestDataProvider"
-    }
 
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxData: Map<String, Any?>
     private var unmatchedService: Any? = null

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleDifferentLibrariesTest.kt
@@ -22,8 +22,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxBundleDifferentLibrariesTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleEventIsolationTest.kt
@@ -23,8 +23,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxBundleEventIsolationTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundleIsolationTest.kt
@@ -28,8 +28,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @TestInstance(PER_CLASS)
 @Suppress("FunctionName")
 class SandboxBundleIsolationTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxBundlePrivateImplementationTest.kt
@@ -22,8 +22,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxBundlePrivateImplementationTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
@@ -27,8 +27,11 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxClassTagTests {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxFragmentBundleTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxFragmentBundleTest.kt
@@ -22,8 +22,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxFragmentBundleTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxGetCallingGroupTest.kt
@@ -24,8 +24,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxGetCallingGroupTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxIrresolvableBundleTest.kt
@@ -25,8 +25,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxIrresolvableBundleTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceEventIsolationTest.kt
@@ -23,8 +23,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxServiceEventIsolationTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxServiceIsolationTest.kt
@@ -29,8 +29,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxServiceIsolationTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxShadowPlatformBundleTest.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxShadowPlatformBundleTest.kt
@@ -24,8 +24,12 @@ import org.osgi.test.junit5.service.ServiceExtension
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class SandboxShadowPlatformBundleTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     private lateinit var sandboxFactory: SandboxFactory
 

--- a/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/test/KryoCheckpointTest.kt
+++ b/libs/serialization/serialization-kryo/src/integrationTest/kotlin/net/corda/kryoserialization/test/KryoCheckpointTest.kt
@@ -26,8 +26,12 @@ import java.util.concurrent.Executors
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(PER_CLASS)
 class KryoCheckpointTest {
-    @RegisterExtension
-    private val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        private val lifecycle = AllTestsLifecycle()
+    }
 
     @InjectService(timeout = 1000)
     lateinit var checkpointSerializerBuilderFactory: CheckpointSerializerBuilderFactory

--- a/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
+++ b/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
@@ -41,8 +41,12 @@ const val TIMEOUT_MILLIS = 30000L
 @ExtendWith(ServiceExtension::class, BundleContextExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class CommonLedgerIntegrationTest {
-    @RegisterExtension
-    val lifecycle = AllTestsLifecycle()
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        val lifecycle = AllTestsLifecycle()
+    }
 
     open val testingCpb = "/META-INF/ledger-common-empty-app.cpb"
 


### PR DESCRIPTION
So JUnit honours `AfterAllCallback` as described in `RegisterExtension` docs.