### PR TITLE
CORE-11196: dont swap branch for tag build on downstream jobs

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -70,7 +70,7 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) { // CHANGE_ID only populated in PRs
+                    if ((params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) && env.TAG_NAME == null ) {  // CHANGE_ID only populated in PRs
                         echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -70,7 +70,7 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if ((params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) && env.TAG_NAME == null ) {  // CHANGE_ID only populated in PRs
+                     if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null && env.TAG_NAME == null ) {
                         echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -70,7 +70,7 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                     if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null && env.TAG_NAME == null ) {
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null && env.TAG_NAME == null ) { // CHANGE_ID only populated in PRs
                         echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {


### PR DESCRIPTION
Ensure when creating a release of C5 we don't attempt to swap branches for tag build - as this will fail, a downstream tag of e2e test should just use the head of that tag