### PR TITLE
CORE-7073 Adding default message to nullable exception messages in flow service

### DIFF
--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -258,7 +258,7 @@ class FlowRestResourceImpl @Activate constructor(
                 flowStatusFeedRegistration.close()
             }
         } catch (e: WebSocketValidationException) {
-            log.warn("Validation error while registering flow status listener - ${e.message}")
+            log.warn("Validation error while registering flow status listener - ${e.message ?: "No exception message provided."}")
             error(e)
         } catch (e: Exception) {
             log.error("Unexpected error at registerFlowStatusListener")

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -69,7 +69,7 @@ class FlowFiberImpl(
                 // suspended by Corda for the last time to mark it was finished already. Logging the callstack here would be
                 // misleading as it would point the log entry to the internal rethrow in Corda. In this case nothing has
                 // gone wrong, so we shouldn't log that it has.
-                log.warn(FiberExceptionConstants.FLOW_DISCONTINUED.format(e.cause?.javaClass?.canonicalName, e.cause?.message))
+                log.warn(FiberExceptionConstants.FLOW_DISCONTINUED.format(e.cause?.javaClass?.canonicalName, e.cause?.message ?: "No exception message provided."))
                 failTopLevelSubFlow(e.cause!!)
             } catch (t: Throwable) {
                 log.warn(FiberExceptionConstants.FLOW_FAILED_THROWABLE, t)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -69,7 +69,9 @@ class FlowFiberImpl(
                 // suspended by Corda for the last time to mark it was finished already. Logging the callstack here would be
                 // misleading as it would point the log entry to the internal rethrow in Corda. In this case nothing has
                 // gone wrong, so we shouldn't log that it has.
-                log.warn(FiberExceptionConstants.FLOW_DISCONTINUED.format(e.cause?.javaClass?.canonicalName, e.cause?.message ?: "No exception message provided."))
+                log.warn(FiberExceptionConstants.FLOW_DISCONTINUED.format(
+                    e.cause?.javaClass?.canonicalName, e.cause?.message ?: "No exception message provided.")
+                )
                 failTopLevelSubFlow(e.cause!!)
             } catch (t: Throwable) {
                 log.warn(FiberExceptionConstants.FLOW_FAILED_THROWABLE, t)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
@@ -38,7 +38,7 @@ class FlowFiberFactoryImpl : FlowFiberFactory {
             val flowFiber = FlowFiberImpl(id, logic, currentScheduler)
             return FiberFuture(flowFiber, flowFiber.startFlow(flowFiberExecutionContext))
         } catch (e: Throwable) {
-            throw FlowFatalException(FiberExceptionConstants.UNABLE_TO_EXECUTE.format(e.message), e)
+            throw FlowFatalException(FiberExceptionConstants.UNABLE_TO_EXECUTE.format(e.message ?: "No exception message provided."), e)
         }
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFactoryImpl.kt
@@ -40,7 +40,8 @@ class FlowFactoryImpl @Activate constructor(
         } catch (e: Exception) {
             throw FlowFatalException(
                 "Could not create ${startFlowEvent.startContext.flowClassName} for " +
-                        "virtual node ${startFlowEvent.startContext.identity}: ${e.message}", e
+                        "virtual node ${startFlowEvent.startContext.identity}: " +
+                        (e.message ?: "No exception message provided."), e
             )
         }
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
@@ -29,7 +29,8 @@ class FlowFiberExecutionContextFactoryImpl @Activate constructor(
         val sandbox = try {
             flowSandboxService.get(checkpoint.flowStartContext.identity.toCorda(), checkpoint.cpkFileHashes)
         } catch (e: Exception) {
-            throw FlowTransientException("Failed to create the sandbox: ${e.message}", e)
+            throw FlowTransientException("Failed to create the sandbox: " +
+                    (e.message ?: "No exception message provided."), e)
         }
         return FlowFiberExecutionContext(
             checkpoint,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -93,7 +93,7 @@ class SessionEventHandler @Activate constructor(
                 // it properly will need some changes to the exception handling to get the context elsewhere. Transient here
                 // will get the right failure eventually, so this is fine for now.
                 throw FlowTransientException(
-                    "Failed to create the flow sandbox: ${e.message}",
+                    "Failed to create the flow sandbox: ${e.message ?: "No exception message provided."}",
                     e
                 )
             }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/InitiateFlowRequestService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/InitiateFlowRequestService.kt
@@ -50,8 +50,8 @@ class InitiateFlowRequestService @Activate constructor(
             flowSandboxService.get(checkpoint.holdingIdentity, checkpoint.cpkFileHashes).protocolStore
         } catch (e: Exception) {
             throw FlowTransientException(
-                "Failed to get the flow sandbox for identity ${checkpoint.holdingIdentity}: ${e.message}",
-                e
+                "Failed to get the flow sandbox for identity ${checkpoint.holdingIdentity}: " +
+                        (e.message?: "No exception message provided."), e
             )
         }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -179,7 +179,9 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             if (!checkpoint.doesExist) {
                 return@withEscalation flowEventContextConverter.convert(
                     context.copy(
-                        outputRecords = createFlowKilledStatusRecord(checkpoint, exception.message),
+                        outputRecords = createFlowKilledStatusRecord(
+                            checkpoint, exception.message ?: "No exception message provided."
+                        ),
                         sendToDlq = false
                     )
                 )
@@ -201,7 +203,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
                 getScheduledCleanupExpiryTime(context, exceptionHandlingStartTime),
                 checkpoint.sessions.filterNot { it.hasScheduledCleanup }
             )
-            val statusRecord = createFlowKilledStatusRecord(checkpoint, exception.message)
+            val statusRecord = createFlowKilledStatusRecord(checkpoint, exception.message ?: "No exception message provided.")
 
             checkpoint.markDeleted()
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -130,7 +130,7 @@ class FlowSessionManagerImpl @Activate constructor(
         throwable: Throwable,
         instant: Instant
     ): List<SessionState> {
-        val errorMessage = throwable.message ?: ""
+        val errorMessage = throwable.message ?: "No exception message provided."
         return sessionIds.map { sessionId ->
             sendSessionMessageToExistingSession(
                 checkpoint,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/PipelineStateManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/PipelineStateManager.kt
@@ -104,7 +104,7 @@ class PipelineStateManager(
     private fun createAvroExceptionEnvelope(exception: Exception): ExceptionEnvelope {
         return ExceptionEnvelope().apply {
             errorType = FlowProcessingExceptionTypes.FLOW_TRANSIENT_EXCEPTION
-            errorMessage = exception.message
+            errorMessage = exception.message ?: "No exception message provided."
         }
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
@@ -842,7 +842,7 @@ class FlowSessionManagerImplTest {
             MessageDirection.OUTBOUND,
             SESSION_ID,
             sequenceNum = null,
-            payload = SessionError(ExceptionEnvelope(IllegalArgumentException::class.qualifiedName, "")),
+            payload = SessionError(ExceptionEnvelope(IllegalArgumentException::class.qualifiedName, "No exception message provided.")),
             timestamp = instant,
             initiatingIdentity = HOLDING_IDENTITY,
             initiatedIdentity = COUNTERPARTY_HOLDING_IDENTITY
@@ -852,7 +852,7 @@ class FlowSessionManagerImplTest {
             MessageDirection.OUTBOUND,
             ANOTHER_SESSION_ID,
             sequenceNum = null,
-            payload = SessionError(ExceptionEnvelope(IllegalArgumentException::class.qualifiedName, "")),
+            payload = SessionError(ExceptionEnvelope(IllegalArgumentException::class.qualifiedName, "No exception message provided.")),
             timestamp = instant,
             initiatingIdentity = HOLDING_IDENTITY,
             initiatedIdentity = COUNTERPARTY_HOLDING_IDENTITY

--- a/libs/flows/external-event-responses-impl/src/main/kotlin/net/corda/flow/external/events/responses/impl/factory/ExternalEventResponseFactoryImpl.kt
+++ b/libs/flows/external-event-responses-impl/src/main/kotlin/net/corda/flow/external/events/responses/impl/factory/ExternalEventResponseFactoryImpl.kt
@@ -53,7 +53,9 @@ class ExternalEventResponseFactoryImpl(
     ): Record<String, FlowEvent> {
         return transientError(
             flowExternalEventContext,
-            ExceptionEnvelope(throwable::class.java.name, throwable.message)
+            ExceptionEnvelope(
+                throwable::class.java.name, throwable.message ?: "No exception message provided"
+            )
         )
     }
 
@@ -70,7 +72,9 @@ class ExternalEventResponseFactoryImpl(
     ): Record<String, FlowEvent> {
         return platformError(
             flowExternalEventContext,
-            ExceptionEnvelope(throwable::class.java.name, throwable.message)
+            ExceptionEnvelope(
+                throwable::class.java.name, throwable.message ?: "No exception message provided."
+            )
         )
     }
 
@@ -87,7 +91,9 @@ class ExternalEventResponseFactoryImpl(
     ): Record<String, FlowEvent> {
         return fatalError(
             flowExternalEventContext,
-            ExceptionEnvelope(throwable::class.java.name, throwable.message)
+            ExceptionEnvelope(
+                throwable::class.java.name, throwable.message ?: "No exception message provided."
+            )
         )
     }
 

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
@@ -213,7 +213,8 @@ class LifecycleCoordinatorImpl(
         val coordinators = try {
             coordinatorNames.mapTo(LinkedHashSet(), registry::getCoordinator)
         } catch (e: LifecycleRegistryException) {
-            logger.error("Failed to register on coordinator as an invalid name was provided. ${e.message}", e)
+            logger.error("Failed to register on coordinator as an invalid name was provided. " +
+                        (e.message ?: "No exception message provided"), e)
             throw LifecycleException("Failed to register on a coordinator as an invalid name was provided", e)
         }
         return followStatusChanges(coordinators)

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
@@ -243,7 +243,7 @@ internal class LifecycleProcessor(
             val errorEvent = ErrorEvent(e)
             logger.info(
                 "$name Lifecycle: An error occurred during the processing of event $event by a lifecycle " +
-                        "coordinator: ${e.message}. Triggering user event handling.",
+                        "coordinator: ${e.message ?: "No exception message provided"}. Triggering user event handling.",
                 e
             )
             try {
@@ -254,7 +254,7 @@ internal class LifecycleProcessor(
             if (!errorEvent.isHandled) {
                 logger.error(
                     "$name Lifecycle: An unhandled error was encountered while processing $event in a lifecycle " +
-                            "coordinator: ${e.message}. This coordinator will now shut down.",
+                            "coordinator: ${e.message ?: "No exception message provided"}. This coordinator will now shut down.",
                     e
                 )
             }


### PR DESCRIPTION
This PR satisfies [CORE-7073](https://r3-cev.atlassian.net/browse/CORE-7073).

It adds a default message to nullable exception messages in both the lifecycle coordinator, and within the flow service as a whole.

[CORE-7073]: https://r3-cev.atlassian.net/browse/CORE-7073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