### PR TITLE
CORE-11440 Phase out MemberX500Name from some e2e-test-utilities arguments

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -7,7 +7,6 @@ import net.corda.crypto.test.certificates.generation.FileSystemCertificatesAutho
 import net.corda.crypto.test.certificates.generation.KeysFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.rest.ResponseCode
-import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.pkcs.PKCS10CertificationRequest
@@ -43,13 +42,13 @@ fun FileSystemCertificatesAuthority.generateCert(csrPem: String): String {
  */
 fun generateCsr(
     clusterInfo: ClusterInfo,
-    x500Name: MemberX500Name,
+    x500Name: String,
     keyId: String,
     tenantId: String = "p2p",
     addHostToSubjectAlternativeNames: Boolean = true
 ) = cluster(clusterInfo) {
     val payload = mutableMapOf<String, Any>(
-        "x500Name" to x500Name.toString()
+        "x500Name" to x500Name
     ).apply {
         if (addHostToSubjectAlternativeNames) {
             put("subjectAlternativeNames", listOf(clusterInfo.p2p.host))

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.rest.ResponseCode
 import net.corda.utilities.seconds
-import net.corda.v5.base.types.MemberX500Name
 import java.io.File
 import java.net.URLEncoder.encode
 import java.nio.charset.Charset.defaultCharset
@@ -18,12 +17,12 @@ import java.time.Duration
 fun onboardMgm(
     clusterInfo: ClusterInfo,
     resourceName: String,
-    mgmName: MemberX500Name = MemberX500Name.parse("O=Mgm, L=London, C=GB, OU=$testRunUniqueId"),
+    mgmName: String = "O=Mgm, L=London, C=GB, OU=$testRunUniqueId",
     groupPolicyConfig: GroupPolicyConfig = GroupPolicyConfig()
 ): NetworkOnboardingMetadata {
     val mgmCpiName = "mgm_$testRunUniqueId.cpi"
     conditionallyUploadCordaPackage(mgmCpiName, resourceName, getMgmGroupPolicy())
-    val mgmHoldingId = getOrCreateVirtualNodeFor(mgmName.toString(), mgmCpiName)
+    val mgmHoldingId = getOrCreateVirtualNodeFor(mgmName, mgmCpiName)
 
     addSoftHsmFor(mgmHoldingId, CAT_SESSION_INIT)
     val sessionKeyId = createKeyFor(
@@ -148,12 +147,12 @@ private fun delete(
 fun createPreAuthToken(
     clusterInfo: ClusterInfo,
     mgmHoldingId: String,
-    ownerX500Name: MemberX500Name,
+    ownerX500Name: String,
     remark: String? = "Token created for automated test run $testRunUniqueId with default remark.",
     ttl: Duration? = null
 ) = cluster(clusterInfo) {
     val payload = mutableMapOf(
-        "ownerX500Name" to ownerX500Name.toString()
+        "ownerX500Name" to ownerX500Name
     ).apply {
         remark?.let { put("remarks", it) }
         ttl?.let { put("ttl", it.toString()) }
@@ -212,7 +211,7 @@ fun getPreAuthTokens(
 fun waitForPendingRegistrationReviews(
     clusterInfo: ClusterInfo,
     mgmHoldingId: String,
-    memberX500Name: MemberX500Name? = null,
+    memberX500Name: String? = null,
     registrationId: String?
 ) {
     cluster(clusterInfo) {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -48,7 +48,7 @@ fun onboardMember(
     cpb: String,
     cpiName: String,
     groupPolicy: String,
-    x500Name: MemberX500Name,
+    x500Name: String,
     waitForApproval: Boolean = true,
     getAdditionalContext: ((holdingId: String) -> Map<String, String>)? = null
 ): NetworkOnboardingMetadata {
@@ -94,7 +94,7 @@ fun onboardNotaryMember(
     resourceName: String,
     cpiName: String,
     groupPolicy: String,
-    x500Name: MemberX500Name,
+    x500Name: String,
     wait: Boolean = true,
     getAdditionalContext: ((holdingId: String) -> Map<String, String>)? = null
 ) = onboardMember(
@@ -262,7 +262,7 @@ fun createRegistrationContext(
  */
 data class NetworkOnboardingMetadata(
     val holdingId: String,
-    val x500Name: MemberX500Name,
+    val x500Name: String,
     val registrationId: String,
     val registrationContext: Map<String, String>
 )


### PR DESCRIPTION
CORE-11440 Phase out MemberX500Name from some e2e-test-utilities arguments to let us remove corda api dependencies from the e2e-tests repo.


Related e2e-tests build: https://github.com/corda/corda-e2e-tests/pull/35