### PR TITLE
CORE-10336 Internalize non api types

### DIFF
--- a/components/crypto/crypto-component-core-impl/build.gradle
+++ b/components/crypto/crypto-component-core-impl/build.gradle
@@ -22,6 +22,5 @@ dependencies {
     implementation project(':libs:crypto:crypto-core')
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:messaging")
-    implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:utilities')
 }

--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/ExceptionsUtils.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/ExceptionsUtils.kt
@@ -1,10 +1,10 @@
 package net.corda.crypto.component.impl
 
+import net.corda.crypto.core.CryptoRetryException
 import net.corda.crypto.core.InvalidParamsException
 import net.corda.crypto.core.KeyAlreadyExistsException
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.v5.crypto.exceptions.CryptoException
-import net.corda.v5.crypto.exceptions.CryptoRetryException
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 
 val exceptionFactories = mapOf<String, (String, Throwable) -> Throwable>(

--- a/components/crypto/crypto-component-core-impl/src/test/kotlin/net/corda/crypto/component/impl/ExceptionsUtilsTests.kt
+++ b/components/crypto/crypto-component-core-impl/src/test/kotlin/net/corda/crypto/component/impl/ExceptionsUtilsTests.kt
@@ -1,10 +1,10 @@
 package net.corda.crypto.component.impl
 
+import net.corda.crypto.core.CryptoRetryException
 import net.corda.crypto.core.InvalidParamsException
 import net.corda.crypto.core.KeyAlreadyExistsException
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.v5.crypto.exceptions.CryptoException
-import net.corda.v5.crypto.exceptions.CryptoRetryException
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.658-beta+
+cordaApiVersion=5.0.0.659-alpha-1677659326045
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.659-alpha-1677659326045
+cordaApiVersion=5.0.0.659-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingException.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingException.kt
@@ -8,8 +8,7 @@ import net.corda.v5.crypto.exceptions.CryptoException
  * Signals that there is a throttling by a downstream service, such as HSM or any other and provides parameters which
  * can be used to retry the operation which caused that.
  */
-@CordaSerializable
-open class CryptoThrottlingException : CryptoException {
+class CryptoThrottlingException : CryptoException {
     companion object {
         /**
          * Creates an instance of the exception with the message
@@ -111,7 +110,7 @@ open class CryptoThrottlingException : CryptoException {
         this.backoff = backoff
     }
 
-    open fun getBackoff(attempt: Int): Long =
+    fun getBackoff(attempt: Int): Long =
         if (attempt < 1 || attempt > backoff.size) {
             -1
         } else {

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingException.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingException.kt
@@ -1,0 +1,120 @@
+package net.corda.crypto.cipher.suite
+
+import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.crypto.exceptions.CryptoException
+
+
+/**
+ * Signals that there is a throttling by a downstream service, such as HSM or any other and provides parameters which
+ * can be used to retry the operation which caused that.
+ */
+@CordaSerializable
+open class CryptoThrottlingException : CryptoException {
+    companion object {
+        /**
+         * Creates an instance of the exception with the message
+         * and default exponential backoff of 6 max attempts with 1s, 2s, 4s, 8s and 16s wait time in between.
+         */
+        @JvmStatic
+        fun createExponential(message: String): CryptoThrottlingException =
+            CryptoThrottlingException(message, null, createExponentialBackoff())
+
+        /**
+         * Creates an instance of the exception with the message, cause
+         * and default exponential backoff of 6 max attempts with 1s, 2s, 4s, 8s and 16s wait time in between.
+         */
+        @JvmStatic
+        fun createExponential(message: String, cause: Throwable?): CryptoThrottlingException =
+            CryptoThrottlingException(message, cause, createExponentialBackoff())
+
+        /**
+         * Creates an instance of the exception with the message and customized exponential backoff.
+         */
+        @JvmStatic
+        fun createExponential(message: String, maxAttempts: Int, initialBackoff: Long): CryptoThrottlingException =
+            CryptoThrottlingException(message, null, createExponentialBackoff(maxAttempts, initialBackoff))
+
+        /**
+         * Creates an instance of the exception with the message, cause and customized exponential backoff.
+         */
+        @JvmStatic
+        fun createExponential(
+            message: String,
+            cause: Throwable?,
+            maxAttempts: Int,
+            initialBackoff: Long
+        ): CryptoThrottlingException =
+            CryptoThrottlingException(message, cause, createExponentialBackoff(maxAttempts, initialBackoff))
+
+        private fun createLinearBackoff(): List<Long> =
+            createBackoff(3, listOf(200L))
+
+        private fun createExponentialBackoff(): List<Long> =
+            createExponentialBackoff(6, 1000L)
+
+        private fun createExponentialBackoff(maxAttempts: Int, initialBackoff: Long): List<Long> = when {
+            maxAttempts <= 1 -> emptyList()
+            else -> {
+                var next = initialBackoff
+                List(maxAttempts - 1) {
+                    val current = next
+                    next *= 2
+                    current
+                }
+            }
+        }
+
+        private fun createBackoff(maxAttempts: Int, backoff: List<Long>): List<Long> = when {
+            maxAttempts <= 1 -> emptyList()
+            backoff.isEmpty() -> createBackoff(maxAttempts, listOf(0L))
+            else -> List(maxAttempts - 1) {
+                    if (it < backoff.size) {
+                        backoff[it]
+                    } else {
+                        backoff[backoff.size - 1]
+                    }
+                }
+        }
+    }
+
+    private val backoff: List<Long>
+
+    /**
+     * Creates an instance of the exception with the message
+     * and linear backoff of 3 max attempts with 200 milliseconds wait time in between.
+     */
+    constructor(message: String) : super(message,true) {
+        this.backoff = createLinearBackoff()
+    }
+
+    /**
+     * Creates an instance of the exception with the message
+     * and specified backoff. The number of max attempts would be the size of the array plus 1.
+     */
+    constructor(message: String, backoff: List<Long>) : super(message, true) {
+        this.backoff = backoff
+    }
+
+    /**
+     * Creates an instance of the exception with the message, cause
+     * and linear backoff of 3 max attempts with 200 milliseconds wait time in between.
+     */
+    constructor(message: String, cause: Throwable?) : super(message, true, cause) {
+        this.backoff = createLinearBackoff()
+    }
+
+    /**
+     * Creates an instance of the exception with the message, cause, and specified backoff.
+     * The number of max attempts would be the size of the array plus 1.
+     */
+    constructor(message: String, cause: Throwable?, backoff: List<Long>) : super(message, true, cause) {
+        this.backoff = backoff
+    }
+
+    open fun getBackoff(attempt: Int): Long =
+        if (attempt < 1 || attempt > backoff.size) {
+            -1
+        } else {
+            backoff[attempt - 1]
+        }
+}

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingException.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingException.kt
@@ -1,6 +1,5 @@
 package net.corda.crypto.cipher.suite
 
-import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.exceptions.CryptoException
 
 

--- a/libs/crypto/cipher-suite/src/test/java/net/corda/crypto/cipher/suite/CryptoThrottlingExceptionJavaApiTest.java
+++ b/libs/crypto/cipher-suite/src/test/java/net/corda/crypto/cipher/suite/CryptoThrottlingExceptionJavaApiTest.java
@@ -1,0 +1,20 @@
+package net.corda.crypto.cipher.suite;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class CryptoThrottlingExceptionJavaApiTest {
+    @Test
+    public void canCreateExceptions() {
+        assertNotNull(CryptoThrottlingException.createExponential("error"));
+        assertNotNull(CryptoThrottlingException.createExponential("error", new RuntimeException()));
+        assertNotNull(CryptoThrottlingException.createExponential("error", 6, 1000));
+        assertNotNull(CryptoThrottlingException.createExponential(
+                "error",
+                new RuntimeException(),
+                6,
+                1000)
+        );
+    }
+}

--- a/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingExceptionTests.kt
+++ b/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/CryptoThrottlingExceptionTests.kt
@@ -1,0 +1,124 @@
+package net.corda.crypto.cipher.suite
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class CryptoThrottlingExceptionTests {
+    @Test
+    fun `Should return default linear backoff with message only`() {
+        val e =  CryptoThrottlingException("Something wrong.")
+        assertNull(e.cause)
+        var backoff = e.getBackoff(1)
+        assertEquals(200L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(200L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(-1L, backoff)
+    }
+
+    @Test
+    fun `Should return customized backoff with message only`() {
+        val e =  CryptoThrottlingException("Something wrong.", listOf(100, 200))
+        assertNull(e.cause)
+        var backoff = e.getBackoff(1)
+        assertEquals(100L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(200L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(-1L, backoff)
+    }
+
+    @Test
+    fun `Should return default linear backoff with message and cause`() {
+        val cause = RuntimeException()
+        val e =  CryptoThrottlingException("Something wrong.", cause)
+        assertSame(cause, e.cause)
+        var backoff = e.getBackoff(1)
+        assertEquals(200L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(200L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(-1L, backoff)
+    }
+
+    @Test
+    fun `Should return customized backoff with message and cause`() {
+        val cause = RuntimeException()
+        val e =  CryptoThrottlingException("Something wrong.", cause, listOf(100, 200))
+        assertSame(cause, e.cause)
+        var backoff = e.getBackoff(1)
+        assertEquals(100L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(200L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(-1L, backoff)
+    }
+
+    @Test
+    fun `Should return default exponential backoff with message only`() {
+        val e =  CryptoThrottlingException.createExponential("Something wrong.")
+        assertNull(e.cause)
+        var backoff = e.getBackoff(1,)
+        assertEquals(1000L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(2000L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(4000L, backoff)
+        backoff = e.getBackoff(4)
+        assertEquals(8000L, backoff)
+        backoff = e.getBackoff(5)
+        assertEquals(16000L, backoff)
+        backoff = e.getBackoff(6)
+        assertEquals(-1, backoff)
+    }
+
+    @Test
+    fun `Should return customized exponential backoff with message only`() {
+        val e =  CryptoThrottlingException.createExponential("Something wrong.", 4, 3000)
+        assertNull(e.cause)
+        var backoff = e.getBackoff(1)
+        assertEquals(3000L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(6000L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(12000L, backoff)
+        backoff = e.getBackoff(4)
+        assertEquals(-1, backoff)
+    }
+
+    @Test
+    fun `Should return default exponential backoff with message and cause`() {
+        val cause = RuntimeException()
+        val e =  CryptoThrottlingException.createExponential("Something wrong.", cause)
+        assertSame(cause, e.cause)
+        var backoff = e.getBackoff(1)
+        assertEquals(1000L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(2000L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(4000L, backoff)
+        backoff = e.getBackoff(4)
+        assertEquals(8000L, backoff)
+        backoff = e.getBackoff(5)
+        assertEquals(16000L, backoff)
+        backoff = e.getBackoff(6)
+        assertEquals(-1, backoff)
+    }
+
+    @Test
+    fun `Should return customized exponential backoff with message and cause`() {
+        val cause = RuntimeException()
+        val e =  CryptoThrottlingException.createExponential("Something wrong.", cause, 4, 3000)
+        assertSame(cause, e.cause)
+        var backoff = e.getBackoff(1)
+        assertEquals(3000L, backoff)
+        backoff = e.getBackoff(2)
+        assertEquals(6000L, backoff)
+        backoff = e.getBackoff(3)
+        assertEquals(12000L, backoff)
+        backoff = e.getBackoff(4)
+        assertEquals(-1, backoff)
+    }
+}

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoRetryException.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoRetryException.kt
@@ -1,0 +1,24 @@
+package net.corda.crypto.core
+
+import net.corda.v5.crypto.exceptions.CryptoException
+
+/**
+ * Signals that the transient fault handling was attempted but wasn't successful as such
+ * the operation cannot be retried anymore.
+ */
+class CryptoRetryException : CryptoException {
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message The detailed message.
+     */
+    constructor(message: String) : super(message)
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message The detailed message.
+     * @param cause The cause.
+     */
+    constructor(message: String, cause: Throwable?) : super(message, cause)
+}

--- a/libs/crypto/crypto-core/src/test/kotlin/net/corda/crypto/core/CryptoExceptionsUtilsTests.kt
+++ b/libs/crypto/crypto-core/src/test/kotlin/net/corda/crypto/core/CryptoExceptionsUtilsTests.kt
@@ -1,7 +1,6 @@
 package net.corda.crypto.core
 
 import net.corda.v5.crypto.exceptions.CryptoException
-import net.corda.v5.crypto.exceptions.CryptoRetryException
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/decorators/CryptoServiceThrottlingDecorator.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/decorators/CryptoServiceThrottlingDecorator.kt
@@ -2,6 +2,7 @@ package net.corda.crypto.impl.decorators
 
 import net.corda.crypto.cipher.suite.CryptoService
 import net.corda.crypto.cipher.suite.CryptoServiceExtensions
+import net.corda.crypto.cipher.suite.CryptoThrottlingException
 import net.corda.crypto.cipher.suite.GeneratedKey
 import net.corda.crypto.cipher.suite.KeyGenerationSpec
 import net.corda.crypto.cipher.suite.SharedSecretSpec
@@ -9,7 +10,6 @@ import net.corda.crypto.cipher.suite.SigningSpec
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoException
-import net.corda.v5.crypto.exceptions.CryptoThrottlingException
 import org.slf4j.LoggerFactory
 import java.util.UUID
 

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/retrying/CryptoRetryingExecutor.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/retrying/CryptoRetryingExecutor.kt
@@ -1,8 +1,8 @@
 package net.corda.crypto.impl.retrying
 
+import net.corda.crypto.core.CryptoRetryException
 import net.corda.crypto.core.isRecoverable
 import net.corda.utilities.debug
-import net.corda.v5.crypto.exceptions.CryptoRetryException
 import org.slf4j.Logger
 import java.util.UUID
 

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/decorators/CryptoServiceDecoratorTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/decorators/CryptoServiceDecoratorTests.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.CRYPTO_CATEGORY
 import net.corda.crypto.cipher.suite.CRYPTO_TENANT_ID
 import net.corda.crypto.cipher.suite.CryptoService
 import net.corda.crypto.cipher.suite.CryptoServiceExtensions
+import net.corda.crypto.cipher.suite.CryptoThrottlingException
 import net.corda.crypto.cipher.suite.GeneratedKey
 import net.corda.crypto.cipher.suite.KeyGenerationSpec
 import net.corda.crypto.cipher.suite.SharedSecretSpec
@@ -15,7 +16,6 @@ import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoException
 import net.corda.v5.crypto.exceptions.CryptoRetryException
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
-import net.corda.v5.crypto.exceptions.CryptoThrottlingException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/decorators/CryptoServiceDecoratorTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/decorators/CryptoServiceDecoratorTests.kt
@@ -12,9 +12,9 @@ import net.corda.crypto.cipher.suite.SigningSpec
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import net.corda.crypto.cipher.suite.schemes.RSA_TEMPLATE
 import net.corda.crypto.core.CryptoConsts
+import net.corda.crypto.core.CryptoRetryException
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoException
-import net.corda.v5.crypto.exceptions.CryptoRetryException
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/retrying/CryptoRetryingExecutorsTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/retrying/CryptoRetryingExecutorsTests.kt
@@ -1,7 +1,7 @@
 package net.corda.crypto.impl.retrying
 
+import net.corda.crypto.core.CryptoRetryException
 import net.corda.v5.crypto.exceptions.CryptoException
-import net.corda.v5.crypto.exceptions.CryptoRetryException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows


### PR DESCRIPTION
Internalizes `corda-api` crypto types which should be internal.

- moves `CryptoThrottlingException` from corda-api repo
- moves `CryptoRetryException` from corda-api repo