### PR TITLE
CORE-9467: Reuse ObjectMapper

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -1,6 +1,5 @@
 package net.corda.e2etest.utilities
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.crypto.test.certificates.generation.Algorithm.Companion.toAlgorithm
 import net.corda.crypto.test.certificates.generation.CertificateAuthorityFactory
 import net.corda.crypto.test.certificates.generation.FileSystemCertificatesAuthority
@@ -56,7 +55,7 @@ fun generateCsr(
     }
 
     assertWithRetry {
-        command { post("/api/v1/certificates/$tenantId/$keyId", ObjectMapper().writeValueAsString(payload)) }
+        command { post("/api/v1/certificates/$tenantId/$keyId", objectMapper.writeValueAsString(payload)) }
         condition { it.code == ResponseCode.OK.statusCode }
     }.body
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -1,7 +1,6 @@
 package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.commons.text.StringEscapeUtils.escapeJson
 import java.time.Duration
 import java.util.UUID
@@ -11,7 +10,7 @@ const val RPC_FLOW_STATUS_SUCCESS = "COMPLETED"
 const val RPC_FLOW_STATUS_FAILED = "FAILED"
 
 fun FlowStatus.getRpcFlowResult(): RpcSmokeTestOutput =
-    ObjectMapper().readValue(this.flowResult!!, RpcSmokeTestOutput::class.java)
+    objectMapper.readValue(this.flowResult!!, RpcSmokeTestOutput::class.java)
 
 fun startRpcFlow(
     holdingId: String,
@@ -33,7 +32,7 @@ fun startRpcFlow(
                     holdingId,
                     requestId,
                     SMOKE_TEST_CLASS_NAME,
-                    escapeJson(ObjectMapper().writeValueAsString(args))
+                    escapeJson(objectMapper.writeValueAsString(args))
                 )
             }
             condition { it.code == expectedCode }
@@ -59,7 +58,7 @@ fun startRpcFlow(holdingId: String, args: Map<String, Any>, flowName: String, ex
                     holdingId,
                     requestId,
                     flowName,
-                    escapeJson(ObjectMapper().writeValueAsString(args))
+                    escapeJson(objectMapper.writeValueAsString(args))
                 )
             }
             condition { it.code == expectedCode }
@@ -77,7 +76,7 @@ fun awaitRpcFlowFinished(holdingId: String, requestId: String): FlowStatus {
             PASSWORD
         )
 
