### PR TITLE
CORE-11213: update to 700 to avoid collision with beta2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.663-beta+
+cordaApiVersion=5.0.0.700-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
See https://github.com/corda/corda-api/pull/908 

bumping api version to 700 to avoid clashing versions now that beta2 branch has been cut 