### PR TITLE
CORE-9215 Clearing DLQ in StateAndEventSubscription and DurableSubscription after outputting items

### DIFF
--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -180,7 +180,8 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
                     dbRecord.recordOffset,
                     deserializeKey(dbRecord.key),
                     deserializedValue,
-                    dbRecord.timestamp.toEpochMilli()
+                    dbRecord.timestamp.toEpochMilli(),
+                    headerSerializer.deserialize(dbRecord.headers ?: "{}")
                 )
             } else {
                 null

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -8,7 +8,6 @@ import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
 import net.corda.messagebus.db.configuration.ResolvedConsumerConfig
 import net.corda.messagebus.db.datamodel.CommittedPositionEntry
-import net.corda.messagebus.db.datamodel.TopicRecordEntry
 import net.corda.messagebus.db.datamodel.TransactionState
 import net.corda.messagebus.db.persistence.DBAccess
 import net.corda.messagebus.db.persistence.DBAccess.Companion.ATOMIC_TRANSACTION

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -170,15 +170,20 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
         }
 
         val result = dbRecords.mapNotNull { dbRecord ->
-            deserializeValue(dbRecord.value)?.let {
+            val deserializedValue = deserializeValue(dbRecord.value)
+            val isDeserialized = deserializedValue != null || dbRecord.value == null
+
+            if (isDeserialized) {
                 CordaConsumerRecord(
                     dbRecord.topic,
                     dbRecord.partition,
                     dbRecord.recordOffset,
                     deserializeKey(dbRecord.key),
-                    it,
+                    deserializedValue,
                     dbRecord.timestamp.toEpochMilli()
                 )
+            } else {
+                null
             }
         }
 

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -179,7 +179,8 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
                 dbRecord.timestamp.toEpochMilli(),
                 headerSerializer.deserialize(dbRecord.headers ?: "{}")
             )
