### PR TITLE
CORE-9678 Hibernate errors during crypto worker startup

### DIFF
--- a/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/HSMStoreImpl.kt
+++ b/components/crypto/crypto-persistence-impl/src/main/kotlin/net/corda/crypto/persistence/impl/HSMStoreImpl.kt
@@ -20,6 +20,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import java.time.Instant
 import java.util.UUID
+import javax.persistence.EntityManager
 import javax.persistence.Tuple
 
 @Component(service = [HSMStore::class])
@@ -94,38 +95,42 @@ class HSMStoreImpl @Activate constructor(
             category: String,
             hsmId: String,
             masterKeyPolicy: MasterKeyPolicy
-        ): HSMAssociationInfo {
-            val association = findHSMAssociationEntity(tenantId, hsmId)
-                ?: createAndPersistAssociation(tenantId, hsmId, masterKeyPolicy)
-            val categoryAssociation = HSMCategoryAssociationEntity(
-                id = UUID.randomUUID().toString(),
-                tenantId = tenantId,
-                category = category,
-                timestamp = Instant.now(),
-                hsmAssociation = association,
-                deprecatedAt = 0
-            )
-            entityManagerFactory().transaction {
-                it.persist(categoryAssociation)
+        ): HSMAssociationInfo = entityManagerFactory().use {
+            it.transaction { em ->
+                val association =
+                    findHSMAssociationEntity(em, tenantId, hsmId)
+                        ?: createAndPersistAssociation(em, tenantId, hsmId, masterKeyPolicy)
+
+                val categoryAssociation = HSMCategoryAssociationEntity(
+                    id = UUID.randomUUID().toString(),
+                    tenantId = tenantId,
+                    category = category,
+                    timestamp = Instant.now(),
+                    hsmAssociation = association,
+                    deprecatedAt = 0
+                )
+
+                em.persist(categoryAssociation)
+                categoryAssociation.toHSMAssociation()
             }
-            return categoryAssociation.toHSMAssociation()
         }
 
         private fun findHSMAssociationEntity(
+            entityManager: EntityManager,
             tenantId: String,
             hsmId: String
-        ) = entityManagerFactory().use {
-            it.createQuery(
-            """
+        ) =
+            entityManager.createQuery(
+                """
             SELECT a 
             FROM HSMAssociationEntity a
             WHERE a.tenantId = :tenantId AND a.hsmId = :hsmId
             """.trimIndent(),
                 HSMAssociationEntity::class.java
             ).setParameter("tenantId", tenantId).setParameter("hsmId", hsmId).resultList.singleOrNull()
-        }
 
         private fun createAndPersistAssociation(
+            entityManager: EntityManager,
             tenantId: String,
             hsmId: String,
             masterKeyPolicy: MasterKeyPolicy
@@ -141,9 +146,8 @@ class HSMStoreImpl @Activate constructor(
                     null
                 }
             )
-            entityManagerFactory().transaction {
-                it.persist(association)
-            }
+
+            entityManager.persist(association)
             return association
         }
 


### PR DESCRIPTION
Following error is currently observed at crypto worker start up: 

`ERROR: duplicate key value violates unique constraint "crypto_hsm_category_association_uc"
  Detail: Key (tenant_id, category, deprecated_at)=(rpc-api, JWT_KEY, 0) already exists.
Failed to assign SOFT HSM for rpc-api:JWT_KEY `

This should be caused from DB find and persist calls not being transactional when it comes to `HSMStoreImpl.associate`.

- makes `HSMStoreImpl.associate` DB find and persist calls transactional