### PR TITLE
CORE-10698 - Add more validations for notary service names

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
@@ -48,7 +48,8 @@ internal sealed class MemberRole {
         }
 
         private fun readNotary(context: Map<String, String>): Notary {
-            val serviceName = context[NOTARY_SERVICE_NAME] ?: throw IllegalArgumentException("Notary must have a service name")
+            val serviceName = context[NOTARY_SERVICE_NAME]
+            if(serviceName.isNullOrEmpty()) throw IllegalArgumentException("Notary must have a non-empty service name.")
             val plugin = context[NOTARY_SERVICE_PLUGIN]
             return Notary(
                 serviceName = MemberX500Name.parse(serviceName),

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -232,9 +232,10 @@ internal class StartRegistrationHandler(
                     " name cannot be the same." }
             // The notary service x500 name is different from any existing virtual node x500 name (notary or otherwise).
             validateRegistrationRequest(
-                membershipQueryClient.queryMemberInfo(mgmHoldingId).getOrThrow().firstOrNull {
-                    it.name == notary.serviceName
-                } == null
+                membershipQueryClient.queryMemberInfo(
+                    mgmHoldingId,
+                    listOf(HoldingIdentity(notary.serviceName, member.groupId))
+                ).getOrThrow().firstOrNull() == null
             ) { "There is a virtual node having the same name as the notary service ${notary.serviceName}." }
         }
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -107,7 +107,8 @@ internal class StartRegistrationHandler(
                 existingMemberInfo is MembershipQueryResult.Success
                         && (existingMemberInfo.payload.isEmpty()
                         || !existingMemberInfo.payload.sortedBy { it.modifiedTime }.last().isActive)
-            ) { "The latest member info for given member is in 'Active' status" }
+            ) { "The latest member info for given member is in 'Active' status or " +
+                    "there is a member with the same name." }
 
             // The group ID matches the group ID of the MGM
             validateRegistrationRequest(
@@ -120,7 +121,7 @@ internal class StartRegistrationHandler(
             ) { "Registering member has not specified any endpoints" }
 
             // Validate role-specific information if any role is set
-            validateRoleInformation(pendingMemberInfo)
+            validateRoleInformation(mgmHoldingId, pendingMemberInfo)
 
             // Persist pending member info
             membershipPersistenceClient.persistMemberInfo(mgmHoldingId, listOf(pendingMemberInfo)).also {
@@ -213,7 +214,7 @@ internal class StartRegistrationHandler(
         )
     }
 
-    private fun validateRoleInformation(member: MemberInfo) {
+    private fun validateRoleInformation(mgmHoldingId: HoldingIdentity, member: MemberInfo) {
         // If role is set to notary, notary details are specified
         member.notaryDetails?.let { notary ->
             validateRegistrationRequest(
@@ -224,6 +225,17 @@ internal class StartRegistrationHandler(
                     it.isNotBlank()
                 ) { "Registering member has specified an invalid notary service plugin type." }
             }
+            // The notary service x500 name is different from the notary virtual node being registered.
+            validateRegistrationRequest(
+                member.name != notary.serviceName
+            ) { "The virtual node `${member.name}` and the notary service `${notary.serviceName}`" +
+                    " name cannot be the same." }
+            // The notary service x500 name is different from any existing virtual node x500 name (notary or otherwise).
+            validateRegistrationRequest(
+                membershipQueryClient.queryMemberInfo(mgmHoldingId).getOrThrow().firstOrNull {
+                    it.name == notary.serviceName
+                } == null
+            ) { "There is a virtual node having the same name as the notary service ${notary.serviceName}." }
         }
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -289,9 +289,6 @@ class StaticMemberRegistrationService @Activate constructor(
         notaryInfo: Collection<Pair<String, String>>
     ) {
         val serviceName = notaryInfo.firstOrNull { it.first == MemberInfoExtension.NOTARY_SERVICE_NAME }?.second
-        require(serviceName.isNullOrEmpty()) {
-            "Notary service name invalid: Notary service name cannot be null or empty."
-        }
         //The notary service x500 name is different from the notary virtual node being registered.
         require(registeringMember.name != serviceName) {
             "Notary service name invalid: Notary service name $serviceName and virtual node name cannot be the same."

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -28,6 +28,7 @@ import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplate
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.ENDPOINT_URL
 import net.corda.membership.lib.EndpointInfoFactory
 import net.corda.membership.lib.GroupParametersFactory
+import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_KEY
@@ -282,6 +283,25 @@ class StaticMemberRegistrationService @Activate constructor(
         ).getOrThrow()
     }
 
+    private fun validateNotaryDetails(
+        registeringMember: StaticMember,
+        staticMemberList: List<StaticMember>,
+        notaryInfo: Collection<Pair<String, String>>
+    ) {
+        val serviceName = notaryInfo.firstOrNull { it.first == MemberInfoExtension.NOTARY_SERVICE_NAME }?.second
+        require(serviceName.isNullOrEmpty()) {
+            "Notary service name invalid: Notary service name cannot be null or empty."
+        }
+        //The notary service x500 name is different from the notary virtual node being registered.
+        require(registeringMember.name != serviceName) {
+            "Notary service name invalid: Notary service name $serviceName and virtual node name cannot be the same."
+        }
+        //The notary service x500 name is different from any existing virtual node x500 name (notary or otherwise).
+        require(staticMemberList.none { it.name == serviceName }) {
+            "Notary service name invalid: There is a virtual node having the same name $serviceName."
+        }
+    }
+
     /**
      * Parses the static member list template, creates the MemberInfo for the registering member and the records for the
      * kafka publisher.
@@ -299,9 +319,12 @@ class StaticMemberRegistrationService @Activate constructor(
         val memberName = registeringMember.x500Name
         val memberId = registeringMember.shortHash.value
 
-        val staticMemberInfo = staticMemberList.firstOrNull {
+        val staticMemberInfo = staticMemberList.singleOrNull {
             MemberX500Name.parse(it.name!!) == memberName
-        } ?: throw IllegalArgumentException("Our membership $memberName is not listed in the static member list.")
+        } ?: throw IllegalArgumentException(
+            "Our membership $memberName is either not listed in the static member list or there is another member " +
+                    "with the same name."
+        )
 
         validateStaticMemberDeclaration(staticMemberInfo)
         // single key scheme used for both session and ledger key
@@ -311,6 +334,19 @@ class StaticMemberRegistrationService @Activate constructor(
             keyScheme,
             memberId,
         )
+
+        fun configureNotaryKey(): List<KeyDetails> {
+            hsmRegistrationClient.assignSoftHSM(memberId, NOTARY)
+            return listOf(keysFactory.getOrGenerateKeyPair(NOTARY))
+        }
+
+        val notaryInfo = roles.toMemberInfo(::configureNotaryKey)
+        // validate if provided notary details are correct to fail-fast,
+        // before assigning more HSMs, generating other keys for member
+        if(notaryInfo.isNotEmpty()) {
+            validateNotaryDetails(staticMemberInfo, staticMemberList, notaryInfo)
+        }
+
         hsmRegistrationClient.assignSoftHSM(memberId, LEDGER)
         val ledgerKey = keysFactory.getOrGenerateKeyPair(LEDGER)
 
@@ -329,11 +365,6 @@ class StaticMemberRegistrationService @Activate constructor(
 
         val optionalContext = mapOf(MEMBER_CPI_SIGNER_HASH to cpi.signerSummaryHash.toString())
 
-        fun configureNotaryKey(): List<KeyDetails> {
-            hsmRegistrationClient.assignSoftHSM(memberId, NOTARY)
-            return listOf(keysFactory.getOrGenerateKeyPair(NOTARY))
-        }
-
         @Suppress("SpreadOperator")
         val memberContext = mapOf(
             PARTY_NAME to memberName.toString(),
@@ -343,7 +374,7 @@ class StaticMemberRegistrationService @Activate constructor(
             LEDGER_KEYS_KEY.format(0) to ledgerKey.pem,
             LEDGER_KEY_HASHES_KEY.format(0) to ledgerKey.hash.toString(),
             *convertEndpoints(staticMemberInfo).toTypedArray(),
-            *roles.toMemberInfo(::configureNotaryKey).toTypedArray(),
+            *notaryInfo.toTypedArray(),
             SOFTWARE_VERSION to platformInfoProvider.localWorkerSoftwareVersion,
             PLATFORM_VERSION to platformInfoProvider.activePlatformVersion.toString(),
             MEMBER_CPI_NAME to cpi.name,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -62,9 +62,11 @@ class StartRegistrationHandlerTest {
     private companion object {
         val clock = TestClock(Instant.ofEpochSecond(0))
         val registrationId = UUID(0, 1).toString()
-        val x500Name = MemberX500Name.parse("O=Tester,L=London,C=GB")
+        val aliceX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
+        val bobX500Name = MemberX500Name.parse("O=Bob,L=London,C=GB")
         val groupId = UUID(0, 1).toString()
-        val holdingIdentity = HoldingIdentity(x500Name.toString(), groupId)
+        val aliceHoldingIdentity = HoldingIdentity(aliceX500Name.toString(), groupId)
+        val bobHoldingIdentity = HoldingIdentity(bobX500Name.toString(), groupId)
 
         val mgmX500Name = MemberX500Name.parse("O=TestMGM,L=London,C=GB")
         val mgmHoldingIdentity = HoldingIdentity(mgmX500Name.toString(), groupId)
@@ -80,7 +82,7 @@ class StartRegistrationHandlerTest {
             )
         )
 
-        val startRegistrationCommand = getStartRegistrationCommand(holdingIdentity, memberContext)
+        val startRegistrationCommand = getStartRegistrationCommand(aliceHoldingIdentity, memberContext)
 
         fun getStartRegistrationCommand(holdingIdentity: HoldingIdentity, memberContext: KeyValuePairList) =
             RegistrationCommand(
@@ -118,7 +120,7 @@ class StartRegistrationHandlerTest {
         on { entries } doReturn emptySet()
     }
     private val memberInfo: MemberInfo = mock {
-        on { name } doReturn x500Name
+        on { name } doReturn aliceX500Name
         on { isActive } doReturn true
         on { memberProvidedContext } doReturn memberMemberContext
         on { mgmProvidedContext } doReturn memberMgmContext
@@ -184,7 +186,7 @@ class StartRegistrationHandlerTest {
         with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(2)
 
             assertRegistrationStarted()
@@ -212,7 +214,7 @@ class StartRegistrationHandlerTest {
         with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
@@ -230,7 +232,7 @@ class StartRegistrationHandlerTest {
         with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
@@ -242,12 +244,12 @@ class StartRegistrationHandlerTest {
 
     @Test
     fun `declined if target member is an mgm`() {
-        whenever(memberTypeChecker.isMgm(holdingIdentity.toCorda())).doReturn(true)
+        whenever(memberTypeChecker.isMgm(aliceHoldingIdentity.toCorda())).doReturn(true)
 
         with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
@@ -261,7 +263,7 @@ class StartRegistrationHandlerTest {
                 null,
                 Record(
                     testTopic, testTopicKey, getStartRegistrationCommand(
-                        holdingIdentity,
+                        aliceHoldingIdentity,
                         KeyValuePairList(
                             emptyList()
                         )
@@ -271,7 +273,7 @@ class StartRegistrationHandlerTest {
         ) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
@@ -320,7 +322,7 @@ class StartRegistrationHandlerTest {
         ) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
@@ -341,7 +343,7 @@ class StartRegistrationHandlerTest {
         ) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(2)
 
             assertRegistrationStarted()
@@ -354,7 +356,7 @@ class StartRegistrationHandlerTest {
         with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
@@ -374,7 +376,7 @@ class StartRegistrationHandlerTest {
         with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
-            assertThat(updatedState!!.registeringMember).isEqualTo(holdingIdentity)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
             assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
@@ -390,11 +392,13 @@ class StartRegistrationHandlerTest {
     @Test
     fun `invoke returns follow on records when role is set to notary`() {
         val notaryDetails = MemberNotaryDetails(
-            x500Name,
+            MemberX500Name.parse("O=NotaryService,L=London,C=GB"),
             "Notary Plugin A",
             listOf(mock())
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+        whenever(membershipQueryClient.queryMemberInfo(mgmHoldingIdentity.toCorda()))
+            .thenReturn(MembershipQueryResult.Success(listOf(memberInfo)))
 
         val result = handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))
 
@@ -404,7 +408,7 @@ class StartRegistrationHandlerTest {
     @Test
     fun `declined if role is set to notary but notary keys are missing`() {
         val notaryDetails = MemberNotaryDetails(
-            x500Name,
+            aliceX500Name,
             null,
             emptyList()
         )
@@ -418,7 +422,7 @@ class StartRegistrationHandlerTest {
     @Test
     fun `declined if role is set to notary and notary service plugin type is specified but blank`() {
         val notaryDetails = MemberNotaryDetails(
-            x500Name,
+            aliceX500Name,
             " ",
             listOf(mock())
         )
@@ -426,6 +430,42 @@ class StartRegistrationHandlerTest {
 
         val result = handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))
 
+        result.assertDeclinedRegistration()
+    }
+
+    @Test
+    fun `declined if notary service name is the same as the virtual node name`() {
+        val notaryDetails = MemberNotaryDetails(
+            aliceX500Name,
+            "pluginType",
+            listOf(mock())
+        )
+        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+
+        val result = handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))
+        result.assertDeclinedRegistration()
+    }
+
+    @Test
+    fun `declined if notary service name is the same as an existing member's virtual node name`() {
+        val notaryDetails = MemberNotaryDetails(
+            aliceX500Name,
+            "pluginType",
+            listOf(mock())
+        )
+        val bobInfo: MemberInfo = mock {
+            on { name } doReturn bobX500Name
+            on { isActive } doReturn true
+            on { memberProvidedContext } doReturn memberMemberContext
+            on { mgmProvidedContext } doReturn memberMgmContext
+        }
+        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+        whenever(memberInfoFactory.create(any<SortedMap<String, String?>>(), any())).thenReturn(bobInfo)
+        whenever(membershipQueryClient.queryMemberInfo(mgmHoldingIdentity.toCorda()))
+            .thenReturn(MembershipQueryResult.Success(listOf(memberInfo)))
+
+        val registrationCommand = getStartRegistrationCommand(bobHoldingIdentity, memberContext)
+        val result = handler.invoke(null, Record(testTopic, testTopicKey, registrationCommand))
         result.assertDeclinedRegistration()
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -391,14 +391,19 @@ class StartRegistrationHandlerTest {
 
     @Test
     fun `invoke returns follow on records when role is set to notary`() {
+        val notaryServiceName = MemberX500Name.parse("O=NotaryService,L=London,C=GB")
         val notaryDetails = MemberNotaryDetails(
-            MemberX500Name.parse("O=NotaryService,L=London,C=GB"),
+            notaryServiceName,
             "Notary Plugin A",
             listOf(mock())
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
-        whenever(membershipQueryClient.queryMemberInfo(mgmHoldingIdentity.toCorda()))
-            .thenReturn(MembershipQueryResult.Success(listOf(memberInfo)))
+        whenever(
+            membershipQueryClient.queryMemberInfo(
+                mgmHoldingIdentity.toCorda(),
+                listOf(HoldingIdentity(notaryServiceName.toString(), groupId).toCorda())
+            )
+        ).thenReturn(MembershipQueryResult.Success(emptyList()))
 
         val result = handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))
 
@@ -461,8 +466,12 @@ class StartRegistrationHandlerTest {
         }
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         whenever(memberInfoFactory.create(any<SortedMap<String, String?>>(), any())).thenReturn(bobInfo)
-        whenever(membershipQueryClient.queryMemberInfo(mgmHoldingIdentity.toCorda()))
-            .thenReturn(MembershipQueryResult.Success(listOf(memberInfo)))
+        whenever(
+            membershipQueryClient.queryMemberInfo(
+                mgmHoldingIdentity.toCorda(),
+                listOf(HoldingIdentity(aliceX500Name.toString(), groupId).toCorda())
+            )
+        ).thenReturn(MembershipQueryResult.Success(listOf(memberInfo)))
 
         val registrationCommand = getStartRegistrationCommand(bobHoldingIdentity, memberContext)
         val result = handler.invoke(null, Record(testTopic, testTopicKey, registrationCommand))

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -70,6 +70,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.CompactedSubscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.data.p2p.HostedIdentityEntry
+import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.groupPolicyWithStaticNetworkAndDuplicatedVNodeName
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.registration.InvalidMembershipRegistrationException
@@ -110,6 +111,7 @@ import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -553,8 +555,8 @@ class StaticMemberRegistrationServiceTest {
 
             assertThat(exception)
                 .hasMessage(
-                    "Registration failed. Reason: Our membership O=Daisy, L=London, C=GB " +
-                        "is not listed in the static member list."
+                    "Registration failed. Reason: Our membership O=Daisy, L=London, C=GB is either not " +
+                            "listed in the static member list or there is another member with the same name."
                 )
             registrationService.stop()
         }
@@ -775,6 +777,67 @@ class StaticMemberRegistrationServiceTest {
             verify(groupParametersWriterService).put(eq(bob), eq(mockGroupParameters))
             verify(groupParametersWriterService).put(eq(alice), eq(mockGroupParameters))
             verify(groupParametersWriterService, never()).put(eq(charlie), eq(mockGroupParameters))
+        }
+
+        @Test
+        fun `registration fails when there is a virtual node having the same name as the notary service`() {
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to aliceName.toString(),
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
+            )
+
+            whenever(groupPolicyProvider.getGroupPolicy(bob)).thenReturn(groupPolicyWithStaticNetwork)
+            whenever(virtualNodeInfoReadService.get(bob)).thenReturn(buildTestVirtualNodeInfo(bob))
+            setUpPublisher()
+            registrationService.start()
+
+            val message = assertFailsWith<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationId, bob, context)
+            }
+            assertThat(message.message).contains("There is a virtual node having the same name.")
+        }
+
+        @Test
+        fun `registration fails when the virtual node and notary service name is the same`() {
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to bobName.toString(),
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
+            )
+
+            whenever(groupPolicyProvider.getGroupPolicy(bob)).thenReturn(groupPolicyWithStaticNetwork)
+            whenever(virtualNodeInfoReadService.get(bob)).thenReturn(buildTestVirtualNodeInfo(bob))
+            setUpPublisher()
+            registrationService.start()
+
+            val message = assertFailsWith<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationId, bob, context)
+            }
+            assertThat(message.message).contains("Notary service name and virtual node name cannot be the same.")
+        }
+
+        @Test
+        fun `registration fails when there are two virtual nodes in the static list having the same name`() {
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
+            )
+
+            whenever(groupPolicyProvider.getGroupPolicy(alice))
+                .thenReturn(groupPolicyWithStaticNetworkAndDuplicatedVNodeName)
+            whenever(virtualNodeInfoReadService.get(alice)).thenReturn(buildTestVirtualNodeInfo(alice))
+            setUpPublisher()
+            registrationService.start()
+
+            val message = assertFailsWith<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationId, alice, context)
+            }
+            assertThat(message.message).contains("or there is another member with the same name.")
         }
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -796,7 +796,27 @@ class StaticMemberRegistrationServiceTest {
             val message = assertFailsWith<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationId, bob, context)
             }
-            assertThat(message.message).contains("There is a virtual node having the same name.")
+            assertThat(message.message).contains("There is a virtual node having the same name")
+        }
+
+        @Test
+        fun `registration fails when notary service name is blank`() {
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to "",
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
+            )
+
+            whenever(groupPolicyProvider.getGroupPolicy(bob)).thenReturn(groupPolicyWithStaticNetwork)
+            whenever(virtualNodeInfoReadService.get(bob)).thenReturn(buildTestVirtualNodeInfo(bob))
+            setUpPublisher()
+            registrationService.start()
+
+            val message = assertFailsWith<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationId, bob, context)
+            }
+            assertThat(message.message).contains("Notary must have a non-empty service name.")
         }
 
         @Test
@@ -816,7 +836,7 @@ class StaticMemberRegistrationServiceTest {
             val message = assertFailsWith<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationId, bob, context)
             }
-            assertThat(message.message).contains("Notary service name and virtual node name cannot be the same.")
+            assertThat(message.message).contains("and virtual node name cannot be the same")
         }
 
         @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/TestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/TestUtils.kt
@@ -92,6 +92,31 @@ class TestUtils {
             ]
         """.trimIndent()
 
+        private val staticMemberTemplateWithDuplicatedVNodeName = """
+            [
+                {
+                    "$NAME": "$aliceName",
+                    "$MEMBER_STATUS": "$MEMBER_STATUS_ACTIVE",
+                    "${String.format(ENDPOINT_URL, 1)}": "$TEST_ENDPOINT_URL",
+                    "${String.format(ENDPOINT_PROTOCOL, 1)}": "$TEST_ENDPOINT_PROTOCOL"
+                },
+                {
+                    "$NAME": "$aliceName",
+                    "$MEMBER_STATUS": "$MEMBER_STATUS_ACTIVE",
+                    "${String.format(ENDPOINT_URL, 1)}": "$TEST_ENDPOINT_URL",
+                    "${String.format(ENDPOINT_PROTOCOL, 1)}": "$TEST_ENDPOINT_PROTOCOL"
+                },
+                {
+                    "$NAME": "$charlieName",
+                    "$MEMBER_STATUS": "$MEMBER_STATUS_SUSPENDED",
+                    "${String.format(ENDPOINT_URL, 1)}": "$TEST_ENDPOINT_URL",
+                    "${String.format(ENDPOINT_PROTOCOL, 1)}": "$TEST_ENDPOINT_PROTOCOL",
+                    "${String.format(ENDPOINT_URL, 2)}": "$TEST_ENDPOINT_URL",
+                    "${String.format(ENDPOINT_PROTOCOL, 2)}": "$TEST_ENDPOINT_PROTOCOL"   
+                }
+            ]
+        """.trimIndent()
+
 
         val groupPolicyWithStaticNetwork = MemberGroupPolicyImpl(
             ObjectMapper().readTree(
@@ -105,6 +130,36 @@ class TestUtils {
                         "$SESSION_KEY_POLICY": "$COMBINED",
                         "$STATIC_NETWORK": {
                             "$MEMBERS": $staticMemberTemplate
+                        }
+                    },
+                    "$P2P_PARAMETERS": {
+                        "$SESSION_PKI": "$NO_PKI",
+                        "$TLS_TRUST_ROOTS": [
+                            "$r3comCert"
+                        ],
+                        "$TLS_PKI": "$STANDARD",
+                        "$TLS_TYPE": "${ONE_WAY.groupPolicyName}",
+                        "$TLS_VERSION": "$VERSION_1_3",
+                        "$PROTOCOL_MODE": "$AUTH_ENCRYPT"
+                    },
+                    "$CIPHER_SUITE": {}
+                }
+            """.trimIndent()
+            )
+        )
+
+        val groupPolicyWithStaticNetworkAndDuplicatedVNodeName = MemberGroupPolicyImpl(
+            ObjectMapper().readTree(
+                """
+                {
+                    "$FILE_FORMAT_VERSION": 1,
+                    "$GROUP_ID": "$DUMMY_GROUP_ID",
+                    "$REGISTRATION_PROTOCOL": "com.foo.bar.RegistrationProtocol",
+                    "$SYNC_PROTOCOL": "com.foo.bar.SyncProtocol",
+                    "$PROTOCOL_PARAMETERS": {
+                        "$SESSION_KEY_POLICY": "$COMBINED",
+                        "$STATIC_NETWORK": {
+                            "$MEMBERS": $staticMemberTemplateWithDuplicatedVNodeName
                         }
                     },
                     "$P2P_PARAMETERS": {


### PR DESCRIPTION
As part of this bug, we’ll add logic to ensure:
- The notary service x500 name is different from any existing virtual node x500 name (notary or otherwise).
- The notary service x500 name is different from the notary virtual node being registered.
- The notary vnode x500 name is different from any existing virtual node x500 name (notary or otherwise).

That’s for both static and dynamic networks.