### PR TITLE
CORE-11044: Check member status in the database instead of Kafka

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandler.kt
@@ -18,6 +18,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.impl.registration.staticnetwork.cache.GroupParametersCache
+import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
@@ -80,7 +81,8 @@ class RegistrationServiceLifecycleHandler(
                 setOf(
                     LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
                     LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
-                    LifecycleCoordinatorName.forComponent<HSMRegistrationClient>()
+                    LifecycleCoordinatorName.forComponent<MembershipQueryClient>(),
+                    LifecycleCoordinatorName.forComponent<HSMRegistrationClient>(),
                 )
             )
         }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -17,6 +17,7 @@ import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.impl.registration.staticnetwork.TestUtils.Companion.configs
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
+import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.publisher.Publisher
@@ -82,6 +83,7 @@ class RegistrationServiceLifecycleHandlerTest {
     private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider> {
         on { getGroupReader(any()) } doReturn mock()
     }
+    private val membershipQueryClient = mock<MembershipQueryClient>()
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock {
         on { createAvroSerializer<Any>(any()) } doReturn mock()
     }
@@ -105,6 +107,7 @@ class RegistrationServiceLifecycleHandlerTest {
         virtualNodeInfoReadService,
         mock(),
         membershipGroupReaderProvider,
+        membershipQueryClient,
     )
 
     private val registrationServiceLifecycleHandler = RegistrationServiceLifecycleHandler(
@@ -272,6 +275,7 @@ class RegistrationServiceLifecycleHandlerTest {
             addDependency<GroupPolicyProvider>()
             addDependency<ConfigurationReadService>()
             addDependency<HSMRegistrationClient>()
+            addDependency<MembershipQueryClient>()
             addDependency(subName)
 
             val staticMemberRegistrationService = StaticMemberRegistrationService(
@@ -293,6 +297,7 @@ class RegistrationServiceLifecycleHandlerTest {
                 virtualNodeInfoReadService,
                 mock(),
                 membershipGroupReaderProvider,
+                membershipQueryClient,
             )
 
             val handle = RegistrationServiceLifecycleHandler(staticMemberRegistrationService)

--- a/processors/member-processor/build.gradle
+++ b/processors/member-processor/build.gradle
@@ -9,6 +9,7 @@ description 'Member Processor'
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:osgi.annotation"
+    compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'


### PR DESCRIPTION
When we get the registration request, the compacted topic that holds the member info might have yet to get the snapshot. This change will check if there are any previous successful registration requests instead. 

This should affect the static network only.

Tested a few times using:
```
cd ~/corda-runtime-os
./applications/tools/p2p-test/app-simulator/scripts/deploy.sh yift-cluster-a
kubectl port-forward --namespace yift-cluster-a deployment/corda-rest-worker 8888

----
cd ~/corda-non-functional-test/
scripts/build_cpi.sh
./gradlew test -Dcorda.namespace="yift-cluster-a" -Dtest.duration=PT3M --tests="*MembershipWorkerFailureTests*"
```
And all the tests passed