### PR TITLE
CORE-11065 `utxo_relevant_transaction_state` new columns

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -398,7 +398,7 @@ class UtxoPersistenceServiceImplTest {
                     assertThat(dbRelevancy.field<Int>("groupIndex")).isEqualTo(UtxoComponentGroup.OUTPUTS.ordinal)
                     assertThat(dbRelevancy.field<Int>("leafIndex")).isEqualTo(relevantStateIndex)
                     assertThat(dbRelevancy.field<String>("customRepresentation")).isEqualTo("{\"temp\": \"value\"}")
-                    assertThat(dbRelevancy.field<Instant>("consumedTimestamp")).isNull()
+                    assertThat(dbRelevancy.field<Instant>("consumed")).isNull()
                 }
 
             val signatures = signedTransaction.signatures

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -14,7 +14,7 @@ import net.corda.ledger.common.testkit.getPrivacySalt
 import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.common.testkit.transactionMetadataExample
 import net.corda.ledger.persistence.consensual.tests.datamodel.field
-import net.corda.ledger.persistence.utxo.StateCustomJson
+import net.corda.ledger.persistence.utxo.CustomRepresentation
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.ledger.persistence.utxo.UtxoRepository
 import net.corda.ledger.persistence.utxo.UtxoTransactionReader
@@ -186,7 +186,7 @@ class UtxoPersistenceServiceImplTest {
                 UtxoComponentGroup.OUTPUTS.ordinal,
                 1,
                 false,
-                StateCustomJson("{}"),
+                CustomRepresentation("{}"),
                 createdTs
             )
 
@@ -196,7 +196,7 @@ class UtxoPersistenceServiceImplTest {
                 UtxoComponentGroup.OUTPUTS.ordinal,
                 0,
                 false,
-                StateCustomJson("{}"),
+                CustomRepresentation("{}"),
                 createdTs
             )
 
@@ -206,7 +206,7 @@ class UtxoPersistenceServiceImplTest {
                 UtxoComponentGroup.OUTPUTS.ordinal,
                 1,
                 true,
-                StateCustomJson("{}"),
+                CustomRepresentation("{}"),
                 createdTs
             )
         }
@@ -397,7 +397,7 @@ class UtxoPersistenceServiceImplTest {
                 .forEach { (dbRelevancy, relevantStateIndex) ->
                     assertThat(dbRelevancy.field<Int>("groupIndex")).isEqualTo(UtxoComponentGroup.OUTPUTS.ordinal)
                     assertThat(dbRelevancy.field<Int>("leafIndex")).isEqualTo(relevantStateIndex)
-                    assertThat(dbRelevancy.field<String>("custom")).isEqualTo("{\"temp\": \"value\"}")
+                    assertThat(dbRelevancy.field<String>("customRepresentation")).isEqualTo("{\"temp\": \"value\"}")
                     assertThat(dbRelevancy.field<Instant>("consumedTimestamp")).isNull()
                 }
 

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/datamodel/UtxoEntityFactory.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/datamodel/UtxoEntityFactory.kt
@@ -52,18 +52,6 @@ class UtxoEntityFactory(entityManagerFactory: EntityManagerFactory) {
         )
     }
 
