### PR TITLE
CORE-9865 Creation of InterOpFacade Processor  - send a seed message

### DIFF
--- a/components/interop/interop-service/src/integrationTest/kotlin/net/corda/interop/service/integration/InteropServiceIntegrationTest.kt
+++ b/components/interop/interop-service/src/integrationTest/kotlin/net/corda/interop/service/integration/InteropServiceIntegrationTest.kt
@@ -179,7 +179,7 @@ class InteropServiceIntegrationTest {
         clearHostedIdsSub.close()
 
         interopService.start()
-        val memberExpectedOutputMessages = 4
+        val memberExpectedOutputMessages = 5
         val memberMapperLatch = CountDownLatch(memberExpectedOutputMessages)
         val memberProcessor = MemberInfoMessageCounter(memberMapperLatch, memberExpectedOutputMessages)
         val memberOutSub = subscriptionFactory.createDurableSubscription(
@@ -194,7 +194,7 @@ class InteropServiceIntegrationTest {
         //As this is a test of temporary code, relaxing check on getting more messages
         memberOutSub.close()
 
-        val hostedIdsExpected = 2
+        val hostedIdsExpected = 3
         val hostedIdMapperLatch = CountDownLatch(hostedIdsExpected)
         val hostedIdProcessor = HostedIdentitiesMessageCounter(hostedIdMapperLatch, hostedIdsExpected)
         val hostedIdOutSub = subscriptionFactory.createDurableSubscription(

--- a/components/interop/interop-service/src/integrationTest/kotlin/net/corda/interop/service/integration/InteropServiceIntegrationTest.kt
+++ b/components/interop/interop-service/src/integrationTest/kotlin/net/corda/interop/service/integration/InteropServiceIntegrationTest.kt
@@ -179,7 +179,7 @@ class InteropServiceIntegrationTest {
         clearHostedIdsSub.close()
 
         interopService.start()
-        val memberExpectedOutputMessages = 5
+        val memberExpectedOutputMessages = 4
         val memberMapperLatch = CountDownLatch(memberExpectedOutputMessages)
         val memberProcessor = MemberInfoMessageCounter(memberMapperLatch, memberExpectedOutputMessages)
         val memberOutSub = subscriptionFactory.createDurableSubscription(
@@ -194,7 +194,7 @@ class InteropServiceIntegrationTest {
         //As this is a test of temporary code, relaxing check on getting more messages
         memberOutSub.close()
 
-        val hostedIdsExpected = 3
+        val hostedIdsExpected = 2
         val hostedIdMapperLatch = CountDownLatch(hostedIdsExpected)
         val hostedIdProcessor = HostedIdentitiesMessageCounter(hostedIdMapperLatch, hostedIdsExpected)
         val hostedIdOutSub = subscriptionFactory.createDurableSubscription(

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
@@ -63,7 +63,7 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
             //TODO temporary logic for seed messages only, to process the first 10 messages as more is not required
             // this check will be phased out as part of eliminating seed messages in CORE-10446
             if (interopMessage.messageId.startsWith("seed-message")
-                && (interopMessage.messageId.toIntOrNull() ?: 0 > 10)) return null
+                && (interopMessage.messageId.extractInt() ?: 0 > 10)) return null
             val message : InteropMessage = InteropMessageTransformer.getInteropMessage(
                 interopMessage.messageId.incrementOrUuid(), facadeRequest)
             logger.info("Converted facade request to interop message : $message")
@@ -98,7 +98,7 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
         )
     }
 
-    //Temporary code  to increment message id to debug the lifecycle of seed messages
+    //Temporary function to increment message id to debug the lifecycle of seed messages
     private fun String.incrementOrUuid() = try {
         if (this.contains("-")) {
             val text = this.substringBeforeLast('-')
@@ -108,6 +108,16 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
             "${toInt() + 1}"
     } catch (e: NumberFormatException) {
         "${UUID.randomUUID()}"
+    }
+
+    //Temporary function to filter number from messageId to debug the lifecycle of seed messages
+    private fun String.extractInt(): Int? = try {
+        if (this.contains("-"))
+            this.substringAfterLast('-').toInt()
+        else
+            null
+    } catch (e: NumberFormatException) {
+        null
     }
 
     //The class gathers common fields of UnauthenticatedMessageHeader and AuthenticateMessageHeader

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
@@ -98,13 +98,14 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
         )
     }
 
+    //Temporary code  to increment message id to debug the lifecycle of seed messages
     private fun String.incrementOrUuid() = try {
         if (this.contains("-")) {
             val text = this.substringBeforeLast('-')
             val number = this.substringAfterLast('-')
             "$text-${number.toInt() + 1}"
         } else
-        "${toInt() + 1}"
+            "${toInt() + 1}"
     } catch (e: NumberFormatException) {
         "${UUID.randomUUID()}"
     }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
@@ -40,6 +40,8 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
             unAuthMessage !is UnauthenticatedMessage ||
             unAuthMessage.header.subsystem != SUBSYSTEM
         ) return@mapNotNull null
+        //TODO consider checking SUBSYSTEM for other message types and log warning if they have SUBSYSTEM=Interop but
+        // they are of not the expected type (not UnauthenticatedMessage)
 
         val header = with(unAuthMessage.header) { CommonHeader(source, destination, null, messageId) }
         getOutputRecord(header, unAuthMessage.payload, key)

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
@@ -62,7 +62,8 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
             logger.info("Converted interop message to facade request : $facadeRequest")
             //TODO temporary logic for seed messages only, to process the first 10 messages as more is not required
             // this check will be phased out as part of eliminating seed messages in CORE-10446
-            if (key.startsWith("seed-message") && (interopMessage.messageId.toIntOrNull() ?: 0) > 10) return null
+            if (interopMessage.messageId.startsWith("seed-message")
+                && (interopMessage.messageId.toIntOrNull() ?: 0 > 10)) return null
             val message : InteropMessage = InteropMessageTransformer.getInteropMessage(
                 interopMessage.messageId.incrementOrUuid(), facadeRequest)
             logger.info("Converted facade request to interop message : $message")
@@ -98,6 +99,11 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
     }
 
     private fun String.incrementOrUuid() = try {
+        if (this.contains("-")) {
+            val text = this.substringBeforeLast('-')
+            val number = this.substringAfterLast('-')
+            "$text-${number.toInt() + 1}"
+        } else
         "${toInt() + 1}"
     } catch (e: NumberFormatException) {
         "${UUID.randomUUID()}"

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
@@ -60,6 +60,7 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
         return if (interopMessage != null) {
             val facadeRequest = InteropMessageTransformer.getFacadeRequest(interopMessage)
             logger.info("Converted interop message to facade request : $facadeRequest")
+            if ((interopMessage.messageId.toIntOrNull() ?: 0) > 10) return null
             val message : InteropMessage = InteropMessageTransformer.getInteropMessage(
                 interopMessage.messageId.incrementOrUuid(), facadeRequest)
             logger.info("Converted facade request to interop message : $message")
@@ -101,7 +102,8 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
     }
 
     //The class gathers common fields of UnauthenticatedMessageHeader and AuthenticateMessageHeader
-    data class CommonHeader(val destination: net.corda.data.identity.HoldingIdentity,
-                            val source: net.corda.data.identity.HoldingIdentity, val ttl: Instant? = null,
+    data class CommonHeader(val source: net.corda.data.identity.HoldingIdentity,
+                            val destination: net.corda.data.identity.HoldingIdentity,
+                            val ttl: Instant? = null,
                             val messageId: String, val traceId: String? = null, val subsystem: String = SUBSYSTEM)
     }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropProcessor.kt
@@ -125,6 +125,6 @@ class InteropProcessor(cordaAvroSerializationFactory: CordaAvroSerializationFact
     //The class gathers common fields of UnauthenticatedMessageHeader and AuthenticateMessageHeader
     data class CommonHeader(val source: net.corda.data.identity.HoldingIdentity,
                             val destination: net.corda.data.identity.HoldingIdentity,
-                            val ttl: Instant? = null,
-                            val messageId: String, val traceId: String? = null, val subsystem: String = SUBSYSTEM)
+                            val ttl: Instant? = null, val messageId: String,
+                            val traceId: String? = null, val subsystem: String = SUBSYSTEM)
     }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropService.kt
@@ -109,8 +109,8 @@ class InteropService @Activate constructor(
         publisher?.publish(registrationService.createDummyMemberInfo())
         logger.info("Publishing hosted identities")
         publisher?.publish(registrationService.createDummyHostedIdentity())
-        //logger.info("Publishing seed message")
-        //publisher?.publish(registrationService.seedMessage())
+        logger.info("Publishing seed message")
+        publisher?.publish(registrationService.seedMessage())
         coordinator.updateStatus(LifecycleStatus.UP)
     }
 

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -43,11 +43,8 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
 ): InteropMemberRegistrationService {
 
     companion object {
-        private const val ALICE_ALTER_EGO_X500 = "CN=Alice Alter Ego, O=Alice Alter Ego Corp, L=LDN, C=GB"
-        private const val ALICE_X500 = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
-        private val ALICE_ALTER_EGO_X500_NAME = MemberX500Name.parse(ALICE_ALTER_EGO_X500)
-        private val ALICE_X500_NAME = MemberX500Name.parse(ALICE_X500)
-        private val ALICE_OTHER_CLUSTER_X500 = MemberX500Name.parse("CN=Alice from Other Cluster, O=Alice Corp, L=LDN, C=GB")
+        private val ALICE_ALTER_EGO_X500_NAME = MemberX500Name.parse("CN=Alice Alter Ego, O=Alice Alter Ego Corp, L=LDN, C=GB")
+        private val ALICE_X500_NAME = MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB")
         private const val INTEROP_GROUP_ID = "3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08"
         private const val NON_EXISTING_GROUP_ID = "non-existing-group"
         private const val SUBSYSTEM = "interop"
@@ -55,23 +52,36 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             this::class.java.getResource("/dummy_certificate.pem")?.readText()
         private val DUMMY_PUBLIC_SESSION_KEY =
             this::class.java.getResource("/dummy_session_key.pem")?.readText()
-        private val memberList =
-            listOf(HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID), HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID),
-                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, NON_EXISTING_GROUP_ID), HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP_ID),
-                HoldingIdentity(ALICE_OTHER_CLUSTER_X500, INTEROP_GROUP_ID))
+
+        private val membersOfInteropGroup =
+            listOf(ALICE_X500_NAME, ALICE_ALTER_EGO_X500_NAME).map { HoldingIdentity(it, INTEROP_GROUP_ID) }
+        private val memberFromOtherClusterOfInteropGroup =
+            HoldingIdentity(MemberX500Name.parse("CN=Alice from Other Cluster, O=Alice Corp, L=LDN, C=GB"), INTEROP_GROUP_ID)
+        private val unpublishedMemberOfInteropGroup =
+            HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"), INTEROP_GROUP_ID)
+
+        private val membersOfNonExistingGroup =
+          listOf(ALICE_X500_NAME, ALICE_ALTER_EGO_X500_NAME).map { HoldingIdentity(it, NON_EXISTING_GROUP_ID) }
     }
