### PR TITLE
CORE-11243: Configure Quasar to ignore Lifecycle and Security Manager.

### DIFF
--- a/components/security-manager/build.gradle
+++ b/components/security-manager/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compileOnly "org.osgi:osgi.annotation"
     compileOnly "org.osgi:osgi.core"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":components:configuration:configuration-read-service")

--- a/components/security-manager/src/main/java/net/corda/securitymanager/package-info.java
+++ b/components/security-manager/src/main/java/net/corda/securitymanager/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.securitymanager;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorFactoryImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorFactoryImpl.kt
@@ -18,9 +18,8 @@ class LifecycleCoordinatorFactoryImpl @Activate constructor(
     @Reference
     private val registry: LifecycleRegistryCoordinatorAccess,
     @Reference
-    private val schedulerFactory: LifecycleCoordinatorSchedulerFactory,
-
-    ) : LifecycleCoordinatorFactory {
+    private val schedulerFactory: LifecycleCoordinatorSchedulerFactory
+) : LifecycleCoordinatorFactory {
 
     override fun createCoordinator(
         name: LifecycleCoordinatorName,

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorSchedulerFactoryImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorSchedulerFactoryImpl.kt
@@ -8,7 +8,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 
-@Component(service = [LifecycleCoordinatorSchedulerFactory::class], immediate = true)
+@Component(service = [ LifecycleCoordinatorSchedulerFactory::class ])
 class LifecycleCoordinatorSchedulerFactoryImpl @Activate constructor(): LifecycleCoordinatorSchedulerFactory {
     /**
      * The executor on which events are processed. Note that all events should be processed on an executor thread,

--- a/libs/lifecycle/lifecycle/build.gradle
+++ b/libs/lifecycle/lifecycle/build.gradle
@@ -7,6 +7,7 @@ description "Lifecycle API"
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'

--- a/libs/lifecycle/lifecycle/src/main/java/net/corda/lifecycle/package-info.java
+++ b/libs/lifecycle/lifecycle/src/main/java/net/corda/lifecycle/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.lifecycle;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Do not allow Quasar to instrument "immediate" OSGi components, specifically Lifecycle and Security Manager ones. These components may activate before the `co.paralleluniverse.quasar-core` bundle has started, which means that the OSGi framework will not be able to find the `SuspendExecution` class required by any Quasar instrumentation.

Components which already implicitly reference Quasar classes _before_ Quasar instruments them do not have this problem.