### PR TITLE
CORE-11034: Add a cache per sandbox type and make the size of each configurable

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -42,7 +42,7 @@ class VNodeServiceImpl @Activate constructor(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        sandboxGroupContextComponent.initCache(1)
+        sandboxGroupContextComponent.initCaches(1)
     }
 
     override fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
@@ -9,11 +9,7 @@ import net.corda.flow.pipeline.sandbox.impl.FlowSandboxGroupContextImpl
 import net.corda.flow.pipeline.sessions.protocol.FlowProtocolStore
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.sandbox.SandboxGroup
-import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
-import net.corda.sandboxgroupcontext.RequireSandboxAMQP
-import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
-import net.corda.sandboxgroupcontext.VirtualNodeContext
+import net.corda.sandboxgroupcontext.*
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.v5.application.flows.Flow
@@ -68,7 +64,7 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
         return cpkChecksums.any { availableCpk.contains(it) }
     }
 
-    override fun initCache(capacity: Long) {
+    override fun initCache(type: SandboxGroupType, capacity: Long) {
         TODO("Not yet implemented")
     }
 

--- a/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/helpers/VirtualNodeService.kt
+++ b/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/helpers/VirtualNodeService.kt
@@ -28,7 +28,7 @@ class VirtualNodeService @Activate constructor(
     }
 
     init {
-        sandboxGroupContextComponent.initCache(2)
+        sandboxGroupContextComponent.initCaches(2)
     }
 
     fun load(resourceName: String): VirtualNodeInfo {

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
@@ -44,7 +44,7 @@ class VirtualNodeService @Activate constructor(
     }
     init {
         // setting cache size to 2 as some tests require 2 concurrent sandboxes for validating they don't overlap
-        sandboxGroupContextComponent.initCache(2)
+        sandboxGroupContextComponent.initCaches(2)
     }
 
     private val vnodes = mutableMapOf<SandboxGroupContext, VirtualNodeInfo>()

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheControl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheControl.kt
@@ -1,11 +1,14 @@
 package net.corda.sandboxgroupcontext.service
 
+import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
 interface CacheControl {
-    fun initCache(capacity: Long)
+    fun initCaches(capacity: Long) = SandboxGroupType.values().forEach { initCache(it, capacity) }
+
+    fun initCache(type: SandboxGroupType, capacity: Long)
     fun flushCache(): CompletableFuture<*>
     fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
 

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
@@ -3,17 +3,18 @@ package net.corda.sandboxgroupcontext.service.impl
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 
 interface SandboxGroupContextCache : AutoCloseable {
-    val capacity: Long
+    val capacities: Map<SandboxGroupType, Long>
     fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
     fun get(
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext
 
-    fun resize(newCapacity: Long): SandboxGroupContextCache
+    fun resize(sandboxGroupType: SandboxGroupType, newCapacity: Long): SandboxGroupContextCache
     fun flush(): CompletableFuture<*>
 
     @Throws(InterruptedException::class)

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
@@ -66,7 +66,7 @@ class SandboxGroupContextServiceImplTest {
             scr,
             bundleContext
         )
-        service.initCache(1)
+        service.initCaches(1)
         virtualNodeContext = createVirtualNodeContextForFlow(
             holdingIdentity,
             cpks.mapTo(mutableSetOf()) { it.metadata.fileChecksum }
@@ -146,7 +146,7 @@ class SandboxGroupContextServiceImplTest {
         val cpkService = CpkReadServiceFake(cpks1 + cpks2 + cpks3)
 
         val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext).apply {
-            initCache(1)
+            initCaches(1)
         }
 
         val dog1 = Dog("Rover", "Woof!")

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImplTest.kt
@@ -10,7 +10,11 @@ import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextComponentIm
 import net.corda.schema.configuration.ConfigKeys
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class SandboxGroupContextComponentImplTest {
 

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImplTest.kt
@@ -1,0 +1,98 @@
+package net.corda.sandboxgroupcontext.service.impl
+
+import com.typesafe.config.ConfigFactory
+import net.corda.configuration.read.ConfigChangedEvent
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleEventHandler
+import net.corda.sandboxgroupcontext.SandboxGroupType
+import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextComponentImpl.Companion.SANDBOX_CACHE_SIZE_DEFAULT
+import net.corda.schema.configuration.ConfigKeys
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.*
+
+class SandboxGroupContextComponentImplTest {
+
+    @Test
+    fun `correct cache size is created when provided by config`() {
+        val sandboxGroupContextService = mock<SandboxGroupContextServiceImpl>()
+        val handler = argumentCaptor<LifecycleEventHandler>()
+        val coordinatorFactory = mock<LifecycleCoordinatorFactory>().also {
+            whenever(it.createCoordinator(any(), handler.capture())).thenReturn(mock())
+        }
+        val config = SmartConfigFactory.createWithoutSecurityServices().create(
+            ConfigFactory.parseString(
+                """
+              flow {
+                cache {
+                  size = 4
+                }
+              }
+              persistence {
+                cache {
+                  size = 3
+                }
+              }
+              verification {
+                cache {
+                  size = 2
+                }
+              }
+        """.trimIndent()
+            )
+        )
+
+        @Suppress("UNUSED_VARIABLE") val sandboxGroupContextComponentImpl = SandboxGroupContextComponentImpl(
+            mock(),
+            mock(),
+            coordinatorFactory,
+            sandboxGroupContextService,
+            mock(),
+            mock(),
+        )
+
+        handler.lastValue.processEvent(
+            ConfigChangedEvent(
+                setOf(ConfigKeys.SANDBOX_CONFIG),
+                mapOf(ConfigKeys.SANDBOX_CONFIG to config)
+            ),
+            mock()
+        )
+
+        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.FLOW), eq(4))
+        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.PERSISTENCE), eq(3))
+        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.VERIFICATION), eq(2))
+    }
+
+    @Test
+    fun `default cache size is created when no config is given`() {
+        val sandboxGroupContextService = mock<SandboxGroupContextServiceImpl>()
+        val handler = argumentCaptor<LifecycleEventHandler>()
+        val coordinatorFactory = mock<LifecycleCoordinatorFactory>().also {
+            whenever(it.createCoordinator(any(), handler.capture())).thenReturn(mock())
+        }
+        val config = SmartConfigFactory.createWithoutSecurityServices().create(ConfigFactory.parseString(""))
+
+        @Suppress("UNUSED_VARIABLE") val sandboxGroupContextComponentImpl = SandboxGroupContextComponentImpl(
+            mock(),
+            mock(),
+            coordinatorFactory,
+            sandboxGroupContextService,
+            mock(),
+            mock(),
+        )
+
+        handler.lastValue.processEvent(
+            ConfigChangedEvent(
+                setOf(ConfigKeys.SANDBOX_CONFIG),
+                mapOf(ConfigKeys.SANDBOX_CONFIG to config)
+            ),
+            mock()
+        )
+
+        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.FLOW), eq(SANDBOX_CACHE_SIZE_DEFAULT))
+        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.PERSISTENCE), eq(SANDBOX_CACHE_SIZE_DEFAULT))
+        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.VERIFICATION), eq(SANDBOX_CACHE_SIZE_DEFAULT))
+    }
+}

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
@@ -40,7 +40,7 @@ class VirtualNodeService @Activate constructor(
     private var connectionCounter = AtomicInteger(0)
 
     init {
-        sandboxGroupContextComponent.initCache(2)
+        sandboxGroupContextComponent.initCaches(2)
     }
 
     fun load(resourceName: String): VirtualNodeInfo {

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.testing.sandboxes.testkit.impl
 
 import net.corda.sandboxgroupcontext.SandboxGroupContextService
+import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheControl
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
@@ -24,9 +25,9 @@ class SandboxGroupContextComponentImpl @Activate constructor(
 
     override val isRunning: Boolean = true
 
-    override fun initCache(capacity: Long) {
+    override fun initCache(type: SandboxGroupType, capacity: Long) {
         (sandboxGroupContextService as? CacheControl
-            ?: throw IllegalStateException("Cannot initialize sandbox cache")).initCache(capacity)
+            ?: throw IllegalStateException("Cannot initialize sandbox cache")).initCache(type, capacity)
     }
 
     override fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>? {

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
@@ -36,7 +36,7 @@ class VirtualNodeServiceImpl @Activate constructor(
     }
 
     init {
-        sandboxGroupContextComponent.initCache(1)
+        sandboxGroupContextComponent.initCaches(1)
     }
 
     override fun loadVirtualNode(resourceName: String): VirtualNodeInfo {


### PR DESCRIPTION
The cache is stored away in `MultiCache` which holds a map of one cache per `SandboxGroupType`.  Where possible, the calling interfaces weren't changed.  In some cases (see `CacheControl`, for example) the `SandboxGroupType` had to be added to distinguish between which cache a call was for.  This should be external to any Sandbox users, however, as at their level it's the `VirtualNodeContext` which they'll (still) be passing in.