### PR TITLE
CORE-11094 reduce logging levels and reduce unnecessary logging output

### DIFF
--- a/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
@@ -10,30 +10,6 @@
             <AppenderRef ref="Console" level="info"/>
         </logger>
 
-        <logger name="net.corda.ledger.utxo.flow.impl" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.ledger.utxo.flow.impl.flows.finality" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-        </logger>
-
-        <logger name="com.r3.corda.notary.plugin.nonvalidating" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.flow.pipeline" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.session.manager" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.flow.mapper.impl.executor" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-        </logger>
-
         <!-- log warn only for these 3rd party libs -->
         <Logger name="org.apache.aries.spifly" level="warn" />
         <Logger name="org.apache.kafka" level="warn" />

--- a/osgi-framework-bootstrap/src/main/resources/log4j2.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2.xml
@@ -33,36 +33,6 @@
             <AppenderRef ref="Console" level="info"/>
         </logger>
 
-        <logger name="net.corda.ledger.utxo.flow.impl" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-            <AppenderRef ref="App" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.ledger.utxo.flow.impl.flows.finality" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-            <AppenderRef ref="App" level="trace"/>
-        </logger>
-
-        <logger name="com.r3.corda.notary.plugin.nonvalidating" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-            <AppenderRef ref="App" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.flow.pipeline" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-            <AppenderRef ref="App" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.session.manager" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-            <AppenderRef ref="App" level="trace"/>
-        </logger>
-
-        <logger name="net.corda.flow.mapper.impl.executor" level="trace" additivity="false">
-            <AppenderRef ref="Console" level="trace"/>
-            <AppenderRef ref="App" level="trace"/>
-        </logger>
-
         <!-- log warn only for these 3rd party libs -->
         <Logger name="com.zaxxer.hikari" level="warn" />
         <Logger name="io.javalin.Javalin" level="warn" />

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/SendReceiveAllMessagingFlow.kt
@@ -137,7 +137,8 @@ class SendReceiveAllInitiatedFlow : ResponderFlow {
 
 
         val received3 = session.receive(MyClass::class.java)
-        log.info("Receive from send from peer: $received3")
+        //this string is so large it activates chunking so do not log it
+        log.info("Receive from send from peer. Message size: ${received3.string.length}")
         session.send(received3.copy(string = "this is a new object 3"))
         log.info("Closing session")
 


### PR DESCRIPTION
Logging levels were increased to TRACE to help identify problems in flakey tests.
also do not log the string which is multiple megabytes in size in the chunking test at info level.