### PR TITLE
CORE-9550 Use strong typed hashes in DTOs

### DIFF
--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
@@ -48,11 +48,13 @@ import net.corda.orm.utils.use
 import net.corda.schema.configuration.BootConfig
 import net.corda.test.util.eventually
 import net.corda.v5.base.util.EncodingUtils.toHex
+import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.EDDSA_ED25519_CODE_NAME
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.X25519_CODE_NAME
 import net.corda.v5.crypto.publicKeyId
+import net.corda.v5.crypto.sha256Bytes
 import net.corda.virtualnode.ShortHash
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.junit.jupiter.api.AfterAll
@@ -73,6 +75,7 @@ import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.PublicKey
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
@@ -735,9 +738,9 @@ class PersistenceTests {
             )
         )
         assertEquals(3, keys.size)
-        assertSigningCachedKey(tenantId, p1, keys.firstOrNull { it.id == p1.key.publicKey.publicKeyId() })
-        assertSigningCachedKey(tenantId, p3, keys.firstOrNull { it.id == p3.key.publicKey.publicKeyId() })
-        assertSigningCachedKey(tenantId, w2, keys.firstOrNull { it.id == w2.key.publicKey.publicKeyId() })
+        assertSigningCachedKey(tenantId, p1, keys.firstOrNull { it.id == p1.key.publicKey.id() })
+        assertSigningCachedKey(tenantId, p3, keys.firstOrNull { it.id == p3.key.publicKey.id() })
+        assertSigningCachedKey(tenantId, w2, keys.firstOrNull { it.id == w2.key.publicKey.id() })
     }
 
     @ParameterizedTest
