### PR TITLE
CORE-11752 Make a test only run against Postgres

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -169,6 +169,7 @@ class UtxoPersistenceServiceImplTest {
 
     @Test
     fun `find unconsumed relevant transaction states`() {
+        Assumptions.assumeFalse(DbUtils.isInMemory, "Skipping this test when run against in-memory DB.")
         val createdTs = testClock.instant()
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
         val transaction1 = createSignedTransaction(createdTs)


### PR DESCRIPTION
`UtxoPersistenceServiceImplTest.find unconsumed relevant transaction states` uses postgres specific syntax and tables, so restrict the test to postgres only.