### PR TITLE
CORE-11493: Make CLI commands SSL secure by default

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/FlowExecutorE2eTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/FlowExecutorE2eTest.kt
@@ -41,7 +41,8 @@ class FlowExecutorE2eTest {
                 "-t",
                 "https://${cordaCluster.clusterConfig.restHost}:${cordaCluster.clusterConfig.restPort}",
                 "-v",
-                randomVNodeHash
+                randomVNodeHash,
+                "-k"
             )
         )
         assertThat(result.exitCode).withFailMessage(result.stdErr).isEqualTo(0)

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -409,7 +409,7 @@ spec:
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'user-admin', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
-            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443"]
+            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443", '--insecure']
           volumeMounts:
             {{ include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
@@ -422,7 +422,7 @@ spec:
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'vnode-creator', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
-            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443"]
+            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443", '--insecure']
           volumeMounts:
             {{ include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
@@ -435,7 +435,7 @@ spec:
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
           args: ['initial-rbac', 'corda-developer', '--yield', '300', '--user', "$(INITIAL_ADMIN_USER_USERNAME)",
             '--password', "$(INITIAL_ADMIN_USER_PASSWORD)",
-            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443"]
+            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443", '--insecure']
           volumeMounts:
             {{ include "corda.log4jVolumeMount" . | nindent 12 }}
           env:

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/README.md
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/README.md
@@ -17,5 +17,5 @@ This is a sub-command under the `network` plugin to view the member list via HTT
 For example,
 
 ```shell
-./corda-cli.sh network --user=admin --password=admin --target=https://localhost:8888 members-list -h=<holding-identity-short-hash>
+./corda-cli.sh network --user=admin --password=admin --target=https://localhost:8888 --insecure members-list -h=<holding-identity-short-hash>
 ```

--- a/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestClientUtils.kt
+++ b/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestClientUtils.kt
@@ -25,7 +25,7 @@ object RestClientUtils {
             restResource.java,
             RestClientConfig()
                 .enableSSL(true)
-                .secureSSL(false)
+                .secureSSL(!insecure)
                 .minimumServerProtocolVersion(minimumServerProtocolVersion)
                 .username(username)
                 .password(password),

--- a/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestCommand.kt
+++ b/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestCommand.kt
@@ -40,4 +40,11 @@ abstract class RestCommand : ExtensionPoint {
                 "Defaults to 10 seconds if missing."]
     )
     var waitDurationSeconds: Int = 10
+
+    @Option(
+        names = ["-k", "--insecure"],
+        required = false,
+        description = ["Allow insecure server connections with SSL. Defaults to 'false' if missing."]
+    )
+    var insecure: Boolean = false
 }

--- a/tools/plugins/virtual-node/README.md
+++ b/tools/plugins/virtual-node/README.md
@@ -11,7 +11,7 @@ deletes vault data for the affected Virtual Nodes.
 
 Example:
 ```bash
-$ corda-cli vnode reset -t https://localhost:8888 -u admin -p password --cpi mycpifile.cpi -w
+$ corda-cli vnode reset -t https://localhost:8888 -u admin -p password --cpi mycpifile.cpi -w -k
 ```
 
 Flags:
@@ -21,3 +21,4 @@ Flags:
  - `-pv` `--protocol-version` NOT REQUIRED, defaults to 1
  - `-c` `--cpi` the cpi file to upload
  - `-w` `--wait` wait for the result, or have a result ID returned to be checked later.
+ - `-k` `--insecure` Allow for invalid Server-side SSL certificates


### PR DESCRIPTION
Usages within E2E tests been updated to use `--insecure` option as they are often executed against `localhost`.

Also, with my changes, I have tested locally.

Using CLI tool as before gives:
```
corda-cli network -u admin -p <pwd> -t https://localhost:8888 members-list -h 698A22FA9260
StdErr> Unable to verify server's SSL certificate. Please check the target parameter or use '--insecure' option.
```
Then, as suggested, there are two ways of improving the situation:
1. To use an endpoint with a valid SSL certificate:
```
corda-cli network -u admin -p <pwd> -t https://<UUID>.eu.ngrok.io members-list -h 698A22FA9260
```

or

2. Use `--insecure` option:
``` 
corda-cli network -u admin -p <pwd> -t https://localhost:8888 --insecure members-list -h 698A22FA9260
````