### PR TITLE
CORE-11434: Case insensitive maintenance mode REST request

### DIFF
--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -2,7 +2,7 @@ package net.corda.flow.rest.impl.v1
 
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.virtualnode.VirtualNodeInfo
-import net.corda.data.virtualnode.VirtualNodeState
+import net.corda.data.virtualnode.VirtualNodeOperationalState
 import net.corda.flow.rest.FlowRestResourceServiceException
 import net.corda.flow.rest.FlowStatusCacheService
 import net.corda.flow.rest.factory.MessageFactory
@@ -115,7 +115,7 @@ class FlowRestResourceImpl @Activate constructor(
 
         val vNode = getVirtualNode(holdingIdentityShortHash)
 
-        if (vNode.flowStartOperationalStatus == VirtualNodeState.INACTIVE) {
+        if (vNode.flowStartOperationalStatus == VirtualNodeOperationalState.INACTIVE) {
             throw OperationNotAllowedException("Flow start capabilities of virtual node $holdingIdentityShortHash are not operational.")
         }
 

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -17,16 +17,10 @@ import net.corda.data.virtualnode.VirtualNodeState
 import net.corda.data.virtualnode.VirtualNodeStateChangeRequest
 import net.corda.data.virtualnode.VirtualNodeStateChangeResponse
 import net.corda.data.virtualnode.VirtualNodeUpgradeRequest
-import net.corda.rest.PluggableRestResource
-import net.corda.rest.exception.InternalServerException
-import net.corda.rest.exception.InvalidInputDataException
-import net.corda.rest.exception.ResourceNotFoundException
-import net.corda.rest.security.CURRENT_REST_CONTEXT
-import net.corda.rest.asynchronous.v1.AsyncResponse
-import net.corda.rest.messagebus.MessageBusUtils.tryWithExceptionHandling
-import net.corda.rest.response.ResponseEntity
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.cpiupload.endpoints.v1.CpiIdentifier
+import net.corda.libs.virtualnode.common.constant.VirtualNodeStateTransitions
+import net.corda.libs.virtualnode.common.exception.InvalidStateChangeRuntimeException
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
@@ -46,6 +40,15 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.messaging.api.publisher.config.PublisherConfig
+import net.corda.rest.PluggableRestResource
+import net.corda.rest.asynchronous.v1.AsyncResponse
+import net.corda.rest.exception.InternalServerException
+import net.corda.rest.exception.InvalidInputDataException
+import net.corda.rest.exception.InvalidStateChangeException
+import net.corda.rest.exception.ResourceNotFoundException
+import net.corda.rest.messagebus.MessageBusUtils.tryWithExceptionHandling
+import net.corda.rest.response.ResponseEntity
+import net.corda.rest.security.CURRENT_REST_CONTEXT
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.debug
 import net.corda.utilities.time.ClockFactory
@@ -63,14 +66,10 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
-import java.time.Instant
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.time.Instant
 import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity as HoldingIdentityEndpointType
-import java.lang.IllegalArgumentException
-import net.corda.rest.exception.InvalidStateChangeException
-import net.corda.libs.virtualnode.common.constant.VirtualNodeStateTransitions
-import net.corda.libs.virtualnode.common.exception.InvalidStateChangeRuntimeException
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @Component(service = [PluggableRestResource::class])
@@ -263,7 +262,7 @@ internal class VirtualNodeRestResourceImpl @Activate constructor(
                             it.requestTimestamp,
                             it.latestUpdateTimestamp,
                             it.heartbeatTimestamp,
-                            it.state.name,
+                            it.state,
                             it.errors
                         )
                     }

--- a/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rpcops-service-impl/src/main/kotlin/net/corda/virtualnode/rpcops/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -13,7 +13,7 @@ import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.data.virtualnode.VirtualNodeOperationStatusRequest
 import net.corda.data.virtualnode.VirtualNodeOperationStatusResponse
-import net.corda.data.virtualnode.VirtualNodeState
+import net.corda.data.virtualnode.VirtualNodeOperationalState
 import net.corda.data.virtualnode.VirtualNodeStateChangeRequest
 import net.corda.data.virtualnode.VirtualNodeStateChangeResponse
 import net.corda.data.virtualnode.VirtualNodeUpgradeRequest
@@ -393,8 +393,8 @@ internal class VirtualNodeRestResourceImpl @Activate constructor(
             "${this.javaClass.simpleName} is not running! Its status is: ${lifecycleCoordinator.status}"
         )
         val virtualNodeState = when (validateStateChange(virtualNodeShortId, newState)) {
-            VirtualNodeStateTransitions.ACTIVE -> VirtualNodeState.ACTIVE
-            VirtualNodeStateTransitions.MAINTENANCE -> VirtualNodeState.INACTIVE
+            VirtualNodeStateTransitions.ACTIVE -> VirtualNodeOperationalState.ACTIVE
+            VirtualNodeStateTransitions.MAINTENANCE -> VirtualNodeOperationalState.INACTIVE
         }
         // Send request for update to kafka, precessed by the db worker in VirtualNodeWriterProcessor
         val rpcRequest = VirtualNodeManagementRequest(

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterProcessor.kt
@@ -11,7 +11,7 @@ import net.corda.data.virtualnode.VirtualNodeManagementRequest
 import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.data.virtualnode.VirtualNodeOperationStatusRequest
-import net.corda.data.virtualnode.VirtualNodeState
+import net.corda.data.virtualnode.VirtualNodeOperationalState
 import net.corda.data.virtualnode.VirtualNodeStateChangeRequest
 import net.corda.data.virtualnode.VirtualNodeStateChangeResponse
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
@@ -415,7 +415,7 @@ internal class VirtualNodeWriterProcessor(
                 }
 
                 val changelogsPerCpk = changeLogsRepository.findByCpiId(em, nodeInfo.cpiIdentifier)
-                if (stateChangeRequest.newState == VirtualNodeState.ACTIVE) {
+                if (stateChangeRequest.newState == VirtualNodeOperationalState.ACTIVE) {
                     val inSync = migrationUtility.isVaultSchemaAndTargetCpiInSync(
                         stateChangeRequest.holdingIdentityShortHash, changelogsPerCpk, nodeInfo.vaultDmlConnectionId
                     )

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeOperationStatusHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeOperationStatusHandler.kt
@@ -6,6 +6,7 @@ import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.data.virtualnode.VirtualNodeOperationStatus
 import net.corda.data.virtualnode.VirtualNodeOperationStatusRequest
 import net.corda.data.virtualnode.VirtualNodeOperationStatusResponse
+import net.corda.data.virtualnode.VirtualNodeState
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepository
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepositoryImpl
@@ -33,7 +34,7 @@ internal class VirtualNodeOperationStatusHandler(
                     it.requestTimestamp,
                     it.latestUpdateTimestamp,
                     it.heartbeatTimestamp,
-                    it.state,
+                    VirtualNodeState.valueOf(it.state),
                     it.errors
                 )
             }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeOperationStatusHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeOperationStatusHandler.kt
@@ -6,7 +6,6 @@ import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
 import net.corda.data.virtualnode.VirtualNodeOperationStatus
 import net.corda.data.virtualnode.VirtualNodeOperationStatusRequest
 import net.corda.data.virtualnode.VirtualNodeOperationStatusResponse
-import net.corda.data.virtualnode.VirtualNodeState
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepository
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepositoryImpl
@@ -34,7 +33,7 @@ internal class VirtualNodeOperationStatusHandler(
                     it.requestTimestamp,
                     it.latestUpdateTimestamp,
                     it.heartbeatTimestamp,
-                    VirtualNodeState.valueOf(it.state),
+                    it.state,
                     it.errors
                 )
             }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterProcessorTests.kt
@@ -112,10 +112,10 @@ class VirtualNodeWriterProcessorTests {
             connectionId,
             connectionId,
             null,
-            OperationalStatus.ACTIVE.name,
-            OperationalStatus.ACTIVE.name,
-            OperationalStatus.ACTIVE.name,
-            OperationalStatus.ACTIVE.name,
+            OperationalStatus.ACTIVE.toAvro(),
+            OperationalStatus.ACTIVE.toAvro(),
+            OperationalStatus.ACTIVE.toAvro(),
+            OperationalStatus.ACTIVE.toAvro(),
             null,
             -1,
             clock.instant()
@@ -483,10 +483,10 @@ class VirtualNodeWriterProcessorTests {
                 connectionId,
                 connectionId,
                 null,
-                OperationalStatus.ACTIVE.name,
-                OperationalStatus.ACTIVE.name,
-                OperationalStatus.ACTIVE.name,
-                OperationalStatus.ACTIVE.name
+                OperationalStatus.ACTIVE.toAvro(),
+                OperationalStatus.ACTIVE.toAvro(),
+                OperationalStatus.ACTIVE.toAvro(),
+                OperationalStatus.ACTIVE.toAvro()
             )
         )
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.664-Gecko-beta+
+cordaApiVersion=5.0.0.663-Gecko-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.663-Gecko-beta+
+cordaApiVersion=5.0.0.665-Gecko-alpha-1678357013826
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.665-Gecko-alpha-1678357013826
+cordaApiVersion=5.0.0.665-Gecko-alpha-1678363056443
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.665-Gecko-alpha-1678363056443
+cordaApiVersion=5.0.0.665-Gecko-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -230,7 +230,7 @@ class VirtualNodeRepositoryTest {
 
         entityManagerFactory.createEntityManager().use {
             VirtualNodeRepositoryImpl().updateVirtualNodeState(
-                it, vnode.holdingIdentity.holdingIdentityShortHash, "maintenance")
+                it, vnode.holdingIdentity.holdingIdentityShortHash, OperationalStatus.INACTIVE)
         }
 
         val changedEntity = entityManagerFactory.createEntityManager().use {

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -11,6 +11,7 @@ import java.util.stream.Stream
 import javax.persistence.EntityManager
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
+import net.corda.virtualnode.OperationalStatus
 
 /**
  * Interface for CRUD operations for a virtual node.
@@ -51,7 +52,7 @@ interface VirtualNodeRepository {
     /**
      * Update a virtual node's state.
      */
-    fun updateVirtualNodeState(entityManager: EntityManager, holdingIdentityShortHash: String, newState: String): VirtualNodeInfo
+    fun updateVirtualNodeState(entityManager: EntityManager, holdingIdentityShortHash: String, newState: OperationalStatus): VirtualNodeInfo
 
     /**
      * Upgrade the CPI associated with a virtual node.

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -137,24 +137,19 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
     override fun updateVirtualNodeState(
         entityManager: EntityManager,
         holdingIdentityShortHash: String,
-        newState: String
+        newState: OperationalStatus
     ): VirtualNodeInfo {
         entityManager.transaction {
             // Lookup virtual node and grab the latest one based on the cpi Version.
             val latestVirtualNodeInstance = findEntity(entityManager, holdingIdentityShortHash)
                 ?: throw VirtualNodeNotFoundException(holdingIdentityShortHash)
 
-            var operationalStatus = OperationalStatus.ACTIVE
-            if (newState == "maintenance") {
-                operationalStatus = OperationalStatus.INACTIVE
-            }
-
             val updatedVirtualNodeInstance = latestVirtualNodeInstance.apply {
                 update(
-                    operationalStatus,
-                    operationalStatus,
-                    operationalStatus,
-                    operationalStatus
+                    flowP2pOperationalStatus = newState,
+                    flowStartOperationalStatus = newState,
+                    flowOperationalStatus = newState,
+                    vaultDbOperationalStatus = newState
                 )
             }
             return it.merge(updatedVirtualNodeInstance).toVirtualNodeInfo()

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -68,7 +68,7 @@ interface VirtualNodeRestResource : RestResource {
         @RestPathParameter(description = "Short ID of the virtual node instance to update")
         virtualNodeShortId: String,
         @RestPathParameter(description = "State to transition virtual node instance into. " +
-                "Possible values are: IN_MAINTENANCE and ACTIVE.")
+                "Possible values are: MAINTENANCE and ACTIVE.")
         newState: String
     ): ChangeVirtualNodeStateResponse
 

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -1,5 +1,6 @@
 package net.corda.virtualnode
 
+import net.corda.data.virtualnode.VirtualNodeState
 import net.corda.libs.packaging.core.CpiIdentifier
 import java.time.Instant
 import java.util.UUID
@@ -69,10 +70,10 @@ fun VirtualNodeInfo.toAvro(): VirtualNodeInfoAvro =
             uniquenessDdlConnectionId?.let{ uniquenessDdlConnectionId.toString() },
             uniquenessDmlConnectionId.toString(),
             hsmConnectionId?.let { hsmConnectionId.toString() },
-            flowP2pOperationalStatus.toString(),
-            flowStartOperationalStatus.toString(),
-            flowOperationalStatus.toString(),
-            vaultDbOperationalStatus.toString(),
+            flowP2pOperationalStatus.toAvro(),
+            flowStartOperationalStatus.toAvro(),
+            flowOperationalStatus.toAvro(),
+            vaultDbOperationalStatus.toAvro(),
             operationInProgress,
             version,
             timestamp
@@ -91,10 +92,10 @@ fun VirtualNodeInfoAvro.toCorda(): VirtualNodeInfo {
         uniquenessDdlConnectionId?.let { UUID.fromString(uniquenessDdlConnectionId) },
         UUID.fromString(uniquenessDmlConnectionId),
         hsmConnectionId?.let { UUID.fromString(hsmConnectionId) },
-        OperationalStatus.valueOf(flowP2pOperationalStatus),
-        OperationalStatus.valueOf(flowStartOperationalStatus),
-        OperationalStatus.valueOf(flowOperationalStatus),
-        OperationalStatus.valueOf(vaultDbOperationalStatus),
+        OperationalStatus.fromAvro(flowP2pOperationalStatus),
+        OperationalStatus.fromAvro(flowStartOperationalStatus),
+        OperationalStatus.fromAvro(flowOperationalStatus),
+        OperationalStatus.fromAvro(vaultDbOperationalStatus),
         operationInProgress,
         version,
         timestamp,
@@ -104,5 +105,21 @@ fun VirtualNodeInfoAvro.toCorda(): VirtualNodeInfo {
 
 enum class OperationalStatus {
     ACTIVE,
-    INACTIVE
+    INACTIVE;
+
+    companion object {
+        fun fromAvro(status: VirtualNodeState): OperationalStatus {
+            return when (status) {
+                VirtualNodeState.ACTIVE -> ACTIVE
+                VirtualNodeState.INACTIVE -> INACTIVE
+            }
+        }
+    }
+
+    fun toAvro(): VirtualNodeState {
+        return when (this) {
+            ACTIVE -> VirtualNodeState.ACTIVE
+            INACTIVE -> VirtualNodeState.INACTIVE
+        }
+    }
 }

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -1,6 +1,6 @@
 package net.corda.virtualnode
 
-import net.corda.data.virtualnode.VirtualNodeState
+import net.corda.data.virtualnode.VirtualNodeOperationalState
 import net.corda.libs.packaging.core.CpiIdentifier
 import java.time.Instant
 import java.util.UUID
@@ -108,18 +108,18 @@ enum class OperationalStatus {
     INACTIVE;
 
     companion object {
-        fun fromAvro(status: VirtualNodeState): OperationalStatus {
+        fun fromAvro(status: VirtualNodeOperationalState): OperationalStatus {
             return when (status) {
-                VirtualNodeState.ACTIVE -> ACTIVE
-                VirtualNodeState.INACTIVE -> INACTIVE
+                VirtualNodeOperationalState.ACTIVE -> ACTIVE
+                VirtualNodeOperationalState.INACTIVE -> INACTIVE
             }
         }
     }
 
-    fun toAvro(): VirtualNodeState {
+    fun toAvro(): VirtualNodeOperationalState {
         return when (this) {
-            ACTIVE -> VirtualNodeState.ACTIVE
-            INACTIVE -> VirtualNodeState.INACTIVE
+            ACTIVE -> VirtualNodeOperationalState.ACTIVE
+            INACTIVE -> VirtualNodeOperationalState.INACTIVE
         }
     }
 }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -3779,11 +3779,11 @@
         }, {
           "name" : "newstate",
           "in" : "path",
-          "description" : "State to transition virtual node instance into. Possible values are: IN_MAINTENANCE and ACTIVE.",
+          "description" : "State to transition virtual node instance into. Possible values are: MAINTENANCE and ACTIVE.",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "State to transition virtual node instance into. Possible values are: IN_MAINTENANCE and ACTIVE.",
+            "description" : "State to transition virtual node instance into. Possible values are: MAINTENANCE and ACTIVE.",
             "nullable" : false,
             "example" : "string"
           }
@@ -4103,7 +4103,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4242,7 +4241,6 @@
       },
       "GenerateCsrWrapperRequest" : {
         "required" : [ "x500Name" ],
-        "type" : "object",
         "properties" : {
           "contextMap" : {
             "type" : "object",
@@ -4523,7 +4521,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4567,7 +4564,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4604,7 +4600,6 @@
             "example" : "string"
           },
           "status" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "REVOKED",
             "enum" : [ "AVAILABLE", "REVOKED", "CONSUMED", "AUTO_INVALIDATED" ]
@@ -4758,7 +4753,6 @@
             "example" : "2022-06-24T10:15:30Z"
           },
           "registrationStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "SENT_TO_MGM",
             "enum" : [ "NEW", "SENT_TO_MGM", "RECEIVED_BY_MGM", "PENDING_MEMBER_VERIFICATION", "PENDING_APPROVAL_FLOW", "PENDING_MANUAL_APPROVAL", "PENDING_AUTO_APPROVAL", "DECLINED", "INVALID", "APPROVED" ]
@@ -5063,19 +5057,16 @@
             "example" : "string"
           },
           "flowOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowP2pOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowStartOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
@@ -5104,7 +5095,6 @@
             "example" : "string"
           },
           "vaultDbOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]


### PR DESCRIPTION
* Add new Avro type `VirtualNodeState` with values matching `OperationalStatus`
* Replace `String` status values with `VirtualNodeState` in Avro types
* Convert the REST request `newState` string to `VirtualNodeStateTransitions` and then `VirtualNodeState` early in the request processing
* Fix `updateVirtualNodeState` parameter documentation

API PR: https://github.com/corda/corda-api/pull/923