### PR TITLE
CORE-11493: Add an option to pass `secureSSL` option to `RestClient`

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/TestToolkitImpl.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/TestToolkitImpl.kt
@@ -36,6 +36,7 @@ class TestToolkitImpl(private val testCaseClass: Class<Any>, private val baseAdd
         return RestClient(
             baseAddress, restResourceClass, RestClientConfig()
                 .enableSSL(true)
+                .secureSSL(false)
                 .minimumServerProtocolVersion(1)
                 .username(userName)
                 .password(password)

--- a/libs/rest/rest-client/src/integrationTest/kotlin/net/corda/rest/client/RestSSLClientIntegrationTest.kt
+++ b/libs/rest/rest-client/src/integrationTest/kotlin/net/corda/rest/client/RestSSLClientIntegrationTest.kt
@@ -72,6 +72,7 @@ class RestSSLClientIntegrationTest : RestIntegrationTestBase() {
             TestHealthCheckAPI::class.java,
             RestClientConfig()
                 .enableSSL(true)
+                .secureSSL(false)
                 .minimumServerProtocolVersion(1)
                 .username(userAlice.username)
                 .password(requireNotNull(userAlice.password))
@@ -97,6 +98,7 @@ class RestSSLClientIntegrationTest : RestIntegrationTestBase() {
             CustomSerializationAPI::class.java,
             RestClientConfig()
                 .enableSSL(true)
+                .secureSSL(false)
                 .minimumServerProtocolVersion(1)
                 .username(userAlice.username)
                 .password(requireNotNull(userAlice.password))
@@ -118,6 +120,7 @@ class RestSSLClientIntegrationTest : RestIntegrationTestBase() {
             TestHealthCheckAPI::class.java,
             RestClientConfig()
                 .enableSSL(true)
+                .secureSSL(false)
                 .minimumServerProtocolVersion(1)
                 .username(userAlice.username)
                 .password(requireNotNull(userAlice.password))
@@ -144,6 +147,7 @@ class RestSSLClientIntegrationTest : RestIntegrationTestBase() {
             TestHealthCheckAPI::class.java,
             RestClientConfig()
                 .enableSSL(true)
+                .secureSSL(false)
                 .minimumServerProtocolVersion(3)
                 .username(userAlice.username)
                 .password(requireNotNull(userAlice.password))

--- a/libs/rest/rest-client/src/integrationTest/kotlin/net/corda/rest/client/RestSSLClientIntegrationTest.kt
+++ b/libs/rest/rest-client/src/integrationTest/kotlin/net/corda/rest/client/RestSSLClientIntegrationTest.kt
@@ -1,7 +1,7 @@
 package net.corda.rest.client
 
 import net.corda.rest.client.config.RestClientConfig
-import net.corda.rest.client.exceptions.InternalErrorException
+import net.corda.rest.client.exceptions.ClientSslHandshakeException
 import net.corda.rest.server.config.models.RestSSLSettings
 import net.corda.rest.server.config.models.RestServerSettings
 import net.corda.rest.server.impl.RestServerImpl
@@ -167,7 +167,7 @@ class RestSSLClientIntegrationTest : RestIntegrationTestBase() {
         )
 
         client.use {
-            assertThatThrownBy { client.start() }.isInstanceOf(InternalErrorException::class.java)
+            assertThatThrownBy { client.start() }.isInstanceOf(ClientSslHandshakeException::class.java)
                 .hasMessageContaining("unable to find valid certification path to requested target")
         }
     }

--- a/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/RestClient.kt
+++ b/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/RestClient.kt
@@ -92,7 +92,9 @@ class RestClient<I : RestResource> internal constructor(
         log.trace { "Start." }
         return log.logElapsedTime("REST client") {
             val proxyHandler = RestClientProxyHandler(
-                RemoteUnirestClient(baseAddress, clientConfig.enableSSL), clientConfig.authenticationConfig, restResourceClass
+                RemoteUnirestClient(baseAddress, clientConfig.enableSSL, clientConfig.secureSSL),
+                clientConfig.authenticationConfig,
+                restResourceClass
             )
             try {
                 ops = proxyGenerator(restResourceClass, proxyHandler)

--- a/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/config/RestClientConfig.kt
+++ b/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/config/RestClientConfig.kt
@@ -8,7 +8,7 @@ data class RestClientConfig internal constructor(
     val minimumServerProtocolVersion: Int,
     val authenticationConfig: AuthenticationConfig
 ) {
-    constructor() : this(false, secureSSL = false, 1, EmptyAuthenticationConfig)
+    constructor() : this(false, secureSSL = true, 1, EmptyAuthenticationConfig)
 
     fun enableSSL(enableSSL: Boolean) = copy(enableSSL = enableSSL)
 

--- a/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/config/RestClientConfig.kt
+++ b/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/config/RestClientConfig.kt
@@ -4,12 +4,16 @@ import net.corda.rest.client.auth.credentials.BearerTokenProvider
 
 data class RestClientConfig internal constructor(
     val enableSSL: Boolean,
+    val secureSSL: Boolean,
     val minimumServerProtocolVersion: Int,
     val authenticationConfig: AuthenticationConfig
 ) {
-    constructor() : this(false, 1, EmptyAuthenticationConfig)
+    constructor() : this(false, secureSSL = false, 1, EmptyAuthenticationConfig)
 
     fun enableSSL(enableSSL: Boolean) = copy(enableSSL = enableSSL)
+
+    fun secureSSL(secureSSL: Boolean) = copy(secureSSL = secureSSL)
+
     fun minimumServerProtocolVersion(minimumServerProtocolVersion: Int) = copy(minimumServerProtocolVersion = minimumServerProtocolVersion)
     fun username(username: String) = copy(
         authenticationConfig = if (authenticationConfig is BasicAuthenticationConfig)

--- a/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/connect/remote/RemoteClient.kt
+++ b/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/connect/remote/RemoteClient.kt
@@ -21,7 +21,7 @@ import net.corda.rest.client.processing.WebRequest
 import net.corda.rest.client.processing.WebResponse
 import net.corda.rest.exception.ResourceAlreadyExistsException
 import net.corda.rest.tools.HttpVerb
-import net.corda.utilities.trace
+import net.corda.utilities.debug
 import org.apache.http.conn.ssl.NoopHostnameVerifier
 import org.apache.http.conn.ssl.TrustAllStrategy
 import org.apache.http.impl.client.HttpClients
@@ -41,7 +41,11 @@ internal interface RemoteClient {
     val baseAddress: String
 }
 
-internal class RemoteUnirestClient(override val baseAddress: String, private val enableSsl: Boolean = false) : RemoteClient {
+internal class RemoteUnirestClient(
+    override val baseAddress: String,
+    private val enableSsl: Boolean,
+    private val secureSsl: Boolean
+) : RemoteClient {
     internal companion object {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
@@ -80,7 +84,7 @@ internal class RemoteUnirestClient(override val baseAddress: String, private val
         remoteCallFn: HttpRequest<*>.() -> HttpResponse<R>
     ): WebResponse<R> where R : Any {
         val path = baseAddress + webRequest.path
-        log.trace { """Do call "$verb $path".""" }
+        log.debug { """Do call "$verb $path".""" }
 
         var request = when (verb) {
             HttpVerb.GET -> unirestInstance.get(path)
@@ -120,8 +124,9 @@ internal class RemoteUnirestClient(override val baseAddress: String, private val
                 response.body, response.headers.all().associateBy({ it.name }, { it.value }),
                 response.status, response.statusText
             )
-                .also { log.trace { """Do call "$verb $path" completed.""" } }
+                .also { log.debug { """Do call "$verb $path" completed.""" } }
         } catch (e: UnirestException) {
+            log.error("Unable to make HTTP call", e)
             throw InternalErrorException(e.message ?: "No message provided")
         }
     }
@@ -169,19 +174,28 @@ internal class RemoteUnirestClient(override val baseAddress: String, private val
 
     private fun Config.addSslParams() {
         if (enableSsl) {
-            log.trace { "Add Ssl params." }
-            val sslContext: SSLContext = SSLContexts.custom()
-                .loadTrustMaterial(TrustAllStrategy())
-                .build()
 
-            val httpClient = HttpClients.custom()
-                .setSSLContext(sslContext)
-                .setSSLHostnameVerifier(NoopHostnameVerifier())
-                .build()
+            log.debug { "Add Ssl params." }
 
-            val apacheClient = ApacheClient.builder(httpClient).apply(this)
+            val apacheClient = if (secureSsl) {
+                log.debug { "Creating secure SSL context" }
+                ApacheClient.builder().apply(this)
+            } else {
+                log.debug { "Creating insecure SSL context" }
+                val sslContext: SSLContext = SSLContexts.custom()
+                    .loadTrustMaterial(TrustAllStrategy())
+                    .build()
+
+                val httpClient = HttpClients.custom()
+                    .setSSLContext(sslContext)
+                    .setSSLHostnameVerifier(NoopHostnameVerifier())
+                    .build()
+
+                ApacheClient.builder(httpClient).apply(this)
+            }
             this.httpClient(apacheClient)
-            log.trace { "Add Ssl params completed." }
+
+            log.debug { "Add Ssl params completed." }
         }
     }
 

--- a/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/exceptions/ClientSslHandshakeException.kt
+++ b/libs/rest/rest-client/src/main/kotlin/net/corda/rest/client/exceptions/ClientSslHandshakeException.kt
@@ -1,0 +1,8 @@
+package net.corda.rest.client.exceptions
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+/**
+ * Cannot use [javax.net.ssl.SSLHandshakeException] since it is a checked exception
+ */
+class ClientSslHandshakeException(message: String) : CordaRuntimeException(message)

--- a/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestClientUtils.kt
+++ b/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestClientUtils.kt
@@ -25,6 +25,7 @@ object RestClientUtils {
             restResource.java,
             RestClientConfig()
                 .enableSSL(true)
+                .secureSSL(false)
                 .minimumServerProtocolVersion(minimumServerProtocolVersion)
                 .username(username)
                 .password(password),


### PR DESCRIPTION
Changes been done to `RestClient` only for now.

CLI tool will be updated with `--insecure` option in the PR to follow.