### PR TITLE
CORE-11773: move crypto repository code into softhsm impl

### DIFF
--- a/components/crypto/crypto-persistence/build.gradle
+++ b/components/crypto/crypto-persistence/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation project(":libs:crypto:crypto-core")
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(':libs:virtual-node:virtual-node-info')
-    implementation project(":components:virtual-node:virtual-node-info-read-service")
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"

--- a/components/crypto/crypto-softhsm-impl/build.gradle
+++ b/components/crypto/crypto-softhsm-impl/build.gradle
@@ -15,18 +15,24 @@ dependencies {
 
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "net.corda:corda-config-schema"
+    implementation 'net.corda:corda-db-schema'
 
     implementation project(":components:configuration:configuration-read-service")
     implementation project(":components:crypto:crypto-component-core-impl")
     implementation project(":components:crypto:crypto-hes")
     implementation project(":components:crypto:crypto-hes-core-impl")
     implementation project(":components:crypto:crypto-persistence")
+    implementation project(":components:db:db-connection-manager")
+    implementation project(":components:virtual-node:virtual-node-info-read-service")
     implementation project(":libs:cache:cache-caffeine")
     implementation project(":libs:configuration:configuration-core")
     implementation project(':libs:crypto:cipher-suite-impl')
     implementation project(':libs:crypto:crypto-core')
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(':libs:utilities')
+    implementation project(':libs:virtual-node:virtual-node-info')
+
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation project(":components:crypto:crypto-component-test-utils")

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/CryptoRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/CryptoRepository.kt
@@ -1,5 +1,6 @@
-package net.corda.crypto.persistence
+package net.corda.crypto.softhsm
 
+import net.corda.crypto.persistence.WrappingKeyInfo
 import java.io.Closeable
 
 /**

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/CryptoRepositoryFactory.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/CryptoRepositoryFactory.kt
@@ -1,4 +1,4 @@
-package net.corda.crypto.persistence
+package net.corda.crypto.softhsm
 
 interface CryptoRepositoryFactory {
     /**

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/CryptoRepositoryFactoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/CryptoRepositoryFactoryImpl.kt
@@ -1,8 +1,9 @@
-package net.corda.crypto.persistence
+package net.corda.crypto.softhsm.impl
 
 import net.corda.crypto.core.CryptoTenants
 import net.corda.crypto.core.ShortHash
-import net.corda.crypto.persistence.v1schema.V1CryptoRepositoryImpl
+import net.corda.crypto.softhsm.CryptoRepository
+import net.corda.crypto.softhsm.CryptoRepositoryFactory
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/V1CryptoRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/V1CryptoRepositoryImpl.kt
@@ -1,7 +1,7 @@
-package net.corda.crypto.persistence.v1schema
+package net.corda.crypto.softhsm.impl
 
-import net.corda.crypto.persistence.CryptoRepository
 import net.corda.crypto.persistence.WrappingKeyInfo
+import net.corda.crypto.softhsm.CryptoRepository
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
 import java.time.Instant

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/V1WrappingKeyEntity.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/V1WrappingKeyEntity.kt
@@ -1,4 +1,4 @@
-package net.corda.crypto.persistence.v1schema
+package net.corda.crypto.softhsm.impl
 
 import net.corda.db.schema.DbSchema
 import java.time.Instant

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestCryptoRepositoryFactoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestCryptoRepositoryFactoryImpl.kt
@@ -1,4 +1,4 @@
-package net.corda.crypto.persistence
+package net.corda.crypto.softhsm.impl
 
 import net.corda.crypto.core.CryptoTenants
 import net.corda.db.connection.manager.DbConnectionManager

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestV1CryptoRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestV1CryptoRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package net.corda.crypto.persistence.v1schema
+package net.corda.crypto.softhsm.impl
 
 import net.corda.crypto.persistence.WrappingKeyInfo
 import org.assertj.core.api.Assertions.assertThat


### PR DESCRIPTION
Move the crypto repository code into SoftHSM where it will be used. This is simpler and possibly faster to bootstrap than referencing a separate OSGi package. I tried using the separate OSGi approach first and got stuck with OSGi errors, and it turned out to be a larger step.