### PR TITLE
CORE-11808: Declare DigestAlgorithmFactoryProvider and PagedQueryFactory services as uninjectable.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/PagedQueryFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/PagedQueryFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.application.persistence.query
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.persistence.PagedQuery
 import net.corda.v5.application.serialization.SerializationService
@@ -46,7 +47,11 @@ interface PagedQueryFactory {
  * be able to contain its own [PagedQueryFactory] instance which uses that
  * [SerializationService].
  */
-@Component(service = [ PagedQueryFactory::class, UsedByFlow::class ], scope = PROTOTYPE)
+@Component(
+    service = [ PagedQueryFactory::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
 internal class PagedQueryFactoryImpl @Activate constructor(
     @Reference(service = ExternalEventExecutor::class)
     private val externalEventExecutor: ExternalEventExecutor,

--- a/components/virtual-node/sandbox-crypto/src/main/kotlin/net/corda/sandbox/crypto/DigestAlgorithmFactoryProviderImpl.kt
+++ b/components/virtual-node/sandbox-crypto/src/main/kotlin/net/corda/sandbox/crypto/DigestAlgorithmFactoryProviderImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.sandbox.crypto
 
 import net.corda.crypto.core.DigestAlgorithmFactoryProvider
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
@@ -20,6 +21,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
         UsedByPersistence::class,
         UsedByVerification::class
     ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
     scope = PROTOTYPE
 )
 class DigestAlgorithmFactoryProviderImpl @Activate constructor()


### PR DESCRIPTION
These services are not supposed to be `@CordaInject`-able, but the FLOW sandbox still needs to use them. Prevent `SandboxDependencyInjectorFactory` complaining that they do not implement `SingletonSerializeAsToken` by declaring them as "uninjectable".