### PR TITLE
CORE-9596 Vault named query parsing

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/versioning/impl/VersioningFlow.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/versioning/impl/VersioningFlow.kt
@@ -86,13 +86,13 @@ class VersioningFlow<T>(
             )
         }
         when {
-            log.isDebugEnabled -> log.debug(
-                "Using ${agreedVersionedFlow::class.java.name} due to agreed platform version $agreedVersion."
-            )
             log.isTraceEnabled -> log.trace(
                 "Using ${agreedVersionedFlow::class.java.name} due to agreed platform version $agreedVersion. " +
                         "Local platform version $localPlatformVersion. Peer platform versions " +
                         "${counterpartyPlatformVersions.mapKeys { (name, _) -> name }}."
+            )
+            log.isDebugEnabled -> log.debug(
+                "Using ${agreedVersionedFlow::class.java.name} due to agreed platform version $agreedVersion."
             )
         }
         return flowEngine.subFlow(agreedVersionedFlow)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQuery.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQuery.kt
@@ -10,8 +10,14 @@ import net.corda.v5.ledger.utxo.query.VaultNamedQueryTransformer
  */
 data class VaultNamedQuery(
     val name: String,
-    val jsonString: String?,
+    val query: ParsedQuery,
     val filter: VaultNamedQueryFilter<*>?,
     val mapper: VaultNamedQueryTransformer<*, *>?,
     val collector: VaultNamedQueryCollector<*, *>?
-)
+) {
+    data class ParsedQuery(val originalQuery: String, val query: String, val type: Type)
+
+    enum class Type {
+        WHERE_JSON
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderCollectedImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderCollectedImpl.kt
@@ -1,22 +1,15 @@
 package net.corda.ledger.persistence.query.impl
 
 import net.corda.ledger.persistence.query.VaultNamedQueryRegistry
-import net.corda.utilities.debug
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryBuilderCollected
-import org.slf4j.LoggerFactory
 
 class VaultNamedQueryBuilderCollectedImpl(
     private val registry: VaultNamedQueryRegistry,
     private val vaultNamedQuery: VaultNamedQuery
 ) : VaultNamedQueryBuilderCollected {
 
-    private companion object {
-        private val logger = LoggerFactory.getLogger(VaultNamedQueryBuilderCollectedImpl::class.java)
-    }
-
     override fun register() {
-        logger.debug { "Registering custom query with name: ${vaultNamedQuery.name}" }
-
+        logQueryRegistration(vaultNamedQuery.name, vaultNamedQuery.query)
         registry.registerQuery(vaultNamedQuery)
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderFactoryImpl.kt
@@ -1,6 +1,11 @@
 package net.corda.ledger.persistence.query.impl
 
 import net.corda.ledger.persistence.query.VaultNamedQueryRegistry
+import net.corda.ledger.persistence.query.impl.parsing.VaultNamedQueryParser
+import net.corda.ledger.persistence.query.impl.parsing.VaultNamedQueryParserImpl
+import net.corda.ledger.persistence.query.impl.parsing.converters.PostgresVaultNamedQueryConverter
+import net.corda.ledger.persistence.query.impl.parsing.expressions.PostgresVaultNamedQueryExpressionParser
+import net.corda.ledger.persistence.query.impl.parsing.expressions.VaultNamedQueryExpressionValidatorImpl
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.utilities.debug
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryBuilder
@@ -20,17 +25,30 @@ import org.slf4j.LoggerFactory
     ],
     scope = ServiceScope.PROTOTYPE
 )
-class VaultNamedQueryBuilderFactoryImpl @Activate constructor(
-    @Reference(service = VaultNamedQueryRegistry::class, scope = ReferenceScope.PROTOTYPE)
-    private val vaultNamedQueryRegistry: VaultNamedQueryRegistry
-): VaultNamedQueryBuilderFactory, UsedByPersistence {
+class VaultNamedQueryBuilderFactoryImpl constructor(
+    private val vaultNamedQueryRegistry: VaultNamedQueryRegistry,
+    private val vaultNamedQueryParser: VaultNamedQueryParser
+) : VaultNamedQueryBuilderFactory, UsedByPersistence {
 
     private companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
+    @Activate
+    constructor(
+        @Reference(service = VaultNamedQueryRegistry::class, scope = ReferenceScope.PROTOTYPE)
+        vaultNamedQueryRegistry: VaultNamedQueryRegistry
+    ) : this(
+        vaultNamedQueryRegistry,
+        VaultNamedQueryParserImpl(
+            PostgresVaultNamedQueryExpressionParser(),
+            VaultNamedQueryExpressionValidatorImpl(),
+            PostgresVaultNamedQueryConverter()
+        )
+    )
+
     override fun create(queryName: String): VaultNamedQueryBuilder {
-        logger.debug { "Creating custom query with name: $queryName" }
-        return VaultNamedQueryBuilderImpl(vaultNamedQueryRegistry, queryName)
+        logger.debug { "Creating vault named query with name: $queryName" }
+        return VaultNamedQueryBuilderImpl(vaultNamedQueryRegistry, vaultNamedQueryParser, queryName)
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderUtils.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderUtils.kt
@@ -1,0 +1,18 @@
+package net.corda.ledger.persistence.query.impl
+
+import org.slf4j.LoggerFactory
+
+private val log = LoggerFactory.getLogger("net.corda.ledger.persistence.query.impl.VaultNamedQueryBuilderUtils")
+
+fun logQueryRegistration(name: String, query: VaultNamedQuery.ParsedQuery) {
+    when {
+        log.isTraceEnabled -> log.trace(
+            "Registering vault named query with name: $name, original query: ${query.originalQuery.replace(
+                    "\n",
+                    " "
+                )
+            }, parsed query: ${query.query}"
+        )
+        log.isDebugEnabled -> log.debug("Registering vault named query with name: $name")
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryFactoryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryFactoryProvider.kt
@@ -35,7 +35,11 @@ class VaultNamedQueryFactoryProvider @Activate constructor(
         val metadataServices = context.getMetadataServices<VaultNamedQueryFactory>()
 
         if (logger.isDebugEnabled) {
-            logger.debug("Found ${metadataServices.size} custom ledger queries.")
+            if (metadataServices.size == 1) {
+                logger.debug("Found 1 vault named query.")
+            } else {
+                logger.debug("Found ${metadataServices.size} vault named queries.")
+            }
         }
 
         // TODO extra checks needed?

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/ExpressionTokens.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/ExpressionTokens.kt
@@ -1,0 +1,55 @@
+package net.corda.ledger.persistence.query.impl.parsing
+
+interface Token
+
+interface Reference : Token {
+    val ref: String
+}
+
+interface Keyword : Token
+
+data class PathReference(override val ref: String) : Reference
+
+data class PathReferenceWithSpaces(override val ref: String) : Reference
+
+data class Number(override val ref: String) : Reference
+
+data class JsonCast(val value: String) : Keyword
+
+data class Parameter(override val ref: String) : Reference
+
+class LeftParentheses : Token {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+}
+
+class RightParentheses : Token {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+}
+
+class ParameterEnd : Token {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/Keywords.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/Keywords.kt
@@ -1,0 +1,313 @@
+package net.corda.ledger.persistence.query.impl.parsing
+
+class NotEquals : Keyword {
+    override fun toString(): String {
+        return "!="
+    }
+
+    override fun hashCode(): Int {
+        return "!=".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class And : Keyword {
+    override fun toString(): String {
+        return "AND"
+    }
+
+    override fun hashCode(): Int {
+        return "AND".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class Or : Keyword {
+    override fun toString(): String {
+        return "OR"
+    }
+
+    override fun hashCode(): Int {
+        return "OR".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class IsNull : Keyword {
+    override fun toString(): String {
+        return "IS NULL"
+    }
+
+    override fun hashCode(): Int {
+        return "IS NULL".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class IsNotNull : Keyword {
+    override fun toString(): String {
+        return "IS NOT NULL"
+    }
+
+    override fun hashCode(): Int {
+        return "IS NOT NULL".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class GreaterThan : Keyword {
+    override fun toString(): String {
+        return ">"
+    }
+
+    override fun hashCode(): Int {
+        return ">".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class GreaterThanEquals : Keyword {
+    override fun toString(): String {
+        return ">="
+    }
+
+    override fun hashCode(): Int {
+        return ">=".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class LessThan : Keyword {
+    override fun toString(): String {
+        return "<"
+    }
+
+    override fun hashCode(): Int {
+        return "<".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class LessThanEquals : Keyword {
+    override fun toString(): String {
+        return "<="
+    }
+
+    override fun hashCode(): Int {
+        return "<=".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class JsonArrayOrObjectAsText : Keyword {
+    override fun toString(): String {
+        return "->>"
+    }
+
+    override fun hashCode(): Int {
+        return "->>".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class As : Keyword {
+    override fun toString(): String {
+        return "AS"
+    }
+
+    override fun hashCode(): Int {
+        return "AS".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class From : Keyword {
+    override fun toString(): String {
+        return "FROM"
+    }
+
+    override fun hashCode(): Int {
+        return "FROM".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class Select : Keyword {
+    override fun toString(): String {
+        return "SELECT"
+    }
+
+    override fun hashCode(): Int {
+        return "SELECT".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class Where : Keyword {
+    override fun toString(): String {
+        return "WHERE"
+    }
+
+    override fun hashCode(): Int {
+        return "WHERE".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class Equals : Keyword {
+    override fun toString(): String {
+        return "="
+    }
+
+    override fun hashCode(): Int {
+        return "=".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class In : Keyword {
+    override fun toString(): String {
+        return "IN"
+    }
+
+    override fun hashCode(): Int {
+        return "IN".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class JsonKeyExists : Keyword {
+    override fun toString(): String {
+        return "?"
+    }
+
+    override fun hashCode(): Int {
+        return "?".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+class Like : Keyword {
+    override fun toString(): String {
+        return "LIKE"
+    }
+
+    override fun hashCode(): Int {
+        return "LIKE".hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+}
+
+fun operatorFactory(op: String): Keyword {
+    return when (op.uppercase()) {
+        "!=" -> NotEquals()
+        ">" -> GreaterThan()
+        ">=" -> GreaterThanEquals()
+        "<" -> LessThan()
+        "<=" -> LessThanEquals()
+        "IS NULL" -> IsNull()
+        "IS NOT NULL" -> IsNotNull()
+        "->>" -> JsonArrayOrObjectAsText()
+        "AS" -> As()
+        "FROM" -> From()
+        "SELECT" -> Select()
+        "WHERE" -> Where()
+        "OR" -> Or()
+        "AND" -> And()
+        "=" -> Equals()
+        "IN" -> In()
+        "?" -> JsonKeyExists()
+        "LIKE" -> Like()
+        else -> throw IllegalArgumentException("Unknown operator $op")
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/Keywords.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/Keywords.kt
@@ -1,313 +1,221 @@
 package net.corda.ledger.persistence.query.impl.parsing
 
+interface Keyword : Token
+
 class NotEquals : Keyword {
-    override fun toString(): String {
-        return "!="
-    }
-
-    override fun hashCode(): Int {
-        return "!=".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class And : Keyword {
-    override fun toString(): String {
-        return "AND"
-    }
-
-    override fun hashCode(): Int {
-        return "AND".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class Or : Keyword {
-    override fun toString(): String {
-        return "OR"
-    }
-
-    override fun hashCode(): Int {
-        return "OR".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class IsNull : Keyword {
-    override fun toString(): String {
-        return "IS NULL"
-    }
-
-    override fun hashCode(): Int {
-        return "IS NULL".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class IsNotNull : Keyword {
-    override fun toString(): String {
-        return "IS NOT NULL"
-    }
-
-    override fun hashCode(): Int {
-        return "IS NOT NULL".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class GreaterThan : Keyword {
-    override fun toString(): String {
-        return ">"
-    }
-
-    override fun hashCode(): Int {
-        return ">".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class GreaterThanEquals : Keyword {
-    override fun toString(): String {
-        return ">="
-    }
-
-    override fun hashCode(): Int {
-        return ">=".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class LessThan : Keyword {
-    override fun toString(): String {
-        return "<"
-    }
-
-    override fun hashCode(): Int {
-        return "<".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class LessThanEquals : Keyword {
-    override fun toString(): String {
-        return "<="
-    }
-
-    override fun hashCode(): Int {
-        return "<=".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class JsonArrayOrObjectAsText : Keyword {
-    override fun toString(): String {
-        return "->>"
-    }
-
-    override fun hashCode(): Int {
-        return "->>".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class As : Keyword {
-    override fun toString(): String {
-        return "AS"
-    }
-
-    override fun hashCode(): Int {
-        return "AS".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class From : Keyword {
-    override fun toString(): String {
-        return "FROM"
-    }
-
-    override fun hashCode(): Int {
-        return "FROM".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class Select : Keyword {
-    override fun toString(): String {
-        return "SELECT"
-    }
-
-    override fun hashCode(): Int {
-        return "SELECT".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class Where : Keyword {
-    override fun toString(): String {
-        return "WHERE"
-    }
-
-    override fun hashCode(): Int {
-        return "WHERE".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class Equals : Keyword {
-    override fun toString(): String {
-        return "="
-    }
-
-    override fun hashCode(): Int {
-        return "=".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class In : Keyword {
-    override fun toString(): String {
-        return "IN"
-    }
-
-    override fun hashCode(): Int {
-        return "IN".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class JsonKeyExists : Keyword {
-    override fun toString(): String {
-        return "?"
-    }
-
-    override fun hashCode(): Int {
-        return "?".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
 
 class Like : Keyword {
-    override fun toString(): String {
-        return "LIKE"
-    }
-
-    override fun hashCode(): Int {
-        return "LIKE".hashCode()
-    }
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return true
     }
-}
 
-fun operatorFactory(op: String): Keyword {
-    return when (op.uppercase()) {
-        "!=" -> NotEquals()
-        ">" -> GreaterThan()
-        ">=" -> GreaterThanEquals()
-        "<" -> LessThan()
-        "<=" -> LessThanEquals()
-        "IS NULL" -> IsNull()
-        "IS NOT NULL" -> IsNotNull()
-        "->>" -> JsonArrayOrObjectAsText()
-        "AS" -> As()
-        "FROM" -> From()
-        "SELECT" -> Select()
-        "WHERE" -> Where()
-        "OR" -> Or()
-        "AND" -> And()
-        "=" -> Equals()
-        "IN" -> In()
-        "?" -> JsonKeyExists()
-        "LIKE" -> Like()
-        else -> throw IllegalArgumentException("Unknown operator $op")
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
     }
 }
+
+data class JsonCast(val value: String) : Keyword

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/References.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/References.kt
@@ -1,0 +1,13 @@
+package net.corda.ledger.persistence.query.impl.parsing
+
+interface Reference : Token {
+    val ref: String
+}
+
+data class PathReference(override val ref: String) : Reference
+
+data class PathReferenceWithSpaces(override val ref: String) : Reference
+
+data class Number(override val ref: String) : Reference
+
+data class Parameter(override val ref: String) : Reference

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/Tokens.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/Tokens.kt
@@ -2,22 +2,6 @@ package net.corda.ledger.persistence.query.impl.parsing
 
 interface Token
 
-interface Reference : Token {
-    val ref: String
-}
-
-interface Keyword : Token
-
-data class PathReference(override val ref: String) : Reference
-
-data class PathReferenceWithSpaces(override val ref: String) : Reference
-
-data class Number(override val ref: String) : Reference
-
-data class JsonCast(val value: String) : Keyword
-
-data class Parameter(override val ref: String) : Reference
-
 class LeftParentheses : Token {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParser.kt
@@ -1,0 +1,6 @@
+package net.corda.ledger.persistence.query.impl.parsing
+
+interface VaultNamedQueryParser {
+
+    fun parseWhereJson(query: String): String
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImpl.kt
@@ -13,8 +13,9 @@ class VaultNamedQueryParserImpl(
     override fun parseWhereJson(query: String): String {
         val expression = expressionParser.parse(query)
         expressionValidator.validateWhereJson(query, expression)
-        return converter.convert(StringBuilder(""), expression)
-            .toString()
+        val output = StringBuilder("")
+        converter.convert(output, expression)
+        return output.toString()
             .replace("  ", " ")
             .trim()
     }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImpl.kt
@@ -1,0 +1,21 @@
+package net.corda.ledger.persistence.query.impl.parsing
+
+import net.corda.ledger.persistence.query.impl.parsing.converters.VaultNamedQueryConverter
+import net.corda.ledger.persistence.query.impl.parsing.expressions.VaultNamedQueryExpressionParser
+import net.corda.ledger.persistence.query.impl.parsing.expressions.VaultNamedQueryExpressionValidator
+
+class VaultNamedQueryParserImpl(
+    private val expressionParser: VaultNamedQueryExpressionParser,
+    private val expressionValidator: VaultNamedQueryExpressionValidator,
+    private val converter: VaultNamedQueryConverter
+) : VaultNamedQueryParser {
+
+    override fun parseWhereJson(query: String): String {
+        val expression = expressionParser.parse(query)
+        expressionValidator.validateWhereJson(query, expression)
+        return converter.convert(StringBuilder(""), expression)
+            .toString()
+            .replace("  ", " ")
+            .trim()
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverter.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverter.kt
@@ -30,7 +30,7 @@ import net.corda.ledger.persistence.query.impl.parsing.Where
 
 class PostgresVaultNamedQueryConverter : VaultNamedQueryConverter {
 
-    override fun convert(output: StringBuilder, expression: List<Token>): StringBuilder {
+    override fun convert(output: StringBuilder, expression: List<Token>) {
         for (token in expression) {
             when (token) {
                 is PathReference -> output.append(token.ref)
@@ -67,6 +67,5 @@ class PostgresVaultNamedQueryConverter : VaultNamedQueryConverter {
                 else -> throw IllegalArgumentException("Invalid token in expression - $token")
             }
         }
-        return output
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverter.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverter.kt
@@ -1,0 +1,72 @@
+package net.corda.ledger.persistence.query.impl.parsing.converters
+
+import net.corda.ledger.persistence.query.impl.parsing.And
+import net.corda.ledger.persistence.query.impl.parsing.As
+import net.corda.ledger.persistence.query.impl.parsing.Equals
+import net.corda.ledger.persistence.query.impl.parsing.From
+import net.corda.ledger.persistence.query.impl.parsing.GreaterThan
+import net.corda.ledger.persistence.query.impl.parsing.GreaterThanEquals
+import net.corda.ledger.persistence.query.impl.parsing.In
+import net.corda.ledger.persistence.query.impl.parsing.IsNotNull
+import net.corda.ledger.persistence.query.impl.parsing.IsNull
+import net.corda.ledger.persistence.query.impl.parsing.JsonArrayOrObjectAsText
+import net.corda.ledger.persistence.query.impl.parsing.JsonCast
+import net.corda.ledger.persistence.query.impl.parsing.JsonKeyExists
+import net.corda.ledger.persistence.query.impl.parsing.LeftParentheses
+import net.corda.ledger.persistence.query.impl.parsing.LessThan
+import net.corda.ledger.persistence.query.impl.parsing.LessThanEquals
+import net.corda.ledger.persistence.query.impl.parsing.Like
+import net.corda.ledger.persistence.query.impl.parsing.NotEquals
+import net.corda.ledger.persistence.query.impl.parsing.Number
+import net.corda.ledger.persistence.query.impl.parsing.Or
+import net.corda.ledger.persistence.query.impl.parsing.Parameter
+import net.corda.ledger.persistence.query.impl.parsing.ParameterEnd
+import net.corda.ledger.persistence.query.impl.parsing.PathReference
+import net.corda.ledger.persistence.query.impl.parsing.PathReferenceWithSpaces
+import net.corda.ledger.persistence.query.impl.parsing.RightParentheses
+import net.corda.ledger.persistence.query.impl.parsing.Select
+import net.corda.ledger.persistence.query.impl.parsing.Token
+import net.corda.ledger.persistence.query.impl.parsing.Where
+
+class PostgresVaultNamedQueryConverter : VaultNamedQueryConverter {
+
+    override fun convert(output: StringBuilder, expression: List<Token>): StringBuilder {
+        for (token in expression) {
+            when (token) {
+                is PathReference -> output.append(token.ref)
+                is PathReferenceWithSpaces -> output.append(token.ref)
+                is Parameter -> output.append(token.ref)
+                is Number -> output.append(token.ref)
+                is JsonArrayOrObjectAsText -> output.append(" ->> ")
+                is Select -> output.append(" SELECT ")
+                is As -> output.append(" AS ")
+                is From -> output.append(" FROM ")
+                is Where -> output.append(" WHERE ")
+                is And -> output.append(" AND ")
+                is Or -> output.append(" OR ")
+                is Equals -> output.append(" = ")
+                is NotEquals -> output.append(" != ")
+                is GreaterThan -> output.append(" > ")
+                is GreaterThanEquals -> output.append(" >= ")
+                is LessThan -> output.append(" < ")
+                is LessThanEquals -> output.append(" <= ")
+                is In -> output.append(" IN ")
+                is IsNull -> output.append(" IS NULL ")
+                is IsNotNull -> output.append(" IS NOT NULL ")
+                is LeftParentheses -> output.append("(")
+                is RightParentheses -> {
+                    if (output.lastOrNull()?.isWhitespace() == true) {
+                        output.deleteAt(output.length - 1)
+                    }
+                    output.append(")")
+                }
+                is JsonKeyExists -> output.append(" ? ")
+                is JsonCast -> output.append("::${token.value}")
+                is Like -> output.append(" LIKE ")
+                is ParameterEnd -> output.append(", ")
+                else -> throw IllegalArgumentException("Invalid token in expression - $token")
+            }
+        }
+        return output
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/VaultNamedQueryConverter.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/VaultNamedQueryConverter.kt
@@ -2,7 +2,16 @@ package net.corda.ledger.persistence.query.impl.parsing.converters
 
 import net.corda.ledger.persistence.query.impl.parsing.Token
 
+/**
+ * [VaultNamedQueryConverter] converts an expression in [Token] form into a database specific query.
+ */
 interface VaultNamedQueryConverter {
 
-    fun convert(output: StringBuilder, expression: List<Token>): StringBuilder
+    /**
+     * Converts an expression in [Token] form into a database specific query.
+     *
+     * @param output A [StringBuilder] that the output query should be appended to.
+     * @param expression A list of [Token]s that represent the parsed query to be converted.
+     */
+    fun convert(output: StringBuilder, expression: List<Token>)
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/VaultNamedQueryConverter.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/VaultNamedQueryConverter.kt
@@ -1,0 +1,8 @@
+package net.corda.ledger.persistence.query.impl.parsing.converters
+
+import net.corda.ledger.persistence.query.impl.parsing.Token
+
+interface VaultNamedQueryConverter {
+
+    fun convert(output: StringBuilder, expression: List<Token>): StringBuilder
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
@@ -16,6 +16,7 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
         """(?<str>('[^']*)'|("[^"]*)")"""
     )
 
+    @Suppress("MaxLineLength")
     private val pathPattern = Regex(
         """(?<path>(\$?[a-zA-Z_][a-zA-Z0-9_]*(\[([0-9]+|"[a-zA-Z_][a-zA-Z0-9_]*")])?)(\.[a-zA-Z_][a-zA-Z0-9_]*(\[([0-9]+|"[a-zA-Z_][a-zA-Z0-9_]*")])?)*)"""
     )
@@ -24,7 +25,7 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
         """(?<num>[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?)"""
     )
 
-    // like? need to keep % in that case
+    @Suppress("MaxLineLength")
     private val opsPattern = Regex(
         """(?<op>(->>)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
     )
@@ -33,6 +34,7 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
 
     private val parameterPattern = Regex("""(?<parameter>:[^:]\S+)""")
 
+    @Suppress("NestedBlockDepth")
     override fun parse(query: String): List<Token> {
         val outputTokens = mutableListOf<Token>()
         var index = 0

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
@@ -1,0 +1,120 @@
+package net.corda.ledger.persistence.query.impl.parsing.expressions
+
+import net.corda.ledger.persistence.query.impl.parsing.JsonCast
+import net.corda.ledger.persistence.query.impl.parsing.LeftParentheses
+import net.corda.ledger.persistence.query.impl.parsing.Number
+import net.corda.ledger.persistence.query.impl.parsing.Parameter
+import net.corda.ledger.persistence.query.impl.parsing.ParameterEnd
+import net.corda.ledger.persistence.query.impl.parsing.PathReference
+import net.corda.ledger.persistence.query.impl.parsing.PathReferenceWithSpaces
+import net.corda.ledger.persistence.query.impl.parsing.RightParentheses
+import net.corda.ledger.persistence.query.impl.parsing.Token
+import net.corda.ledger.persistence.query.impl.parsing.operatorFactory
+
+class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser {
+    private val stringPattern = Regex(
+        """(?<str>('[^']*)'|("[^"]*)")"""
+    )
+
+    private val pathPattern = Regex(
+        """(?<path>(\$?[a-zA-Z_][a-zA-Z0-9_]*(\[([0-9]+|"[a-zA-Z_][a-zA-Z0-9_]*")])?)(\.[a-zA-Z_][a-zA-Z0-9_]*(\[([0-9]+|"[a-zA-Z_][a-zA-Z0-9_]*")])?)*)"""
+    )
+
+    private val numberPattern = Regex(
+        """(?<num>[0-9]+(\.[0-9]+)?([eE]-?[0-9]+)?)"""
+    )
+
+    // like? need to keep % in that case
+    private val opsPattern = Regex(
+        """(?<op>(->>)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
+    )
+
+    private val jsonCastPattern = Regex("""(?<cast>::.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s)""")
+
+    private val parameterPattern = Regex("""(?<parameter>:[^:]\S+)""")
+
+    override fun parse(query: String): List<Token> {
+        val outputTokens = mutableListOf<Token>()
+        var index = 0
+        while (index < query.length) {
+            if (query[index].isWhitespace() || query[index] == '\n') {
+                ++index
+                continue
+            }
+            val strMatch = stringPattern.find(query, index)
+            if (strMatch != null && strMatch.range.first == index) {
+                val str = strMatch.groups["str"]
+                if (str != null) {
+                    outputTokens += when {
+                        " " !in str.value -> PathReference(str.value)
+                        else -> PathReferenceWithSpaces(str.value)
+                    }
+                    index = strMatch.range.last + 1
+                    continue
+                }
+            }
+            if (query[index] == '(') {
+                outputTokens += LeftParentheses()
+                ++index
+                continue
+            }
+            if (query[index] == ')') {
+                outputTokens += RightParentheses()
+                ++index
+                continue
+            }
+            if (query[index] == ',') {
+                outputTokens += ParameterEnd()
+                ++index
+                continue
+            }
+            val opsMatch = opsPattern.find(query, index)
+            if (opsMatch != null && opsMatch.range.first == index) {
+                val ops = opsMatch.groups["op"]
+                if (ops != null) {
+                    outputTokens += operatorFactory(ops.value)
+                    index = opsMatch.range.last + 1
+                    continue
+                }
+            }
+            val jsonCastMatch = jsonCastPattern.find(query, index)
+            if (jsonCastMatch != null && jsonCastMatch.range.first == index) {
+                val cast = jsonCastMatch.groups["cast"]
+                if (cast != null) {
+                    outputTokens += JsonCast(cast.value.removePrefix("::"))
+                    index = cast.range.last + 1
+                    continue
+                }
+            }
+            val parameterMatch = parameterPattern.find(query, index)
+            if (parameterMatch != null && parameterMatch.range.first == index) {
+                val cast = parameterMatch.groups["parameter"]
+                if (cast != null) {
+                    outputTokens += Parameter(cast.value)
+                    index = parameterMatch.range.last + 1
+                    continue
+                }
+            }
+            val pathMatch = pathPattern.find(query, index)
+            if (pathMatch != null && pathMatch.range.first == index) {
+                val path = pathMatch.groups["path"]
+                if (path != null) {
+                    outputTokens += PathReference(path.value)
+                    index = pathMatch.range.last + 1
+                    continue
+                }
+            }
+            val numberMatch = numberPattern.find(query, index)
+            if (numberMatch != null && numberMatch.range.first == index) {
+                val number = numberMatch.groups["num"]
+                if (number != null) {
+                    outputTokens += Number(number.value)
+                    index = numberMatch.range.last + 1
+                    continue
+                }
+            }
+            throw IllegalArgumentException("Unexpected input index: $index, value: (${query[index]}), query: ($query)")
+        }
+        return outputTokens
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
@@ -61,8 +61,8 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
                 ++index
                 continue
             }
-            val strMatch = stringPattern.find(query, index)
-            if (strMatch != null && strMatch.range.first == index) {
+            val strMatch = stringPattern.matchAt(query, index)
+            if (strMatch != null) {
                 val str = strMatch.groups["str"]
                 if (str != null) {
                     outputTokens += when {
@@ -88,8 +88,8 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
                 ++index
                 continue
             }
-            val opsMatch = opsPattern.find(query, index)
-            if (opsMatch != null && opsMatch.range.first == index) {
+            val opsMatch = opsPattern.matchAt(query, index)
+            if (opsMatch != null) {
                 val ops = opsMatch.groups["op"]
                 if (ops != null) {
                     outputTokens += toKeyword(ops.value)
@@ -97,8 +97,8 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
                     continue
                 }
             }
-            val jsonCastMatch = jsonCastPattern.find(query, index)
-            if (jsonCastMatch != null && jsonCastMatch.range.first == index) {
+            val jsonCastMatch = jsonCastPattern.matchAt(query, index)
+            if (jsonCastMatch != null) {
                 val cast = jsonCastMatch.groups["cast"]
                 if (cast != null) {
                     outputTokens += JsonCast(cast.value)
@@ -106,8 +106,8 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
                     continue
                 }
             }
-            val parameterMatch = parameterPattern.find(query, index)
-            if (parameterMatch != null && parameterMatch.range.first == index) {
+            val parameterMatch = parameterPattern.matchAt(query, index)
+            if (parameterMatch != null) {
                 val cast = parameterMatch.groups["parameter"]
                 if (cast != null) {
                     outputTokens += Parameter(cast.value)
@@ -115,8 +115,8 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
                     continue
                 }
             }
-            val pathMatch = pathPattern.find(query, index)
-            if (pathMatch != null && pathMatch.range.first == index) {
+            val pathMatch = pathPattern.matchAt(query, index)
+            if (pathMatch != null) {
                 val path = pathMatch.groups["path"]
                 if (path != null) {
                     outputTokens += PathReference(path.value)
@@ -124,8 +124,8 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
                     continue
                 }
             }
-            val numberMatch = numberPattern.find(query, index)
-            if (numberMatch != null && numberMatch.range.first == index) {
+            val numberMatch = numberPattern.matchAt(query, index)
+            if (numberMatch != null) {
                 val number = numberMatch.groups["num"]
                 if (number != null) {
                     outputTokens += Number(number.value)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
@@ -48,7 +48,7 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
         """(?<op>(->>)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
     )
 
-    private val jsonCastPattern = Regex("""(?<cast>::.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s)""")
+    private val jsonCastPattern = Regex("""::(?<cast>.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s|$)""")
 
     private val parameterPattern = Regex("""(?<parameter>:[^:]\S+)""")
 
@@ -101,7 +101,7 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
             if (jsonCastMatch != null && jsonCastMatch.range.first == index) {
                 val cast = jsonCastMatch.groups["cast"]
                 if (cast != null) {
-                    outputTokens += JsonCast(cast.value.removePrefix("::"))
+                    outputTokens += JsonCast(cast.value)
                     index = cast.range.last + 1
                     continue
                 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionParser.kt
@@ -2,7 +2,18 @@ package net.corda.ledger.persistence.query.impl.parsing.expressions
 
 import net.corda.ledger.persistence.query.impl.parsing.Token
 
+/**
+ * [VaultNamedQueryExpressionParser] parses query strings into an expression of [Token]s that can be later converted into a database
+ * specific query string.
+ */
 interface VaultNamedQueryExpressionParser {
 
+    /**
+     * Parses a query string into an expression of [Token]s.
+     *
+     * @param query The query to parse.
+     *
+     * @return A list of [Token]s representing the parsed query.
+     */
     fun parse(query: String): List<Token>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionParser.kt
@@ -1,0 +1,8 @@
+package net.corda.ledger.persistence.query.impl.parsing.expressions
+
+import net.corda.ledger.persistence.query.impl.parsing.Token
+
+interface VaultNamedQueryExpressionParser {
+
+    fun parse(query: String): List<Token>
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidator.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidator.kt
@@ -1,0 +1,8 @@
+package net.corda.ledger.persistence.query.impl.parsing.expressions
+
+import net.corda.ledger.persistence.query.impl.parsing.Token
+
+interface VaultNamedQueryExpressionValidator {
+
+    fun validateWhereJson(query: String, expression: List<Token>)
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidator.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidator.kt
@@ -2,7 +2,16 @@ package net.corda.ledger.persistence.query.impl.parsing.expressions
 
 import net.corda.ledger.persistence.query.impl.parsing.Token
 
+/**
+ * [VaultNamedQueryExpressionValidator] validates an expression.
+ */
 interface VaultNamedQueryExpressionValidator {
 
+    /**
+     * Validates a `whereJson` expression.
+     *
+     * @param query The original query before it was parsed.
+     * @param expression The parsed expression to validate.
+     */
     fun validateWhereJson(query: String, expression: List<Token>)
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidatorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidatorImpl.kt
@@ -1,0 +1,21 @@
+package net.corda.ledger.persistence.query.impl.parsing.expressions
+
+import net.corda.ledger.persistence.query.impl.parsing.From
+import net.corda.ledger.persistence.query.impl.parsing.Select
+import net.corda.ledger.persistence.query.impl.parsing.Token
+
+class VaultNamedQueryExpressionValidatorImpl : VaultNamedQueryExpressionValidator {
+
+    override fun validateWhereJson(query: String, expression: List<Token>) {
+        for (token in expression) {
+            when (token) {
+                is Select -> throw exception(query, "SELECT")
+                is From -> throw exception(query, "FROM")
+            }
+        }
+    }
+
+    private fun exception(query: String, keyword: String): IllegalArgumentException {
+        return IllegalArgumentException("Vault named queries cannot contain the $keyword keyword. Query: $query")
+    }
+}

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderFactoryImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryBuilderFactoryImplTest.kt
@@ -1,23 +1,26 @@
-package net.corda.ledger.persistence.query
+package net.corda.ledger.persistence.query.impl
 
-import net.corda.ledger.persistence.query.impl.VaultNamedQuery
-import net.corda.ledger.persistence.query.impl.VaultNamedQueryBuilderFactoryImpl
+import net.corda.ledger.persistence.query.VaultNamedQueryRegistry
+import net.corda.ledger.persistence.query.impl.parsing.VaultNamedQueryParser
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryCollector
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryFilter
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryTransformer
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class VaultNamedQueryBuilderFactoryImplTest {
 
     private companion object {
         const val DUMMY_QUERY_NAME = "dummy"
-        const val DUMMY_WHERE_CLAUSE = "WHERE custom ->> 'TestUtxoState.testField' = :testField"
+        const val DUMMY_WHERE_CLAUSE = "original"
+        const val PARSED_WHERE_CLAUSE = "parsed"
     }
 
     private val storedQueries = mutableListOf<VaultNamedQuery>()
@@ -27,6 +30,7 @@ class VaultNamedQueryBuilderFactoryImplTest {
             Unit
         }
     }
+    private val vaultNamedQueryParser = mock<VaultNamedQueryParser>()
 
     @BeforeEach
     fun clear() {
@@ -39,7 +43,9 @@ class VaultNamedQueryBuilderFactoryImplTest {
         val mockMapper = mock<VaultNamedQueryTransformer<ContractState, DummyPojo>>()
         val mockCollector = mock<VaultNamedQueryCollector<DummyPojo, Int>>()
 
-        VaultNamedQueryBuilderFactoryImpl(mockRegistry)
+        whenever(vaultNamedQueryParser.parseWhereJson(DUMMY_WHERE_CLAUSE)).thenReturn(PARSED_WHERE_CLAUSE)
+
+        VaultNamedQueryBuilderFactoryImpl(mockRegistry, vaultNamedQueryParser)
             .create(DUMMY_QUERY_NAME)
             .whereJson(DUMMY_WHERE_CLAUSE)
             .map(mockMapper)
@@ -53,28 +59,25 @@ class VaultNamedQueryBuilderFactoryImplTest {
 
         assertThat(storedQuery).isNotNull
         assertThat(storedQuery.name).isEqualTo(DUMMY_QUERY_NAME)
-        assertThat(storedQuery.jsonString).isEqualTo(DUMMY_WHERE_CLAUSE)
+        assertThat(storedQuery.query).isEqualTo(
+            VaultNamedQuery.ParsedQuery(
+                DUMMY_WHERE_CLAUSE,
+                PARSED_WHERE_CLAUSE,
+                VaultNamedQuery.Type.WHERE_JSON
+            )
+        )
         assertThat(storedQuery.filter).isNotNull
         assertThat(storedQuery.mapper).isNotNull
         assertThat(storedQuery.collector).isNotNull
     }
 
     @Test
-    fun `builder will register a query that only has a name`() {
-        VaultNamedQueryBuilderFactoryImpl(mockRegistry)
-            .create(DUMMY_QUERY_NAME)
-            .register()
-
-        assertThat(storedQueries).hasSize(1)
-
-        val storedQuery = storedQueries.first()
-
-        assertThat(storedQuery).isNotNull
-        assertThat(storedQuery.name).isEqualTo(DUMMY_QUERY_NAME)
-        assertThat(storedQuery.jsonString).isNull()
-        assertThat(storedQuery.filter).isNull()
-        assertThat(storedQuery.mapper).isNull()
-        assertThat(storedQuery.collector).isNull()
+    fun `builder will not register a query that only has a name`() {
+        assertThatThrownBy {
+            VaultNamedQueryBuilderFactoryImpl(mockRegistry)
+                .create(DUMMY_QUERY_NAME)
+                .register()
+        }.isExactlyInstanceOf(IllegalArgumentException::class.java)
     }
 
 

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryRegistryImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/VaultNamedQueryRegistryImplTest.kt
@@ -1,7 +1,5 @@
-package net.corda.ledger.persistence.query
+package net.corda.ledger.persistence.query.impl
 
-import net.corda.ledger.persistence.query.impl.VaultNamedQuery
-import net.corda.ledger.persistence.query.impl.VaultNamedQueryRegistryImpl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -12,12 +10,16 @@ class VaultNamedQueryRegistryImplTest {
 
     private companion object {
         const val DUMMY_QUERY_NAME = "DUMMY"
-        const val DUMMY_JSON_QUERY = "WHERE custom ->> 'TestUtxoState.testField' = :testField"
+        val DUMMY_JSON_QUERY = VaultNamedQuery.ParsedQuery(
+            originalQuery = "WHERE custom ->> 'TestUtxoState.testField' = :testField",
+            query ="WHERE custom ->> 'TestUtxoState.testField' = :testField",
+            VaultNamedQuery.Type.WHERE_JSON
+        )
     }
 
     private val mockNamedQuery = mock<VaultNamedQuery> {
         on { name } doReturn DUMMY_QUERY_NAME
-        on { jsonString } doReturn DUMMY_JSON_QUERY
+        on { query } doReturn DUMMY_JSON_QUERY
     }
 
     @Test
@@ -31,7 +33,7 @@ class VaultNamedQueryRegistryImplTest {
         assertThat(storedNamedQuery).isNotNull
         assertThat(storedNamedQuery?.name).isNotNull
         assertThat(storedNamedQuery?.name).isEqualTo(DUMMY_QUERY_NAME)
-        assertThat(storedNamedQuery?.jsonString).isEqualTo(DUMMY_JSON_QUERY)
+        assertThat(storedNamedQuery?.query).isEqualTo(DUMMY_JSON_QUERY)
     }
 
     @Test

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
@@ -1,0 +1,115 @@
+package net.corda.ledger.persistence.query.impl.parsing
+
+import net.corda.ledger.persistence.query.impl.parsing.converters.PostgresVaultNamedQueryConverter
+import net.corda.ledger.persistence.query.impl.parsing.expressions.PostgresVaultNamedQueryExpressionParser
+import net.corda.ledger.persistence.query.impl.parsing.expressions.VaultNamedQueryExpressionValidatorImpl
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class PostgresVaultNamedQueryParserIntegrationTest {
+
+    private val vaultNamedQueryParser = VaultNamedQueryParserImpl(
+        PostgresVaultNamedQueryExpressionParser(),
+        VaultNamedQueryExpressionValidatorImpl(),
+        PostgresVaultNamedQueryConverter()
+    )
+
+    private companion object {
+        @JvmStatic
+        fun inputsToOutputs(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of("WHERE non_json_column = 'some_value'", "WHERE non_json_column = 'some_value'"),
+                Arguments.of("WHERE field ->> property = 'some_value'", "WHERE field ->> property = 'some_value'"),
+                Arguments.of("WHERE field ->> property = :value", "WHERE field ->> property = :value"),
+                Arguments.of(
+                    "WHERE \"field name\" ->> \"json property\" = 'some_value'",
+                    "WHERE \"field name\" ->> \"json property\" = 'some_value'"
+                ),
+                Arguments.of("WHERE (field ->> property)::int = 5", "WHERE (field ->> property)::int = 5"),
+                Arguments.of("WHERE (field ->> property)::int != 5", "WHERE (field ->> property)::int != 5"),
+                Arguments.of("WHERE (field ->> property)::int < 5", "WHERE (field ->> property)::int < 5"),
+                Arguments.of("WHERE (field ->> property)::int <= 5", "WHERE (field ->> property)::int <= 5"),
+                Arguments.of("WHERE (field ->> property)::int > 5", "WHERE (field ->> property)::int > 5"),
+                Arguments.of("WHERE (field ->> property)::int >= 5", "WHERE (field ->> property)::int >= 5"),
+                Arguments.of("WHERE (field ->> property)::int <= :value", "WHERE (field ->> property)::int <= :value"),
+                Arguments.of("WHERE (field ->> property)::int = 1234.5678900", "WHERE (field ->> property)::int = 1234.5678900"),
+
+                Arguments.of(
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value'",
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value'"
+                ),
+                Arguments.of(
+                    "WHERE field ->> property = 'some_value' OR field ->> property2 = 'another value'",
+                    "WHERE field ->> property = 'some_value' OR field ->> property2 = 'another value'"
+                ),
+                Arguments.of(
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value' OR field ->> property3 = 'third property'",
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value' OR field ->> property3 = 'third property'"
+                ),
+                Arguments.of(
+                    "WHERE (field ->> property = 'some_value' AND field ->> property2 = 'another value') OR field ->> property3 = 'third property'",
+                    "WHERE (field ->> property = 'some_value' AND field ->> property2 = 'another value') OR field ->> property3 = 'third property'"
+                ),
+                Arguments.of(
+                    "WHERE field ->> property = 'some_value' AND (field ->> property2 = 'another value') OR field ->> property3 = 'third property')",
+                    "WHERE field ->> property = 'some_value' AND (field ->> property2 = 'another value') OR field ->> property3 = 'third property')"
+                ),
+                Arguments.of(
+                    "WHERE (field ->> property = 'some_value' AND (field ->> property2 = 'another value') OR field ->> property3 = 'third property'))",
+                    "WHERE (field ->> property = 'some_value' AND (field ->> property2 = 'another value') OR field ->> property3 = 'third property'))"
+                ),
+                Arguments.of("WHERE field ->> property IS NULL", "WHERE field ->> property IS NULL"),
+                Arguments.of("WHERE field ->> property IS NOT NULL", "WHERE field ->> property IS NOT NULL"),
+                Arguments.of(
+                    "WHERE field ->> property IN ('asd', 'fields value', 'asd')",
+                    "WHERE field ->> property IN ('asd', 'fields value', 'asd')"
+                ),
+                Arguments.of(
+                    "WHERE (field ->> property IN ('asd', 'fields value', 'asd') AND field ->> property2 = 'another value')",
+                    "WHERE (field ->> property IN ('asd', 'fields value', 'asd') AND field ->> property2 = 'another value')"
+                ),
+                Arguments.of(
+                    "WHERE (field ->> property LIKE '%hello there%')",
+                    "WHERE (field ->> property LIKE '%hello there%')"
+                ),
+                Arguments.of(
+                    """
+                        where
+                            ("custom"->>'salary'='10'
+                            and (custom ->> 'salary')::int>9.00000000
+                            or custom ->> 'field with space' is null)
+                    """,
+                    "WHERE (\"custom\" ->> 'salary' = '10' AND (custom ->> 'salary')::int > 9.00000000 OR custom ->> 'field with space' IS NULL)"
+                ),
+                Arguments.of(
+                    """WHERE custom ->> 'TestUtxoState.testField' = :testField
+                        |AND custom ->> 'Corda.participants' IN :participants
+                        |AND custom?:contractStateType
+                        |AND created > :created""".trimMargin(),
+                    "WHERE custom ->> 'TestUtxoState.testField' = :testField AND custom ->> 'Corda.participants' IN :participants AND custom ? :contractStateType AND created > :created"
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputsToOutputs")
+    fun `queries are parsed from a postgres query and output back into a postgres query`(input: String, output: String) {
+        assertThat(vaultNamedQueryParser.parseWhereJson(input)).isEqualTo(output)
+    }
+
+    @Test
+    fun `queries containing a select throws an exception`() {
+        assertThatThrownBy { vaultNamedQueryParser.parseWhereJson("SELECT field") }.isExactlyInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `queries containing a from throws an exception`() {
+        assertThatThrownBy { vaultNamedQueryParser.parseWhereJson("FROM table") }.isExactlyInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
+@Suppress("MaxLineLength")
 class PostgresVaultNamedQueryParserIntegrationTest {
 
     private val vaultNamedQueryParser = VaultNamedQueryParserImpl(

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImplTest.kt
@@ -6,10 +6,11 @@ import net.corda.ledger.persistence.query.impl.parsing.expressions.VaultNamedQue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.lang.StringBuilder
 
 class VaultNamedQueryParserImplTest {
 
@@ -21,6 +22,7 @@ class VaultNamedQueryParserImplTest {
     private val expressionParser = mock<VaultNamedQueryExpressionParser>()
     private val expressionValidator = mock<VaultNamedQueryExpressionValidator>()
     private val converter = mock<VaultNamedQueryConverter>()
+    private val stringBuilderCaptor = argumentCaptor<StringBuilder>()
     private val postgresVaultNamedQueryParser = VaultNamedQueryParserImpl(expressionParser, expressionValidator, converter)
 
     @Test
@@ -28,16 +30,27 @@ class VaultNamedQueryParserImplTest {
         val expression = listOf(PATH_REFERENCE)
         val output = "output"
         whenever(expressionParser.parse(QUERY)).thenReturn(expression)
-        whenever(converter.convert(any(), any())).thenReturn(StringBuilder(output))
+        whenever(
+            converter.convert(
+                stringBuilderCaptor.capture(),
+                any()
+            )
+        ).then { stringBuilderCaptor.firstValue.append(output) }
         assertThat(postgresVaultNamedQueryParser.parseWhereJson(QUERY)).isEqualTo(output)
         verify(expressionParser).parse(QUERY)
         verify(expressionValidator).validateWhereJson(QUERY, expression)
+        verify(converter).convert(any(), eq(expression))
     }
 
     @Test
     fun `repeated spaces and leading and trailing whitespace are not included in the output`() {
         whenever(expressionParser.parse(any())).thenReturn(listOf())
-        whenever(converter.convert(any(), any())).thenReturn(StringBuilder(" SELECT  FROM  WHERE  IS NOT NULL "))
+        whenever(
+            converter.convert(
+                stringBuilderCaptor.capture(),
+                any()
+            )
+        ).then { stringBuilderCaptor.firstValue.append(" SELECT  FROM  WHERE  IS NOT NULL ") }
         assertThat(postgresVaultNamedQueryParser.parseWhereJson(QUERY)).isEqualTo("SELECT FROM WHERE IS NOT NULL")
     }
 }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/VaultNamedQueryParserImplTest.kt
@@ -1,0 +1,43 @@
+package net.corda.ledger.persistence.query.impl.parsing
+
+import net.corda.ledger.persistence.query.impl.parsing.converters.VaultNamedQueryConverter
+import net.corda.ledger.persistence.query.impl.parsing.expressions.VaultNamedQueryExpressionParser
+import net.corda.ledger.persistence.query.impl.parsing.expressions.VaultNamedQueryExpressionValidator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.lang.StringBuilder
+
+class VaultNamedQueryParserImplTest {
+
+    private companion object {
+        const val QUERY = "my query"
+        val PATH_REFERENCE = PathReference("field")
+    }
+
+    private val expressionParser = mock<VaultNamedQueryExpressionParser>()
+    private val expressionValidator = mock<VaultNamedQueryExpressionValidator>()
+    private val converter = mock<VaultNamedQueryConverter>()
+    private val postgresVaultNamedQueryParser = VaultNamedQueryParserImpl(expressionParser, expressionValidator, converter)
+
+    @Test
+    fun `parses query and validates it`() {
+        val expression = listOf(PATH_REFERENCE)
+        val output = "output"
+        whenever(expressionParser.parse(QUERY)).thenReturn(expression)
+        whenever(converter.convert(any(), any())).thenReturn(StringBuilder(output))
+        assertThat(postgresVaultNamedQueryParser.parseWhereJson(QUERY)).isEqualTo(output)
+        verify(expressionParser).parse(QUERY)
+        verify(expressionValidator).validateWhereJson(QUERY, expression)
+    }
+
+    @Test
+    fun `repeated spaces and leading and trailing whitespace are not included in the output`() {
+        whenever(expressionParser.parse(any())).thenReturn(listOf())
+        whenever(converter.convert(any(), any())).thenReturn(StringBuilder(" SELECT  FROM  WHERE  IS NOT NULL "))
+        assertThat(postgresVaultNamedQueryParser.parseWhereJson(QUERY)).isEqualTo("SELECT FROM WHERE IS NOT NULL")
+    }
+}

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverterTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverterTest.kt
@@ -1,0 +1,266 @@
+package net.corda.ledger.persistence.query.impl.parsing.converters
+
+import net.corda.ledger.persistence.query.impl.parsing.And
+import net.corda.ledger.persistence.query.impl.parsing.As
+import net.corda.ledger.persistence.query.impl.parsing.Equals
+import net.corda.ledger.persistence.query.impl.parsing.From
+import net.corda.ledger.persistence.query.impl.parsing.GreaterThan
+import net.corda.ledger.persistence.query.impl.parsing.GreaterThanEquals
+import net.corda.ledger.persistence.query.impl.parsing.In
+import net.corda.ledger.persistence.query.impl.parsing.IsNotNull
+import net.corda.ledger.persistence.query.impl.parsing.IsNull
+import net.corda.ledger.persistence.query.impl.parsing.JsonArrayOrObjectAsText
+import net.corda.ledger.persistence.query.impl.parsing.JsonCast
+import net.corda.ledger.persistence.query.impl.parsing.JsonKeyExists
+import net.corda.ledger.persistence.query.impl.parsing.LeftParentheses
+import net.corda.ledger.persistence.query.impl.parsing.LessThan
+import net.corda.ledger.persistence.query.impl.parsing.LessThanEquals
+import net.corda.ledger.persistence.query.impl.parsing.NotEquals
+import net.corda.ledger.persistence.query.impl.parsing.Number
+import net.corda.ledger.persistence.query.impl.parsing.Or
+import net.corda.ledger.persistence.query.impl.parsing.Parameter
+import net.corda.ledger.persistence.query.impl.parsing.ParameterEnd
+import net.corda.ledger.persistence.query.impl.parsing.PathReference
+import net.corda.ledger.persistence.query.impl.parsing.PathReferenceWithSpaces
+import net.corda.ledger.persistence.query.impl.parsing.RightParentheses
+import net.corda.ledger.persistence.query.impl.parsing.Select
+import net.corda.ledger.persistence.query.impl.parsing.Token
+import net.corda.ledger.persistence.query.impl.parsing.Where
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class PostgresVaultNamedQueryConverterTest {
+
+    private companion object {
+        val PATH_REFERENCE = PathReference("field")
+    }
+
+    private val postgresVaultNamedQueryParser = PostgresVaultNamedQueryConverter()
+
+    private val output = StringBuilder("")
+
+    @Test
+    fun `PathReference is appended directly to the output with no spaces`() {
+        val expression = listOf(PATH_REFERENCE)
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("field")
+    }
+
+    @Test
+    fun `PathReferenceWithSpace is appended directly to the output with no spaces`() {
+        val expression = listOf(PathReferenceWithSpaces("'field name'"))
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("'field name'")
+    }
+
+    @Test
+    fun `Parameter is appended directly to the output with no spaces`() {
+        val expression = listOf(Parameter(":parameter"))
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(":parameter")
+    }
+
+    @Test
+    fun `Number is appended directly to the output with no spaces`() {
+        val expression = listOf(Number("1"))
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("1")
+    }
+
+    @Test
+    fun `JsonArrayOrObjectAsText is appended to the output with a space on either side`() {
+        val expression =
+            listOf(
+                PATH_REFERENCE,
+                JsonArrayOrObjectAsText(),
+                PATH_REFERENCE
+            )
+
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} ->> ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `Select is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, Select(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} SELECT ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `As is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, As(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} AS ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `From is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, From(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} FROM ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `Where is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, Where(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} WHERE ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `And is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, And(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} AND ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `Or is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, Or(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} OR ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `Equals is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, Equals(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} = ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `NotEquals is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, NotEquals(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} != ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `GreaterThan is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, GreaterThan(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} > ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `GreaterThanEquals is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, GreaterThanEquals(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} >= ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `LessThan is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, LessThan(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} < ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `LessThanEquals is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, LessThanEquals(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} <= ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `In is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, In(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} IN ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `IsNull is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, IsNull(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} IS NULL ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `IsNotNull is appended to the output with a space on either side`() {
+        val expression = listOf(PATH_REFERENCE, IsNotNull(), PATH_REFERENCE)
+        assertThat(
+            postgresVaultNamedQueryParser.convert(output, expression)
+                .toString()
+        ).isEqualTo("${PATH_REFERENCE.ref} IS NOT NULL ${PATH_REFERENCE.ref}")
+    }
+
+    @Test
+    fun `LeftParentheses is appended directly to the output with no spaces`() {
+        val expression = listOf(LeftParentheses())
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("(")
+    }
+
+    @Test
+    fun `RightParentheses is appended directly to the output with no spaces`() {
+        val expression = listOf(RightParentheses())
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(")")
+    }
+
+    @Test
+    fun `RightParentheses removes last space to the left if previous token was a keyword`() {
+        val expression1 = listOf(IsNull(), RightParentheses())
+        val expression2 = listOf(IsNotNull(), RightParentheses())
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression1).toString()).isEqualTo(" IS NULL)")
+        output.clear()
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression2).toString()).isEqualTo(" IS NOT NULL)")
+    }
+
+    @Test
+    fun `JsonCast is appended directly to the output with no spaces`() {
+        val expression = listOf(JsonCast("int"))
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("::int")
+    }
+
+    @Test
+    fun `JsonKeyExists is appended to the output with a space on either side`() {
+        val expression = listOf(JsonKeyExists())
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(" ? ")
+    }
+
+    @Test
+    fun `ParameterEnd is appended with a space on its right`() {
+        val expression = listOf(ParameterEnd())
+        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(", ")
+    }
+
+    @Test
+    fun `unexpected token throws an exception`() {
+        val expression = listOf(object : Token {})
+        assertThatThrownBy { postgresVaultNamedQueryParser.convert(output, expression) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `empty expressions return an empty output`() {
+        assertThat(postgresVaultNamedQueryParser.convert(output, emptyList()).toString()).isEqualTo("")
+    }
+}

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverterTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverterTest.kt
@@ -43,25 +43,29 @@ class PostgresVaultNamedQueryConverterTest {
     @Test
     fun `PathReference is appended directly to the output with no spaces`() {
         val expression = listOf(PATH_REFERENCE)
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("field")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("field")
     }
 
     @Test
     fun `PathReferenceWithSpace is appended directly to the output with no spaces`() {
         val expression = listOf(PathReferenceWithSpaces("'field name'"))
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("'field name'")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("'field name'")
     }
 
     @Test
     fun `Parameter is appended directly to the output with no spaces`() {
         val expression = listOf(Parameter(":parameter"))
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(":parameter")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo(":parameter")
     }
 
     @Test
     fun `Number is appended directly to the output with no spaces`() {
         val expression = listOf(Number("1"))
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("1")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("1")
     }
 
     @Test
@@ -73,184 +77,157 @@ class PostgresVaultNamedQueryConverterTest {
                 PATH_REFERENCE
             )
 
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} ->> ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} ->> ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `Select is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, Select(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} SELECT ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} SELECT ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `As is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, As(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} AS ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} AS ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `From is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, From(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} FROM ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} FROM ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `Where is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, Where(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} WHERE ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} WHERE ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `And is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, And(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} AND ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} AND ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `Or is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, Or(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} OR ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} OR ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `Equals is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, Equals(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} = ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} = ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `NotEquals is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, NotEquals(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} != ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} != ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `GreaterThan is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, GreaterThan(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} > ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} > ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `GreaterThanEquals is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, GreaterThanEquals(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} >= ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} >= ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `LessThan is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, LessThan(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} < ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} < ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `LessThanEquals is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, LessThanEquals(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} <= ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} <= ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `In is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, In(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} IN ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} IN ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `IsNull is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, IsNull(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} IS NULL ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} IS NULL ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `IsNotNull is appended to the output with a space on either side`() {
         val expression = listOf(PATH_REFERENCE, IsNotNull(), PATH_REFERENCE)
-        assertThat(
-            postgresVaultNamedQueryParser.convert(output, expression)
-                .toString()
-        ).isEqualTo("${PATH_REFERENCE.ref} IS NOT NULL ${PATH_REFERENCE.ref}")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("${PATH_REFERENCE.ref} IS NOT NULL ${PATH_REFERENCE.ref}")
     }
 
     @Test
     fun `LeftParentheses is appended directly to the output with no spaces`() {
         val expression = listOf(LeftParentheses())
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("(")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("(")
     }
 
     @Test
     fun `RightParentheses is appended directly to the output with no spaces`() {
         val expression = listOf(RightParentheses())
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(")")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo(")")
     }
 
     @Test
     fun `RightParentheses removes last space to the left if previous token was a keyword`() {
-        val expression1 = listOf(IsNull(), RightParentheses())
-        val expression2 = listOf(IsNotNull(), RightParentheses())
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression1).toString()).isEqualTo(" IS NULL)")
+        postgresVaultNamedQueryParser.convert(output, listOf(IsNull(), RightParentheses()))
+        assertThat(output.toString()).isEqualTo(" IS NULL)")
         output.clear()
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression2).toString()).isEqualTo(" IS NOT NULL)")
+        postgresVaultNamedQueryParser.convert(output, listOf(IsNotNull(), RightParentheses()))
+        assertThat(output.toString()).isEqualTo(" IS NOT NULL)")
     }
 
     @Test
     fun `JsonCast is appended directly to the output with no spaces`() {
         val expression = listOf(JsonCast("int"))
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo("::int")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo("::int")
     }
 
     @Test
     fun `JsonKeyExists is appended to the output with a space on either side`() {
         val expression = listOf(JsonKeyExists())
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(" ? ")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo(" ? ")
     }
 
     @Test
     fun `ParameterEnd is appended with a space on its right`() {
         val expression = listOf(ParameterEnd())
-        assertThat(postgresVaultNamedQueryParser.convert(output, expression).toString()).isEqualTo(", ")
+        postgresVaultNamedQueryParser.convert(output, expression)
+        assertThat(output.toString()).isEqualTo(", ")
     }
 
     @Test
@@ -261,6 +238,7 @@ class PostgresVaultNamedQueryConverterTest {
 
     @Test
     fun `empty expressions return an empty output`() {
-        assertThat(postgresVaultNamedQueryParser.convert(output, emptyList()).toString()).isEqualTo("")
+        postgresVaultNamedQueryParser.convert(output, emptyList())
+        assertThat(output.toString()).isEqualTo("")
     }
 }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
@@ -1,0 +1,451 @@
+package net.corda.ledger.persistence.query.impl.parsing.expressions
+
+import net.corda.ledger.persistence.query.impl.parsing.And
+import net.corda.ledger.persistence.query.impl.parsing.As
+import net.corda.ledger.persistence.query.impl.parsing.Equals
+import net.corda.ledger.persistence.query.impl.parsing.From
+import net.corda.ledger.persistence.query.impl.parsing.GreaterThan
+import net.corda.ledger.persistence.query.impl.parsing.GreaterThanEquals
+import net.corda.ledger.persistence.query.impl.parsing.In
+import net.corda.ledger.persistence.query.impl.parsing.IsNotNull
+import net.corda.ledger.persistence.query.impl.parsing.IsNull
+import net.corda.ledger.persistence.query.impl.parsing.JsonArrayOrObjectAsText
+import net.corda.ledger.persistence.query.impl.parsing.JsonCast
+import net.corda.ledger.persistence.query.impl.parsing.JsonKeyExists
+import net.corda.ledger.persistence.query.impl.parsing.LeftParentheses
+import net.corda.ledger.persistence.query.impl.parsing.LessThan
+import net.corda.ledger.persistence.query.impl.parsing.LessThanEquals
+import net.corda.ledger.persistence.query.impl.parsing.Like
+import net.corda.ledger.persistence.query.impl.parsing.NotEquals
+import net.corda.ledger.persistence.query.impl.parsing.Number
+import net.corda.ledger.persistence.query.impl.parsing.Or
+import net.corda.ledger.persistence.query.impl.parsing.Parameter
+import net.corda.ledger.persistence.query.impl.parsing.ParameterEnd
+import net.corda.ledger.persistence.query.impl.parsing.PathReference
+import net.corda.ledger.persistence.query.impl.parsing.PathReferenceWithSpaces
+import net.corda.ledger.persistence.query.impl.parsing.RightParentheses
+import net.corda.ledger.persistence.query.impl.parsing.Select
+import net.corda.ledger.persistence.query.impl.parsing.Where
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.data.Index
+import org.junit.jupiter.api.Test
+
+class PostgresVaultNamedQueryExpressionParserTest {
+
+    private val expressionParser = PostgresVaultNamedQueryExpressionParser()
+
+    @Test
+    fun `field name not in quotes is parsed as PathReference`() {
+        val expression = expressionParser.parse("these ARE 123 field nAmEs != ->> is null is not null")
+        assertThat(expression.filterIsInstance<PathReference>()).hasSize(4)
+        assertThat(expression)
+            .contains(PathReference("these"), Index.atIndex(0))
+            .contains(PathReference("ARE"), Index.atIndex(1))
+            .contains(PathReference("field"), Index.atIndex(3))
+            .contains(PathReference("nAmEs"), Index.atIndex(4))
+    }
+
+    @Test
+    fun `field name in quotes is parsed as PathReference`() {
+        val expression = expressionParser.parse("'these' 'ARE' 123 '456' 'field' 'nAmEs.' != ->> '->>' is null is not null")
+        assertThat(expression.filterIsInstance<PathReference>()).hasSize(6)
+        assertThat(expression)
+            .contains(PathReference("'these'"), Index.atIndex(0))
+            .contains(PathReference("'ARE'"), Index.atIndex(1))
+            .contains(PathReference("'456'"), Index.atIndex(3))
+            .contains(PathReference("'field'"), Index.atIndex(4))
+            .contains(PathReference("'nAmEs.'"), Index.atIndex(5))
+            .contains(PathReference("'->>'"), Index.atIndex(8))
+    }
+
+    @Test
+    fun `field name in quotes with spaces is parsed as PathReferenceWithSpace`() {
+        val expression = expressionParser.parse("'these ARE' 123 '456 789' 'field nAmEs.' != ->> '->> is null' is not null")
+        assertThat(expression.filterIsInstance<PathReferenceWithSpaces>()).hasSize(4)
+        assertThat(expression)
+            .contains(PathReferenceWithSpaces("'these ARE'"), Index.atIndex(0))
+            .contains(PathReferenceWithSpaces("'456 789'"), Index.atIndex(2))
+            .contains(PathReferenceWithSpaces("'field nAmEs.'"), Index.atIndex(3))
+            .contains(PathReferenceWithSpaces("'->> is null'"), Index.atIndex(6))
+    }
+
+    /**
+     * Valid for columns in tables but not for JSON keys.
+     */
+    @Test
+    fun `field name in double quotes is parsed as PathReference`() {
+        val expression = expressionParser.parse("\"these\" \"ARE\" 123 \"456\" \"field\" \"nAmEs.\" != ->> \"->>\" is null is not null")
+        assertThat(expression.filterIsInstance<PathReference>()).hasSize(6)
+        assertThat(expression)
+            .contains(PathReference("\"these\""), Index.atIndex(0))
+            .contains(PathReference("\"ARE\""), Index.atIndex(1))
+            .contains(PathReference("\"456\""), Index.atIndex(3))
+            .contains(PathReference("\"field\""), Index.atIndex(4))
+            .contains(PathReference("\"nAmEs.\""), Index.atIndex(5))
+            .contains(PathReference("\"->>\""), Index.atIndex(8))
+    }
+
+    /**
+     * Valid for columns in tables but not for JSON keys.
+     */
+    @Test
+    fun `field name in double quotes with spaces is parsed as PathReferenceWithSpace`() {
+        val expression = expressionParser.parse("\"these ARE\" 123 \"456 789\" \"field nAmEs.\" != ->> \"->> is null\" is not null")
+        assertThat(expression.filterIsInstance<PathReferenceWithSpaces>()).hasSize(4)
+        assertThat(expression)
+            .contains(PathReferenceWithSpaces("\"these ARE\""), Index.atIndex(0))
+            .contains(PathReferenceWithSpaces("\"456 789\""), Index.atIndex(2))
+            .contains(PathReferenceWithSpaces("\"field nAmEs.\""), Index.atIndex(3))
+            .contains(PathReferenceWithSpaces("\"->> is null\""), Index.atIndex(6))
+    }
+
+    @Test
+    fun `parameter name is parsed as Parameter`() {
+        val expression = expressionParser.parse(":parameter ARE 123 :another_one nAmEs != :with-dashes ::int ->> is null is not null")
+        assertThat(expression.filterIsInstance<Parameter>()).hasSize(3)
+        assertThat(expression)
+            .contains(Parameter(":parameter"), Index.atIndex(0))
+            .contains(Parameter(":another_one"), Index.atIndex(3))
+            .contains(Parameter(":with-dashes"), Index.atIndex(6))
+
+    }
+
+    @Test
+    fun `number with no decimal points is parsed as Number`() {
+        val expression = expressionParser.parse("1 23456 field nAmEs 78910 != ->> is null is not null")
+        assertThat(expression.filterIsInstance<Number>()).hasSize(3)
+        assertThat(expression)
+            .contains(Number("1"), Index.atIndex(0))
+            .contains(Number("23456"), Index.atIndex(1))
+            .contains(Number("78910"), Index.atIndex(4))
+    }
+
+    @Test
+    fun `number with decimal points is parsed as Number`() {
+        val expression = expressionParser.parse("1.0 23.456 field nAmEs 78910.00000001 != ->> is null is not null")
+        assertThat(expression.filterIsInstance<Number>()).hasSize(3)
+        assertThat(expression)
+            .contains(Number("1.0"), Index.atIndex(0))
+            .contains(Number("23.456"), Index.atIndex(1))
+            .contains(Number("78910.00000001"), Index.atIndex(4))
+    }
+
+    /**
+     * JSON array or object to text = "->>"
+     */
+    @Test
+    fun `json array or object to text is parsed as JsonArrayOrObjectAsText`() {
+        val expression = expressionParser.parse("these ARE ->> field nAmEs != ->> is null is not null")
+        assertThat(expression.filterIsInstance<JsonArrayOrObjectAsText>()).hasSize(2)
+        assertThat(expression)
+            .contains(JsonArrayOrObjectAsText(), Index.atIndex(2))
+            .contains(JsonArrayOrObjectAsText(), Index.atIndex(6))
+    }
+
+    @Test
+    fun `as is parsed (case insensitive) as As`() {
+        val expression = expressionParser.parse("asasas AS ->> as aS zasz != ->> is null is not null")
+        assertThat(expression.filterIsInstance<As>()).hasSize(3)
+        assertThat(expression)
+            .contains(As(), Index.atIndex(1))
+            .contains(As(), Index.atIndex(3))
+            .contains(As(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `from is parsed (case insensitive) as From`() {
+        val expression = expressionParser.parse("fromfromfrom FROM ->> from frOM zfromz != ->> is null is not null")
+        assertThat(expression.filterIsInstance<From>()).hasSize(3)
+        assertThat(expression)
+            .contains(From(), Index.atIndex(1))
+            .contains(From(), Index.atIndex(3))
+            .contains(From(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `select is parsed (case insensitive) as Select`() {
+        val expression = expressionParser.parse("selectselectselect SELECT ->> select seLEcT zselectz != ->> is null is not null")
+        assertThat(expression.filterIsInstance<Select>()).hasSize(3)
+        assertThat(expression)
+            .contains(Select(), Index.atIndex(1))
+            .contains(Select(), Index.atIndex(3))
+            .contains(Select(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `where is parsed (case insensitive) as Where`() {
+        val expression = expressionParser.parse("wherewherewhere WHERE ->> where wheRE zwherez != ->> is null is not null")
+        assertThat(expression.filterIsInstance<Where>()).hasSize(3)
+        assertThat(expression)
+            .contains(Where(), Index.atIndex(1))
+            .contains(Where(), Index.atIndex(3))
+            .contains(Where(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `and is parsed (case insensitive) as And`() {
+        val expression = expressionParser.parse("andandand AND ->> and ANd zandz != ->> is null is not null")
+        assertThat(expression.filterIsInstance<And>()).hasSize(3)
+        assertThat(expression)
+            .contains(And(), Index.atIndex(1))
+            .contains(And(), Index.atIndex(3))
+            .contains(And(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `or is parsed (case insensitive) as Or`() {
+        val expression = expressionParser.parse("ororor OR ->> or Or zorz != ->> is null is not null")
+        assertThat(expression.filterIsInstance<Or>()).hasSize(3)
+        assertThat(expression)
+            .contains(Or(), Index.atIndex(1))
+            .contains(Or(), Index.atIndex(3))
+            .contains(Or(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `is null is parsed (case insensitive) as IsNull`() {
+        val expression = expressionParser.parse("is nullis nullis null IS NULL ->> is null Is NuLL zis nullz != ->> is not null")
+        assertThat(expression.filterIsInstance<IsNull>()).hasSize(3)
+        assertThat(expression)
+            .contains(IsNull(), Index.atIndex(4))
+            .contains(IsNull(), Index.atIndex(6))
+            .contains(IsNull(), Index.atIndex(7))
+    }
+
+    @Test
+    fun `is not null is parsed (case insensitive) as IsNotNull`() {
+        val expression =
+            expressionParser.parse("is not nullis not nullis not null IS NOT NULL ->> is not null Is NoT NuLL zis not nullz != ->> is null")
+        assertThat(expression.filterIsInstance<IsNotNull>()).hasSize(3)
+        assertThat(expression)
+            .contains(IsNotNull(), Index.atIndex(7))
+            .contains(IsNotNull(), Index.atIndex(9))
+            .contains(IsNotNull(), Index.atIndex(10))
+    }
+
+    /**
+     * !in or not in??
+     */
+    @Test
+    fun `in is parsed (case insensitive) as In`() {
+        val expression = expressionParser.parse("ininin IN ->> in iN zinz != ->> is null is not null")
+        assertThat(expression.filterIsInstance<In>()).hasSize(3)
+        assertThat(expression)
+            .contains(In(), Index.atIndex(1))
+            .contains(In(), Index.atIndex(3))
+            .contains(In(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `equals is parsed as Equals`() {
+        val expression = expressionParser.parse("=== = ->> = = z=z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<Equals>()).hasSize(7)
+        assertThat(expression)
+            .contains(Equals(), Index.atIndex(0))
+            .contains(Equals(), Index.atIndex(1))
+            .contains(Equals(), Index.atIndex(2))
+            .contains(Equals(), Index.atIndex(3))
+            .contains(Equals(), Index.atIndex(5))
+            .contains(Equals(), Index.atIndex(6))
+            .contains(Equals(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `not equals is parsed as NotEquals`() {
+        val expression = expressionParser.parse("!=!=!= != ->> != != z!=z ->> is null is not null")
+        assertThat(expression.filterIsInstance<NotEquals>()).hasSize(7)
+        assertThat(expression)
+            .contains(NotEquals(), Index.atIndex(0))
+            .contains(NotEquals(), Index.atIndex(1))
+            .contains(NotEquals(), Index.atIndex(2))
+            .contains(NotEquals(), Index.atIndex(3))
+            .contains(NotEquals(), Index.atIndex(5))
+            .contains(NotEquals(), Index.atIndex(6))
+            .contains(NotEquals(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `less than is parsed as LessThan`() {
+        val expression = expressionParser.parse("<<< < ->> < < z<z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<LessThan>()).hasSize(7)
+        assertThat(expression)
+            .contains(LessThan(), Index.atIndex(0))
+            .contains(LessThan(), Index.atIndex(1))
+            .contains(LessThan(), Index.atIndex(2))
+            .contains(LessThan(), Index.atIndex(3))
+            .contains(LessThan(), Index.atIndex(5))
+            .contains(LessThan(), Index.atIndex(6))
+            .contains(LessThan(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `less than or equal to is parsed as LessThanEquals`() {
+        val expression = expressionParser.parse("<=<=<= <= ->> <= <= z<=z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<LessThanEquals>()).hasSize(7)
+        assertThat(expression)
+            .contains(LessThanEquals(), Index.atIndex(0))
+            .contains(LessThanEquals(), Index.atIndex(1))
+            .contains(LessThanEquals(), Index.atIndex(2))
+            .contains(LessThanEquals(), Index.atIndex(3))
+            .contains(LessThanEquals(), Index.atIndex(5))
+            .contains(LessThanEquals(), Index.atIndex(6))
+            .contains(LessThanEquals(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `greater than is parsed as GreaterThan`() {
+        val expression = expressionParser.parse(">>> > ->> > > z>z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<GreaterThan>()).hasSize(7)
+        assertThat(expression)
+            .contains(GreaterThan(), Index.atIndex(0))
+            .contains(GreaterThan(), Index.atIndex(1))
+            .contains(GreaterThan(), Index.atIndex(2))
+            .contains(GreaterThan(), Index.atIndex(3))
+            .contains(GreaterThan(), Index.atIndex(5))
+            .contains(GreaterThan(), Index.atIndex(6))
+            .contains(GreaterThan(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `greater than or equal to is parsed as GreaterThanEquals`() {
+        val expression = expressionParser.parse(">=>=>= >= ->> >= >= z>=z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<GreaterThanEquals>()).hasSize(7)
+        assertThat(expression)
+            .contains(GreaterThanEquals(), Index.atIndex(0))
+            .contains(GreaterThanEquals(), Index.atIndex(1))
+            .contains(GreaterThanEquals(), Index.atIndex(2))
+            .contains(GreaterThanEquals(), Index.atIndex(3))
+            .contains(GreaterThanEquals(), Index.atIndex(5))
+            .contains(GreaterThanEquals(), Index.atIndex(6))
+            .contains(GreaterThanEquals(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `json cast to is parsed as JsonCast`() {
+        val expression = expressionParser.parse("::int::int::int ::date ::string->> ::int=5 ::int>5 z::intz<=1 != ->> is null is not null")
+        assertThat(expression.filterIsInstance<JsonCast>()).hasSize(6)
+        assertThat(expression)
+            .contains(JsonCast("int::int::int"), Index.atIndex(0))
+            .contains(JsonCast("date"), Index.atIndex(1))
+            .contains(JsonCast("string"), Index.atIndex(2))
+            .contains(JsonCast("int"), Index.atIndex(4))
+            .contains(JsonCast("int"), Index.atIndex(7))
+            .contains(JsonCast("intz"), Index.atIndex(11))
+    }
+
+    @Test
+    fun `json key exist is parsed as JsonKeyExists`() {
+        val expression = expressionParser.parse("??? ? ->> ? ? z?z ->> is null is not null")
+        assertThat(expression.filterIsInstance<JsonKeyExists>()).hasSize(7)
+        assertThat(expression)
+            .contains(JsonKeyExists(), Index.atIndex(0))
+            .contains(JsonKeyExists(), Index.atIndex(1))
+            .contains(JsonKeyExists(), Index.atIndex(2))
+            .contains(JsonKeyExists(), Index.atIndex(3))
+            .contains(JsonKeyExists(), Index.atIndex(5))
+            .contains(JsonKeyExists(), Index.atIndex(6))
+            .contains(JsonKeyExists(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `like is parsed as Like`() {
+        val expression = expressionParser.parse("likelikelike LIKE ->> like LiKe zlikez != ->> is null is not null")
+        assertThat(expression.filterIsInstance<Like>()).hasSize(3)
+        assertThat(expression)
+            .contains(Like(), Index.atIndex(1))
+            .contains(Like(), Index.atIndex(3))
+            .contains(Like(), Index.atIndex(4))
+    }
+
+    @Test
+    fun `spaces are ignored`() {
+        val expression = expressionParser.parse("  spaces spaces  spaces      spaces ")
+        assertThat(expression).hasSize(4)
+        assertThat(expression.filterIsInstance<PathReference>()).hasSize(4)
+    }
+
+    @Test
+    fun `tabs are ignored`() {
+        val expression = expressionParser.parse("\t\tspaces\tspaces \t spaces \t \t spaces \t")
+        assertThat(expression).hasSize(4)
+        assertThat(expression.filterIsInstance<PathReference>()).hasSize(4)
+    }
+
+    @Test
+    fun `new lines are ignored`() {
+        val expression = expressionParser.parse("\n\nspaces\nspaces \n spaces \n \n spaces \n")
+        assertThat(expression).hasSize(4)
+        assertThat(expression.filterIsInstance<PathReference>()).hasSize(4)
+    }
+
+    @Test
+    fun `commas are parsed as ParameterEnds`() {
+        val expression = expressionParser.parse(",,, , ->> , , z,z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<ParameterEnd>()).hasSize(7)
+        assertThat(expression)
+            .contains(ParameterEnd(), Index.atIndex(0))
+            .contains(ParameterEnd(), Index.atIndex(1))
+            .contains(ParameterEnd(), Index.atIndex(2))
+            .contains(ParameterEnd(), Index.atIndex(3))
+            .contains(ParameterEnd(), Index.atIndex(5))
+            .contains(ParameterEnd(), Index.atIndex(6))
+            .contains(ParameterEnd(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `left parentheses are parsed as LeftParentheses`() {
+        val expression = expressionParser.parse("((( ( ->> ( ( z(z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<LeftParentheses>()).hasSize(7)
+        assertThat(expression)
+            .contains(LeftParentheses(), Index.atIndex(0))
+            .contains(LeftParentheses(), Index.atIndex(1))
+            .contains(LeftParentheses(), Index.atIndex(2))
+            .contains(LeftParentheses(), Index.atIndex(3))
+            .contains(LeftParentheses(), Index.atIndex(5))
+            .contains(LeftParentheses(), Index.atIndex(6))
+            .contains(LeftParentheses(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `right parentheses are parsed as RightParentheses`() {
+        val expression = expressionParser.parse("))) ) ->> ) ) z)z != ->> is null is not null")
+        assertThat(expression.filterIsInstance<RightParentheses>()).hasSize(7)
+        assertThat(expression)
+            .contains(RightParentheses(), Index.atIndex(0))
+            .contains(RightParentheses(), Index.atIndex(1))
+            .contains(RightParentheses(), Index.atIndex(2))
+            .contains(RightParentheses(), Index.atIndex(3))
+            .contains(RightParentheses(), Index.atIndex(5))
+            .contains(RightParentheses(), Index.atIndex(6))
+            .contains(RightParentheses(), Index.atIndex(8))
+    }
+
+    @Test
+    fun `full stops by themselves fail parsing`() {
+        assertThatThrownBy { expressionParser.parse("ok until we get to the full stop .") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `full stops at the start of a string fail parsing`() {
+        assertThatThrownBy { expressionParser.parse(".ok until we get to the full stop") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `full stops at the end of a string fail parsing`() {
+        assertThatThrownBy { expressionParser.parse("ok until we get to the full stop.") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `full stops within a string are parsed as PathReferences`() {
+        val expression = expressionParser.parse("o.k unt.il we get to the full sto.p")
+        assertThat(expression.filterIsInstance<PathReference>()).hasSize(8)
+        assertThat(expression)
+            .contains(PathReference("o.k"), Index.atIndex(0))
+            .contains(PathReference("unt.il"), Index.atIndex(1))
+            .contains(PathReference("sto.p"), Index.atIndex(7))
+    }
+}

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidatorImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/VaultNamedQueryExpressionValidatorImplTest.kt
@@ -1,0 +1,35 @@
+package net.corda.ledger.persistence.query.impl.parsing.expressions
+
+import net.corda.ledger.persistence.query.impl.parsing.From
+import net.corda.ledger.persistence.query.impl.parsing.Number
+import net.corda.ledger.persistence.query.impl.parsing.PathReference
+import net.corda.ledger.persistence.query.impl.parsing.Select
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class VaultNamedQueryExpressionValidatorImplTest {
+
+    private val validator = VaultNamedQueryExpressionValidatorImpl()
+
+    @Test
+    fun `acceptable expression does not throw an exception`() {
+        assertDoesNotThrow { validator.validateWhereJson("my query", listOf(PathReference("field"), Number("1"))) }
+    }
+
+    @Test
+    fun `expression containing a select token throws an exception`() {
+        assertThatThrownBy { validator.validateWhereJson("my query", listOf(PathReference("field"), Select())) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("cannot contain the SELECT keyword")
+            .hasMessageContaining("my query")
+    }
+
+    @Test
+    fun `expression containing a from token throws an exception`() {
+        assertThatThrownBy { validator.validateWhereJson("my query", listOf(PathReference("field"), From())) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("cannot contain the FROM keyword")
+            .hasMessageContaining("my query")
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.persistence
 
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.v5.application.persistence.CordaPersistenceException
+import net.corda.v5.application.persistence.ParameterizedQuery
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
@@ -12,6 +13,7 @@ import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
  * by the platform.
  */
 interface UtxoLedgerPersistenceService {
+
     /**
      * Find a UTXO signed transaction in the persistence context given it's [id].
      *

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -2,7 +2,6 @@ package net.corda.ledger.utxo.flow.impl.persistence
 
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.v5.application.persistence.CordaPersistenceException
-import net.corda.v5.application.persistence.ParameterizedQuery
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -87,7 +87,7 @@ class EntitySandboxServiceImpl @Activate constructor(
     ): AutoCloseable {
         val customCrypto = sandboxService.registerCustomCryptography(ctx)
         val customSerializers = sandboxService.registerCordappCustomSerializers(ctx)
-        val customQueryFactories = sandboxService.registerLedgerCustomQueryFactories(ctx)
+        val namedQueryFactories = sandboxService.registerLedgerNamedQueryFactories(ctx)
         val emfCloseable = putEntityManager(ctx, cpks, virtualNode)
         putTokenStateObservers(ctx, cpks)
 
@@ -114,7 +114,7 @@ class EntitySandboxServiceImpl @Activate constructor(
             emfCloseable.close()
             customSerializers.close()
             customCrypto.close()
-            customQueryFactories.close()
+            namedQueryFactories.close()
         }
     }
 
@@ -215,12 +215,12 @@ class EntitySandboxServiceImpl @Activate constructor(
             null
         )
 
-    private fun SandboxGroupContextComponent.registerLedgerCustomQueryFactories(
+    private fun SandboxGroupContextComponent.registerLedgerNamedQueryFactories(
         sandboxGroupContext: SandboxGroupContext
     ): AutoCloseable {
         return registerMetadataServices(
             sandboxGroupContext,
-            serviceNames = { metadata -> metadata.cordappManifest.ledgerCustomQueryClasses },
+            serviceNames = { metadata -> metadata.cordappManifest.ledgerNamedQueryClasses },
             serviceMarkerType = VaultNamedQueryFactory::class.java
         )
     }

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CordappManifest.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CordappManifest.kt
@@ -55,7 +55,7 @@ data class CordappManifest(
         const val CORDAPP_DIGEST_ALGORITHM_FACTORIES = "Corda-DigestAlgorithmFactory-Classes"
         const val CORDAPP_ENTITIES = "Corda-Entity-Classes"
         const val CORDAPP_TOKEN_STATE_OBSERVERS = "Corda-Token-Observer-Classes"
-        const val CORDAPP_LEDGER_CUSTOM_QUERY_CLASSES = "Corda-Ledger-CustomQuery-Classes"
+        const val CORDAPP_LEDGER_NAMED_QUERY_CLASSES = "Corda-Ledger-Named-Query-Classes"
 
         private operator fun Manifest.get(key: String): String? = mainAttributes.getValue(key)
 
@@ -185,7 +185,7 @@ data class CordappManifest(
     val digestAlgorithmFactories: Set<String> get() = parseSet(CORDAPP_DIGEST_ALGORITHM_FACTORIES)
     val entities: Set<String> get() = parseSet(CORDAPP_ENTITIES)
     val tokenStateObservers: Set<String> get() = parseSet(CORDAPP_TOKEN_STATE_OBSERVERS)
-    val ledgerCustomQueryClasses: Set<String> get() = parseSet(CORDAPP_LEDGER_CUSTOM_QUERY_CLASSES)
+    val ledgerNamedQueryClasses: Set<String> get() = parseSet(CORDAPP_LEDGER_NAMED_QUERY_CLASSES)
 
     fun toAvro(): CorDappManifestAvro =
         CorDappManifestAvro(

--- a/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/UtxoVaultNamedQueryFactory.kt
+++ b/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/UtxoVaultNamedQueryFactory.kt
@@ -1,12 +1,11 @@
 package net.cordapp.demo.utxo.contract
 
-import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryBuilderFactory
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryFactory
 
 @Suppress("unused")
 class UtxoVaultNamedQueryFactory : VaultNamedQueryFactory {
-    @Suspendable
+
     override fun create(vaultNamedQueryBuilderFactory: VaultNamedQueryBuilderFactory) {
         vaultNamedQueryBuilderFactory.create("UTXO_DUMMY_QUERY")
             // TODO This is just a dummy where clause for now and has absolutely no effect


### PR DESCRIPTION
Adds vault named query parsing of a Postgres syntax into an expression and back into a Postgres query to be executed at some point.

`VaultNamedQueryParser` provides the entry point for parsing a query. The implementation of this interface then delegates to a `VaultNamedQueryExpressionParser` to convert a query string into an expression, a `VaultNamedQueryExpressionValidator` to validate the expression and a `VaultNamedQueryConverter` that converts the expression into an output query string.

The `PostgresVaultNamedQueryExpressionParser` converts a Postgres query string into an expression, and `PostgresVaultNamedQueryConverter` converts that expression into a Postgres query string.

These interfaces give us the flexibility to parse from different formats and output queries for different databases.