### PR TITLE
CORE-10511: Change exception thrown if invalid CPI given for upgrade vNode operation

### DIFF
--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -42,12 +42,12 @@ internal class VirtualNodeValidationServiceImpl(
     }
 
     override fun validateCpiUpgradePrerequisites(currentCpi: CpiMetadata, upgradeCpi: CpiMetadata) {
-        require(upgradeCpi.cpiId.name == currentCpi.cpiId.name) {
-            "Upgrade CPI must have the same name as the current CPI."
+        if (upgradeCpi.cpiId.name != currentCpi.cpiId.name) {
+            throw BadRequestException("Upgrade CPI must have the same name as the current CPI.")
         }
 
-        require(upgradeCpi.cpiId.signerSummaryHash == currentCpi.cpiId.signerSummaryHash) {
-            "Upgrade CPI must have the same signature summary hash."
+        if (upgradeCpi.cpiId.signerSummaryHash != currentCpi.cpiId.signerSummaryHash) {
+            throw BadRequestException("Upgrade CPI must have the same signature summary hash.")
         }
     }
 

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/test/kotlin/net/corda/virtualnode/rpcops/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/test/kotlin/net/corda/virtualnode/rpcops/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
@@ -115,7 +115,7 @@ class VirtualNodeValidationServiceImplTest {
             whenever(it.cpiId).thenReturn(cpiId2)
         }
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<BadRequestException> {
             validationService.validateCpiUpgradePrerequisites(currentCpi, targetCpi)
         }
     }
@@ -132,7 +132,7 @@ class VirtualNodeValidationServiceImplTest {
             whenever(it.cpiId).thenReturn(cpiId2)
         }
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<BadRequestException> {
             validationService.validateCpiUpgradePrerequisites(currentCpi, targetCpi)
         }
     }


### PR DESCRIPTION
Throw BadRequestException if CPI name or signerSummaryHash don't match previous CPI during upgrade.

Fixes: https://r3-cev.atlassian.net/browse/CORE-10511