### PR TITLE
CORE-10694 Allow single vnode under a notary service

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -71,6 +71,7 @@ class RegistrationProcessor(
             memberTypeChecker,
             membershipPersistenceClient,
             membershipQueryClient,
+            membershipGroupReaderProvider,
             cordaAvroSerializationFactory,
         ),
         ApproveRegistration::class.java to ApproveRegistrationHandler(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -70,6 +70,9 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.CompactedSubscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.data.p2p.HostedIdentityEntry
+import net.corda.membership.lib.MemberInfoExtension
+import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
+import net.corda.membership.lib.notary.MemberNotaryDetails
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.registration.InvalidMembershipRegistrationException
@@ -86,6 +89,7 @@ import net.corda.v5.crypto.RSA_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.calculateHash
 import net.corda.v5.membership.GroupParameters
+import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -128,6 +132,8 @@ class StaticMemberRegistrationServiceTest {
     private val charlie = HoldingIdentity(charlieName, DUMMY_GROUP_ID)
     private val daisy = HoldingIdentity(daisyName, DUMMY_GROUP_ID)
     private val eric = HoldingIdentity(ericName, DUMMY_GROUP_ID)
+    
+    private val notary = MemberX500Name.parse("O=MyNotaryService, L=London, C=GB")
 
     private val aliceId = alice.shortHash
     private val bobId = bob.shortHash
@@ -270,8 +276,9 @@ class StaticMemberRegistrationServiceTest {
         on { create(any()) } doReturn mockGroupParameters
     }
     private val groupParametersWriterService: GroupParametersWriterService = mock()
-    private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider> {
-        on { getGroupReader(any()) } doReturn mock()
+    private val groupReader: MembershipGroupReader = mock()
+    private val membershipGroupReaderProvider: MembershipGroupReaderProvider = mock {
+        on { getGroupReader(any()) } doReturn groupReader
     }
 
     private val registrationService = StaticMemberRegistrationService(
@@ -440,10 +447,7 @@ class StaticMemberRegistrationServiceTest {
             val memberInfo = mock<MemberInfo> {
                 on { isActive } doReturn false
             }
-            val reader = mock<MembershipGroupReader> {
-                on { lookup(any()) } doReturn memberInfo
-            }
-            whenever(membershipGroupReaderProvider.getGroupReader(any())).thenReturn(reader)
+            whenever(groupReader.lookup(any())).thenReturn(memberInfo)
             setUpPublisher()
             registrationService.start()
 
@@ -454,10 +458,7 @@ class StaticMemberRegistrationServiceTest {
 
         @Test
         fun `registration pass when the member is not found`() {
-            val reader = mock<MembershipGroupReader> {
-                on { lookup(any()) } doReturn null
-            }
-            whenever(membershipGroupReaderProvider.getGroupReader(any())).thenReturn(reader)
+            whenever(groupReader.lookup(any())).thenReturn(null)
             setUpPublisher()
             registrationService.start()
 
@@ -474,10 +475,7 @@ class StaticMemberRegistrationServiceTest {
             val memberInfo = mock<MemberInfo> {
                 on { isActive } doReturn true
             }
-            val reader = mock<MembershipGroupReader> {
-                on { lookup(any()) } doReturn memberInfo
-            }
-            whenever(membershipGroupReaderProvider.getGroupReader(any())).thenReturn(reader)
+            whenever(groupReader.lookup(any())).thenReturn(memberInfo)
             setUpPublisher()
             registrationService.start()
 
@@ -589,6 +587,37 @@ class StaticMemberRegistrationServiceTest {
         }
 
         @Test
+        fun `registration fails when role is set to notary and notary service name already exists`() {
+            setUpPublisher()
+            registrationService.start()
+            val context = mapOf(
+                KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
+                "corda.roles.0" to "notary",
+                "corda.notary.service.name" to notary.toString(),
+                "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
+            )
+            val mockNotaryDetails = MemberNotaryDetails(
+                notary,
+                null,
+                emptyList()
+            )
+            val mockMemberContext: MemberContext = mock {
+                on { entries } doReturn mapOf(
+                    String.format(ROLES_PREFIX, 0) to MemberInfoExtension.NOTARY_ROLE
+                ).entries
+                on { parse(eq("corda.notary"), eq(MemberNotaryDetails::class.java)) } doReturn mockNotaryDetails
+            }
+            val mockNotaryMember: MemberInfo = mock {
+                on { memberProvidedContext } doReturn mockMemberContext
+            }
+            whenever(groupReader.lookup()).thenReturn(listOf(mockNotaryMember))
+
+            assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationId, alice, context)
+            }
+        }
+
+        @Test
         fun `registration fails if the registration context doesn't match the schema`() {
             setUpPublisher()
             val err = "ERROR-MESSAGE"
@@ -643,7 +672,7 @@ class StaticMemberRegistrationServiceTest {
             val context = mapOf(
                 KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
                 "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.name" to notary.toString(),
                 "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
             )
 
@@ -675,7 +704,7 @@ class StaticMemberRegistrationServiceTest {
             val context = mapOf(
                 KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
                 "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.name" to notary.toString(),
                 "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
             )
 
@@ -691,7 +720,7 @@ class StaticMemberRegistrationServiceTest {
             assertSoftly {
                 assertThat(notaryDetails).isNotNull
                 assertThat(notaryDetails?.serviceName)
-                    .isEqualTo(MemberX500Name.parse("O=MyNotaryService, L=London, C=GB"))
+                    .isEqualTo(MemberX500Name.parse(notary.toString()))
                 assertThat(notaryDetails?.servicePlugin).isEqualTo("net.corda.notary.MyNotaryService")
 
                 assertThat(notaryDetails?.keys?.toList())
@@ -736,7 +765,7 @@ class StaticMemberRegistrationServiceTest {
             val context = mapOf(
                 KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
                 "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.name" to notary.toString(),
                 "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
             )
             whenever(
@@ -762,7 +791,7 @@ class StaticMemberRegistrationServiceTest {
             val context = mapOf(
                 KEY_SCHEME to ECDSA_SECP256R1_CODE_NAME,
                 "corda.roles.0" to "notary",
-                "corda.notary.service.name" to "O=MyNotaryService, L=London, C=GB",
+                "corda.notary.service.name" to notary.toString(),
                 "corda.notary.service.plugin" to "net.corda.notary.MyNotaryService",
             )
             whenever(groupPolicyProvider.getGroupPolicy(bob)).thenReturn(groupPolicyWithStaticNetwork)


### PR DESCRIPTION
This change allows only a single notary virtual node to be registered under a particular notary service (until support for multiple notary virtual nodes is added). Multiple notary services may be added in a membership group. This applies to both static and dynamic network types.

1. Static
<img width="628" alt="Screenshot 2023-02-28 at 14 00 04" src="https://user-images.githubusercontent.com/17948697/221890121-051a03f5-3746-4f26-82e1-4b8a4e7b6134.png">

2. Dynamic
<img width="1786" alt="Screenshot 2023-02-28 at 11 35 29" src="https://user-images.githubusercontent.com/17948697/221890513-9e6abd49-89da-44d6-8910-6c7904936119.png">

<img width="1303" alt="Screenshot 2023-02-28 at 11 34 39" src="https://user-images.githubusercontent.com/17948697/221890300-848336df-c132-4778-8fc4-4ca9d92d9152.png">