-    fun createUtxoRelevantTransactionStateEntity(
-        utxoTransaction: Any,
-        groupIdx: Int,
-        leafIdx: Int,
-        consumed: Boolean,
-        created: Instant
-    ): Any {
-        return utxoRelevantTransactionState.constructors.single { it.parameterCount == 5 }.newInstance(
-            utxoTransaction, groupIdx, leafIdx, consumed, created
-        )
-    }
-
     fun createUtxoTransactionStatusEntity(
         utxoTransaction: Any,
         status: String,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/CustomRepresentation.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/CustomRepresentation.kt
@@ -1,0 +1,3 @@
+package net.corda.ledger.persistence.utxo
+
+data class CustomRepresentation(val json: String)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/StateCustomJson.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/StateCustomJson.kt
@@ -1,3 +1,0 @@
-package net.corda.ledger.persistence.utxo
-
-data class StateCustomJson(val value: String)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/StateCustomJson.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/StateCustomJson.kt
@@ -1,0 +1,3 @@
+package net.corda.ledger.persistence.utxo
+
+data class StateCustomJson(val value: String)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -110,7 +110,7 @@ interface UtxoRepository {
         groupIndex: Int,
         leafIndex: Int,
         consumed: Boolean,
-        stateCustomJson: StateCustomJson,
+        customRepresentation: CustomRepresentation,
         timestamp: Instant
     )
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -52,7 +52,8 @@ interface UtxoRepository {
     /** Marks relevant states of transactions consumed */
     fun markTransactionRelevantStatesConsumed(
         entityManager: EntityManager,
-        stateRefs: List<StateRef>
+        stateRefs: List<StateRef>,
+        timestamp: Instant
     )
 
     /** Persists transaction (operation is idempotent) */
@@ -109,6 +110,7 @@ interface UtxoRepository {
         groupIndex: Int,
         leafIndex: Int,
         consumed: Boolean,
+        stateCustomJson: StateCustomJson,
         timestamp: Instant
     )
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -2,7 +2,7 @@ package net.corda.ledger.persistence.utxo.impl
 
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
-import net.corda.ledger.persistence.utxo.StateCustomJson
+import net.corda.ledger.persistence.utxo.CustomRepresentation
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.ledger.persistence.utxo.UtxoRepository
 import net.corda.ledger.persistence.utxo.UtxoTransactionReader
@@ -148,7 +148,7 @@ class UtxoPersistenceServiceImpl constructor(
                 UtxoComponentGroup.OUTPUTS.ordinal,
                 relevantStateIndex,
                 consumed = false,
-                StateCustomJson("{\"temp\": \"value\"}"),
+                CustomRepresentation("{\"temp\": \"value\"}"),
                 nowUtc
             )
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.persistence.utxo.impl
 
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
+import net.corda.ledger.persistence.utxo.StateCustomJson
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.ledger.persistence.utxo.UtxoRepository
 import net.corda.ledger.persistence.utxo.UtxoTransactionReader
@@ -147,6 +148,7 @@ class UtxoPersistenceServiceImpl constructor(
                 UtxoComponentGroup.OUTPUTS.ordinal,
                 relevantStateIndex,
                 consumed = false,
+                StateCustomJson("{\"temp\": \"value\"}"),
                 nowUtc
             )
         }
@@ -157,7 +159,8 @@ class UtxoPersistenceServiceImpl constructor(
             if (inputStateRefs.isNotEmpty()) {
                 repository.markTransactionRelevantStatesConsumed(
                     em,
-                    inputStateRefs
+                    inputStateRefs,
+                    nowUtc
                 )
             }
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -6,7 +6,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.ledger.persistence.common.ComponentLeafDto
 import net.corda.ledger.persistence.common.mapToComponentGroups
-import net.corda.ledger.persistence.utxo.StateCustomJson
+import net.corda.ledger.persistence.utxo.CustomRepresentation
 import net.corda.ledger.persistence.utxo.UtxoRepository
 import net.corda.sandbox.type.SandboxConstants.CORDA_MARKER_ONLY_SERVICE
 import net.corda.sandbox.type.UsedByPersistence
@@ -334,20 +334,20 @@ class UtxoRepositoryImpl @Activate constructor(
         groupIndex: Int,
         leafIndex: Int,
         consumed: Boolean,
-        stateCustomJson: StateCustomJson,
-        timestamp: Instant
+        customRepresentation: CustomRepresentation,
+        timestamp: Instant,
     ) {
         entityManager.createNativeQuery(
             """
             INSERT INTO {h-schema}utxo_relevant_transaction_state(
-                transaction_id, group_idx, leaf_idx, consumed, custom, created, consumed_timestamp
+                transaction_id, group_idx, leaf_idx, consumed, custom_representation, created, consumed_timestamp
             )
             VALUES(
                 :transactionId, 
                 :groupIndex, 
                 :leafIndex, 
                 :consumed, 
-                CAST(:custom as JSONB), 
+                CAST(:custom_representation as JSONB), 
                 :createdAt, 
                 ${if (consumed) ":consumedTimestamp" else "null"}
             )
@@ -357,7 +357,7 @@ class UtxoRepositoryImpl @Activate constructor(
             .setParameter("groupIndex", groupIndex)
             .setParameter("leafIndex", leafIndex)
             .setParameter("consumed", consumed)
-            .setParameter("custom", stateCustomJson.value)
+            .setParameter("custom_representation", customRepresentation.json)
             .setParameter("createdAt", timestamp)
             .run { if (consumed) setParameter("consumedTimestamp", timestamp) else this }
             .executeUpdate()

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoRelevantTransactionStateEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoRelevantTransactionStateEntity.kt
@@ -38,8 +38,14 @@ data class UtxoRelevantTransactionStateEntity(
     @Column(name = "consumed", nullable = false)
     val isConsumed: Boolean,
 
+    @Column(name = "custom", nullable = false, columnDefinition = "jsonb")
+    val custom: String,
+
     @Column(name = "created", nullable = false)
-    val created: Instant
+    val created: Instant,
+
+    @Column(name = "consumed_timestamp", nullable = true)
+    val consumedTimestamp: Instant?
 )
 
 @Embeddable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoRelevantTransactionStateEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoRelevantTransactionStateEntity.kt
@@ -35,17 +35,14 @@ data class UtxoRelevantTransactionStateEntity(
     @Column(name = "leaf_idx", nullable = false)
     val leafIndex: Int,
 
-    @Column(name = "consumed", nullable = false)
-    val isConsumed: Boolean,
-
     @Column(name = "custom_representation", nullable = false, columnDefinition = "jsonb")
     val customRepresentation: String,
 
     @Column(name = "created", nullable = false)
     val created: Instant,
 
-    @Column(name = "consumed_timestamp", nullable = true)
-    val consumedTimestamp: Instant?
+    @Column(name = "consumed", nullable = true)
+    val consumed: Instant?
 )
 
 @Embeddable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoRelevantTransactionStateEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoRelevantTransactionStateEntity.kt
@@ -38,8 +38,8 @@ data class UtxoRelevantTransactionStateEntity(
     @Column(name = "consumed", nullable = false)
     val isConsumed: Boolean,
 
-    @Column(name = "custom", nullable = false, columnDefinition = "jsonb")
-    val custom: String,
+    @Column(name = "custom_representation", nullable = false, columnDefinition = "jsonb")
+    val customRepresentation: String,
 
     @Column(name = "created", nullable = false)
     val created: Instant,

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.716-beta+
+cordaApiVersion=5.0.0.717-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
Store data in the `custom_representation` and `consumed` columns.

Fill `custom_representation` with temporary data.

The original `consumed` column now stores a timestamp instead of a boolean.