### PR TITLE
CORE-9586 Add Custom Fields To Metadata In MemberInfo

### DIFF
--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -160,7 +160,7 @@ class MemberRegistrationIntegrationTest {
         const val URL_KEY = "corda.endpoints.0.connectionURL"
         const val URL_VALUE = "https://localhost:1080"
         const val PROTOCOL_KEY = "corda.endpoints.0.protocolVersion"
-        const val CUSTOM_KEY = "MyCustomKey"
+        const val CUSTOM_KEY = "ext.MyCustomKey"
         const val CUSTOM_VALUE = "MyCustomValue"
         const val PROTOCOL_VALUE = "1"
         const val CPI_VERSION = "1.1"

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -160,6 +160,8 @@ class MemberRegistrationIntegrationTest {
         const val URL_KEY = "corda.endpoints.0.connectionURL"
         const val URL_VALUE = "https://localhost:1080"
         const val PROTOCOL_KEY = "corda.endpoints.0.protocolVersion"
+        const val CUSTOM_KEY = "MyCustomKey"
+        const val CUSTOM_VALUE = "MyCustomValue"
         const val PROTOCOL_VALUE = "1"
         const val CPI_VERSION = "1.1"
         const val CPI_SIGNER_HASH = "ALG:A1B2C3D4"
@@ -310,6 +312,7 @@ class MemberRegistrationIntegrationTest {
                     it.assertThat(getValue(MEMBER_CPI_SIGNER_HASH)).isEqualTo(CPI_SIGNER_HASH)
                     it.assertThat(getValue(PLATFORM_VERSION)).isEqualTo(TEST_ACTIVE_PLATFORM_VERSION.toString())
                     it.assertThat(getValue(SOFTWARE_VERSION)).isEqualTo(TEST_SOFTWARE_VERSION)
+                    it.assertThat(getValue(CUSTOM_KEY)).isEqualTo(CUSTOM_VALUE)
 
                     with(map { pair -> pair.key }) {
                         it.assertThat(contains(String.format(LEDGER_KEYS_KEY, 0))).isTrue
@@ -351,6 +354,7 @@ class MemberRegistrationIntegrationTest {
             PROTOCOL_KEY to PROTOCOL_VALUE,
             "corda.ledger.keys.0.id" to ledgerKeyId,
             "corda.ledger.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+            CUSTOM_KEY to CUSTOM_VALUE
         )
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -190,12 +190,9 @@ internal class StartRegistrationHandler(
             "Empty member context in the registration request."
         }
 
-        when(val result = registrationContextCustomFieldsVerifier.verify(memberContext)) {
-            is RegistrationContextCustomFieldsVerifier.Result.Failure -> {
-                logger.info(result.reason)
-                throw InvalidRegistrationRequestException(result.reason)
-            }
-            RegistrationContextCustomFieldsVerifier.Result.Success -> {}
+        val customFieldsValid = registrationContextCustomFieldsVerifier.verify(memberContext)
+        validateRegistrationRequest(customFieldsValid is RegistrationContextCustomFieldsVerifier.Result.Failure) {
+            (customFieldsValid as RegistrationContextCustomFieldsVerifier.Result.Failure).reason
         }
 
         val now = clock.instant().toString()

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -191,7 +191,7 @@ internal class StartRegistrationHandler(
         }
 
         val customFieldsValid = registrationContextCustomFieldsVerifier.verify(memberContext)
-        validateRegistrationRequest(customFieldsValid is RegistrationContextCustomFieldsVerifier.Result.Failure) {
+        validateRegistrationRequest(customFieldsValid !is RegistrationContextCustomFieldsVerifier.Result.Failure) {
             (customFieldsValid as RegistrationContextCustomFieldsVerifier.Result.Failure).reason
         }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -13,6 +13,7 @@ import net.corda.layeredpropertymap.toAvro
 import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
+import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
@@ -53,6 +54,7 @@ internal class StartRegistrationHandler(
     private val membershipQueryClient: MembershipQueryClient,
     private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
     cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    private val registrationContextCustomFieldsVerifier: RegistrationContextCustomFieldsVerifier = RegistrationContextCustomFieldsVerifier()
 ) : RegistrationHandler<StartRegistration> {
 
     private companion object {
@@ -95,7 +97,6 @@ internal class StartRegistrationHandler(
             val pendingMemberInfo = buildPendingMemberInfo(registrationRequest)
 
             validatePreAuthTokenUsage(mgmHoldingId, pendingMemberInfo)
-
             // Parse the registration request and verify contents
             // The MemberX500Name matches the source MemberX500Name from the P2P messaging
             validateRegistrationRequest(
@@ -187,6 +188,14 @@ internal class StartRegistrationHandler(
             ?: emptyMap()
         validateRegistrationRequest(memberContext.isNotEmpty()) {
             "Empty member context in the registration request."
+        }
+
+        when(val result = registrationContextCustomFieldsVerifier.verify(memberContext)) {
+            is RegistrationContextCustomFieldsVerifier.Result.Failure -> {
+                logger.info(result.reason)
+                throw InvalidRegistrationRequestException(result.reason)
+            }
+            RegistrationContextCustomFieldsVerifier.Result.Success -> {}
         }
 
         val now = clock.instant().toString()

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/RegistrationContextCustomFieldsVerifier.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/RegistrationContextCustomFieldsVerifier.kt
@@ -1,0 +1,41 @@
+package net.corda.membership.impl.registration.dynamic.verifiers
+
+internal class RegistrationContextCustomFieldsVerifier {
+
+    private companion object {
+        const val RESERVED_KEY_PREFIX = "corda."
+        const val MAX_VALUE_LENGTH = 128
+        const val MAX_KEY_LENGTH = 128
+        const val MAX_CUSTOM_FIELDS = 100
+    }
+
+    fun verify(context: Map<String, String>): Result {
+        val customFields = context.filterNot { it.key.startsWith(RESERVED_KEY_PREFIX) }
+        if (customFields.size > MAX_CUSTOM_FIELDS ) {
+            return Result.Failure("The number of custom fields (${customFields.size}) in the registration context is larger than " +
+                "the maximum allowed ($MAX_CUSTOM_FIELDS).")
+        }
+
+        var errorMessages = ""
+        customFields.forEach {
+            if (it.key.length > MAX_KEY_LENGTH) {
+                errorMessages += "The key: ${it.key} has too many characters (${it.key.length}). Maximum of $MAX_KEY_LENGTH characters " +
+                   "allowed.\n"
+            }
+            if (it.value.length > MAX_VALUE_LENGTH) {
+                errorMessages += "The key: ${it.key} has a value which has too many characters (${it.value.length}). Maximum of" +
+                   " $MAX_VALUE_LENGTH characters allowed.\n"
+            }
+        }
+        return if (errorMessages.isEmpty()) {
+            Result.Success
+        } else {
+            Result.Failure("Failed to validate the registration context with the following errors:\n$errorMessages")
+        }
+    }
+
+    sealed class Result {
+        object Success: Result()
+        data class Failure(val reason: String): Result()
+    }
+}

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/RegistrationContextCustomFieldsVerifier.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/RegistrationContextCustomFieldsVerifier.kt
@@ -3,14 +3,14 @@ package net.corda.membership.impl.registration.dynamic.verifiers
 internal class RegistrationContextCustomFieldsVerifier {
 
     private companion object {
-        const val RESERVED_KEY_PREFIX = "corda."
-        const val MAX_VALUE_LENGTH = 128
+        const val CUSTOM_KEY_PREFIX = "ext."
+        const val MAX_VALUE_LENGTH = 256
         const val MAX_KEY_LENGTH = 128
         const val MAX_CUSTOM_FIELDS = 100
     }
 
     fun verify(context: Map<String, String>): Result {
-        val customFields = context.filterNot { it.key.startsWith(RESERVED_KEY_PREFIX) }
+        val customFields = context.filter { it.key.startsWith(CUSTOM_KEY_PREFIX) }
         if (customFields.size > MAX_CUSTOM_FIELDS ) {
             return Result.Failure("The number of custom fields (${customFields.size}) in the registration context is larger than " +
                 "the maximum allowed ($MAX_CUSTOM_FIELDS).")

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationContextCustomFieldsVerifierTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationContextCustomFieldsVerifierTest.kt
@@ -1,0 +1,51 @@
+package net.corda.membership.impl.registration
+
+import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.StringBuilder
+
+class RegistrationContextCustomFieldsVerifierTest {
+    private companion object {
+        val CUSTOM_KEY = "customKey"
+        val CUSTOM_VALUE = "customValue"
+    }
+    private val fieldsVerifier = RegistrationContextCustomFieldsVerifier()
+    private val longString = StringBuilder().apply { for(i in 0..128){ this.append("a") } }.toString()
+
+    @Test
+    fun `adding a custom field verifies successfully`() {
+        assertThat(fieldsVerifier.verify(mapOf(CUSTOM_KEY to CUSTOM_VALUE)))
+            .isSameAs(RegistrationContextCustomFieldsVerifier.Result.Success)
+    }
+
+    @Test
+    fun `adding to many custom keys causes verification to fail`() {
+        val bigMap = (0..100).associate { it.toString() to CUSTOM_VALUE }
+        val result = fieldsVerifier.verify(bigMap)
+        assertThat(result).isInstanceOf(RegistrationContextCustomFieldsVerifier.Result.Failure::class.java)
+    }
+
+    @Test
+    fun `adding a long key causes verification to fail`() {
+        val result = fieldsVerifier.verify(mapOf(longString to CUSTOM_VALUE))
+        assertThat(result).isInstanceOf(RegistrationContextCustomFieldsVerifier.Result.Failure::class.java)
+        assertThat((result as RegistrationContextCustomFieldsVerifier.Result.Failure).reason).contains(longString)
+    }
+
+    @Test
+    fun `adding a long value causes verification to fail`() {
+        val result = fieldsVerifier.verify(mapOf(CUSTOM_KEY to longString))
+        assertThat(result).isInstanceOf(RegistrationContextCustomFieldsVerifier.Result.Failure::class.java)
+        assertThat((result as RegistrationContextCustomFieldsVerifier.Result.Failure).reason).contains(CUSTOM_KEY)
+    }
+
+    @Test
+    fun `adding two long values causes verification to fail`() {
+        val anotherCustomKey = "CUSTOM KEY 1"
+        val result = fieldsVerifier.verify(mapOf(CUSTOM_KEY to longString, anotherCustomKey to longString))
+        assertThat(result).isInstanceOf(RegistrationContextCustomFieldsVerifier.Result.Failure::class.java)
+        assertThat((result as RegistrationContextCustomFieldsVerifier.Result.Failure).reason).contains(CUSTOM_KEY)
+        assertThat(result.reason).contains(anotherCustomKey)
+    }
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -17,6 +17,7 @@ import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
+import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
 import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
@@ -29,6 +30,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.NOTARY_SERVICE_NAME_KEY
 import net.corda.membership.lib.notary.MemberNotaryDetails
+import net.corda.membership.lib.toMap
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
 import net.corda.membership.persistence.client.MembershipQueryClient
@@ -166,6 +168,9 @@ class StartRegistrationHandlerTest {
     private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider> {
         on { getGroupReader(mgmHoldingIdentity.toCorda()) } doReturn groupReader
     }
+    private val registrationContextCustomFieldsVerifier = mock<RegistrationContextCustomFieldsVerifier> {
+        on { verify(any()) } doReturn RegistrationContextCustomFieldsVerifier.Result.Success
+    }
 
     @BeforeEach
     fun setUp() {
@@ -199,6 +204,7 @@ class StartRegistrationHandlerTest {
             membershipQueryClient,
             membershipGroupReaderProvider,
             cordaAvroSerializationFactory,
+            registrationContextCustomFieldsVerifier
         )
     }
 
@@ -222,6 +228,7 @@ class StartRegistrationHandlerTest {
         verifyServices(
             persistRegistrationRequest = true,
             verify = true,
+            verifyCustomFields = true,
             queryMemberInfo = true,
             persistMemberInfo = true
         )
@@ -305,6 +312,26 @@ class StartRegistrationHandlerTest {
         )
     }
 
+
+    @Test
+    fun `declined if customs fields in member fail validation`() {
+        whenever(registrationContextCustomFieldsVerifier.verify(any()))
+            .thenReturn(RegistrationContextCustomFieldsVerifier.Result.Failure(""))
+        with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
+            assertThat(updatedState).isNotNull
+            assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
+            assertThat(outputStates).isNotEmpty.hasSize(1)
+
+            assertDeclinedRegistration()
+        }
+        verifyServices(
+            persistRegistrationRequest = true,
+            verify = true,
+            verifyCustomFields = true,
+        )
+    }
+
     @Test
     fun `declined if member name in context does not match the source member`() {
         val badHoldingIdentity = HoldingIdentity(MemberX500Name.parse("O=BadName,L=London,C=GB").toString(), groupId)
@@ -314,9 +341,7 @@ class StartRegistrationHandlerTest {
                 Record(
                     testTopic, testTopicKey, getStartRegistrationCommand(
                         badHoldingIdentity,
-                        KeyValuePairList(
-                            emptyList()
-                        )
+                        memberContext
                     )
                 )
             )
@@ -331,6 +356,7 @@ class StartRegistrationHandlerTest {
         verifyServices(
             persistRegistrationRequest = true,
             verify = true,
+            verifyCustomFields = true,
         )
     }
 
@@ -351,6 +377,7 @@ class StartRegistrationHandlerTest {
         verifyServices(
             persistRegistrationRequest = true,
             verify = true,
+            verifyCustomFields = true,
             queryMemberInfo = true,
         )
     }
@@ -385,6 +412,7 @@ class StartRegistrationHandlerTest {
         verifyServices(
             persistRegistrationRequest = true,
             verify = true,
+            verifyCustomFields = true,
             queryMemberInfo = true,
         )
     }
@@ -405,6 +433,7 @@ class StartRegistrationHandlerTest {
         verifyServices(
             persistRegistrationRequest = true,
             verify = true,
+            verifyCustomFields = true,
             queryMemberInfo = true,
             persistMemberInfo = true
         )
@@ -674,6 +703,7 @@ class StartRegistrationHandlerTest {
     private fun verifyServices(
         persistRegistrationRequest: Boolean = false,
         verify: Boolean = false,
+        verifyCustomFields: Boolean = false,
         queryMemberInfo: Boolean = false,
         persistMemberInfo: Boolean = false
     ) {
@@ -687,6 +717,9 @@ class StartRegistrationHandlerTest {
 
         verify(membershipPersistenceClient, getVerificationMode(persistMemberInfo))
             .persistMemberInfo(eq(mgmHoldingIdentity.toCorda()), any())
+
+        verify(registrationContextCustomFieldsVerifier, getVerificationMode(verifyCustomFields))
+            .verify(memberContext.toMap())
 
         verify(memberTypeChecker, getVerificationMode(verify))
             .getMgmMemberInfo(eq(mgmHoldingIdentity.toCorda()))

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -21,8 +21,6 @@ import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.p2p.gateway.certificates.RevocationCheckRequest
-import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.platform.PlatformInfoProvider
@@ -78,7 +76,6 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
-import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.membership.MembershipSchema

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.716-beta+
+cordaApiVersion=5.0.0.716-alpha-1678901404424
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
Allow a user to specify custom fields in the registration context, which get signed and added to the member.info during registration. These fields must start with `ext.`, everything else is reserved for future platform usage. Verify there are at most 100 custom fields being added and limit the key size and value size 128 and 256 characters respectively. We verify this on both the member and MGM side during registration. Currently we don't verify any of the other fields on the MGM side, so we have future flexibility i.e. a cluster running a more recent version of Corda, can register with an MGM running an old version. Tested with schema update here: https://github.com/corda/corda-api/pull/936

Testing
===

Happy Path
----

We can add extra keys to the registration context e.g.:
```
{
  "memberRegistrationRequest": {
    "action": "requestJoin",
    "context": {
      "corda.session.key.id": "11FB261B5078",
      "corda.ledger.keys.0.id": "07300EE8A425",
      "corda.ledger.keys.0.signature.spec": "SHA256withECDSA",
      "corda.endpoints.0.connectionURL": "https://corda-p2p-gateway-worker.williamvigor-cluster-a:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "ext.myCustomKey": "myCustomValue"
    }
  }
}
```
Then the custom key gets added to the member info:
```
curl -X 'GET' -s -S --insecure -u admin:admin  'https://localhost:8888/api/v1/members/61F0DA49D3DC' -H 'accept: application/json' | jq
{
  "members": [
    {
      "memberContext": {
        "corda.cpi.name": "mgm cordapp",
        "corda.cpi.signer.summary.hash": "SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC",
        "corda.cpi.version": "1.0.0.0-SNAPSHOT",
        "corda.ecdh.key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8eaPi2jXJ6g1XAnsnO+wWapaRopg\nN32uryXDFCcRvMT1/8bFT1eos0IPgBJ4+Wjs1SO3+YhGUDUFvy5Dyr2KMA==\n-----END PUBLIC KEY-----\n",
        "corda.endpoints.0.connectionURL": "https://corda-p2p-gateway-worker.williamvigor-mgm:8080",
        "corda.endpoints.0.protocolVersion": "1",
        "corda.groupId": "e5069233-a9ac-469e-ab76-7333dd67c2d5",
        "corda.name": "O=MGM, L=London, C=GB",
        "corda.platformVersion": "5000",
        "corda.session.key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEP/iZfu42xXGdGDiYh8kEH5QgW4Rl\nml3MSahU6NWfOvGXwZo4BitNzUV8MvWNhp0Vp2ddDr1h6lNjRA7x1/7wOw==\n-----END PUBLIC KEY-----\n",
        "corda.session.key.hash": "A7228EF0A4E1C5F7D765662AA96D804C72F5FFD4CF2DB6CF10AAA6E4EA5BB2CE",
        "corda.softwareVersion": "5.0.0.0-SNAPSHOT"
      },
      "mgmContext": {
        "corda.creationTime": "2023-03-17T15:53:47.319469Z",
        "corda.mgm": "true",
        "corda.modifiedTime": "2023-03-17T15:53:47.319469Z",
        "corda.serial": "1",
        "corda.status": "ACTIVE"
      }
    },
    {
      "memberContext": {
        "corda.cpi.name": "test cordapp",
        "corda.cpi.signer.summary.hash": "SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC",
        "corda.cpi.version": "1.0.0.0-SNAPSHOT",
        "corda.endpoints.0.connectionURL": "https://corda-p2p-gateway-worker.williamvigor-cluster-a:8080",
        "corda.endpoints.0.protocolVersion": "1",
        "corda.groupId": "e5069233-a9ac-469e-ab76-7333dd67c2d5",
        "corda.ledger.keys.0.hash": "07300EE8A425CE481CB7CC29A3AA2FBEB11AC326A11E8A49C99BB93B77A27292",
        "corda.ledger.keys.0.pem": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErO/sNttAeVT4Vo6Ka7sXuMAygvjB\n23xGpOCSnskCFSgG4u++dpZsVdkakQ3y37SUKB03xkXNQo/ePjhEHM/mMQ==\n-----END PUBLIC KEY-----\n",
        "corda.ledger.keys.0.signature.spec": "SHA256withECDSA",
        "corda.name": "O=Alice, L=London, C=GB",
        "corda.platformVersion": "5000",
        "corda.registration.id": "964bbc2e-a131-4f5a-8033-69b48b3bfac6",
        "corda.session.key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAJGLg7HOt61901VvvpHi29iD1dev\nloRLx9rs1sADX10GEz/EtTCfIwblw2zMSYqmrDqXF2OpcUmTrheLd29LNA==\n-----END PUBLIC KEY-----\n",
        "corda.session.key.hash": "11FB261B50784B8FB3485D6E904C0400C56E2A2434DCAE0DC5C3D6D4F3B17668",
        "corda.session.key.signature.spec": "SHA256withECDSA",
        "corda.softwareVersion": "5.0.0.0-SNAPSHOT",
        "ext.myCustomKey": "myCustomValue"
      },
      "mgmContext": {
        "corda.creationTime": "2023-03-17T15:54:44.530886Z",
        "corda.modifiedTime": "2023-03-17T15:54:44.530886Z",
        "corda.serial": "1",
        "corda.status": "ACTIVE"
      }
    }
  ]
}
```

Error Validation
----

You cannot add a custom field to the MGM context. Registering using:
```
{
  "corda.session.key.id": "86FF674369CD",
  "corda.ecdh.key.id": "919ED61C3D0A",
  "corda.group.protocol.registration": "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
  "corda.group.protocol.synchronisation": "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
  "corda.group.protocol.p2p.mode": "Authenticated_Encryption",
  "corda.group.key.session.policy": "Combined",
  "corda.group.pki.session": "NoPKI",
  "corda.group.pki.tls": "Standard",
  "corda.group.tls.version": "1.3",
  "corda.group.tls.type": "OneWay",
  "corda.endpoints.0.connectionURL": "https://corda-p2p-gateway-worker.williamvigor-mgm:8080",
  "corda.endpoints.0.protocolVersion": "1",
  "corda.group.truststore.tls.0": "-----BEGIN CERTIFICATE-----\nMIIBSjCB8aADAgECAgECMAoGCCqGSM49BAMCMB4xCzAJBgNVBAYTAlVLMQ8wDQYD\nVQQDDAZyMy5jb20wHhcNMjMwMzE0MTU1ODUyWhcNMjMwNDEzMTU1ODUyWjAeMQsw\nCQYDVQQGEwJVSzEPMA0GA1UEAwwGcjMuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAE1SarEO1yBXz7pZzk8A93olrwvuZ6+94A3Omnwq1Wn8FFsU+KvsyvVZ6y\nmCeTvcIx2L5/znkoVB3pUTjAtrWLvqMgMB4wDwYDVR0TAQH/BAUwAwEB/zALBgNV\nHQ8EBAMCAa4wCgYIKoZIzj0EAwIDSAAwRQIhANO+1x3idmhyvFFKTP11cKAB4nyX\naiSlG0sseXCDTdcEAiAO5qx/ejFIeXT6Z1RA/wJFVokHVsm1rG2pxeXovir8Ww==\n-----END CERTIFICATE-----\n",
  "corda.group.truststore.session.0": "-----BEGIN CERTIFICATE-----\nMIIBSjCB8aADAgECAgECMAoGCCqGSM49BAMCMB4xCzAJBgNVBAYTAlVLMQ8wDQYD\nVQQDDAZyMy5jb20wHhcNMjMwMzE0MTU1ODUyWhcNMjMwNDEzMTU1ODUyWjAeMQsw\nCQYDVQQGEwJVSzEPMA0GA1UEAwwGcjMuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAE1SarEO1yBXz7pZzk8A93olrwvuZ6+94A3Omnwq1Wn8FFsU+KvsyvVZ6y\nmCeTvcIx2L5/znkoVB3pUTjAtrWLvqMgMB4wDwYDVR0TAQH/BAUwAwEB/zALBgNV\nHQ8EBAMCAa4wCgYIKoZIzj0EAwIDSAAwRQIhANO+1x3idmhyvFFKTP11cKAB4nyX\naiSlG0sseXCDTdcEAiAO5qx/ejFIeXT6Z1RA/wJFVokHVsm1rG2pxeXovir8Ww==\n-----END CERTIFICATE-----\n",
  "myCustomKey": "myCustomValue"
}
```
Gives status invalid:
```
[{"registrationId":"a14b2a59-630e-4ff0-b4e6-068303841eaf","registrationSent":"2023-03-15T18:08:40.023Z","registrationUpdated":"2023-03-15T18:08:42.611Z","registrationStatus":"INVALID","memberInfoSubmitted":{"data":{"registrationProtocolVersion":"1","corda.session.key.id":"86FF674369CD","corda.ecdh.key.id":"919ED61C3D0A","corda.group.protocol.registration":"net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService","corda.group.protocol.synchronisation":"net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl","corda.group.protocol.p2p.mode":"Authenticated_Encryption","corda.group.key.session.policy":"Combined","corda.group.pki.session":"NoPKI","corda.group.pki.tls":"Standard","corda.group.tls.version":"1.3","corda.group.tls.type":"OneWay","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.williamvigor-mgm:8080","corda.endpoints.0.protocolVersion":"1","corda.group.truststore.tls.0":"-----BEGIN CERTIFICATE-----\nMIIBSjCB8aADAgECAgECMAoGCCqGSM49BAMCMB4xCzAJBgNVBAYTAlVLMQ8wDQYD\nVQQDDAZyMy5jb20wHhcNMjMwMzE0MTU1ODUyWhcNMjMwNDEzMTU1ODUyWjAeMQsw\nCQYDVQQGEwJVSzEPMA0GA1UEAwwGcjMuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAE1SarEO1yBXz7pZzk8A93olrwvuZ6+94A3Omnwq1Wn8FFsU+KvsyvVZ6y\nmCeTvcIx2L5/znkoVB3pUTjAtrWLvqMgMB4wDwYDVR0TAQH/BAUwAwEB/zALBgNV\nHQ8EBAMCAa4wCgYIKoZIzj0EAwIDSAAwRQIhANO+1x3idmhyvFFKTP11cKAB4nyX\naiSlG0sseXCDTdcEAiAO5qx/ejFIeXT6Z1RA/wJFVokHVsm1rG2pxeXovir8Ww==\n-----END CERTIFICATE-----\n","corda.group.truststore.session.0":"-----BEGIN CERTIFICATE-----\nMIIBSjCB8aADAgECAgECMAoGCCqGSM49BAMCMB4xCzAJBgNVBAYTAlVLMQ8wDQYD\nVQQDDAZyMy5jb20wHhcNMjMwMzE0MTU1ODUyWhcNMjMwNDEzMTU1ODUyWjAeMQsw\nCQYDVQQGEwJVSzEPMA0GA1UEAwwGcjMuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAE1SarEO1yBXz7pZzk8A93olrwvuZ6+94A3Omnwq1Wn8FFsU+KvsyvVZ6y\nmCeTvcIx2L5/znkoVB3pUTjAtrWLvqMgMB4wDwYDVR0TAQH/BAUwAwEB/zALBgNV\nHQ8EBAMCAa4wCgYIKoZIzj0EAwIDSAAwRQIhANO+1x3idmhyvFFKTP11cKAB4nyX\naiSlG0sseXCDTdcEAiAO5qx/ejFIeXT6Z1RA/wJFVokHVsm1rG2pxeXovir8Ww==\n-----END CERTIFICATE-----\n","myCustomKey":"myCustomValue"}},"reason":"Onboarding MGM failed. Exception when validating membership schema.. Failed to validate against schema \"corda.mgm.registration\" due to the following error(s): [$.myCustomKey: is not defined in the schema and the schema does not allow additional properties"}]%
```
You can't have too large a value:
Using:
```
{
  "memberRegistrationRequest": {
    "action": "requestJoin",
    "context": {
      "corda.session.key.id": "C280FEB80157",
      "corda.ledger.keys.0.id": "051D6FF85D16",
      "corda.ledger.keys.0.signature.spec": "SHA256withECDSA",
      "corda.endpoints.0.connectionURL": "https://corda-p2p-gateway-worker.williamvigor-cluster-a:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "ext.myCustomKey101": "myCustomValueAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
    }
  }
}
```
Gives:
```
{"registrationId":"a791159f-f0b3-420f-9a03-7e52ed597884","registrationSent":"2023-03-17T15:14:29.160Z","registrationUpdated":"2023-03-17T15:14:32.063Z","registrationStatus":"INVALID","memberInfoSubmitted":{"data":{"registrationProtocolVersion":"1","corda.session.key.id":"C280FEB80157","corda.ledger.keys.0.id":"051D6FF85D16","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.williamvigor-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","ext.myCustomKey101":"myCustomValueAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}},"reason":"Registration failed. The registration context is invalid. Exception when validating membership schema.. Failed to validate against schema \"corda.member.dynamic.registration\" due to the following error(s): [$.ext.myCustomKey101: may only be 256 characters ","serial":0}%
```
You can't have too large a key:
```
curl --fail-with-body -s -S --insecure -u admin:admin -X GET  https://localhost:8888/api/v1/membership/37B88C6327C6/f5f164ad-e276-4ea9-a6fb-ca1bcd7b1ee1
{"registrationId":"f5f164ad-e276-4ea9-a6fb-ca1bcd7b1ee1","registrationSent":"2023-03-17T15:23:41.271Z","registrationUpdated":"2023-03-17T15:23:43.624Z","registrationStatus":"INVALID","memberInfoSubmitted":{"data":{"registrationProtocolVersion":"1","corda.session.key.id":"1B7E5A7AC5EC","corda.ledger.keys.0.id":"3FF836994062","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.williamvigor-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","ext.myCustomKeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA":"myCustomValue"}},"reason":"Registration failed. Failed to validate the registration context with the following errors:\nThe key: ext.myCustomKeyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","serial":0}%
```
You can't have more than 100 keys:
```
{"registrationId":"3176602a-5e94-48f6-b9da-82ebf37e242a","registrationSent":"2023-03-17T15:03:01.122Z","registrationUpdated":"2023-03-17T15:03:03.517Z","registrationStatus":"INVALID","memberInfoSubmitted":{"data":{"registrationProtocolVersion":"1","corda.session.key.id":"5D39D7E3AA17","corda.ledger.keys.0.id":"2076ABBDFB74","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.williamvigor-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","ext.myCustomKey1":"myCustomValue","ext.myCustomKey2":"myCustomValue","ext.myCustomKey3":"myCustomValue","ext.myCustomKey4":"myCustomValue","ext.myCustomKey5":"myCustomValue","ext.myCustomKey6":"myCustomValue","ext.myCustomKey7":"myCustomValue","ext.myCustomKey8":"myCustomValue","ext.myCustomKey9":"myCustomValue","ext.myCustomKey10":"myCustomValue","ext.myCustomKey11":"myCustomValue","ext.myCustomKey12":"myCustomValue","ext.myCustomKey13":"myCustomValue","ext.myCustomKey14":"myCustomValue","ext.myCustomKey15":"myCustomValue","ext.myCustomKey16":"myCustomValue","ext.myCustomKey17":"myCustomValue","ext.myCustomKey18":"myCustomValue","ext.myCustomKey19":"myCustomValue","ext.myCustomKey20":"myCustomValue","ext.myCustomKey21":"myCustomValue","ext.myCustomKey22":"myCustomValue","ext.myCustomKey23":"myCustomValue","ext.myCustomKey24":"myCustomValue","ext.myCustomKey25":"myCustomValue","ext.myCustomKey26":"myCustomValue","ext.myCustomKey27":"myCustomValue","ext.myCustomKey28":"myCustomValue","ext.myCustomKey29":"myCustomValue","ext.myCustomKey30":"myCustomValue","ext.myCustomKey31":"myCustomValue","ext.myCustomKey32":"myCustomValue","ext.myCustomKey33":"myCustomValue","ext.myCustomKey34":"myCustomValue","ext.myCustomKey35":"myCustomValue","ext.myCustomKey36":"myCustomValue","ext.myCustomKey37":"myCustomValue","ext.myCustomKey38":"myCustomValue","ext.myCustomKey39":"myCustomValue","ext.myCustomKey40":"myCustomValue","ext.myCustomKey41":"myCustomValue","ext.myCustomKey42":"myCustomValue","ext.myCustomKey43":"myCustomValue","ext.myCustomKey44":"myCustomValue","ext.myCustomKey45":"myCustomValue","ext.myCustomKey46":"myCustomValue","ext.myCustomKey47":"myCustomValue","ext.myCustomKey48":"myCustomValue","ext.myCustomKey49":"myCustomValue","ext.myCustomKey50":"myCustomValue","ext.myCustomKey51":"myCustomValue","ext.myCustomKey52":"myCustomValue","ext.myCustomKey53":"myCustomValue","ext.myCustomKey54":"myCustomValue","ext.myCustomKey55":"myCustomValue","ext.myCustomKey56":"myCustomValue","ext.myCustomKey57":"myCustomValue","ext.myCustomKey58":"myCustomValue","ext.myCustomKey59":"myCustomValue","ext.myCustomKey60":"myCustomValue","ext.myCustomKey61":"myCustomValue","ext.myCustomKey62":"myCustomValue","ext.myCustomKey63":"myCustomValue","ext.myCustomKey64":"myCustomValue","ext.myCustomKey65":"myCustomValue","ext.myCustomKey66":"myCustomValue","ext.myCustomKey67":"myCustomValue","ext.myCustomKey68":"myCustomValue","ext.myCustomKey69":"myCustomValue","ext.myCustomKey70":"myCustomValue","ext.myCustomKey71":"myCustomValue","ext.myCustomKey72":"myCustomValue","ext.myCustomKey73":"myCustomValue","ext.myCustomKey74":"myCustomValue","ext.myCustomKey75":"myCustomValue","ext.myCustomKey76":"myCustomValue","ext.myCustomKey77":"myCustomValue","ext.myCustomKey78":"myCustomValue","ext.myCustomKey79":"myCustomValue","ext.myCustomKey80":"myCustomValue","ext.myCustomKey81":"myCustomValue","ext.myCustomKey82":"myCustomValue","ext.myCustomKey83":"myCustomValue","ext.myCustomKey84":"myCustomValue","ext.myCustomKey85":"myCustomValue","ext.myCustomKey86":"myCustomValue","ext.myCustomKey87":"myCustomValue","ext.myCustomKey88":"myCustomValue","ext.myCustomKey89":"myCustomValue","ext.myCustomKey90":"myCustomValue","ext.myCustomKey91":"myCustomValue","ext.myCustomKey92":"myCustomValue","ext.myCustomKey93":"myCustomValue","ext.myCustomKey94":"myCustomValue","ext.myCustomKey95":"myCustomValue","ext.myCustomKey96":"myCustomValue","ext.myCustomKey97":"myCustomValue","ext.myCustomKey98":"myCustomValue","ext.myCustomKey99":"myCustomValue","ext.myCustomKey100":"myCustomValue","ext.myCustomKey101":"myCustomValue"}},
"reason":"Registration failed. The number of custom fields (101) in the registration context is larger than the maximum allowed (100).","serial":0}%
```