### PR TITLE
CORE-10427 - Alias Identity Mapper

### DIFF
--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -78,7 +78,7 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                 KeyValuePair(SOFTWARE_VERSION, "5.0.0.0-Fox10-RC03"),
                 KeyValuePair(PLATFORM_VERSION, "5000"),
                 KeyValuePair(INTEROP_ROLE, "interop"),
-                KeyValuePair(INTEROP_ALIAS_MAPPING, "O=Alice,L=London,C=GB@Gold"),
+                KeyValuePair(INTEROP_ALIAS_MAPPING, "O=Alice,L=London,C=GB"),
                 //TODO : Following info may not be required for interops group,
                 // need to investigate that LinkManager is happy without this info.
 //            KeyValuePair(MEMBER_CPI_NAME, "calculator.cpi"),

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -78,7 +78,7 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                 KeyValuePair(SOFTWARE_VERSION, "5.0.0.0-Fox10-RC03"),
                 KeyValuePair(PLATFORM_VERSION, "5000"),
                 KeyValuePair(INTEROP_ROLE, "interop"),
-                KeyValuePair(INTEROP_ALIAS_MAPPING, "O=Alice,L=London,C=GB"),
+                KeyValuePair(INTEROP_ALIAS_MAPPING, "O=Alice,L=London,C=GB"),// Incomplete value, missing GroupId for testing purposes
                 //TODO : Following info may not be required for interops group,
                 // need to investigate that LinkManager is happy without this info.
 //            KeyValuePair(MEMBER_CPI_NAME, "calculator.cpi"),

--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/service/impl/HardcodedInteropMemberRegistrationService.kt
@@ -12,6 +12,8 @@ import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.interop.service.InteropMemberRegistrationService
 import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.INTEROP_ALIAS_MAPPING
+import net.corda.membership.lib.MemberInfoExtension.Companion.INTEROP_ROLE
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_SIGNATURE_SPEC
@@ -75,6 +77,8 @@ class HardcodedInteropMemberRegistrationService @Activate constructor(
                 KeyValuePair(LEDGER_KEY_SIGNATURE_SPEC.format(0), "SHA256withECDSA"),
                 KeyValuePair(SOFTWARE_VERSION, "5.0.0.0-Fox10-RC03"),
                 KeyValuePair(PLATFORM_VERSION, "5000"),
+                KeyValuePair(INTEROP_ROLE, "interop"),
+                KeyValuePair(INTEROP_ALIAS_MAPPING, "O=Alice,L=London,C=GB@Gold"),
                 //TODO : Following info may not be required for interops group,
                 // need to investigate that LinkManager is happy without this info.
 //            KeyValuePair(MEMBER_CPI_NAME, "calculator.cpi"),

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -147,6 +147,11 @@ class MemberInfoExtension {
          */
         const val INTEROP_SERVICE_NAME = "corda.interop.service.name"
 
+        /**
+         * Interop alias identity mapping
+         */
+        const val INTEROP_ALIAS_MAPPING = "corda.interop.mapping"
+
 
         /** Key name for TLS certificate subject. */
         const val TLS_CERTIFICATE_SUBJECT = "corda.tls.certificate.subject"

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -150,7 +150,7 @@ class MemberInfoExtension {
         /**
          * Interop alias identity mapping
          */
-        const val INTEROP_ALIAS_MAPPING = "corda.interop.mapping"
+        const val INTEROP_ALIAS_MAPPING = "corda.interop.alias.identity"
 
 
         /** Key name for TLS certificate subject. */


### PR DESCRIPTION
Translating the alias into it’s underlying holding identity to enable it to start a flow in the flow processor. Alias Mapping is only required in the direction of Alias to underlying Holding Identity. This involves adding mapping information to the Alias's MemberInfo.