### PR TITLE
CORE-11705: Upgrade to Corda Gradle plugins 7.0.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ allprojects {
     }
 
     pluginManager.withPlugin('biz.aQute.bnd.builder') {
-        tasks.withType(aQute.bnd.gradle.Bndrun).configureEach {
+        tasks.withType(aQute.bnd.gradle.TestOSGi).configureEach {
             javaLauncher = javaToolchains.launcherFor {
                 languageVersion = of(javaVersion.getMajorVersion().toInteger())
             }
@@ -410,19 +410,17 @@ subprojects {
         }
     }
 
-    configurations {
-        all {
-            resolutionStrategy {
-                // FORCE Gradle to use latest dynamic versions.
-                cacheDynamicVersionsFor 0, 'seconds'
+    configurations.configureEach {
+        resolutionStrategy {
+            // FORCE Gradle to use latest dynamic versions.
+             cacheDynamicVersionsFor 0, 'seconds'
 
-                // FORCE Gradle to use latest SNAPSHOT versions.
-                cacheChangingModulesFor 0, 'seconds'
+            // FORCE Gradle to use latest SNAPSHOT versions.
+            cacheChangingModulesFor 0, 'seconds'
 
-                dependencySubstitution {
-                    substitute module("antlr:antlr") using module("antlr:antlr.osgi:$antlrVersion")
-                    substitute module("org.dom4j:dom4j") using module("org.apache.servicemix.bundles:org.apache.servicemix.bundles.dom4j:$dom4jOsgiVersion")
-                }
+            dependencySubstitution {
+                substitute module("antlr:antlr") using module("antlr:antlr.osgi:$antlrVersion")
+                substitute module("org.dom4j:dom4j") using module("org.apache.servicemix.bundles:org.apache.servicemix.bundles.dom4j:$dom4jOsgiVersion")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ cordaRuntimeRevision=0-Gecko
 
 # Plugin dependency versions
 bndVersion=6.4.0
-cordaGradlePluginsVersion=7.0.1
+cordaGradlePluginsVersion=7.0.2
 detektPluginVersion=1.22.+
 internalPublishVersion=1.+
 internalDockerVersion=1.+

--- a/libs/sandbox-internal/sandbox-cpk-one/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-one/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Sandbox CPK One'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     workflow {
         name 'Sandbox CPK-1'
         versionId 1
@@ -21,7 +21,6 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     implementation project(':libs:sandbox-internal:sandbox-cpk-library')
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.osgi:osgi.core'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/libs/sandbox-internal/sandbox-cpk-three/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-three/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Sandbox CPK Three'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     workflow {
         name 'Sandbox CPK-3'
         versionId 1
@@ -20,7 +20,6 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     implementation project(':libs:sandbox-internal:sandbox-cpk-library')
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.osgi:osgi.core'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/libs/sandbox-internal/sandbox-cpk-two/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-two/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Sandbox CPK Two'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     workflow {
         name 'Sandbox CPK-2'
         versionId 1
@@ -20,7 +20,6 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     implementation project(':libs:sandbox-internal:sandbox-cpk-library')
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.osgi:osgi.core'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/libs/sandbox-internal/sandbox-fragment-cpk/build.gradle
+++ b/libs/sandbox-internal/sandbox-fragment-cpk/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group = 'com.example'
 
 cordapp {
-    targetPlatformVersion platformVersion.toInteger()
+    targetPlatformVersion = platformVersion.toInteger()
     contract {
         name 'Corda Fragment CPK'
         versionId 1
@@ -18,7 +18,6 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided 'org.osgi:org.osgi.service.component.annotations'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-base'
     implementation project('fragment')

--- a/testing/cpbs/crypto-custom-digest-one-consumer/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-one-consumer/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Crypto Custom Digest Consumer One'
 group 'com.example.crypto.consumer'
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     workflow {
         name 'Custom Crypto Digest One Consumer CPK'
         versionId 1
@@ -19,7 +19,6 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-crypto'

--- a/testing/cpbs/crypto-custom-digest-two-consumer/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-two-consumer/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Crypto Custom Digest Consumer Two'
 group 'org.example.crypto.consumer'
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     workflow {
         name 'Custom Crypto Digest Two Consumer CPK'
         versionId 1
@@ -19,7 +19,6 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-crypto'

--- a/testing/cpbs/sandbox-scr-cpk/build.gradle
+++ b/testing/cpbs/sandbox-scr-cpk/build.gradle
@@ -8,7 +8,7 @@ group 'com.example.sandbox'
 version ''
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     workflow {
         name 'Sandbox SCR-Using-CPK'
         versionId 1
@@ -19,7 +19,6 @@ cordapp {
 dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     cordaProvided "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'

--- a/testing/cpbs/sandbox-security-manager-one/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-one/build.gradle
@@ -8,7 +8,7 @@ description 'Security Manager One'
 group 'com.example.securitymanager'
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     contract {
         name 'Security Manager One CPK'
         versionId 1
@@ -22,7 +22,6 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     cordaProvided 'org.osgi:osgi.core'
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/testing/cpbs/sandbox-security-manager-two/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-two/build.gradle
@@ -8,7 +8,7 @@ description 'Security Manager Two'
 group 'com.example.securitymanager'
 
 cordapp {
-    targetPlatformVersion 999 as Integer
+    targetPlatformVersion = 999
     contract {
         name 'Security Manager Two CPK'
         versionId 1
@@ -20,7 +20,6 @@ dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.slf4j:slf4j-api'

--- a/testing/cpbs/sandbox-singletons-cpk/build.gradle
+++ b/testing/cpbs/sandbox-singletons-cpk/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Sandbox Singletons CPK'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion 999
+    targetPlatformVersion = 999
     workflow {
         name 'Sandbox Singletons CPK'
         versionId 1
@@ -20,7 +20,6 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     cordaProvided project(':testing:sandboxes:test-api')
     cordaProvided 'net.corda:corda-application'

--- a/testing/cpbs/test-cordapp/build.gradle
+++ b/testing/cpbs/test-cordapp/build.gradle
@@ -3,8 +3,8 @@ plugins {
 }
 
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion = platformVersion.toInteger()
+    minimumPlatformVersion = platformVersion.toInteger()
     workflow {
         name "Flow Worker Development"
         versionId 1
@@ -14,7 +14,6 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    cordaProvided 'org.jetbrains:annotations'
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-ledger-utxo'
     cordaProvided 'net.corda:corda-notary-plugin'


### PR DESCRIPTION
Upgrade to Corda Gradle plugns 7.0.2.

These new plugins add `org.jetbrains:annotations` as a `compileOnly` dependency to CPKs' compilation classpath, which removes a warning when Bnd scans the CPK bytecode. It also makes `cordapp-cpk2` tolerant of multi-release bundles such as BouncyCastle being included inside the CPK.