### PR TITLE
CORE-5630 - Add support for CPK metadata files

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -159,7 +159,17 @@ internal class DatabaseCpiPersistenceTest {
             type = CpkType.UNKNOWN,
             fileChecksum = fileChecksum,
             cordappCertificates = emptySet(),
-            timestamp = Instant.now()
+            timestamp = Instant.now(),
+            externalChannelsConfig = """
+                {
+                    "channel 1" : {
+                        "type" : "send"
+                    },
+                    "channel 2" :{
+                        "type" : "send-receive"
+                    }
+                }
+            """.trimIndent()
         )
         whenever(cpk.path).thenReturn(mockCpkContent.writeToPath())
         whenever(cpk.originalFileName).thenReturn("$name.cpk")
@@ -716,6 +726,7 @@ internal class DatabaseCpiPersistenceTest {
 
             assertThat(cpkMetadata.cpkFileChecksum).isEqualTo(expectedCpkFileChecksum?.toString() ?: cpk.metadata.fileChecksum.toString())
             assertThat(cpkFile.fileChecksum).isEqualTo(expectedCpkFileChecksum ?: cpk.metadata.fileChecksum)
+            assertThat(cpkMetadata.serializedMetadata).isEqualTo(cpk.metadata.toJsonAvro())
 
             assertThat(cpkMetadata.entityVersion)
                 .withFailMessage("CpkMetadataEntity.entityVersion expected $expectedMetadataEntityVersion but was ${cpkMetadata.entityVersion}.")

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -160,16 +160,7 @@ internal class DatabaseCpiPersistenceTest {
             fileChecksum = fileChecksum,
             cordappCertificates = emptySet(),
             timestamp = Instant.now(),
-            externalChannelsConfig = """
-                {
-                    "channel 1" : {
-                        "type" : "send"
-                    },
-                    "channel 2" :{
-                        "type" : "send-receive"
-                    }
-                }
-            """.trimIndent()
+            externalChannelsConfig = "{}"
         )
         whenever(cpk.path).thenReturn(mockCpkContent.writeToPath())
         whenever(cpk.originalFileName).thenReturn("$name.cpk")

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
@@ -136,16 +136,7 @@ class UpsertCpiTests {
             fileChecksum = fileChecksum,
             cordappCertificates = emptySet(),
             timestamp = Instant.now(),
-            externalChannelsConfig = """
-                {
-                    "channel 1" : {
-                        "type" : "send"
-                    },
-                    "channel 2" :{
-                        "type" : "send-receive"
-                    }
-                }
-            """.trimIndent()
+            externalChannelsConfig = "{}"
         )
         whenever(cpk.path).thenReturn(getRandomString(1024).writeToPath())
         whenever(cpk.originalFileName).thenReturn(name)

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
@@ -145,7 +145,7 @@ class UpsertCpiTests {
                         "type" : "send-receive"
                     }
                 }
-            """
+            """.trimIndent()
         )
         whenever(cpk.path).thenReturn(getRandomString(1024).writeToPath())
         whenever(cpk.originalFileName).thenReturn(name)

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/UpsertCpiTests.kt
@@ -135,7 +135,17 @@ class UpsertCpiTests {
             type = CpkType.UNKNOWN,
             fileChecksum = fileChecksum,
             cordappCertificates = emptySet(),
-            timestamp = Instant.now()
+            timestamp = Instant.now(),
+            externalChannelsConfig = """
+                {
+                    "channel 1" : {
+                        "type" : "send"
+                    },
+                    "channel 2" :{
+                        "type" : "send-receive"
+                    }
+                }
+            """
         )
         whenever(cpk.path).thenReturn(getRandomString(1024).writeToPath())
         whenever(cpk.originalFileName).thenReturn(name)

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import javax.persistence.EntityManagerFactory
+import net.corda.chunking.db.impl.validation.ExternalChannelsConfigValidatorImpl
 
 @Suppress("UNUSED", "LongParameterList")
 @Component(service = [ChunkDbWriterFactory::class])
