### PR TITLE
CORE-10126 Added hint to flowStack exceptions as to potential root cause

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/ClientRequestBodyImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/ClientRequestBodyImpl.kt
@@ -15,7 +15,7 @@ class ClientRequestBodyImpl(private val fiberService: FlowFiberService) : Client
 
     override fun getRequestBody(): String {
         return fiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.flowStartContext.startArgs
-            ?: throw IllegalStateException("Failed to find the start args for Rest started flow")
+            ?: throw IllegalStateException(FiberExceptionConstants.MISSING_START_ARGUMENTS)
     }
 
     override fun <T : Any> getRequestBodyAs(marshallingService: MarshallingService, clazz: Class<T>): T {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FiberExceptionConstants.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FiberExceptionConstants.kt
@@ -1,0 +1,21 @@
+package net.corda.flow.fiber
+
+object FiberExceptionConstants {
+    private const val MISSING_SUSPENDABLE_ANNOTATION =
+        "(Note: This may happen if you're missing a `@Suspendable` annotation somewhere in your flow.)"
+    const val MISSING_START_ARGUMENTS = "Failed to find the start args for Rest started flow."
+    const val FLOW_DISCONTINUED = "Flow was discontinued, reason: %s thrown, %s."
+    const val FLOW_FAILED_THROWABLE = "FlowFiber failed due to Throwable being thrown."
+    const val FLOW_FAILED_GENERIC = "runFlow failed to complete normally, forcing a failure."
+    const val UNEXPECTED_OUTCOME = "Unexpected Flow outcome."
+    const val INVALID_FLOW_RETURN = "Tried to return when suspension outcome says to continue."
+    const val INVALID_FLOW_KEY = "Expected the flow key to have a UUID id found '%s' instead."
+    const val UNABLE_TO_EXECUTE = "Unable to execute flow fiber: %s."
+    const val NULL_FLOW_STACK_SERVICE =
+        "Flow [%s] should have a single flow stack item when finishing but the stack was null. $MISSING_SUSPENDABLE_ANNOTATION"
+    const val EMPTY_FLOW_STACK =
+        "Flow [%s] should have a single flow stack item when finishing but was empty. $MISSING_SUSPENDABLE_ANNOTATION"
+    const val INCORRECT_ITEM_COUNT =
+        "Flow [%s] should have a single flow stack item when finishing but contained %s. $MISSING_SUSPENDABLE_ANNOTATION"
+
+}

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -188,28 +188,45 @@ class FlowFiberImpl(
         val flowStackService = flowFiberExecutionContext?.flowStackService
         return when {
             flowStackService == null -> {
-                log.debug { "Flow [$flowId] should have a single flow stack item when finishing but the stack was null" }
-                throw CordaRuntimeException("Flow [$flowId] should have a single flow stack item when finishing but the stack was null")
+                log.debug {
+                    "Flow [$flowId] should have a single flow stack item when finishing but the stack was null. " +
+                    "(Note: This may happen if you're missing a `@Suspendable` annotation somewhere in your flow.)" }
+                throw CordaRuntimeException(
+                    "Flow [$flowId] should have a single flow stack item when finishing but the stack was null. " +
+                    "(Note: This may happen if you're missing a `@Suspendable` annotation somewhere in your flow.)"
+                )
             }
             flowStackService.size > 1 -> {
                 log.debug {
                     "Flow [$flowId] should have a single flow stack item when finishing but contained the following elements instead: " +
-                            "${flowFiberExecutionContext?.flowStackService}"
-                }
+                    "${flowFiberExecutionContext?.flowStackService} (Note: This may happen if you're missing a `@Suspendable` )" +
+                    "annotation somewhere in your flow.)" }
                 throw CordaRuntimeException(
                     "Flow [$flowId] should have a single flow stack item when finishing but contained " +
-                            "${flowFiberExecutionContext?.flowStackService?.size} elements"
+                    "${flowFiberExecutionContext?.flowStackService?.size} elements. " +
+                    "(Note: This may happen if you're missing a `@Suspendable` annotation " +
+                    "somewhere in your flow.)"
                 )
             }
             flowStackService.size == 0 -> {
-                log.debug { "Flow [$flowId] should have a single flow stack item when finishing but was empty" }
-                throw CordaRuntimeException("Flow [$flowId] should have a single flow stack item when finishing but was empty")
+                log.debug {
+                    "Flow [$flowId] should have a single flow stack item when finishing but was empty. " +
+                    "(Note: This may happen if you're missing a `@Suspendable` annotation somewhere in your flow.)" }
+                throw CordaRuntimeException(
+                    "Flow [$flowId] should have a single flow stack item when finishing but was empty. " +
+                    "(Note: This may happen if you're missing a `@Suspendable` annotation somewhere in your flow.)"
+                )
             }
             else -> {
                 when (val item = flowStackService.peek()) {
                     null -> {
-                        log.debug { "Flow [$flowId] should have a single flow stack item when finishing but was empty" }
-                        throw CordaRuntimeException("Flow [$flowId] should have a single flow stack item when finishing but was empty")
+                        log.debug {
+                            "Flow [$flowId] should have a single flow stack item when finishing but was empty. " +
+                            "(Note: This may happen if you're missing a `@Suspendable` annotation somewhere in your flow.)" }
+                        throw CordaRuntimeException(
+                            "Flow [$flowId] should have a single flow stack item when finishing but was empty. " +
+                            "(Note: This may happen if you're missing a `@Suspendable` annotation somewhere in your flow.)"
+                        )
                     }
                     else -> item
                 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
@@ -31,13 +31,13 @@ class FlowFiberFactoryImpl : FlowFiberFactory {
         val id = try {
             UUID.fromString(flowId)
         } catch (e: IllegalArgumentException) {
-            throw FlowFatalException("Expected the flow key to have a UUID id found '${flowId}' instead.", e)
+            throw FlowFatalException(FiberExceptionConstants.INVALID_FLOW_KEY.format(flowId), e)
         }
         try {
             val flowFiber = FlowFiberImpl(id, logic, currentScheduler)
             return FiberFuture(flowFiber, flowFiber.startFlow(flowFiberExecutionContext))
         } catch (e: Throwable) {
-            throw FlowFatalException("Unable to execute flow fiber: ${e.message}", e)
+            throw FlowFatalException(FiberExceptionConstants.UNABLE_TO_EXECUTE.format(e.message), e)
         }
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
@@ -8,6 +8,7 @@ import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.fiber.FlowFiberImpl
 import net.corda.flow.fiber.FlowLogicAndArgs
+import net.corda.flow.fiber.FiberExceptionConstants
 import net.corda.flow.pipeline.exceptions.FlowFatalException
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate


### PR DESCRIPTION
This PR satisfies [CORE-10126](https://r3-cev.atlassian.net/browse/CORE-10126), and consists of 2 commits. The [first](https://github.com/corda/corda-runtime-os/pull/3243/commits/c78a157429029f84d42beddfa111e4e40b1f6262) adds the suggested hint line to the relevant messages, and the [second](https://github.com/corda/corda-runtime-os/pull/3243/commits/f4e7933171e11ac7b7ffa07e9bd4a015df714d72) moves exception messages to a new file to avoid repetition. Either one of these options can be cherry picked; leaving this decision to the reviewer.

[CORE-10126]: https://r3-cev.atlassian.net/browse/CORE-10126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