### PR TITLE
CORE-8638 Move getCpiMetadata, getCpkMetadata, getNumberOfComponentGroups, getSchemaVersion from TransactionMetadata to impl

### DIFF
--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualTransactionBuilderImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.consensual.flow.impl.transaction
 
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.test.dummyCpkSignerSummaryHash
 import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.ledger.consensual.testkit.ConsensualStateClassExample
@@ -57,8 +58,8 @@ internal class ConsensualTransactionBuilderImplTest: ConsensualLedgerTest() {
             .withStates(consensualStateExample)
             .toSignedTransaction() as ConsensualSignedTransactionImpl
 
-        val metadata = tx.wireTransaction.metadata
-        assertEquals(1, metadata.getLedgerVersion())
+        val metadata = tx.wireTransaction.metadata as TransactionMetadataInternal
+        assertEquals(1, metadata.ledgerVersion)
 
         val expectedCpiMetadata = CordaPackageSummaryImpl(
             "CPI name",

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerRepositoryTest.kt
@@ -4,6 +4,7 @@ import net.corda.common.json.validation.JsonValidator
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.testkit.DbUtils
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.ledger.common.testkit.getPrivacySalt
@@ -116,7 +117,7 @@ class ConsensualLedgerRepositoryTest {
         // truncating to millis as on windows builds the micros are lost after fetching the data from Postgres
         val createdTs = Instant.now().truncatedTo(ChronoUnit.MILLIS)
         val signedTransaction = createSignedTransaction(createdTs)
-        val cpks = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        val cpks = (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
         val existingCpks = cpks.take(2)
         val entityFactory = ConsensualEntityFactory(entityManagerFactory)
         entityManagerFactory.transaction { em ->
@@ -265,7 +266,7 @@ class ConsensualLedgerRepositoryTest {
         // truncating to millis as on windows builds the micros are lost after fetching the data from Postgres
         val createdTs = Instant.now().truncatedTo(ChronoUnit.MILLIS)
         val signedTransaction = createSignedTransaction(createdTs)
-        val cpks = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        val cpks = (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
         val existingCpks = cpks.take(2)
         val entityFactory = ConsensualEntityFactory(entityManagerFactory)
         entityManagerFactory.transaction { em ->
@@ -293,7 +294,7 @@ class ConsensualLedgerRepositoryTest {
             repository.persistTransactionCpk(
                 em,
                 signedTransaction.id.toString(),
-                signedTransaction.wireTransaction.metadata.getCpkMetadata()
+                (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
             )
         }
 
@@ -323,7 +324,7 @@ class ConsensualLedgerRepositoryTest {
     fun `can find file checksums of CPKs linked to transaction`() {
         val account = "Account"
         val signedTransaction = createSignedTransaction(Instant.now())
-        val cpks = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        val cpks = (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
         val existingCpks = cpks.take(2)
         val entityFactory = ConsensualEntityFactory(entityManagerFactory)
         entityManagerFactory.transaction { em ->
@@ -352,7 +353,7 @@ class ConsensualLedgerRepositoryTest {
         val cpkChecksums = entityManagerFactory.transaction { em ->
             repository.findTransactionCpkChecksums(
                 em,
-                signedTransaction.wireTransaction.metadata.cpkMetadata
+                (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
             )
         }
 
@@ -397,7 +398,7 @@ class ConsensualLedgerRepositoryTest {
         override val signatures: List<DigitalSignatureAndMetadata>
             get() = transactionContainer.signatures
         override val cpkMetadata: List<CordaPackageSummary>
-            get() = transactionContainer.wireTransaction.metadata.getCpkMetadata()
+            get() = (transactionContainer.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
     }
 
     private fun digest(algorithm: String, data: ByteArray) =

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -4,6 +4,7 @@ import net.corda.common.json.validation.JsonValidator
 import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.testkit.DbUtils
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
@@ -556,7 +557,7 @@ class UtxoPersistenceServiceImplTest {
         override val signatures: List<DigitalSignatureAndMetadata>
             get() = transactionContainer.signatures
         override val cpkMetadata: List<CordaPackageSummary>
-            get() = transactionContainer.wireTransaction.metadata.cpkMetadata
+            get() = (transactionContainer.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
 
         override fun getProducedStates(): List<StateAndRef<ContractState>> {
             return listOf(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualTransactionReaderImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualTransactionReaderImpl.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.persistence.consensual.impl
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.consensual.ConsensualTransactionReader
@@ -46,5 +47,5 @@ class ConsensualTransactionReaderImpl(
         get() = signedTransaction.signatures
 
     override val cpkMetadata: List<CordaPackageSummary>
-        get() = signedTransaction.wireTransaction.metadata.getCpkMetadata()
+        get() = (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
@@ -4,6 +4,7 @@ import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.ledger.persistence.PersistTransactionIfDoesNotExist
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
@@ -84,7 +85,7 @@ class UtxoTransactionReaderImpl(
         get() = signedTransaction.signatures
 
     override val cpkMetadata: List<CordaPackageSummary>
-        get() = signedTransaction.wireTransaction.metadata.cpkMetadata
+        get() = (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
 
     override fun getProducedStates(): List<StateAndRef<ContractState>> {
         val relevantStatesSet = relevantStatesIndexes.toSet()

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction.verifier
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.utxo.verification.CordaPackageSummary
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionContainer
@@ -60,7 +61,7 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
 
     private fun UtxoLedgerTransaction.getCpkMetadata() =
         (this as UtxoLedgerTransactionInternal).run {
-            wireTransaction.metadata.cpkMetadata
+            (wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
         }
 
     private fun serialize(payload: Any) = ByteBuffer.wrap(serializationService.serialize(payload).bytes)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction
 
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.test.dummyCpkSignerSummaryHash
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.test.UtxoLedgerTest
@@ -80,8 +81,8 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
             .addAttachment(SecureHash("SHA-256", ByteArray(12)))
             .toSignedTransaction() as UtxoSignedTransactionImpl
 
-        val metadata = tx.wireTransaction.metadata
-        assertEquals(1, metadata.getLedgerVersion())
+        val metadata = tx.wireTransaction.metadata as TransactionMetadataInternal
+        assertEquals(1, metadata.ledgerVersion)
 
         val expectedCpiMetadata = CordaPackageSummaryImpl(
             "CPI name",

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction.verifier
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationResult
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
@@ -8,7 +9,6 @@ import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.verifier.external.events.TransactionVerificationExternalEventFactory
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.serialization.SerializedBytes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -60,7 +60,7 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
 
         val transaction = mock<UtxoLedgerTransactionInternal>()
         val wireTransaction = mock<WireTransaction>()
-        val transactionMetadata = mock<TransactionMetadata>()
+        val transactionMetadata = mock<TransactionMetadataInternal>()
         whenever(transaction.wireTransaction).thenReturn(wireTransaction)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)
         whenever(transactionMetadata.getCpkMetadata()).thenReturn(listOf(mock()))
@@ -90,7 +90,7 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
         val transactionId = mock<SecureHash>()
         val transaction = mock<UtxoLedgerTransactionInternal>()
         val wireTransaction = mock<WireTransaction>()
-        val transactionMetadata = mock<TransactionMetadata>()
+        val transactionMetadata = mock<TransactionMetadataInternal>()
         whenever(transaction.id).thenReturn(transactionId)
         whenever(transaction.wireTransaction).thenReturn(wireTransaction)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.703-beta+
+cordaApiVersion=5.0.0.704-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
@@ -6,7 +6,8 @@ import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
 @CordaSerializable
-class TransactionMetadataImpl (private val properties: Map<String, Any>) : TransactionMetadata {
+class TransactionMetadataImpl(private val properties: Map<String, Any>) : TransactionMetadata,
+    TransactionMetadataInternal {
 
     operator fun get(key: String): Any? = properties[key]
 

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataImpl.kt
@@ -3,11 +3,9 @@ package net.corda.ledger.common.data.transaction
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
-import net.corda.v5.ledger.common.transaction.TransactionMetadata
 
 @CordaSerializable
-class TransactionMetadataImpl(private val properties: Map<String, Any>) : TransactionMetadata,
-    TransactionMetadataInternal {
+class TransactionMetadataImpl(private val properties: Map<String, Any>) : TransactionMetadataInternal {
 
     operator fun get(key: String): Any? = properties[key]
 

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataInternal.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionMetadataInternal.kt
@@ -1,0 +1,35 @@
+package net.corda.ledger.common.data.transaction
+
+import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+import net.corda.v5.ledger.common.transaction.TransactionMetadata
+
+interface TransactionMetadataInternal : TransactionMetadata {
+    /**
+     * Gets information about the CPI running on the virtual node creating the transaction.
+     *
+     * @return A summary of the CPI.
+     */
+    fun getCpiMetadata(): CordaPackageSummary?
+
+    /**
+     * Gets information about the contract CPKs governing the transaction (installed on the virtual node when the transaction was created).
+     *
+     * @return A list of CPK summaries.
+     */
+    fun getCpkMetadata(): List<CordaPackageSummary>
+
+
+    /**
+     * Gets the number of the component groups included in the transaction.
+     *
+     * @return The number of component groups.
+     */
+    fun getNumberOfComponentGroups(): Int
+
+    /**
+     * Gets the version of the metadata JSON schema to parse this metadata entity.
+     *
+     * @return The schema version.
+     */
+    fun getSchemaVersion(): Int
+}

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/WireTransactionExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/WireTransactionExample.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.common.testkit
 
 import net.corda.common.json.validation.JsonValidator
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.v5.application.crypto.DigestService
@@ -48,7 +49,7 @@ fun getWireTransactionExample(
         listOf(canonicalJson.toByteArray()),
     ) + componentGroupLists
 
-    val completeComponentGroupLists = (0 until metadata.getNumberOfComponentGroups())
+    val completeComponentGroupLists = (0 until (metadata as TransactionMetadataInternal).getNumberOfComponentGroups())
         .map { index -> groups.getOrElse(index) { arrayListOf() } }
 
     return WireTransaction(


### PR DESCRIPTION
CORE-8638 Move getCpiMetadata, getCpkMetadata, getNumberOfComponentGroups, getSchemaVersion from TransactionMetadata to impl

API: https://github.com/corda/corda-api/pull/915