### PR TITLE
CORE-11769 - support file boot config

### DIFF
--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -27,9 +27,7 @@ import net.corda.processors.p2p.linkmanager.LinkManagerProcessor
 import net.corda.processors.rest.RestProcessor
 import net.corda.processors.uniqueness.UniquenessProcessor
 import net.corda.processors.verification.VerificationProcessor
-import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
-import net.corda.schema.configuration.BootConfig.BOOT_REST_PARAMS
+import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.DatabaseConfig
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -110,9 +108,9 @@ class CombinedWorker @Activate constructor(
             // the combined worker may use SOFT HSM by default unlike the crypto worker
             params.hsmId = SOFT_HSM_ID
         }
-        val databaseConfig = PathAndConfig(BOOT_DB_PARAMS, params.databaseParams)
-        val cryptoConfig = PathAndConfig(BOOT_CRYPTO, createCryptoBootstrapParamsMap(params.hsmId))
-        val restConfig = PathAndConfig(BOOT_REST_PARAMS, params.restParams)
+        val databaseConfig = PathAndConfig(BootConfig.BOOT_DB, params.databaseParams)
+        val cryptoConfig = PathAndConfig(BootConfig.BOOT_CRYPTO, createCryptoBootstrapParamsMap(params.hsmId))
+        val restConfig = PathAndConfig(BootConfig.BOOT_REST, params.restParams)
         val config = getBootstrapConfig(
             secretsServiceFactoryResolver,
             params.defaultParams,
@@ -123,10 +121,10 @@ class CombinedWorker @Activate constructor(
         val superUser = System.getenv("CORDA_DEV_POSTGRES_USER") ?: "postgres"
         val superUserPassword = System.getenv("CORDA_DEV_POSTGRES_PASSWORD") ?: "password"
         val dbName = dbUrl.split("/").last().split("?").first()
-        val dbAdmin = if (config.getConfig(BOOT_DB_PARAMS).hasPath(DatabaseConfig.DB_USER))
-            config.getConfig(BOOT_DB_PARAMS).getString(DatabaseConfig.DB_USER) else "user"
-        val dbAdminPassword = if (config.getConfig(BOOT_DB_PARAMS).hasPath(DatabaseConfig.DB_PASS))
-            config.getConfig(BOOT_DB_PARAMS).getString(DatabaseConfig.DB_PASS) else "password"
+        val dbAdmin = if (config.getConfig(BootConfig.BOOT_DB).hasPath(DatabaseConfig.DB_USER))
+            config.getConfig(BootConfig.BOOT_DB).getString(DatabaseConfig.DB_USER) else "user"
+        val dbAdminPassword = if (config.getConfig(BootConfig.BOOT_DB).hasPath(DatabaseConfig.DB_PASS))
+            config.getConfig(BootConfig.BOOT_DB).getString(DatabaseConfig.DB_PASS) else "password"
 
         // Part of DB setup is to generate defaults for the crypto code. That currently includes a
         // default master wrapping key passphrase and salt, which we want to keep secret, and so
@@ -186,12 +184,13 @@ private class CombinedWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams(COMBINED_WORKER_MONITOR_PORT)
 
-    @Option(names = ["-d", "--database-params"], description = ["Database parameters for the worker."])
+    @Option(names = ["-d", "--${BootConfig.BOOT_DB}"], description = ["Database parameters for the worker."])
     var databaseParams = emptyMap<String, String>()
 
-    @Option(names = ["-r", "--rest-params"], description = ["REST parameters for the worker."])
+    @Option(names = ["-r", "--${BootConfig.BOOT_REST}"], description = ["REST parameters for the worker."])
     var restParams = emptyMap<String, String>()
 
+    // TODO - remove when reviewing crypto config
     @Option(names = ["--hsm-id"], description = ["HSM ID which is handled by this worker instance."])
     var hsmId = ""
 

--- a/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
+++ b/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
@@ -20,6 +20,7 @@ import net.corda.osgi.api.Shutdown
 import net.corda.processors.crypto.CryptoProcessor
 import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -85,7 +86,7 @@ class CryptoWorker @Activate constructor(
         params.defaultParams,
         configurationValidatorFactory.createConfigValidator(),
         listOf(
-            PathAndConfig(BootConfig.BOOT_DB_PARAMS, params.databaseParams),
+            PathAndConfig(BootConfig.BOOT_DB, params.databaseParams),
             PathAndConfig(BOOT_CRYPTO, createCryptoBootstrapParamsMap(params.hsmId))
         )
     )
@@ -95,7 +96,7 @@ class CryptoWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
 
-    @CommandLine.Option(names = ["-d", "--database-params"], description = ["Database parameters for the worker."])
+    @CommandLine.Option(names = ["-d", "--$BOOT_DB"], description = ["Database parameters for the worker."])
     var databaseParams = emptyMap<String, String>()
 
     // TODO - delete me as part of removing multiple HSM support, CORE-10050

--- a/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
+++ b/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
@@ -17,7 +17,7 @@ import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.db.DBProcessor
 import net.corda.processors.uniqueness.UniquenessProcessor
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -64,7 +64,7 @@ class DBWorker @Activate constructor(
         if (printHelpOrVersion(params.defaultParams, DBWorker::class.java, shutDownService)) return
         setupMonitor(workerMonitor, params.defaultParams, this.javaClass.simpleName)
 
-        val databaseConfig = PathAndConfig(BOOT_DB_PARAMS, params.databaseParams)
+        val databaseConfig = PathAndConfig(BOOT_DB, params.databaseParams)
         val config = getBootstrapConfig(
             secretsServiceFactoryResolver,
             params.defaultParams,
@@ -88,6 +88,6 @@ private class DBWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
 
-    @Option(names = ["-d", "--database-params"], description = ["Database parameters for the worker."])
+    @Option(names = ["-d", "--$BOOT_DB"], description = ["Database parameters for the worker."])
     var databaseParams = emptyMap<String, String>()
 }

--- a/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
+++ b/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
@@ -16,7 +16,7 @@ import net.corda.libs.configuration.validation.ConfigurationValidatorFactory
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.db.DBProcessor
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.schema.configuration.BootConfig.BOOT_KAFKA_COMMON
 import net.corda.schema.configuration.BootConfig.BOOT_MAX_ALLOWED_MSG_SIZE
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
@@ -75,7 +75,7 @@ class ConfigTests {
             WORKSPACE_DIR,
             TEMP_DIR,
             "$BOOT_KAFKA_COMMON.$MSG_KEY_ONE",
-            "$BOOT_DB_PARAMS.$DB_KEY_ONE"
+            "$BOOT_DB.$DB_KEY_ONE"
         )
         val actualKeys = config.entrySet().map { entry -> entry.key }.toSet()
         assertEquals(expectedKeys, actualKeys)
@@ -84,7 +84,7 @@ class ConfigTests {
         assertEquals(VALUE_TOPIC_PREFIX, config.getAnyRef(TOPIC_PREFIX))
         assertEquals(VALUE_MAX_SIZE, config.getString(BOOT_MAX_ALLOWED_MSG_SIZE))
         assertEquals(MSG_VAL_ONE, config.getAnyRef("$BOOT_KAFKA_COMMON.$MSG_KEY_ONE"))
-        assertEquals(DB_VAL_ONE, config.getAnyRef("$BOOT_DB_PARAMS.$DB_KEY_ONE"))
+        assertEquals(DB_VAL_ONE, config.getAnyRef("$BOOT_DB.$DB_KEY_ONE"))
     }
 
     @Test
@@ -196,8 +196,8 @@ class ConfigTests {
         dbWorker.startup(args.toTypedArray())
         val config = dbProcessor.config!!
 
-        assertEquals(DB_VAL_ONE, config.getAnyRef("$BOOT_DB_PARAMS.$DB_KEY_ONE"))
-        assertEquals(DB_VAL_TWO, config.getAnyRef("$BOOT_DB_PARAMS.$DB_KEY_TWO"))
+        assertEquals(DB_VAL_ONE, config.getAnyRef("$BOOT_DB.$DB_KEY_ONE"))
+        assertEquals(DB_VAL_TWO, config.getAnyRef("$BOOT_DB.$DB_KEY_TWO"))
     }
 
     /** A [DBProcessor] that stores the passed-in config in [config] for inspection. */

--- a/applications/workers/release/rest-worker/src/main/kotlin/net/corda/applications/workers/rest/RestWorker.kt
+++ b/applications/workers/release/rest-worker/src/main/kotlin/net/corda/applications/workers/rest/RestWorker.kt
@@ -61,7 +61,7 @@ class RestWorker @Activate constructor(
         if (printHelpOrVersion(params.defaultParams, RestWorker::class.java, shutDownService)) return
         setupMonitor(workerMonitor, params.defaultParams, this.javaClass.simpleName)
 
-        val restConfig = PathAndConfig(BootConfig.BOOT_REST_PARAMS, params.restParams)
+        val restConfig = PathAndConfig(BootConfig.BOOT_REST, params.restParams)
         val config = getBootstrapConfig(
                 secretsServiceFactoryResolver,
                 params.defaultParams,
@@ -83,6 +83,6 @@ private class RestWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
 
-    @CommandLine.Option(names = ["-r", "--rest-params"], description = ["REST worker specific params."])
+    @CommandLine.Option(names = ["-r", "--${BootConfig.BOOT_REST}"], description = ["REST worker specific params."])
     var restParams = emptyMap<String, String>()
 }

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
@@ -1,10 +1,8 @@
 package net.corda.applications.workers.workercommon
 
-import kotlin.math.absoluteValue
-import kotlin.random.Random
 import net.corda.applications.workers.workercommon.internal.WORKER_MONITOR_PORT
-import net.corda.schema.configuration.ConfigDefaults
 import picocli.CommandLine.Option
+import java.nio.file.Path
 
 /** The startup parameters handled by all workers. */
 class DefaultWorkerParams(healthPortOverride: Int = WORKER_MONITOR_PORT) {
@@ -18,14 +16,14 @@ class DefaultWorkerParams(healthPortOverride: Int = WORKER_MONITOR_PORT) {
         names = ["-i", "--instance-id"],
         description = ["The Kafka instance ID for this worker. Defaults to a random value."]
     )
-    var instanceId = Random.nextInt().absoluteValue
+    var instanceId: Int? = null
 
     @Option(
         names = ["-t", "--topic-prefix"],
         description = ["The prefix to use for Kafka topics. Defaults to the empty string."]
     )
     // This needs revision as arguably it belongs to the `messagingParams`
-    var topicPrefix = ""
+    var topicPrefix : String? = null
 
     // This needs revision as arguably it belongs to the `messagingParams`. Defaulting to 1MB to match kafkas default and our config
     // schema default
@@ -33,7 +31,7 @@ class DefaultWorkerParams(healthPortOverride: Int = WORKER_MONITOR_PORT) {
         names = ["-M", "--max-message-size"],
         description = ["The maximum message size in bytes allowed to be sent to the message bus."]
     )
-    var maxAllowedMessageSize = 972800
+    var maxAllowedMessageSize: Int? = null
 
     @Option(names = ["-n", "--no-worker-monitor"], description = ["Disables the worker monitor."])
     var disableWorkerMonitor = false
@@ -47,15 +45,21 @@ class DefaultWorkerParams(healthPortOverride: Int = WORKER_MONITOR_PORT) {
     @Option(names = ["-m", "--messaging-params"], description = ["Messaging parameters for the worker."])
     var messagingParams = emptyMap<String, String>()
 
-    @Option(names = ["-s", "--secrets-params"], description = ["Secrets parameters for the worker."], required = true)
+    @Option(names = ["-s", "secrets"], description = ["Secrets parameters for the worker."], required = true)
     var secretsParams = emptyMap<String, String>()
 
     @Option(names = ["--workspace-dir"], description = ["Corda workspace directory."])
-    var workspaceDir = ConfigDefaults.WORKSPACE_DIR
+    var workspaceDir: String? = null
 
     @Option(names = ["--temp-dir"], description = ["Corda temp directory."])
-    var tempDir = ConfigDefaults.TEMP_DIR
+    var tempDir: String? = null
 
     @Option(names = ["-a", "--addon"], description = ["Add-on configuration"])
     var addonParams = emptyMap<String, String>()
+
+    @Option(names = ["-f", "--values"], description = ["Load configuration from a file. " +
+            "This configuration is merged in with the configuration set in the command line flags. " +
+            "Command line flags win. " +
+            "When multiple files are specified, values in the right-most file wins."])
+    var configFiles = emptyList<Path>()
 }

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
@@ -1,6 +1,7 @@
 package net.corda.applications.workers.workercommon
 
 import net.corda.applications.workers.workercommon.internal.WORKER_MONITOR_PORT
+import net.corda.schema.configuration.BootConfig
 import picocli.CommandLine.Option
 import java.nio.file.Path
 
@@ -28,12 +29,12 @@ class DefaultWorkerParams(healthPortOverride: Int = WORKER_MONITOR_PORT) {
     // This needs revision as arguably it belongs to the `messagingParams`. Defaulting to 1MB to match kafkas default and our config
     // schema default
     @Option(
-        names = ["-M", "--max-message-size"],
+        names = ["-M", "--max-allowed-message-size"],
         description = ["The maximum message size in bytes allowed to be sent to the message bus."]
     )
     var maxAllowedMessageSize: Int? = null
 
-    @Option(names = ["-n", "--no-worker-monitor"], description = ["Disables the worker monitor."])
+    @Option(names = ["-n", "--disable-worker-monitor"], description = ["Disables the worker monitor."])
     var disableWorkerMonitor = false
 
     @Option(
@@ -43,10 +44,10 @@ class DefaultWorkerParams(healthPortOverride: Int = WORKER_MONITOR_PORT) {
     var workerMonitorPort = healthPortOverride
 
     @Option(names = ["-m", "--messaging-params"], description = ["Messaging parameters for the worker."])
-    var messagingParams = emptyMap<String, String>()
+    var messaging = emptyMap<String, String>()
 
-    @Option(names = ["-s", "secrets"], description = ["Secrets parameters for the worker."], required = true)
-    var secretsParams = emptyMap<String, String>()
+    @Option(names = ["-s", "--${BootConfig.BOOT_SECRETS}"], description = ["Secrets parameters for the worker."], required = true)
+    var secrets = emptyMap<String, String>()
 
     @Option(names = ["--workspace-dir"], description = ["Corda workspace directory."])
     var workspaceDir: String? = null
@@ -55,7 +56,7 @@ class DefaultWorkerParams(healthPortOverride: Int = WORKER_MONITOR_PORT) {
     var tempDir: String? = null
 
     @Option(names = ["-a", "--addon"], description = ["Add-on configuration"])
-    var addonParams = emptyMap<String, String>()
+    var addon = emptyMap<String, String>()
 
     @Option(names = ["-f", "--values"], description = ["Load configuration from a file. " +
             "This configuration is merged in with the configuration set in the command line flags. " +

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
@@ -1,29 +1,25 @@
 package net.corda.applications.workers.workercommon
 
 import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigValueFactory
-import java.io.InputStream
-import java.lang.management.ManagementFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
 import net.corda.libs.configuration.validation.ConfigurationValidator
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.osgi.api.Shutdown
-import net.corda.schema.configuration.BootConfig.BOOT_DB
-import net.corda.schema.configuration.BootConfig.BOOT_JDBC_PASS
-import net.corda.schema.configuration.BootConfig.BOOT_KAFKA_COMMON
-import net.corda.schema.configuration.BootConfig.INSTANCE_ID
-import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
+import net.corda.schema.configuration.BootConfig
+import net.corda.schema.configuration.ConfigDefaults
 import net.corda.schema.configuration.ConfigKeys
-import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
-import net.corda.utilities.debug
 import org.osgi.framework.FrameworkUtil
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
+import java.io.InputStream
+import java.lang.management.ManagementFactory
+import kotlin.math.absoluteValue
+import kotlin.random.Random
 
 /** Associates a configuration key/value map with the path at which the configuration should be stored. */
 data class PathAndConfig(val path: String, val config: Map<String, String>)
@@ -83,36 +79,49 @@ class WorkerHelpers {
                 .flatMap { map -> map.entries }
                 .associate { (key, value) -> key to value }
 
-            val dirsConfig = mapOf(
-                ConfigKeys.WORKSPACE_DIR to defaultParams.workspaceDir,
-                ConfigKeys.TEMP_DIR to defaultParams.tempDir
+            val defaultParamsAndValues = listOf<Triple<String,Any?,Any>>(
+                Triple(ConfigKeys.WORKSPACE_DIR,defaultParams.workspaceDir, ConfigDefaults.WORKSPACE_DIR),
+                Triple(ConfigKeys.TEMP_DIR,defaultParams.tempDir, ConfigDefaults.TEMP_DIR),
+                Triple(BootConfig.INSTANCE_ID,defaultParams.instanceId, Random.nextInt().absoluteValue),
+                Triple(BootConfig.TOPIC_PREFIX,defaultParams.topicPrefix, ""),
+                Triple(MAX_ALLOWED_MSG_SIZE,defaultParams.maxAllowedMessageSize, 972800),
             )
+            val defaultParamsMap = defaultParamsAndValues
+                .mapNotNull { t -> t.second?.let { t.first to t.second } }
+                .toMap()
+
+            val defaultParamsDefaultValuesMap = defaultParamsAndValues
+                .map { it.first to it.third }
+                .toMap()
 
             //if we've requested a db message bus use that. default use kafka when not set
             val defaultMessagingParams = defaultParams.messagingParams
             val messagingParams = if (defaultMessagingParams[BUS_TYPE] == BusType.DB.name) {
-                defaultMessagingParams.mapKeys { (key, _) -> "$BOOT_DB.${key.trim()}" }
+                defaultMessagingParams.mapKeys { (key, _) -> "${BootConfig.BOOT_DB}.${key.trim()}" }
             } else {
-                defaultMessagingParams.mapKeys { (key, _) -> "$BOOT_KAFKA_COMMON.${key.trim()}" }
+                defaultMessagingParams.mapKeys { (key, _) -> "${BootConfig.BOOT_KAFKA_COMMON}.${key.trim()}" }
             }
 
-            val config = ConfigFactory
-                .parseMap(messagingParams + dirsConfig + extraParamsMap)
-                .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(defaultParams.instanceId))
-                .withValue(TOPIC_PREFIX, ConfigValueFactory.fromAnyRef(defaultParams.topicPrefix))
-                .withValue(MAX_ALLOWED_MSG_SIZE, ConfigValueFactory.fromAnyRef(defaultParams.maxAllowedMessageSize))
-
             val secretsConfig =
-                ConfigFactory.parseMap(defaultParams.secretsParams.mapKeys { (key, _) -> "${ConfigKeys.SECRETS_CONFIG}.${key.trim()}" })
+                defaultParams.secretsParams.mapKeys { (key, _) -> "${BootConfig.BOOT_SECRETS}.${key.trim()}" }
+
+            val config = ConfigFactory
+                .parseMap(messagingParams + defaultParamsMap + extraParamsMap + secretsConfig)
+
+            // merge with all files
+            val configWithFiles = defaultParams.configFiles.reversed().fold(config) { acc, next ->
+                val fileConfig = ConfigFactory.parseFile(next.toFile())
+                acc.withFallback(fileConfig)
+            }.withFallback(ConfigFactory.parseMap(defaultParamsDefaultValuesMap))
 
             val smartConfigFactory = SmartConfigFactory
-                .createWith(secretsConfig, secretsServiceFactoryResolver.findAll())
+                .createWith(
+                    configWithFiles.getConfig(BootConfig.BOOT_SECRETS).atPath(BootConfig.BOOT_SECRETS),
+                    secretsServiceFactoryResolver.findAll())
 
-            val bootConfig = smartConfigFactory.create(config)
-            val bootConfigWithSecrets = makeSecrets(smartConfigFactory, bootConfig)
-            logger.debug { "Worker boot config\n: ${bootConfig.root().render()}" }
+            val bootConfig = smartConfigFactory.create(configWithFiles.withoutPath(BootConfig.BOOT_SECRETS))
 
-            validator.validate(BOOT_CONFIG, bootConfigWithSecrets, loadResource(BOOT_CONFIG_PATH), true)
+            validator.validate(ConfigKeys.BOOT_CONFIG, bootConfig, loadResource(BOOT_CONFIG_PATH), true)
 
             // we now know bootConfig has:
             //
@@ -127,22 +136,7 @@ class WorkerHelpers {
             //  - have database configuration records applied
             //  - have unspecified fields filled in with defaults from the schema. (This part is handled later)
 
-            return bootConfigWithSecrets
-        }
-
-        /**
-         * Hide any fields which should be hidden such as passwords.
-         * @param smartConfigFactory used to generate secrets
-         * @param config base config
-         * @return New config object with boot values such as passwords made secret.
-         */
-        private fun makeSecrets(smartConfigFactory: SmartConfigFactory, config: SmartConfig): SmartConfig {
-            return if (config.hasPath(BOOT_JDBC_PASS)) {
-                smartConfigFactory.makeSecret(config.getString(BOOT_JDBC_PASS), "boot-db-pass").atPath(BOOT_JDBC_PASS)
-                    .withFallback(config)
-            } else {
-                config
-            }
+            return bootConfig
         }
 
         private fun loadResource(resource: String): InputStream {

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
@@ -95,7 +95,7 @@ class WorkerHelpers {
                 .toMap()
 
             //if we've requested a db message bus use that. default use kafka when not set
-            val defaultMessagingParams = defaultParams.messagingParams
+            val defaultMessagingParams = defaultParams.messaging
             val messagingParams = if (defaultMessagingParams[BUS_TYPE] == BusType.DB.name) {
                 defaultMessagingParams.mapKeys { (key, _) -> "${BootConfig.BOOT_DB}.${key.trim()}" }
             } else {
@@ -103,7 +103,7 @@ class WorkerHelpers {
             }
 
             val secretsConfig =
-                defaultParams.secretsParams.mapKeys { (key, _) -> "${BootConfig.BOOT_SECRETS}.${key.trim()}" }
+                defaultParams.secrets.mapKeys { (key, _) -> "${BootConfig.BOOT_SECRETS}.${key.trim()}" }
 
             val config = ConfigFactory
                 .parseMap(messagingParams + defaultParamsMap + extraParamsMap + secretsConfig)

--- a/applications/workers/worker-common/src/main/resources/net/corda/applications/workers/workercommon/boot/corda.boot.json
+++ b/applications/workers/worker-common/src/main/resources/net/corda/applications/workers/workercommon/boot/corda.boot.json
@@ -32,10 +32,7 @@
     "db": {
       "description": "Configuration options related to database.",
       "properties": {
-        "params": {
-          "description": "Additional db params the worker is bootstrapped with.",
-          "properties": {
-            "database" : {
+        "database" : {
               "description": "Database params",
               "properties": {
                 "jdbc": {
@@ -79,9 +76,7 @@
                   ]
                 }
               }
-            }
-          }
-        },
+            },
         "bus": {
           "description": "Details about the bus type if it is backed by a DB",
           "properties": {
@@ -131,30 +126,25 @@
     "rest": {
       "description": "Configuration options related to REST worker.",
       "properties": {
-        "params": {
-          "description": "Additional params REST worker is bootstrapped with.",
+        "tls" : {
+          "description": "Transport Layer Security (TLS) params",
           "properties": {
-            "tls" : {
-              "description": "Transport Layer Security (TLS) params",
+            "keystore": {
+              "description": "Keystore info",
               "properties": {
-                "keystore": {
-                  "description": "Keystore info",
-                  "properties": {
-                    "path": {
-                      "description": "Path to a Keystore file",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "password": {
-                      "description": "The password for the Keystore",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
+                "path": {
+                  "description": "Path to a Keystore file",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "description": "The password for the Keystore",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             }

--- a/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/BootstrapConfigTest.kt
+++ b/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/BootstrapConfigTest.kt
@@ -1,0 +1,145 @@
+package net.corda.applications.workers.workercommon.internal
+
+import net.corda.applications.workers.workercommon.DefaultWorkerParams
+import net.corda.applications.workers.workercommon.PathAndConfig
+import net.corda.applications.workers.workercommon.WorkerHelpers
+import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
+import net.corda.libs.configuration.secret.SecretsServiceFactoryResolver
+import net.corda.libs.configuration.validation.ConfigurationValidator
+import net.corda.schema.configuration.BootConfig
+import net.corda.schema.configuration.ConfigDefaults
+import net.corda.schema.configuration.ConfigKeys
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.nio.file.Path
+
+class BootstrapConfigTest {
+    private val mockSecretsServiceFactoryResolver = mock<SecretsServiceFactoryResolver> {
+        on { findAll() }.thenReturn(listOf(EncryptionSecretsServiceFactory()))
+    }
+    private val mockConfigurationValidator = mock<ConfigurationValidator>()
+    private val defaultWorkerParams = DefaultWorkerParams(1234).also {
+        it.secretsParams = mapOf(
+            "salt" to "foo",
+            "passphrase" to "bar",
+        )
+    }
+    private val extraParamsMap = listOf(
+        PathAndConfig("fred", mapOf("age" to "12", "hair" to "none"))
+    )
+    private val file1 = Path.of(this::class.java.classLoader.getResource("test1.properties").toURI())
+    private val file2 = Path.of(this::class.java.classLoader.getResource("test2.properties").toURI())
+
+    @Test
+    fun `when file is provided use it as fallback`() {
+        defaultWorkerParams.configFiles = listOf(file1)
+        val config = WorkerHelpers.getBootstrapConfig(
+            mockSecretsServiceFactoryResolver,
+            defaultWorkerParams,
+            mockConfigurationValidator,
+            extraParamsMap
+        )
+
+        assertThat(config.getString("fred.age")).isEqualTo("12")
+        assertThat(config.getString("fred.street")).isEqualTo("sesame")
+    }
+
+    @Test
+    fun `when 2 files are provided use last (properties)`() {
+        defaultWorkerParams.configFiles = listOf(file1,file2)
+        val config = WorkerHelpers.getBootstrapConfig(
+            mockSecretsServiceFactoryResolver,
+            defaultWorkerParams,
+            mockConfigurationValidator,
+            extraParamsMap
+        )
+
+        assertThat(config.getString("fred.street")).isEqualTo("London Wall")
+    }
+
+    @Test
+    fun `when file is provided cmd line overrides (properties)`() {
+        defaultWorkerParams.configFiles = listOf(file1)
+        val config = WorkerHelpers.getBootstrapConfig(
+            mockSecretsServiceFactoryResolver,
+            defaultWorkerParams,
+            mockConfigurationValidator,
+            extraParamsMap
+        )
+
+        assertThat(config.getString("fred.hair")).isEqualTo("none")
+    }
+
+    @Test
+    fun `full config can be provided in file (json)`() {
+
+        val config = WorkerHelpers.getBootstrapConfig(
+            mockSecretsServiceFactoryResolver,
+            DefaultWorkerParams(1234).also {
+                it.configFiles =
+                    listOf(Path.of(this::class.java.classLoader.getResource("example-config.json").toURI()))
+            },
+            mockConfigurationValidator,
+            listOf(
+                PathAndConfig(BootConfig.BOOT_DB, emptyMap()),
+                PathAndConfig(BootConfig.BOOT_CRYPTO, emptyMap()),
+                PathAndConfig(BootConfig.BOOT_REST, emptyMap()),
+            )
+        )
+
+        assertSoftly { softly ->
+            softly.assertThat(config.getString("${BootConfig.BOOT_CRYPTO}.hsmId")).isEqualTo("hsm-id")
+
+            softly.assertThat(config.getString("${BootConfig.BOOT_DB}.database.jdbc.directory"))
+                .isEqualTo("jdbc-dir")
+            softly.assertThat(config.getString("${BootConfig.BOOT_DB}.database.jdbc.url"))
+                .isEqualTo("jdbc-url")
+            softly.assertThat(config.getString("${BootConfig.BOOT_DB}.database.jdbc.url_messagebus"))
+                .isEqualTo("jdbc-url-msg-bus")
+            softly.assertThat(config.getString("${BootConfig.BOOT_DB}.database.pass"))
+                .isEqualTo("db-pass")
+            softly.assertThat(config.getString("${BootConfig.BOOT_DB}.database.user"))
+                .isEqualTo("db-user")
+
+            softly.assertThat(config.getString(ConfigKeys.TEMP_DIR)).isEqualTo("dir-tmp")
+            softly.assertThat(config.getString(ConfigKeys.WORKSPACE_DIR)).isEqualTo("dir-workspace")
+
+            softly.assertThat(config.getInt("instanceId")).isEqualTo(666)
+
+            softly.assertThat(config.getString("kafka.common.bus.busType")).isEqualTo("kafka-bustype")
+
+            softly.assertThat(config.getInt("maxAllowedMessageSize")).isEqualTo(999)
+
+            softly.assertThat(config.getString("rest.tls.keystore.password")).isEqualTo("tls-pass")
+            softly.assertThat(config.getString("rest.tls.keystore.path")).isEqualTo("tls-path")
+
+            softly.assertThat(config.hasPath("secrets")).isFalse
+        }
+    }
+
+    @Test
+    fun `config with defaults`() {
+        val config = WorkerHelpers.getBootstrapConfig(
+            mockSecretsServiceFactoryResolver,
+            defaultWorkerParams,
+            mockConfigurationValidator,
+            listOf(
+                PathAndConfig(BootConfig.BOOT_SECRETS, emptyMap()),
+                PathAndConfig(BootConfig.BOOT_DB, emptyMap()),
+                PathAndConfig(BootConfig.BOOT_CRYPTO, emptyMap()),
+                PathAndConfig(BootConfig.BOOT_REST, emptyMap()),
+            )
+        )
+
+        assertSoftly { softly ->
+            softly.assertThat(config.getString("dir.tmp")).isEqualTo(ConfigDefaults.TEMP_DIR)
+            softly.assertThat(config.getString("dir.workspace")).isEqualTo(ConfigDefaults.WORKSPACE_DIR)
+            softly.assertThat(config.getInt("instanceId")).isNotNull
+            softly.assertThat(config.getInt("maxAllowedMessageSize")).isEqualTo(972800)
+            softly.assertThat(config.getString("topicPrefix")).isEqualTo("")
+        }
+
+    }
+}

--- a/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/BootstrapConfigTest.kt
+++ b/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/BootstrapConfigTest.kt
@@ -21,7 +21,7 @@ class BootstrapConfigTest {
     }
     private val mockConfigurationValidator = mock<ConfigurationValidator>()
     private val defaultWorkerParams = DefaultWorkerParams(1234).also {
-        it.secretsParams = mapOf(
+        it.secrets = mapOf(
             "salt" to "foo",
             "passphrase" to "bar",
         )

--- a/applications/workers/worker-common/src/test/resources/example-config.json
+++ b/applications/workers/worker-common/src/test/resources/example-config.json
@@ -1,0 +1,42 @@
+{
+  "secrets": {
+    "salt": "secrets-salt",
+    "passphrase": "secrets-passphrase"
+  },
+  "crypto": {
+    "hsmId": "hsm-id"
+  },
+  "db": {
+    "database": {
+      "jdbc": {
+        "directory": "jdbc-dir",
+        "url": "jdbc-url",
+        "url_messagebus": "jdbc-url-msg-bus"
+      },
+      "pass": "db-pass",
+      "user": "db-user"
+    }
+  },
+  "dir": {
+    "tmp": "dir-tmp",
+    "workspace": "dir-workspace"
+  },
+  "instanceId": 666,
+  "kafka": {
+    "common": {
+      "bus": {
+        "busType": "kafka-bustype"
+      }
+    }
+  },
+  "maxAllowedMessageSize": 999,
+  "rest": {
+    "tls": {
+      "keystore": {
+        "password": "tls-pass",
+        "path": "tls-path"
+      }
+    }
+  },
+  "topicPrefix": "prefix"
+}

--- a/applications/workers/worker-common/src/test/resources/test1.properties
+++ b/applications/workers/worker-common/src/test/resources/test1.properties
@@ -1,0 +1,2 @@
+fred.street=sesame
+fred.hair=black

--- a/applications/workers/worker-common/src/test/resources/test2.properties
+++ b/applications/workers/worker-common/src/test/resources/test2.properties
@@ -1,0 +1,1 @@
+fred.street=London Wall

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/PersistenceTests.kt
@@ -152,7 +152,7 @@ class PersistenceTests {
             )
             tracker.component<ConfigurationReadService>().bootstrapConfig(CryptoConfigurationSetup.boostrapConfig)
             tracker.component<DbConnectionManager>().bootstrap(
-                CryptoConfigurationSetup.boostrapConfig.getConfig(BootConfig.BOOT_DB_PARAMS)
+                CryptoConfigurationSetup.boostrapConfig.getConfig(BootConfig.BOOT_DB)
             )
             tracker.waitUntilAllUp(Duration.ofSeconds(60))
         }

--- a/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoConfigurationSetup.kt
+++ b/components/crypto/crypto-persistence-impl/src/integrationTest/kotlin/net/corda/crypto/persistence/impl/tests/infra/CryptoConfigurationSetup.kt
@@ -48,7 +48,7 @@ object CryptoConfigurationSetup {
 
     val boostrapConfig = makeBootstrapConfig(
         mapOf(
-            BootConfig.BOOT_DB_PARAMS to CryptoDBSetup.clusterDb.config
+            BootConfig.BOOT_DB to CryptoDBSetup.clusterDb.config
         )
     )
 

--- a/components/permissions/permission-storage-writer-service/src/test/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandlerTest.kt
+++ b/components/permissions/permission-storage-writer-service/src/test/kotlin/net/corda/permissions/storage/writer/internal/PermissionStorageWriterServiceEventHandlerTest.kt
@@ -15,7 +15,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.permissions.storage.reader.PermissionStorageReaderService
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.DatabaseConfig.DB_PASS
@@ -61,7 +61,7 @@ class PermissionStorageWriterServiceEventHandlerTest {
     private val config = configFactory.create(
         ConfigFactory.empty()
             .withValue(
-                BOOT_DB_PARAMS,
+                BOOT_DB,
                 ConfigValueFactory.fromMap(
                     mapOf(
                         JDBC_URL to "dbUrl",

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.722-alpha-1679077391261
+cordaApiVersion=5.0.0.722-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.721-beta+
+cordaApiVersion=5.0.0.722-alpha-1679077391261
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigFactory.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigFactory.kt
@@ -6,11 +6,12 @@ import net.corda.libs.configuration.secret.MaskedSecretsLookupService
 import net.corda.libs.configuration.secret.SecretsConfigurationException
 import net.corda.libs.configuration.secret.SecretsCreateService
 import net.corda.libs.configuration.secret.SecretsServiceFactory
+import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.ConfigKeys
 
 interface SmartConfigFactory {
     companion object {
-        const val SECRET_SERVICE_TYPE = "${ConfigKeys.SECRETS_CONFIG}.${ConfigKeys.SECRETS_TYPE}"
+        const val SECRET_SERVICE_TYPE = "${BootConfig.BOOT_SECRETS}.${ConfigKeys.SECRETS_TYPE}"
 
         /**
          * Create a [SmartConfigFactory] that is initialized with the [SecretsService] that is relevant based on the

--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceFactory.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.configuration.secret
 
 import com.typesafe.config.Config
+import net.corda.schema.configuration.BootConfig
 import net.corda.schema.configuration.ConfigKeys
 import org.osgi.service.component.annotations.Component
 import org.slf4j.LoggerFactory
@@ -9,8 +10,8 @@ import org.slf4j.LoggerFactory
 class EncryptionSecretsServiceFactory : SecretsServiceFactory {
     companion object {
         const val TYPE = "encryption"
-        const val SECRET_PASSPHRASE_KEY = "${ConfigKeys.SECRETS_CONFIG}.${ConfigKeys.SECRETS_PASSPHRASE}"
-        const val SECRET_SALT_KEY = "${ConfigKeys.SECRETS_CONFIG}.${ConfigKeys.SECRETS_SALT}"
+        const val SECRET_PASSPHRASE_KEY = "${BootConfig.BOOT_SECRETS}.${ConfigKeys.SECRETS_PASSPHRASE}"
+        const val SECRET_SALT_KEY = "${BootConfig.BOOT_SECRETS}.${ConfigKeys.SECRETS_SALT}"
 
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }

--- a/libs/configuration/configuration-merger/src/main/kotlin/net/corda/libs/configuration/merger/impl/ConfigMergerImpl.kt
+++ b/libs/configuration/configuration-merger/src/main/kotlin/net/corda/libs/configuration/merger/impl/ConfigMergerImpl.kt
@@ -5,7 +5,7 @@ import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.libs.configuration.merger.ConfigMerger
 import net.corda.messagebus.api.configuration.BusConfigMerger
 import net.corda.messagebus.api.configuration.getConfigOrEmpty
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -21,10 +21,10 @@ class ConfigMergerImpl @Activate constructor(
     }
 
     override fun getDbConfig(bootConfig: SmartConfig, dbConfig: SmartConfig?): SmartConfig {
-        //TODO - Boot params for db connection details currently passed in via BOOT_DB_PARAMS.*. Db config logic needs to be
+        //TODO - Boot params for db connection details currently passed in via BOOT_DB.*. Db config logic needs to be
         // migrated to use the defined boot schema values. When that this done they can be merged properly from boot db config here.
         val updatedDbConfig = dbConfig?: SmartConfigImpl.empty()
-        val bootDBParamsConfig = bootConfig.getConfigOrEmpty(BOOT_DB_PARAMS)
+        val bootDBParamsConfig = bootConfig.getConfigOrEmpty(BOOT_DB)
         return bootDBParamsConfig.withFallback(updatedDbConfig)
     }
 }

--- a/libs/rest/ssl-cert-read-impl/src/main/kotlin/net/corda/rest/ssl/impl/SslCertReadServiceImpl.kt
+++ b/libs/rest/ssl-cert-read-impl/src/main/kotlin/net/corda/rest/ssl/impl/SslCertReadServiceImpl.kt
@@ -3,9 +3,7 @@ package net.corda.rest.ssl.impl
 import net.corda.libs.configuration.SmartConfig
 import net.corda.rest.ssl.KeyStoreInfo
 import net.corda.rest.ssl.SslCertReadService
-import net.corda.schema.configuration.BootConfig.BOOT_REST_PARAMS
-import net.corda.schema.configuration.BootConfig.BOOT_REST_TLS_KEYSTORE_FILE_PATH
-import net.corda.schema.configuration.BootConfig.BOOT_REST_TLS_KEYSTORE_PASSWORD
+import net.corda.schema.configuration.BootConfig
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -25,7 +23,7 @@ class SslCertReadServiceImpl(private val createDirectory: () -> Path) : SslCertR
 
         private val String.withoutPrefix: String
             get() {
-                return this.removePrefix("$BOOT_REST_PARAMS.")
+                return this.removePrefix("${BootConfig.BOOT_REST}.")
             }
     }
 
@@ -57,15 +55,15 @@ class SslCertReadServiceImpl(private val createDirectory: () -> Path) : SslCertR
 
         if (localKeyStoreInfo != null) return localKeyStoreInfo
 
-        localKeyStoreInfo = if (config.hasPath(BOOT_REST_TLS_KEYSTORE_FILE_PATH)) {
-            val bootKeyStorePath = config.getString(BOOT_REST_TLS_KEYSTORE_FILE_PATH)
-            val keyStorePassword = config.getString(BOOT_REST_TLS_KEYSTORE_PASSWORD)
+        localKeyStoreInfo = if (config.hasPath(BootConfig.BOOT_REST_TLS_KEYSTORE_FILE_PATH)) {
+            val bootKeyStorePath = config.getString(BootConfig.BOOT_REST_TLS_KEYSTORE_FILE_PATH)
+            val keyStorePassword = config.getString(BootConfig.BOOT_REST_TLS_KEYSTORE_PASSWORD)
             KeyStoreInfo(Path.of(bootKeyStorePath), keyStorePassword)
         } else {
             log.warn(
                 "Using default self-signed TLS certificate for REST endpoint. To stop seeing this message, please use bootstrap " +
-                        "parameters: '-r${BOOT_REST_TLS_KEYSTORE_FILE_PATH.withoutPrefix}' and " +
-                        "'-r${BOOT_REST_TLS_KEYSTORE_PASSWORD.withoutPrefix}'."
+                        "parameters: '-r${BootConfig.BOOT_REST_TLS_KEYSTORE_FILE_PATH.withoutPrefix}' and " +
+                        "'-r${BootConfig.BOOT_REST_TLS_KEYSTORE_PASSWORD.withoutPrefix}'."
             )
             val tempDirectoryPath = createDirectory()
             val keyStorePath = Path.of(tempDirectoryPath.toString(), KEYSTORE_NAME)

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestUtils.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/infra/TestUtils.kt
@@ -13,7 +13,7 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.toAvro
 
@@ -77,7 +77,7 @@ fun makeBootstrapConfig(dbParams: SmartConfig): SmartConfig = smartConfigFactory
         .withFallback(
             ConfigFactory.parseMap(
                 mapOf(
-                    BOOT_DB_PARAMS to dbParams.root().unwrapped()
+                    BOOT_DB to dbParams.root().unwrapped()
                 )
             )
         )

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -32,7 +32,7 @@ import net.corda.lifecycle.createCoordinator
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.processors.crypto.CryptoProcessor
 import net.corda.schema.configuration.BootConfig.BOOT_CRYPTO
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -146,7 +146,7 @@ class CryptoProcessorImpl @Activate constructor(
                 configurationReadService.bootstrapConfig(bootstrapConfig)
 
                 logger.info("Bootstrapping {}", dbConnectionManager::class.simpleName)
-                dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB_PARAMS))
+                dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB))
 
                 logger.info("Bootstrapping {}", cryptoServiceFactory::class.simpleName)
                 cryptoServiceFactory.bootstrapConfig(bootstrapConfig.getConfig(BOOT_CRYPTO))

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -45,7 +45,7 @@ import net.corda.permissions.storage.reader.PermissionStorageReaderService
 import net.corda.permissions.storage.writer.PermissionStorageWriterService
 import net.corda.processors.db.DBProcessor
 import net.corda.reconciliation.ReconcilerFactory
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.debug
@@ -217,7 +217,7 @@ class DBProcessorImpl @Activate constructor(
         val instanceId = bootstrapConfig.getInt(INSTANCE_ID)
 
         log.info("Bootstrapping DB connection Manager")
-        dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB_PARAMS))
+        dbConnectionManager.bootstrap(bootstrapConfig.getConfig(BOOT_DB))
 
         log.info("Bootstrapping config publish service")
         configPublishService.bootstrapConfig(bootstrapConfig)

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorIntegrationTest.kt
@@ -60,7 +60,7 @@ import net.corda.processor.member.MemberProcessorTestUtils.Companion.sampleGroup
 import net.corda.processor.member.MemberProcessorTestUtils.Companion.startAndWait
 import net.corda.processors.crypto.CryptoProcessor
 import net.corda.processors.member.MemberProcessor
-import net.corda.schema.configuration.BootConfig.BOOT_DB_PARAMS
+import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.test.util.eventually
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
@@ -166,7 +166,7 @@ class MemberProcessorIntegrationTest {
 
         private val boostrapConfig = makeBootstrapConfig(
             mapOf(
-                BOOT_DB_PARAMS to clusterDb.config
+                BOOT_DB to clusterDb.config
             )
         )
 


### PR DESCRIPTION
Refactor boot config so that it can be provided by one or more files as well as the command line arguments.
This will be needed for being able to set the hashicorp vault auth token using a side container.

API PR: https://github.com/corda/corda-api/pull/962

Docs:
This feature introduces an alternative way of passing in boot configuration to the Corda Workers.
The `-f` or `--values` flags let you specify a path to a configuration file.
This configuration file must be in JSON or properties file format and can contain any of the other configuration options' keys in the format of `<longFormConfigFlag>` or `<longFormConfigFlag>.<paramName>`.
Note that the keys will use [lower camel case ](https://en.wikipedia.org/wiki/Camel_case)

For example:

- `--topic-prefix foo` becomes `topicPrefix=foo` or `{"topicPrefix": "foo"}`
- `--secrets salt=pepper` becomes `secrets.salt=pepper` or ```{"secrets":  { "salt": "pepper"} }`

When keys are provided in multiple ways, priority means:
 
- Files to the right (i.e. specified last) take priority over those to the left.
- Keys provided on the command line take priority over those provided in files.