### PR TITLE
CORE-8774: Simplify DB check

### DIFF
--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerEventHandler.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerEventHandler.kt
@@ -38,6 +38,7 @@ class DbConnectionManagerEventHandler(
             }
             is StopEvent -> {
                 logger.debug { "DbConnectionManager stopping." }
+                onStop(coordinator)
             }
             is ErrorEvent -> {
                 logger.error(
@@ -51,14 +52,16 @@ class DbConnectionManagerEventHandler(
         }
     }
 
-    fun scheduleNextDbCheck(@Suppress("UNUSED_PARAMETER") coordinator: LifecycleCoordinator) {
-        // Turned off while we investigate a failing test
-        // coordinator.setTimer(dbCheckTimerKey, timeBetweenDbChecks.toMillis()) { key -> CheckDbEvent(key) }
+    fun scheduleNextDbCheck(coordinator: LifecycleCoordinator) {
+         coordinator.setTimer(dbCheckTimerKey, timeBetweenDbChecks.toMillis()) { key -> CheckDbEvent(key) }
     }
 
-    @Synchronized
+    private fun onStop(coordinator: LifecycleCoordinator) {
+        coordinator.cancelTimer(dbCheckTimerKey)
+    }
+
     private fun checkDb(coordinator: LifecycleCoordinator) {
-        if (dbConnectionManager.testAllConnections()) {
+        if (dbConnectionManager.testConnection()) {
             coordinator.updateStatus(LifecycleStatus.UP, "DB check passed")
         } else {
             coordinator.updateStatus(LifecycleStatus.DOWN, "DB check failed")

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionManagerImpl.kt
@@ -77,11 +77,12 @@ class DbConnectionManagerImpl (
         lifecycleCoordinator.postEvent(BootstrapConfigProvided(config))
     }
 
-    override fun testAllConnections(): Boolean {
-        return dbConnectionsRepository?.testAllConnections() ?: run {
-            logger.warn("DB check scheduled while dbConnectionsRepository is null")
-            false
-        }
+    override fun testConnection(): Boolean = try {
+        checkDatabaseConnection(getClusterDataSource())
+        true
+    }  catch (e: DBConfigurationException) {
+        logger.debug("DB check failed", e)
+        false
     }
 
     override val isRunning: Boolean

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionsRepositoryImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionsRepositoryImpl.kt
@@ -108,27 +108,4 @@ class DbConnectionsRepositoryImpl(
     }
 
     override fun getClusterDataSource(): CloseableDataSource = clusterDataSource
-
-    override fun testAllConnections(): Boolean {
-        try {
-            val connectionConfigs = entityManagerFactory.createEntityManager().use {
-                it.createQuery("SELECT c FROM DbConnectionConfig c", DbConnectionConfig::class.java).resultList
-            }
-            return connectionConfigs.all(::testConnection)
-        } catch (e: Exception) {
-            logger.debug("DB check failed", e)
-            return false
-        }
-    }
-
-    private fun testConnection(connectionConfig: DbConnectionConfig): Boolean = try {
-        logger.debug("Checking connection ${connectionConfig.name}")
-        val config = dbConfigFactory.create(ConfigFactory.parseString(connectionConfig.config))
-        dataSourceFactory.createFromConfig(config).use { it.connection.close() }
-        true
-    } catch (e: Exception) {
-        logger.debug("DB check failed", e)
-        false
-    }
 }
-

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionManager.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionManager.kt
@@ -59,5 +59,5 @@ interface DbConnectionManager : DbConnectionOps, DataSourceFactory, Lifecycle {
     /**
      * Test all connections, returns true if all connections are working.
      */
-    fun testAllConnections(): Boolean
+    fun testConnection(): Boolean
 }

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionsRepository.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionsRepository.kt
@@ -75,9 +75,4 @@ interface DbConnectionsRepository {
      * @return The cluster DB [DataSource]
      */
     fun getClusterDataSource(): CloseableDataSource
-
-    /**
-     * Test all connections, returns true if all connections are working.
-     */
-    fun testAllConnections(): Boolean
 }

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
@@ -80,7 +80,7 @@ class DbConnectionManagerImpl @Activate constructor(
     override fun bootstrap(config: SmartConfig) {
     }
 
-    override fun testAllConnections(): Boolean {
+    override fun testConnection(): Boolean {
         return true
     }
 

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -71,7 +71,7 @@ class FakeDbConnectionManager(
         logger.info("Fake DbConnectionManager bootstrapped with $config")
     }
 
-    override fun testAllConnections(): Boolean {
+    override fun testConnection(): Boolean {
         return true
     }
 


### PR DESCRIPTION
Simplify the DB check so we can restore 87 services after the DB goes offline and returns.