@@ -120,6 +121,7 @@ class ChunkDbWriterFactoryImpl(
         val cpiCacheDir = tempPathProvider.getOrCreate(bootConfig, CPI_CACHE_DIR)
         val cpiPartsDir = tempPathProvider.getOrCreate(bootConfig, CPI_PARTS_DIR)
         val membershipSchemaValidator = membershipSchemaValidatorFactory.createValidator()
+        val externalChannelsConfigValidator = ExternalChannelsConfigValidatorImpl()
         val validator = CpiValidatorImpl(
             statusPublisher,
             chunkPersistence,
@@ -127,6 +129,7 @@ class ChunkDbWriterFactoryImpl(
             cpiInfoWriteService,
             membershipSchemaValidator,
             membershipGroupPolicyValidator,
+            externalChannelsConfigValidator,
             cpiCacheDir,
             cpiPartsDir,
             certificatesService,

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -101,7 +101,7 @@ class CpiValidatorImpl(
         publisher.update(requestId, "Extracting Liquibase scripts from CPKs in CPI")
         val liquibaseScripts = cpi.extractLiquibaseScripts()
 
-        // Todos: Call publisher.update(requestId, "Validating configuration for external channels") ?
+        publisher.update(requestId, "Validating configuration for external channels")
         cpi.validateExternalChannelsConfig(externalChannelsConfigValidator)
 
         publisher.update(requestId, "Persisting CPI")

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -102,7 +102,7 @@ class CpiValidatorImpl(
         val liquibaseScripts = cpi.extractLiquibaseScripts()
 
         publisher.update(requestId, "Validating configuration for external channels")
-        cpi.validateExternalChannelsConfig(externalChannelsConfigValidator)
+        externalChannelsConfigValidator.validate(cpi)
 
         publisher.update(requestId, "Persisting CPI")
         val cpiMetadataEntity =

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -35,6 +35,7 @@ class CpiValidatorImpl(
     private val cpiInfoWriteService: CpiInfoWriteService,
     private val membershipSchemaValidator: MembershipSchemaValidator,
     private val membershipGroupPolicyValidator: MembershipGroupPolicyValidator,
+    private val externalChannelsConfigValidator: ExternalChannelsConfigValidator,
     private val cpiCacheDir: Path,
     private val cpiPartsDir: Path,
     certificatesService: CertificatesService,
@@ -99,6 +100,9 @@ class CpiValidatorImpl(
 
         publisher.update(requestId, "Extracting Liquibase scripts from CPKs in CPI")
         val liquibaseScripts = cpi.extractLiquibaseScripts()
+
+        // Todos: Call publisher.update(requestId, "Validating configuration for external channels") ?
+        cpi.validateExternalChannelsConfig(externalChannelsConfigValidator)
 
         publisher.update(requestId, "Persisting CPI")
         val cpiMetadataEntity =

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/CpiValidatorImpl.kt
@@ -102,7 +102,7 @@ class CpiValidatorImpl(
         val liquibaseScripts = cpi.extractLiquibaseScripts()
 
         publisher.update(requestId, "Validating configuration for external channels")
-        externalChannelsConfigValidator.validate(cpi)
+        externalChannelsConfigValidator.validate(cpi.metadata.cpksMetadata)
 
         publisher.update(requestId, "Persisting CPI")
         val cpiMetadataEntity =

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
@@ -1,6 +1,5 @@
 package net.corda.chunking.db.impl.validation
 
-import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpkMetadata
 
 interface ExternalChannelsConfigValidator {

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
@@ -1,0 +1,7 @@
+package net.corda.chunking.db.impl.validation
+
+import net.corda.libs.packaging.core.CpkIdentifier
+
+interface ExternalChannelsConfigValidator {
+    fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?)
+}

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
@@ -1,7 +1,7 @@
 package net.corda.chunking.db.impl.validation
 
-import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.libs.packaging.Cpi
 
 interface ExternalChannelsConfigValidator {
-    fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?)
+    fun validate(cpi: Cpi)
 }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidator.kt
@@ -1,7 +1,8 @@
 package net.corda.chunking.db.impl.validation
 
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.core.CpkMetadata
 
 interface ExternalChannelsConfigValidator {
-    fun validate(cpi: Cpi)
+    fun validate(cpksMetadata: Collection<CpkMetadata>)
 }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -1,0 +1,20 @@
+package net.corda.chunking.db.impl.validation
+
+import net.corda.libs.packaging.core.CpkIdentifier
+import org.slf4j.LoggerFactory
+
+class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    override fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?) {
+        if (externalChannelsConfig==null) {
+            log.debug("Skipping null external channel configuration string for $cpkIdentifier")
+            return
+        }
+
+        throw NotImplementedError("Failed to validate configuration. Method not implemented")
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -2,6 +2,7 @@ package net.corda.chunking.db.impl.validation
 
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
 
 class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
@@ -18,7 +19,7 @@ class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
 
     private fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?) {
         if (externalChannelsConfig == null) {
-            log.debug("Skipping null external channel configuration string for $cpkIdentifier")
+            log.debug { "Skipping null external channel configuration string for $cpkIdentifier" }
             return
         }
 

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.chunking.db.impl.validation
 
-import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpkMetadata
 
 class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.chunking.db.impl.validation
 
+import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpkIdentifier
 import org.slf4j.LoggerFactory
 
@@ -9,7 +10,13 @@ class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    override fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?) {
+    override fun validate(cpi: Cpi) {
+        cpi.metadata.cpksMetadata.forEach {
+            validate(it.cpkId, it.externalChannelsConfig)
+        }
+    }
+
+    private fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?) {
         if (externalChannelsConfig==null) {
             log.debug("Skipping null external channel configuration string for $cpkIdentifier")
             return

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -1,11 +1,12 @@
 package net.corda.chunking.db.impl.validation
 
 import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.core.CpkMetadata
 
 class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
 
-    override fun validate(cpi: Cpi) {
-        cpi.metadata.cpksMetadata.forEach {
+    override fun validate(cpksMetadata: Collection<CpkMetadata>) {
+        cpksMetadata.forEach {
             validate(it.externalChannelsConfig)
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -1,9 +1,6 @@
 package net.corda.chunking.db.impl.validation
 
 import net.corda.libs.packaging.Cpi
-import net.corda.libs.packaging.core.CpkIdentifier
-import net.corda.utilities.debug
-import org.slf4j.LoggerFactory
 
 class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
 

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -7,13 +7,9 @@ import org.slf4j.LoggerFactory
 
 class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
 
-    companion object {
-        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
-    }
-
     override fun validate(cpi: Cpi) {
         cpi.metadata.cpksMetadata.forEach {
-            validate(it.cpkId, it.externalChannelsConfig)
+            validate(it.externalChannelsConfig)
         }
     }
 
@@ -23,3 +19,5 @@ class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
         }
     }
 }
+
+class SchemaValidationError(message: String): Exception(message)

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -17,7 +17,7 @@ class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
     }
 
     private fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?) {
-        if (externalChannelsConfig==null) {
+        if (externalChannelsConfig == null) {
             log.debug("Skipping null external channel configuration string for $cpkIdentifier")
             return
         }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorImpl.kt
@@ -17,12 +17,9 @@ class ExternalChannelsConfigValidatorImpl: ExternalChannelsConfigValidator {
         }
     }
 
-    private fun validate(cpkIdentifier: CpkIdentifier, externalChannelsConfig: String?) {
-        if (externalChannelsConfig == null) {
-            log.debug { "Skipping null external channel configuration string for $cpkIdentifier" }
-            return
+    private fun validate(externalChannelsConfig: String?) {
+        if(externalChannelsConfig!=null){
+            throw SchemaValidationError("The external channels configuration '$externalChannelsConfig' is invalid")
         }
-
-        throw NotImplementedError("Failed to validate configuration. Method not implemented")
     }
 }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -222,3 +222,8 @@ fun Cpi.validateAndGetGroupPolicyFileVersion(): Int {
  */
 fun Cpi.extractLiquibaseScripts(): List<CpkDbChangeLog> =
     LiquibaseScriptExtractor().extract(this)
+
+fun Cpi.validateExternalChannelsConfig(validator: ExternalChannelsConfigValidator) =
+    metadata.cpksMetadata.forEach {
+        validator.validate(it.cpkId, it.externalChannelsConfig)
+    }

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -222,8 +222,3 @@ fun Cpi.validateAndGetGroupPolicyFileVersion(): Int {
  */
 fun Cpi.extractLiquibaseScripts(): List<CpkDbChangeLog> =
     LiquibaseScriptExtractor().extract(this)
-
-fun Cpi.validateExternalChannelsConfig(validator: ExternalChannelsConfigValidator) =
-    metadata.cpksMetadata.forEach {
-        validator.validate(it.cpkId, it.externalChannelsConfig)
-    }

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -3,45 +3,58 @@ package net.corda.chunking.db.impl.validation
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkMetadata
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@Disabled("This test should be enabled once the schema is available")
 class ExternalChannelsConfigValidatorTest {
 
     private val externalChannelsConfigValidator = ExternalChannelsConfigValidatorImpl()
 
     @Test
-    fun `throws exception when string is not null because the method is not implemented - non-empty string`() {
-        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "{}") }
-        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
-        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
-
-        assertThrows<NotImplementedError> {
-            externalChannelsConfigValidator.validate(cpi)
-        }
-    }
-
-    @Test
-    fun `throws exception when string is not null because the method is not implemented - empty string`() {
-        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "") }
-        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
-        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
-
-        assertThrows<NotImplementedError> {
-            externalChannelsConfigValidator.validate(cpi)
-        }
-    }
-
-    @Test
-    fun `does not throw exception when string is null`() {
-        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( null) }
+    fun `does not throw exception when the configuration is valid`() {
+        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "{ }" ) }
         val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
         val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
 
         assertDoesNotThrow {
+            externalChannelsConfigValidator.validate(cpi)
+        }
+    }
+
+    @Test
+    fun `does not throw exception when the configuration is null`() {
+        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( null ) }
+        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
+        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
+
+        assertDoesNotThrow {
+            externalChannelsConfigValidator.validate(cpi)
+        }
+    }
+
+    @Test
+    fun `throws exception when the configuration is invalid`() {
+        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "invalid schema") }
+        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
+        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
+
+        assertThrows<NotImplementedError> {
+            externalChannelsConfigValidator.validate(cpi)
+        }
+    }
+
+    @Test
+    fun `throws exception when the configuration string is empty`() {
+        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "" ) }
+        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
+        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
+
+        assertThrows<NotImplementedError> {
             externalChannelsConfigValidator.validate(cpi)
         }
     }

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -1,6 +1,5 @@
 package net.corda.chunking.db.impl.validation
 
-import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkMetadata
 import org.junit.jupiter.api.Disabled

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -1,0 +1,51 @@
+package net.corda.chunking.db.impl.validation
+
+import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.v5.crypto.SecureHash
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class ExternalChannelsConfigValidatorTest {
+
+    private val externalChannelsConfigValidator = ExternalChannelsConfigValidatorImpl()
+
+    @Test
+    fun `throws exception when string is not null because the method is not implemented`() {
+        assertThrows<NotImplementedError> {
+            externalChannelsConfigValidator.validate(
+                cpkIdentifier = CpkIdentifier(
+                    "name",
+                    "1.0",
+                    SecureHash("SHA-256", "abc".toByteArray())
+                ),
+                ""
+            )
+        }
+
+        assertThrows<NotImplementedError> {
+            externalChannelsConfigValidator.validate(
+                cpkIdentifier = CpkIdentifier(
+                    "name",
+                    "1.0",
+                    SecureHash("SHA-256", "abc".toByteArray())
+                ),
+                "invalid configuration"
+            )
+        }
+    }
+
+    @Test
+    fun `does not throw exception when string is null`() {
+        assertDoesNotThrow {
+            externalChannelsConfigValidator.validate(
+                cpkIdentifier = CpkIdentifier(
+                    "name",
+                    "1.0",
+                    SecureHash("SHA-256", "abc".toByteArray())
+                ),
+                null
+            )
+        }
+    }
+}

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -2,9 +2,7 @@ package net.corda.chunking.db.impl.validation
 
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiMetadata
-import net.corda.libs.packaging.core.CpkIdentifier
 import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.v5.crypto.SecureHash
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -19,10 +19,9 @@ class ExternalChannelsConfigValidatorTest {
     fun `does not throw exception when the configuration is valid`() {
         val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "{ }" ) }
         val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
-        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
 
         assertDoesNotThrow {
-            externalChannelsConfigValidator.validate(cpi)
+            externalChannelsConfigValidator.validate(mockCpiMetadata.cpksMetadata)
         }
     }
 
