### PR TITLE
CORE-10407: set J17 base image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,4 +15,5 @@ cordaPipeline(
     publishToMavenS3Repository: true,
     // allow publishing an installer to a download site
     publishToDownloadSiteTask: ':tools:plugins:publish',
+    workerBaseImageTag: '17.0.4.1',
     )


### PR DESCRIPTION
setting Java17 base image on corda-cli

Missed in intal branch set up for these j17 branches