### PR TITLE
CORE-11551: Throw HTTP API exception in the tryWithExceptionHandling

### DIFF
--- a/libs/rest/rest-common/src/main/kotlin/net/corda/rest/messagebus/MessageBusUtils.kt
+++ b/libs/rest/rest-common/src/main/kotlin/net/corda/rest/messagebus/MessageBusUtils.kt
@@ -3,6 +3,7 @@ package net.corda.rest.messagebus
 import net.corda.rest.exception.InternalServerException
 import net.corda.rest.exception.ServiceUnavailableException
 import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
+import net.corda.rest.exception.HttpApiException
 import org.slf4j.Logger
 
 object MessageBusUtils {
@@ -34,6 +35,9 @@ object MessageBusUtils {
                 untranslatedExceptions.contains(ex::class.java) -> {
                     throw ex
                 }
+
+                ex  is HttpApiException ->
+                    throw ex
 
                 ex is CordaRPCAPIPartitionException -> {
                     logger.warn("Could not $operation", ex)


### PR DESCRIPTION
When we are getting an `HttpApiException`  we can throw it as is.

Tested by running the generate CSR API with non-hex key ID.