### PR TITLE
CORE-11786 Remove `SecureHash.getBytes`

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseChunkPersistence.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/persistence/database/DatabaseChunkPersistence.kt
@@ -6,6 +6,7 @@ import net.corda.chunking.datamodel.ChunkEntity
 import net.corda.chunking.datamodel.ChunkPropertyEntity
 import net.corda.chunking.db.impl.AllChunksReceived
 import net.corda.chunking.db.impl.persistence.ChunkPersistence
+import net.corda.crypto.core.bytes
 import net.corda.crypto.core.parseSecureHash
 import net.corda.crypto.core.toAvro
 import net.corda.crypto.core.toCorda

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -12,6 +12,7 @@ import net.corda.crypto.core.CryptoTenants
 import net.corda.crypto.core.KEY_LOOKUP_INPUT_ITEMS_LIMIT
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.ShortHash
+import net.corda.crypto.core.bytes
 import net.corda.crypto.core.publicKeyIdFromBytes
 import net.corda.crypto.impl.createWireRequestContext
 import net.corda.crypto.impl.toWire

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/PipelineStateManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/PipelineStateManager.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.state.impl
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.PipelineState

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
@@ -2,6 +2,7 @@ package net.corda.flow.state
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
+import net.corda.crypto.core.bytes
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
 import net.corda.data.flow.FlowKey

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
@@ -2,7 +2,7 @@ package net.corda.flow.state
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
-import net.corda.crypto.core.bytes
+import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
 import net.corda.data.flow.FlowKey
@@ -29,13 +29,10 @@ import net.corda.schema.configuration.FlowConfig
 import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
 
@@ -251,10 +248,8 @@ class FlowCheckpointImplTest {
             contextPlatformProperties = platformPropertiesLevel0.avro
         }
 
-        val cpk = mock<SecureHash>()
+        val cpk = SecureHashImpl(DigestAlgorithmName.SHA2_256.name, "abc".toByteArray())
         val cpks = setOf(cpk)
-        whenever(cpk.bytes).thenReturn("abc".toByteArray())
-        whenever(cpk.algorithm).thenReturn(DigestAlgorithmName.SHA2_256.name)
 
         val flowCheckpoint = createFlowCheckpoint(setupAvroCheckpoint(initialiseFlowState = false))
         flowCheckpoint.initFlowState(flowStartContext, cpks)
@@ -522,9 +517,8 @@ class FlowCheckpointImplTest {
             identity = BOB_X500_HOLDING_IDENTITY
             contextPlatformProperties = platformPropertiesLevel0.avro
         }
-        val cpk = mock<SecureHash>()
+        val cpk = SecureHashImpl("dummyDigestAlgo", byteArrayOf(0x00))
         val cpks = setOf(cpk)
-        whenever(cpk.bytes).thenReturn(byteArrayOf())
 
         flowCheckpoint.initFlowState(context, cpks)
         flowCheckpoint.putSessionState(SessionState().apply { sessionId = "sid1" })

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.common.flow.impl.transaction
 
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.ledger.common.data.transaction.BATCH_MERKLE_TREE_DIGEST_OPTIONS_LEAF_PREFIX_B64_KEY
 import net.corda.ledger.common.data.transaction.BATCH_MERKLE_TREE_DIGEST_OPTIONS_NODE_PREFIX_B64_KEY
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/ResolveStateRefsExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/ResolveStateRefsExternalEventFactory.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.persistence.external.events
 
+import net.corda.crypto.core.bytes
 import net.corda.data.crypto.SecureHash
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.bytes
 import net.corda.crypto.core.toAvro
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.bytes
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
@@ -17,7 +18,6 @@ import net.corda.test.util.time.TestClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.merkle.MerkleTree
 import net.corda.v5.membership.GroupParameters
