### PR TITLE
CORE-11199 - remove failed migrations from "vnode.operationInProgress"

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/VirtualNodeUpgradeRejectedException.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/exception/VirtualNodeUpgradeRejectedException.kt
@@ -2,4 +2,4 @@ package net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception
 
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
-class VirtualNodeUpgradeRejectedException(val reason: String, val requestId: String) : CordaRuntimeException("$reason (request $requestId)")
+class VirtualNodeUpgradeRejectedException(val reason: String, requestId: String) : CordaRuntimeException("$reason (request $requestId)")

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -63,6 +63,14 @@ internal class VirtualNodeUpgradeOperationHandler(
         return null
     }
 
+    /**
+     * If migrations have failed, we do not roll back the changes to the VirtualNode entity. We remove the operationInProgress (since there
+     * is no longer an active operation). Some migrations could have run on the vault, while others may have failed. In this situation, the
+     * virtual node operator is restricted from transitioning the virtual node to "ACTIVE" state because the vault won't be in sync with
+     * the currently associated CPI. In this situation, it is up to DB admin to correct the vault using liquibase commands to manually run
+     * migrations. Alternatively, if the migrations failed due to some internal server error, the virtual node operator can re-trigger the
+     * upgrade and have corda re-attempt the migrations.
+     */
     private fun handleMigrationsFailed(
         request: VirtualNodeUpgradeRequest,
         requestId: String,

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -327,8 +327,7 @@ class VirtualNodeRepositoryTest {
         }
 
         assertThat(foundEntity).isNotNull
-        assertThat(foundEntity.operationInProgress).isNotNull
-        assertThat(foundEntity.operationInProgress!!.id).isEqualTo(operationId)
+        assertThat(foundEntity.operationInProgress).isNull()
 
         val foundOperation = entityManagerFactory.createEntityManager().transaction {
             it.find(VirtualNodeOperationEntity::class.java, operationId)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/dto/VirtualNodeOperationDto.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/dto/VirtualNodeOperationDto.kt
@@ -1,0 +1,17 @@
+package net.corda.libs.virtualnode.datamodel.dto
+
+import java.time.Instant
+
+/**
+ * DTO to capture virtual node operations.
+ */
+data class VirtualNodeOperationDto(
+    val requestId: String,
+    val requestData: String,
+    val operationType: String,
+    val requestTimestamp: Instant,
+    val latestUpdateTimestamp: Instant?,
+    val heartbeatTimestamp: Instant?,
+    val state: String,
+    val errors: String?
+)

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -8,6 +8,7 @@ import net.corda.virtualnode.VirtualNodeInfo
 import java.util.UUID
 import java.util.stream.Stream
 import javax.persistence.EntityManager
+import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationDto
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
 
 /**
@@ -23,6 +24,11 @@ interface VirtualNodeRepository {
      * Find a virtual node identified by the given holdingIdentity short hash
      */
     fun find(entityManager: EntityManager, holdingIdentityShortHash: ShortHash): VirtualNodeInfo?
+
+    /**
+     * Find a virtual node operation by the given operation requestId
+     */
+    fun findVirtualNodeOperationByRequestId(entityManager: EntityManager, requestId: String) : List<VirtualNodeOperationDto>
 
     /**
      * Persist a holding identity with the given holdingId and CPI.

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -15,6 +15,7 @@ import net.corda.virtualnode.VirtualNodeInfo
 import java.util.UUID
 import java.util.stream.Stream
 import javax.persistence.EntityManager
+import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationDto
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationState
@@ -54,6 +55,31 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
             .resultList
             .singleOrNull()
             ?.toVirtualNodeInfo()
+    }
+
+    override fun findVirtualNodeOperationByRequestId(entityManager: EntityManager, requestId: String): List<VirtualNodeOperationDto> {
+        entityManager.transaction {
+            val operationStatuses = entityManager.createQuery(
+                "from ${VirtualNodeOperationEntity::class.java.simpleName} where requestId = :requestId " +
+                        "order by latestUpdateTimestamp desc",
+                VirtualNodeOperationEntity::class.java
+            )
+                .setParameter("requestId", requestId)
+                .resultList
+
+            return operationStatuses.map {
+                VirtualNodeOperationDto(
+                    it.requestId,
+                    it.data,
+                    it.operationType.name,
+                    it.requestTimestamp,
+                    it.latestUpdateTimestamp,
+                    it.heartbeatTimestamp,
+                    it.state.name,
+                    it.errors
+                )
+            }
+        }
     }
 
     /**
@@ -208,7 +234,9 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
         failedOperation.latestUpdateTimestamp = Instant.now()
         failedOperation.state = VirtualNodeOperationState.MIGRATIONS_FAILED
         failedOperation.errors = reason
+        virtualNode.operationInProgress = null
 
+        entityManager.merge(failedOperation)
         entityManager.merge(virtualNode)
     }
 


### PR DESCRIPTION
Previously, if migrations failed, we would leave the operationInProgress, but this prevents further attempts to upgrade to rectify the situation.

This allows the following situation:
1. Performs an upgrade
2. Upgrade fails during migrations
3. attempts upgrade again or upgrade to an even newer version