### PR TITLE
CORE-10678 Make subsequent MGM Registrations Fail

### DIFF
--- a/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/MtlsMgmClientCertificateKeeper.kt
+++ b/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/MtlsMgmClientCertificateKeeper.kt
@@ -40,15 +40,17 @@ internal class MtlsMgmClientCertificateKeeper(
             .firstOrNull()?.subjectX500Principal ?:
         throw CordaRuntimeException("Can not extract TLS certificate subject.")
         val normalizedSubject = MemberX500Name.parse(subject.toString()).toString()
-        val newGroupPolicy = membershipQueryClient
+        val (persistedGroupPolicy, version) = membershipQueryClient
             .queryGroupPolicy(holdingIdentity)
             .getOrThrow()
-            .entries.associate { it.key to it.value } +
+
+        val newGroupPolicy = persistedGroupPolicy.entries.associate { it.key to it.value } +
                 (MGM_CLIENT_CERTIFICATE_SUBJECT to normalizedSubject)
 
         membershipPersistenceClient.persistGroupPolicy(
             holdingIdentity,
             layeredPropertyMapFactory.createMap(newGroupPolicy),
+            version + 1
         ).getOrThrow()
     }
 }

--- a/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/MtlsMgmClientCertificateKeeperTest.kt
+++ b/components/membership/certificates-client-impl/src/test/kotlin/net/corda/membership/certificate/client/impl/MtlsMgmClientCertificateKeeperTest.kt
@@ -60,7 +60,7 @@ class MtlsMgmClientCertificateKeeperTest {
             eq(mgmHoldingIdentity),
             eq(createdPropertyMap),
             any()
-        ) } doReturn MembershipPersistenceResult.Success(2)
+        ) } doReturn MembershipPersistenceResult.success()
     }
     private val savedGroupPolicy = mock<LayeredPropertyMap> {
         on { entries } doReturn mapOf("hello" to "world").entries

--- a/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
+++ b/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
@@ -277,7 +277,7 @@ class GroupPolicyProviderImpl @Activate constructor(
             return null
         }
         fun persistedPropertyQuery(): LayeredPropertyMap? = try {
-            membershipQueryClient.queryGroupPolicy(holdingIdentity).getOrThrow()
+            membershipQueryClient.queryGroupPolicy(holdingIdentity).getOrThrow().first
         } catch (e: MembershipQueryResult.QueryException) {
             logger.warn("Failed to retrieve persisted group policy properties.", e)
             null

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -219,7 +219,7 @@ class GroupPolicyProviderImplTest {
     }
 
     private val membershipQueryClient: MembershipQueryClient = mock {
-        on { queryGroupPolicy(any()) }.doReturn(MembershipQueryResult.Success(properties))
+        on { queryGroupPolicy(any()) }.doReturn(MembershipQueryResult.Success(properties to 1L))
     }
 
     private fun postStartEvent() = postEvent(StartEvent())
@@ -685,7 +685,7 @@ class GroupPolicyProviderImplTest {
         val argCap = argumentCaptor<() -> LayeredPropertyMap?>()
 
         whenever(membershipQueryClient.queryGroupPolicy(any()))
-            .doReturn(MembershipQueryResult.Success(properties))
+            .doReturn(MembershipQueryResult.Success(properties to 1L))
         groupPolicyProvider.getGroupPolicy(holdingIdentity1)
         verify(groupPolicyParser).parse(any(), any(), argCap.capture())
         assertThat(argCap.firstValue.invoke()).isEqualTo(properties)

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -226,7 +226,7 @@ class MemberResourceClientImpl @Activate constructor(
                     listOf(
                         Record(
                             MEMBERSHIP_ASYNC_REQUEST_TOPIC,
-                            memberRegistrationRequest.holdingIdentityShortHash,
+                            memberRegistrationRequest.holdingIdentityShortHash.toString(),
                             MembershipAsyncRequest(
                                 RegistrationAsyncRequest(
                                     memberRegistrationRequest.holdingIdentityShortHash.toString(),

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -226,7 +226,7 @@ class MemberResourceClientImpl @Activate constructor(
                     listOf(
                         Record(
                             MEMBERSHIP_ASYNC_REQUEST_TOPIC,
-                            requestId,
+                            memberRegistrationRequest.holdingIdentityShortHash,
                             MembershipAsyncRequest(
                                 RegistrationAsyncRequest(
                                     memberRegistrationRequest.holdingIdentityShortHash.toString(),

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MemberResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MemberResourceClientTest.kt
@@ -511,9 +511,9 @@ class MemberResourceClientTest {
         assertThat(records.firstValue).hasSize(1)
             .anySatisfy { record ->
                 assertThat(record.topic).isEqualTo(MEMBERSHIP_ASYNC_REQUEST_TOPIC)
+                assertThat(record.key.toString()).isEqualTo(HOLDING_IDENTITY_ID)
                 val value = record.value as? MembershipAsyncRequest
                 val request = value?.request as? RegistrationAsyncRequest
-                assertThat(request?.requestId).isEqualTo(record.key)
                 assertThat(request?.holdingIdentityId).isEqualTo(HOLDING_IDENTITY_ID)
                 assertThat(request?.registrationAction).isEqualTo(RegistrationAction.REQUEST_JOIN)
                 assertThat(request?.context).isEqualTo(mapOf("property" to "test").toWire())

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
@@ -128,12 +128,13 @@ class MembershipPersistenceClientImpl(
     override fun persistGroupPolicy(
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
+        version: Long
     ): MembershipPersistenceResult<Int> {
         logger.info("Persisting group policy.")
         val avroViewOwningIdentity = viewOwningIdentity.toAvro()
         val result = MembershipPersistenceRequest(
             buildMembershipRequestContext(avroViewOwningIdentity),
-            PersistGroupPolicy(groupPolicy.toAvro())
+            PersistGroupPolicy(groupPolicy.toAvro(), version)
         ).execute()
         return when (val response = result.payload) {
             is PersistGroupPolicyResponse -> MembershipPersistenceResult.Success(response.version)

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
@@ -217,7 +217,7 @@ class MembershipQueryClientImpl(
         }
     }
 
-    override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<LayeredPropertyMap> {
+    override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Pair<LayeredPropertyMap, Long>> {
         val result = MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
             QueryGroupPolicy()
@@ -225,7 +225,7 @@ class MembershipQueryClientImpl(
         return when (val payload = result.payload) {
             is GroupPolicyQueryResponse -> {
                 MembershipQueryResult.Success(
-                    layeredPropertyMapFactory.createMap(payload.properties.toMap())
+                    layeredPropertyMapFactory.createMap(payload.properties.toMap()) to payload.version
                 )
             }
             else -> {

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -459,7 +459,7 @@ class MembershipPersistenceClientImplTest {
             PersistGroupPolicyResponse(103),
         )
 
-        val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy)
+        val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy, 1L)
 
         assertThat(result).isEqualTo(MembershipPersistenceResult.Success(103))
     }
@@ -472,7 +472,7 @@ class MembershipPersistenceClientImplTest {
             PersistenceFailedResponse("Placeholder error"),
         )
 
-        val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy)
+        val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy, 1L)
 
         assertThat(result).isEqualTo(MembershipPersistenceResult.Failure<Int>("Placeholder error"))
     }
@@ -485,7 +485,7 @@ class MembershipPersistenceClientImplTest {
             null,
         )
 
-        val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy)
+        val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy, 1L)
 
         assertThat(result).isEqualTo(MembershipPersistenceResult.Failure<Int>("Unexpected response: null"))
     }
@@ -501,7 +501,7 @@ class MembershipPersistenceClientImplTest {
         val response = CompletableFuture.completedFuture(mock<MembershipPersistenceResponse>())
         whenever(rpcSender.sendRequest(argument.capture())).thenReturn(response)
 
-        membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy)
+        membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy, 1L)
 
         val properties = (argument.firstValue.request as? PersistGroupPolicy)?.properties?.items
         assertThat(properties).containsExactly(

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -30,7 +30,6 @@ import net.corda.data.membership.db.response.MembershipResponseContext
 import net.corda.data.membership.db.response.command.DeleteApprovalRuleResponse
 import net.corda.data.membership.db.response.command.PersistApprovalRuleResponse
 import net.corda.data.membership.db.response.command.PersistGroupParametersResponse
-import net.corda.data.membership.db.response.command.PersistGroupPolicyResponse
 import net.corda.data.membership.db.response.command.RevokePreAuthTokenResponse
 import net.corda.data.membership.db.response.query.PersistenceFailedResponse
 import net.corda.data.membership.db.response.query.UpdateMemberAndRegistrationRequestResponse
@@ -452,16 +451,14 @@ class MembershipPersistenceClientImplTest {
     }
 
     @Test
-    fun `persistGroupPolicy return the correct version`() {
+    fun `persistGroupPolicy return success on success`() {
         val groupPolicy = mock<LayeredPropertyMap>()
         postConfigChangedEvent()
-        mockPersistenceResponse(
-            PersistGroupPolicyResponse(103),
-        )
+        mockPersistenceResponse()
 
         val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy, 1L)
 
-        assertThat(result).isEqualTo(MembershipPersistenceResult.Success(103))
+        assertThat(result).isEqualTo(MembershipPersistenceResult.success())
     }
 
     @Test
@@ -475,19 +472,6 @@ class MembershipPersistenceClientImplTest {
         val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy, 1L)
 
         assertThat(result).isEqualTo(MembershipPersistenceResult.Failure<Int>("Placeholder error"))
-    }
-
-    @Test
-    fun `persistGroupPolicy return failure for unexpected result`() {
-        val groupPolicy = mock<LayeredPropertyMap>()
-        postConfigChangedEvent()
-        mockPersistenceResponse(
-            null,
-        )
-
-        val result = membershipPersistenceClient.persistGroupPolicy(ourHoldingIdentity, groupPolicy, 1L)
-
-        assertThat(result).isEqualTo(MembershipPersistenceResult.Failure<Int>("Unexpected response: null"))
     }
 
     @Test

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -435,14 +435,15 @@ class MembershipQueryClientImplTest {
             CompletableFuture.completedFuture(
                 MembershipPersistenceResponse(
                     context,
-                    GroupPolicyQueryResponse(KeyValuePairList(listOf(KeyValuePair("Key", "Value"))))
+                    GroupPolicyQueryResponse(KeyValuePairList(listOf(KeyValuePair("Key", "Value"))), 101L)
                 )
             )
         }
 
         val result = membershipQueryClient.queryGroupPolicy(ourHoldingIdentity)
         assertThat(result.getOrThrow()).isNotNull
-        assertThat(result.getOrThrow().entries.size).isEqualTo(1)
+        assertThat(result.getOrThrow().first.entries.size).isEqualTo(1)
+        assertThat(result.getOrThrow().second).isEqualTo(101L)
     }
 
     @Test
@@ -461,14 +462,15 @@ class MembershipQueryClientImplTest {
             CompletableFuture.completedFuture(
                 MembershipPersistenceResponse(
                     context,
-                    GroupPolicyQueryResponse(KeyValuePairList(emptyList()))
+                    GroupPolicyQueryResponse(KeyValuePairList(emptyList()), 0L)
                 )
             )
         }
 
         val result = membershipQueryClient.queryGroupPolicy(ourHoldingIdentity)
         assertThat(result.getOrThrow()).isNotNull
-        assertThat(result.getOrThrow().entries).isEmpty()
+        assertThat(result.getOrThrow().first.entries).isEmpty()
+        assertThat(result.getOrThrow().second).isEqualTo(0L)
     }
 
     @Nested

--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
@@ -42,6 +42,7 @@ interface MembershipPersistenceClient : Lifecycle {
      *
      * @param viewOwningIdentity The holding identity of the owner of the view of data.
      * @param groupPolicy The group policy.
+     * @param version The version of the group policy to persist.
      *
      * @return membership persistence result to indicate the result of the persistence operation.
      *  In the case of success the payload will include the newly created version number.
@@ -49,6 +50,7 @@ interface MembershipPersistenceClient : Lifecycle {
     fun persistGroupPolicy(
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
+        version: Long
     ): MembershipPersistenceResult<Int>
 
     /**

--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
@@ -51,7 +51,7 @@ interface MembershipPersistenceClient : Lifecycle {
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
         version: Long
-    ): MembershipPersistenceResult<Int>
+    ): MembershipPersistenceResult<Unit>
 
     /**
      * Create and persist the first version of group parameters. This method is expected to be used by an MGM to persist

--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipQueryClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipQueryClient.kt
@@ -85,10 +85,10 @@ interface MembershipQueryClient : Lifecycle {
      *
      * @param viewOwningIdentity The holding identity whose view is being requested.
      *
-     * @return a query result with the latest version of group policy if the query executed successfully.
-     * Returns an empty [LayeredPropertyMap] if there was no group policy persisted.
+     * @return a query result with the latest version of group policy if the query executed successfully and the version number.
+     * Returns an empty [LayeredPropertyMap] and version 0 if there was no group policy persisted.
      */
-    fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<LayeredPropertyMap>
+    fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Pair<LayeredPropertyMap, Long>>
 
 
     /**

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -217,8 +217,9 @@ class MembershipPersistenceTest {
             override fun persistGroupPolicy(
                 viewOwningIdentity: HoldingIdentity,
                 groupPolicy: LayeredPropertyMap,
+                version: Long
             ) = safeCall {
-                membershipPersistenceClient.persistGroupPolicy(viewOwningIdentity, groupPolicy)
+                membershipPersistenceClient.persistGroupPolicy(viewOwningIdentity, groupPolicy, version)
             }
 
             override fun persistGroupParameters(
@@ -527,20 +528,6 @@ class MembershipPersistenceTest {
             assertThat(first().key).isEqualTo(MEMBER_CONTEXT_KEY)
             assertThat(first().value).isEqualTo(MEMBER_CONTEXT_VALUE)
         }
-    }
-    @Test
-    @Disabled
-    fun `persistGroupPolicy will increase the version every persistance`() {
-        val groupPolicy1 = layeredPropertyMapFactory.createMap(mapOf("aa" to "BBB"))
-        val persisted1 = membershipPersistenceClientWrapper.persistGroupPolicy(viewOwningHoldingIdentity, groupPolicy1)
-        assertThat(persisted1).isInstanceOf(MembershipPersistenceResult.Success::class.java)
-        val version1 = (persisted1 as? MembershipPersistenceResult.Success<Int>)?.payload !!
-
-        val groupPolicy2 = layeredPropertyMapFactory.createMap(mapOf("aa" to "BBB1"))
-        val persisted2 = membershipPersistenceClientWrapper.persistGroupPolicy(viewOwningHoldingIdentity, groupPolicy2)
-        assertThat(persisted2).isInstanceOf(MembershipPersistenceResult.Success::class.java)
-        val version2 = (persisted2 as? MembershipPersistenceResult.Success<Int>)?.payload
-        assertThat(version2).isEqualTo(version1 + 1)
     }
 
     @Test

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -97,6 +97,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
@@ -528,6 +529,7 @@ class MembershipPersistenceTest {
         }
     }
     @Test
+    @Disabled
     fun `persistGroupPolicy will increase the version every persistance`() {
         val groupPolicy1 = layeredPropertyMapFactory.createMap(mapOf("aa" to "BBB"))
         val persisted1 = membershipPersistenceClientWrapper.persistGroupPolicy(viewOwningHoldingIdentity, groupPolicy1)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
@@ -23,6 +23,12 @@ internal class PersistGroupParametersInitialSnapshotHandler(
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")
         }
+    private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> =
+        cordaAvroSerializationFactory.createAvroDeserializer (
+            { logger.error("Failed to deserialize key value pair list.") },
+            KeyValuePairList::class.java
+        )
+
 
     private fun serializeProperties(context: KeyValuePairList): ByteArray {
         return keyValuePairListSerializer.serialize(context) ?: throw MembershipPersistenceException(
@@ -48,12 +54,23 @@ internal class PersistGroupParametersInitialSnapshotHandler(
         context: MembershipRequestContext,
         request: PersistGroupParametersInitialSnapshot
     ): PersistGroupParametersResponse {
+        val activePlatformVersion = platformInfoProvider.activePlatformVersion.toString()
         val persistedGroupParameters = transaction(context.holdingIdentity.toCorda().shortHash) { em ->
+            val currentGroupParameters = em.find(GroupParametersEntity::class.java, 1, LockModeType.PESSIMISTIC_WRITE)?.let {
+                keyValuePairListDeserializer.deserialize(it.parameters)
+            }
+            currentGroupParameters?.let {
+                if (it.get(MPV_KEY) != activePlatformVersion) {
+                    throw MembershipPersistenceException("Group parameters already exists with a different platform version.")
+                }
+                return@transaction currentGroupParameters
+            }
+
             // Create initial snapshot of group parameters.
             val groupParameters = KeyValuePairList(
                 listOf(
                     KeyValuePair(EPOCH_KEY, "1"),
-                    KeyValuePair(MPV_KEY, platformInfoProvider.activePlatformVersion.toString()),
+                    KeyValuePair(MPV_KEY, activePlatformVersion),
                     KeyValuePair(MODIFIED_TIME_KEY, clock.instant().toString())
                 )
             )

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
@@ -23,11 +23,6 @@ internal class PersistGroupParametersInitialSnapshotHandler(
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")
         }
-    private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> =
-        cordaAvroSerializationFactory.createAvroDeserializer (
-            { logger.error("Failed to deserialize key value pair list.") },
-            KeyValuePairList::class.java
-        )
 
     private fun serializeProperties(context: KeyValuePairList): ByteArray {
         return keyValuePairListSerializer.serialize(context) ?: throw MembershipPersistenceException(
@@ -53,23 +48,12 @@ internal class PersistGroupParametersInitialSnapshotHandler(
         context: MembershipRequestContext,
         request: PersistGroupParametersInitialSnapshot
     ): PersistGroupParametersResponse {
-        val activePlatformVersion = platformInfoProvider.activePlatformVersion.toString()
         val persistedGroupParameters = transaction(context.holdingIdentity.toCorda().shortHash) { em ->
-            val currentGroupParameters = em.find(GroupParametersEntity::class.java, 1, LockModeType.PESSIMISTIC_WRITE)?.let {
-                keyValuePairListDeserializer.deserialize(it.parameters)
-            }
-            currentGroupParameters?.let {
-                if (it.items.find { item -> item.key == MPV_KEY }?.value != activePlatformVersion) {
-                    throw MembershipPersistenceException("Group parameters already exists with a different platform version.")
-                }
-                return@transaction currentGroupParameters
-            }
-
             // Create initial snapshot of group parameters.
             val groupParameters = KeyValuePairList(
                 listOf(
                     KeyValuePair(EPOCH_KEY, "1"),
-                    KeyValuePair(MPV_KEY, activePlatformVersion),
+                    KeyValuePair(MPV_KEY, platformInfoProvider.activePlatformVersion.toString()),
                     KeyValuePair(MODIFIED_TIME_KEY, clock.instant().toString())
                 )
             )

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
@@ -60,7 +60,7 @@ internal class PersistGroupParametersInitialSnapshotHandler(
                 keyValuePairListDeserializer.deserialize(it.parameters)
             }
             currentGroupParameters?.let {
-                if (it.get(MPV_KEY) != activePlatformVersion) {
+                if (it.items.find { item -> item.key == MPV_KEY }?.value != activePlatformVersion) {
                     throw MembershipPersistenceException("Group parameters already exists with a different platform version.")
                 }
                 return@transaction currentGroupParameters

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
@@ -29,7 +29,6 @@ internal class PersistGroupParametersInitialSnapshotHandler(
             KeyValuePairList::class.java
         )
 
-
     private fun serializeProperties(context: KeyValuePairList): ByteArray {
         return keyValuePairListSerializer.serialize(context) ?: throw MembershipPersistenceException(
             "Failed to serialize key value pair list."

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
@@ -40,7 +40,7 @@ internal class PersistGroupPolicyHandler(
             em.createQuery(query).setLockMode(LockModeType.PESSIMISTIC_WRITE).setMaxResults(1).resultList.singleOrNull()?.let {
                 val lastProperties = keyValuePairListDeserializer.deserialize(it.properties)
                 if (lastProperties?.items != request.properties.items) {
-                    throw MembershipPersistenceException("")
+                    throw MembershipPersistenceException("Cannot update group policy: items differs from original.")
                 }
                 return@transaction it.version
             }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
@@ -36,23 +36,38 @@ internal class PersistGroupPolicyHandler(
         }
 
         transaction(context.holdingIdentity.toCorda().shortHash) { em ->
-            em.find(GroupPolicyEntity::class.java, request.version, LockModeType.PESSIMISTIC_WRITE)?.let {
-                val persistedProperties = keyValuePairListDeserializer.deserialize(it.properties)
-                if (persistedProperties != request.properties) {
-                    throw MembershipPersistenceException(
-                        "Cannot update group policy: a group policy with version ${request.version} already exists."
-                    )
-                }
-                return@transaction
+            val criteriaBuilder = em.criteriaBuilder
+            val queryBuilder = criteriaBuilder.createQuery(GroupPolicyEntity::class.java)
+            val root = queryBuilder.from(GroupPolicyEntity::class.java)
+            val query = queryBuilder
+                .select(root)
+                .orderBy(criteriaBuilder.desc(root.get<String>("version")))
+
+            val lastPersistedVersion = with(em.createQuery(query).setLockMode(LockModeType.PESSIMISTIC_WRITE).setMaxResults(1).resultList) {
+                singleOrNull()?.let { persistedGroupPolicy ->
+                    if (request.version == persistedGroupPolicy.version) {
+                        val persistedProperties = keyValuePairListDeserializer.deserialize(persistedGroupPolicy.properties)
+                        if (persistedProperties != request.properties) {
+                            throw MembershipPersistenceException(
+                                "Cannot update group policy: a group policy with version ${request.version} already exists."
+                            )
+                        }
+                        return@transaction
+                    }
+                    persistedGroupPolicy.version
+                } ?: 0
             }
 
-            if (request.version > 1) {
-                val previousVersion = request.version - 1
-                em.find(GroupPolicyEntity::class.java, previousVersion, LockModeType.PESSIMISTIC_WRITE)
-                    ?: throw MembershipPersistenceException(
-                        "Cannot update group policy: with version ${request.version}. No policy with version $previousVersion exists."
-                    )
+            if (request.version != lastPersistedVersion + 1) {
+                if (request.version > lastPersistedVersion) {
+                    throw MembershipPersistenceException("Cannot update group policy: with version ${request.version}. No policy " +
+                        "with version ${request.version - 1} exists.")
+                } else {
+                    throw MembershipPersistenceException("Cannot update group policy: with version ${request.version} smaller " +
+                            "than the latest persisted version.")
+                }
             }
+
             val entity = GroupPolicyEntity(
                 version = request.version,
                 createdAt = clock.instant(),

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.impl.persistence.service.handler
 
+import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.db.request.MembershipRequestContext
@@ -8,6 +9,7 @@ import net.corda.data.membership.db.response.command.PersistGroupPolicyResponse
 import net.corda.membership.datamodel.GroupPolicyEntity
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.virtualnode.toCorda
+import javax.persistence.LockModeType
 
 internal class PersistGroupPolicyHandler(
     persistenceHandlerServices: PersistenceHandlerServices
@@ -16,6 +18,11 @@ internal class PersistGroupPolicyHandler(
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")
         }
+    private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> =
+        cordaAvroSerializationFactory.createAvroDeserializer (
+            { logger.error("Failed to deserialize key value pair list.") },
+            KeyValuePairList::class.java
+        )
     private fun serializeProperties(context: KeyValuePairList): ByteArray {
         return keyValuePairListSerializer.serialize(context) ?: throw MembershipPersistenceException(
             "Failed to serialize key value pair list."
@@ -24,6 +31,20 @@ internal class PersistGroupPolicyHandler(
 
     override fun invoke(context: MembershipRequestContext, request: PersistGroupPolicy): PersistGroupPolicyResponse {
         val version = transaction(context.holdingIdentity.toCorda().shortHash) { em ->
+            val criteriaBuilder = em.criteriaBuilder
+            val queryBuilder = criteriaBuilder.createQuery(GroupPolicyEntity::class.java)
+            val root = queryBuilder.from(GroupPolicyEntity::class.java)
+            val query = queryBuilder
+                .select(root)
+                .orderBy(criteriaBuilder.desc(root.get<String>("version")))
+            em.createQuery(query).setLockMode(LockModeType.PESSIMISTIC_WRITE).setMaxResults(1).resultList.singleOrNull()?.let {
+                val lastProperties = keyValuePairListDeserializer.deserialize(it.properties)
+                if (lastProperties?.items != request.properties.items) {
+                    throw MembershipPersistenceException("")
+                }
+                return@transaction it.version
+            }
+
             val entity = GroupPolicyEntity(
                 version = null,
                 createdAt = clock.instant(),

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
@@ -7,9 +7,11 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.PersistMemberInfo
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
+import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
+import net.corda.membership.lib.toMap
 import net.corda.virtualnode.toCorda
 import javax.persistence.LockModeType
 
@@ -59,7 +61,7 @@ internal class PersistMemberInfoHandler(
                                 "Cannot update member info with same serial number: member context differs from original."
                             )
                         }
-                        if (currentMgmContext.items != it.mgmContext.items) {
+                        if (currentMgmContext.toMap().removeTime() != it.mgmContext.toMap().removeTime()) {
                             throw MembershipPersistenceException(
                                 "Cannot update member info with same serial: mgm context differs from original."
                             )
@@ -80,5 +82,8 @@ internal class PersistMemberInfoHandler(
                 }
             }
         }
+    }
+    private fun Map<String, String>.removeTime(): Map<String, String>  = this.filterKeys {
+        it != MemberInfoExtension.CREATION_TIME && it != MemberInfoExtension.MODIFIED_TIME
     }
 }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
@@ -54,11 +54,15 @@ internal class PersistMemberInfoHandler(
                     if (currentMemberInfo?.serialNumber == memberInfo.serial) {
                         val currentMemberContext = deserialize(currentMemberInfo.memberContext)
                         val currentMgmContext = deserialize(currentMemberInfo.mgmContext)
-                        if (currentMemberContext.items == it.memberContext.items) {
-                            throw MembershipPersistenceException("")
+                        if (currentMemberContext.items != it.memberContext.items) {
+                            throw MembershipPersistenceException(
+                                "Cannot update member info with same serial number: member context differs from original."
+                            )
                         }
                         if (currentMgmContext.items != it.mgmContext.items) {
-                            throw MembershipPersistenceException("")
+                            throw MembershipPersistenceException(
+                                "Cannot update member info with same serial: mgm context differs from original."
+                            )
                         }
                         return@forEach
                     }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
@@ -57,14 +57,12 @@ internal class PersistMemberInfoHandler(
                         val currentMemberContext = deserialize(currentMemberInfo.memberContext)
                         val currentMgmContext = deserialize(currentMemberInfo.mgmContext)
                         if (currentMemberContext.items != it.memberContext.items) {
-                            throw MembershipPersistenceException(
-                                "Cannot update member info with same serial number: member context differs from original."
-                            )
+                            throw MembershipPersistenceException("Cannot update member info with same serial number " +
+                                "(${memberInfo.serial}): member context differs from original.")
                         }
                         if (currentMgmContext.toMap().removeTime() != it.mgmContext.toMap().removeTime()) {
-                            throw MembershipPersistenceException(
-                                "Cannot update member info with same serial: mgm context differs from original."
-                            )
+                            throw MembershipPersistenceException("Cannot update member info with same serial number " +
+                                "(${memberInfo.serial}): mgm context differs from original.")
                         }
                         return@forEach
                     }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
@@ -1,14 +1,17 @@
 package net.corda.membership.impl.persistence.service.handler
 
+import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.PersistMemberInfo
 import net.corda.membership.datamodel.MemberInfoEntity
+import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.virtualnode.toCorda
+import javax.persistence.LockModeType
 
 internal class PersistMemberInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
@@ -18,6 +21,11 @@ internal class PersistMemberInfoHandler(
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")
         }
+    private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> =
+        cordaAvroSerializationFactory.createAvroDeserializer (
+            { logger.error("Failed to deserialize key value pair list.") },
+            KeyValuePairList::class.java
+        )
 
     private fun serializeContext(context: KeyValuePairList): ByteArray {
         return keyValuePairListSerializer.serialize(context) ?: throw MembershipPersistenceException(
@@ -25,12 +33,36 @@ internal class PersistMemberInfoHandler(
         )
     }
 
+    private fun deserialize(data: ByteArray): KeyValuePairList {
+        return keyValuePairListDeserializer.deserialize(data) ?: throw MembershipPersistenceException(
+            "Failed to serialize key value pair list."
+        )
+    }
+
+
     override fun invoke(context: MembershipRequestContext, request: PersistMemberInfo) {
         if (request.members.isNotEmpty()) {
             logger.info("Persisting member information.")
             transaction(context.holdingIdentity.toCorda().shortHash) { em ->
                 request.members.forEach {
                     val memberInfo = memberInfoFactory.create(it)
+                    val currentMemberInfo = em.find(
+                        MemberInfoEntity::class.java,
+                        MemberInfoEntityPrimaryKey(memberInfo.groupId, memberInfo.name.toString()),
+                        LockModeType.PESSIMISTIC_WRITE
+                    )
+                    if (currentMemberInfo?.serialNumber == memberInfo.serial) {
+                        val currentMemberContext = deserialize(currentMemberInfo.memberContext)
+                        val currentMgmContext = deserialize(currentMemberInfo.mgmContext)
+                        if (currentMemberContext.items == it.memberContext.items) {
+                            throw MembershipPersistenceException("")
+                        }
+                        if (currentMgmContext.items != it.mgmContext.items) {
+                            throw MembershipPersistenceException("")
+                        }
+                        return@forEach
+                    }
+
                     val entity = MemberInfoEntity(
                         memberInfo.groupId,
                         memberInfo.name.toString(),

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandler.kt
@@ -34,11 +34,11 @@ internal class QueryGroupPolicyHandler(
             if(result.isEmpty()) {
                 logger.warn("There was no persisted group policy found for identity ${context.holdingIdentity}. " +
                         "Returning empty properties.")
-                GroupPolicyQueryResponse(KeyValuePairList(emptyList<KeyValuePair>()))
+                GroupPolicyQueryResponse(KeyValuePairList(emptyList<KeyValuePair>()), 0)
             } else {
                 logger.info("Persisted group policy was found for identity ${context.holdingIdentity}. " +
                         "Returning properties.")
-                GroupPolicyQueryResponse(keyValuePairListDeserializer.deserialize(result.first().properties))
+                GroupPolicyQueryResponse(keyValuePairListDeserializer.deserialize(result.first().properties), result.first().version)
             }
         }
     }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.persistence.service
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
@@ -225,8 +226,10 @@ class MembershipPersistenceRPCProcessorTest {
     }
     private val memberInfoFactory: MemberInfoFactory = mock()
     private val keyValuePairListSerializer = mock<CordaAvroSerializer<KeyValuePairList>>()
+    private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
+        on { createAvroDeserializer<KeyValuePairList>(any(), any()) } doReturn keyValuePairListDeserializer
     }
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
         on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
@@ -54,7 +54,7 @@ class PersistGroupParametersInitialSnapshotHandlerTest {
     private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
     private val serializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
-        on { createAvroDeserializer<KeyValuePairList>(any(), any()) } doReturn keyValuePairListDeserializer
+        on { createAvroDeserializer<KeyValuePairList>(any(), any())} doReturn keyValuePairListDeserializer
     }
     private val identity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group").toCorda()
     private val vaultDmlConnectionId = UUID(1, 2)

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
@@ -54,7 +54,7 @@ class PersistGroupParametersInitialSnapshotHandlerTest {
     private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
     private val serializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
-        on { createAvroDeserializer<KeyValuePairList>(any(), any())} doReturn keyValuePairListDeserializer
+        on { createAvroDeserializer<KeyValuePairList>(any(), any()) } doReturn keyValuePairListDeserializer
     }
     private val identity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group").toCorda()
     private val vaultDmlConnectionId = UUID(1, 2)

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.impl.persistence.service.handler
 
+import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePair
@@ -22,20 +23,29 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
+import javax.persistence.TypedQuery
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaQuery
+import javax.persistence.criteria.Order
+import javax.persistence.criteria.Path
+import javax.persistence.criteria.Root
 
 class PersistGroupPolicyHandlerTest {
     private val context = byteArrayOf(1, 2, 3)
     private val keyValuePairListSerializer = mock<CordaAvroSerializer<KeyValuePairList>> {
         on { serialize(any()) } doReturn context
     }
+    private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
     private val serializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
+        on { createAvroDeserializer<KeyValuePairList>(any(), any())} doReturn keyValuePairListDeserializer
     }
     private val identity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group").toCorda()
     private val vaultDmlConnectionId = UUID(1, 2)
@@ -51,11 +61,33 @@ class PersistGroupPolicyHandlerTest {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn entitySet
     }
     private val transaction = mock<EntityTransaction>()
+    private val previousEntry: TypedQuery<GroupPolicyEntity> = mock {
+        on { resultList } doReturn emptyList()
+    }
+    private val groupPolicyQuery: TypedQuery<GroupPolicyEntity> = mock {
+        on { setMaxResults(1) } doReturn previousEntry
+        on { setLockMode(any()) } doReturn mock
+    }
+    private val root = mock<Root<GroupPolicyEntity>> {
+        on { get<String>("version") } doReturn mock<Path<String>>()
+    }
+    private val order = mock<Order>()
+    private val query = mock<CriteriaQuery<GroupPolicyEntity>> {
+        on { from(GroupPolicyEntity::class.java) } doReturn root
+        on { select(root) } doReturn mock
+        on { orderBy(order) } doReturn mock
+    }
+    private val criteriaBuilder = mock<CriteriaBuilder> {
+        on { createQuery(GroupPolicyEntity::class.java) } doReturn query
+        on { desc(any()) } doReturn order
+    }
     private val entityManager = mock<EntityManager> {
         on { persist(any<GroupPolicyEntity>()) } doAnswer {
             val group = it.arguments[0] as GroupPolicyEntity
             group.version = 1002
         }
+        on { criteriaBuilder } doReturn criteriaBuilder
+        on { createQuery(eq(query)) } doReturn groupPolicyQuery
         on { transaction } doReturn transaction
     }
     private val entityManagerFactory = mock<EntityManagerFactory> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -11,37 +11,43 @@ import net.corda.data.membership.db.request.command.PersistGroupPolicy
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
 import net.corda.membership.datamodel.GroupPolicyEntity
+import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
 import net.corda.test.util.time.TestClock
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
-import org.junit.jupiter.api.Disabled
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.capture
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
-import javax.persistence.TypedQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaQuery
-import javax.persistence.criteria.Order
-import javax.persistence.criteria.Path
-import javax.persistence.criteria.Root
+import javax.persistence.LockModeType
 
 class PersistGroupPolicyHandlerTest {
     private val context = byteArrayOf(1, 2, 3)
     private val keyValuePairListSerializer = mock<CordaAvroSerializer<KeyValuePairList>> {
         on { serialize(any()) } doReturn context
     }
-    private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
+    private val mockKeyPairList = mock<KeyValuePairList>()
+    private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>> {
+        on { deserialize(any()) } doReturn mockKeyPairList
+    }
     private val serializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
         on { createAvroDeserializer<KeyValuePairList>(any(), any())} doReturn keyValuePairListDeserializer
@@ -60,33 +66,9 @@ class PersistGroupPolicyHandlerTest {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn entitySet
     }
     private val transaction = mock<EntityTransaction>()
-    private val previousEntry: TypedQuery<GroupPolicyEntity> = mock {
-        on { resultList } doReturn emptyList()
-    }
-    private val groupPolicyQuery: TypedQuery<GroupPolicyEntity> = mock {
-        on { setMaxResults(1) } doReturn previousEntry
-        on { setLockMode(any()) } doReturn mock
-    }
-    private val root = mock<Root<GroupPolicyEntity>> {
-        on { get<String>("version") } doReturn mock<Path<String>>()
-    }
-    private val order = mock<Order>()
-    private val query = mock<CriteriaQuery<GroupPolicyEntity>> {
-        on { from(GroupPolicyEntity::class.java) } doReturn root
-        on { select(root) } doReturn mock
-        on { orderBy(order) } doReturn mock
-    }
-    private val criteriaBuilder = mock<CriteriaBuilder> {
-        on { createQuery(GroupPolicyEntity::class.java) } doReturn query
-        on { desc(any()) } doReturn order
-    }
+    private val persistCapture = argumentCaptor<GroupPolicyEntity>()
     private val entityManager = mock<EntityManager> {
-        on { persist(any<GroupPolicyEntity>()) } doAnswer {
-            val group = it.arguments[0] as GroupPolicyEntity
-            group.version = 1002
-        }
-        on { criteriaBuilder } doReturn criteriaBuilder
-        on { createQuery(eq(query)) } doReturn groupPolicyQuery
+        on { persist(persistCapture.capture()) } doAnswer {}
         on { transaction } doReturn transaction
     }
     private val entityManagerFactory = mock<EntityManagerFactory> {
@@ -111,9 +93,8 @@ class PersistGroupPolicyHandlerTest {
     private val handler = PersistGroupPolicyHandler(persistenceHandlerServices)
 
     @Test
-    @Disabled
-    fun `invoke return the correct version`() {
-        val context = mock<MembershipRequestContext> {
+    fun `invoke persists a group policy with version 1 when nothing already persisted`() {
+        val requestContext = mock<MembershipRequestContext> {
             on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
         }
         val request = mock<PersistGroupPolicy> {
@@ -123,8 +104,113 @@ class PersistGroupPolicyHandlerTest {
                     KeyValuePair("2", "two"),
                 )
             )
+            on { version } doReturn 1L
         }
 
-        handler.invoke(context, request)
+        handler.invoke(requestContext, request)
+
+        persistCapture.lastValue.apply {
+            assertThat(this.version).isEqualTo(1L)
+            assertThat(this.properties).isEqualTo(context)
+        }
     }
+
+    @Test
+    fun `invoke persists a group policy with version 2 when version 1 already persisted`() {
+        whenever(entityManager.find(eq(GroupPolicyEntity::class.java), eq(1L), any<LockModeType>())).thenReturn(mock())
+        val requestContext = mock<MembershipRequestContext> {
+            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
+        }
+        val request = mock<PersistGroupPolicy> {
+            on { properties } doReturn KeyValuePairList(
+                listOf(
+                    KeyValuePair("1", "one"),
+                    KeyValuePair("2", "two"),
+                )
+            )
+            on { version } doReturn 2L
+        }
+
+        handler.invoke(requestContext, request)
+
+        persistCapture.lastValue.apply {
+            assertThat(this.version).isEqualTo(2L)
+            assertThat(this.properties).isEqualTo(context)
+        }
+    }
+
+    @Test
+    fun `invoke does not persists a group policy with version 1 when version 1 already persisted`() {
+        val mockEntity = mock<GroupPolicyEntity> {
+            on { properties } doReturn context
+        }
+        whenever(entityManager.find(eq(GroupPolicyEntity::class.java), eq(1L), any<LockModeType>())).doReturn(mockEntity)
+        val requestContext = mock<MembershipRequestContext> {
+            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
+        }
+        val request = mock<PersistGroupPolicy> {
+            on { properties } doReturn mockKeyPairList
+            on { version } doReturn 1L
+        }
+
+        handler.invoke(requestContext, request)
+
+        verify(entityManager, never()).persist(any())
+    }
+
+    @Test
+    fun `invoke throws when persisting a different group policy with version 1 when version 1 already persisted`() {
+        val mockEntity = mock<GroupPolicyEntity> {
+            on { properties } doReturn context
+        }
+        whenever(entityManager.find(eq(GroupPolicyEntity::class.java), eq(1L), any<LockModeType>())).thenReturn(mockEntity)
+        val requestContext = mock<MembershipRequestContext> {
+            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
+        }
+        val request = mock<PersistGroupPolicy> {
+            on { properties } doReturn KeyValuePairList(
+                listOf(
+                    KeyValuePair("1", "one"),
+                    KeyValuePair("2", "two"),
+                )
+            )
+            on { version } doReturn 1L
+        }
+
+        assertThrows<MembershipPersistenceException> { handler.invoke(requestContext, request) }
+        verify(entityManager, never()).persist(any())
+    }
+
+    @Test
+    fun `invoke throws when trying to persist a version smaller than 1`() {
+        val requestContext = mock<MembershipRequestContext> {
+            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
+        }
+        val request = mock<PersistGroupPolicy> {
+            on { version } doReturn 0L
+        }
+
+        assertThrows<MembershipPersistenceException> { handler.invoke(requestContext, request) }
+        verify(entityManager, never()).persist(any())
+    }
+
+    @Test
+    fun `invoke throws when trying to persist version 2 when nothing already persisted`() {
+        val requestContext = mock<MembershipRequestContext> {
+            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
+        }
+        val request = mock<PersistGroupPolicy> {
+            on { properties } doReturn KeyValuePairList(
+                listOf(
+                    KeyValuePair("1", "one"),
+                    KeyValuePair("2", "two"),
+                )
+            )
+            on { version } doReturn 2L
+        }
+
+        assertThrows<MembershipPersistenceException> { handler.invoke(requestContext, request) }
+        verify(entityManager, never()).persist(any())
+    }
+
 }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -21,10 +21,8 @@ import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.capture
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -19,6 +19,7 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
@@ -112,6 +113,7 @@ class PersistGroupPolicyHandlerTest {
     private val handler = PersistGroupPolicyHandler(persistenceHandlerServices)
 
     @Test
+    @Disabled
     fun `invoke return the correct version`() {
         val context = mock<MembershipRequestContext> {
             on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -35,12 +35,7 @@ import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
-import javax.persistence.TypedQuery
-import javax.persistence.criteria.CriteriaBuilder
-import javax.persistence.criteria.CriteriaQuery
-import javax.persistence.criteria.Order
-import javax.persistence.criteria.Path
-import javax.persistence.criteria.Root
+import javax.persistence.LockModeType
 
 class PersistGroupPolicyHandlerTest {
     private val context = byteArrayOf(1, 2, 3)
@@ -69,36 +64,9 @@ class PersistGroupPolicyHandlerTest {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn entitySet
     }
     private val transaction = mock<EntityTransaction>()
-    private val resultList: List<GroupPolicyEntity> = mock {
-        on { isEmpty() } doReturn true
-        on { size } doReturn 1
-        on { singleOrNull() } doReturn null
-    }
-    private val previousEntry: TypedQuery<GroupPolicyEntity> = mock {
-        on { resultList } doReturn resultList
-    }
-    private val groupPolicyQuery: TypedQuery<GroupPolicyEntity> = mock {
-        on { setMaxResults(1) } doReturn previousEntry
-        on { setLockMode(any()) } doReturn mock
-    }
-    private val root = mock<Root<GroupPolicyEntity>> {
-        on { get<String>("version") } doReturn mock<Path<String>>()
-    }
-    private val order = mock<Order>()
     private val persistCapture = argumentCaptor<GroupPolicyEntity>()
-    private val query = mock<CriteriaQuery<GroupPolicyEntity>> {
-        on { from(GroupPolicyEntity::class.java) } doReturn root
-        on { select(root) } doReturn mock
-        on { orderBy(order) } doReturn mock
-    }
-    private val criteriaBuilder = mock<CriteriaBuilder> {
-        on { createQuery(GroupPolicyEntity::class.java) } doReturn query
-        on { desc(any()) } doReturn order
-    }
     private val entityManager = mock<EntityManager> {
         on { persist(persistCapture.capture()) } doAnswer {}
-        on { criteriaBuilder } doReturn criteriaBuilder
-        on { createQuery(eq(query)) } doReturn groupPolicyQuery
         on { transaction } doReturn transaction
     }
     private val entityManagerFactory = mock<EntityManagerFactory> {
@@ -147,10 +115,7 @@ class PersistGroupPolicyHandlerTest {
 
     @Test
     fun `invoke persists a group policy with version 2 when version 1 already persisted`() {
-        val persistedMemberInfo = mock<GroupPolicyEntity> {
-            on { version } doReturn 1L
-        }
-        whenever(resultList.singleOrNull()).doReturn(persistedMemberInfo)
+        whenever(entityManager.find(eq(GroupPolicyEntity::class.java), eq(1L), any<LockModeType>())).thenReturn(mock())
         val requestContext = mock<MembershipRequestContext> {
             on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
         }
@@ -174,11 +139,10 @@ class PersistGroupPolicyHandlerTest {
 
     @Test
     fun `invoke does not persists a group policy with version 1 when version 1 already persisted`() {
-        val persistedMemberInfo = mock<GroupPolicyEntity> {
+        val mockEntity = mock<GroupPolicyEntity> {
             on { properties } doReturn context
-            on { version } doReturn 1L
         }
-        whenever(resultList.singleOrNull()).doReturn(persistedMemberInfo)
+        whenever(entityManager.find(eq(GroupPolicyEntity::class.java), eq(1L), any<LockModeType>())).doReturn(mockEntity)
         val requestContext = mock<MembershipRequestContext> {
             on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
         }
@@ -194,11 +158,10 @@ class PersistGroupPolicyHandlerTest {
 
     @Test
     fun `invoke throws when persisting a different group policy with version 1 when version 1 already persisted`() {
-        val persistedMemberInfo = mock<GroupPolicyEntity> {
+        val mockEntity = mock<GroupPolicyEntity> {
             on { properties } doReturn context
-            on { version } doReturn 1L
         }
-        whenever(resultList.singleOrNull()).doReturn(persistedMemberInfo)
+        whenever(entityManager.find(eq(GroupPolicyEntity::class.java), eq(1L), any<LockModeType>())).thenReturn(mockEntity)
         val requestContext = mock<MembershipRequestContext> {
             on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
         }
@@ -223,48 +186,6 @@ class PersistGroupPolicyHandlerTest {
         }
         val request = mock<PersistGroupPolicy> {
             on { version } doReturn 0L
-        }
-
-        assertThrows<MembershipPersistenceException> { handler.invoke(requestContext, request) }
-        verify(entityManager, never()).persist(any())
-    }
-
-    @Test
-    fun `invoke throws when trying to persist version 2 when nothing already persisted`() {
-        val requestContext = mock<MembershipRequestContext> {
-            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
-        }
-        val request = mock<PersistGroupPolicy> {
-            on { properties } doReturn KeyValuePairList(
-                listOf(
-                    KeyValuePair("1", "one"),
-                    KeyValuePair("2", "two"),
-                )
-            )
-            on { version } doReturn 2L
-        }
-
-        assertThrows<MembershipPersistenceException> { handler.invoke(requestContext, request) }
-        verify(entityManager, never()).persist(any())
-    }
-    @Test
-    fun `invoke throws when trying to persist version 2 when version 4 already persisted`() {
-        val persistedMemberInfo = mock<GroupPolicyEntity> {
-            on { properties } doReturn context
-            on { version } doReturn 4L
-        }
-        whenever(resultList.singleOrNull()).doReturn(persistedMemberInfo)
-        val requestContext = mock<MembershipRequestContext> {
-            on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")
-        }
-        val request = mock<PersistGroupPolicy> {
-            on { properties } doReturn KeyValuePairList(
-                listOf(
-                    KeyValuePair("1", "one"),
-                    KeyValuePair("2", "two"),
-                )
-            )
-            on { version } doReturn 2L
         }
 
         assertThrows<MembershipPersistenceException> { handler.invoke(requestContext, request) }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -8,7 +8,6 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.PersistGroupPolicy
-import net.corda.data.membership.db.response.command.PersistGroupPolicyResponse
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
 import net.corda.membership.datamodel.GroupPolicyEntity
@@ -18,7 +17,6 @@ import net.corda.test.util.time.TestClock
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -127,8 +125,6 @@ class PersistGroupPolicyHandlerTest {
             )
         }
 
-        val result = handler.invoke(context, request)
-
-        assertThat(result).isEqualTo(PersistGroupPolicyResponse(1002))
+        handler.invoke(context, request)
     }
 }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -2,6 +2,7 @@ package net.corda.membership.impl.persistence.service.handler
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.core.ShortHash
+import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
@@ -98,8 +99,10 @@ class PersistMemberInfoHandlerTest {
     private val keyValueSerializer: CordaAvroSerializer<KeyValuePairList> = mock {
         on { serialize(any()) } doReturn "123".toByteArray()
     }
+    private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValueSerializer
+        on { createAvroDeserializer<KeyValuePairList>(any(), any())} doReturn keyValuePairListDeserializer
     }
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
         on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -5,6 +5,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
+import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.db.request.MembershipRequestContext
@@ -14,10 +15,13 @@ import net.corda.db.schema.CordaDb
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.MemberInfoEntity
+import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
+import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.test.util.TestRandom
 import net.corda.test.util.time.TestClock
@@ -32,6 +36,7 @@ import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -39,14 +44,18 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
+import javax.persistence.LockModeType
 
 class PersistMemberInfoHandlerTest {
-
+    private companion object {
+        const val SERIAL_NUMBER = 1L
+    }
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = UUID.randomUUID().toString()
     private val ourHoldingIdentity = HoldingIdentity(
@@ -64,7 +73,7 @@ class PersistMemberInfoHandlerTest {
         on { groupId } doReturn ourGroupId
         on { name } doReturn ourX500Name
         on { status } doReturn MEMBER_STATUS_ACTIVE
-        on { serial } doReturn 1
+        on { serial } doReturn SERIAL_NUMBER
     }
     private val vaultDmlConnectionId = UUID(0, 1)
 
@@ -189,4 +198,122 @@ class PersistMemberInfoHandlerTest {
         }
     }
 
+    @Test
+    fun `invoke does not persist if version already persisted`() {
+        val memberInfo = getPersistentMemberInfo()
+        val requestContext = getMemberRequestContext()
+        val serializedMemberContext = "123".toByteArray()
+        val serializedMgmContext = "456".toByteArray()
+        whenever(keyValuePairListDeserializer.deserialize(serializedMemberContext)).doReturn(KeyValuePairList(emptyList()))
+        whenever(keyValuePairListDeserializer.deserialize(serializedMgmContext)).doReturn(KeyValuePairList(emptyList()))
+        val memberInfoEntity = mock<MemberInfoEntity> {
+            on { serialNumber } doReturn SERIAL_NUMBER
+            on { memberContext } doReturn serializedMemberContext
+            on { mgmContext } doReturn serializedMgmContext
+        }
+        whenever(entityManager.find(
+            eq(MemberInfoEntity::class.java),
+            eq(MemberInfoEntityPrimaryKey(requestContext.holdingIdentity.groupId, requestContext.holdingIdentity.x500Name.toString())),
+            any<LockModeType>())
+        ).doReturn (memberInfoEntity)
+
+        persistMemberInfoHandler.invoke(
+            requestContext,
+            PersistMemberInfo(listOf(memberInfo))
+        )
+
+        verify(entityManager, never()).merge(any<MemberInfoEntity>())
+    }
+
+    @Test
+    fun `invoke throws if already persisted member context differs`() {
+        val memberInfo = getPersistentMemberInfo()
+        val requestContext = getMemberRequestContext()
+        val serializedMemberContext = "123".toByteArray()
+        val serializedMgmContext = "456".toByteArray()
+        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMemberContext))).doReturn(
+            KeyValuePairList(mutableListOf(KeyValuePair("100", "b")))
+        )
+        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMgmContext))).doReturn(KeyValuePairList(emptyList()))
+        val memberInfoEntity = mock<MemberInfoEntity> {
+            on { serialNumber } doReturn SERIAL_NUMBER
+            on { memberContext } doReturn serializedMemberContext
+            on { mgmContext } doReturn serializedMgmContext
+        }
+        whenever(entityManager.find(
+            eq(MemberInfoEntity::class.java),
+            eq(MemberInfoEntityPrimaryKey(requestContext.holdingIdentity.groupId, requestContext.holdingIdentity.x500Name.toString())),
+            any<LockModeType>())
+        ).doReturn (memberInfoEntity)
+
+        assertThrows<MembershipPersistenceException> {
+            persistMemberInfoHandler.invoke(requestContext, PersistMemberInfo(listOf(memberInfo)))
+        }
+
+        verify(entityManager, never()).merge(any<MemberInfoEntity>())
+    }
+
+    @Test
+    fun `invoke throws if already persisted mgm context differs`() {
+        val memberInfo = getPersistentMemberInfo()
+        val requestContext = getMemberRequestContext()
+        val serializedMemberContext = "123".toByteArray()
+        val serializedMgmContext = "456".toByteArray()
+        whenever(keyValuePairListDeserializer.deserialize(serializedMemberContext)).doReturn(KeyValuePairList(emptyList()))
+        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMgmContext))).doReturn(
+            KeyValuePairList(mutableListOf(KeyValuePair("100", "b")))
+        )
+        val memberInfoEntity = mock<MemberInfoEntity> {
+            on { serialNumber } doReturn SERIAL_NUMBER
+            on { memberContext } doReturn serializedMemberContext
+            on { mgmContext } doReturn serializedMgmContext
+        }
+        whenever(entityManager.find(
+            eq(MemberInfoEntity::class.java),
+            eq(MemberInfoEntityPrimaryKey(requestContext.holdingIdentity.groupId, requestContext.holdingIdentity.x500Name.toString())),
+            any<LockModeType>())
+        ).doReturn (memberInfoEntity)
+
+        assertThrows<MembershipPersistenceException> {
+            persistMemberInfoHandler.invoke(requestContext, PersistMemberInfo(listOf(memberInfo)))
+        }
+
+        verify(entityManager, never()).merge(any<MemberInfoEntity>())
+    }
+
+    @Test
+    fun `invoke does not persist or throw if persisted mgm context differs only by time`() {
+        val memberInfo = PersistentMemberInfo(
+            ourHoldingIdentity.toAvro(),
+            KeyValuePairList(emptyList()),
+            KeyValuePairList(mutableListOf(
+                KeyValuePair(MemberInfoExtension.CREATION_TIME, "a"),
+                KeyValuePair(MemberInfoExtension.MODIFIED_TIME, "b")
+            ))
+        )
+        val requestContext = getMemberRequestContext()
+        val serializedMemberContext = "123".toByteArray()
+        val serializedMgmContext = "456".toByteArray()
+        whenever(keyValuePairListDeserializer.deserialize(serializedMemberContext)).doReturn(KeyValuePairList(emptyList()))
+        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMgmContext))).doReturn(
+            KeyValuePairList(mutableListOf(
+                KeyValuePair(MemberInfoExtension.CREATION_TIME, "c"),
+                KeyValuePair(MemberInfoExtension.MODIFIED_TIME, "d")
+            ))
+        )
+        val memberInfoEntity = mock<MemberInfoEntity> {
+            on { serialNumber } doReturn SERIAL_NUMBER
+            on { memberContext } doReturn serializedMemberContext
+            on { mgmContext } doReturn serializedMgmContext
+        }
+        whenever(entityManager.find(
+            eq(MemberInfoEntity::class.java),
+            eq(MemberInfoEntityPrimaryKey(requestContext.holdingIdentity.groupId, requestContext.holdingIdentity.x500Name.toString())),
+            any<LockModeType>())
+        ).doReturn (memberInfoEntity)
+
+        persistMemberInfoHandler.invoke(requestContext, PersistMemberInfo(listOf(memberInfo)))
+
+        verify(entityManager, never()).merge(any<MemberInfoEntity>())
+    }
 }

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessor.kt
@@ -129,7 +129,7 @@ class MemberOpsServiceProcessor(
 
             val persistedGroupPolicyProperties = membershipQueryClient
                 .queryGroupPolicy(holdingIdentity)
-                .getOrThrow()
+                .getOrThrow().first
 
             val registrationProtocol: String = persistedGroupPolicyProperties.parse(PropertyKeys.REGISTRATION_PROTOCOL)
             val syncProtocol: String = persistedGroupPolicyProperties.parse(PropertyKeys.SYNC_PROTOCOL)

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -125,7 +125,7 @@ class MemberOpsServiceProcessorTest {
 
     private val testPersistedGroupPolicyEntries: LayeredPropertyMap =
         LayeredPropertyMapMocks.create<LayeredContextImpl>(testProperties)
-    private val membershipQueryResult = MembershipQueryResult.Success(testPersistedGroupPolicyEntries)
+    private val membershipQueryResult = MembershipQueryResult.Success(testPersistedGroupPolicyEntries to 1L)
     private val membershipQueryClient: MembershipQueryClient = mock {
         on { queryGroupPolicy(eq(mgmHoldingIdentity)) } doReturn membershipQueryResult
     }
@@ -214,7 +214,7 @@ class MemberOpsServiceProcessorTest {
             LayeredPropertyMapMocks.create<LayeredContextImpl>(testPropertiesWithMutualTls)
         whenever(
             membershipQueryClient.queryGroupPolicy(eq(mgmHoldingIdentity))
-        ).doReturn(MembershipQueryResult.Success(testPersistedGroupPolicyEntries))
+        ).doReturn(MembershipQueryResult.Success(testPersistedGroupPolicyEntries to 1L))
         val requestTimestamp = now
         val requestContext = MembershipRpcRequestContext(
             UUID.randomUUID().toString(),

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipPersistenceClientImpl.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipPersistenceClientImpl.kt
@@ -31,6 +31,7 @@ class TestMembershipPersistenceClientImpl @Activate constructor() : MembershipPe
     override fun persistGroupPolicy(
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
+        version: Long
     ) = MembershipPersistenceResult.Success(1)
 
     override fun persistGroupParametersInitialSnapshot(

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipPersistenceClientImpl.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipPersistenceClientImpl.kt
@@ -32,7 +32,7 @@ class TestMembershipPersistenceClientImpl @Activate constructor() : MembershipPe
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
         version: Long
-    ) = MembershipPersistenceResult.Success(1)
+    ) = MembershipPersistenceResult.success()
 
     override fun persistGroupParametersInitialSnapshot(
         viewOwningIdentity: HoldingIdentity

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandler.kt
@@ -11,6 +11,9 @@ internal class MGMRegistrationGroupPolicyHandler(
     private val layeredPropertyMapFactory: LayeredPropertyMapFactory,
     private val membershipPersistenceClient: MembershipPersistenceClient,
 ) {
+    private companion object {
+        const val GROUP_POLICY_VERSION = 1L
+    }
 
     fun buildAndPersist(
         holdingIdentity: HoldingIdentity,
@@ -25,6 +28,7 @@ internal class MGMRegistrationGroupPolicyHandler(
         val groupPolicyPersistenceResult = membershipPersistenceClient.persistGroupPolicy(
             holdingIdentity,
             groupPolicy,
+            GROUP_POLICY_VERSION
         )
         if (groupPolicyPersistenceResult is MembershipPersistenceResult.Failure) {
             throw MGMRegistrationGroupPolicyHandlingException(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -29,6 +29,8 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.membership.MemberInfo

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -9,8 +9,6 @@ import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.ShortHashException
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePairList
-import net.corda.data.crypto.wire.CryptoSignatureWithKey
-import net.corda.data.membership.common.RegistrationStatus
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
@@ -29,8 +27,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoFactory
-import net.corda.membership.lib.registration.RegistrationRequest
-import net.corda.membership.lib.toWire
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.utilities.time.Clock
@@ -39,9 +35,7 @@ import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
-import java.nio.ByteBuffer
 import java.security.PublicKey
-import java.util.UUID
 
 @Suppress("LongParameterList")
 internal class MGMRegistrationMemberInfoHandler(
@@ -73,37 +67,6 @@ internal class MGMRegistrationMemberInfoHandler(
     ): MemberInfo {
         return buildMgmInfo(holdingIdentity, context).also {
             persistMemberInfo(holdingIdentity, it)
-        }
-    }
-
-    fun persistRegistrationRequest(
-        registrationId: UUID,
-        holdingIdentity: HoldingIdentity,
-        mgmInfo: MemberInfo
-    ) {
-        val serializedMemberContext = keyValuePairListSerializer.serialize(
-            mgmInfo.memberProvidedContext.toWire()
-        ) ?: throw MGMRegistrationMemberInfoHandlingException(
-            "Failed to serialize the member context for this request."
-        )
-        val registrationRequestPersistenceResult = membershipPersistenceClient.persistRegistrationRequest(
-            viewOwningIdentity = holdingIdentity,
-            registrationRequest = RegistrationRequest(
-                status = RegistrationStatus.APPROVED,
-                registrationId = registrationId.toString(),
-                requester = holdingIdentity,
-                memberContext = ByteBuffer.wrap(serializedMemberContext),
-                signature = CryptoSignatureWithKey(
-                    ByteBuffer.wrap(byteArrayOf()),
-                    ByteBuffer.wrap(byteArrayOf()),
-                    KeyValuePairList(emptyList())
-                )
-            )
-        )
-        if (registrationRequestPersistenceResult is MembershipPersistenceResult.Failure) {
-            throw MGMRegistrationMemberInfoHandlingException(
-                "Registration failed, persistence error. Reason: ${registrationRequestPersistenceResult.errorMsg}"
-            )
         }
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -29,8 +29,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
-import net.corda.membership.persistence.client.MembershipQueryClient
-import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.membership.MemberInfo

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
@@ -1,0 +1,72 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureWithKey
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.membership.lib.registration.RegistrationRequest
+import net.corda.membership.lib.toWire
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.registration.InvalidMembershipRegistrationException
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.util.UUID
+
+internal class MGMRegistrationRequestHandler (
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    private val membershipPersistenceClient: MembershipPersistenceClient,
+    private val membershipQueryClient: MembershipQueryClient,
+) {
+
+    private companion object {
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    private val keyValuePairListSerializer =
+        cordaAvroSerializationFactory.createAvroSerializer<KeyValuePairList> {
+            logger.error("Failed to serialize key value pair list.")
+        }
+
+    fun persistRegistrationRequest(
+        registrationId: UUID,
+        holdingIdentity: HoldingIdentity,
+        mgmInfo: MemberInfo
+    ) {
+        val serializedMemberContext = keyValuePairListSerializer.serialize(
+            mgmInfo.memberProvidedContext.toWire()
+        ) ?: throw InvalidMembershipRegistrationException(
+            "Failed to serialize the member context for this request."
+        )
+        val registrationRequestPersistenceResult = membershipPersistenceClient.persistRegistrationRequest(
+            viewOwningIdentity = holdingIdentity,
+            registrationRequest = RegistrationRequest(
+                status = RegistrationStatus.APPROVED,
+                registrationId = registrationId.toString(),
+                requester = holdingIdentity,
+                memberContext = ByteBuffer.wrap(serializedMemberContext),
+                signature = CryptoSignatureWithKey(
+                    ByteBuffer.wrap(byteArrayOf()),
+                    ByteBuffer.wrap(byteArrayOf()),
+                    KeyValuePairList(emptyList())
+                )
+            )
+        )
+        if (registrationRequestPersistenceResult is MembershipPersistenceResult.Failure) {
+            throw InvalidMembershipRegistrationException(
+                "Registration failed, persistence error. Reason: ${registrationRequestPersistenceResult.errorMsg}"
+            )
+        }
+    }
+
+    fun throwIfRegistrationAlreadyApproved(holdingIdentity: HoldingIdentity) {
+        val result = membershipQueryClient.queryRegistrationRequestsStatus(holdingIdentity).getOrThrow()
+        result.find { it.status == RegistrationStatus.APPROVED }?.let { approvedRegistration ->
+            throw InvalidMembershipRegistrationException("Registration failed, there is already an approved registration for" +
+                " ${holdingIdentity.shortHash} with id ${approvedRegistration.registrationId}.")
+        }
+    }
+}

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -183,11 +183,7 @@ class MGMRegistrationService @Activate constructor(
             try {
                 mgmRegistrationContextValidator.validate(context)
 
-                val mgmInfo = mgmRegistrationMemberInfoHandler.buildAndPersist(
-                    registrationId,
-                    member,
-                    context
-                )
+                val mgmInfo = mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(member, context)
 
                 mgmRegistrationGroupPolicyHandler.buildAndPersist(
                     member,
@@ -200,6 +196,7 @@ class MGMRegistrationService @Activate constructor(
                 if (groupParametersPersistenceResult is MembershipPersistenceResult.Failure) {
                     throw NotReadyMembershipRegistrationException(groupParametersPersistenceResult.errorMsg)
                 }
+                mgmRegistrationMemberInfoHandler.persistRegistrationRequest(registrationId, member, mgmInfo)
 
                 // Publish group parameters to Kafka
                 val groupParameters = groupParametersFactory.create(groupParametersPersistenceResult.getOrThrow())

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
@@ -37,7 +37,7 @@ class MGMRegistrationGroupPolicyHandlerTest {
     private val membershipPersistenceClient: MembershipPersistenceClient = mock {
         on {
             persistGroupPolicy(eq(testHoldingIdentity), eq(mockLayeredPropertyMap), any())
-        } doReturn MembershipPersistenceResult.Success(0)
+        } doReturn MembershipPersistenceResult.success()
 
         on {
             persistGroupParametersInitialSnapshot(eq(testHoldingIdentity))

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationGroupPolicyHandlerTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -35,7 +36,7 @@ class MGMRegistrationGroupPolicyHandlerTest {
     }
     private val membershipPersistenceClient: MembershipPersistenceClient = mock {
         on {
-            persistGroupPolicy(eq(testHoldingIdentity), eq(mockLayeredPropertyMap))
+            persistGroupPolicy(eq(testHoldingIdentity), eq(mockLayeredPropertyMap), any())
         } doReturn MembershipPersistenceResult.Success(0)
 
         on {
@@ -74,20 +75,21 @@ class MGMRegistrationGroupPolicyHandlerTest {
 
         verify(membershipPersistenceClient).persistGroupPolicy(
             eq(testHoldingIdentity),
-            eq(mockLayeredPropertyMap)
+            eq(mockLayeredPropertyMap),
+            eq(1)
         )
     }
 
     @Test
     fun `Failed group policy persistence is rethrown as group policy handling exception`() {
         whenever (
-            membershipPersistenceClient.persistGroupPolicy(any(), any())
+            membershipPersistenceClient.persistGroupPolicy(any(), any(), anyLong())
         ) doReturn MembershipPersistenceResult.Failure("")
 
         assertThrows<MGMRegistrationGroupPolicyHandlingException> {
             mgmRegistrationGroupPolicyHandler.buildAndPersist(testHoldingIdentity, testContext)
         }
-        verify(membershipPersistenceClient).persistGroupPolicy(any(), any())
+        verify(membershipPersistenceClient).persistGroupPolicy(any(), any(), eq(1))
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
@@ -214,8 +214,7 @@ class MGMRegistrationMemberInfoHandlerTest {
     @Test
     fun `MGM info is returned if all is processed successfully`() {
         val result = assertDoesNotThrow {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -225,18 +224,15 @@ class MGMRegistrationMemberInfoHandlerTest {
     }
 
     @Test
-    fun `Expected services are called`() {
+    fun `Expected services are called by buildAndPersistMgmMemberInfo`() {
         assertDoesNotThrow {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
         }
 
-        verify(membershipPersistenceClient).persistRegistrationRequest(any(), any())
         verify(membershipPersistenceClient).persistMemberInfo(any(), any())
-        verify(cordaAvroSerializer).serialize(any())
         verify(memberInfoFactory).create(any(), any<SortedMap<String, String?>>())
         verify(platformInfoProvider).activePlatformVersion
         verify(platformInfoProvider).localWorkerSoftwareVersion
@@ -247,10 +243,23 @@ class MGMRegistrationMemberInfoHandlerTest {
     }
 
     @Test
+    fun `Expected services are called by persistRegistrationRequest`() {
+        assertDoesNotThrow {
+            mgmRegistrationMemberInfoHandler.persistRegistrationRequest(
+                registrationId,
+                holdingIdentity,
+                memberInfo
+            )
+        }
+
+        verify(membershipPersistenceClient).persistRegistrationRequest(any(), any())
+        verify(cordaAvroSerializer).serialize(any())
+    }
+
+    @Test
     fun `Member context filters out group policy properties`() {
         assertDoesNotThrow {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -262,8 +271,7 @@ class MGMRegistrationMemberInfoHandlerTest {
     @Test
     fun `Member context is built as expected`() {
         assertDoesNotThrow {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -288,8 +296,7 @@ class MGMRegistrationMemberInfoHandlerTest {
     @Test
     fun `MGM context is built as expected`() {
         assertDoesNotThrow {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -309,8 +316,7 @@ class MGMRegistrationMemberInfoHandlerTest {
             )
         ).doReturn(null)
         assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -329,8 +335,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         ).doReturn(emptyList())
 
         assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -350,8 +355,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         ).doThrow(RuntimeException::class)
 
         assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -370,8 +374,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         ).doReturn(MembershipPersistenceResult.Failure(""))
 
         assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -391,10 +394,10 @@ class MGMRegistrationMemberInfoHandlerTest {
         ).doReturn(MembershipPersistenceResult.Failure(""))
 
         assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
+            mgmRegistrationMemberInfoHandler.persistRegistrationRequest(
                 registrationId,
                 holdingIdentity,
-                validTestContext
+                memberInfo
             )
         }
         verify(membershipPersistenceClient).persistRegistrationRequest(
@@ -412,10 +415,10 @@ class MGMRegistrationMemberInfoHandlerTest {
         ).doReturn(null)
 
         assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
+            mgmRegistrationMemberInfoHandler.persistRegistrationRequest(
                 registrationId,
                 holdingIdentity,
-                validTestContext
+                memberInfo
             )
         }
         verify(cordaAvroSerializer).serialize(any())
@@ -455,8 +458,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         whenever(keyEncodingService.decodePublicKey(encryptedPublicKey)).doReturn(ecdhPublicKey)
 
         assertThrows<MGMRegistrationContextValidationException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -491,8 +493,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         )
 
         assertThrows<MGMRegistrationContextValidationException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )
@@ -527,8 +528,7 @@ class MGMRegistrationMemberInfoHandlerTest {
         )
 
         assertThrows<MGMRegistrationContextValidationException> {
-            mgmRegistrationMemberInfoHandler.buildAndPersist(
-                registrationId,
+            mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(
                 holdingIdentity,
                 validTestContext
             )

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandlerTest.kt
@@ -73,7 +73,6 @@ class MGMRegistrationMemberInfoHandlerTest {
         const val GROUP_POLICY_PROPERTY_KEY = GROUP_POLICY_PREFIX_WITH_DOT + "test"
     }
 
-    private val registrationId = UUID(0, 1)
     private val cordaAvroSerializer: CordaAvroSerializer<KeyValuePairList> = mock {
         on { serialize(any()) } doReturn "".toByteArray()
     }
@@ -166,10 +165,6 @@ class MGMRegistrationMemberInfoHandlerTest {
         on {
             persistMemberInfo(eq(holdingIdentity), eq(listOf(memberInfo)))
         } doReturn MembershipPersistenceResult.success()
-
-        on {
-            persistRegistrationRequest(any(), any())
-        } doReturn MembershipPersistenceResult.success()
     }
 
     private val platformInfoProvider: PlatformInfoProvider = mock {
@@ -240,20 +235,6 @@ class MGMRegistrationMemberInfoHandlerTest {
         verify(keyEncodingService, times(2)).decodePublicKey(any<ByteArray>())
         verify(cryptoOpsClient, times(2)).lookupKeysByIds(any(), any())
         verify(virtualNodeInfoReadService).get(any())
-    }
-
-    @Test
-    fun `Expected services are called by persistRegistrationRequest`() {
-        assertDoesNotThrow {
-            mgmRegistrationMemberInfoHandler.persistRegistrationRequest(
-                registrationId,
-                holdingIdentity,
-                memberInfo
-            )
-        }
-
-        verify(membershipPersistenceClient).persistRegistrationRequest(any(), any())
-        verify(cordaAvroSerializer).serialize(any())
     }
 
     @Test
@@ -383,45 +364,6 @@ class MGMRegistrationMemberInfoHandlerTest {
             eq(holdingIdentity),
             eq(listOf(memberInfo))
         )
-    }
-
-    @Test
-    fun `expected exception thrown if registration request persistence fails`() {
-        whenever(
-            membershipPersistenceClient.persistRegistrationRequest(
-                eq(holdingIdentity), any()
-            )
-        ).doReturn(MembershipPersistenceResult.Failure(""))
-
-        assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.persistRegistrationRequest(
-                registrationId,
-                holdingIdentity,
-                memberInfo
-            )
-        }
-        verify(membershipPersistenceClient).persistRegistrationRequest(
-            eq(holdingIdentity),
-            any()
-        )
-    }
-
-    @Test
-    fun `expected exception thrown if serializing the registration request fails`() {
-        whenever(
-            cordaAvroSerializer.serialize(
-                any()
-            )
-        ).doReturn(null)
-
-        assertThrows<MGMRegistrationMemberInfoHandlingException> {
-            mgmRegistrationMemberInfoHandler.persistRegistrationRequest(
-                registrationId,
-                holdingIdentity,
-                memberInfo
-            )
-        }
-        verify(cordaAvroSerializer).serialize(any())
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -214,7 +214,7 @@ class MGMRegistrationServiceTest {
     private val statusUpdate = argumentCaptor<RegistrationRequest>()
     private val membershipPersistenceClient = mock<MembershipPersistenceClient> {
         on { persistMemberInfo(any(), any()) } doReturn MembershipPersistenceResult.Success(Unit)
-        on { persistGroupPolicy(any(), any()) } doReturn MembershipPersistenceResult.Success(2)
+        on { persistGroupPolicy(any(), any(), any()) } doReturn MembershipPersistenceResult.Success(2)
         on {
             persistRegistrationRequest(
                 eq(mgm),
@@ -408,6 +408,7 @@ class MGMRegistrationServiceTest {
                     .persistGroupPolicy(
                         eq(mgm),
                         groupProperties.capture(),
+                        eq(1)
                     )
             ).thenReturn(MembershipPersistenceResult.Success(3))
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -69,6 +69,8 @@ import net.corda.membership.lib.schema.validation.MembershipSchemaValidator
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.membership.registration.InvalidMembershipRegistrationException
 import net.corda.membership.registration.NotReadyMembershipRegistrationException
 import net.corda.messaging.api.publisher.Publisher
@@ -96,6 +98,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
@@ -212,6 +215,9 @@ class MGMRegistrationServiceTest {
     private val memberInfoFactory: MemberInfoFactory = MemberInfoFactoryImpl(layeredPropertyMapFactory)
     private val mockGroupParametersList: KeyValuePairList = mock()
     private val statusUpdate = argumentCaptor<RegistrationRequest>()
+    private val membershipQueryClient = mock<MembershipQueryClient> {
+        on { queryRegistrationRequestsStatus(any(), anyOrNull(), any()) } doReturn MembershipQueryResult.Success(emptyList())
+    }
     private val membershipPersistenceClient = mock<MembershipPersistenceClient> {
         on { persistMemberInfo(any(), any()) } doReturn MembershipPersistenceResult.Success(Unit)
         on { persistGroupPolicy(any(), any(), any()) } doReturn MembershipPersistenceResult.success()
@@ -251,6 +257,7 @@ class MGMRegistrationServiceTest {
         keyEncodingService,
         memberInfoFactory,
         membershipPersistenceClient,
+        membershipQueryClient,
         layeredPropertyMapFactory,
         cordaAvroSerializationFactory,
         membershipSchemaValidatorFactory,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -214,7 +214,7 @@ class MGMRegistrationServiceTest {
     private val statusUpdate = argumentCaptor<RegistrationRequest>()
     private val membershipPersistenceClient = mock<MembershipPersistenceClient> {
         on { persistMemberInfo(any(), any()) } doReturn MembershipPersistenceResult.Success(Unit)
-        on { persistGroupPolicy(any(), any(), any()) } doReturn MembershipPersistenceResult.Success(2)
+        on { persistGroupPolicy(any(), any(), any()) } doReturn MembershipPersistenceResult.success()
         on {
             persistRegistrationRequest(
                 eq(mgm),
@@ -410,7 +410,7 @@ class MGMRegistrationServiceTest {
                         groupProperties.capture(),
                         eq(1)
                     )
-            ).thenReturn(MembershipPersistenceResult.Success(3))
+            ).thenReturn(MembershipPersistenceResult.success())
 
             registrationService.register(registrationRequest, mgm, properties)
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MgmRegistrationRequestHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MgmRegistrationRequestHandlerTest.kt
@@ -1,0 +1,136 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.CordaAvroSerializer
+import net.corda.data.KeyValuePairList
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.membership.lib.registration.RegistrationRequestStatus
+import net.corda.membership.persistence.client.MembershipPersistenceClient
+import net.corda.membership.persistence.client.MembershipPersistenceResult
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.persistence.client.MembershipQueryResult
+import net.corda.membership.registration.InvalidMembershipRegistrationException
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.MemberContext
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class MgmRegistrationRequestHandlerTest {
+
+    private val registrationId = UUID(0, 1)
+    private val holdingIdentity = HoldingIdentity(
+        MemberX500Name.parse("O=Alice, L=London, C=GB"),
+        UUID(0, 1).toString()
+    )
+    private val mockMemberContext: MemberContext = mock()
+    private val memberInfo: MemberInfo = mock {
+        on { memberProvidedContext } doReturn mockMemberContext
+    }
+    private val cordaAvroSerializer: CordaAvroSerializer<KeyValuePairList> = mock {
+        on { serialize(any()) } doReturn "".toByteArray()
+    }
+    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock {
+        on { createAvroSerializer<KeyValuePairList>(any()) } doReturn cordaAvroSerializer
+    }
+    private val membershipPersistenceClient: MembershipPersistenceClient = mock {
+        on {
+            persistRegistrationRequest(any(), any())
+        } doReturn MembershipPersistenceResult.success()
+    }
+    private val membershipQueryClient = mock<MembershipQueryClient> {
+
+    }
+    private val mgmRegistrationRequestHandler = MGMRegistrationRequestHandler(
+        cordaAvroSerializationFactory,
+        membershipPersistenceClient,
+        membershipQueryClient
+    )
+
+    @Test
+    fun `Expected services are called by persistRegistrationRequest`() {
+        assertDoesNotThrow {
+            mgmRegistrationRequestHandler.persistRegistrationRequest(
+                registrationId,
+                holdingIdentity,
+                memberInfo
+            )
+        }
+
+        verify(membershipPersistenceClient).persistRegistrationRequest(any(), any())
+        verify(cordaAvroSerializer).serialize(any())
+    }
+
+    @Test
+    fun `expected services is called by throwIfRegistrationAlreadyApproved`() {
+        whenever(membershipQueryClient.queryRegistrationRequestsStatus(holdingIdentity)).doReturn(
+            MembershipQueryResult.Success(emptyList())
+        )
+        mgmRegistrationRequestHandler.throwIfRegistrationAlreadyApproved(holdingIdentity)
+        verify(membershipQueryClient).queryRegistrationRequestsStatus(
+            eq(holdingIdentity), anyOrNull(), any()
+        )
+    }
+
+    @Test
+    fun `expected exception thrown if registration request persistence fails`() {
+        whenever(
+            membershipPersistenceClient.persistRegistrationRequest(
+                eq(holdingIdentity), any()
+            )
+        ).doReturn(MembershipPersistenceResult.Failure(""))
+
+        assertThrows<InvalidMembershipRegistrationException> {
+            mgmRegistrationRequestHandler.persistRegistrationRequest(
+                registrationId,
+                holdingIdentity,
+                memberInfo
+            )
+        }
+        verify(membershipPersistenceClient).persistRegistrationRequest(
+            eq(holdingIdentity),
+            any()
+        )
+    }
+
+    @Test
+    fun `expected exception thrown if serializing the registration request fails`() {
+        whenever(
+            cordaAvroSerializer.serialize(
+                any()
+            )
+        ).doReturn(null)
+
+        assertThrows<InvalidMembershipRegistrationException> {
+            mgmRegistrationRequestHandler.persistRegistrationRequest(
+                registrationId,
+                holdingIdentity,
+                memberInfo
+            )
+        }
+        verify(cordaAvroSerializer).serialize(any())
+    }
+
+    @Test
+    fun `expected exception thrown if registration already approved for holding id`() {
+        val persistedRegistrationRequest = mock<RegistrationRequestStatus> {
+            on {status} doReturn RegistrationStatus.APPROVED
+        }
+        whenever(membershipQueryClient.queryRegistrationRequestsStatus(holdingIdentity)).doReturn(
+            MembershipQueryResult.Success(listOf(persistedRegistrationRequest))
+        )
+        assertThrows<InvalidMembershipRegistrationException> {
+            mgmRegistrationRequestHandler.throwIfRegistrationAlreadyApproved(holdingIdentity)
+        }
+    }
+}

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
@@ -66,7 +66,8 @@ class TestMembershipPersistenceClientImpl @Activate constructor(
 
     override fun persistGroupPolicy(
         viewOwningIdentity: HoldingIdentity,
-        groupPolicy: LayeredPropertyMap
+        groupPolicy: LayeredPropertyMap,
+        version: Long
     ): MembershipPersistenceResult<Int> {
         with(UNIMPLEMENTED_FUNCTION) {
             logger.warn(this)

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
@@ -68,7 +68,7 @@ class TestMembershipPersistenceClientImpl @Activate constructor(
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
         version: Long
-    ): MembershipPersistenceResult<Int> {
+    ): MembershipPersistenceResult<Unit> {
         with(UNIMPLEMENTED_FUNCTION) {
             logger.warn(this)
             throw UnsupportedOperationException(this)

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
@@ -106,7 +106,7 @@ class TestMembershipQueryClientImpl @Activate constructor(
         )
     }
 
-    override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<LayeredPropertyMap> {
+    override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Pair<LayeredPropertyMap, Long>> {
         with(UNIMPLEMENTED_FUNCTION) {
             logger.warn(this)
             throw UnsupportedOperationException(this)

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.663-Gecko-beta+
+cordaApiVersion=5.0.0.663-alpha-1677769862520
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26
@@ -112,7 +112,7 @@ unirestVersion = 3.14.1
 jettyVersion = 9.4.49.v20220914
 # Enables the substitution of binaries for source code if it exists in expected location
 # Default behaviour is false.
-compositeBuild=false
+compositeBuild=true
 cordaApiLocation=../corda-api
 cordaCliHostLocation=../corda-cli-plugin-host
 jibCoreVersion=0.22.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.663-alpha-1677769862520
+cordaApiVersion=5.0.0.664-Gecko-alpha-1678266428511
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -112,7 +112,7 @@ unirestVersion = 3.14.1
 jettyVersion = 9.4.49.v20220914
 # Enables the substitution of binaries for source code if it exists in expected location
 # Default behaviour is false.
-compositeBuild=true
+compositeBuild=false
 cordaApiLocation=../corda-api
 cordaCliHostLocation=../corda-cli-plugin-host
 jibCoreVersion=0.22.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.664-Gecko-alpha-1678266428511
+cordaApiVersion=5.0.0.664-Gecko-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupPolicyEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupPolicyEntity.kt
@@ -20,9 +20,8 @@ import javax.persistence.Table
 @Suppress("LongParameterList")
 class GroupPolicyEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "version", nullable = false, updatable = false)
-    var version: Int? = null,
+    var version: Long,
 
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: Instant,
@@ -35,10 +34,10 @@ class GroupPolicyEntity(
         if (other === this) return true
         if (other == null) return false
         if (other !is GroupPolicyEntity) return false
-        return other.createdAt == this.createdAt && Arrays.equals(other.properties, this.properties)
+        return other.version == this.version
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(createdAt, ByteBuffer.wrap(properties))
+        return Objects.hash(version)
     }
 }

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupPolicyEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupPolicyEntity.kt
@@ -1,14 +1,10 @@
 package net.corda.membership.datamodel
 
 import net.corda.db.schema.DbSchema
-import java.nio.ByteBuffer
 import java.time.Instant
-import java.util.Arrays
 import java.util.Objects
 import javax.persistence.Column
 import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
@@ -43,6 +43,7 @@ internal class TestMembershipPersistenceClientImpl @Activate constructor(
     override fun persistGroupPolicy(
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
+        version: Long
     ) = MembershipPersistenceResult.Success(1)
 
     override fun persistGroupParametersInitialSnapshot(viewOwningIdentity: HoldingIdentity) =
@@ -164,7 +165,7 @@ internal class TestMembershipPersistenceClientImpl @Activate constructor(
         holdingsIdentities: Collection<HoldingIdentity>,
     ): MembershipQueryResult<Map<HoldingIdentity, CryptoSignatureWithKey>> = MembershipQueryResult.Success(emptyMap())
 
-    override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<LayeredPropertyMap> =
+    override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Pair<LayeredPropertyMap, Long>> =
         MembershipQueryResult.Failure("Unsupported")
 
     override fun mutualTlsListAllowedCertificates(mgmHoldingIdentity: HoldingIdentity): MembershipQueryResult<Collection<String>> = MembershipQueryResult.Success(

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
@@ -44,7 +44,7 @@ internal class TestMembershipPersistenceClientImpl @Activate constructor(
         viewOwningIdentity: HoldingIdentity,
         groupPolicy: LayeredPropertyMap,
         version: Long
-    ) = MembershipPersistenceResult.Success(1)
+    ) = MembershipPersistenceResult.success()
 
     override fun persistGroupParametersInitialSnapshot(viewOwningIdentity: HoldingIdentity) =
         MembershipPersistenceResult.Success(KeyValuePairList())


### PR DESCRIPTION
Make subsequent MGM Registration's fail. When registering the MGM check if there is already a registered MGM for a given holding identity and fail if it has status `approved`. Prevent concurrent registrations for the same holding identity by keying the registrations request topic by holding id short hash.

To help with robustness. I have also made the database operations: `PersistGroupPolicy` and `PersistMemberInfoHandler` idempotent (`PersistGroupParametersInitialSnapshot` was made idempotent as apart of CORE-10347). I have also MGM Registration so that we persist the registration request with status approved as the last database operation. Previously we were doing that at the beginning, this means that MGMRegistration will now be retried, if database operations fail (see CORE-9972).

Examples
---
Registration status endpoint after registering an MGM twice:
```
curl --fail-with-body -s -S --insecure -u admin:admin -X GET  https://localhost:8888/api/v1/membership/A1BA22CF875E/7a52b4fd-3593-4f2a-917c-430db3a0bd75
{"registrationId":"7a52b4fd-3593-4f2a-917c-430db3a0bd75","registrationSent":"2023-03-07T12:16:48.063Z","registrationUpdated":"2023-03-07T12:16:50.668Z","registrationStatus":"INVALID","memberInfoSubmitted":{"data":{"registrationProtocolVersion":"1","corda.session.key.id":"4B31A4AC802E","corda.ecdh.key.id":"6EBA7116B94D","corda.group.protocol.registration":"net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService","corda.group.protocol.synchronisation":"net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl","corda.group.protocol.p2p.mode":"Authenticated_Encryption","corda.group.key.session.policy":"Combined","corda.group.pki.session":"NoPKI","corda.group.pki.tls":"Standard","corda.group.tls.version":"1.3","corda.group.tls.type":"OneWay","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.williamvigor-mgm:8080","corda.endpoints.0.protocolVersion":"1","corda.group.truststore.tls.0":"-----BEGIN CERTIFICATE-----\nMIIBSzCB8aADAgECAgECMAoGCCqGSM49BAMCMB4xCzAJBgNVBAYTAlVLMQ8wDQYD\nVQQDDAZyMy5jb20wHhcNMjMwMTEzMTYyNzU0WhcNMjMwMjEyMTYyNzU0WjAeMQsw\nCQYDVQQGEwJVSzEPMA0GA1UEAwwGcjMuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAEXUeAx/hgsvduAG3I6mNJ3a21gngAqNEgEpx/t8x+U32Ja4mfjaYDlEDt\ngxu8m2qLTDB1p31/XwLJsZXxRLTrNqMgMB4wDwYDVR0TAQH/BAUwAwEB/zALBgNV\nHQ8EBAMCAa4wCgYIKoZIzj0EAwIDSQAwRgIhAMaucrweYGt9GeIpmDz3TztcZswe\nQ16vXJ+vyaCgFDVoAiEAlNAhrytnZiCHfyJ76X+h5bEokvPcxsODFJpM765+Vd8=\n-----END CERTIFICATE-----\n","corda.group.truststore.session.0":"-----BEGIN CERTIFICATE-----\nMIIBSzCB8aADAgECAgECMAoGCCqGSM49BAMCMB4xCzAJBgNVBAYTAlVLMQ8wDQYD\nVQQDDAZyMy5jb20wHhcNMjMwMTEzMTYyNzU0WhcNMjMwMjEyMTYyNzU0WjAeMQsw\nCQYDVQQGEwJVSzEPMA0GA1UEAwwGcjMuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAEXUeAx/hgsvduAG3I6mNJ3a21gngAqNEgEpx/t8x+U32Ja4mfjaYDlEDt\ngxu8m2qLTDB1p31/XwLJsZXxRLTrNqMgMB4wDwYDVR0TAQH/BAUwAwEB/zALBgNV\nHQ8EBAMCAa4wCgYIKoZIzj0EAwIDSQAwRgIhAMaucrweYGt9GeIpmDz3TztcZswe\nQ16vXJ+vyaCgFDVoAiEAlNAhrytnZiCHfyJ76X+h5bEokvPcxsODFJpM765+Vd8=\n-----END CERTIFICATE-----\n"}},"reason":"Registration failed, there is already an approved registration for A1BA22CF875E with id 967022b7-b550-48ec-ac60-1f98d7afa334."}%
```

Merge https://github.com/corda/corda-api/pull/904 first.