### PR TITLE
CORE-11213: use beta 2 version of shared lib

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@beta2') _ // not to be merged back to release/os/5.0
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@beta2') _ // not to be merged back to release/os/5.0
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H 03 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@beta2') _ // not to be merged back to release/os/5.0
 
 cordaPipeline(
     dailyBuildCron: 'H H/6 * * *',


### PR DESCRIPTION
Use a dedicated version of shared lib to protect from breaking changes 