@@ -30,10 +29,9 @@ class ExternalChannelsConfigValidatorTest {
     fun `does not throw exception when the configuration is null`() {
         val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( null ) }
         val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
-        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
 
         assertDoesNotThrow {
-            externalChannelsConfigValidator.validate(cpi)
+            externalChannelsConfigValidator.validate(mockCpiMetadata.cpksMetadata)
         }
     }
 
@@ -41,10 +39,9 @@ class ExternalChannelsConfigValidatorTest {
     fun `throws exception when the configuration is invalid`() {
         val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "invalid schema") }
         val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
-        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
 
         assertThrows<NotImplementedError> {
-            externalChannelsConfigValidator.validate(cpi)
+            externalChannelsConfigValidator.validate(mockCpiMetadata.cpksMetadata)
         }
     }
 
@@ -52,10 +49,9 @@ class ExternalChannelsConfigValidatorTest {
     fun `throws exception when the configuration string is empty`() {
         val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "" ) }
         val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
-        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
 
         assertThrows<NotImplementedError> {
-            externalChannelsConfigValidator.validate(cpi)
+            externalChannelsConfigValidator.validate(mockCpiMetadata.cpksMetadata)
         }
     }
 }

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -1,51 +1,50 @@
 package net.corda.chunking.db.impl.validation
 
