### PR TITLE
NOTICK: Prevent Quasar from instrumenting Byte-Buddy and YAML.

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -29,11 +29,13 @@ quasar {
     excludePackages.addAll([
             'com.zaxxer.hikari**',
             'liquibase**',
+            'net.bytebuddy**',
             'net.corda.membership**',
             'org.eclipse.jetty**',
             'org.hibernate**',
             'org.jboss.logging',
-            'org.postgresql**'
+            'org.postgresql**',
+            'org.yaml.snakeyaml**'
     ])
 }
 


### PR DESCRIPTION
Byte-Buddy and Snake YAML are used by the `db-worker` and not by the `flow-worker`, so prevent Quasar from instrumenting either of their contents inside the `combined-worker`.