### PR TITLE
CORE-11493: Avoid using `static` variables from `Unirest` class

### DIFF
--- a/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/RestClient.kt
+++ b/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/RestClient.kt
@@ -22,7 +22,6 @@ import kotlin.concurrent.scheduleAtFixedRate
  * [RestResource] interface should be used.
  *
  * @property baseAddress The base address of the server.
- * @property restResource The [RestResource] interface for which the proxy will be created.
  * @property restResourceClass The [RestResource] interface for which the proxy will be created.
  * @property clientConfig The configuration for the client to use.
  * @property healthCheckInterval The interval on which health check calls to the server will happen, ensuring


### PR DESCRIPTION
Use of static variables is not a good practice, especially when we might have multiple instances of `RemoteUnirestClient` in a JVM used concurrently.

Also `addSslParams()` method can be called at creation time once rather than on every REST invocation. This should have a positive impact on performance.