### PR TITLE
CORE-11849: Prevent Kryo from accidentally serializing Avro classes.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
@@ -18,7 +18,6 @@ class FlowFiberExecutionContext(
     val currentSandboxGroupContext: CurrentSandboxGroupContext,
     val mdcLoggingData: Map<String, String>
 ) : NonSerializable {
-    val memberX500Name: MemberX500Name = holdingIdentity.x500Name
-    val flowStackService: FlowStack = flowCheckpoint.flowStack
+    val memberX500Name: MemberX500Name get() = holdingIdentity.x500Name
+    val flowStackService: FlowStack get() = flowCheckpoint.flowStack
 }
-

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -141,7 +141,7 @@ class FlowFiberImpl(
         setCurrentSandboxGroupContext()
 
         @Suppress("unchecked_cast")
-        return when (val outcome = suspensionOutcome!!) {
+        return when (val outcome = suspensionOutcome ?: throw IllegalStateException("FlowFiber suspensionOutcome is missing!")) {
             is FlowContinuation.Run -> outcome.value as SUSPENDRETURN
             is FlowContinuation.Error -> throw FlowContinuationErrorException(
                 // We populate the container exception message in case user code has a try/catch around the failing statement.

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
@@ -8,19 +8,19 @@ import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.FlowEventPipeline
 import net.corda.flow.pipeline.FlowGlobalPostProcessor
 import net.corda.flow.pipeline.exceptions.FlowFatalException
+import net.corda.flow.pipeline.exceptions.FlowMarkedForKillException
+import net.corda.flow.pipeline.exceptions.FlowTransientException
 import net.corda.flow.pipeline.handlers.events.FlowEventHandler
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
 import net.corda.flow.pipeline.handlers.waiting.FlowWaitingForHandler
 import net.corda.flow.pipeline.runner.FlowRunner
+import net.corda.virtualnode.OperationalStatus
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import net.corda.flow.pipeline.exceptions.FlowMarkedForKillException
-import net.corda.flow.pipeline.exceptions.FlowTransientException
-import net.corda.virtualnode.OperationalStatus
-import net.corda.virtualnode.read.VirtualNodeInfoReadService
 
 /**
  * [FlowEventPipelineImpl] encapsulates the pipeline steps that are executed when a [FlowEvent] is received by a [FlowEventProcessor].
@@ -41,7 +41,7 @@ class FlowEventPipelineImpl(
     private val flowRequestHandlers: Map<Class<out FlowIORequest<*>>, FlowRequestHandler<out FlowIORequest<*>>>,
     private val flowRunner: FlowRunner,
     private val flowGlobalPostProcessor: FlowGlobalPostProcessor,
-    context: FlowEventContext<Any>,
+    override var context: FlowEventContext<Any>,
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     private var output: FlowIORequest<*>? = null
 ) : FlowEventPipeline {
@@ -49,11 +49,6 @@ class FlowEventPipelineImpl(
     private companion object {
         val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
-
-    override var context: FlowEventContext<Any> = context
-        private set(value) {
-            field = value
-        }
 
     override fun eventPreProcessing(): FlowEventPipelineImpl {
         log.trace { "Preprocessing of ${context.inputEventPayload::class.qualifiedName}" }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
@@ -65,6 +65,7 @@ class FlowRunnerImpl @Activate constructor(
         sessionInitEvent: SessionInit
     ): FiberFuture {
         val flowStartContext = context.checkpoint.flowStartContext
+        val sessionId = flowStartContext.statusKey.id
 
         val localContext = remoteToLocalContextMapper(
             remoteUserContextProperties = sessionInitEvent.contextUserProperties,
@@ -80,10 +81,14 @@ class FlowRunnerImpl @Activate constructor(
                     localContext.counterpartySessionProperties
                 )
             },
-            updateFlowStackItem = { fsi -> fsi.sessions.add(FlowStackItemSession(flowStartContext.statusKey.id, true)) },
+            updateFlowStackItem = { fsi -> addFlowStackItemSession(fsi, sessionId) },
             contextUserProperties = localContext.userProperties,
             contextPlatformProperties = localContext.platformProperties
         )
+    }
+
+    private fun addFlowStackItemSession(fsi: FlowStackItem, sessionId: String) {
+        fsi.sessions.add(FlowStackItemSession(sessionId, true))
     }
 
     private fun startFlow(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -27,9 +27,7 @@ class FlowCheckpointImpl(
 ) : FlowCheckpoint {
 
     private val pipelineStateManager = PipelineStateManager(checkpoint.pipelineState, config, instantProvider)
-    private var flowStateManager = checkpoint.flowState?.let {
-        FlowStateManager(it)
-    }
+    private var flowStateManager = checkpoint.flowState?.let(::FlowStateManager)
     private var nullableFlowStack: FlowStackImpl? = checkpoint.flowState?.let {
         FlowStackImpl(it.flowStackItems)
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
@@ -2,7 +2,6 @@ package net.corda.ledger.utxo.flow.impl.transaction.verifier
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
-import net.corda.ledger.utxo.verification.CordaPackageSummary
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
@@ -38,9 +37,7 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
             TransactionVerificationExternalEventFactory::class.java,
             TransactionVerificationParameters(
                 serialize(transaction.toContainer()),
-                transaction.getCpkMetadata().map {
-                    CordaPackageSummary(it.name, it.version, it.signerSummaryHash, it.fileChecksum)
-                }
+                transaction.getCpkMetadata()
             )
         )
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/external/events/TransactionVerificationExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/external/events/TransactionVerificationExternalEventFactory.kt
@@ -6,16 +6,17 @@ import net.corda.flow.external.events.factory.ExternalEventRecord
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationResult
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
+import net.corda.ledger.utxo.verification.CordaPackageSummary as CordaPackageSummaryAvro
+import net.corda.ledger.utxo.verification.TransactionVerificationStatus as TransactionVerificationStatusAvro
+import net.corda.ledger.utxo.verification.TransactionVerificationRequest as TransactionVerificationRequestAvro
+import net.corda.ledger.utxo.verification.TransactionVerificationResponse as TransactionVerificationResponseAvro
 import net.corda.schema.Schemas
+import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.virtualnode.toAvro
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import java.nio.ByteBuffer
 import java.time.Clock
-import net.corda.ledger.utxo.verification.CordaPackageSummary as CordaPackageSummaryAvro
-import net.corda.ledger.utxo.verification.TransactionVerificationStatus as TransactionVerificationStatusAvro
-import net.corda.ledger.utxo.verification.TransactionVerificationRequest as TransactionVerificationRequestAvro
-import net.corda.ledger.utxo.verification.TransactionVerificationResponse as TransactionVerificationResponseAvro
 
 @Component(service = [ExternalEventFactory::class])
 class TransactionVerificationExternalEventFactory(
@@ -38,7 +39,7 @@ class TransactionVerificationExternalEventFactory(
                 .setTimestamp(clock.instant())
                 .setHoldingIdentity(checkpoint.holdingIdentity.toAvro())
                 .setTransaction(parameters.transaction)
-                .setCpkMetadata(parameters.cpkMetadata)
+                .setCpkMetadata(parameters.cpkMetadata.map(CordaPackageSummary::toAvro))
                 .setFlowExternalEventContext(flowExternalEventContext)
                 .build()
         )
@@ -63,5 +64,9 @@ class TransactionVerificationExternalEventFactory(
 
 data class TransactionVerificationParameters(
     val transaction: ByteBuffer,
-    val cpkMetadata: List<CordaPackageSummaryAvro>
+    val cpkMetadata: List<CordaPackageSummary>
 )
+
+fun CordaPackageSummary.toAvro(): CordaPackageSummaryAvro {
+    return CordaPackageSummaryAvro(name, version, signerSummaryHash, fileChecksum)
+}

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/external/events/TransactionVerificationExternalEventFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/external/events/TransactionVerificationExternalEventFactoryTest.kt
@@ -3,10 +3,11 @@ package net.corda.ledger.utxo.flow.impl.transaction.verifier.external.events
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.flow.state.FlowCheckpoint
-import net.corda.ledger.utxo.verification.CordaPackageSummary
+import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.utxo.verification.TransactionVerificationRequest
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.ALICE_X500_HOLDING_IDENTITY
 import net.corda.schema.Schemas
+import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.virtualnode.toCorda
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -24,13 +25,13 @@ class TransactionVerificationExternalEventFactoryTest {
         val checkpoint = mock<FlowCheckpoint>()
         val transaction = ByteBuffer.wrap(byteArrayOf(1))
         val cpkMetadata = listOf(
-            CordaPackageSummary(
+            CordaPackageSummaryImpl(
                 "cpk1",
                 "1.0",
                 "SHA-256:0000000000000001",
                 "SHA-256:0000000000000011"
             ),
-            CordaPackageSummary(
+            CordaPackageSummaryImpl(
                 "cpk2",
                 "2.0",
                 "SHA-256:0000000000000002",
@@ -59,7 +60,7 @@ class TransactionVerificationExternalEventFactoryTest {
                 testClock.instant(),
                 ALICE_X500_HOLDING_IDENTITY,
                 transaction,
-                cpkMetadata,
+                cpkMetadata.map(CordaPackageSummary::toAvro),
                 externalEventContext
             ),
             externalEventRecord.payload

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
     testRuntimeOnly "co.paralleluniverse:quasar-core-osgi:$quasarVersion:framework-extension"
     testImplementation project(":testing:kryo-serialization-testkit")
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project('cpks:serializable-cpk-one')

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
@@ -10,7 +10,6 @@ import com.esotericsoftware.kryo.serializers.FieldSerializer
 import de.javakaffee.kryoserializers.ArraysAsListSerializer
 import de.javakaffee.kryoserializers.BitSetSerializer
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer
-import net.corda.kryoserialization.resolver.CordaClassResolver
 import net.corda.kryoserialization.serializers.AutoCloseableSerializer
 import net.corda.kryoserialization.serializers.AvroRecordRejectSerializer
 import net.corda.kryoserialization.serializers.CertPathSerializer
@@ -47,18 +46,9 @@ class DefaultKryoCustomizer {
         internal fun customize(
             kryo: Kryo,
             serializers: Map<Class<*>, Serializer<*>>,
-            classResolver: CordaClassResolver,
-            classSerializer: ClassSerializer,
+            classSerializer: ClassSerializer
         ): Kryo {
             return kryo.apply {
-
-                classResolver.setKryo(this)
-
-                // The ClassResolver can only be set in the Kryo constructor and Quasar doesn't
-                // provide us with a way of doing that
-                Kryo::class.java.getDeclaredField("classResolver").apply {
-                    isAccessible = true
-                }.set(this, classResolver)
 
                 // Take the safest route here and allow subclasses to have fields named the same as super classes.
                 fieldSerializerConfig.cachedFieldNameStrategy = FieldSerializer.CachedFieldNameStrategy.EXTENDED
@@ -75,8 +65,8 @@ class DefaultKryoCustomizer {
                     LinkedHashMapIteratorSerializer.getIterator()::class.java.superclass,
                     LinkedHashMapIteratorSerializer
                 )
-                addDefaultSerializer(LinkedHashMapEntrySerializer.getEntry()::class.java, LinkedHashMapEntrySerializer)
-                addDefaultSerializer(LinkedListItrSerializer.getListItr()::class.java, LinkedListItrSerializer)
+                addDefaultSerializer(LinkedHashMapEntrySerializer.serializedType, LinkedHashMapEntrySerializer)
+                addDefaultSerializer(LinkedListItrSerializer.serializedType, LinkedListItrSerializer)
                 addDefaultSerializer(Arrays.asList("").javaClass, ArraysAsListSerializer())
                 addDefaultSerializer(LazyMappedList::class.java, LazyMappedListSerializer)
                 UnmodifiableCollectionsSerializer.registerSerializers(this)

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/serializers/LinkedHashMapEntrySerializer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/serializers/LinkedHashMapEntrySerializer.kt
@@ -16,10 +16,10 @@ import java.lang.reflect.Constructor
  */
 internal object LinkedHashMapEntrySerializer : Serializer<Map.Entry<*, *>>() {
     // Create a dummy map so that we can get the LinkedHashMap$Entry from it
-    // The element type of the map doesn't matter.  The entry is all we want
-    private val DUMMY_MAP = linkedMapOf(1L to 1)
-    fun getEntry(): Any = DUMMY_MAP.entries.first()
-    private val constr: Constructor<*> = getEntry()::class.java.declaredConstructors.single().apply { isAccessible = true }
+    // The element type of the map doesn't matter. The entry is all we want.
+    val serializedType: Class<out Map.Entry<*,*>> = linkedMapOf(Any() to Any()).entries.first()::class.java
+
+    private val constr: Constructor<*> = serializedType.declaredConstructors.single().apply { isAccessible = true }
 
     /**
      * Kryo would end up serialising "this" entry, then serialise "this.after" recursively, leading to a very large stack.

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializer.kt
@@ -17,11 +17,10 @@ import java.util.*
 */
 internal object LinkedListItrSerializer : Serializer<ListIterator<*>>() {
     // Create a dummy list so that we can get the ListItr from it
-    // The element type of the list doesn't matter.  The iterator is all we want
-    private val DUMMY_LIST = LinkedList<Long>(listOf(1))
-    fun getListItr(): Any  = DUMMY_LIST.listIterator()
+    // The element type of the list doesn't matter. The iterator is all we want.
+    val serializedType: Class<out ListIterator<*>> = LinkedList<Any>(emptyList()).listIterator()::class.java
 
-    private val outerListField: Field = getListItr()::class.java.getDeclaredField("this$0").apply {
+    private val outerListField: Field = serializedType.getDeclaredField("this$0").apply {
         isAccessible = true
     }
 

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/KryoCheckpointSerializerTest.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/KryoCheckpointSerializerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.kryoserialization
 
 import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.util.MapReferenceResolver
 import net.corda.data.flow.state.checkpoint.FlowStackItem
 import net.corda.kryoserialization.TestClass.Companion.TEST_INT
 import net.corda.kryoserialization.TestClass.Companion.TEST_STRING
@@ -51,9 +52,8 @@ internal class KryoCheckpointSerializerTest {
         val sandboxGroup = mockSandboxGroup(setOf(FlowStackItem::class.java))
         val serializer = KryoCheckpointSerializer(
             DefaultKryoCustomizer.customize(
-                Kryo(),
+                Kryo(CordaClassResolver(sandboxGroup), MapReferenceResolver()),
                 emptyMap(),
-                CordaClassResolver(sandboxGroup),
                 ClassSerializer(sandboxGroup)
             )
         )
@@ -91,9 +91,8 @@ internal class KryoCheckpointSerializerTest {
         val sandboxGroup = mockSandboxGroup(setOf(TestClass::class.java))
         val serializer = KryoCheckpointSerializer(
             DefaultKryoCustomizer.customize(
-                Kryo(),
+                Kryo(CordaClassResolver(sandboxGroup), MapReferenceResolver()),
                 emptyMap(),
-                CordaClassResolver(sandboxGroup),
                 ClassSerializer(sandboxGroup)
             )
         )

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/IteratorSerializerTest.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/IteratorSerializerTest.kt
@@ -4,6 +4,7 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer
+import com.esotericsoftware.kryo.util.MapReferenceResolver
 import net.corda.kryoserialization.DefaultKryoCustomizer
 import net.corda.kryoserialization.resolver.CordaClassResolver
 import org.assertj.core.api.Assertions.assertThat
@@ -22,11 +23,10 @@ internal class IteratorSerializerTest {
         list.addAll(listOf(3, 4))
 
         val output = Output(2048)
-        val kryo = Kryo()
+        val kryo = Kryo(CordaClassResolver(mock()), MapReferenceResolver())
         DefaultKryoCustomizer.customize(
             kryo,
             emptyMap(),
-            CordaClassResolver(mock()),
             ClassSerializer(mock())
         )
         val compatibleFieldSerializer: CompatibleFieldSerializer<Iterator<*>> = mock()

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializerTest.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/LinkedListItrSerializerTest.kt
@@ -5,7 +5,7 @@ import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.*
+import java.util.LinkedList
 
 internal class LinkedListItrSerializerTest {
     @Test

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/SingletonSerializeAsTokenSerializerTest.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/SingletonSerializeAsTokenSerializerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.kryoserialization.serializers
 
 import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.util.MapReferenceResolver
 import net.corda.kryoserialization.CordaKryoException
 import net.corda.kryoserialization.DefaultKryoCustomizer
 import net.corda.kryoserialization.KryoCheckpointSerializer
@@ -35,9 +36,8 @@ internal class SingletonSerializeAsTokenSerializerTest {
 
         val serializer = KryoCheckpointSerializer(
             DefaultKryoCustomizer.customize(
-                Kryo(),
+                Kryo(CordaClassResolver(sandboxGroup), MapReferenceResolver()),
                 mapOf(SingletonSerializeAsToken::class.java to SingletonSerializeAsTokenSerializer(emptyMap())),
-                CordaClassResolver(sandboxGroup),
                 ClassSerializer(sandboxGroup)
             )
         )
@@ -56,9 +56,8 @@ internal class SingletonSerializeAsTokenSerializerTest {
         val sandboxGroup = mockSandboxGroup(setOf(Tester::class.java))
         val deserializer = KryoCheckpointSerializer(
             DefaultKryoCustomizer.customize(
-                Kryo(),
+                Kryo(CordaClassResolver(sandboxGroup), MapReferenceResolver()),
                 emptyMap(),
-                CordaClassResolver(sandboxGroup),
                 ClassSerializer(sandboxGroup)
             )
         )


### PR DESCRIPTION
Remove some stray Avro classes from the stack so that Kryo cannot try to serialize them accidentally.

The latest Quasar SNAPSHOT also allows us to provide Quasar's `FiberSerializer` with the `ClassResolver` instance that we want its Kryo to use, which means we no longer need to reset this `final` field via Java reflection :relieved:.