### PR TITLE
CORE-11213: dont clobber tag for unstable from beta2 branch

### DIFF
--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -134,7 +134,7 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('cliBaseTag')) {
         baseImageTag = cliBaseTag
     } else {
-        it.baseImageTag = (cordaCliIncluded) ? "latest-local" : "unstable"
+        it.baseImageTag = (cordaCliIncluded) ? "latest-local" : "unstable-Gecko"  // not to be merged back to release/os/5.0
     }
 
     if (project.hasProperty('useDockerDaemon')) {


### PR DESCRIPTION
ensure we consume the correct version of corda-cli base image for beta2 branch 

related PR must be merged first 
https://github.com/corda/corda-cli-plugin-host/pull/146 