+    //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
+    override fun createDummyMemberInfo(): List<Record<String, PersistentMemberInfo>>
+        = createDummyMemberInfo(membersOfInteropGroup + listOf(memberFromOtherClusterOfInteropGroup), INTEROP_GROUP_ID) +
+            createDummyMemberInfo(membersOfNonExistingGroup, NON_EXISTING_GROUP_ID)
 
     //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
-    override fun createDummyMemberInfo(): List<Record<String, PersistentMemberInfo>> {
+    override fun createDummyHostedIdentity(): List<Record<String, HostedIdentityEntry>>
+            = createDummyHostedIdentity(membersOfInteropGroup) + createDummyHostedIdentity(membersOfNonExistingGroup)
+
+    private fun createDummyMemberInfo(identities : List<HoldingIdentity>, groupId: String): List<Record<String, PersistentMemberInfo>> {
         val memberInfoList = mutableListOf<Record<String, PersistentMemberInfo>>()
-        memberList.forEach {member ->
+        identities.forEach { member ->
             val memberContext = listOf(
                 KeyValuePair(PARTY_NAME, member.x500Name.toString()),
                 KeyValuePair(String.format(URL_KEY, "0"), "http://localhost:8080"),
                 KeyValuePair(String.format(PROTOCOL_VERSION, "0"), "1"),
                 KeyValuePair(PARTY_SESSION_KEY, DUMMY_CERTIFICATE),
                 KeyValuePair(SESSION_KEY_HASH, "9DEA9C982267BD142162ADC141C1C11C2F547C3C37B4C693A3EA3A017C2C6563"),
-                KeyValuePair(GROUP_ID, INTEROP_GROUP_ID),
+                KeyValuePair(GROUP_ID, groupId),
                 KeyValuePair(LEDGER_KEYS_KEY.format(0), DUMMY_PUBLIC_SESSION_KEY),
                 KeyValuePair(
                     LEDGER_KEY_HASHES_KEY.format(0),
@@ -79,27 +89,19 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                 ),
                 KeyValuePair(LEDGER_KEY_SIGNATURE_SPEC.format(0), "SHA256withECDSA"),
                 KeyValuePair(SOFTWARE_VERSION, "5.0.0.0-Fox10-RC03"),
-                KeyValuePair(PLATFORM_VERSION, "5000"),
-                //TODO : Following info may not be required for interops group,
-                // need to investigate that LinkManager is happy without this info.
-//            KeyValuePair(MEMBER_CPI_NAME, "calculator.cpi"),
-//            KeyValuePair(MEMBER_CPI_VERSION, "1.0.0.0-SNAPSHOT"),
-//            KeyValuePair(
-//                MEMBER_CPI_SIGNER_HASH,
-//                "SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC"
-//            )
+                KeyValuePair(PLATFORM_VERSION, "5000")
             ).sorted()
             val mgmContext = listOf(
                 KeyValuePair(STATUS, "ACTIVE"),
                 KeyValuePair(MODIFIED_TIME, Instant.now().toString()),
                 KeyValuePair(MemberInfoExtension.SERIAL, "1"),
             ).sorted()
-            memberInfoList.addAll(memberList.map {
+            memberInfoList.addAll(identities.map { viewOwningMember ->
                 Record(
                     Schemas.Membership.MEMBER_LIST_TOPIC,
-                    "${it.shortHash}-${member.shortHash.value}",
+                    "${viewOwningMember.shortHash}-${member.shortHash.value}",
                     PersistentMemberInfo(
-                        it.toAvro(),
+                        viewOwningMember.toAvro(),
                         KeyValuePairList(memberContext),
                         KeyValuePairList(mgmContext)
                     )
@@ -109,9 +111,8 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
         return memberInfoList
     }
 
-    override fun createDummyHostedIdentity(): List<Record<String, HostedIdentityEntry>> {
-        return memberList.map {
-            val registeringMember = it
+    private fun createDummyHostedIdentity(identities: List<HoldingIdentity>): List<Record<String, HostedIdentityEntry>>
+        = identities.map { registeringMember ->
             val hostedIdentity = HostedIdentityEntry(
                 net.corda.data.identity.HoldingIdentity(
                     registeringMember.x500Name.toString(),
@@ -128,7 +129,6 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                 hostedIdentity
             )
         }
-    }
 
     override fun seedMessage() : List<Record<*,*>> {
         val interopMessageSerializer = cordaAvroSerializationFactory.createAvroSerializer<InteropMessage> { }
@@ -150,17 +150,10 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                 )
             )
 
-        val unpublishedHoldingIdentity =
-                HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"), INTEROP_GROUP_ID)
-
         return listOf(
-            createRecord("seed-message-correct-1", HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID),
-                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID)),
-            createRecord("seed-message-no-dest-1", unpublishedHoldingIdentity,
-                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID)),
-            createRecord("seed-message-no-policy-1", HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP_ID),
-                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, NON_EXISTING_GROUP_ID)),
-            createRecord("seed-message-other-cluster-1", HoldingIdentity(ALICE_OTHER_CLUSTER_X500, INTEROP_GROUP_ID),
-                HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID)))
+            createRecord("seed-message-correct-1", membersOfInteropGroup[0], membersOfInteropGroup[1]),
+            createRecord("seed-message-no-dest-1", unpublishedMemberOfInteropGroup, membersOfInteropGroup[0]),
+            createRecord("seed-message-other-cluster-1", memberFromOtherClusterOfInteropGroup, membersOfInteropGroup[0]),
+            createRecord("seed-message-no-policy-1", membersOfNonExistingGroup[0], membersOfNonExistingGroup[1]))
     }
 }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -128,7 +128,7 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
     override fun seedMessage() : List<Record<*,*>> {
         val interopMessageSerializer = cordaAvroSerializationFactory.createAvroSerializer<InteropMessage> { }
         val key = "seed-message-1"
-        val header = UnauthenticatedMessageHeader(memberList.first().toAvro(), memberList[1].toAvro(), "interop", "123")
+        val header = UnauthenticatedMessageHeader(memberList.first().toAvro(), memberList[1].toAvro(), "interop", "1")
         val payload = """
             {
                 "method": "org.corda.interop/platform/tokens/v1.0/reserve-tokens",
@@ -138,8 +138,15 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
 
         val interopMessage = InteropMessage("1", payload)
 
+        val headerNoDestination = UnauthenticatedMessageHeader(
+            HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"),INTEROP_GROUP_ID).toAvro(),
+            memberList[1].toAvro(), "interop", "1")
+
         return listOf(Record(
             Schemas.P2P.P2P_IN_TOPIC, key,
-            AppMessage(UnauthenticatedMessage(header, ByteBuffer.wrap(interopMessageSerializer.serialize(interopMessage))))))
+            AppMessage(UnauthenticatedMessage(header, ByteBuffer.wrap(interopMessageSerializer.serialize(interopMessage))))),
+            Record(Schemas.P2P.P2P_IN_TOPIC, "seed-message-2",
+            AppMessage(UnauthenticatedMessage(headerNoDestination, ByteBuffer.wrap(interopMessageSerializer.serialize(interopMessage)))))
+        )
     }
 }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -142,10 +142,6 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
 
         val headerNoDestination = UnauthenticatedMessageHeader(UNPUBLISHED_HOLDING_IDENTITY, memberList[1].toAvro(), SUBSYSTEM, "1")
 
-        val headerNoExistingGroup = UnauthenticatedMessageHeader(
-            HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP).toAvro(),
-            HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, NON_EXISTING_GROUP).toAvro(), SUBSYSTEM, "1")
-
         return listOf(
             Record(
                 Schemas.P2P.P2P_IN_TOPIC, "seed-message-correct-1",
@@ -162,15 +158,6 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                     UnauthenticatedMessage(
                         headerNoDestination,
                         ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage("seed-message-no-dest-1", payload)))
-                    )
-                )
-            ),
-            Record(
-                Schemas.P2P.P2P_IN_TOPIC, "seed-message-no-policy-1",
-                AppMessage(
-                    UnauthenticatedMessage(
-                        headerNoExistingGroup,
-                        ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage("seed-message-no-policy-1", payload)))
                     )
                 )
             )

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -47,17 +47,16 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
         private const val ALICE_X500 = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
         private val ALICE_ALTER_EGO_X500_NAME = MemberX500Name.parse(ALICE_ALTER_EGO_X500)
         private val ALICE_X500_NAME = MemberX500Name.parse(ALICE_X500)
+        private val ALICE_OTHER_CLUSTER_X500 = MemberX500Name.parse("CN=Alice from Other Cluster, O=Alice Corp, L=LDN, C=GB")
         private const val INTEROP_GROUP_ID = "3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08"
-        private val UNPUBLISHED_HOLDING_IDENTITY
-            = HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"), INTEROP_GROUP_ID).toAvro()
-        private const val NON_EXISTING_GROUP = "non-existing-group"
         private const val SUBSYSTEM = "interop"
         private val DUMMY_CERTIFICATE =
             this::class.java.getResource("/dummy_certificate.pem")?.readText()
         private val DUMMY_PUBLIC_SESSION_KEY =
             this::class.java.getResource("/dummy_session_key.pem")?.readText()
         private val memberList =
-            listOf(HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID), HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID))
+            listOf(HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID), HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID),
+                HoldingIdentity(ALICE_OTHER_CLUSTER_X500, INTEROP_GROUP_ID))
     }
 
     //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
@@ -131,7 +130,6 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
 
     override fun seedMessage() : List<Record<*,*>> {
         val interopMessageSerializer = cordaAvroSerializationFactory.createAvroSerializer<InteropMessage> { }
-        val correctHeader = UnauthenticatedMessageHeader(memberList.first().toAvro(), memberList[1].toAvro(), SUBSYSTEM, "1")
         val payload = """
             {
                 "method": "org.corda.interop/platform/tokens/v1.0/reserve-tokens",
@@ -139,40 +137,29 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             }
         """.trimIndent()
 
-        val headerNoDestination = UnauthenticatedMessageHeader(UNPUBLISHED_HOLDING_IDENTITY, memberList[1].toAvro(), SUBSYSTEM, "1")
-
-        val headerNoExistingGroup = UnauthenticatedMessageHeader(
-            HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP).toAvro(),
-            HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, NON_EXISTING_GROUP).toAvro(), SUBSYSTEM, "1")
-
-        return listOf(
+        fun createRecord(key: String, destination: HoldingIdentity, source: HoldingIdentity) =
             Record(
-                Schemas.P2P.P2P_IN_TOPIC, "seed-message-correct-1",
+                Schemas.P2P.P2P_IN_TOPIC, key,
                 AppMessage(
                     UnauthenticatedMessage(
-                        correctHeader,
-                        ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage("seed-message-correct-1", payload)))
-                    )
-                )
-            ),
-            Record(
-                Schemas.P2P.P2P_IN_TOPIC, "seed-message-no-dest-1",
-                AppMessage(
-                    UnauthenticatedMessage(
-                        headerNoDestination,
-                        ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage("seed-message-no-dest-1", payload)))
-                    )
-                )
-            ),
-            Record(
-                Schemas.P2P.P2P_IN_TOPIC, "seed-message-no-policy-1",
-                AppMessage(
-                    UnauthenticatedMessage(
-                        headerNoExistingGroup,
-                        ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage("seed-message-no-policy-1", payload)))
+                        UnauthenticatedMessageHeader(destination.toAvro(), source.toAvro(), SUBSYSTEM, "1"),
+                        ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage(key, payload)))
                     )
                 )
             )
-        )
+
+        val unpublishedHoldingIdentity =
+                HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"), INTEROP_GROUP_ID)
+        val nonExistingGroupId = "non-existing-group"
+
+        return listOf(
+            createRecord("seed-message-correct-1", HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID),
+                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID)),
+            createRecord("seed-message-no-dest-1", unpublishedHoldingIdentity,
+                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID)),
+            createRecord("seed-message-no-policy-1", HoldingIdentity(ALICE_X500_NAME, nonExistingGroupId),
+                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, nonExistingGroupId)),
+            createRecord("seed-message-other-cluster-1", HoldingIdentity(ALICE_OTHER_CLUSTER_X500, INTEROP_GROUP_ID),
+                HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID)))
     }
 }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -57,8 +57,8 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             this::class.java.getResource("/dummy_session_key.pem")?.readText()
         private val memberList =
             listOf(HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID), HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID),
-                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID), HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP_ID),
-                HoldingIdentity(ALICE_OTHER_CLUSTER_X500, NON_EXISTING_GROUP_ID) )
+                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, NON_EXISTING_GROUP_ID), HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP_ID),
+                HoldingIdentity(ALICE_OTHER_CLUSTER_X500, INTEROP_GROUP_ID))
     }
 
     //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -49,6 +49,7 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
         private val ALICE_X500_NAME = MemberX500Name.parse(ALICE_X500)
         private val ALICE_OTHER_CLUSTER_X500 = MemberX500Name.parse("CN=Alice from Other Cluster, O=Alice Corp, L=LDN, C=GB")
         private const val INTEROP_GROUP_ID = "3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08"
+        private const val NON_EXISTING_GROUP_ID = "non-existing-group"
         private const val SUBSYSTEM = "interop"
         private val DUMMY_CERTIFICATE =
             this::class.java.getResource("/dummy_certificate.pem")?.readText()
@@ -56,7 +57,8 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             this::class.java.getResource("/dummy_session_key.pem")?.readText()
         private val memberList =
             listOf(HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID), HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID),
-                HoldingIdentity(ALICE_OTHER_CLUSTER_X500, INTEROP_GROUP_ID))
+                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID), HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP_ID),
+                HoldingIdentity(ALICE_OTHER_CLUSTER_X500, NON_EXISTING_GROUP_ID) )
     }
 
     //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
@@ -150,15 +152,14 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
 
         val unpublishedHoldingIdentity =
                 HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"), INTEROP_GROUP_ID)
-        val nonExistingGroupId = "non-existing-group"
 
         return listOf(
             createRecord("seed-message-correct-1", HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID),
                 HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID)),
             createRecord("seed-message-no-dest-1", unpublishedHoldingIdentity,
                 HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, INTEROP_GROUP_ID)),
-            createRecord("seed-message-no-policy-1", HoldingIdentity(ALICE_X500_NAME, nonExistingGroupId),
-                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, nonExistingGroupId)),
+            createRecord("seed-message-no-policy-1", HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP_ID),
+                HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, NON_EXISTING_GROUP_ID)),
             createRecord("seed-message-other-cluster-1", HoldingIdentity(ALICE_OTHER_CLUSTER_X500, INTEROP_GROUP_ID),
                 HoldingIdentity(ALICE_X500_NAME, INTEROP_GROUP_ID)))
     }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -43,34 +43,25 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
 ): InteropMemberRegistrationService {
 
     companion object {
-        private val ALICE_ALTER_EGO_X500_NAME = MemberX500Name.parse("CN=Alice Alter Ego, O=Alice Alter Ego Corp, L=LDN, C=GB")
-        private val ALICE_X500_NAME = MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB")
+        private val ALICE_ALTER_EGO_X500 = MemberX500Name.parse("CN=Alice Alter Ego, O=Alice Alter Ego Corp, L=LDN, C=GB")
+        private val ALICE_X500 = MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB")
         private const val INTEROP_GROUP_ID = "3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08"
-        private const val NON_EXISTING_GROUP_ID = "non-existing-group"
         private const val SUBSYSTEM = "interop"
         private val DUMMY_CERTIFICATE =
             this::class.java.getResource("/dummy_certificate.pem")?.readText()
         private val DUMMY_PUBLIC_SESSION_KEY =
             this::class.java.getResource("/dummy_session_key.pem")?.readText()
-
-        private val membersOfInteropGroup =
-            listOf(ALICE_X500_NAME, ALICE_ALTER_EGO_X500_NAME).map { HoldingIdentity(it, INTEROP_GROUP_ID) }
-        private val memberFromOtherClusterOfInteropGroup =
-            HoldingIdentity(MemberX500Name.parse("CN=Alice from Other Cluster, O=Alice Corp, L=LDN, C=GB"), INTEROP_GROUP_ID)
-        private val unpublishedMemberOfInteropGroup =
-            HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"), INTEROP_GROUP_ID)
-
-        private val membersOfNonExistingGroup =
-          listOf(ALICE_X500_NAME, ALICE_ALTER_EGO_X500_NAME).map { HoldingIdentity(it, NON_EXISTING_GROUP_ID) }
+        private val memberList =
+            listOf(ALICE_X500, ALICE_ALTER_EGO_X500).map { HoldingIdentity(it, INTEROP_GROUP_ID) }
     }
-    //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
-    override fun createDummyMemberInfo(): List<Record<String, PersistentMemberInfo>>
-        = createDummyMemberInfo(membersOfInteropGroup + listOf(memberFromOtherClusterOfInteropGroup), INTEROP_GROUP_ID) +
-            createDummyMemberInfo(membersOfNonExistingGroup, NON_EXISTING_GROUP_ID)
 
     //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
-    override fun createDummyHostedIdentity(): List<Record<String, HostedIdentityEntry>>
-            = createDummyHostedIdentity(membersOfInteropGroup) + createDummyHostedIdentity(membersOfNonExistingGroup)
+    override fun createDummyMemberInfo(): List<Record<String, PersistentMemberInfo>> =
+        createDummyMemberInfo(memberList, INTEROP_GROUP_ID)
+
+    //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
+    override fun createDummyHostedIdentity(): List<Record<String, HostedIdentityEntry>> =
+        createDummyHostedIdentity(memberList)
 
     private fun createDummyMemberInfo(identities : List<HoldingIdentity>, groupId: String): List<Record<String, PersistentMemberInfo>> {
         val memberInfoList = mutableListOf<Record<String, PersistentMemberInfo>>()
@@ -151,9 +142,6 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             )
 
         return listOf(
-            createRecord("seed-message-correct-1", membersOfInteropGroup[0], membersOfInteropGroup[1]),
-            createRecord("seed-message-no-dest-1", unpublishedMemberOfInteropGroup, membersOfInteropGroup[0]),
-            createRecord("seed-message-other-cluster-1", memberFromOtherClusterOfInteropGroup, membersOfInteropGroup[0]),
-            createRecord("seed-message-no-policy-1", membersOfNonExistingGroup[0], membersOfNonExistingGroup[1]))
+            createRecord("seed-message-correct-1", memberList[0], memberList[1]))
     }
 }

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -131,6 +131,7 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
 
     override fun seedMessage() : List<Record<*,*>> {
         val interopMessageSerializer = cordaAvroSerializationFactory.createAvroSerializer<InteropMessage> { }
+        val correctHeader = UnauthenticatedMessageHeader(memberList.first().toAvro(), memberList[1].toAvro(), SUBSYSTEM, "1")
         val payload = """
             {
                 "method": "org.corda.interop/platform/tokens/v1.0/reserve-tokens",
@@ -138,9 +139,11 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             }
         """.trimIndent()
 
-        val correctHeader = UnauthenticatedMessageHeader(memberList.first().toAvro(), memberList[1].toAvro(), SUBSYSTEM, "1")
-
         val headerNoDestination = UnauthenticatedMessageHeader(UNPUBLISHED_HOLDING_IDENTITY, memberList[1].toAvro(), SUBSYSTEM, "1")
+
+        val headerNoExistingGroup = UnauthenticatedMessageHeader(
+            HoldingIdentity(ALICE_X500_NAME, NON_EXISTING_GROUP).toAvro(),
+            HoldingIdentity(ALICE_ALTER_EGO_X500_NAME, NON_EXISTING_GROUP).toAvro(), SUBSYSTEM, "1")
 
         return listOf(
             Record(
@@ -158,6 +161,15 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                     UnauthenticatedMessage(
                         headerNoDestination,
                         ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage("seed-message-no-dest-1", payload)))
+                    )
+                )
+            ),
+            Record(
+                Schemas.P2P.P2P_IN_TOPIC, "seed-message-no-policy-1",
+                AppMessage(
+                    UnauthenticatedMessage(
+                        headerNoExistingGroup,
+                        ByteBuffer.wrap(interopMessageSerializer.serialize(InteropMessage("seed-message-no-policy-1", payload)))
                     )
                 )
             )

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -136,7 +136,7 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             }
         """.trimIndent()
 
-        val interopMessage = InteropMessage("1", payload)
+        val interopMessage = InteropMessage(key, payload)
 
         val headerNoDestination = UnauthenticatedMessageHeader(
             HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"),INTEROP_GROUP_ID).toAvro(),

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -68,7 +68,7 @@ internal class InboundMessageProcessor(
                     processSessionMessage(message)
                 }
                 is UnauthenticatedMessage -> {
-                    logger.info(
+                    logger.info( //TODO info level for Interop Team, revert to debug as part of CORE-10683
                         "Processing unauthenticated message ${payload.header.messageId}"
                     )
                     listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(payload)))

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -48,7 +48,6 @@ internal class InboundMessageProcessor(
     private var logger = LoggerFactory.getLogger(this::class.java.name)
 
     override fun onNext(events: List<EventLogRecord<String, LinkInMessage>>): List<Record<*, *>> {
-        logger.info("Processing inbound messages ${events.size}.")
         val records = mutableListOf<Record<*, *>>()
         for (event in events) {
             val message = event.value

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -48,6 +48,7 @@ internal class InboundMessageProcessor(
     private var logger = LoggerFactory.getLogger(this::class.java.name)
 
     override fun onNext(events: List<EventLogRecord<String, LinkInMessage>>): List<Record<*, *>> {
+        logger.info("Processing inbound messages ${events.size}.")
         val records = mutableListOf<Record<*, *>>()
         for (event in events) {
             val message = event.value
@@ -68,9 +69,9 @@ internal class InboundMessageProcessor(
                     processSessionMessage(message)
                 }
                 is UnauthenticatedMessage -> {
-                    logger.debug {
+                    logger.info(
                         "Processing unauthenticated message ${payload.header.messageId}"
-                    }
+                    )
                     listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(payload)))
                 }
                 else -> {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -131,7 +131,7 @@ internal class OutboundMessageProcessor(
     }
 
     private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
-        //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
+        //TODO new log statement added temporarily for Interop Team, revert to debug as part of CORE-10683
         logger.info ("Processing outbound message ${message.header.messageId} from ${message.header.source} " +
                 "to ${message.header.destination}." )
 
@@ -152,7 +152,7 @@ internal class OutboundMessageProcessor(
             message.header.destination.toCorda()
         )
         if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
-            //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
+            //TODO new log statement added temporarily for Interop Team, revert to debug as part of CORE-10683
             logger.info ("Processing outbound message hosted locally ${message.header.messageId} from ${message.header.source} " +
                     "to ${message.header.destination}." )
             return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -132,8 +132,8 @@ internal class OutboundMessageProcessor(
 
     private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
         //TODO new log statement added temporarily for Interop Team, revert to debug as part of CORE-10683
-        logger.info ("Processing outbound message ${message.header.messageId} from ${message.header.source} " +
-                "to ${message.header.destination}." )
+        logger.info("Processing outbound message ${message.header.messageId} from ${message.header.source} " +
+                "to ${message.header.destination}.")
 
         val discardReason = checkSourceAndDestinationValid(
             message.header.source, message.header.destination
@@ -153,8 +153,8 @@ internal class OutboundMessageProcessor(
         )
         if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
             //TODO new log statement added temporarily for Interop Team, revert to debug as part of CORE-10683
-            logger.info ("Sending outbound message hosted locally ${message.header.messageId} from ${message.header.source} " +
-                    "to ${message.header.destination}." )
+            logger.info("Sending outbound message hosted locally ${message.header.messageId} from ${message.header.source} " +
+                    "to ${message.header.destination}.")
             return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))
         } else if (destMemberInfo != null) {
             val source = message.header.source.toCorda()

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -153,7 +153,7 @@ internal class OutboundMessageProcessor(
         )
         if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
             //TODO new log statement added temporarily for Interop Team, revert to debug as part of CORE-10683
-            logger.info ("Processing outbound message hosted locally ${message.header.messageId} from ${message.header.source} " +
+            logger.info ("Sending outbound message hosted locally ${message.header.messageId} from ${message.header.source} " +
                     "to ${message.header.destination}." )
             return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))
         } else if (destMemberInfo != null) {
@@ -169,7 +169,7 @@ internal class OutboundMessageProcessor(
 
             val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(message, destMemberInfo, groupPolicy)
             //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
-            logger.info ("Processing outbound message ${message.header.messageId} to ${message.header.destination} " +
+            logger.info ("Sending outbound message ${message.header.messageId} to ${message.header.destination} " +
                     "for ${linkOutMessage.header.address}." )
             return listOf(Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), linkOutMessage))
         } else {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -28,7 +28,6 @@ import net.corda.data.p2p.markers.Component
 import net.corda.schema.Schemas
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.virtualnode.toCorda
 import org.slf4j.Logger
@@ -132,7 +131,8 @@ internal class OutboundMessageProcessor(
     }
 
     private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
-        logger.debug { "Processing outbound message ${message.header.messageId} to ${message.header.destination}." }
+        logger.info ("Processing outbound message ${message.header.messageId} from ${message.header.source} " +
+                "to ${message.header.destination}." )
 
         val discardReason = checkSourceAndDestinationValid(
             message.header.source, message.header.destination
@@ -151,6 +151,8 @@ internal class OutboundMessageProcessor(
             message.header.destination.toCorda()
         )
         if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
+            logger.info ("Processing outbound message hosted locally ${message.header.messageId} from ${message.header.source} " +
+                    "to ${message.header.destination}." )
             return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))
         } else if (destMemberInfo != null) {
             val source = message.header.source.toCorda()
@@ -164,6 +166,8 @@ internal class OutboundMessageProcessor(
             }
 
             val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(message, destMemberInfo, groupPolicy)
+            logger.info ("Processing outbound message ${message.header.messageId} to ${message.header.destination} " +
+                    "for ${linkOutMessage.header.address}." )
             return listOf(Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), linkOutMessage))
         } else {
             logger.warn("Trying to send unauthenticated message ${message.header.messageId} from ${message.header.source.toCorda()} " +

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -131,6 +131,7 @@ internal class OutboundMessageProcessor(
     }
 
     private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
+        //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
         logger.info ("Processing outbound message ${message.header.messageId} from ${message.header.source} " +
                 "to ${message.header.destination}." )
 
@@ -151,6 +152,7 @@ internal class OutboundMessageProcessor(
             message.header.destination.toCorda()
         )
         if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
+            //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
             logger.info ("Processing outbound message hosted locally ${message.header.messageId} from ${message.header.source} " +
                     "to ${message.header.destination}." )
             return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))
@@ -166,6 +168,7 @@ internal class OutboundMessageProcessor(
             }
 
             val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(message, destMemberInfo, groupPolicy)
+            //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
             logger.info ("Processing outbound message ${message.header.messageId} to ${message.header.destination} " +
                     "for ${linkOutMessage.header.address}." )
             return listOf(Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), linkOutMessage))


