### PR TITLE
CORE-11681 Erroring session state before throwing exception when flow unconfirmed counterparty timeout reached

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
@@ -100,6 +100,7 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
                 val msg = "[${context.checkpoint.holdingIdentity.x500Name}] has failed to create a flow with counterparty: " +
                         "[${counterparty}] as the recipient doesn't exist in the network."
                 log.debug(msg)
+                sessionManager.errorSession(sessionState)
                 throw FlowPlatformException(msg)
             }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
@@ -97,10 +97,10 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
             ).plusMillis(timeoutWindow)
 
             if (expiryTime < now) {
+                context.checkpoint.putSessionState(sessionManager.errorSession(sessionState))
                 val msg = "[${context.checkpoint.holdingIdentity.x500Name}] has failed to create a flow with counterparty: " +
                         "[${counterparty}] as the recipient doesn't exist in the network."
                 log.debug(msg)
-                sessionManager.errorSession(sessionState)
                 throw FlowPlatformException(msg)
             }
 

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
@@ -115,6 +115,10 @@ class SessionManagerImpl @Activate constructor(
         return Pair(sessionState, messagesToReturn)
     }
 
+    override fun errorSession(sessionState: SessionState) {
+        sessionState.status = SessionStateType.ERROR
+    }
+
     /**
      * If no heartbeat received from counterparty after session timeout has been reached, error the session
      * If no messages to send, and current time has surpassed the heartbeat window (message resend window), send a new ack.
@@ -142,7 +146,7 @@ class SessionManagerImpl @Activate constructor(
 
         return if (instant > sessionTimeoutTimestamp) {
             //send an error if the session has timed out
-            sessionState.status = SessionStateType.ERROR
+            errorSession(sessionState)
             val (initiatingIdentity, initiatedIdentity) = getInitiatingAndInitiatedParties(sessionState, identity)
             listOf(
                 generateErrorEvent(

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
@@ -26,6 +26,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
 
+@Suppress("TooManyFunctions")
 @Component
 class SessionManagerImpl @Activate constructor(
     @Reference(service = SessionEventProcessorFactory::class)

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
@@ -116,8 +116,9 @@ class SessionManagerImpl @Activate constructor(
         return Pair(sessionState, messagesToReturn)
     }
 
-    override fun errorSession(sessionState: SessionState) {
+    override fun errorSession(sessionState: SessionState) : SessionState {
         sessionState.status = SessionStateType.ERROR
+        return sessionState
     }
 
     /**
@@ -147,11 +148,11 @@ class SessionManagerImpl @Activate constructor(
 
         return if (instant > sessionTimeoutTimestamp) {
             //send an error if the session has timed out
-            errorSession(sessionState)
-            val (initiatingIdentity, initiatedIdentity) = getInitiatingAndInitiatedParties(sessionState, identity)
+            val updatedSessionState = errorSession(sessionState)
+            val (initiatingIdentity, initiatedIdentity) = getInitiatingAndInitiatedParties(updatedSessionState, identity)
             listOf(
                 generateErrorEvent(
-                    sessionState,
+                    updatedSessionState,
                     initiatingIdentity,
                     initiatedIdentity,
                     "Session has timed out. No messages received since $lastReceivedMessageTime",

--- a/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
+++ b/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
@@ -3,6 +3,7 @@ package net.corda.session.manager
 import java.time.Instant
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.state.session.SessionState
+import net.corda.data.flow.state.session.SessionStateType
 import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfig
 
@@ -84,4 +85,10 @@ interface SessionManager {
      */
     fun getMessagesToSend(sessionState: SessionState, instant: Instant, config: SmartConfig, identity: HoldingIdentity): Pair<SessionState,
             List<SessionEvent>>
+
+    /**
+     * Sets the [SessionState.status] of the passed [SessionState] to [SessionStateType.ERROR].
+     * @param sessionState The session state.
+     */
+    fun errorSession(sessionState: SessionState)
 }

--- a/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
+++ b/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
@@ -87,8 +87,9 @@ interface SessionManager {
             List<SessionEvent>>
 
     /**
-     * Sets the [SessionState.status] of the passed [SessionState] to [SessionStateType.ERROR].
+     * Errors the passed [SessionState], returning the updated state.
      * @param sessionState The session state.
+     * @return The updated [SessionState] with status set to [SessionStateType.ERROR]
      */
-    fun errorSession(sessionState: SessionState)
+    fun errorSession(sessionState: SessionState): SessionState
 }


### PR DESCRIPTION
This PR addresses [CORE-11681](https://r3-cev.atlassian.net/browse/CORE-11681).

#### Context:
Previously, changes were made [HERE](https://github.com/corda/corda-runtime-os/pull/3413) as part of CORE-9215 which errors sessions early if the counterparty doesn't materialise within some timeout window, however the sessionState was not updated to `ERROR` before erroring the session. We need to update this state first to provide quicker feedback to customers.

#### Changes:
Added an `errorSession(sessionState: String)` function to the `SessionManager` to allow for erroring of session state through the manager. This is now called in the FlowGlobabPostProcessor when we timeout a session for missing counterparty.

[CORE-11681]: https://r3-cev.atlassian.net/browse/CORE-11681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