### PR TITLE
CORE-11302 Fix handling of failure in receive finality

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoReceiveFinalityFlow.kt
@@ -6,8 +6,6 @@ import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResol
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityNotarizationFailureType.Companion.toFinalityNotarizationFailureType
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.sandbox.CordaSystemFlow
-import net.corda.utilities.debug
-import net.corda.utilities.trace
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
@@ -36,10 +34,14 @@ class UtxoReceiveFinalityFlow(
         verifyExistingSignatures(initialTransaction, session)
         verifyTransaction(initialTransaction)
         var transaction = if (validateTransaction(initialTransaction)) {
-            log.trace { "Successfully validated transaction: $transactionId" }
+            if (log.isTraceEnabled) {
+                log.trace( "Successfully validated transaction: $transactionId")
+            }
             val (transaction, payload) = signTransaction(initialTransaction)
             persistenceService.persist(transaction, TransactionStatus.UNVERIFIED)
-            log.debug { "Recorded transaction with the initial and our signatures: $transactionId" }
+            if (log.isDebugEnabled) {
+                log.debug( "Recorded transaction with the initial and our signatures: $transactionId")
+            }
             session.send(payload)
             transaction
         } else {
@@ -62,7 +64,9 @@ class UtxoReceiveFinalityFlow(
     @Suspendable
     private fun receiveTransactionAndBackchain(): UtxoSignedTransactionInternal {
         val initialTransaction = session.receive(UtxoSignedTransactionInternal::class.java)
-        log.debug { "Beginning receive finality for transaction: ${initialTransaction.id}" }
+        if (log.isDebugEnabled) {
+            log.debug( "Beginning receive finality for transaction: ${initialTransaction.id}")
+        }
         flowEngine.subFlow(TransactionBackchainResolutionFlow(initialTransaction, session))
         return initialTransaction
     }
@@ -76,7 +80,9 @@ class UtxoReceiveFinalityFlow(
             // Should we only catch a specific exception type? Otherwise, some errors can be swallowed by this warning.
             // Means contracts can't use [check] or [require] unless we provide our own functions for this.
             if (e is IllegalStateException || e is IllegalArgumentException || e is CordaRuntimeException) {
-                log.debug { "Transaction ${signedTransaction.id} failed verification. Message: ${e.message}" }
+                if (log.isDebugEnabled) {
+                    log.debug( "Transaction ${signedTransaction.id} failed verification. Message: ${e.message}")
+                }
                 false
             } else {
                 throw e
@@ -88,15 +94,21 @@ class UtxoReceiveFinalityFlow(
     private fun signTransaction(
         initialTransaction: UtxoSignedTransactionInternal,
     ): Pair<UtxoSignedTransactionInternal, Payload<List<DigitalSignatureAndMetadata>>> {
-        log.debug { "Signing transaction: ${initialTransaction.id} with our available required keys." }
+        if (log.isDebugEnabled) {
+            log.debug( "Signing transaction: ${initialTransaction.id} with our available required keys.")
+        }
         val (transaction, mySignatures) = initialTransaction.addMissingSignatures()
-        log.debug { "Signing transaction: ${initialTransaction.id} resulted (${mySignatures.size}) signatures." }
+        if (log.isDebugEnabled) {
+            log.debug( "Signing transaction: ${initialTransaction.id} resulted (${mySignatures.size}) signatures.")
+        }
         return transaction to Payload.Success(mySignatures)
     }
 
     @Suspendable
     private fun receiveSignaturesAndAddToTransaction(transaction: UtxoSignedTransactionInternal): UtxoSignedTransactionInternal {
-        log.debug { "Waiting for other parties' signatures for transaction: ${transaction.id}" }
+        if (log.isDebugEnabled) {
+            log.debug("Waiting for other parties' signatures for transaction: ${transaction.id}")
+        }
         @Suppress("unchecked_cast")
         val otherPartiesSignatures = session.receive(List::class.java) as List<DigitalSignatureAndMetadata>
         var signedTransaction = transaction
@@ -111,7 +123,9 @@ class UtxoReceiveFinalityFlow(
 
     @Suspendable
     private fun verifyAllReceivedSignatures(transaction: UtxoSignedTransactionInternal) {
-        log.debug { "Verifying signatures of transaction: ${transaction.id}" }
+        if (log.isDebugEnabled) {
+            log.debug("Verifying signatures of transaction: ${transaction.id}")
+        }
         try {
             transaction.verifySignatures()
         } catch (e: Exception) {
@@ -122,19 +136,25 @@ class UtxoReceiveFinalityFlow(
 
     @Suspendable
     private fun receiveNotarySignaturesAndAddToTransaction(transaction: UtxoSignedTransactionInternal): UtxoSignedTransactionInternal {
-        log.debug { "Waiting for Notary's signature for transaction: ${transaction.id}" }
+        if (log.isDebugEnabled) {
+            log.debug("Waiting for Notary's signature for transaction: ${transaction.id}")
+        }
         @Suppress("unchecked_cast")
         val notarySignaturesPayload = session.receive(Payload::class.java) as Payload<List<DigitalSignatureAndMetadata>>
 
-        val notarySignatures = notarySignaturesPayload.getOrThrow { failure ->
-            val message = "Notarization failed. Failure received from ${session.counterparty} for transaction " +
-                    "${transaction.id} with message: ${failure.message}"
-            log.warn(message)
-            val reason = failure.reason
-            if (reason != null && reason.toFinalityNotarizationFailureType() == FinalityNotarizationFailureType.FATAL) {
-                persistInvalidTransaction(transaction)
+        val notarySignatures = when (notarySignaturesPayload){
+            is Payload.Success -> notarySignaturesPayload.getOrThrow()
+            is Payload.Failure ->
+            {
+                val message = "Notarization failed. Failure received from ${session.counterparty} for transaction " +
+                        "${transaction.id} with message: ${notarySignaturesPayload.message}"
+                log.warn(message)
+                val reason = notarySignaturesPayload.reason
+                if (reason != null && reason.toFinalityNotarizationFailureType() == FinalityNotarizationFailureType.FATAL) {
+                    persistInvalidTransaction(transaction)
+                }
+                throw CordaRuntimeException(message)
             }
-            CordaRuntimeException(message)
         }
 
         if (notarySignatures.isEmpty()) {
@@ -144,7 +164,9 @@ class UtxoReceiveFinalityFlow(
             throw CordaRuntimeException(message)
 
         }
-        log.debug { "Verifying and adding notary signatures for transaction: ${transaction.id}" }
+        if (log.isDebugEnabled) {
+            log.debug("Verifying and adding notary signatures for transaction: ${transaction.id}")
+        }
 
         var notarizedTransaction = transaction
         notarySignatures.forEach {
@@ -158,6 +180,8 @@ class UtxoReceiveFinalityFlow(
     private fun persistNotarizedTransaction(notarizedTransaction: UtxoSignedTransactionInternal) {
         val relevantStatesIndexes = notarizedTransaction.getRelevantStatesIndexes(memberLookup.getMyLedgerKeys())
         persistenceService.persist(notarizedTransaction, TransactionStatus.VERIFIED, relevantStatesIndexes)
-        log.debug { "Recorded transaction with all parties' and the notary's signature ${notarizedTransaction.id}" }
+        if (log.isDebugEnabled) {
+            log.debug("Recorded transaction with all parties' and the notary's signature ${notarizedTransaction.id}")
+        }
     }
 }


### PR DESCRIPTION
The `receiveFinality` did not handle persistent failures correctly - a exception that while suspending caused by a non-suspendable lambda used to stop the transaction failure reaching the database worker. Remove all lambdas from the codepath that commits a potentially failed transaction as they don't play nicely with quasar.