@@ -791,7 +794,7 @@ class PersistenceTests {
             mapOf(
                 CATEGORY_FILTER to CryptoConsts.Categories.LEDGER
             )
-        ).filter { thisTestKeys.contains(it.id) }
+        ).filter { thisTestKeys.contains(it.id.value) }
         assertEquals(2, result1.size)
         listOf(p1, p4).sortedBy { it.alias }.forEachIndexed { i, o ->
             assertSigningCachedKey(tenantId, o, result1.elementAt(i))
@@ -804,7 +807,7 @@ class PersistenceTests {
             mapOf(
                 CATEGORY_FILTER to CryptoConsts.Categories.LEDGER
             )
-        ).filter { thisTestKeys.contains(it.id) }
+        ).filter { thisTestKeys.contains(it.id.value) }
         assertEquals(2, result2.size)
         listOf(p1, p4).sortedByDescending { it.alias }.forEachIndexed { i, o ->
             assertSigningCachedKey(tenantId, o, result2.elementAt(i))
@@ -818,7 +821,7 @@ class PersistenceTests {
                 CATEGORY_FILTER to CryptoConsts.Categories.CI,
                 SCHEME_CODE_NAME_FILTER to EDDSA_ED25519_CODE_NAME
             )
-        ).filter { thisTestKeys.contains(it.id) }
+        ).filter { thisTestKeys.contains(it.id.value) }
         assertEquals(1, result3.size)
         assertSigningCachedKey(tenantId, w1, result3.first())
         val result4 = signingKeyStore.lookup(
@@ -831,7 +834,7 @@ class PersistenceTests {
                 SCHEME_CODE_NAME_FILTER to ECDSA_SECP256R1_CODE_NAME,
                 CATEGORY_FILTER to CryptoConsts.Categories.TLS
             )
-        ).filter { thisTestKeys.contains(it.id) }
+        ).filter { thisTestKeys.contains(it.id.value) }
         assertEquals(1, result4.size)
         assertSigningCachedKey(tenantId, p2, result4.first())
         val result5 = signingKeyStore.lookup(
@@ -845,7 +848,7 @@ class PersistenceTests {
                 CATEGORY_FILTER to CryptoConsts.Categories.CI,
                 EXTERNAL_ID_FILTER to w3.externalId!!
             )
-        ).filter { thisTestKeys.contains(it.id) }
+        ).filter { thisTestKeys.contains(it.id.value) }
         assertEquals(1, result5.size)
         assertSigningCachedKey(tenantId, w3, result5.first())
         val result6 = signingKeyStore.lookup(
@@ -857,7 +860,7 @@ class PersistenceTests {
                 CREATED_AFTER_FILTER to Instant.now().minusSeconds(300).toString(),
                 CREATED_BEFORE_FILTER to Instant.now().minusSeconds(-1).toString()
             )
-        ).filter { thisTestKeys.contains(it.id) }
+        ).filter { thisTestKeys.contains(it.id.value) }
         assertEquals(7, result6.size)
         listOf(p1, p2, p3, p4, w1, w2, w3).sortedBy {
             when (it) {
@@ -968,3 +971,6 @@ class PersistenceTests {
         assertEquals(0, page3.size)
     }
 }
+
+fun PublicKey.id(): ShortHash =
+    ShortHash.of(SecureHash(DigestAlgorithmName.SHA2_256.name, this.sha256Bytes()))

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
@@ -278,7 +278,7 @@ class PersistenceTests {
             actual: SigningCachedKey?
         ) {
             assertNotNull(actual)
-            assertEquals(expected.key.publicKey.publicKeyId(), actual!!.id)
+            assertEquals(expected.key.publicKey.publicKeyId(), actual!!.id.value)
             assertEquals(tenantId, actual.tenantId)
             assertEquals(expected.category, actual.category)
             assertEquals(expected.alias, actual.alias)
@@ -302,7 +302,7 @@ class PersistenceTests {
             actual: SigningCachedKey?
         ) {
             assertNotNull(actual)
-            assertEquals(expected.key.publicKey.publicKeyId(), actual!!.id)
+            assertEquals(expected.key.publicKey.publicKeyId(), actual!!.id.value)
             assertEquals(tenantId, actual.tenantId)
             assertEquals(expected.category, actual.category)
             assertEquals(expected.alias, actual.alias)

--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeysRepositoryImpl.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/SigningKeysRepositoryImpl.kt
@@ -69,8 +69,8 @@ object SigningKeysRepositoryImpl : SigningKeysRepository {
 
 fun SigningKeyEntity.toSigningCachedKey(): SigningCachedKey =
     SigningCachedKey(
-        id = keyId,
-        fullId = fullKeyId,
+        id = ShortHash.parse(keyId),
+        fullId = SecureHash.parse(fullKeyId),
         tenantId = tenantId,
         category = category,
         alias = alias,

--- a/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
+++ b/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
@@ -100,8 +100,8 @@ class SigningKeyStoreUnitTest {
         val shortKeyId1 = ShortHash.of(fullKeyId1)
 
         val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
-            val cachedKey0 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId0.toString()) }
-            val cachedKey1 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId1.toString()) }
+            val cachedKey0 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId0) }
+            val cachedKey1 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId1) }
             createCache(config = signingServiceConfig).also {
                 it.put(CacheKey(tenantId, shortKeyId0), cachedKey0)
                 it.put(CacheKey(tenantId, shortKeyId1), cachedKey1)
@@ -109,7 +109,7 @@ class SigningKeyStoreUnitTest {
         }
         setUpSigningKeyStore(cacheFactory)
         assertEquals(
-            setOf(fullKeyId0, fullKeyId1).map { it.toString() }.toSet(),
+            setOf(fullKeyId0, fullKeyId1),
             signingKeyStore.lookupByKeyIds(tenantId, setOf(shortKeyId0, shortKeyId1)).map { it.fullId }.toSet()
         )
         // verify it didn't go to the database
@@ -125,8 +125,8 @@ class SigningKeyStoreUnitTest {
 
         val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
             val cachedKey0 = mock<SigningCachedKey>().also {
-                whenever(it.id).thenReturn(shortKeyId0.toString())
-                whenever(it.fullId).thenReturn(fullKeyId0.toString())
+                whenever(it.id).thenReturn(shortKeyId0)
+                whenever(it.fullId).thenReturn(fullKeyId0)
             }
             createCache(config = signingServiceConfig).also {
                 it.put(CacheKey(tenantId, shortKeyId0), cachedKey0)
@@ -135,7 +135,7 @@ class SigningKeyStoreUnitTest {
 
         val keysCaptor = argumentCaptor<Set<ShortHash>>()
         signingKeysRepository.run {
-            val dbFetchedKey = mock<SigningCachedKey>().also { whenever(it.id).thenReturn(shortKeyId1.value) }
+            val dbFetchedKey = mock<SigningCachedKey>().also { whenever(it.id).thenReturn(shortKeyId1) }
             whenever(this.findKeysByIds(any(), eq(tenantId), keysCaptor.capture())).thenReturn(setOf(dbFetchedKey))
         }
 
@@ -144,7 +144,7 @@ class SigningKeyStoreUnitTest {
 
         val expectedNotFoundInCache = setOf(shortKeyId1)
         assertEquals(expectedNotFoundInCache, keysCaptor.firstValue)
-        assertEquals(setOf(shortKeyId0.value, shortKeyId1.value), lookedUpByKeyIdsKeys.mapTo(mutableSetOf()) { it.id })
+        assertEquals(setOf(shortKeyId0, shortKeyId1), lookedUpByKeyIdsKeys.mapTo(mutableSetOf()) { it.id })
         verify(connectionsFactory, times(1)).getEntityManagerFactory(any())
     }
 
@@ -157,8 +157,8 @@ class SigningKeyStoreUnitTest {
         val shortKeyId1 = ShortHash.of(fullKeyId1)
 
         val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
-            val cachedKey0 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId0.toString()) }
-            val cachedKey1 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId1.toString()) }
+            val cachedKey0 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId0) }
+            val cachedKey1 = mock<SigningCachedKey>().also { whenever(it.fullId).thenReturn(fullKeyId1) }
 
             createCache(config = signingServiceConfig).also {
                 it.put(CacheKey(tenantId, shortKeyId0), cachedKey0)
@@ -168,7 +168,7 @@ class SigningKeyStoreUnitTest {
 
         setUpSigningKeyStore(cacheFactory)
         assertEquals(
-            setOf(fullKeyId0, fullKeyId1).map { it.toString() }.toSet(),
+            setOf(fullKeyId0, fullKeyId1),
             signingKeyStore.lookupByFullKeyIds(tenantId, setOf(fullKeyId0, fullKeyId1)).map { it.fullId }.toSet()
         )
         // verify it didn't go to the database
@@ -184,8 +184,8 @@ class SigningKeyStoreUnitTest {
 
         val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
             val cachedKey0 = mock<SigningCachedKey>().also {
-                whenever(it.id).thenReturn(shortKeyId0.toString())
-                whenever(it.fullId).thenReturn(fullKeyId0.toString())
+                whenever(it.id).thenReturn(shortKeyId0)
+                whenever(it.fullId).thenReturn(fullKeyId0)
             }
 
             createCache(config = signingServiceConfig).also {
@@ -196,8 +196,8 @@ class SigningKeyStoreUnitTest {
         val keysCaptor = argumentCaptor<Set<SecureHash>>()
         signingKeysRepository.run {
             val dbFetchedKey = mock<SigningCachedKey>().also {
-                whenever(it.id).thenReturn(shortKeyId1.value)
-                whenever(it.fullId).thenReturn(fullKeyId1.toString())
+                whenever(it.id).thenReturn(shortKeyId1)
+                whenever(it.fullId).thenReturn(fullKeyId1)
             }
             whenever(this.findKeysByFullIds(any(), eq(tenantId), keysCaptor.capture())).thenReturn(setOf(dbFetchedKey))
         }
@@ -207,7 +207,7 @@ class SigningKeyStoreUnitTest {
 
         val expectedNotFoundInCache = setOf(fullKeyId1)
         assertEquals(expectedNotFoundInCache, keysCaptor.firstValue)
-        assertEquals(setOf(fullKeyId0.toString(), fullKeyId1.toString()), lookedUpByFullKeyIdsKeys.mapTo(mutableSetOf()) { it.fullId })
+        assertEquals(setOf(fullKeyId0, fullKeyId1.toString()), lookedUpByFullKeyIdsKeys.mapTo(mutableSetOf()) { it.fullId })
         verify(connectionsFactory, times(1)).getEntityManagerFactory(any())
     }
 
@@ -219,8 +219,8 @@ class SigningKeyStoreUnitTest {
 
         val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
             val cachedKey = mock<SigningCachedKey>().also {
-                whenever(it.id).thenReturn(shortKeyId.toString())
-                whenever(it.fullId).thenReturn(fullKeyId.toString())
+                whenever(it.id).thenReturn(shortKeyId)
+                whenever(it.fullId).thenReturn(fullKeyId)
             }
 
             createCache(config = signingServiceConfig).also {
@@ -251,8 +251,8 @@ class SigningKeyStoreUnitTest {
 
         val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
             val cachedKey = mock<SigningCachedKey>().also {
-                whenever(it.id).thenReturn(shortKeyId.toString())
-                whenever(it.fullId).thenReturn(fullKeyId.toString())
+                whenever(it.id).thenReturn(shortKeyId)
+                whenever(it.fullId).thenReturn(fullKeyId)
             }
 
             createCache(config = signingServiceConfig).also {
@@ -263,7 +263,7 @@ class SigningKeyStoreUnitTest {
         setUpSigningKeyStore(cacheFactory)
         val lookedUpByFullKeyIdKey = signingKeyStore.lookupByFullKeyId(tenantId, fullKeyId)
 
-        assertEquals(fullKeyId.toString(), lookedUpByFullKeyIdKey!!.fullId)
+        assertEquals(fullKeyId, lookedUpByFullKeyIdKey!!.fullId)
         verify(connectionsFactory, times(0)).getEntityManagerFactory(any())
     }
 
@@ -276,8 +276,8 @@ class SigningKeyStoreUnitTest {
 
         val cacheFactory: (CryptoSigningServiceConfig) -> Cache<CacheKey, SigningCachedKey> = {
             val cachedKey = mock<SigningCachedKey>().also {
-                whenever(it.id).thenReturn(shortKeyId.toString())
-                whenever(it.fullId).thenReturn(fullKeyId.toString())
+                whenever(it.id).thenReturn(shortKeyId)
+                whenever(it.fullId).thenReturn(fullKeyId)
             }
 
             createCache(config = signingServiceConfig).also {

--- a/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
+++ b/components/crypto/crypto-persistence-impl/src/test/kotlin/net/corda/crypto/persistence/impl/tests/SigningKeyStoreUnitTest.kt
@@ -207,7 +207,7 @@ class SigningKeyStoreUnitTest {
 
         val expectedNotFoundInCache = setOf(fullKeyId1)
         assertEquals(expectedNotFoundInCache, keysCaptor.firstValue)
-        assertEquals(setOf(fullKeyId0, fullKeyId1.toString()), lookedUpByFullKeyIdsKeys.mapTo(mutableSetOf()) { it.fullId })
+        assertEquals(setOf(fullKeyId0, fullKeyId1), lookedUpByFullKeyIdsKeys.mapTo(mutableSetOf()) { it.fullId })
         verify(connectionsFactory, times(1)).getEntityManagerFactory(any())
     }
 

--- a/components/crypto/crypto-persistence/src/main/kotlin/net/corda/crypto/persistence/SigningCachedKey.kt
+++ b/components/crypto/crypto-persistence/src/main/kotlin/net/corda/crypto/persistence/SigningCachedKey.kt
@@ -1,11 +1,13 @@
 package net.corda.crypto.persistence
 
+import net.corda.v5.crypto.SecureHash
+import net.corda.virtualnode.ShortHash
 import java.time.Instant
 
 @Suppress("LongParameterList")
 class SigningCachedKey(
-    val id: String,
-    val fullId: String,
+    val id: ShortHash,
+    val fullId: SecureHash,
     val tenantId: String,
     val category: String,
     val alias: String?,

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/SigningKeyInfo.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/SigningKeyInfo.kt
@@ -1,10 +1,11 @@
 package net.corda.crypto.service
 
+import net.corda.virtualnode.ShortHash
 import java.time.Instant
 
 @Suppress("LongParameterList")
 class SigningKeyInfo(
-    val id: String,
+    val id: ShortHash,
     // TODO see if we need to add full id here
     val tenantId: String,
     val category: String,

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -12,7 +12,7 @@ import net.corda.crypto.cipher.suite.SigningAliasSpec
 import net.corda.crypto.cipher.suite.SigningWrappedSpec
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import net.corda.crypto.core.KeyAlreadyExistsException
-import net.corda.crypto.core.fullId
+import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.persistence.SigningCachedKey
 import net.corda.crypto.persistence.SigningKeyOrderBy
 import net.corda.crypto.persistence.SigningKeyStore
@@ -274,12 +274,12 @@ class SigningServiceImpl(
     private fun getOwnedKeyRecord(tenantId: String, publicKey: PublicKey): OwnedKeyRecord {
         if (publicKey is CompositeKey) {
             val leafKeysIdsChunks = publicKey.leafKeys.map {
-                it.fullId(schemeMetadata, digestService) to it
+                it.fullIdHash(schemeMetadata, digestService) to it
             }.chunked(KEY_LOOKUP_INPUT_ITEMS_LIMIT)
             for (chunk in leafKeysIdsChunks) {
                 val found = store.lookupByFullIds(
                     tenantId,
-                    chunk.map { SecureHash.parse(it.first) }
+                    chunk.map { it.first }
                 )
                 if (found.isNotEmpty()) {
                     for (key in chunk) {

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
@@ -53,7 +53,7 @@ class CryptoOpsBusProcessor(
 
         private fun SigningKeyInfo.toAvro(): CryptoSigningKey =
             CryptoSigningKey(
-                this.id,
+                this.id.value,
                 this.tenantId,
                 this.category,
                 this.alias,

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -21,7 +21,9 @@ import net.corda.crypto.persistence.SigningPublicKeySaveContext
 import net.corda.crypto.service.CryptoServiceRef
 import net.corda.crypto.service.KeyOrderBy
 import net.corda.v5.crypto.ECDSA_SECP256R1_CODE_NAME
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.SignatureSpec
+import net.corda.virtualnode.ShortHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeAll
@@ -159,8 +161,8 @@ class SigningServiceGeneralTests {
     @Test
     fun `Should throw KeyAlreadyExistsException when generating key with existing alias`() {
         val existingKey = SigningCachedKey(
-            id = UUID.randomUUID().toString(),
-            fullId = UUID.randomUUID().toString(),
+            id = ShortHash.of("0123456789AB"),
+            fullId = SecureHash.parse("SHA-256:0123456789AB"),
             tenantId = UUID.randomUUID().toString(),
             category = CryptoConsts.Categories.LEDGER,
             alias = "alias1",

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -162,7 +162,7 @@ class SigningServiceGeneralTests {
     fun `Should throw KeyAlreadyExistsException when generating key with existing alias`() {
         val existingKey = SigningCachedKey(
             id = ShortHash.of("0123456789AB"),
-            fullId = SecureHash.parse("SHA-256:0123456789AB"),
+            fullId = SecureHash.parse("SHA-256:0123456789ABCDEF"),
             tenantId = UUID.randomUUID().toString(),
             category = CryptoConsts.Categories.LEDGER,
             alias = "alias1",

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningKeyStore.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningKeyStore.kt
@@ -1,7 +1,5 @@
 package net.corda.crypto.service.impl.infra
 
-import net.corda.crypto.core.fullPublicKeyIdFromBytes
-import net.corda.crypto.core.publicKeyIdFromBytes
 import net.corda.crypto.persistence.SigningCachedKey
 import net.corda.crypto.persistence.SigningKeyStore
 import net.corda.crypto.persistence.SigningKeyFilterMapImpl
@@ -24,7 +22,6 @@ import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.publicKeyId
 import net.corda.v5.crypto.sha256Bytes
 import net.corda.virtualnode.ShortHash
 import java.security.PublicKey

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningKeyStore.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningKeyStore.kt
@@ -22,8 +22,10 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
+import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.publicKeyId
+import net.corda.v5.crypto.sha256Bytes
 import net.corda.virtualnode.ShortHash
 import java.security.PublicKey
 import java.time.Instant
@@ -38,7 +40,7 @@ class TestSigningKeyStore(
     ) { e, c -> if(e is StartEvent) { c.updateStatus(LifecycleStatus.UP) } }
 
     private val lock = ReentrantLock()
-    private val keys = mutableMapOf<Pair<String, String>, SigningCachedKey>()
+    private val keys = mutableMapOf<Pair<String, ShortHash>, SigningCachedKey>()
 
     override fun save(tenantId: String, context: SigningKeySaveContext) = lock.withLock {
         val now = Instant.now()
@@ -46,8 +48,8 @@ class TestSigningKeyStore(
             is SigningPublicKeySaveContext -> {
                 val encodedKey = context.key.publicKey.encoded
                 SigningCachedKey(
-                    id = publicKeyIdFromBytes(encodedKey),
-                    fullId = fullPublicKeyIdFromBytes(encodedKey),
+                    id = keyIdFromBytes(encodedKey),
+                    fullId = fullKeyIdFromBytes(encodedKey),
                     tenantId = tenantId,
                     category = context.category,
                     alias = context.alias,
@@ -66,8 +68,8 @@ class TestSigningKeyStore(
             is SigningWrappedKeySaveContext -> {
                 val encodedKey = context.key.publicKey.encoded
                 SigningCachedKey(
-                    id = publicKeyIdFromBytes(encodedKey),
-                    fullId = fullPublicKeyIdFromBytes(encodedKey),
+                    id = keyIdFromBytes(encodedKey),
+                    fullId = fullKeyIdFromBytes(encodedKey),
                     tenantId = tenantId,
                     category = context.category,
                     alias = context.alias,
@@ -95,7 +97,7 @@ class TestSigningKeyStore(
     }
 
     override fun find(tenantId: String, publicKey: PublicKey): SigningCachedKey? = lock.withLock {
-        keys[Pair(tenantId, publicKey.publicKeyId())]
+        keys[Pair(tenantId, keyIdFromKey(publicKey))]
     }
 
     @Suppress("ComplexMethod")
@@ -124,7 +126,7 @@ class TestSigningKeyStore(
         }
         return when(orderBy) {
             SigningKeyOrderBy.NONE -> filtered
-            SigningKeyOrderBy.ID -> filtered.sortedBy { it.id }
+            SigningKeyOrderBy.ID -> filtered.sortedBy { it.id.value }
             SigningKeyOrderBy.TIMESTAMP -> filtered.sortedBy { it.timestamp }
             SigningKeyOrderBy.CATEGORY -> filtered.sortedBy { it.category }
             SigningKeyOrderBy.SCHEME_CODE_NAME -> filtered.sortedBy { it.schemeCodeName }
@@ -137,14 +139,14 @@ class TestSigningKeyStore(
             SigningKeyOrderBy.ALIAS_DESC -> filtered.sortedByDescending { it.alias }
             SigningKeyOrderBy.MASTER_KEY_ALIAS_DESC -> filtered.sortedByDescending { it.masterKeyAlias }
             SigningKeyOrderBy.EXTERNAL_ID_DESC -> filtered.sortedByDescending { it.externalId }
-            SigningKeyOrderBy.ID_DESC -> filtered.sortedByDescending { it.id }
+            SigningKeyOrderBy.ID_DESC -> filtered.sortedByDescending { it.id.value }
         }.drop(skip).take(take)
     }
 
     override fun lookupByIds(tenantId: String, keyIds: List<ShortHash>): Collection<SigningCachedKey> {
         val result = mutableListOf<SigningCachedKey>()
         keyIds.forEach {
-            val found = keys[Pair(tenantId, it.value)]
+            val found = keys[Pair(tenantId, it)]
             if(found != null) {
                 result.add(found)
             }
@@ -171,3 +173,13 @@ class TestSigningKeyStore(
     }
 
 }
+
+
+fun fullKeyIdFromBytes(publicKey: ByteArray): SecureHash =
+    SecureHash(DigestAlgorithmName.SHA2_256.name, publicKey.sha256Bytes())
+
+fun keyIdFromBytes(publicKey: ByteArray): ShortHash =
+    ShortHash.of(fullKeyIdFromBytes(publicKey))
+
+fun keyIdFromKey(publicKey: PublicKey): ShortHash =
+    keyIdFromBytes(publicKey.encoded)


### PR DESCRIPTION
* changes hex string hashes to strong typed hashes in DTOs to be more consistent in business layer and save `ShortHash` and `SecureHash` parsing