-        ObjectMapper().readValue(
+        objectMapper.readValue(
             assertWithRetry {
                 command { flowStatus(holdingId, requestId) }
                 //CORE-6118 - tmp increase this timeout to a large number to allow tests to pass while slow flow sessions are investigated
@@ -100,7 +99,7 @@ fun getFlowStatus(holdingId: String, requestId: String, expectedCode: Int): Flow
             PASSWORD
         )
 
-        ObjectMapper().readValue(
+        objectMapper.readValue(
             assertWithRetry {
                 command { flowStatus(holdingId, requestId) }
                 timeout(Duration.ofMinutes(6))

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/GroupPolicyUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/GroupPolicyUtils.kt
@@ -1,7 +1,5 @@
 package net.corda.e2etest.utilities
 
-import com.fasterxml.jackson.databind.ObjectMapper
-
 private fun createCertificate(certificateResource: String) = CpiLoader::class.java.classLoader.getResource(certificateResource)!!
     .readText()
     .replace("\r", "")
@@ -55,7 +53,7 @@ fun getDefaultStaticNetworkGroupPolicy(
             "corda.cryptoservice.provider" to "default"
         )
     )
-    return ObjectMapper().writeValueAsString(groupPolicy)
+    return objectMapper.writeValueAsString(groupPolicy)
 }
 
 fun getMgmGroupPolicy(): String {
@@ -67,5 +65,5 @@ fun getMgmGroupPolicy(): String {
         "synchronisationProtocol"
                 to "net.corda.membership.impl.synchronisation.MgmSynchronisationServiceImpl"
     )
-    return ObjectMapper().writeValueAsString(groupPolicy)
+    return objectMapper.writeValueAsString(groupPolicy)
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -2,7 +2,6 @@
 
 package net.corda.e2etest.utilities
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.rest.ResponseCode
 import net.corda.utilities.seconds
@@ -105,7 +104,7 @@ private fun createApprovalRuleCommon(
     )
 
     assertWithRetry {
-        command { post(url, ObjectMapper().writeValueAsString(payload)) }
+        command { post(url, objectMapper.writeValueAsString(payload)) }
         condition { it.code == ResponseCode.OK.statusCode }
     }.toJson()["ruleId"].textValue()
 }
@@ -159,7 +158,7 @@ fun createPreAuthToken(
     }
 
     assertWithRetry {
-        command { post("/api/v1/mgm/$mgmHoldingId/preauthtoken", ObjectMapper().writeValueAsString(payload)) }
+        command { post("/api/v1/mgm/$mgmHoldingId/preauthtoken", objectMapper.writeValueAsString(payload)) }
         condition { it.code == ResponseCode.OK.statusCode }
     }.toJson()["id"].textValue()
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -1,12 +1,9 @@
 package net.corda.e2etest.utilities
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.rest.ResponseCode
 import net.corda.utilities.seconds
 import net.corda.v5.base.types.MemberX500Name
 import java.io.File
-
-private val mapper = ObjectMapper()
 
 const val REGISTRATION_KEY_PRE_AUTH = "corda.auth.token"
 const val REGISTRATION_DECLINED = "DECLINED"
@@ -152,7 +149,7 @@ fun register(
     )
 
     assertWithRetry {
-        command { register(holdingIdentityShortHash, mapper.writeValueAsString(payload)) }
+        command { register(holdingIdentityShortHash, objectMapper.writeValueAsString(payload)) }
         condition {
             it.code == ResponseCode.OK.statusCode
                     && it.toJson().get("registrationStatus")?.textValue() == REGISTRATION_SUBMITTED

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/SimpleResponse.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/SimpleResponse.kt
@@ -1,9 +1,8 @@
 package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 
 /** Simplified response in case we switch underlying web clients, again */
 data class SimpleResponse(val code: Int, val body: String, val url: String) {
-    fun toJson(): JsonNode = ObjectMapper().readTree(this.body)!!
+    fun toJson(): JsonNode = objectMapper.readTree(this.body)!!
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/Utils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/Utils.kt
@@ -28,15 +28,17 @@ const val TEST_NOTARY_CPB_LOCATION = "/META-INF/notary-plugin-non-validating-ser
 
 val CLUSTER_URI = URI(System.getProperty("restEndpointUrl", "NONE"))
 
+internal val objectMapper by lazy { ObjectMapper() }
+
 // BUG:  Not sure if we should be requiring clients to use a method similar to this because we
 // return a full hash (64 chars?) but the same API only accepts the first 12 chars.
 fun truncateLongHash(shortHash:String):String {
     return shortHash.substring(0,12)
 }
 
-fun String.toJson(): JsonNode = ObjectMapper().readTree(this)
+fun String.toJson(): JsonNode = objectMapper.readTree(this)
 
-fun <K, V> Map<K, V>.toJsonString(): String = ObjectMapper().writeValueAsString(this)
+fun <K, V> Map<K, V>.toJsonString(): String = objectMapper.writeValueAsString(this)
 
 fun Any.contextLogger(): Logger = LoggerFactory.getLogger(javaClass.enclosingClass)
 


### PR DESCRIPTION
The docs say to reuse ObjectMapper but we create a new instance in a few places.

https://www.javadoc.io/static/com.fasterxml.jackson.core/jackson-databind/2.15.0-rc2/com/fasterxml/jackson/databind/ObjectMapper.html