### PR TITLE
CORE-11751: Enable crypto-utils publishing

### DIFF
--- a/libs/crypto/crypto-utils/build.gradle
+++ b/libs/crypto/crypto-utils/build.gradle
@@ -1,6 +1,11 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
+    id 'corda.javadoc-generation'
+}
+
+ext {
+    releasable = true
 }
 
 description 'Crypto utilities'


### PR DESCRIPTION
Issue flagged testing CSDE as `crypto-utils` dependency is required in `simulator`. 