### PR TITLE
CORE-10698 - Fix notary validations

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -244,6 +244,9 @@ internal class StartRegistrationHandler(
                 ).getOrThrow().firstOrNull() == null
             ) { "There is a virtual node having the same name as the notary service ${notary.serviceName}." }
             membershipGroupReaderProvider.getGroupReader(mgmHoldingId).groupParameters?.let { groupParameters ->
+                validateRegistrationRequest(groupParameters.notaries.none { it.name == member.name }) {
+                    "Registering member's name '${member.name}' is already in use as a notary service name."
+                }
                 validateRegistrationRequest(groupParameters.notaries.none { it.name == notary.serviceName }) {
                     "Notary service '${notary.serviceName}' already exists."
                 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -299,17 +299,25 @@ class StaticMemberRegistrationService @Activate constructor(
         notaryInfo: Collection<Pair<String, String>>,
         membershipGroupReader: MembershipGroupReader,
     ) {
-        val serviceName = notaryInfo.firstOrNull { it.first == MemberInfoExtension.NOTARY_SERVICE_NAME }?.second
+        val serviceName = MemberX500Name.parse(
+            notaryInfo.first { it.first == MemberInfoExtension.NOTARY_SERVICE_NAME }.second
+        )
         //The notary service x500 name is different from the notary virtual node being registered.
-        require(registeringMember.name != serviceName) {
+        require(
+            MemberX500Name.parse(registeringMember.name!!) != serviceName
+        ) {
             "Notary service name invalid: Notary service name $serviceName and virtual node name cannot be the same."
         }
         //The notary service x500 name is different from any existing virtual node x500 name (notary or otherwise).
-        require(staticMemberList.none { it.name == serviceName }) {
+        require(
+            staticMemberList.none { MemberX500Name.parse(it.name!!) == serviceName }
+        ) {
             "Notary service name invalid: There is a virtual node having the same name $serviceName."
         }
         // Allow only a single notary virtual node under each notary service.
-        require(membershipGroupReader.lookup().none { it.notaryDetails?.serviceName.toString() == serviceName }) {
+        require(
+            membershipGroupReader.lookup().none { it.notaryDetails?.serviceName == serviceName }
+        ) {
             throw InvalidMembershipRegistrationException("Notary service '$serviceName' already exists.")
         }
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -473,6 +473,23 @@ class StartRegistrationHandlerTest {
     }
 
     @Test
+    fun `declined if registering member's name is the same as an existing notary's service name`() {
+        val notaryDetails = MemberNotaryDetails(
+            notaryX500Name,
+            "pluginType",
+            listOf(mock())
+        )
+        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+
+        val notaryResult = handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))
+        notaryResult.assertRegistrationStarted()
+
+        val memberStartRegistrationCommand = getStartRegistrationCommand(HoldingIdentity(notaryX500Name.toString(), groupId), memberContext)
+        val memberResult = handler.invoke(null, Record(testTopic, testTopicKey, memberStartRegistrationCommand))
+        memberResult.assertDeclinedRegistration()
+    }
+
+    @Test
     fun `declined if role is set to notary and notary service name already exists`() {
         val notaryDetails = MemberNotaryDetails(
             notaryX500Name,


### PR DESCRIPTION
Fix for notary service name validations when a member, notary joins. We should avoid having the same name for virtual nodes and notary services.

**Testing:**

**Static networks:**

1) There is an existing virtual node with the same name as registering notary's service name
![Screenshot 2023-03-09 at 17 18 59](https://user-images.githubusercontent.com/61757742/224343067-0c940bdb-2485-4015-b5fa-630e292dfc95.png)

2) Notary service name and virtual node name are the same
![Screenshot 2023-03-09 at 17 19 52](https://user-images.githubusercontent.com/61757742/224343426-b53a29e0-4ebe-489e-98ab-534d23c70aa7.png)

3) Duplicated virtual node name
![Screenshot 2023-03-09 at 17 28 53](https://user-images.githubusercontent.com/61757742/224344491-74a2f079-f855-44e6-878f-390c4769106b.png)

**Dynamic networks:**

1) Registering virtual node's name is already in use as notary service name
![Screenshot 2023-03-10 at 13 55 04](https://user-images.githubusercontent.com/61757742/224344722-50ef9e0a-0116-4107-9bb3-810b73ed0ca7.png)
`13:51:01.799 [Thread-61] WARN  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Declined registration.
net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler$InvalidRegistrationRequestException: Registering member's name 'O=Bob, L=London, C=GB' is already in use as a notary service name.
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.validateRegistrationRequest(StartRegistrationHandler.kt:178) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.validateRoleInformation(StartRegistrationHandler.kt:247) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.invoke(StartRegistrationHandler.kt:128) ~[?:?]`

2) Notary service name and virtual node name are the same
![Screenshot 2023-03-10 at 14 16 36](https://user-images.githubusercontent.com/61757742/224345060-1d593571-40f6-4c81-a973-7f978aea6efe.png)
`14:14:24.354 [Thread-61] WARN  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Declined registration.
net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler$InvalidRegistrationRequestException: The virtual node `O=Charlie, L=London, C=GB` and the notary service `O=Charlie, L=London, C=GB` name cannot be the same.
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.validateRegistrationRequest(StartRegistrationHandler.kt:178) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.validateRoleInformation(StartRegistrationHandler.kt:235) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.invoke(StartRegistrationHandler.kt:128) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.invoke(StartRegistrationHandler.kt:47) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler.invoke(RegistrationHandler.kt:13) ~[?:?]
at net.corda.membership.impl.registration.dynamic.RegistrationProcessor.onNext(RegistrationProcessor.kt:141) ~[?:?]`

3) There is an existing virtual node with the same name as registering notary's service name
![Screenshot 2023-03-10 at 14 19 34](https://user-images.githubusercontent.com/61757742/224345252-1a728c28-2088-4cc8-9601-bd9323d4ae82.png)
`14:18:57.415 [Thread-61] WARN  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Declined registration.
net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler$InvalidRegistrationRequestException: There is a virtual node having the same name as the notary service O=Alice, L=London, C=GB.
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.validateRegistrationRequest(StartRegistrationHandler.kt:178) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.validateRoleInformation(StartRegistrationHandler.kt:240) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.invoke(StartRegistrationHandler.kt:128) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler.invoke(StartRegistrationHandler.kt:47) ~[?:?]
at net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler.invoke(RegistrationHandler.kt:13) ~[?:?]`

