### PR TITLE
CORE-11521 Remove `DigitalSignature.WithKey.context`

### DIFF
--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -274,8 +274,7 @@ class CryptoOpsClientImpl(
         val response = request.execute(Duration.ofSeconds(20), CryptoSignatureWithKey::class.java)
         return DigitalSignature.WithKey(
             schemeMetadata.decodePublicKey(response!!.publicKey.array()),
-            response.bytes.array(),
-            response.context.toMap()
+            response.bytes.array()
         )
     }
 

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -14,7 +14,6 @@ import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.publicKeyIdFromBytes
 import net.corda.crypto.impl.createWireRequestContext
-import net.corda.crypto.impl.toMap
 import net.corda.crypto.impl.toWire
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.SecureHashes

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -24,7 +24,6 @@ import net.corda.crypto.core.CryptoTenants
 import net.corda.crypto.core.KEY_LOOKUP_INPUT_ITEMS_LIMIT
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.publicKeyIdFromBytes
-import net.corda.crypto.impl.toWire
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.ShortHashes
@@ -760,12 +759,10 @@ class CryptoOpsClientComponentTests {
             DigestAlgorithmName.SHA2_256.name,
             null
         )
-        val opCtx = knownOperationContext.toWire()
         setupCompletedResponse {
             CryptoSignatureWithKey(
                 publicKey,
-                ByteBuffer.wrap(signature),
-                opCtx
+                ByteBuffer.wrap(signature)
             )
         }
         val result = sender.act {
@@ -774,7 +771,6 @@ class CryptoOpsClientComponentTests {
         assertNotNull(result.value)
         assertArrayEquals(publicKey.array(), result.value.publicKey.array())
         assertArrayEquals(signature, result.value.bytes.array())
-        assertSame(opCtx, result.value.context)
         val command = assertOperationType<SignRpcCommand>()
         assertNotNull(command)
         assertSame(spec, command.signatureSpec)
@@ -813,8 +809,7 @@ class CryptoOpsClientComponentTests {
         setupCompletedResponse {
             CryptoSignatureWithKey(
                 ByteBuffer.wrap(schemeMetadata.encodeAsByteArray(keyPair.public)),
-                ByteBuffer.wrap(signature),
-                knownOperationContext.toWire()
+                ByteBuffer.wrap(signature)
             )
         }
         val result = sender.act {
@@ -823,10 +818,6 @@ class CryptoOpsClientComponentTests {
         assertNotNull(result.value)
         assertEquals(keyPair.public, result.value.by)
         assertArrayEquals(signature, result.value.bytes)
-        assertThat(result.value.context).hasSize(knownOperationContext.size)
-        knownOperationContext.forEach {
-            assertThat(result.value.context).containsEntry(it.key, it.value)
-        }
         val command = assertOperationType<SignRpcCommand>()
         assertNotNull(command)
         assertEquals(SignatureSpec.ECDSA_SHA256.signatureName, command.signatureSpec.signatureName)
@@ -854,8 +845,7 @@ class CryptoOpsClientComponentTests {
         setupCompletedResponse {
             CryptoSignatureWithKey(
                 ByteBuffer.wrap(schemeMetadata.encodeAsByteArray(keyPair.public)),
-                ByteBuffer.wrap(signature),
-                knownOperationContext.toWire()
+                ByteBuffer.wrap(signature)
             )
         }
         val result = sender.act {
@@ -864,10 +854,6 @@ class CryptoOpsClientComponentTests {
         assertNotNull(result.value)
         assertEquals(keyPair.public, result.value.by)
         assertArrayEquals(signature, result.value.bytes)
-        assertThat(result.value.context).hasSize(knownOperationContext.size)
-        knownOperationContext.forEach {
-            assertThat(result.value.context).containsEntry(it.key, it.value)
-        }
         val command = assertOperationType<SignRpcCommand>()
         assertNotNull(command)
         assertEquals(spec.signatureName, command.signatureSpec.signatureName)

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -175,7 +175,7 @@ class SigningServiceImpl(
         else
             SigningAliasSpec(getHsmAlias(record, publicKey, tenantId), publicKey, scheme, signatureSpec)
         val signedBytes = cryptoService.sign(spec, data, context + mapOf(CRYPTO_TENANT_ID to tenantId))
-        return DigitalSignature.WithKey(record.publicKey, signedBytes, context)
+        return DigitalSignature.WithKey(record.publicKey, signedBytes)
     }
     
     override fun deriveSharedSecret(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessor.kt
@@ -13,7 +13,6 @@ import net.corda.crypto.impl.retrying.BackoffStrategy
 import net.corda.crypto.impl.retrying.CryptoRetryingExecutor
 import net.corda.crypto.impl.toMap
 import net.corda.crypto.impl.toSignatureSpec
-import net.corda.crypto.impl.toWire
 import net.corda.crypto.service.KeyOrderBy
 import net.corda.crypto.service.SigningKeyInfo
 import net.corda.crypto.service.SigningService
@@ -227,8 +226,7 @@ class CryptoOpsBusProcessor(
             )
             return CryptoSignatureWithKey(
                 ByteBuffer.wrap(signingService.schemeMetadata.encodeAsByteArray(signature.by)),
-                ByteBuffer.wrap(signature.bytes),
-                signature.context.toWire()
+                ByteBuffer.wrap(signature.bytes)
             )
         }
 

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
@@ -291,18 +291,15 @@ class CryptoFlowOpsBusProcessorTests {
         var passedTenantId = UUID.randomUUID().toString()
         var passedPublicKey = ByteBuffer.allocate(1)
         var passedData = ByteBuffer.allocate(1)
-        var passedContext = KeyValuePairList()
         var passedSignatureSpec = CryptoSignatureSpec()
         doAnswer {
             passedTenantId = it.getArgument(0)
             passedPublicKey = it.getArgument(1)
             passedSignatureSpec = it.getArgument(2)
             passedData = it.getArgument(3)
-            passedContext = it.getArgument(4)
             CryptoSignatureWithKey(
                 ByteBuffer.wrap(keyEncodingService.encodeAsByteArray(publicKey)),
-                ByteBuffer.wrap(signature),
-                passedContext
+                ByteBuffer.wrap(signature)
             )
         }.whenever(cryptoOpsClient).signProxy(any(), any(), any(), any(), any())
 
@@ -355,11 +352,6 @@ class CryptoFlowOpsBusProcessorTests {
         assertArrayEquals(keyEncodingService.encodeAsByteArray(publicKey), passedPublicKey.array())
         assertArrayEquals(data, passedData.array())
         assertEquals(SignatureSpec.EDDSA_ED25519.signatureName, passedSignatureSpec.signatureName)
-        assertNotNull(passedContext.items)
-        assertEquals(1, passedContext.items.size)
-        assertTrue {
-            passedContext.items[0].key == "key1" && passedContext.items[0].value == "value1"
-        }
         val transformed = transformer.transform(flowOpsResponseArgumentCaptor.firstValue)
         assertInstanceOf(DigitalSignature.WithKey::class.java, transformed)
         val transformedSignature = transformed as DigitalSignature.WithKey

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -24,7 +24,7 @@ class SigningServiceImplTest {
 
     @Test
     fun `sign returns the signature returned from the flow resuming`() {
-        val signature = DigitalSignature.WithKey(mock(), byteArrayOf(1), emptyMap())
+        val signature = DigitalSignature.WithKey(mock(), byteArrayOf(1))
         val publicKey = mock<PublicKey>()
         val encodedPublicKeyBytes = byteArrayOf(2)
         whenever(keyEncodingService.encodeAsByteArray(publicKey)).thenReturn(encodedPublicKeyBytes)

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestCryptoOpsClient.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestCryptoOpsClient.kt
@@ -95,7 +95,7 @@ internal class TestCryptoOpsClient(
         signature.initSign(privateKey)
         (signatureSpec as? ParameterizedSignatureSpec)?.let { signature.setParameter(it.params) }
         signature.update(data)
-        return DigitalSignature.WithKey(publicKey, signature.sign(), context)
+        return DigitalSignature.WithKey(publicKey, signature.sign())
     }
 
     override fun sign(

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
@@ -239,7 +239,7 @@ class DynamicKeyStoreTest {
         @Test
         fun `when keystore is not using stubs, sign with known publicKey will send the correct data`() {
             val returnedData = "ok".toByteArray()
-            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData, emptyMap())
+            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData)
             whenever(cryptoOpsClient.sign(anyString(), any(), any<SignatureSpec>(), any(), any()))
                 .doReturn(signatureWithKey)
             dynamicKeyStore.sign(publicKeyOne, spec, data)
@@ -250,7 +250,7 @@ class DynamicKeyStoreTest {
         @Test
         fun `when keystore is not using stubs, sign with known publicKey will return the correct data`() {
             val returnedData = "ok".toByteArray()
-            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData, emptyMap())
+            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData)
             whenever(cryptoOpsClient.sign(anyString(), any(), any<SignatureSpec>(), any(), any()))
                 .doReturn(signatureWithKey)
 
@@ -277,7 +277,7 @@ class DynamicKeyStoreTest {
         @Test
         fun `onNext will replace the public key`() {
             val returnedData = "ok".toByteArray()
-            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData, emptyMap())
+            val signatureWithKey = DigitalSignature.WithKey(publicKeyOne, returnedData)
             whenever(cryptoOpsClient.sign(anyString(), any(), any<SignatureSpec>(), any(), any()))
                 .doReturn(signatureWithKey)
             processorForKeystore.firstValue.onNext(
@@ -395,7 +395,7 @@ class DynamicKeyStoreTest {
             val data = "hello".toByteArray()
             val returnedData = "ok".toByteArray()
             val publicKey = certificates["certificate1"]?.publicKey!!
-            val signatureWithKey = DigitalSignature.WithKey(publicKey, returnedData, emptyMap())
+            val signatureWithKey = DigitalSignature.WithKey(publicKey, returnedData)
             whenever(
                 cryptoOpsClient.sign(
                     "id",

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualFinalityFlowV1Test.kt
@@ -302,7 +302,7 @@ class ConsensualFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
+            DigitalSignature.WithKey(publicKey, byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualReceiveFinalityFlowV1Test.kt
@@ -238,7 +238,7 @@ class ConsensualReceiveFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
+            DigitalSignature.WithKey(publicKey, byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -923,7 +923,7 @@ class UtxoFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
+            DigitalSignature.WithKey(publicKey, byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -443,7 +443,7 @@ class UtxoReceiveFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKey(publicKey, byteArray, emptyMap()),
+            DigitalSignature.WithKey(publicKey, byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -591,7 +591,7 @@ class P2PLayerEndToEndTest {
                 signature.initSign(key)
                 (signatureSpec as? ParameterizedSignatureSpec)?.let { signature.setParameter(it.params) }
                 signature.update(data)
-                DigitalSignature.WithKey(publicKey, signature.sign(), emptyMap())
+                DigitalSignature.WithKey(publicKey, signature.sign())
             }
         }
         private val groupPolicyProvider = mockLifeCycle<GroupPolicyProvider> {

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -6,6 +6,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.async.request.MembershipAsyncRequest
 import net.corda.data.membership.async.request.RegistrationAction
@@ -272,6 +273,7 @@ class MemberResourceClientImpl @Activate constructor(
                             ByteBuffer.wrap(byteArrayOf()),
                             ByteBuffer.wrap(byteArrayOf())
                         ),
+                        CryptoSignatureSpec.newBuilder().build(),
                         true
                     )
                 ).getOrThrow()

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -273,7 +273,7 @@ class MemberResourceClientImpl @Activate constructor(
                             ByteBuffer.wrap(byteArrayOf()),
                             ByteBuffer.wrap(byteArrayOf())
                         ),
-                        CryptoSignatureSpec.newBuilder().build(),
+                        CryptoSignatureSpec("", null, null),
                         true
                     )
                 ).getOrThrow()

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -270,8 +270,7 @@ class MemberResourceClientImpl @Activate constructor(
                         ByteBuffer.wrap(context),
                         CryptoSignatureWithKey(
                             ByteBuffer.wrap(byteArrayOf()),
-                            ByteBuffer.wrap(byteArrayOf()),
-                            KeyValuePairList(emptyList())
+                            ByteBuffer.wrap(byteArrayOf())
                         ),
                         true
                     )

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -305,8 +305,7 @@ class MembershipP2PIntegrationTest {
         val memberContext = KeyValuePairList(listOf(KeyValuePair(MEMBER_CONTEXT_KEY, MEMBER_CONTEXT_VALUE)))
         val fakeSigWithKey = CryptoSignatureWithKey(
             ByteBuffer.wrap(fakeKey.encodeToByteArray()),
-            ByteBuffer.wrap(fakeSig.encodeToByteArray()),
-            KeyValuePairList(emptyList())
+            ByteBuffer.wrap(fakeSig.encodeToByteArray())
         )
         val messageHeader = UnauthenticatedMessageHeader(
             destination.toAvro(),

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -14,6 +14,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.config.Configuration
 import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.data.crypto.SecureHash
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.registration.RegistrationCommand
@@ -307,6 +308,7 @@ class MembershipP2PIntegrationTest {
             ByteBuffer.wrap(fakeKey.encodeToByteArray()),
             ByteBuffer.wrap(fakeSig.encodeToByteArray())
         )
+        val fakeSigSpec = CryptoSignatureSpec("", null, null)
         val messageHeader = UnauthenticatedMessageHeader(
             destination.toAvro(),
             source.toAvro(),
@@ -317,6 +319,7 @@ class MembershipP2PIntegrationTest {
             registrationId,
             ByteBuffer.wrap(keyValuePairListSerializer.serialize(memberContext)),
             fakeSigWithKey,
+            fakeSigSpec,
             true
         )
 

--- a/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
+++ b/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
@@ -20,6 +20,12 @@ import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequestHeader
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.AuthenticatedMessage
+import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.data.p2p.app.MembershipStatusFilter
+import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.data.sync.BloomFilter
 import net.corda.membership.impl.p2p.MembershipP2PProcessor.Companion.MEMBERSHIP_P2P_SUBSYSTEM
 import net.corda.membership.lib.MemberInfoExtension.Companion.ecdhKey
@@ -27,12 +33,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.AuthenticatedMessageHeader
-import net.corda.data.p2p.app.MembershipStatusFilter
-import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.Schemas.Membership.SYNCHRONIZATION_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
@@ -74,7 +74,7 @@ class MembershipP2PProcessorTest {
 
     private val memberContext = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
     private val testSig =
-        CryptoSignatureWithKey("ABC".toByteBuffer(), "DEF".toByteBuffer(), KeyValuePairList(emptyList()))
+        CryptoSignatureWithKey("ABC".toByteBuffer(), "DEF".toByteBuffer())
     private val registrationId = UUID.randomUUID().toString()
     private val registrationRequest = MembershipRegistrationRequest(
         registrationId,

--- a/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
+++ b/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
@@ -5,6 +5,7 @@ import net.corda.crypto.hes.StableKeyPairDecryptor
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.SecureHash
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.registration.RegistrationCommand
@@ -75,11 +76,13 @@ class MembershipP2PProcessorTest {
     private val memberContext = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
     private val testSig =
         CryptoSignatureWithKey("ABC".toByteBuffer(), "DEF".toByteBuffer())
+    private val testSigSpec = CryptoSignatureSpec("", null, null)
     private val registrationId = UUID.randomUUID().toString()
     private val registrationRequest = MembershipRegistrationRequest(
         registrationId,
         memberContext,
         testSig,
+        testSigSpec,
         true
     )
     private val registrationReqMsgPayload = registrationRequest.toByteBuffer()

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
@@ -4,7 +4,6 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.core.toAvro
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
-import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.SignedMemberInfo
@@ -41,11 +40,6 @@ class MembershipPackageFactory(
         CryptoSignatureWithKey.newBuilder()
             .setBytes(ByteBuffer.wrap(this.bytes))
             .setPublicKey(ByteBuffer.wrap(keyEncodingService.encodeAsByteArray(this.by)))
-            .setContext(
-                KeyValuePairList(
-                    this.context.map { KeyValuePair(it.key, it.value) }
-                )
-            )
             .build()
 
     private val serializer: CordaAvroSerializer<KeyValuePairList> by lazy {

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
@@ -60,11 +60,10 @@ class MembershipPackageFactory(
         hashCheck: SecureHash,
         groupParameters: GroupParameters,
     ): MembershipPackage {
+        val mgmSignatureSpec = mgmSigner.signatureSpec.toAvro()
         val signedMembers = membersToSend.map {
             val memberTree = merkleTreeGenerator.generateTree(listOf(it))
             val mgmSignature = mgmSigner.sign(memberTree.root.bytes).toAvro()
-            val mgmSignatureSpec =
-                CryptoSignatureSpec(mgmSigner.signatureSpec.signatureName, null, null)
             val (memberSignature, memberSignatureSpec) =
                 membersSignatures[it.holdingIdentity]?.let { signatureAndSpec ->
                     signatureAndSpec.first to signatureAndSpec.second

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/Signer.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/Signer.kt
@@ -1,7 +1,6 @@
 package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.client.CryptoOpsClient
-import net.corda.membership.p2p.helpers.Verifier.Companion.SIGNATURE_SPEC
 import java.security.PublicKey
 
 class Signer(
@@ -9,7 +8,7 @@ class Signer(
     private val publicKey: PublicKey,
     private val cryptoOpsClient: CryptoOpsClient,
 ) {
-    private val spec by lazy {
+    val signatureSpec by lazy {
         val keySpecExtractor = KeySpecExtractor(
             tenantId,
             cryptoOpsClient,
@@ -22,7 +21,6 @@ class Signer(
             tenantId = tenantId,
             publicKey = publicKey,
             data = data,
-            signatureSpec = spec,
-            context = mapOf(SIGNATURE_SPEC to spec.signatureName),
+            signatureSpec = signatureSpec
         )
 }

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/Verifier.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/Verifier.kt
@@ -14,7 +14,6 @@ class Verifier(
     fun verify(signature: CryptoSignatureWithKey, signatureSpecAvro: CryptoSignatureSpec, data: ByteArray) {
         val publicKey = keyEncodingService.decodePublicKey(signature.publicKey.array())
         val signatureSpec = signatureSpecAvro.signatureName?.let {
-            // Maybe use `SignatureSpecService` here to check signature spec should be one of compatible ones
             SignatureSpec(it)
         } ?: throw CordaRuntimeException("Can not find signature spec")
         signatureVerificationService.verify(

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
@@ -1,8 +1,8 @@
 package net.corda.membership.p2p.helpers
 
+import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
-import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.SignedMemberInfo
@@ -14,7 +14,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.merkle.MerkleTree
@@ -88,8 +87,7 @@ class MembershipPackageFactoryTest {
             }
             val signature = DigitalSignature.WithKey(
                 publicKey,
-                bytes,
-                mapOf("name" to entry.key.name.toString())
+                bytes
             )
             whenever(mgmSigner.sign(hash)).thenReturn(signature)
         }
@@ -97,12 +95,7 @@ class MembershipPackageFactoryTest {
     private val signature = members.associate {
         it.holdingIdentity to CryptoSignatureWithKey(
             ByteBuffer.wrap("pk-${it.name}".toByteArray()),
-            ByteBuffer.wrap("sig-${it.name}".toByteArray()),
-            KeyValuePairList(
-                listOf(
-                    KeyValuePair("name", it.name.toString())
-                )
-            ),
+            ByteBuffer.wrap("sig-${it.name}".toByteArray())
         )
     }
     private val allAlg = "all-alg"
@@ -145,8 +138,7 @@ class MembershipPackageFactoryTest {
                 it.assertThat(this.mgmSignature).isEqualTo(
                     CryptoSignatureWithKey(
                         ByteBuffer.wrap(pubKey.encoded),
-                        ByteBuffer.wrap(signedGroupParameters.bytes),
-                        KeyValuePairList(emptyList()),
+                        ByteBuffer.wrap(signedGroupParameters.bytes)
                     )
                 )
             }
@@ -182,21 +174,11 @@ class MembershipPackageFactoryTest {
         val expectedMembers = (1..membersCount).map { index ->
             val memberSignature = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk-O=name-$index, L=London, C=GB".toByteArray()),
-                ByteBuffer.wrap("sig-O=name-$index, L=London, C=GB".toByteArray()),
-                KeyValuePairList(
-                    listOf(
-                        KeyValuePair("name", "O=name-$index, L=London, C=GB")
-                    )
-                )
+                ByteBuffer.wrap("sig-O=name-$index, L=London, C=GB".toByteArray())
             )
             val mgmSignature = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk-O=name-$index, L=London, C=GB".toByteArray()),
-                ByteBuffer.wrap("bytes-O=name-$index, L=London, C=GB".toByteArray()),
-                KeyValuePairList(
-                    listOf(
-                        KeyValuePair("name", "O=name-$index, L=London, C=GB")
-                    )
-                )
+                ByteBuffer.wrap("bytes-O=name-$index, L=London, C=GB".toByteArray())
             )
             SignedMemberInfo(
                 ByteBuffer.wrap("memberContext-name-$index".toByteArray()),

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.SignedMemberInfo
 import net.corda.data.membership.p2p.DistributionMetaData
@@ -176,15 +177,20 @@ class MembershipPackageFactoryTest {
                 ByteBuffer.wrap("pk-O=name-$index, L=London, C=GB".toByteArray()),
                 ByteBuffer.wrap("sig-O=name-$index, L=London, C=GB".toByteArray())
             )
+            val memberSignatureSpec = CryptoSignatureSpec("dummySignatureName", null, null)
             val mgmSignature = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk-O=name-$index, L=London, C=GB".toByteArray()),
                 ByteBuffer.wrap("bytes-O=name-$index, L=London, C=GB".toByteArray())
             )
+            val mgmSignatureSpec = CryptoSignatureSpec("dummySignatureName", null, null)
+
             SignedMemberInfo(
                 ByteBuffer.wrap("memberContext-name-$index".toByteArray()),
                 ByteBuffer.wrap("mgmContext-name-$index".toByteArray()),
                 memberSignature,
-                mgmSignature
+                memberSignatureSpec,
+                mgmSignature,
+                mgmSignatureSpec
             )
         }
         assertThat(memberships)

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerTest.kt
@@ -4,7 +4,6 @@ import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.ShortHash
 import net.corda.data.crypto.wire.CryptoSigningKey
-import net.corda.membership.p2p.helpers.Verifier.Companion.SIGNATURE_SPEC
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.KeySchemeCodes.RSA_CODE_NAME
@@ -39,8 +38,7 @@ class SignerTest {
                 tenantId = tenantId,
                 publicKey = publicKey,
                 data = data,
-                signatureSpec = SignatureSpec.RSA_SHA512,
-                context = mapOf(SIGNATURE_SPEC to SignatureSpec.RSA_SHA512.signatureName)
+                signatureSpec = SignatureSpec.RSA_SHA512
             )
         ).doReturn(signature)
 

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
@@ -208,6 +208,7 @@ class MembershipPersistenceClientImpl(
                         registrationId,
                         memberContext,
                         signature,
+                        signatureSpec,
                         isPending
                     )
                 }

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.persistence.client
 
 import net.corda.configuration.read.ConfigurationReadService
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
@@ -193,7 +194,7 @@ class MembershipQueryClientImpl(
     override fun queryMembersSignatures(
         viewOwningIdentity: HoldingIdentity,
         holdingsIdentities: Collection<HoldingIdentity>,
-    ): MembershipQueryResult<Map<HoldingIdentity, CryptoSignatureWithKey>> {
+    ): MembershipQueryResult<Map<HoldingIdentity, Pair<CryptoSignatureWithKey, CryptoSignatureSpec>>> {
         if (holdingsIdentities.isEmpty()) {
             return MembershipQueryResult.Success(emptyMap())
         }
@@ -205,7 +206,8 @@ class MembershipQueryClientImpl(
             is MemberSignatureQueryResponse -> {
                 MembershipQueryResult.Success(
                     payload.membersSignatures.associate { memberSignature ->
-                        memberSignature.holdingIdentity.toCorda() to memberSignature.signature
+                        memberSignature.holdingIdentity.toCorda() to
+                                (memberSignature.signature to memberSignature.signatureSpec)
                     }
                 )
             }

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -5,6 +5,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
@@ -142,12 +143,8 @@ class MembershipPersistenceClientImplTest {
         CryptoSignatureWithKey(
             ByteBuffer.wrap("456".toByteArray()),
             ByteBuffer.wrap("789".toByteArray()),
-            KeyValuePairList(
-                listOf(
-                    KeyValuePair("key", "value")
-                )
-            ),
         ),
+        CryptoSignatureSpec(null, null, null)
     )
 
     private val memberInfoFactory = mock<MemberInfoFactory>()

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -5,6 +5,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
@@ -483,28 +484,24 @@ class MembershipQueryClientImplTest {
         }
 
         @Test
-        fun `it will returns the correct data in case of successful result`() {
+        fun `it will return the correct data in case of successful result`() {
             val bob = createTestHoldingIdentity("O=Bob ,L=London, C=GB", ourGroupId)
             postConfigChangedEvent()
             val holdingId1 = createTestHoldingIdentity("O=Alice ,L=London, C=GB", ourGroupId)
             val signature1 = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk1".toByteArray()),
-                ByteBuffer.wrap("ct1".toByteArray()),
-                KeyValuePairList(emptyList()),
+                ByteBuffer.wrap("ct1".toByteArray())
             )
+            val signatureSpec1 = CryptoSignatureSpec("", null, null)
             val holdingId2 = createTestHoldingIdentity("O=Donald ,L=London, C=GB", ourGroupId)
             val signature2 = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk2".toByteArray()),
-                ByteBuffer.wrap("ct2".toByteArray()),
-                KeyValuePairList(emptyList()),
+                ByteBuffer.wrap("ct2".toByteArray())
             )
+            val signatureSpec2 = CryptoSignatureSpec("", null, null)
             val signatures = listOf(
-                MemberSignature(
-                    holdingId1.toAvro(), signature1
-                ),
-                MemberSignature(
-                    holdingId2.toAvro(), signature2
-                ),
+                MemberSignature(holdingId1.toAvro(), signature1, signatureSpec1),
+                MemberSignature(holdingId2.toAvro(), signature2, signatureSpec2),
             )
             whenever(rpcSender.sendRequest(any())).thenAnswer {
                 val context = with((it.arguments.first() as MembershipPersistenceRequest).context) {

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -492,13 +492,13 @@ class MembershipQueryClientImplTest {
                 ByteBuffer.wrap("pk1".toByteArray()),
                 ByteBuffer.wrap("ct1".toByteArray())
             )
-            val signatureSpec1 = CryptoSignatureSpec("", null, null)
+            val signatureSpec1 = CryptoSignatureSpec("dummy", null, null)
             val holdingId2 = createTestHoldingIdentity("O=Donald ,L=London, C=GB", ourGroupId)
             val signature2 = CryptoSignatureWithKey(
                 ByteBuffer.wrap("pk2".toByteArray()),
                 ByteBuffer.wrap("ct2".toByteArray())
             )
-            val signatureSpec2 = CryptoSignatureSpec("", null, null)
+            val signatureSpec2 = CryptoSignatureSpec("dummy", null, null)
             val signatures = listOf(
                 MemberSignature(holdingId1.toAvro(), signature1, signatureSpec1),
                 MemberSignature(holdingId2.toAvro(), signature2, signatureSpec2),
@@ -520,14 +520,15 @@ class MembershipQueryClientImplTest {
                 )
             }
 
-            val result = membershipQueryClient.queryMembersSignatures(ourHoldingIdentity, listOf(bob))
+            val result =
+                membershipQueryClient.queryMembersSignatures(ourHoldingIdentity, listOf(bob))
 
             assertThat(result.getOrThrow())
                 .containsEntry(
-                    holdingId1, signature1
+                    holdingId1, signature1 to signatureSpec1
                 )
                 .containsEntry(
-                    holdingId2, signature2
+                    holdingId2, signature2 to signatureSpec2
                 )
         }
 

--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipQueryClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipQueryClient.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.persistence.client
 
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.preauth.PreAuthTokenStatus
 import net.corda.data.membership.preauth.PreAuthToken
@@ -80,7 +81,7 @@ interface MembershipQueryClient : Lifecycle {
     fun queryMembersSignatures(
         viewOwningIdentity: HoldingIdentity,
         holdingsIdentities: Collection<HoldingIdentity>,
-    ): MembershipQueryResult<Map<HoldingIdentity, CryptoSignatureWithKey>>
+    ): MembershipQueryResult<Map<HoldingIdentity, Pair<CryptoSignatureWithKey, CryptoSignatureSpec>>>
 
     /**
      * Query for GroupPolicy.

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -1027,7 +1027,9 @@ class MembershipPersistenceTest {
                 )
             ).getOrThrow()
             val cryptoSignatureWithKey = CryptoSignatureWithKey(publicKey, signature)
-            holdingId to cryptoSignatureWithKey
+            holdingId to (
+                    cryptoSignatureWithKey to CryptoSignatureSpec("", null, null)
+            )
         }
 
         // before approval only non-pending information is available

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -77,6 +77,7 @@ import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
 import net.corda.schema.Schemas
+import net.corda.schema.configuration.BootConfig.BOOT_MAX_ALLOWED_MSG_SIZE
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
@@ -99,7 +100,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -113,8 +113,6 @@ import java.time.Instant
 import java.util.UUID
 import java.util.UUID.randomUUID
 import javax.persistence.EntityManagerFactory
-import net.corda.schema.configuration.BootConfig
-import net.corda.schema.configuration.BootConfig.BOOT_MAX_ALLOWED_MSG_SIZE
 
 @ExtendWith(ServiceExtension::class, DBSetup::class)
 class MembershipPersistenceTest {
@@ -501,7 +499,7 @@ class MembershipPersistenceTest {
                     ByteBuffer.wrap(byteArrayOf()),
                     ByteBuffer.wrap(byteArrayOf())
                 ),
-                CryptoSignatureSpec.newBuilder().build(),
+                CryptoSignatureSpec("", null, null),
                 true
             )
         )
@@ -1008,11 +1006,6 @@ class MembershipPersistenceTest {
                     KeyValuePair(MEMBER_CONTEXT_KEY, MEMBER_CONTEXT_VALUE)
                 )
             )
-            val signatureContext = KeyValuePairList(
-                listOf(
-                    KeyValuePair("key", "value")
-                )
-            )
             persistMember(holdingId.x500Name)
             membershipPersistenceClientWrapper.persistRegistrationRequest(
                 viewOwningHoldingIdentity,
@@ -1029,7 +1022,7 @@ class MembershipPersistenceTest {
                         publicKey,
                         signature
                     ),
-                    CryptoSignatureSpec.newBuilder().build(),
+                    CryptoSignatureSpec("", null, null),
                     true
                 )
             ).getOrThrow()
@@ -1080,7 +1073,7 @@ class MembershipPersistenceTest {
                     ByteBuffer.wrap(byteArrayOf()),
                     ByteBuffer.wrap(byteArrayOf())
                 ),
-                CryptoSignatureSpec.newBuilder().build(),
+                CryptoSignatureSpec("", null, null),
                 true
             )
         )
@@ -1352,7 +1345,7 @@ class MembershipPersistenceTest {
                     ByteBuffer.wrap(byteArrayOf()),
                     ByteBuffer.wrap(byteArrayOf())
                 ),
-                CryptoSignatureSpec.newBuilder().build(),
+                CryptoSignatureSpec("", null, null),
                 true
             )
         )

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -11,6 +11,7 @@ import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.config.Configuration
 import net.corda.data.config.ConfigurationSchemaVersion
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
@@ -498,9 +499,9 @@ class MembershipPersistenceTest {
                 ),
                 CryptoSignatureWithKey(
                     ByteBuffer.wrap(byteArrayOf()),
-                    ByteBuffer.wrap(byteArrayOf()),
-                    KeyValuePairList(emptyList()),
+                    ByteBuffer.wrap(byteArrayOf())
                 ),
+                CryptoSignatureSpec.newBuilder().build(),
                 true
             )
         )
@@ -1026,15 +1027,13 @@ class MembershipPersistenceTest {
                     ),
                     CryptoSignatureWithKey(
                         publicKey,
-                        signature,
-                        signatureContext,
+                        signature
                     ),
+                    CryptoSignatureSpec.newBuilder().build(),
                     true
                 )
             ).getOrThrow()
-            val cryptoSignatureWithKey = CryptoSignatureWithKey(
-                publicKey, signature, signatureContext
-            )
+            val cryptoSignatureWithKey = CryptoSignatureWithKey(publicKey, signature)
             holdingId to cryptoSignatureWithKey
         }
 
@@ -1079,9 +1078,9 @@ class MembershipPersistenceTest {
                 ),
                 CryptoSignatureWithKey(
                     ByteBuffer.wrap(byteArrayOf()),
-                    ByteBuffer.wrap(byteArrayOf()),
-                    KeyValuePairList(emptyList()),
+                    ByteBuffer.wrap(byteArrayOf())
                 ),
+                CryptoSignatureSpec.newBuilder().build(),
                 true
             )
         )
@@ -1351,9 +1350,9 @@ class MembershipPersistenceTest {
                 ),
                 CryptoSignatureWithKey(
                     ByteBuffer.wrap(byteArrayOf()),
-                    ByteBuffer.wrap(byteArrayOf()),
-                    KeyValuePairList(emptyList()),
+                    ByteBuffer.wrap(byteArrayOf())
                 ),
+                CryptoSignatureSpec.newBuilder().build(),
                 true
             )
         )

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
@@ -14,10 +14,6 @@ import javax.persistence.LockModeType
 internal class PersistRegistrationRequestHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistRegistrationRequest, Unit>(persistenceHandlerServices) {
-    private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> =
-        cordaAvroSerializationFactory.createAvroSerializer {
-            logger.error("Failed to serialize key value pair list.")
-        }
 
     override fun invoke(context: MembershipRequestContext, request: PersistRegistrationRequest) {
         val registrationId = request.registrationRequest.registrationId

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
@@ -51,7 +51,7 @@ internal class PersistRegistrationRequestHandler(
                     groupId = request.registeringHoldingIdentity.groupId,
                     memberX500Name = request.registeringHoldingIdentity.x500Name,
                     publicKey = request.registrationRequest.memberSignature.publicKey.array(),
-                    context = keyValuePairListSerializer.serialize(request.registrationRequest.memberSignature.context) ?: byteArrayOf(),
+                    signatureSpec = request.registrationRequest.memberSignatureSpec.signatureName,
                     content = request.registrationRequest.memberSignature.bytes.array(),
                     isPending = request.registrationRequest.isPending
                 )

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
@@ -1,7 +1,5 @@
 package net.corda.membership.impl.persistence.service.handler
 
-import net.corda.data.CordaAvroSerializer
-import net.corda.data.KeyValuePairList
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.PersistRegistrationRequest
 import net.corda.membership.datamodel.MemberSignatureEntity

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
@@ -1,7 +1,5 @@
 package net.corda.membership.impl.persistence.service.handler
 
-import net.corda.data.CordaAvroDeserializer
-import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.db.request.MembershipRequestContext

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
@@ -2,6 +2,7 @@ package net.corda.membership.impl.persistence.service.handler
 
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.query.QueryMemberSignature
@@ -16,14 +17,6 @@ import java.nio.ByteBuffer
 internal class QueryMemberSignatureHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryMemberSignature, MemberSignatureQueryResponse>(persistenceHandlerServices) {
-    private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
-        cordaAvroSerializationFactory.createAvroDeserializer(
-            {
-                logger.error("Failed to deserialize key value pair list.")
-            },
-            KeyValuePairList::class.java
-        )
-    }
 
     override fun invoke(
         context: MembershipRequestContext,
@@ -40,18 +33,19 @@ internal class QueryMemberSignatureHandler(
                             false
                         )
                     ) ?: throw MembershipPersistenceException("Could not find signature for $holdingIdentity")
-                    val signatureContext = if (signatureEntity.context.isEmpty()) {
-                        KeyValuePairList(emptyList())
+                    val signatureSpec = if (signatureEntity.signatureSpec.isEmpty()) {
+                        CryptoSignatureSpec("", null, null)
                     } else {
-                        keyValuePairListDeserializer.deserialize(signatureEntity.context)
+                        CryptoSignatureSpec(signatureEntity.signatureSpec, null, null)
                     }
                     val signature = CryptoSignatureWithKey(
                         ByteBuffer.wrap(signatureEntity.publicKey),
-                        ByteBuffer.wrap(signatureEntity.content),
-                        signatureContext,
+                        ByteBuffer.wrap(signatureEntity.content)
                     )
                     MemberSignature(
-                        holdingIdentity, signature
+                        holdingIdentity,
+                        signature,
+                        signatureSpec
                     )
                 }
             )

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
@@ -107,7 +107,7 @@ internal class UpdateMemberAndRegistrationRequestToApprovedHandler(
                     member.memberX500Name,
                     false,
                     signature.publicKey,
-                    signature.context,
+                    signature.signatureSpec,
                     signature.content
                 )
             )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -5,6 +5,7 @@ import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
@@ -300,9 +301,9 @@ class MembershipPersistenceRPCProcessorTest {
                     ByteBuffer.wrap("8".toByteArray()),
                     CryptoSignatureWithKey(
                         ByteBuffer.wrap("123".toByteArray()),
-                        ByteBuffer.wrap("456".toByteArray()),
-                        KeyValuePairList(emptyList())
+                        ByteBuffer.wrap("456".toByteArray())
                     ),
+                    CryptoSignatureSpec("", null, null),
                     true
                 )
             )
@@ -396,9 +397,9 @@ class MembershipPersistenceRPCProcessorTest {
                     ByteBuffer.wrap("8".toByteArray()),
                     CryptoSignatureWithKey(
                         ByteBuffer.wrap("123".toByteArray()),
-                        ByteBuffer.wrap("456".toByteArray()),
-                        KeyValuePairList(emptyList())
+                        ByteBuffer.wrap("456".toByteArray())
                     ),
+                    CryptoSignatureSpec("", null, null),
                     false
                 )
             )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -132,7 +132,7 @@ class PersistRegistrationRequestHandlerTest {
                 ByteBuffer.wrap("123".toByteArray()),
                 ByteBuffer.wrap("456".toByteArray())
             ),
-            CryptoSignatureSpec("", null, null),
+            CryptoSignatureSpec("dummySignature", null, null),
             true
         )
     )
@@ -173,7 +173,7 @@ class PersistRegistrationRequestHandlerTest {
             assertThat(entity.memberX500Name).isEqualTo(ourHoldingIdentity.x500Name.toString())
             assertThat(entity.publicKey).isEqualTo("123".toByteArray())
             assertThat(entity.content).isEqualTo("456".toByteArray())
-            assertThat(entity.signatureSpec).isEqualTo(byteArrayOf(1, 3, 4))
+            assertThat(entity.signatureSpec).isEqualTo("dummySignature")
         }
     }
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -5,6 +5,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipRequestContext
@@ -129,9 +130,9 @@ class PersistRegistrationRequestHandlerTest {
             ByteBuffer.wrap("89".toByteArray()),
             CryptoSignatureWithKey(
                 ByteBuffer.wrap("123".toByteArray()),
-                ByteBuffer.wrap("456".toByteArray()),
-                KeyValuePairList(emptyList())
+                ByteBuffer.wrap("456".toByteArray())
             ),
+            CryptoSignatureSpec("", null, null),
             true
         )
     )
@@ -172,7 +173,7 @@ class PersistRegistrationRequestHandlerTest {
             assertThat(entity.memberX500Name).isEqualTo(ourHoldingIdentity.x500Name.toString())
             assertThat(entity.publicKey).isEqualTo("123".toByteArray())
             assertThat(entity.content).isEqualTo("456".toByteArray())
-            assertThat(entity.context).isEqualTo(byteArrayOf(1, 3, 4))
+            assertThat(entity.signatureSpec).isEqualTo(byteArrayOf(1, 3, 4))
         }
     }
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -5,6 +5,7 @@ import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.db.request.MembershipRequestContext
@@ -138,7 +139,7 @@ class QueryMemberSignatureHandlerTest {
                 memberKey.memberX500Name,
                 true,
                 "pk-${memberKey.memberX500Name}".toByteArray(),
-                "context-${memberKey.memberX500Name}".toByteArray(),
+                "dummySignatureSpec",
                 "sig-${memberKey.memberX500Name}".toByteArray(),
             )
         }
@@ -163,16 +164,9 @@ class QueryMemberSignatureHandlerTest {
                     member,
                     CryptoSignatureWithKey(
                         ByteBuffer.wrap("pk-${member.x500Name}".toByteArray()),
-                        ByteBuffer.wrap("sig-${member.x500Name}".toByteArray()),
-                        KeyValuePairList(
-                            listOf(
-                                KeyValuePair(
-                                    "key",
-                                    "context-${member.x500Name}",
-                                )
-                            )
-                        ),
-                    )
+                        ByteBuffer.wrap("sig-${member.x500Name}".toByteArray())
+                    ),
+                    CryptoSignatureSpec("", null, null)
                 )
             }
         )
@@ -198,7 +192,7 @@ class QueryMemberSignatureHandlerTest {
                 memberKey.memberX500Name,
                 true,
                 "pk-${memberKey.memberX500Name}".toByteArray(),
-                byteArrayOf(),
+                "dummySignatureSpec",
                 "sig-${memberKey.memberX500Name}".toByteArray(),
             )
         }
@@ -212,10 +206,8 @@ class QueryMemberSignatureHandlerTest {
                     CryptoSignatureWithKey(
                         ByteBuffer.wrap("pk-${member.x500Name}".toByteArray()),
                         ByteBuffer.wrap("sig-${member.x500Name}".toByteArray()),
-                        KeyValuePairList(
-                            emptyList()
-                        ),
-                    )
+                    ),
+                    CryptoSignatureSpec("", null, null)
                 )
             }
         )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -166,7 +166,7 @@ class QueryMemberSignatureHandlerTest {
                         ByteBuffer.wrap("pk-${member.x500Name}".toByteArray()),
                         ByteBuffer.wrap("sig-${member.x500Name}".toByteArray())
                     ),
-                    CryptoSignatureSpec("", null, null)
+                    CryptoSignatureSpec("dummySignatureSpec", null, null)
                 )
             }
         )
@@ -207,7 +207,7 @@ class QueryMemberSignatureHandlerTest {
                         ByteBuffer.wrap("pk-${member.x500Name}".toByteArray()),
                         ByteBuffer.wrap("sig-${member.x500Name}".toByteArray()),
                     ),
-                    CryptoSignatureSpec("", null, null)
+                    CryptoSignatureSpec("dummySignatureSpec", null, null)
                 )
             }
         )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -136,14 +136,14 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
     }
 
     private val signatureContentBytes = byteArrayOf(1, 5)
-    private val signatureContextBytes = byteArrayOf(1, 5)
+    private val signatureSpec = "dummySignatureSpec"
     private val publicKey = byteArrayOf(1, 2)
     private val memberSignatureEntity = mock<MemberSignatureEntity> {
         on { groupId } doReturn member.groupId
         on { memberX500Name } doReturn member.x500Name
         on { publicKey } doReturn publicKey
         on { content } doReturn signatureContentBytes
-        on { context } doReturn signatureContextBytes
+        on { signatureSpec } doReturn signatureSpec
     }
 
     private val requestId = "requestId"
@@ -275,7 +275,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
             assertThat(this.memberX500Name).isEqualTo(member.x500Name)
             assertThat(this.groupId).isEqualTo(member.groupId)
             assertThat(this.content).isEqualTo(content)
-            assertThat(this.context).isEqualTo(context)
+            assertThat(this.signatureSpec).isEqualTo(signatureSpec)
         }
     }
 

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -161,8 +161,7 @@ class CertificatesRestResourceImplTest {
             ).doReturn(
                 DigitalSignature.WithKey(
                     publicKey,
-                    byteArrayOf(1),
-                    emptyMap()
+                    byteArrayOf(1)
                 )
             )
             whenever(keyEncodingService.decodePublicKey(publicKeyBytes)).doReturn(publicKey)
@@ -392,8 +391,7 @@ class CertificatesRestResourceImplTest {
             ).doReturn(
                 DigitalSignature.WithKey(
                     publicKey,
-                    byteArrayOf(1),
-                    emptyMap()
+                    byteArrayOf(1)
                 )
             )
             whenever(cryptoOpsClient.lookupKeysByIds(P2P, listOf(ShortHash.of(keyId)))).doReturn(listOf(key))
@@ -435,8 +433,7 @@ class CertificatesRestResourceImplTest {
             ).doReturn(
                 DigitalSignature.WithKey(
                     publicKey,
-                    byteArrayOf(1),
-                    emptyMap()
+                    byteArrayOf(1)
                 )
             )
             whenever(cryptoOpsClient.lookupKeysByIds(tenantId, listOf(ShortHash.of(keyId)))).doReturn(listOf(key))
@@ -478,8 +475,7 @@ class CertificatesRestResourceImplTest {
             ).doReturn(
                 DigitalSignature.WithKey(
                     publicKey,
-                    byteArrayOf(1),
-                    emptyMap()
+                    byteArrayOf(1)
                 )
             )
             whenever(cryptoOpsClient.lookupKeysByIds(tenantId, listOf(ShortHash.of(keyId)))).doReturn(listOf(key))

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestCryptoOpsClient.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestCryptoOpsClient.kt
@@ -137,7 +137,7 @@ class TestCryptoOpsClientImpl @Activate constructor(
         signatureSpec: SignatureSpec,
         data: ByteArray,
         context: Map<String, String>
-    ) = DigitalSignature.WithKey(publicKey, byteArrayOf(1), emptyMap())
+    ) = DigitalSignature.WithKey(publicKey, byteArrayOf(1))
 
     override fun sign(
         tenantId: String,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -216,6 +216,7 @@ internal class StartRegistrationHandler(
             source.toCorda(),
             memberRegistrationRequest.memberContext,
             memberRegistrationRequest.memberSignature,
+            memberRegistrationRequest.memberSignatureSpec,
             true
         )
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
@@ -2,6 +2,7 @@ package net.corda.membership.impl.registration.dynamic.mgm
 
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.membership.lib.registration.RegistrationRequest
@@ -50,9 +51,9 @@ internal class MGMRegistrationRequestHandler (
                 memberContext = ByteBuffer.wrap(serializedMemberContext),
                 signature = CryptoSignatureWithKey(
                     ByteBuffer.wrap(byteArrayOf()),
-                    ByteBuffer.wrap(byteArrayOf()),
-                    KeyValuePairList(emptyList())
-                )
+                    ByteBuffer.wrap(byteArrayOf())
+                ),
+                signatureSpec = CryptoSignatureSpec.newBuilder().build()
             )
         )
         if (registrationRequestPersistenceResult is MembershipPersistenceResult.Failure) {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
@@ -53,7 +53,7 @@ internal class MGMRegistrationRequestHandler (
                     ByteBuffer.wrap(byteArrayOf()),
                     ByteBuffer.wrap(byteArrayOf())
                 ),
-                signatureSpec = CryptoSignatureSpec.newBuilder().build()
+                signatureSpec = CryptoSignatureSpec("", null, null)
             )
         )
         if (registrationRequestPersistenceResult is MembershipPersistenceResult.Failure) {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -289,7 +289,7 @@ class StaticMemberRegistrationService @Activate constructor(
                     ByteBuffer.wrap(byteArrayOf()),
                     ByteBuffer.wrap(byteArrayOf())
                 ),
-                signatureSpec = CryptoSignatureSpec.newBuilder().build()
+                signatureSpec = CryptoSignatureSpec("", null, null)
             )
         ).getOrThrow()
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -10,6 +10,7 @@ import net.corda.crypto.core.CryptoConsts.Categories.SESSION_INIT
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.common.RegistrationStatus
@@ -286,9 +287,9 @@ class StaticMemberRegistrationService @Activate constructor(
                 memberContext = ByteBuffer.wrap(memberContext),
                 signature = CryptoSignatureWithKey(
                     ByteBuffer.wrap(byteArrayOf()),
-                    ByteBuffer.wrap(byteArrayOf()),
-                    KeyValuePairList(emptyList())
-                )
+                    ByteBuffer.wrap(byteArrayOf())
+                ),
+                signatureSpec = CryptoSignatureSpec.newBuilder().build()
             )
         ).getOrThrow()
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
@@ -69,8 +69,7 @@ class  RegistrationProcessorTest {
         val memberContext = KeyValuePairList(listOf(KeyValuePair("key", "value")))
         val signature = CryptoSignatureWithKey(
             ByteBuffer.wrap("456".toByteArray()),
-            ByteBuffer.wrap("789".toByteArray()),
-            KeyValuePairList(emptyList())
+            ByteBuffer.wrap("789".toByteArray())
         )
         val registrationRequest = MembershipRegistrationRequest(
             registrationId, memberContext.toByteBuffer(), signature, true

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
@@ -5,6 +5,7 @@ import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.registration.RegistrationCommand
@@ -71,9 +72,14 @@ class  RegistrationProcessorTest {
             ByteBuffer.wrap("456".toByteArray()),
             ByteBuffer.wrap("789".toByteArray())
         )
-        val registrationRequest = MembershipRegistrationRequest(
-            registrationId, memberContext.toByteBuffer(), signature, true
-        )
+        val registrationRequest =
+            MembershipRegistrationRequest(
+                registrationId,
+                memberContext.toByteBuffer(),
+                signature,
+                CryptoSignatureSpec("", null, null),
+                true
+            )
 
         val startRegistrationCommand = RegistrationCommand(
             StartRegistration(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
@@ -4,13 +4,12 @@ import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.CordaAvroSerializationFactory
-import net.corda.data.KeyValuePair
-import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.state.RegistrationState
+import net.corda.data.p2p.app.AppMessage
 import net.corda.libs.configuration.SmartConfig
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.TestUtils.createHoldingIdentity
@@ -27,7 +26,6 @@ import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.AppMessage
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.configuration.MembershipConfig.TtlsConfig.MEMBERS_PACKAGE_UPDATE
 import net.corda.schema.configuration.MembershipConfig.TtlsConfig.TTLS
@@ -79,12 +77,7 @@ class DistributeMembershipPackageHandlerTest {
         val name = it.name.toString()
         it.holdingIdentity to CryptoSignatureWithKey(
             ByteBuffer.wrap("pk-$name".toByteArray()),
-            ByteBuffer.wrap("sig-$name".toByteArray()),
-            KeyValuePairList(
-                listOf(
-                    KeyValuePair("name", name)
-                )
-            )
+            ByteBuffer.wrap("sig-$name".toByteArray())
         )
     }
     private val membershipQueryClient = mock<MembershipQueryClient> {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DistributeMembershipPackageHandlerTest.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.CordaAvroSerializationFactory
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage
@@ -75,10 +76,10 @@ class DistributeMembershipPackageHandlerTest {
     private val activeMembersWithoutMgm = allActiveMembers - mgm
     private val signatures = activeMembersWithoutMgm.associate {
         val name = it.name.toString()
-        it.holdingIdentity to CryptoSignatureWithKey(
+        it.holdingIdentity to (CryptoSignatureWithKey(
             ByteBuffer.wrap("pk-$name".toByteArray()),
             ByteBuffer.wrap("sig-$name".toByteArray())
-        )
+        ) to CryptoSignatureSpec("dummy", null, null))
     }
     private val membershipQueryClient = mock<MembershipQueryClient> {
         on { queryMemberInfo(owner) } doReturn MembershipQueryResult.Success(allActiveMembers + inactiveMember)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -4,6 +4,7 @@ import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.PersistentMemberInfo
@@ -102,9 +103,9 @@ class StartRegistrationHandlerTest {
                         memberContext.toByteBuffer(),
                         CryptoSignatureWithKey(
                             ByteBuffer.wrap("456".toByteArray()),
-                            ByteBuffer.wrap("789".toByteArray()),
-                            KeyValuePairList(emptyList())
+                            ByteBuffer.wrap("789".toByteArray())
                         ),
+                        CryptoSignatureSpec("", null, null),
                         true
                     )
                 )

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -65,7 +65,6 @@ import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFacto
 import net.corda.membership.lib.toMap
 import net.corda.membership.locally.hosted.identities.IdentityInfo
 import net.corda.membership.locally.hosted.identities.LocallyHostedIdentitiesService
-import net.corda.membership.p2p.helpers.Verifier
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.membership.read.MembershipGroupReader
@@ -210,12 +209,7 @@ class DynamicMemberRegistrationServiceTest {
                 any(),
                 any(),
                 any<SignatureSpec>(),
-                any(),
-                eq(
-                    mapOf(
-                        Verifier.SIGNATURE_SPEC to SignatureSpec.ECDSA_SHA512.signatureName
-                    )
-                ),
+                any()
             )
         }.doReturn(mockSignature)
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -723,21 +723,19 @@ class DynamicMemberRegistrationServiceTest {
                 .containsEntry("corda.notary.keys.0.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
         }
 
-//        @Test
-//        fun `registration adds session spec if needed`() {
-//            val memberContext = argumentCaptor<KeyValuePairList>()
-//            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
-//            val registrationContext = context - "corda.session.key.signature.spec"
-//            postConfigChangedEvent()
-//            registrationService.start()
-//
-//            assertThrows<NotReadyMembershipRegistrationException> {
-//                registrationService.register(registrationResultId, member, registrationContext)
-//            }
-//
-//            assertThat(memberContext.firstValue.toMap())
-//                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
-//        }
+        @Test
+        fun `registration adds session spec if needed`() {
+            val memberContext = argumentCaptor<KeyValuePairList>()
+            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
+            val registrationContext = context - "corda.session.key.signature.spec"
+            postConfigChangedEvent()
+            registrationService.start()
+
+            registrationService.register(registrationResultId, member, registrationContext)
+
+            assertThat(memberContext.firstValue.toMap())
+                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
+        }
 
         @Test
         fun `registration adds ledger spec if needed`() {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -723,21 +723,21 @@ class DynamicMemberRegistrationServiceTest {
                 .containsEntry("corda.notary.keys.0.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
         }
 
-        @Test
-        fun `registration adds session spec if needed`() {
-            val memberContext = argumentCaptor<KeyValuePairList>()
-            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
-            val registrationContext = context - "corda.session.key.signature.spec"
-            postConfigChangedEvent()
-            registrationService.start()
-
-            assertThrows<NotReadyMembershipRegistrationException> {
-                registrationService.register(registrationResultId, member, registrationContext)
-            }
-
-            assertThat(memberContext.firstValue.toMap())
-                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
-        }
+//        @Test
+//        fun `registration adds session spec if needed`() {
+//            val memberContext = argumentCaptor<KeyValuePairList>()
+//            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
+//            val registrationContext = context - "corda.session.key.signature.spec"
+//            postConfigChangedEvent()
+//            registrationService.start()
+//
+//            assertThrows<NotReadyMembershipRegistrationException> {
+//                registrationService.register(registrationResultId, member, registrationContext)
+//            }
+//
+//            assertThat(memberContext.firstValue.toMap())
+//                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
+//        }
 
         @Test
         fun `registration adds ledger spec if needed`() {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -209,7 +209,8 @@ class DynamicMemberRegistrationServiceTest {
                 any(),
                 any(),
                 any<SignatureSpec>(),
-                any()
+                any(),
+                eq(emptyMap())
             )
         }.doReturn(mockSignature)
     }
@@ -722,21 +723,21 @@ class DynamicMemberRegistrationServiceTest {
                 .containsEntry("corda.notary.keys.0.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
         }
 
-        @Test
-        fun `registration adds session spec if needed`() {
-            val memberContext = argumentCaptor<KeyValuePairList>()
-            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
-            val registrationContext = context - "corda.session.key.signature.spec"
-            postConfigChangedEvent()
-            registrationService.start()
-
-            assertThrows<NotReadyMembershipRegistrationException> {
-                registrationService.register(registrationResultId, member, registrationContext)
-            }
-
-            assertThat(memberContext.firstValue.toMap())
-                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
-        }
+//        @Test
+//        fun `registration adds session spec if needed`() {
+//            val memberContext = argumentCaptor<KeyValuePairList>()
+//            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
+//            val registrationContext = context - "corda.session.key.signature.spec"
+//            postConfigChangedEvent()
+//            registrationService.start()
+//
+//            assertThrows<NotReadyMembershipRegistrationException> {
+//                registrationService.register(registrationResultId, member, registrationContext)
+//            }
+//
+//            assertThat(memberContext.firstValue.toMap())
+//                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
+//        }
 
         @Test
         fun `registration adds ledger spec if needed`() {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -723,21 +723,21 @@ class DynamicMemberRegistrationServiceTest {
                 .containsEntry("corda.notary.keys.0.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
         }
 
-//        @Test
-//        fun `registration adds session spec if needed`() {
-//            val memberContext = argumentCaptor<KeyValuePairList>()
-//            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
-//            val registrationContext = context - "corda.session.key.signature.spec"
-//            postConfigChangedEvent()
-//            registrationService.start()
-//
-//            assertThrows<NotReadyMembershipRegistrationException> {
-//                registrationService.register(registrationResultId, member, registrationContext)
-//            }
-//
-//            assertThat(memberContext.firstValue.toMap())
-//                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
-//        }
+        @Test
+        fun `registration adds session spec if needed`() {
+            val memberContext = argumentCaptor<KeyValuePairList>()
+            whenever(keyValuePairListSerializer.serialize(memberContext.capture())).doReturn(MEMBER_CONTEXT_BYTES)
+            val registrationContext = context - "corda.session.key.signature.spec"
+            postConfigChangedEvent()
+            registrationService.start()
+
+            assertThrows<NotReadyMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, registrationContext)
+            }
+
+            assertThat(memberContext.firstValue.toMap())
+                .containsEntry("corda.session.key.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
+        }
 
         @Test
         fun `registration adds ledger spec if needed`() {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -199,10 +199,7 @@ class DynamicMemberRegistrationServiceTest {
     private val mockSignature: DigitalSignature.WithKey =
         DigitalSignature.WithKey(
             sessionKey,
-            byteArrayOf(1),
-            mapOf(
-                Verifier.SIGNATURE_SPEC to SignatureSpec.ECDSA_SHA512.signatureName
-            )
+            byteArrayOf(1)
         )
     private val cryptoOpsClient: CryptoOpsClient = mock {
         on { lookupKeysByIds(memberId.value, listOf(ShortHash.of(SESSION_KEY_ID))) } doReturn listOf(sessionCryptoSigningKey)

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestCryptoOpsClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestCryptoOpsClient.kt
@@ -153,7 +153,7 @@ class TestCryptoOpsClientImpl @Activate constructor(
         )
         signature.initSign(keyPair.private)
         signature.update(data)
-        return DigitalSignature.WithKey(publicKey, signature.sign(), context)
+        return DigitalSignature.WithKey(publicKey, signature.sign())
     }
 
     override fun sign(

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
@@ -96,12 +96,7 @@ class TestMembershipQueryClientImpl @Activate constructor(
             holdingsIdentities.associateWith {
                 CryptoSignatureWithKey(
                     ByteBuffer.wrap(viewOwningIdentity.toAvro().x500Name.toByteArray()),
-                    ByteBuffer.wrap(viewOwningIdentity.toAvro().x500Name.toByteArray()),
-                    KeyValuePairList(
-                        listOf(
-                            KeyValuePair("name", it.x500Name.toString())
-                        )
-                    )
+                    ByteBuffer.wrap(viewOwningIdentity.toAvro().x500Name.toByteArray())
                 )
             }
         )

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
@@ -1,7 +1,6 @@
 package net.corda.membership.impl.synchronisation.dummy
 
-import net.corda.data.KeyValuePair
-import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
@@ -91,13 +90,14 @@ class TestMembershipQueryClientImpl @Activate constructor(
     override fun queryMembersSignatures(
         viewOwningIdentity: HoldingIdentity,
         holdingsIdentities: Collection<HoldingIdentity>
-    ): MembershipQueryResult<Map<HoldingIdentity, CryptoSignatureWithKey>> {
+    ): MembershipQueryResult<Map<HoldingIdentity, Pair<CryptoSignatureWithKey, CryptoSignatureSpec>>> {
         return MembershipQueryResult.Success(
             holdingsIdentities.associateWith {
                 CryptoSignatureWithKey(
                     ByteBuffer.wrap(viewOwningIdentity.toAvro().x500Name.toByteArray()),
                     ByteBuffer.wrap(viewOwningIdentity.toAvro().x500Name.toByteArray())
-                )
+                ) to
+                        CryptoSignatureSpec("", null, null)
             }
         )
     }

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
@@ -378,7 +378,7 @@ class MemberSynchronisationServiceImplTest {
 
     @Test
     fun `failed member signature verification will not persist the member`() {
-        whenever(verifier.verify(eq(memberSignature), any())).thenThrow(CordaRuntimeException("Mock failure"))
+        whenever(verifier.verify(eq(memberSignature), any(), any())).thenThrow(CordaRuntimeException("Mock failure"))
         postConfigChangedEvent()
         synchronisationService.start()
 
@@ -389,7 +389,7 @@ class MemberSynchronisationServiceImplTest {
 
     @Test
     fun `failed MGM signature verification will not persist the member`() {
-        whenever(verifier.verify(eq(mgmSignature), any())).thenThrow(CordaRuntimeException("Mock failure"))
+        whenever(verifier.verify(eq(mgmSignature), any(), any())).thenThrow(CordaRuntimeException("Mock failure"))
         postConfigChangedEvent()
         synchronisationService.start()
 
@@ -400,7 +400,7 @@ class MemberSynchronisationServiceImplTest {
 
     @Test
     fun `failed MGM signature verification will not persist the group parameters`() {
-        whenever(verifier.verify(eq(mgmSignatureGroupParameters), any())).thenThrow(CordaRuntimeException("Mock failure"))
+        whenever(verifier.verify(eq(mgmSignatureGroupParameters), any(), any())).thenThrow(CordaRuntimeException("Mock failure"))
         postConfigChangedEvent()
         synchronisationService.start()
 
@@ -411,7 +411,7 @@ class MemberSynchronisationServiceImplTest {
 
     @Test
     fun `failed MGM signature verification will not publish the group parameters to Kafka`() {
-        whenever(verifier.verify(eq(mgmSignatureGroupParameters), any())).thenThrow(CordaRuntimeException("Mock failure"))
+        whenever(verifier.verify(eq(mgmSignatureGroupParameters), any(), any())).thenThrow(CordaRuntimeException("Mock failure"))
         postConfigChangedEvent()
         synchronisationService.start()
 
@@ -427,8 +427,8 @@ class MemberSynchronisationServiceImplTest {
 
         synchronisationService.processMembershipUpdates(updates)
 
-        verify(verifier).verify(memberSignature, MEMBER_CONTEXT_BYTES)
-        verify(verifier).verify(mgmSignature, byteArrayOf(1, 2, 3))
+        verify(verifier).verify(memberSignature, any(), MEMBER_CONTEXT_BYTES)
+        verify(verifier).verify(mgmSignature, any(), byteArrayOf(1, 2, 3))
     }
 
     @Test

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
@@ -9,6 +9,7 @@ import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.SecureHash
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.SignedMemberInfo
@@ -177,12 +178,16 @@ class MemberSynchronisationServiceImplTest {
         on { array() } doReturn MGM_CONTEXT_BYTES
     }
     private val memberSignature = mock<CryptoSignatureWithKey>()
+    private val memberSignatureSpec = mock<CryptoSignatureSpec>()
     private val mgmSignature = mock<CryptoSignatureWithKey>()
+    private val mgmSignatureSpec = mock<CryptoSignatureSpec>()
     private val signedMemberInfo: SignedMemberInfo = mock {
         on { memberContext } doReturn memberContext
         on { mgmContext } doReturn mgmContext
         on { memberSignature } doReturn memberSignature
+        on { memberSignatureSpec } doReturn memberSignatureSpec
         on { mgmSignature } doReturn mgmSignature
+        on { mgmSignatureSpec } doReturn mgmSignatureSpec
     }
     private val hash = SecureHash("algo", ByteBuffer.wrap(byteArrayOf(1, 2, 3)))
     private val signedMemberships: SignedMemberships = mock {
@@ -192,6 +197,7 @@ class MemberSynchronisationServiceImplTest {
     private val mgmSignatureGroupParameters = mock<CryptoSignatureWithKey>()
     private val wireGroupParameters = mock<WireGroupParameters> {
         on { mgmSignature } doReturn mgmSignatureGroupParameters
+        on { mgmSignatureSpec } doReturn mgmSignatureSpec
         on { groupParameters } doReturn ByteBuffer.wrap(GROUP_PARAMETERS_BYTES)
     }
     private val membershipPackage: MembershipPackage = mock {
@@ -427,8 +433,8 @@ class MemberSynchronisationServiceImplTest {
 
         synchronisationService.processMembershipUpdates(updates)
 
-        verify(verifier).verify(memberSignature, any(), MEMBER_CONTEXT_BYTES)
-        verify(verifier).verify(mgmSignature, any(), byteArrayOf(1, 2, 3))
+        verify(verifier).verify(memberSignature, memberSignatureSpec, MEMBER_CONTEXT_BYTES)
+        verify(verifier).verify(mgmSignature, mgmSignatureSpec, byteArrayOf(1, 2, 3))
     }
 
     @Test

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
@@ -1,12 +1,10 @@
 package net.corda.membership.impl.synchronisation
 
 import com.typesafe.config.ConfigFactory
-import net.corda.crypto.core.toCorda
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
-import net.corda.data.KeyValuePair
-import net.corda.data.KeyValuePairList
+import net.corda.crypto.core.toCorda
 import net.corda.data.crypto.SecureHash
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
@@ -16,6 +14,8 @@ import net.corda.data.membership.command.synchronisation.mgm.ProcessSyncRequest
 import net.corda.data.membership.p2p.DistributionMetaData
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.MembershipSyncRequest
+import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.data.sync.BloomFilter
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.libs.configuration.SmartConfig
@@ -55,8 +55,6 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MEMBERSHIP_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
@@ -84,7 +82,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import kotlin.test.assertFailsWith
 

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
@@ -8,6 +8,7 @@ import net.corda.crypto.client.CryptoOpsClient
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.SecureHash
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.synchronisation.SynchronisationMetaData
@@ -316,10 +317,10 @@ class MgmSynchronisationServiceImplTest {
 
     private fun createSignatures(members: List<MemberInfo>) = members.associate {
         val name = it.name.toString()
-        it.holdingIdentity to CryptoSignatureWithKey(
+        it.holdingIdentity to (CryptoSignatureWithKey(
             ByteBuffer.wrap("pk-$name".toByteArray()),
             ByteBuffer.wrap("sig-$name".toByteArray())
-        )
+        ) to CryptoSignatureSpec("dummy", null, null))
     }
 
     private fun postStartEvent() {

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MgmSynchronisationServiceImplTest.kt
@@ -318,12 +318,7 @@ class MgmSynchronisationServiceImplTest {
         val name = it.name.toString()
         it.holdingIdentity to CryptoSignatureWithKey(
             ByteBuffer.wrap("pk-$name".toByteArray()),
-            ByteBuffer.wrap("sig-$name".toByteArray()),
-            KeyValuePairList(
-                listOf(
-                    KeyValuePair("name", name)
-                )
-            )
+            ByteBuffer.wrap("sig-$name".toByteArray())
         )
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.715-beta+
+cordaApiVersion=5.0.0.716-alpha-1678874589312
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.716-alpha-1678874589312
+cordaApiVersion=5.0.0.716-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
@@ -8,7 +8,6 @@ import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.REQUEST_TTL_KEY
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.RESPONSE_ERROR_KEY
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.RESPONSE_TOPIC
 import net.corda.crypto.impl.createWireRequestContext
-import net.corda.crypto.impl.toMap
 import net.corda.crypto.impl.toWire
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
@@ -140,8 +140,7 @@ class CryptoFlowOpsTransformerImpl(
         val resp = response.validateAndGet<CryptoSignatureWithKey>()
         return DigitalSignature.WithKey(
             keyEncodingService.decodePublicKey(resp.publicKey.array()),
-            resp.bytes.array(),
-            resp.context.toMap()
+            resp.bytes.array()
         )
     }
 

--- a/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
+++ b/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
@@ -501,12 +501,7 @@ class CryptoFlowOpsTransformerImplTests {
         val response = createResponse(
             CryptoSignatureWithKey(
                 ByteBuffer.wrap(keyEncodingService.encodeAsByteArray(publicKey)),
-                ByteBuffer.wrap(signature),
-                KeyValuePairList(
-                    listOf(
-                        KeyValuePair("key1", "value1")
-                    )
-                )
+                ByteBuffer.wrap(signature)
             ),
             SignFlowCommand::class.java
         )
@@ -514,8 +509,6 @@ class CryptoFlowOpsTransformerImplTests {
         assertThat(result).isInstanceOf(DigitalSignature.WithKey::class.java)
         val resultSignature = result as DigitalSignature.WithKey
         assertArrayEquals(publicKey.encoded, resultSignature.by.encoded)
-        assertThat(result.context).hasSize(1)
-        assertThat(result.context).containsEntry("key1", "value1")
         assertArrayEquals(signature, resultSignature.bytes)
     }
 
@@ -526,8 +519,7 @@ class CryptoFlowOpsTransformerImplTests {
         val response = createResponse(
             response = CryptoSignatureWithKey(
                 ByteBuffer.wrap(keyEncodingService.encodeAsByteArray(publicKey)),
-                ByteBuffer.wrap(signature),
-                KeyValuePairList()
+                ByteBuffer.wrap(signature)
             ),
             requestType = SignFlowCommand::class.java,
             error = null,

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CompositeKeyImplTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CompositeKeyImplTests.kt
@@ -52,9 +52,9 @@ class CompositeKeyImplTests {
             alicePublicKey = generateKeyPair(ECDSA_SECP256K1_SPEC).public
             bobPublicKey = generateKeyPair(ECDSA_SECP256R1_SPEC).public
             charliePublicKey = generateKeyPair(EDDSA_ED25519_SPEC).public
-            aliceSignature = DigitalSignature.WithKey(alicePublicKey, ByteArray(5) { 255.toByte() }, emptyMap())
-            bobSignature = DigitalSignature.WithKey(bobPublicKey, ByteArray(5) { 255.toByte() }, emptyMap())
-            charlieSignature = DigitalSignature.WithKey(charliePublicKey, ByteArray(5) { 255.toByte() }, emptyMap())
+            aliceSignature = DigitalSignature.WithKey(alicePublicKey, ByteArray(5) { 255.toByte() })
+            bobSignature = DigitalSignature.WithKey(bobPublicKey, ByteArray(5) { 255.toByte() })
+            charlieSignature = DigitalSignature.WithKey(charliePublicKey, ByteArray(5) { 255.toByte() })
             target = CompositeKeyProviderImpl()
         }
     }
@@ -271,11 +271,11 @@ class CompositeKeyImplTests {
         val publicKeyEd1 = charliePublicKey
         val publicKeyEd2 = generateKeyPair(EDDSA_ED25519_SPEC).public
 
-        val rsaSignature = DigitalSignature.WithKey(publicKeyRSA, ByteArray(5) { 255.toByte() }, emptyMap())
-        val k1Signature = DigitalSignature.WithKey(publicKeyK1, ByteArray(5) { 255.toByte() }, emptyMap())
-        val r1Signature = DigitalSignature.WithKey(publicKeyR1, ByteArray(5) { 255.toByte() }, emptyMap())
-        val edSignature1 = DigitalSignature.WithKey(publicKeyEd1, ByteArray(5) { 255.toByte() }, emptyMap())
-        val edSignature2 = DigitalSignature.WithKey(publicKeyEd2, ByteArray(5) { 255.toByte() }, emptyMap())
+        val rsaSignature = DigitalSignature.WithKey(publicKeyRSA, ByteArray(5) { 255.toByte() })
+        val k1Signature = DigitalSignature.WithKey(publicKeyK1, ByteArray(5) { 255.toByte() })
+        val r1Signature = DigitalSignature.WithKey(publicKeyR1, ByteArray(5) { 255.toByte() })
+        val edSignature1 = DigitalSignature.WithKey(publicKeyEd1, ByteArray(5) { 255.toByte() })
+        val edSignature2 = DigitalSignature.WithKey(publicKeyEd2, ByteArray(5) { 255.toByte() })
 
         val compositeKey = target.createFromKeys(
             publicKeyRSA,

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationRequest.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationRequest.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.lib.registration
 
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.virtualnode.HoldingIdentity
@@ -14,5 +15,6 @@ data class RegistrationRequest(
     val requester: HoldingIdentity,
     val memberContext: ByteBuffer,
     val signature: CryptoSignatureWithKey,
+    val signatureSpec: CryptoSignatureSpec,
     val isPending: Boolean = false,
 )

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberSignatureEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberSignatureEntity.kt
@@ -32,8 +32,10 @@ class MemberSignatureEntity(
     @Column(name = "public_key", nullable = false, updatable = false, columnDefinition = "BLOB")
     val publicKey: ByteArray,
 
-    @Column(name = "context", nullable = false, updatable = false, columnDefinition = "BLOB")
-    val context: ByteArray,
+    // TODO Are we going to be storing `ParameterizedSignatureSpec` here?
+    //  If so need to consider saving extra signature spec parameters.
+    @Column(name = "signature_spec", nullable = false, updatable = false)
+    val signatureSpec: String,
 
     @Column(name = "content", nullable = false, updatable = false, columnDefinition = "BLOB")
     val content: ByteArray,

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberSignatureEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberSignatureEntity.kt
@@ -33,7 +33,7 @@ class MemberSignatureEntity(
     val publicKey: ByteArray,
 
     // TODO Are we going to be storing `ParameterizedSignatureSpec` here?
-    //  If so need to consider saving extra signature spec parameters.
+    //  If so need to consider saving extra signature spec parameters as recorded in https://r3-cev.atlassian.net/browse/CORE-11685
     @Column(name = "signature_spec", nullable = false, updatable = false)
     val signatureSpec: String,
 

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
@@ -3,6 +3,7 @@ package net.corda.membership.lib.impl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.impl.converter.PublicKeyConverter
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.SignedMemberInfo
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
@@ -175,6 +176,8 @@ class MemberInfoTest {
             ByteBuffer.wrap(byteArrayOf())
         )
 
+        private val signatureSpec = CryptoSignatureSpec("", null, null)
+
         @BeforeAll
         @JvmStatic
         fun setUp() {
@@ -200,7 +203,9 @@ class MemberInfoTest {
             memberInfo?.memberProvidedContext?.toAvro()?.toByteBuffer(),
             memberInfo?.mgmProvidedContext?.toAvro()?.toByteBuffer(),
             signature,
-            signature
+            signatureSpec,
+            signature,
+            signatureSpec
         )
 
         dataFileWriter.create(signedMemberInfo.schema, avroMemberInfo)

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
@@ -172,8 +172,7 @@ class MemberInfoTest {
 
         private val signature = CryptoSignatureWithKey(
             ByteBuffer.wrap(byteArrayOf()),
-            ByteBuffer.wrap(byteArrayOf()),
-            KeyValuePairList(emptyList())
+            ByteBuffer.wrap(byteArrayOf())
         )
 
         @BeforeAll

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -394,8 +394,7 @@ class NonValidatingNotaryServerFlowImplTest {
                 NotarizationRequestSignature(
                     DigitalSignature.WithKey(
                         memberCharlieKey,
-                        "ABC".toByteArray(),
-                        emptyMap()
+                        "ABC".toByteArray()
                     ),
                     DUMMY_PLATFORM_VERSION
                 ),

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.processor.member
 
 import net.corda.data.KeyValuePairList
+import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
@@ -158,7 +159,8 @@ internal class TestMembershipPersistenceClientImpl @Activate constructor(
     override fun queryMembersSignatures(
         viewOwningIdentity: HoldingIdentity,
         holdingsIdentities: Collection<HoldingIdentity>,
-    ): MembershipQueryResult<Map<HoldingIdentity, CryptoSignatureWithKey>> = MembershipQueryResult.Success(emptyMap())
+    ): MembershipQueryResult<Map<HoldingIdentity, Pair<CryptoSignatureWithKey, CryptoSignatureSpec>>> =
+        MembershipQueryResult.Success(emptyMap())
 
     override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Pair<LayeredPropertyMap, Long>> =
         MembershipQueryResult.Failure("Unsupported")

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
@@ -47,7 +47,7 @@ class SimWithJsonSigningService(private val keyStore: SimKeyStore) : SigningServ
                 keyParameters
             )
         ).toByteArray()
-        return DigitalSignature.WithKey(publicKey, opaqueBytes, mapOf())
+        return DigitalSignature.WithKey(publicKey, opaqueBytes)
     }
 
     override fun findMySigningKeys(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualSignedTransactionBaseTest.kt
@@ -150,7 +150,7 @@ class ConsensualSignedTransactionBaseTest {
     }
 
     private fun toSignatureWithMetadata(key: PublicKey, timestamp: Instant = now()) = DigitalSignatureAndMetadata(
-        DigitalSignature.WithKey(key, "some bytes".toByteArray(), mapOf()),
+        DigitalSignature.WithKey(key, "some bytes".toByteArray()),
         DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
     )
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualTransactionBuilderBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/ConsensualTransactionBuilderBaseTest.kt
@@ -34,7 +34,7 @@ class ConsensualTransactionBuilderBaseTest {
     fun `set up signing service mock`() {
         publicKeys.map {
             whenever(signingService.sign(any(), eq(it), any()))
-                .thenReturn(DigitalSignature.WithKey(it, "some bytes".toByteArray(), mapOf()))
+                .thenReturn(DigitalSignature.WithKey(it, "some bytes".toByteArray()))
         }
         whenever(myMemberInfo.ledgerKeys).thenReturn(listOf(myLedgerKey))
         whenever(memberLookup.myInfo()).thenReturn(myMemberInfo)
@@ -57,7 +57,7 @@ class ConsensualTransactionBuilderBaseTest {
     fun `should be able to build a consensual transaction and sign with a key`() {
         // Given a key has been generated on the node, so the SigningService can sign with it
         whenever(signingService.sign(any(), eq(publicKeys[0]), eq(SignatureSpec.ECDSA_SHA256)))
-            .thenReturn(DigitalSignature.WithKey(publicKeys[0], "My fake signed things".toByteArray(), mapOf()))
+            .thenReturn(DigitalSignature.WithKey(publicKeys[0], "My fake signed things".toByteArray()))
 
         // And our configuration has a special clock
         val clock = mock<Clock>()

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerServiceTest.kt
@@ -222,7 +222,7 @@ class SimConsensualLedgerServiceTest {
     }
 
     private fun toSignature(key: PublicKey) = DigitalSignatureAndMetadata(
-        DigitalSignature.WithKey(key, "some bytes".toByteArray(), mapOf()),
+        DigitalSignature.WithKey(key, "some bytes".toByteArray()),
         DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
     )
 

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
@@ -9,6 +9,6 @@ import java.time.Instant
 
 fun getSignatureWithMetadataExample(publicKey: PublicKey = publicKeyExample, createdTs: Instant = Instant.now()) =
     DigitalSignatureAndMetadata(
-        DigitalSignature.WithKey(publicKey, "signature".toByteArray(), mapOf("contextKey1" to "contextValue1")),
+        DigitalSignature.WithKey(publicKey, "signature".toByteArray()),
         DigitalSignatureMetadata(createdTs, SignatureSpec("dummySignatureName"), mapOf("propertyKey1" to "propertyValue1"))
     )


### PR DESCRIPTION
`DigitalSignature.WithKey.context` gets returned as part of the signature. Callers of sign operation have no control over it so it's of no use to them (and also as such `DigitalSignature.WithKey.context` is not signed either).

- aligns with having removed from API `DigitalSignature.WithKey.context`

api PR: [#929](https://github.com/corda/corda-api/pull/929)