+import net.corda.libs.packaging.Cpi
+import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.v5.crypto.SecureHash
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class ExternalChannelsConfigValidatorTest {
 
     private val externalChannelsConfigValidator = ExternalChannelsConfigValidatorImpl()
 
     @Test
-    fun `throws exception when string is not null because the method is not implemented`() {
-        assertThrows<NotImplementedError> {
-            externalChannelsConfigValidator.validate(
-                cpkIdentifier = CpkIdentifier(
-                    "name",
-                    "1.0",
-                    SecureHash("SHA-256", "abc".toByteArray())
-                ),
-                ""
-            )
-        }
+    fun `throws exception when string is not null because the method is not implemented - non-empty string`() {
+        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "{}") }
+        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
+        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
 
         assertThrows<NotImplementedError> {
-            externalChannelsConfigValidator.validate(
-                cpkIdentifier = CpkIdentifier(
-                    "name",
-                    "1.0",
-                    SecureHash("SHA-256", "abc".toByteArray())
-                ),
-                "invalid configuration"
-            )
+            externalChannelsConfigValidator.validate(cpi)
+        }
+    }
+
+    @Test
+    fun `throws exception when string is not null because the method is not implemented - empty string`() {
+        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( "") }
+        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
+        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
+
+        assertThrows<NotImplementedError> {
+            externalChannelsConfigValidator.validate(cpi)
         }
     }
 
     @Test
     fun `does not throw exception when string is null`() {
+        val mockCpkMetadata = mock<CpkMetadata> { on { externalChannelsConfig }.doReturn( null) }
+        val mockCpiMetadata = mock<CpiMetadata> { on { cpksMetadata }.doReturn(listOf(mockCpkMetadata) ) }
+        val cpi = mock<Cpi> { on { metadata }.doReturn(mockCpiMetadata) }
+
         assertDoesNotThrow {
-            externalChannelsConfigValidator.validate(
-                cpkIdentifier = CpkIdentifier(
-                    "name",
-                    "1.0",
-                    SecureHash("SHA-256", "abc".toByteArray())
-                ),
-                null
-            )
+            externalChannelsConfigValidator.validate(cpi)
         }
     }
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -163,7 +163,8 @@ class FlowServiceTestContext @Activate constructor(
             CpkType.UNKNOWN,
             cpkChecksum,
             setOf(),
-            timestamp
+            timestamp,
+            null
         )
 
         val cpiMeta = CpiMetadata(

--- a/components/virtual-node/cpi-upload-rest-service/src/test/kotlin/net/corda/cpi/upload/endpoints/v1/EndpointTypeConvertersTest.kt
+++ b/components/virtual-node/cpi-upload-rest-service/src/test/kotlin/net/corda/cpi/upload/endpoints/v1/EndpointTypeConvertersTest.kt
@@ -24,7 +24,8 @@ internal class EndpointTypeConvertersTest {
             type = CpkType.CORDA_API,
             fileChecksum = SecureHash.parse("DONT_CARE:1234"),
             cordappCertificates = emptySet(),
-            timestamp = Instant.now()
+            timestamp = Instant.now(),
+            externalChannelsConfig = null
         )
     }
 

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/Helpers.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/Helpers.kt
@@ -39,7 +39,8 @@ object Helpers {
             CpkType.CORDA_API,
             fileChecksum,
             emptySet(),
-            Instant.now()
+            Instant.now(),
+            null
         )
     }
 

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkMetadata.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkMetadata.kt
@@ -39,7 +39,8 @@ data class CpkMetadata(
     val fileChecksum: SecureHash,
     // TODO - is this needed here?
     val cordappCertificates: Set<Certificate>,
-    val timestamp: Instant
+    val timestamp: Instant,
+    val externalChannelsConfig: String?
 ) {
     companion object {
         fun fromAvro(other: CpkMetadataAvro): CpkMetadata {
@@ -58,7 +59,8 @@ data class CpkMetadata(
                             .use(crtFactory::generateCertificate)
                     }.collect(Collectors.toUnmodifiableSet())
                 },
-                other.timestamp
+                other.timestamp,
+                other.externalChannelsConfig
             )
         }
 
