### PR TITLE
CORE-11750 Update combined worker metrics port from 7000 -> 7004

### DIFF
--- a/metrics/prometheus.yaml
+++ b/metrics/prometheus.yaml
@@ -11,6 +11,6 @@ scrape_configs:
     metrics_path: "/metrics"
     scrape_interval: 5s
     static_configs:
-      - targets: ["host.docker.internal:7000"]
+      - targets: ["host.docker.internal:7004"]
         labels:
           alias: "java-app"

--- a/metrics/readme.md
+++ b/metrics/readme.md
@@ -6,7 +6,7 @@ The docker-compose configuration in this directory can be used to test this in t
 To start Prometheus and Grafana, simply run `docker compose up` in this directory and browse to the grafana dashboard by
 on to `http://localhost:3000/` using the initial username & password of admin/admin. 
 
-Prometheus is using the worker's `/metrics` endpoint exposed on port `7004` (default).
+Prometheus is using the worker's `/metrics` endpoint exposed on the configured worker port (default `7000`, or `7004` for the combined worker by default).
 
 ## Grafana datasource
 

--- a/metrics/readme.md
+++ b/metrics/readme.md
@@ -6,7 +6,7 @@ The docker-compose configuration in this directory can be used to test this in t
 To start Prometheus and Grafana, simply run `docker compose up` in this directory and browse to the grafana dashboard by
 on to `http://localhost:3000/` using the initial username & password of admin/admin. 
 
-Prometheus is using the worker's `/metrics` endpoint exposed on port `7000` (default).
+Prometheus is using the worker's `/metrics` endpoint exposed on port `7004` (default).
 
 ## Grafana datasource
 
@@ -24,4 +24,3 @@ This can be found by going to `Dashboards` -> `Browse`, then searching for `JVM`
 Custom metrics can be added to a dashboard by choosing the metrics name from the datasource. E.g. `http_server_requests_total`.
 An example Corda dashboard has been added (`grafana/provisioning/dashboards/corda.json`). Please note that this is for testing and 
 development purpose and is not officially supported. Feel free to add/change/improve.
-


### PR DESCRIPTION
### Summary
https://github.com/corda/corda-runtime-os/pull/3185 changed the combined worker port for metrics from 7000 to 7004, however the metrics deployment for the combined worker was not updated to reflect this. This PR addresses this issue.

### Testing
Ensure that grafana dashboard is now populated when the combined worker is running.