-        }
+        }.filter { it.value != null }
+
         if (result.isNotEmpty()) {
             seek(topicPartition, result.last().offset + 1)
         }

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
@@ -42,6 +42,9 @@ internal class DBCordaConsumerImplTest {
         private val serializedKey = "key".toByteArray()
         private val serializedValue = "value".toByteArray()
         private const val serializedHeader = "{}"
+        private val invalidSerializedValue = "invalid_value".toByteArray()
+        // Null inputs to deserializer are converted to "" by the @NotNull decorator
+        private val nullValue = "".toByteArray()
 
         private val partition0 = CordaTopicPartition(topic, 0)
         private val partition1 = CordaTopicPartition(topic, 1)
@@ -59,6 +62,8 @@ internal class DBCordaConsumerImplTest {
         val valueDeserializer = mock<CordaAvroDeserializer<String>>()
         whenever(keyDeserializer.deserialize(eq(serializedKey))).thenAnswer { "key" }
         whenever(valueDeserializer.deserialize(eq(serializedValue))).thenAnswer { "value" }
+        whenever(valueDeserializer.deserialize(eq(invalidSerializedValue))).thenAnswer { null }
+        whenever(valueDeserializer.deserialize(eq(nullValue))).thenAnswer { null }
         return DBCordaConsumerImpl(
             config,
             dbAccess,
@@ -342,6 +347,66 @@ internal class DBCordaConsumerImplTest {
         val consumer = makeConsumer()
         val test = consumer.poll(Duration.ZERO)
         assertThat(test.size).isEqualTo(2)
+        assertThat(test).isEqualTo(expectedRecords)
+    }
+
+    @Test
+    fun `consumer poll discards records which were nullified by deserializer`() {
+        val fromOffset = ArgumentCaptor.forClass(Long::class.java)
+        val timestamp = Instant.parse("2022-01-01T00:00:00.00Z")
+
+        val transactionRecord1 = TransactionRecordEntry("id", TransactionState.COMMITTED)
+
+        val pollResult = listOf(
+            TopicRecordEntry(topic, 0, 0, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(topic, 0, 2, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(topic, 0, 5, serializedKey, invalidSerializedValue, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(topic, 0, 7, serializedKey, invalidSerializedValue, serializedHeader, transactionRecord1, timestamp),
+        )
+        val expectedRecords = listOf(
+            CordaConsumerRecord(topic, 0, 0, "key", "value", timestamp.toEpochMilli()),
+            CordaConsumerRecord(topic, 0, 2, "key", "value", timestamp.toEpochMilli()),
+        )
+
+        whenever(dbAccess.getMaxCommittedPositions(any(), any())).thenAnswer { mapOf(partition0 to 0L) }
+        whenever(dbAccess.getLatestRecordOffsets()).thenAnswer { mapOf(partition0 to 7L) }
+        whenever(dbAccess.readRecords(fromOffset.capture(), any(), any())).thenAnswer { pollResult }
+        whenever(consumerGroup.getTopicPartitionsFor(any())).thenAnswer { setOf(partition0) }
+
+        val consumer = makeConsumer()
+        val test = consumer.poll(Duration.ZERO)
+        assertThat(test.size).isEqualTo(2)
+        assertThat(test).isEqualTo(expectedRecords)
+    }
+
+    @Test
+    fun `consumer poll does not discard null values if they were null before deserialization`() {
+        val fromOffset = ArgumentCaptor.forClass(Long::class.java)
+        val timestamp = Instant.parse("2022-01-01T00:00:00.00Z")
+
+        val transactionRecord1 = TransactionRecordEntry("id", TransactionState.COMMITTED)
+
+        val pollResult = listOf(
+            TopicRecordEntry(topic, 0, 0, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(topic, 0, 2, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(topic, 0, 5, serializedKey, value=null, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(topic, 0, 7, serializedKey, value=null, serializedHeader, transactionRecord1, timestamp),
+        )
+        val expectedRecords = listOf(
+            CordaConsumerRecord(topic, 0, 0, "key", "value", timestamp.toEpochMilli()),
+            CordaConsumerRecord(topic, 0, 2, "key", "value", timestamp.toEpochMilli()),
+            CordaConsumerRecord(topic, 0, 5, "key", value=null, timestamp.toEpochMilli()),
+            CordaConsumerRecord(topic, 0, 7, "key", value=null, timestamp.toEpochMilli()),
+        )
+
+        whenever(dbAccess.getMaxCommittedPositions(any(), any())).thenAnswer { mapOf(partition0 to 0L) }
+        whenever(dbAccess.getLatestRecordOffsets()).thenAnswer { mapOf(partition0 to 7L) }
+        whenever(dbAccess.readRecords(fromOffset.capture(), any(), any())).thenAnswer { pollResult }
+        whenever(consumerGroup.getTopicPartitionsFor(any())).thenAnswer { setOf(partition0) }
+
+        val consumer = makeConsumer()
+        val test = consumer.poll(Duration.ZERO)
+        assertThat(test.size).isEqualTo(4)
         assertThat(test).isEqualTo(expectedRecords)
     }
 

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
@@ -358,10 +358,46 @@ internal class DBCordaConsumerImplTest {
         val transactionRecord1 = TransactionRecordEntry("id", TransactionState.COMMITTED)
 
         val pollResult = listOf(
-            TopicRecordEntry(topic, 0, 0, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
-            TopicRecordEntry(topic, 0, 2, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
-            TopicRecordEntry(topic, 0, 5, serializedKey, invalidSerializedValue, serializedHeader, transactionRecord1, timestamp),
-            TopicRecordEntry(topic, 0, 7, serializedKey, invalidSerializedValue, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(
+                topic,
+                0,
+                0,
+                serializedKey,
+                serializedValue,
+                serializedHeader,
+                transactionRecord1,
+                timestamp)
+            ,
+            TopicRecordEntry(
+                topic,
+                0,
+                2,
+                serializedKey,
+                serializedValue,
+                serializedHeader,
+                transactionRecord1,
+                timestamp
+            ),
+            TopicRecordEntry(
+                topic,
+                0,
+                5,
+                serializedKey,
+                invalidSerializedValue,
+                serializedHeader,
+                transactionRecord1,
+                timestamp
+            ),
+            TopicRecordEntry(
+                topic,
+                0,
+                7,
+                serializedKey,
+                invalidSerializedValue,
+                serializedHeader,
+                transactionRecord1,
+                timestamp
+            ),
         )
         val expectedRecords = listOf(
             CordaConsumerRecord(topic, 0, 0, "key", "value", timestamp.toEpochMilli()),
@@ -387,10 +423,46 @@ internal class DBCordaConsumerImplTest {
         val transactionRecord1 = TransactionRecordEntry("id", TransactionState.COMMITTED)
 
         val pollResult = listOf(
-            TopicRecordEntry(topic, 0, 0, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
-            TopicRecordEntry(topic, 0, 2, serializedKey, serializedValue, serializedHeader, transactionRecord1, timestamp),
-            TopicRecordEntry(topic, 0, 5, serializedKey, value=null, serializedHeader, transactionRecord1, timestamp),
-            TopicRecordEntry(topic, 0, 7, serializedKey, value=null, serializedHeader, transactionRecord1, timestamp),
+            TopicRecordEntry(
+                topic,
+                0,
+                0,
+                serializedKey,
+                serializedValue,
+                serializedHeader,
+                transactionRecord1,
+                timestamp
+            ),
+            TopicRecordEntry(
+                topic,
+                0,
+                2,
+                serializedKey,
+                serializedValue,
+                serializedHeader,
+                transactionRecord1,
+                timestamp
+            ),
+            TopicRecordEntry(
+                topic,
+                0,
+                5,
+                serializedKey,
+                value=null,
+                serializedHeader,
+                transactionRecord1,
+                timestamp
+            ),
+            TopicRecordEntry(
+                topic,
+                0,
+                7,
+                serializedKey,
+                value=null,
+                serializedHeader,
+                transactionRecord1,
+                timestamp
+            ),
         )
         val expectedRecords = listOf(
             CordaConsumerRecord(topic, 0, 0, "key", "value", timestamp.toEpochMilli()),

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
@@ -239,6 +239,7 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
                         it
                     )
                 })
+                deadLetterRecords.clear()
             }
             producer.sendAllOffsetsToTransaction(consumer)
             producer.commitTransaction()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -239,6 +239,7 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
                     it
                 )
             })
+            deadLetterRecords.clear()
         }
         producer.sendRecordOffsetsToTransaction(eventConsumer, events.map { it })
         producer.commitTransaction()

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestDurableProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestDurableProcessor.kt
@@ -2,6 +2,7 @@ package net.corda.messaging.integration.processors
 
 import net.corda.data.demo.DemoRecord
 import net.corda.data.demo.DemoStateRecord
+import net.corda.data.flow.event.Wakeup
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
 import java.util.concurrent.CountDownLatch
@@ -58,13 +59,13 @@ class TestDurableStringProcessor(
 
 class TestDurableDummyMessageProcessor(
     private val latch: CountDownLatch, private val outputTopic: String? = null, private val delayProcessor: Long? = null
-) : DurableProcessor<String, DemoStateRecord> {
+) : DurableProcessor<String, Wakeup> {
     override val keyClass: Class<String>
         get() = String::class.java
-    override val valueClass: Class<DemoStateRecord>
-        get() = DemoStateRecord::class.java
+    override val valueClass: Class<Wakeup>
+        get() = Wakeup::class.java
 
-    override fun onNext(events: List<Record<String, DemoStateRecord>>): List<Record<*, *>> {
+    override fun onNext(events: List<Record<String, Wakeup>>): List<Record<*, *>> {
         if (delayProcessor != null) {
             Thread.sleep(delayProcessor)
         }
@@ -74,9 +75,9 @@ class TestDurableDummyMessageProcessor(
         }
 
         return if (outputTopic != null) {
-            listOf(Record(outputTopic, "durableOutputKey", DemoStateRecord(1)))
+            listOf(Record(outputTopic, "durableOutputKey", Wakeup()))
         } else {
-            emptyList<Record<String, DemoStateRecord>>()
+            emptyList<Record<String, Wakeup>>()
         }
     }
 }

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
@@ -445,7 +445,7 @@ class StateAndEventSubscriptionIntegrationTest {
         stateEventSub1.close()
 
         val durableLatch = CountDownLatch(10)
-        val dlqLatch = CountDownLatch(10)
+        val dlqLatch = CountDownLatch(5)
         val durableSub = subscriptionFactory.createDurableSubscription(
             SubscriptionConfig("$EVENTSTATE_OUTPUT7-group",  EVENTSTATE_OUTPUT7),
             TestDurableProcessor(durableLatch),

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/subscription/StateAndEventSubscriptionIntegrationTest.kt
@@ -445,7 +445,7 @@ class StateAndEventSubscriptionIntegrationTest {
         stateEventSub1.close()
 
         val durableLatch = CountDownLatch(10)
-        val dlqLatch = CountDownLatch(5)
+        val dlqLatch = CountDownLatch(10)
         val durableSub = subscriptionFactory.createDurableSubscription(
             SubscriptionConfig("$EVENTSTATE_OUTPUT7-group",  EVENTSTATE_OUTPUT7),
             TestDurableProcessor(durableLatch),


### PR DESCRIPTION
Jira: https://r3-cev.atlassian.net/browse/CORE-9215

#### Context:
As stated in the linked ticket, the in-memory DLQ was not being cleared in the `StateAndEventSubscriptionImpl` and `DurableSubscriptionImpl`.

Fixing this issue caused some integ tests to fail for both the `StateAndEventProcessor` and the `DurableProcessor` which uncovered some additional underlying issues with the `DBCordaConsumerImpl.poll()` whereby it was returning all records, even if they had been DLQ'd during serialization.

Additionally, the test processor used by the `DurableSubscriptionIntegrationTest` (`TestDurableDummyMessageProcessor`) was setup incorrectly for processing dummy records (which are `Wakeup()` events).

#### Changes:
+ Added line to clear `DeadLetterRecords` queues after they'd been submitted to the publisher.
+ Refactored `DBCordaConsumerImpl` with the help of @mbrkic-r3 to prune DLQ'd messages from results. We do this by filtering records which had a non-null value before serialization which became null following serialization, as this is how serialization errors are handled.
+ Added filter to `DBCordaConsumerImpl.poll()` to filter out null, non-DLQ messages.
+ Fixed <K, V> type in `TestDurableDummyMessageProcessor` by making `Wakeup` the expected value.