@@ -90,6 +92,7 @@ data class CpkMetadata(
                         )
                 )
                 .setTimestamp(timestamp)
+                .setExternalChannelsConfig(externalChannelsConfig)
                 .build()
     }
 

--- a/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/ConvertersTest.kt
+++ b/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/ConvertersTest.kt
@@ -17,6 +17,7 @@ class ConvertersTest {
             Assertions.assertEquals(cpkMetadata1.type, cpkMetadata2.type)
             Assertions.assertEquals(cpkMetadata1.fileChecksum, cpkMetadata2.fileChecksum)
             Assertions.assertEquals(cpkMetadata1.cordappCertificates, cpkMetadata2.cordappCertificates)
+            Assertions.assertEquals(cpkMetadata1.externalChannelsConfig, cpkMetadata2.externalChannelsConfig)
         }
 
         fun assertCordappManifestEquals(m1 : CordappManifest, m2 : CordappManifest) {

--- a/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/CpkMetaTestData.kt
+++ b/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/CpkMetaTestData.kt
@@ -45,6 +45,17 @@ object CpkMetaTestData {
         ),
     )
 
+    private const val externalChannelsConfig = """
+                {
+                    "channel 1" : {
+                        "type" : "send"
+                    },
+                    "channel 2" :{
+                        "type" : "send-receive"
+                    }
+                }
+            """
+
     fun create(): CpkMetadata {
         return CpkMetadata(
             cpkId,
@@ -55,7 +66,8 @@ object CpkMetaTestData {
             cpkType,
             SecureHash(DigestAlgorithmName.SHA2_256.name, ByteArray(32).also(random::nextBytes)),
             emptySet(),
-            currentTimeStamp
+            currentTimeStamp,
+            externalChannelsConfig
         )
     }
 }

--- a/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/CpkMetaTestData.kt
+++ b/libs/packaging/packaging-core/src/test/kotlin/net/corda/libs/packaging/core/CpkMetaTestData.kt
@@ -45,16 +45,7 @@ object CpkMetaTestData {
         ),
     )
 
