### PR TITLE
CORE-11492: Remove hardcoded `localhost:8888` from E2e tests

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/CheckClusterRolesE2eTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/CheckClusterRolesE2eTest.kt
@@ -1,7 +1,8 @@
 package net.corda.applications.workers.rest
 
 import net.corda.applications.workers.rest.http.SkipWhenRestEndpointUnavailable
-import net.corda.applications.workers.rest.http.TestToolkitProperty
+import net.corda.applications.workers.rest.utils.E2eClusterBConfig
+import net.corda.applications.workers.rest.utils.E2eClusterFactory
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionResponseType
 import net.corda.libs.permissions.endpoints.v1.permission.types.PermissionType
@@ -19,7 +20,7 @@ import org.junit.jupiter.api.TestMethodOrder
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class CheckClusterRolesE2eTest {
 
-    private val testToolkit by TestToolkitProperty()
+    private val cordaCluster = E2eClusterFactory.getE2eCluster(E2eClusterBConfig)
 
     @Test
     fun `test UserAdminRole content`() {
@@ -28,7 +29,7 @@ class CheckClusterRolesE2eTest {
             return permissionRequested.matches(permissionString.toRegex(RegexOption.IGNORE_CASE))
         }
 
-        testToolkit.httpClientFor(RoleEndpoint::class.java).use { roleClient ->
+        cordaCluster.clusterHttpClientFor(RoleEndpoint::class.java).use { roleClient ->
             val roleProxy = roleClient.start().proxy
 
             val allRoles = roleProxy.getRoles()
@@ -36,7 +37,7 @@ class CheckClusterRolesE2eTest {
             val mayBeUserAdminRole: RoleResponseType? = allRoles.firstOrNull { it.roleName == "UserAdminRole" }
             val userAdminRole = requireNotNull(mayBeUserAdminRole) { "Available roles: $allRoles" }
 
-            testToolkit.httpClientFor(PermissionEndpoint::class.java).use { permClient ->
+            cordaCluster.clusterHttpClientFor(PermissionEndpoint::class.java).use { permClient ->
                 val permProxy = permClient.start().proxy
                 val permissions: List<PermissionResponseType> =
                     userAdminRole.permissions.map { permProxy.getPermission(it.id) }
@@ -54,7 +55,7 @@ class CheckClusterRolesE2eTest {
 
     @Test
     fun `test VNodeCreatorRole content`() {
-        testToolkit.httpClientFor(RoleEndpoint::class.java).use { roleClient ->
+        cordaCluster.clusterHttpClientFor(RoleEndpoint::class.java).use { roleClient ->
             val roleProxy = roleClient.start().proxy
 
             val allRoles = roleProxy.getRoles()
@@ -62,7 +63,7 @@ class CheckClusterRolesE2eTest {
             val mayBeRequiredRole: RoleResponseType? = allRoles.firstOrNull { it.roleName == "VNodeCreatorRole" }
             val requiredRole = requireNotNull(mayBeRequiredRole) { "Available roles: $allRoles" }
 
-            testToolkit.httpClientFor(PermissionEndpoint::class.java).use { permClient ->
+            cordaCluster.clusterHttpClientFor(PermissionEndpoint::class.java).use { permClient ->
                 val permProxy = permClient.start().proxy
                 val permissions = requiredRole.permissions.map { permProxy.getPermission(it.id) }
                 assertThat(permissions.size).withFailMessage("Permissions: $permissions").isEqualTo(8)
@@ -73,7 +74,7 @@ class CheckClusterRolesE2eTest {
 
     @Test
     fun `test CordaDeveloperRole content`() {
-        testToolkit.httpClientFor(RoleEndpoint::class.java).use { roleClient ->
+        cordaCluster.clusterHttpClientFor(RoleEndpoint::class.java).use { roleClient ->
             val roleProxy = roleClient.start().proxy
 
             val allRoles = roleProxy.getRoles()
@@ -81,7 +82,7 @@ class CheckClusterRolesE2eTest {
             val mayBeRequiredRole: RoleResponseType? = allRoles.firstOrNull { it.roleName == "CordaDeveloperRole" }
             val requiredRole = requireNotNull(mayBeRequiredRole) { "Available roles: $allRoles" }
 
-            testToolkit.httpClientFor(PermissionEndpoint::class.java).use { permClient ->
+            cordaCluster.clusterHttpClientFor(PermissionEndpoint::class.java).use { permClient ->
                 val permProxy = permClient.start().proxy
                 val permissions = requiredRole.permissions.map { permProxy.getPermission(it.id) }
                 assertThat(permissions.size).withFailMessage("Permissions: $permissions").isEqualTo(2)

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/CreatePermissionE2eTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/CreatePermissionE2eTest.kt
@@ -1,7 +1,8 @@
 package net.corda.applications.workers.rest
 
-import net.corda.applications.workers.rest.http.TestToolkitProperty
 import net.corda.applications.workers.rest.http.SkipWhenRestEndpointUnavailable
+import net.corda.applications.workers.rest.utils.E2eClusterBConfig
+import net.corda.applications.workers.rest.utils.E2eClusterFactory
 import net.corda.rest.client.exceptions.MissingRequestedResourceException
 import net.corda.rest.response.ResponseEntity
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
@@ -18,11 +19,11 @@ import org.junit.jupiter.api.assertDoesNotThrow
 @SkipWhenRestEndpointUnavailable
 class CreatePermissionE2eTest {
 
-    private val testToolkit by TestToolkitProperty()
+    private val cordaCluster = E2eClusterFactory.getE2eCluster(E2eClusterBConfig)
 
     @Test
     fun testCreateAndGet() {
-        testToolkit.httpClientFor(PermissionEndpoint::class.java).use { client ->
+        cordaCluster.clusterHttpClientFor(PermissionEndpoint::class.java).use { client ->
             val proxy = client.start().proxy
 
             // Check that permission does not exist yet
@@ -32,7 +33,7 @@ class CreatePermissionE2eTest {
             }
 
             // Create permission
-            val setPermString = testToolkit.uniqueName + "-PermissionString"
+            val setPermString = cordaCluster.uniqueName + "-PermissionString"
             val createPermType = CreatePermissionType(PermissionType.ALLOW, setPermString, null, null)
 
             fun PermissionResponseType.assertResponseType(): PermissionResponseType {

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/CreateUserE2eTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/CreateUserE2eTest.kt
@@ -1,7 +1,8 @@
 package net.corda.applications.workers.rest
 
-import net.corda.applications.workers.rest.http.TestToolkitProperty
 import net.corda.applications.workers.rest.http.SkipWhenRestEndpointUnavailable
+import net.corda.applications.workers.rest.utils.E2eClusterBConfig
+import net.corda.applications.workers.rest.utils.E2eClusterFactory
 import net.corda.rest.client.exceptions.MissingRequestedResourceException
 import net.corda.libs.permissions.endpoints.v1.user.UserEndpoint
 import net.corda.libs.permissions.endpoints.v1.user.types.CreateUserType
@@ -17,12 +18,12 @@ import net.corda.rest.exception.ResourceAlreadyExistsException
 @SkipWhenRestEndpointUnavailable
 class CreateUserE2eTest {
 
-    private val testToolkit by TestToolkitProperty()
+    private val cordaCluster = E2eClusterFactory.getE2eCluster(E2eClusterBConfig)
 
     @Test
     fun testCreateAndGet() {
-        testToolkit.httpClientFor(UserEndpoint::class.java).use { client ->
-            val userName = testToolkit.uniqueName
+        cordaCluster.clusterHttpClientFor(UserEndpoint::class.java).use { client ->
+            val userName = cordaCluster.uniqueName
             val proxy = client.start().proxy
 
             // Check the user does not exist yet
@@ -30,7 +31,7 @@ class CreateUserE2eTest {
                 .hasMessageContaining("User '$userName' not found")
 
             // Create user
-            val password = testToolkit.uniqueName
+            val password = cordaCluster.uniqueName
             val passwordExpirySet = Instant.now().plus(1, DAYS).truncatedTo(DAYS)
             val createUserType = CreateUserType(userName, userName, true, password, passwordExpirySet, null)
 

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/FlowExecutorE2eTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/FlowExecutorE2eTest.kt
@@ -2,11 +2,10 @@ package net.corda.applications.workers.rest
 
 import net.corda.applications.workers.rest.cli.CliTask
 import net.corda.applications.workers.rest.http.SkipWhenRestEndpointUnavailable
-import net.corda.applications.workers.rest.http.TestToolkitProperty
-import net.corda.applications.workers.rest.http.TestToolkitProperty.Companion.DEFAULT_HTTP_HOST
-import net.corda.applications.workers.rest.http.TestToolkitProperty.Companion.DEFAULT_HTTP_PORT
 import net.corda.applications.workers.rest.utils.AdminPasswordUtil.adminPassword
 import net.corda.applications.workers.rest.utils.AdminPasswordUtil.adminUser
+import net.corda.applications.workers.rest.utils.E2eClusterBConfig
+import net.corda.applications.workers.rest.utils.E2eClusterFactory
 import net.corda.libs.permissions.endpoints.v1.role.RoleEndpoint
 import net.corda.test.util.eventually
 import net.corda.utilities.seconds
@@ -17,7 +16,7 @@ import java.util.UUID
 
 class FlowExecutorE2eTest {
 
-    private val testToolkit by TestToolkitProperty()
+    private val cordaCluster = E2eClusterFactory.getE2eCluster(E2eClusterBConfig)
 
     @Test
     fun `check help page`() {
@@ -31,14 +30,26 @@ class FlowExecutorE2eTest {
     fun `check FlowExecutor role creation`() {
         val randomVNodeHash = UUID.randomUUID().toString().replace("-", "").take(12)
 
-        val result = CliTask.execute(listOf("initial-rbac", "flow-executor", "-u", adminUser, "-p", adminPassword,
-            "-t", "https://$DEFAULT_HTTP_HOST:$DEFAULT_HTTP_PORT", "-v", randomVNodeHash))
+        val result = CliTask.execute(
+            listOf(
+                "initial-rbac",
+                "flow-executor",
+                "-u",
+                adminUser,
+                "-p",
+                adminPassword,
+                "-t",
+                "https://${cordaCluster.clusterConfig.restHost}:${cordaCluster.clusterConfig.restPort}",
+                "-v",
+                randomVNodeHash
+            )
+        )
         assertThat(result.exitCode).withFailMessage(result.stdErr).isEqualTo(0)
         val roleName = "FlowExecutorRole-$randomVNodeHash"
         assertThat(result.stdOut).contains("Successfully created $roleName")
 
         // Independently check that the role is available with permissions as expected
-        testToolkit.httpClientFor(RoleEndpoint::class.java).use { client ->
+        cordaCluster.clusterHttpClientFor(RoleEndpoint::class.java).use { client ->
             val proxy = client.start().proxy
             eventually(duration = 30.seconds, waitBetween = 1.seconds) {
                 val roleEntity = assertDoesNotThrow { proxy.getRoles().single { it.roleName == roleName } }

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/RbacE2eClientRequestHelper.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/RbacE2eClientRequestHelper.kt
@@ -1,7 +1,7 @@
 package net.corda.applications.workers.rest
 
 import java.time.Instant
-import net.corda.applications.workers.rest.http.TestToolkit
+import net.corda.applications.workers.rest.utils.E2eCluster
 import net.corda.libs.permissions.endpoints.v1.permission.PermissionEndpoint
 import net.corda.libs.permissions.endpoints.v1.permission.types.BulkCreatePermissionsRequestType
 import net.corda.libs.permissions.endpoints.v1.permission.types.CreatePermissionType
@@ -19,12 +19,12 @@ import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.assertDoesNotThrow
 
 class RbacE2eClientRequestHelper(
-    private val testToolkit: TestToolkit,
+    private val cluster: E2eCluster,
     private val requestUserName: String,
     private val requestUserPassword: String,
 ) {
     fun createUser(newUserName: String, newUserPassword: String, newUserPasswordExpiry: Instant) {
-        val client = testToolkit.httpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
 
         val createUserType = CreateUserType(newUserName, newUserName, true, newUserPassword, newUserPasswordExpiry, null)
@@ -53,7 +53,7 @@ class RbacE2eClientRequestHelper(
     }
 
     fun createRole(roleName: String): String {
-        val client = testToolkit.httpClientFor(RoleEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(RoleEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
 
         val createRoleType = CreateRoleType(roleName, null)
@@ -83,14 +83,14 @@ class RbacE2eClientRequestHelper(
     }
 
     fun createPermission(permissionType: PermissionType, permissionString: String, verify: Boolean = true): String {
-        val client = testToolkit.httpClientFor(PermissionEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(PermissionEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
 
         return proxy.createPermission(permissionType, permissionString, verify)
     }
 
     fun addPermissionsToRole(roleId: String, vararg permissionIds: String) {
-        val client = testToolkit.httpClientFor(RoleEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(RoleEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
         for(permissionId in permissionIds) {
             with(proxy.addPermission(roleId, permissionId)) {
@@ -104,7 +104,7 @@ class RbacE2eClientRequestHelper(
     }
 
     fun addRoleToUser(userName: String, roleId: String) {
-        val client = testToolkit.httpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
         with(proxy.addRole(userName, roleId)) {
             SoftAssertions.assertSoftly {
@@ -116,7 +116,7 @@ class RbacE2eClientRequestHelper(
     }
 
     fun removeRoleFromUser(userName: String, roleId: String) {
-        val client = testToolkit.httpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
         with(proxy.removeRole(userName, roleId)) {
             SoftAssertions.assertSoftly {
@@ -128,7 +128,7 @@ class RbacE2eClientRequestHelper(
     }
 
     fun getUser(userLogin: String): UserResponseType {
-        val client = testToolkit.httpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
         return with(proxy.getUser(userLogin)) {
             SoftAssertions.assertSoftly {
@@ -139,7 +139,7 @@ class RbacE2eClientRequestHelper(
     }
 
     fun getRole(roleId: String): RoleResponseType {
-        val client = testToolkit.httpClientFor(RoleEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(RoleEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
         return with(proxy.getRole(roleId)) {
             SoftAssertions.assertSoftly {
@@ -150,7 +150,7 @@ class RbacE2eClientRequestHelper(
     }
 
     fun getPermission(permissionId: String): PermissionResponseType {
-        val client = testToolkit.httpClientFor(PermissionEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(PermissionEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
         return with(proxy.getPermission(permissionId)) {
             SoftAssertions.assertSoftly {
@@ -161,7 +161,7 @@ class RbacE2eClientRequestHelper(
     }
 
     fun getPermissionSummary(userLogin: String): UserPermissionSummaryResponseType {
-        val client = testToolkit.httpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(UserEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
         return with(proxy.getPermissionSummary(userLogin)) {
             SoftAssertions.assertSoftly {
@@ -175,7 +175,7 @@ class RbacE2eClientRequestHelper(
         permissionsToCreate: Set<Pair<PermissionType, String>>,
         roleIds: Set<String>
     ): Set<String> {
-        val client = testToolkit.httpClientFor(PermissionEndpoint::class.java, requestUserName, requestUserPassword)
+        val client = cluster.clusterHttpClientFor(PermissionEndpoint::class.java, requestUserName, requestUserPassword)
         val proxy = client.start().proxy
 
         val permissionsToCreateDto: Set<CreatePermissionType> =

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/UserRoleAssociationE2eTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/UserRoleAssociationE2eTest.kt
@@ -2,8 +2,9 @@ package net.corda.applications.workers.rest
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit.DAYS
-import net.corda.applications.workers.rest.http.TestToolkitProperty
 import net.corda.applications.workers.rest.http.SkipWhenRestEndpointUnavailable
+import net.corda.applications.workers.rest.utils.E2eClusterBConfig
+import net.corda.applications.workers.rest.utils.E2eClusterFactory
 import net.corda.rest.client.exceptions.MissingRequestedResourceException
 import net.corda.rest.client.exceptions.RequestErrorException
 import net.corda.rest.exception.ResourceAlreadyExistsException
@@ -20,13 +21,13 @@ import org.junit.jupiter.api.assertDoesNotThrow
 @SkipWhenRestEndpointUnavailable
 class UserRoleAssociationE2eTest {
 
-    private val testToolkit by TestToolkitProperty()
+    private val cordaCluster = E2eClusterFactory.getE2eCluster(E2eClusterBConfig)
 
     @Test
     fun `test association of user and role`() {
 
-        val roleId = testToolkit.httpClientFor(RoleEndpoint::class.java).use { client ->
-            val name = testToolkit.uniqueName
+        val roleId = cordaCluster.clusterHttpClientFor(RoleEndpoint::class.java).use { client ->
+            val name = cordaCluster.uniqueName
             val proxy = client.start().proxy
 
             // Create role
@@ -61,12 +62,12 @@ class UserRoleAssociationE2eTest {
             roleId
         }
 
-        testToolkit.httpClientFor(UserEndpoint::class.java).use { client ->
-            val userName = testToolkit.uniqueName
+        cordaCluster.clusterHttpClientFor(UserEndpoint::class.java).use { client ->
+            val userName = cordaCluster.uniqueName
             val proxy = client.start().proxy
 
             // Create user
-            val password = testToolkit.uniqueName
+            val password = cordaCluster.uniqueName
             val passwordExpirySet = Instant.now().plus(1, DAYS).truncatedTo(DAYS)
             val createUserType = CreateUserType(userName, userName, true, password, passwordExpirySet, null)
             with(proxy.createUser(createUserType)) {

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/EndpointAvailabilityCondition.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/EndpointAvailabilityCondition.kt
@@ -1,5 +1,7 @@
 package net.corda.applications.workers.rest.http
 
+import net.corda.applications.workers.rest.utils.E2eClusterBConfig
+import net.corda.applications.workers.rest.utils.E2eClusterFactory
 import net.corda.libs.permissions.endpoints.v1.user.UserEndpoint
 import org.junit.jupiter.api.extension.ConditionEvaluationResult
 import org.junit.jupiter.api.extension.ExecutionCondition
@@ -18,7 +20,7 @@ internal class EndpointAvailabilityCondition : ExecutionCondition {
         val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    private val testToolkit by TestToolkitProperty()
+    private val cordaCluster = E2eClusterFactory.getE2eCluster(E2eClusterBConfig)
 
     override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
 
@@ -60,7 +62,7 @@ internal class EndpointAvailabilityCondition : ExecutionCondition {
      */
     private fun checkEndpoint(): Boolean {
         return try {
-            testToolkit.httpClientFor(UserEndpoint::class.java).use { client ->
+            cordaCluster.clusterHttpClientFor(UserEndpoint::class.java).use { client ->
                 val proxy = client.start().proxy
                 proxy.protocolVersion > 0
             }

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/TestToolkitProperty.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/TestToolkitProperty.kt
@@ -9,17 +9,13 @@ import kotlin.reflect.KProperty
  * testcase which contains this property, giving an opportunity to "personalize" implementation
  * for a specific test.
  *
- * Such personalization may, for example, include REST user names that are matching the name of the test class.
+ * Such personalization may, for example, include REST usernames that are matching the name of the test class.
+ *
+ * Rather than using this class, please consider using [net.corda.applications.workers.rest.utils.E2eCluster] to gain
+ * access to multi-cluster deployment as well as other functions available.
  */
 class TestToolkitProperty(private val host: String, private val port: Int) :
     ReadOnlyProperty<Any, TestToolkit> {
-
-    companion object {
-        const val DEFAULT_HTTP_HOST = "localhost"
-        const val DEFAULT_HTTP_PORT = 8888
-    }
-
-    constructor() : this(DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT)
 
     private lateinit var impl: TestToolkit
 

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/E2eCluster.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/E2eCluster.kt
@@ -23,7 +23,8 @@ interface E2eCluster {
      */
     fun <I : RestResource> clusterHttpClientFor(
         restResourceClass: Class<I>,
-        userName: String = AdminPasswordUtil.adminUser
+        userName: String = AdminPasswordUtil.adminUser,
+        restPassword: String = clusterConfig.restPassword
     ): RestClient<I>
 }
 
@@ -58,6 +59,7 @@ private class E2eClusterImpl(
 
     override fun <I : RestResource> clusterHttpClientFor(
         restResourceClass: Class<I>,
-        userName: String
-    ): RestClient<I> = testToolkit.httpClientFor(restResourceClass, userName, clusterConfig.restPassword)
+        userName: String,
+        restPassword: String
+    ): RestClient<I> = testToolkit.httpClientFor(restResourceClass, userName, restPassword)
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/client/SmokeTestWebsocketClient.kt
@@ -1,5 +1,6 @@
 package net.corda.applications.workers.smoketest.websocket.client
 
+import net.corda.e2etest.utilities.CLUSTER_URI
 import net.corda.e2etest.utilities.PASSWORD
 import net.corda.e2etest.utilities.USERNAME
 import net.corda.e2etest.utilities.getOrThrow
@@ -14,6 +15,7 @@ import org.eclipse.jetty.websocket.api.StatusCode
 import org.eclipse.jetty.websocket.api.WebSocketAdapter
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest
 import org.eclipse.jetty.websocket.client.WebSocketClient
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
 import java.time.Duration
@@ -55,8 +57,8 @@ class SmokeTestWebsocketClient(
 ) : AutoCloseable {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
-        const val baseWssPath = "wss://localhost:8888/api/v1"
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        val baseWssPath = with(URI("wss", CLUSTER_URI.schemeSpecificPart, CLUSTER_URI.fragment)) { "${this}api/v1" }
     }
 
     private val httpClient = HttpClient(SslContextFactory.Client(true))


### PR DESCRIPTION
Also remove default constructor from `TestToolkitProperty` to avoid temptation of using default REST endpoint address.

The added benefit here is that E2e tests could be executed against REST endpoint running on any host/port.
The settings will be controlled by the environment variables: `E2E_CLUSTER_B_REST_HOST` and `E2E_CLUSTER_B_REST_PORT` which can be set prior to starting E2E suite.

I have tested locally using [Ngrok](https://ngrok.com/) that it is possible to successfully run E2e using:
```
E2E_CLUSTER_B_REST_PORT=443
E2E_CLUSTER_B_REST_HOST=76ea-81-148-212-130.eu.ngrok.io
```