### PR TITLE
CORE-9865 Creation of InterOpFacade Processor - sending additional seed messages

### DIFF
--- a/components/interop/interop-service/src/integrationTest/kotlin/net/corda/interop/service/integration/InteropServiceIntegrationTest.kt
+++ b/components/interop/interop-service/src/integrationTest/kotlin/net/corda/interop/service/integration/InteropServiceIntegrationTest.kt
@@ -179,7 +179,7 @@ class InteropServiceIntegrationTest {
         clearHostedIdsSub.close()
 
         interopService.start()
-        val memberExpectedOutputMessages = 4
+        val memberExpectedOutputMessages = 5
         val memberMapperLatch = CountDownLatch(memberExpectedOutputMessages)
         val memberProcessor = MemberInfoMessageCounter(memberMapperLatch, memberExpectedOutputMessages)
         val memberOutSub = subscriptionFactory.createDurableSubscription(
@@ -194,7 +194,7 @@ class InteropServiceIntegrationTest {
         //As this is a test of temporary code, relaxing check on getting more messages
         memberOutSub.close()
 
-        val hostedIdsExpected = 2
+        val hostedIdsExpected = 3
         val hostedIdMapperLatch = CountDownLatch(hostedIdsExpected)
         val hostedIdProcessor = HostedIdentitiesMessageCounter(hostedIdMapperLatch, hostedIdsExpected)
         val hostedIdOutSub = subscriptionFactory.createDurableSubscription(

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -48,22 +48,30 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
         private val ALICE_ALTER_EGO_X500 = MemberX500Name.parse("CN=Alice Alter Ego, O=Alice Alter Ego Corp, L=LDN, C=GB")
         private val ALICE_X500 = MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB")
         private const val INTEROP_GROUP_ID = "3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08"
+        private const val NON_EXISTING_GROUP_ID = "non-existing-group"
         private const val SUBSYSTEM = "interop"
         private val DUMMY_CERTIFICATE =
             this::class.java.getResource("/dummy_certificate.pem")?.readText()
         private val DUMMY_PUBLIC_SESSION_KEY =
             this::class.java.getResource("/dummy_session_key.pem")?.readText()
-        private val memberList =
+        private val membersOfInteropGroup =
             listOf(ALICE_X500, ALICE_ALTER_EGO_X500).map { HoldingIdentity(it, INTEROP_GROUP_ID) }
+        private val memberFromOtherClusterOfInteropGroup =
+            HoldingIdentity(MemberX500Name.parse("CN=Alice from Other Cluster, O=Alice Corp, L=LDN, C=GB"), INTEROP_GROUP_ID)
+        private val unpublishedMemberOfInteropGroup =
+            HoldingIdentity(MemberX500Name.parse("CN=Jonny, O=R3, L=LDN, C=GB"), INTEROP_GROUP_ID)
+        private val membersOfNonExistingGroup =
+            listOf(ALICE_X500, ALICE_ALTER_EGO_X500).map { HoldingIdentity(it, NON_EXISTING_GROUP_ID) }
     }
 
     //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
     override fun createDummyMemberInfo(): List<Record<String, PersistentMemberInfo>> =
-        createDummyMemberInfo(memberList, INTEROP_GROUP_ID)
+        createDummyMemberInfo(membersOfInteropGroup + listOf(memberFromOtherClusterOfInteropGroup), INTEROP_GROUP_ID) +
+            createDummyMemberInfo(membersOfNonExistingGroup, NON_EXISTING_GROUP_ID)
 
     //Below method is to push the dummy interops member data to MEMBER_LIST_TOPIC
     override fun createDummyHostedIdentity(): List<Record<String, HostedIdentityEntry>> =
-        createDummyHostedIdentity(memberList)
+        createDummyHostedIdentity(membersOfInteropGroup) + createDummyHostedIdentity(listOf(membersOfNonExistingGroup[0]))
 
     private fun createDummyMemberInfo(identities : List<HoldingIdentity>, groupId: String): List<Record<String, PersistentMemberInfo>> {
         val memberInfoList = mutableListOf<Record<String, PersistentMemberInfo>>()
@@ -154,6 +162,14 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
             )
 
         return listOf(
-            createRecord("seed-message-correct-1", memberList[0], memberList[1]))
+            createRecord("seed-message-correct-1", membersOfInteropGroup[0], membersOfInteropGroup[1]),
+            createRecord("seed-message-no-policy-1", membersOfNonExistingGroup[0], membersOfNonExistingGroup[1]),
+            // In the last two records the intended destination is put as source of the message,
+            // as InteropProcessor will swap destination with source before sending it to LinkManager,
+            // this message is for unpublished HoldingIdentity (unknown destination)...
+            createRecord("seed-message-no-dest-1", membersOfInteropGroup[0], unpublishedMemberOfInteropGroup),
+            // ... this message is for the destination from other cluster( HoldingIdentity is not hosted locally).
+            createRecord("seed-message-other-cluster-1", membersOfInteropGroup[0], memberFromOtherClusterOfInteropGroup),
+            )
     }
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -131,9 +131,6 @@ internal class OutboundMessageProcessor(
     }
 
     private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
-        //TODO new log statement added temporarily for Interop Team, revert to debug as part of CORE-10683
-        logger.info("Processing outbound message ${message.header.messageId} from ${message.header.source} " +
-                "to ${message.header.destination}.")
 
         val discardReason = checkSourceAndDestinationValid(
             message.header.source, message.header.destination
@@ -160,8 +157,9 @@ internal class OutboundMessageProcessor(
             val source = message.header.source.toCorda()
             val groupPolicy = groupPolicyProvider.getGroupPolicy(source)
             if (groupPolicy == null) {
+                //TODO extended warn statement added temporarily for Interop Team, revert to debug as part of CORE-10683
                 logger.warn(
-                    "Could not find the group information in the GroupPolicyProvider for $source. " +
+                    "Could not find the group information in the GroupPolicyProvider for $source to ${message.header.destination}. " +
                     "The message ${message.header.messageId} was discarded."
                 )
                 return emptyList()


### PR DESCRIPTION
Added 2 new seed messages to trigger search for and usage of InteropGroupPolicy 1) the hardcoded interop policy if found and the message is sent to gateway, 2) the group policy id doesn't match and message is dropped. Imporved logs in LinkManager-  log  only 1 statement for a decision about an incmping message, a duplicated entry  (start) "Processing outbound" removed.

Sample logs :
```
cd corda-bob-p2p-link-manager-worker-954749987-nnp22
cat logs.txt| grep -e Dropping -e Sending -e "discarded."  -e "interop" -b3 | cut -d] -f3-
```
The logs were further trimmed of class name et just to show log message.
An outbound message is match with interoperability group (there  is not "normal" group and there is no VitualNode):
```
Could not get virtual node info for holding identity [HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08)]
Could not get CPI metadata for holding identity [HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08)] and CPI with identifier [null]. Any updates to the group policy will be processed later.
Searching for interoperability group for HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08)
Sending outbound message 2 to {"x500Name": "CN=Alice from Other Cluster, O=Alice Corp, L=LDN, C=GB", "groupId": "3dfc0aae-be7c-44c2-aa4f-4d0d7145cf08"} for http://localhost:8080.
```
Neither there is no VirtualNode, nor matching interop group policy id (`groupId=non-existing-group`), the message is dropped:
```
Could not get virtual node info for holding identity [HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=non-existing-group)]
Could not get CPI metadata for holding identity [HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=non-existing-group)] and CPI with identifier [null]. Any updates to the group policy will be processed later.
Searching for interoperability group for HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=non-existing-group)
Could not get interop group policy for holding identity [HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=non-existing-group)].
Could not find the group information in the GroupPolicyProvider for HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=non-existing-group) to {"x500Name": "CN=Alice Alter Ego, O=Alice Alter Ego Corp, L=LDN, C=GB", "groupId": "non-existing-group"}. 
   The message 2 was discarded.
```