### PR DESCRIPTION
Send a seed message allows to observe interaction between InteropProcessor and LinkManager:
1)  Enabled invocation of `seedMessage` to publish seed message
2) Added temporary logic for seed messages only, to process the first 10 messages as more is not required and they were where over-flooding the system,
for this check needed 2 more temporary private methods to parse message id and increment the part with number
3) Temporary log info statements to LinkManager processors for unauthorized message.
4) rename `appMessage` to `record` in `InteropProcessor` loop as the latter variable contains ApplicationMessage
5) Several refactorings in our registration service, this is to remove accidentally constants used to create other constants, shorten names (`_NAME`postfix not needed), more compact way of creating a list using map function.
For follow-up code in the next PR - move logic from public methods `createDummyMemberInfo` and `createDummyHostedIdentity` into private function with arguments, as the logic will be used more times to create various setup for other seed message scenarios (no matching group policy etc).

How to test:
Download any logs from Jenkins from e2e test, go to any p2p link manager :
```
cd run-b83b94c5-b13f-4510-a93c-ffceb790a818/corda-alice-p2p-link-manager-worker-86787595c4-j5f8t
 cat logs.txt| grep -e OutboundMessageProcessor | grep Alice |  cut -d] -f3-
```
Sample line should a message received by `LinkManager` from p2p.out and send back  to p2p.in. There is 11 such messages send from `Alice Alter Ego` to `Alice` back and forth, you can also see the logs from `InteropProcessor` from relevant `FlowWorker`node (use e.g.:
```
cat logs.txt | grep interop | cut -d] -f3-
```
