### PR TITLE
CORE-11411 - Disable temporarily tests failing due to revocation checks connectivity issues

### DIFF
--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -98,6 +98,7 @@ import org.assertj.core.api.Assertions.assertThatIterable
 import org.bouncycastle.jce.PrincipalUtil
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -242,6 +243,7 @@ class GatewayIntegrationTest : TestBase() {
     inner class ClientToGatewayTests {
         @Test
         @Timeout(30)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `gateway response to invalid request`() {
             val port = getOpenPort()
             val serverAddress = URI.create("https://www.alice.net:$port")
@@ -292,6 +294,7 @@ class GatewayIntegrationTest : TestBase() {
 
         @Test
         @Timeout(30)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `http client to gateway`() {
             alice.publish(Record(SESSION_OUT_PARTITIONS, sessionId, SessionPartitions(listOf(1))))
             val port = getOpenPort()
@@ -348,6 +351,7 @@ class GatewayIntegrationTest : TestBase() {
 
         @Test
         @Timeout(30)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `requests with extremely large payloads are rejected`() {
             alice.publish(Record(SESSION_OUT_PARTITIONS, sessionId, SessionPartitions(listOf(1))))
             val port = getOpenPort()
@@ -391,6 +395,7 @@ class GatewayIntegrationTest : TestBase() {
 
         @Test
         @Timeout(30)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `http client to gateway with ip address`() {
             alice.publish(Record(SESSION_OUT_PARTITIONS, sessionId, SessionPartitions(listOf(1))))
             val port = getOpenPort()
@@ -457,6 +462,7 @@ class GatewayIntegrationTest : TestBase() {
     inner class ReconfigurationTests {
         @Test
         @Timeout(100)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `gateway reconfiguration`() {
             val configurationCount = 3
             alice.publish(Record(SESSION_OUT_PARTITIONS, sessionId, SessionPartitions(listOf(1))))
@@ -577,6 +583,7 @@ class GatewayIntegrationTest : TestBase() {
     inner class MultipleClientsToGatewayTests {
         @Test
         @Timeout(60)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `multiple clients to gateway`() {
             val msgNumber = AtomicInteger(1)
             val clientNumber = 4
@@ -640,6 +647,7 @@ class GatewayIntegrationTest : TestBase() {
     inner class GatewayToMultipleServersTest {
         @Test
         @Timeout(60)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `gateway to multiple servers`() {
             val messageCount = 100
             val serversCount = 4
@@ -734,6 +742,7 @@ class GatewayIntegrationTest : TestBase() {
     inner class DualStreamTests {
         @Test
         @Timeout(60)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `gateway to gateway - dual stream`() {
             val aliceGatewayAddress = URI.create("https://www.chip.net:${getOpenPort()}")
             val bobGatewayAddress = URI.create("https://www.dale.net:${getOpenPort()}")
@@ -893,6 +902,7 @@ class GatewayIntegrationTest : TestBase() {
     inner class BadConfigurationTests {
         @Test
         @Timeout(120)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `Gateway can recover from bad configuration`() {
             val configPublisher = ConfigPublisher()
             val host = "www.alice.net"
@@ -1017,6 +1027,7 @@ class GatewayIntegrationTest : TestBase() {
 
         @Test
         @Timeout(120)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `key store can change dynamically`() {
             val aliceAddress = URI.create("https://www.alice.net:${getOpenPort()}")
             val bobAddress = URI.create("https://www.bob.net:${getOpenPort()}")
@@ -1170,6 +1181,7 @@ class GatewayIntegrationTest : TestBase() {
     inner class MutualTls {
         @Test
         @Timeout(60)
+        @Disabled("Disabling temporarily until CORE-11411 is completed.")
         fun `gateway to gateway - mutual TLS`() {
             val aliceGatewayAddress = URI.create("https://127.0.0.1:${getOpenPort()}")
             val bobGatewayAddress = URI.create("https://www.chip.net:${getOpenPort()}")

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
@@ -13,9 +13,11 @@ import net.corda.testing.p2p.certificates.Certificates
 import net.corda.utilities.concurrent.getOrThrow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.MockedConstruction
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -37,17 +39,21 @@ class RevocationCheckerTest {
             )
         } doReturn subscription
     }
-    private val mockDominoTile = Mockito.mockConstruction(RPCSubscriptionDominoTile::class.java) { _, context ->
-        @Suppress("UNCHECKED_CAST")
-        (context.arguments()[1] as  () -> RPCSubscription<RevocationCheckRequest, RevocationCheckResponse>)()
-    }
-    init {
-        RevocationChecker(subscriptionFactory, mock(), mock())
+    private var mockDominoTile: MockedConstruction<RPCSubscriptionDominoTile<*, *>>? = null
+    private var revocationChecker: RevocationChecker? = null
+
+    @BeforeEach
+    fun setup() {
+        mockDominoTile = Mockito.mockConstruction(RPCSubscriptionDominoTile::class.java) { _, context ->
+            @Suppress("UNCHECKED_CAST")
+            (context.arguments()[1] as  () -> RPCSubscription<RevocationCheckRequest, RevocationCheckResponse>)()
+        }
+        revocationChecker = RevocationChecker(subscriptionFactory, mock(), mock())
     }
 
     @AfterEach
     fun tearDown() {
-        mockDominoTile.close()
+        mockDominoTile?.close()
     }
 
     private val aliceCert = Certificates.aliceKeyStorePem.readText()

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
@@ -13,6 +13,7 @@ import net.corda.testing.p2p.certificates.Certificates
 import net.corda.utilities.concurrent.getOrThrow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
@@ -56,6 +57,7 @@ class RevocationCheckerTest {
     private val wrongTrustStore = listOf(Certificates.c4TruststoreCertificatePem.readText())
 
     @Test
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `valid certificate passes validation`() {
         val result = CompletableFuture<RevocationCheckResponse>()
         processor.firstValue.onNext(RevocationCheckRequest(listOf(aliceCert), trustStore, RevocationMode.HARD_FAIL), result)
@@ -70,6 +72,7 @@ class RevocationCheckerTest {
     }
 
     @Test
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `revoked certificate fails validation with HARD FAIL mode`() {
         val result = CompletableFuture<RevocationCheckResponse>()
         processor.firstValue.onNext(RevocationCheckRequest(listOf(revokedBobCert), trustStore, RevocationMode.HARD_FAIL), result)
@@ -77,6 +80,7 @@ class RevocationCheckerTest {
     }
 
     @Test
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `revoked certificate fails validation with SOFT FAIL mode`() {
         val resultFuture = CompletableFuture<RevocationCheckResponse>()
         processor.firstValue.onNext(RevocationCheckRequest(listOf(revokedBobCert), trustStore, RevocationMode.SOFT_FAIL), resultFuture)

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/HttpTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/HttpTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.net.URI
@@ -60,6 +61,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `simple client POST request`() {
         val listener = object : ListenerWithServer() {
             override fun onRequest(request: HttpRequest) {
@@ -97,6 +99,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `multiple clients multiple requests`() {
         val requestNo = 10
         val threadNo = 2
@@ -160,6 +163,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `large payload`() {
         val hugePayload = (1..0xA00_000)
             .map {
@@ -204,6 +208,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `tls handshake succeeds - revocation checking disabled C5`() {
         val listener = object : ListenerWithServer() {
             override fun onRequest(request: HttpRequest) {
@@ -241,6 +246,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `tls handshake succeeds - revocation checking disabled C4`() {
         val listener = object : ListenerWithServer() {
             override fun onRequest(request: HttpRequest) {
@@ -278,6 +284,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `tls handshake fails - server identity check fails C4`() {
         MitmServer(serverAddress.host, serverAddress.port, c4sslKeyStore).use { server ->
             server.start()
@@ -312,6 +319,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `tls handshake fails - server identity check fails C5`() {
         MitmServer(serverAddress.host, serverAddress.port, chipKeyStore).use { server ->
             server.start()
@@ -342,6 +350,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `tls handshake fails - requested SNI is not recognized`() {
 
         HttpServer(
@@ -388,6 +397,7 @@ class HttpTest : TestBase() {
 
     @Test
     @Timeout(30)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `tls handshake fails - server presents revoked certificate`() {
 
         HttpServer(

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -107,6 +107,7 @@ import org.bouncycastle.openssl.PEMKeyPair
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.mockito.kotlin.KStubbing
@@ -148,6 +149,7 @@ class P2PLayerEndToEndTest {
 
     @Test
     @Timeout(60)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `two hosts can exchange data messages over p2p using RSA keys`() {
         val numberOfMessages = 10
         val aliceId = Identity("O=Alice, L=London, C=GB", GROUP_ID, Certificates.aliceKeyStoreFile)
@@ -200,6 +202,7 @@ class P2PLayerEndToEndTest {
 
     @Test
     @Timeout(60)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `two hosts can exchange data messages over p2p with ECDSA keys`() {
         val numberOfMessages = 10
         val receiverId = Identity("O=Alice, L=London, C=GB", GROUP_ID, Certificates.receiverKeyStoreFile)
@@ -285,6 +288,7 @@ class P2PLayerEndToEndTest {
 
     @Test
     @Timeout(60)
+    @Disabled("Disabling temporarily until CORE-11411 is completed.")
     fun `messages with expired ttl have processed marker and ttl expired marker and no received marker`() {
         val numberOfMessages = 10
         val aliceId = Identity("O=Alice, L=London, C=GB", GROUP_ID, Certificates.aliceKeyStoreFile)


### PR DESCRIPTION
Disabling temporarily integration tests failing due to connectivity issues until we come back and investigate/address properly.