@@ -73,10 +73,7 @@ class MembershipPackageFactoryTest {
         members.associateWith { member ->
             val hashBytes = "root-${member.name}".toByteArray()
             val alg = "alg-${member.name}"
-            val treeRoot = mock<SecureHash> {
-                on { bytes } doReturn hashBytes
-                on { algorithm } doReturn alg
-            }
+            val treeRoot = SecureHashImpl(alg, hashBytes)
             mock<MerkleTree> {
                 on { root } doReturn treeRoot
             }
@@ -106,10 +103,7 @@ class MembershipPackageFactoryTest {
                 )
     }
     private val allAlg = "all-alg"
-    private val checkHash = mock<SecureHash> {
-        on { bytes } doReturn "all".toByteArray()
-        on { algorithm } doReturn allAlg
-    }
+    private val checkHash = SecureHashImpl(allAlg, "all".toByteArray())
 
     private val factory = MembershipPackageFactory(
         clock,

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.core.bytes
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
 import net.corda.data.KeyValuePairList

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
@@ -8,6 +8,7 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.client.CryptoOpsClient
+import net.corda.crypto.core.bytes
 import net.corda.crypto.hes.StableKeyPairDecryptor
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -7,6 +7,7 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.cipher.suite.SignatureVerificationService
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.crypto.core.bytes
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePairList

--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntitiesIntegrationTest.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntitiesIntegrationTest.kt
@@ -1,5 +1,6 @@
 package net.corda.uniqueness.backingstore.impl
 
+import net.corda.crypto.core.bytes
 import net.corda.crypto.testkit.SecureHashUtils
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.ClassloaderChangeLog.ChangeLogResourceFiles

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.uniqueness.backingstore.impl
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.core.DbPrivilege

--- a/components/uniqueness/backing-store-impl/src/test/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplTests.kt
+++ b/components/uniqueness/backing-store-impl/src/test/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplTests.kt
@@ -1,5 +1,6 @@
 package net.corda.uniqueness.backingstore.impl
 
+import net.corda.crypto.core.bytes
 import net.corda.crypto.testkit.SecureHashUtils
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.core.CloseableDataSource

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.726-beta+
+cordaApiVersion=5.0.0.727-alpha-1679437546338
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.727-alpha-1679437546338
+cordaApiVersion=5.0.0.727-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImplTest.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImplTest.kt
@@ -2,6 +2,7 @@ package net.corda.cipher.suite.impl
 
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.schemes.DigestScheme
+import net.corda.crypto.core.bytes
 import net.corda.crypto.core.parseSecureHash
 import net.corda.crypto.impl.DoubleSHA256Digest
 import net.corda.v5.crypto.DigestAlgorithmName

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -41,3 +41,10 @@ fun parseSecureHash(algoNameAndHexString: String): SecureHash {
         SecureHashImpl(algorithm, data)
     }
 }
+
+val SecureHash.bytes: ByteArray
+    get() =
+        (this as? SecureHashImpl)?.bytes
+            ?: throw IllegalArgumentException(
+                "User defined subtypes of ${SecureHash::class.java.simpleName} are not permitted"
+            )

--- a/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
+++ b/libs/crypto/crypto-flow/src/main/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImpl.kt
@@ -2,6 +2,7 @@ package net.corda.crypto.flow.impl
 
 import net.corda.crypto.cipher.suite.AlgorithmParameterSpecEncodingService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.bytes
 import net.corda.crypto.flow.CryptoFlowOpsTransformer
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.REQUEST_OP_KEY
 import net.corda.crypto.flow.CryptoFlowOpsTransformer.Companion.REQUEST_TTL_KEY

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/SignatureSpecUtils.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/SignatureSpecUtils.kt
@@ -2,6 +2,7 @@ package net.corda.crypto.impl
 
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
 import net.corda.crypto.cipher.suite.PlatformDigestService
+import net.corda.crypto.core.bytes
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.crypto.SignatureSpec
 

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleTreeHashDigestProviders.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleTreeHashDigestProviders.kt
@@ -1,6 +1,7 @@
 package net.corda.crypto.merkle.impl
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.crypto.core.concatByteArrays
 import net.corda.crypto.core.toByteArray
 import net.corda.v5.application.crypto.DigestService

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -5,6 +5,7 @@ import net.corda.cipher.suite.impl.DigestServiceImpl
 import net.corda.cipher.suite.impl.PlatformDigestServiceImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.crypto.core.toByteArray
 import net.corda.crypto.merkle.impl.mocks.getZeroHash
 import net.corda.v5.application.crypto.DigestService

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/SecureHashSerializationTests.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/SecureHashSerializationTests.kt
@@ -5,6 +5,7 @@ import net.corda.cipher.suite.impl.DigestServiceImpl
 import net.corda.cipher.suite.impl.PlatformDigestServiceImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.crypto.DigestAlgorithmName
 import org.junit.jupiter.api.Assertions.assertArrayEquals

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/WireTransaction.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/WireTransaction.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.common.data.transaction
 
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.crypto.core.bytes
 import net.corda.crypto.core.concatByteArrays
 import net.corda.crypto.core.toByteArray
 import net.corda.v5.application.crypto.DigestService

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpiIdentifier.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpiIdentifier.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.core
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.libs.packaging.core.comparator.identifierComparator
 import net.corda.v5.crypto.SecureHash
 import java.nio.ByteBuffer

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpiMetadata.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpiMetadata.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.core
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.v5.crypto.SecureHash
 import java.nio.ByteBuffer
 import java.time.Instant

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkIdentifier.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkIdentifier.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.core
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.libs.packaging.core.comparator.identifierComparator
 import net.corda.v5.crypto.SecureHash
 import java.nio.ByteBuffer

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkMetadata.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkMetadata.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.core
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.v5.crypto.SecureHash
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/comparator/Comparers.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/comparator/Comparers.kt
@@ -1,5 +1,6 @@
 package net.corda.libs.packaging.core.comparator
 
+import net.corda.crypto.core.bytes
 import net.corda.libs.packaging.core.Identifier
 import net.corda.v5.crypto.SecureHash
 import java.util.Arrays

--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/Utils.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/internal/Utils.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.verify.internal
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.hash
 import net.corda.v5.crypto.DigestAlgorithmName

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/Utils.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/Utils.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.libs.packaging.core.CpkFormatVersion
 import net.corda.libs.packaging.internal.FormatVersionReader
 import net.corda.v5.base.types.MemberX500Name

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.internal.v2
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.CpkReader

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/SimConsensualLedgerService.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.ledger
 
+import net.corda.crypto.core.bytes
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.entities.ConsensualTransactionEntity
 import net.corda.simulator.runtime.messaging.SimFiber

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.testutils
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.test.util.InMemoryZipFile
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpb/packaging/v2/TestCpbLoaderV2.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/cpb/packaging/v2/TestCpbLoaderV2.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.packaging.testutils.cpb.packaging.v2
 
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.CpkReader


### PR DESCRIPTION
`SecureHash` API should be enough to users to just provide the hex string form of the hash.

- adds internal API `SecureHash.bytes` to replace runtime-os uses of public API `SecureHash.getBytes()`

api PR: [#964](https://github.com/corda/corda-api/pull/964)