### PR TITLE
CORE-8744 Align Cpi related entities and repository with latest JPA guidance

### DIFF
--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiEntities.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiEntities.kt
@@ -2,8 +2,8 @@ package net.corda.libs.cpi.datamodel
 
 import net.corda.libs.cpi.datamodel.entities.CpiCpkEntity
 import net.corda.libs.cpi.datamodel.entities.CpiMetadataEntity
-import net.corda.libs.cpi.datamodel.entities.CpkDbChangeLogAuditEntity
-import net.corda.libs.cpi.datamodel.entities.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.entities.internal.CpkDbChangeLogAuditEntity
+import net.corda.libs.cpi.datamodel.entities.internal.CpkDbChangeLogEntity
 import net.corda.libs.cpi.datamodel.entities.internal.CpkFileEntity
 import net.corda.libs.cpi.datamodel.entities.CpkMetadataEntity
 

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogAuditEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogAuditEntity.kt
@@ -1,4 +1,4 @@
-package net.corda.libs.cpi.datamodel.entities
+package net.corda.libs.cpi.datamodel.entities.internal
 
 import java.time.Instant
 import javax.persistence.Column

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogEntity.kt
@@ -1,4 +1,4 @@
-package net.corda.libs.cpi.datamodel.entities
+package net.corda.libs.cpi.datamodel.entities.internal
 
 import java.io.Serializable
 import java.time.Instant

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/CpkDbChangeLogAuditRepositoryImpl.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/CpkDbChangeLogAuditRepositoryImpl.kt
@@ -2,7 +2,7 @@ package net.corda.libs.cpi.datamodel.repository
 
 import net.corda.libs.cpi.datamodel.CpkDbChangeLog
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogAudit
-import net.corda.libs.cpi.datamodel.entities.CpkDbChangeLogAuditEntity
+import net.corda.libs.cpi.datamodel.entities.internal.CpkDbChangeLogAuditEntity
 import javax.persistence.EntityManager
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogIdentifier
 

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/CpkDbChangeLogRepositoryImpl.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/CpkDbChangeLogRepositoryImpl.kt
@@ -3,8 +3,8 @@ package net.corda.libs.cpi.datamodel.repository
 import net.corda.libs.cpi.datamodel.CpkDbChangeLog
 import net.corda.libs.cpi.datamodel.CpkDbChangeLogIdentifier
 import net.corda.libs.cpi.datamodel.entities.CpiCpkEntity
-import net.corda.libs.cpi.datamodel.entities.CpkDbChangeLogEntity
-import net.corda.libs.cpi.datamodel.entities.CpkDbChangeLogKey
+import net.corda.libs.cpi.datamodel.entities.internal.CpkDbChangeLogEntity
+import net.corda.libs.cpi.datamodel.entities.internal.CpkDbChangeLogKey
 import net.corda.libs.packaging.core.CpiIdentifier
 import javax.persistence.EntityManager
 

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/CpkDbChangeLogRepositoryImpl.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/CpkDbChangeLogRepositoryImpl.kt
@@ -21,7 +21,7 @@ class CpkDbChangeLogRepositoryImpl: CpkDbChangeLogRepository {
         em: EntityManager,
         cpkFileChecksums: Set<String>
     ): List<CpkDbChangeLog> {
-        return cpkFileChecksums.chunked(100) { batch ->
+        return cpkFileChecksums.chunked(100).map { batch ->
             em.createQuery(
                 "FROM ${CpkDbChangeLogEntity::class.simpleName}" +
                         " WHERE id.cpkFileChecksum IN :cpkFileChecksums",
@@ -68,7 +68,7 @@ class CpkDbChangeLogRepositoryImpl: CpkDbChangeLogRepository {
     /**
      * Converts a data transport object to an entity.
      */
-    private fun CpkDbChangeLog.toEntity(): CpkDbChangeLogEntity =
+    private fun CpkDbChangeLog.toEntity() =
         CpkDbChangeLogEntity(id.toEntity(), content)
 
     private fun CpkDbChangeLogIdentifier.toEntity() =


### PR DESCRIPTION
Moved CpkDbChangeLogAuditEntity and CpkDbChangeLogEntity to an internal submodule so it is not exported by OSGi.

Fixed build issue related to OSGi after moving the entities to an internal submodule. Without this fix the error "error Export net.corda.libs.cpi.datamodel.repository, has 1, private references [net.corda.libs.cpi.datamodel.entities.internal]" is raised.