### PR TITLE
CORE-11198 only remove CPIs locally not in a Jenkins env

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CpiLoader.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CpiLoader.kt
@@ -81,7 +81,10 @@ object CpiLoader {
             // Read CPI
             return cpiPath.readAll().inputStream()
         } finally {
-            tempDirectory.deleteRecursively()
+            // only remove in a local environment, not in Jenkins where JENKINS_URL is always set
+            if (System.getenv("JENKINS_URL") == null) {
+                tempDirectory.deleteRecursively()
+            }
         }
     }
 


### PR DESCRIPTION
Check for the presence of `JENKINS_URL` env var, which will always be present if running in Jenkins as its set by the system. if this is available, take no action otherwise, delete CPIs.

Change raised as there is an ask to keep CPIs in a Jenkins env and archive them as part of the build process. 

Tested against e2e repo here using artifact produced by this PR
https://ci02.dev.r3.com/job/Corda5/job/corda5-e2e-tests/job/PR-29/