-    private const val externalChannelsConfig = """
-                {
-                    "channel 1" : {
-                        "type" : "send"
-                    },
-                    "channel 2" :{
-                        "type" : "send-receive"
-                    }
-                }
-            """
+    private const val externalChannelsConfig = "{}"
 
     fun create(): CpkMetadata {
         return CpkMetadata(

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/PackagingConstants.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/PackagingConstants.kt
@@ -7,6 +7,7 @@ object PackagingConstants {
     const val CPK_FILE_EXTENSION = ".cpk"
     const val CPK_LIB_FOLDER = "lib" // The folder that contains a CPK's library JARs.
     const val CPK_LIB_FOLDER_V2 = "META-INF/privatelib/"
+    const val CPK_CONFIG_FOLDER = "config"
     const val CPK_DEPENDENCIES_FILE_NAME = "CPKDependencies"
     const val CPK_DEPENDENCY_CONSTRAINTS_FILE_NAME = "DependencyConstraints"
     const val CPK_DEPENDENCIES_FILE_ENTRY = "$META_INF_FOLDER/$CPK_DEPENDENCIES_FILE_NAME"

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoader.kt
@@ -1,0 +1,16 @@
+package net.corda.libs.packaging.internal
+
+import net.corda.libs.packaging.internal.v2.JarEntryAndBytes
+
+interface ExternalChannelsConfigLoader {
+
+    companion object {
+        const val EXTERNAL_CHANNELS_CONFIG_FILE_NAME =
+            "external-channels.json" // Todos: this probably should be in a more accessible file
+    }
+
+    /**
+     * Loads an external channel configuration from a java entry which corresponds to a file
+     */
+    fun read(javaEntries: List<JarEntryAndBytes>): String?
+}

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoader.kt
@@ -1,12 +1,14 @@
 package net.corda.libs.packaging.internal
 
+import net.corda.libs.packaging.PackagingConstants
 import net.corda.libs.packaging.internal.v2.JarEntryAndBytes
 
 interface ExternalChannelsConfigLoader {
 
     companion object {
-        const val EXTERNAL_CHANNELS_CONFIG_FILE_NAME =
-            "external-channels.json" // Todos: this probably should be in a more accessible file
+        // Todos: this probably should be in a more accessible file
+        const val EXTERNAL_CHANNELS_CONFIG_FILE_PATH =
+            "${PackagingConstants.CPK_CONFIG_FOLDER}/external-channels.json"
     }
 
     /**

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoaderImpl.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoaderImpl.kt
@@ -1,0 +1,23 @@
+package net.corda.libs.packaging.internal
+
+import java.lang.IllegalArgumentException
+import net.corda.libs.packaging.PackagingConstants
+import net.corda.libs.packaging.internal.v2.JarEntryAndBytes
+
+class ExternalChannelsConfigLoaderImpl : ExternalChannelsConfigLoader {
+    override fun read(javaEntries: List<JarEntryAndBytes>): String? {
+        val externalChannelsConfigLoader =
+            javaEntries.filter {
+                it.entry.name.equals(
+                    "${PackagingConstants.CPK_CONFIG_FOLDER}/${ExternalChannelsConfigLoader.EXTERNAL_CHANNELS_CONFIG_FILE_NAME}"
+                )
+            }
+                .map { String(it.bytes) }
+
+        require(externalChannelsConfigLoader.size <= 1) {
+            throw IllegalArgumentException("More than one configuration file was found for the external channels")
+        }
+
+        return externalChannelsConfigLoader.singleOrNull()
+    }
+}

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoaderImpl.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoaderImpl.kt
@@ -1,16 +1,12 @@
 package net.corda.libs.packaging.internal
 
-import java.lang.IllegalArgumentException
-import net.corda.libs.packaging.PackagingConstants
 import net.corda.libs.packaging.internal.v2.JarEntryAndBytes
 
 class ExternalChannelsConfigLoaderImpl : ExternalChannelsConfigLoader {
     override fun read(javaEntries: List<JarEntryAndBytes>): String? {
         val externalChannelsConfigLoader =
             javaEntries.filter {
-                it.entry.name.equals(
-                    "${PackagingConstants.CPK_CONFIG_FOLDER}/${ExternalChannelsConfigLoader.EXTERNAL_CHANNELS_CONFIG_FILE_NAME}"
-                )
+                it.entry.name.equals(ExternalChannelsConfigLoader.EXTERNAL_CHANNELS_CONFIG_FILE_PATH)
             }
                 .map { String(it.bytes) }
 

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoaderImpl.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/ExternalChannelsConfigLoaderImpl.kt
@@ -14,10 +14,6 @@ class ExternalChannelsConfigLoaderImpl : ExternalChannelsConfigLoader {
             }
                 .map { String(it.bytes) }
 
-        require(externalChannelsConfigLoader.size <= 1) {
-            throw IllegalArgumentException("More than one configuration file was found for the external channels")
-        }
-
         return externalChannelsConfigLoader.singleOrNull()
     }
 }

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2.kt
@@ -23,10 +23,15 @@ import java.security.cert.Certificate
 import java.util.Collections
 import java.util.jar.JarInputStream
 import java.util.jar.Manifest
+import net.corda.libs.packaging.internal.ExternalChannelsConfigLoader
+import net.corda.libs.packaging.internal.ExternalChannelsConfigLoaderImpl
 
 internal const val CPK_TYPE = "Corda-CPK-Type"
 
-class CpkLoaderV2(private val clock: Clock = UTCClock()) : CpkLoader {
+class CpkLoaderV2(
+    private val clock: Clock = UTCClock(),
+    private val externalChannelsConfigLoader: ExternalChannelsConfigLoader = ExternalChannelsConfigLoaderImpl()
+) : CpkLoader {
 
     override fun loadCPK(
         source: ByteArray,
@@ -81,6 +86,9 @@ class CpkLoaderV2(private val clock: Clock = UTCClock()) : CpkLoader {
         // List all libraries
         val libNames = readLibNames(cpkEntries)
 
+        // Read the configuration for the external channels
+        val externalChannelsConfig = externalChannelsConfigLoader.read(cpkEntries)
+
         return CpkMetadata(
             cpkId = CpkIdentifier(
                 cordappManifest.bundleSymbolicName,
@@ -94,7 +102,8 @@ class CpkLoaderV2(private val clock: Clock = UTCClock()) : CpkLoader {
             cordappManifest = cordappManifest,
             cordappCertificates = cordappCertificates,
             libraries = Collections.unmodifiableList(libNames),
-            timestamp = clock.instant()
+            timestamp = clock.instant(),
+            externalChannelsConfig = externalChannelsConfig
         )
     }
 

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2Test.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2Test.kt
@@ -39,6 +39,7 @@ class CpkLoaderV2Test {
                 )
             },
             { assertEquals(CPK_FORMAT_VERSION2_MAINBUNDLE_PLACEHOLDER, cpk.metadata.mainBundle) },
+            { assertEquals( TestUtils.EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT, cpk.metadata.externalChannelsConfig) }
         )
     }
 }

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -573,7 +573,9 @@ private data class CpkAndContents(
             fileChecksum = cpkChecksum ?:
                 SecureHash(HASH_ALGORITHM, MessageDigest.getInstance(HASH_ALGORITHM).digest(cpkBytes.toByteArray())),
             cordappCertificates = emptySet(),
-            timestamp = Instant.now())
+            timestamp = Instant.now(),
+            null
+        )
         override fun getInputStream() = ByteArrayInputStream(cpkBytes.toByteArray())
         override fun getResourceAsStream(resourceName: String) = ByteArrayInputStream(ByteArray(0))
         override fun getMainBundle(): InputStream = ByteArrayInputStream(ByteArray(0))

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
@@ -67,7 +67,7 @@ class CpiInfoDbReconcilerReaderTest {
                         "type" : "send-receive"
                     }
                 }
-            """
+            """.trimIndent()
     )
 
     private val dummyCpk =

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
@@ -57,7 +57,17 @@ class CpiInfoDbReconcilerReaderTest {
         CpkType.CORDA_API,
         SecureHash(DigestAlgorithmName.SHA2_256.name, ByteArray(32).also(random::nextBytes)),
         emptySet(),
-        Instant.now().truncatedTo(ChronoUnit.MILLIS)
+        Instant.now().truncatedTo(ChronoUnit.MILLIS),
+        externalChannelsConfig = """
+                {
+                    "channel 1" : {
+                        "type" : "send"
+                    },
+                    "channel 2" :{
+                        "type" : "send-receive"
+                    }
+                }
+            """
     )
 
     private val dummyCpk =

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiInfoDbReconcilerReaderTest.kt
@@ -58,16 +58,7 @@ class CpiInfoDbReconcilerReaderTest {
         SecureHash(DigestAlgorithmName.SHA2_256.name, ByteArray(32).also(random::nextBytes)),
         emptySet(),
         Instant.now().truncatedTo(ChronoUnit.MILLIS),
-        externalChannelsConfig = """
-                {
-                    "channel 1" : {
-                        "type" : "send"
-                    },
-                    "channel 2" :{
-                        "type" : "send-receive"
-                    }
-                }
-            """.trimIndent()
+        externalChannelsConfig = "{}"
     )
 
     private val dummyCpk =

--- a/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/TestCatalogue.kt
+++ b/testing/cpi-info-read-service-fake/src/test/kotlin/net/corda/cpiinfo/read/fake/TestCatalogue.kt
@@ -40,7 +40,8 @@ object TestCatalogue {
                         CpkType.UNKNOWN,
                         SecureHash("ALG", byteArrayOf(0, 0, 0, 0)),
                         setOf(),
-                        timestamp
+                        timestamp,
+                        null
                     )
                 ),
                 "",

--- a/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/MockCurrentSandboxGroupContext.kt
+++ b/testing/ledger/ledger-common-base-test/src/main/kotlin/net/corda/ledger/common/test/MockCurrentSandboxGroupContext.kt
@@ -59,5 +59,6 @@ private fun makeCpkMetadata(i: Int, cordappType: CordappType) = CpkMetadata(
     CpkType.UNKNOWN,
     SecureHash(DigestAlgorithmName.SHA2_256.name, ByteArray(32) { i.toByte() }),
     emptySet(),
-    Instant.now()
+    Instant.now(),
+    null
 )

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
@@ -25,16 +25,7 @@ object TestUtils {
     internal val CA1 = certificate("ca1", resourceInputStream("ca1.p12"))
     internal val CA2 = certificate("ca2", resourceInputStream("ca2.p12"))
     internal val CODE_SIGNER_ALICE = codeSigner("alice", resourceInputStream("alice.p12"))
-    const val EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT = """
-                {
-                    "channel 1" : {
-                        "type" : "send"
-                    },
-                    "channel 2" :{
-                        "type" : "send-receive"
-                    }
-                }
-            """
+    const val EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT = "{}"
 
     val ROOT_CA_KEY_STORE : InputStream
         get() = resourceInputStream("rootca.p12")

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
@@ -25,6 +25,16 @@ object TestUtils {
     internal val CA1 = certificate("ca1", resourceInputStream("ca1.p12"))
     internal val CA2 = certificate("ca2", resourceInputStream("ca2.p12"))
     internal val CODE_SIGNER_ALICE = codeSigner("alice", resourceInputStream("alice.p12"))
+    const val EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT = """
+                {
+                    "channel 1" : {
+                        "type" : "send"
+                    },
+                    "channel 2" :{
+                        "type" : "send-receive"
+                    }
+                }
+            """
 
     val ROOT_CA_KEY_STORE : InputStream
         get() = resourceInputStream("rootca.p12")

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpk/TestCpkV2Builder.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpk/TestCpkV2Builder.kt
@@ -7,7 +7,6 @@ import net.corda.libs.packaging.testutils.TestUtils.toBase64
 import net.corda.test.util.InMemoryZipFile
 import java.io.ByteArrayInputStream
 import java.util.jar.Manifest
-import net.corda.libs.packaging.PackagingConstants
 import net.corda.libs.packaging.internal.ExternalChannelsConfigLoader.Companion.EXTERNAL_CHANNELS_CONFIG_FILE_PATH
 
 const val CPK_BUNDLE_NAME_ATTRIBUTE = "Bundle-SymbolicName"

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpk/TestCpkV2Builder.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpk/TestCpkV2Builder.kt
@@ -8,7 +8,7 @@ import net.corda.test.util.InMemoryZipFile
 import java.io.ByteArrayInputStream
 import java.util.jar.Manifest
 import net.corda.libs.packaging.PackagingConstants
-import net.corda.libs.packaging.internal.ExternalChannelsConfigLoader.Companion.EXTERNAL_CHANNELS_CONFIG_FILE_NAME
+import net.corda.libs.packaging.internal.ExternalChannelsConfigLoader.Companion.EXTERNAL_CHANNELS_CONFIG_FILE_PATH
 
 const val CPK_BUNDLE_NAME_ATTRIBUTE = "Bundle-SymbolicName"
 const val CPK_BUNDLE_VERSION_ATTRIBUTE = "Bundle-Version"
@@ -48,10 +48,7 @@ class TestCpkV2Builder {
             for (i in 1..3) addFile("package/Cpk$i.class")
             addFile("migration/schema-v1.changelog-master.xml")
             addFile("migration/schema.changelog-init.xml")
-            addFile(
-                "${PackagingConstants.CPK_CONFIG_FOLDER}/$EXTERNAL_CHANNELS_CONFIG_FILE_NAME",
-                content = TestUtils.EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT
-            )
+            addFile(EXTERNAL_CHANNELS_CONFIG_FILE_PATH, content = TestUtils.EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT)
         }.signedBy(signers = signers)
 
     private fun cpkV2Manifest() =

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpk/TestCpkV2Builder.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpk/TestCpkV2Builder.kt
@@ -7,6 +7,8 @@ import net.corda.libs.packaging.testutils.TestUtils.toBase64
 import net.corda.test.util.InMemoryZipFile
 import java.io.ByteArrayInputStream
 import java.util.jar.Manifest
+import net.corda.libs.packaging.PackagingConstants
+import net.corda.libs.packaging.internal.ExternalChannelsConfigLoader.Companion.EXTERNAL_CHANNELS_CONFIG_FILE_NAME
 
 const val CPK_BUNDLE_NAME_ATTRIBUTE = "Bundle-SymbolicName"
 const val CPK_BUNDLE_VERSION_ATTRIBUTE = "Bundle-Version"
@@ -46,6 +48,10 @@ class TestCpkV2Builder {
             for (i in 1..3) addFile("package/Cpk$i.class")
             addFile("migration/schema-v1.changelog-master.xml")
             addFile("migration/schema.changelog-init.xml")
+            addFile(
+                "${PackagingConstants.CPK_CONFIG_FOLDER}/$EXTERNAL_CHANNELS_CONFIG_FILE_NAME",
+                content = TestUtils.EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT
+            )
         }.signedBy(signers = signers)
 
     private fun cpkV2Manifest() =


### PR DESCRIPTION
Added the feature to load configuration files for external channels for each cpk.
It is assumed the configuration format is JSON but no validation has been implemented yet.
`CpkLoaderV2` is responsible for loading the file containing the configuration for external channels.
The class `CpiValidatorImpl` is responsible for validating the JSON. (Keep in mind that the logic for validating the configuration is not implemented, yet).
The configuration for external channels is stored in the `CpkMetadata`.
Added unit-tests.
Updated other tests that are related to the `CpkMetadata`.