### PR TITLE
CORE-1196: CI build fix for tags on downstream jobs

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -70,8 +70,8 @@ pipeline {
         stage('check out') {
             steps {
                 script {
-                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null) { // CHANGE_ID only populated in PRs
-                        echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
+                    if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null && env.TAG_NAME == null ) { // CHANGE_ID only populated in PRs
+		    	echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
                         if (env.CHANGE_ID) {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -71,7 +71,7 @@ pipeline {
             steps {
                 script {
                     if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null && env.TAG_NAME == null ) { // CHANGE_ID only populated in PRs
-		    	echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
+		    	        echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
                         if (env.CHANGE_ID) {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -71,7 +71,7 @@ pipeline {
             steps {
                 script {
                     if (params.COMMIT_TO_CHECKOUT && env.CHANGE_ID == null && env.TAG_NAME == null ) { // CHANGE_ID only populated in PRs
-		    	        echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
+                        echo "Checking out commit ID from upstream job ${params.COMMIT_TO_CHECKOUT}"
                         sh 'git checkout "$COMMIT_TO_CHECKOUT"'
                     } else {
                         if (env.CHANGE_ID) {


### PR DESCRIPTION
Patching https://github.com/corda/corda-runtime-os/pull/3284 into the beta2 branch, which did not make it pre-cut, needed for successful release activity. 