### PR TITLE
CORE-11895-Add-headers-to-messaging-api

### DIFF
--- a/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TopicRecordEntry.kt
+++ b/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TopicRecordEntry.kt
@@ -39,6 +39,8 @@ class TopicRecordEntry(
     val key: ByteArray,
     @Column(name = "record_value")
     val value: ByteArray?,
+    @Column(name = "record_headers")
+    val headers: String?,
     @ManyToOne
     @JoinColumn(name = "transaction_id")
     val transactionId: TransactionRecordEntry,

--- a/libs/messaging/db-message-bus-impl/src/integrationTest/kotlin/net/corda/messagebus/db/persistence/DBAccessIntegrationTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/integrationTest/kotlin/net/corda/messagebus/db/persistence/DBAccessIntegrationTest.kt
@@ -101,11 +101,11 @@ class DBAccessIntegrationTest {
         val transactionRecord = TransactionRecordEntry(randomId())
 
         val records = listOf(
-            TopicRecordEntry(topic, 0, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 0, 1, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 1, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 2, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 3, 0, key, value, transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 0, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 0, 1, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 1, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 2, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 3, 0, key, value, "", transactionRecord, timestamp = timestamp),
         )
 
         val dbAccess = DBAccess(emf)
@@ -135,22 +135,22 @@ class DBAccessIntegrationTest {
         dbAccess.writeTransactionRecord(transactionRecord2)
         dbAccess.writeTransactionRecord(transactionRecord3)
         val partition5 = listOf(
-            TopicRecordEntry(topic, 5, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 5, 1, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 5, 3, key, value, transactionRecord2, timestamp = timestamp),
-            TopicRecordEntry(topic, 5, 4, key, value, transactionRecord2, timestamp = timestamp),
-            TopicRecordEntry(topic, 5, 5, key, value, transactionRecord3, timestamp = timestamp),
+            TopicRecordEntry(topic, 5, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 5, 1, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 5, 3, key, value, "", transactionRecord2, timestamp = timestamp),
+            TopicRecordEntry(topic, 5, 4, key, value, "", transactionRecord2, timestamp = timestamp),
+            TopicRecordEntry(topic, 5, 5, key, value, "", transactionRecord3, timestamp = timestamp),
         )
         val partition6 = listOf(
-            TopicRecordEntry(topic, 6, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 6, 1, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 6, 2, key, value, transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 6, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 6, 1, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 6, 2, key, value, "", transactionRecord, timestamp = timestamp),
         )
         val partition7 = listOf(
-            TopicRecordEntry(topic, 7, 0, key, value, transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 7, 0, key, value, "", transactionRecord, timestamp = timestamp),
         )
         val partition8 = listOf(
-            TopicRecordEntry(topic, 8, 0, key, value, transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 8, 0, key, value, "", transactionRecord, timestamp = timestamp),
         )
         val records = partition5 + partition6 + partition7 + partition8
 
@@ -249,20 +249,20 @@ class DBAccessIntegrationTest {
         dbAccess.writeTransactionRecord(transactionRecord)
 
         val records = listOf(
-            TopicRecordEntry(topic, 0, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 0, 1, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 1, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 1, 1, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 1, 2, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 1, 3, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 2, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 2, 7, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic, 3, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic2, 0, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic2, 1, 1, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic2, 2, 0, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic2, 3, 1, key, value, transactionRecord, timestamp = timestamp),
-            TopicRecordEntry(topic2, 4, 2, key, value, transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 0, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 0, 1, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 1, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 1, 1, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 1, 2, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 1, 3, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 2, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 2, 7, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic, 3, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic2, 0, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic2, 1, 1, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic2, 2, 0, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic2, 3, 1, key, value, "", transactionRecord, timestamp = timestamp),
+            TopicRecordEntry(topic2, 4, 2, key, value, "", transactionRecord, timestamp = timestamp),
         )
 
         dbAccess.writeRecords(records)
@@ -340,15 +340,15 @@ class DBAccessIntegrationTest {
 
         dbAccess.writeRecords(
             listOf(
-                TopicRecordEntry(topic, 0, 1, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 0, 2, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 0, 3, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 1, 6, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 1, 7, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 1, 8, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 2, 7, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 2, 8, key, value, transactionRecord, timestamp = timestamp),
-                TopicRecordEntry(topic, 2, 9, key, value, transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 0, 1, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 0, 2, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 0, 3, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 1, 6, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 1, 7, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 1, 8, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 2, 7, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 2, 8, key, value, "", transactionRecord, timestamp = timestamp),
+                TopicRecordEntry(topic, 2, 9, key, value, "", transactionRecord, timestamp = timestamp),
             )
         )
 
@@ -361,9 +361,9 @@ class DBAccessIntegrationTest {
         // Shouldn't matter as transactionRecord2 is still pending
         dbAccess.writeRecords(
             listOf(
-                TopicRecordEntry(topic, 0, 5, key, value, transactionRecord2, timestamp = timestamp),
-                TopicRecordEntry(topic, 0, 6, key, value, transactionRecord2, timestamp = timestamp),
-                TopicRecordEntry(topic, 0, 7, key, value, transactionRecord2, timestamp = timestamp),
+                TopicRecordEntry(topic, 0, 5, key, value, "", transactionRecord2, timestamp = timestamp),
+                TopicRecordEntry(topic, 0, 6, key, value, "", transactionRecord2, timestamp = timestamp),
+                TopicRecordEntry(topic, 0, 7, key, value, "", transactionRecord2, timestamp = timestamp),
             )
         )
 

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/builder/DBCordaConsumerBuilderImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/builder/DBCordaConsumerBuilderImpl.kt
@@ -11,6 +11,7 @@ import net.corda.messagebus.db.consumer.DBCordaConsumerImpl
 import net.corda.messagebus.db.persistence.DBAccess
 import net.corda.messagebus.db.persistence.EntityManagerFactoryHolder
 import net.corda.messagebus.db.serialization.CordaDBAvroDeserializerImpl
+import net.corda.messagebus.db.serialization.MessageHeaderSerializerImpl
 import net.corda.schema.registry.AvroSchemaRegistry
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -19,6 +20,7 @@ import org.osgi.service.component.annotations.Reference
 /**
  * Generate a DB-backed [CordaConsumer].
  */
+@Suppress("Unused")
 @Component(service = [CordaConsumerBuilder::class])
 class DBCordaConsumerBuilderImpl @Activate constructor(
     @Reference(service = AvroSchemaRegistry::class)
@@ -56,7 +58,8 @@ class DBCordaConsumerBuilderImpl @Activate constructor(
             consumerGroup,
             CordaDBAvroDeserializerImpl(avroSchemaRegistry, onSerializationError, kClazz),
             CordaDBAvroDeserializerImpl(avroSchemaRegistry, onSerializationError, vClazz),
-            listener
+            listener,
+            MessageHeaderSerializerImpl()
         )
     }
 }

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/CordaAtomicDBProducerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/CordaAtomicDBProducerImpl.kt
@@ -9,6 +9,7 @@ import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messagebus.db.datamodel.TopicRecordEntry
 import net.corda.messagebus.db.persistence.DBAccess
 import net.corda.messagebus.db.persistence.DBAccess.Companion.ATOMIC_TRANSACTION
+import net.corda.messagebus.db.serialization.MessageHeaderSerializer
 import net.corda.messagebus.db.util.WriteOffsets
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import kotlin.math.abs
@@ -17,7 +18,8 @@ import kotlin.math.abs
 class CordaAtomicDBProducerImpl(
     private val serializer: CordaAvroSerializer<Any>,
     private val dbAccess: DBAccess,
-    private val writeOffsets: WriteOffsets
+    private val writeOffsets: WriteOffsets,
+    private val headerSerializer: MessageHeaderSerializer
 ) : CordaProducer {
 
     init {
@@ -54,12 +56,14 @@ class CordaAtomicDBProducerImpl(
             } else {
                 null
             }
+            val serializedHeaders = headerSerializer.serialize(record.headers)
             TopicRecordEntry(
                 record.topic,
                 partition,
                 offset,
                 serializedKey,
                 serializedValue,
+                serializedHeaders,
                 ATOMIC_TRANSACTION,
             )
         }

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/CordaTransactionalDBProducerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/CordaTransactionalDBProducerImpl.kt
@@ -12,6 +12,7 @@ import net.corda.messagebus.db.datamodel.TopicRecordEntry
 import net.corda.messagebus.db.datamodel.TransactionRecordEntry
 import net.corda.messagebus.db.datamodel.TransactionState
 import net.corda.messagebus.db.persistence.DBAccess
+import net.corda.messagebus.db.serialization.MessageHeaderSerializer
 import net.corda.messagebus.db.util.WriteOffsets
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import org.slf4j.Logger
@@ -19,10 +20,12 @@ import org.slf4j.LoggerFactory
 import java.util.UUID
 import kotlin.math.abs
 
+@Suppress("TooManyFunctions")
 class CordaTransactionalDBProducerImpl(
     private val serializer: CordaAvroSerializer<Any>,
     private val dbAccess: DBAccess,
-    private val writeOffsets: WriteOffsets
+    private val writeOffsets: WriteOffsets,
+    private val headerSerializer: MessageHeaderSerializer
 ) : CordaProducer {
 
     companion object {
@@ -73,12 +76,14 @@ class CordaTransactionalDBProducerImpl(
             } else {
                 null
             }
+            val serializedHeaders = headerSerializer.serialize(record.headers)
             TopicRecordEntry(
                 record.topic,
                 partition,
                 offset,
                 serialisedKey,
                 serialisedValue,
+                serializedHeaders,
                 transaction,
             )
         }

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/builder/DBCordaProducerBuilderImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/producer/builder/DBCordaProducerBuilderImpl.kt
@@ -11,6 +11,7 @@ import net.corda.messagebus.db.persistence.EntityManagerFactoryHolder
 import net.corda.messagebus.db.producer.CordaAtomicDBProducerImpl
 import net.corda.messagebus.db.producer.CordaTransactionalDBProducerImpl
 import net.corda.messagebus.db.serialization.CordaDBAvroSerializerImpl
+import net.corda.messagebus.db.serialization.MessageHeaderSerializerImpl
 import net.corda.messagebus.db.util.WriteOffsets
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.schema.registry.AvroSchemaRegistry
@@ -21,6 +22,7 @@ import org.osgi.service.component.annotations.Reference
 /**
  * Builder for a DB Producer.
  */
+@Suppress("Unused")
 @Component(service = [CordaProducerBuilder::class])
 class DBCordaProducerBuilderImpl @Activate constructor(
     @Reference(service = AvroSchemaRegistry::class)
@@ -58,15 +60,16 @@ class DBCordaProducerBuilderImpl @Activate constructor(
             CordaTransactionalDBProducerImpl(
                 CordaDBAvroSerializerImpl(avroSchemaRegistry),
                 DBAccess(emf),
-                getWriteOffsets(resolvedConfig)
+                getWriteOffsets(resolvedConfig),
+                MessageHeaderSerializerImpl()
             )
         } else {
             CordaAtomicDBProducerImpl(
                 CordaDBAvroSerializerImpl(avroSchemaRegistry),
                 DBAccess(emf),
-                getWriteOffsets(resolvedConfig)
+                getWriteOffsets(resolvedConfig),
+                MessageHeaderSerializerImpl()
             )
         }
     }
-
 }

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/MessageHeaderSerializer.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/MessageHeaderSerializer.kt
@@ -1,0 +1,7 @@
+package net.corda.messagebus.db.serialization
+
+interface MessageHeaderSerializer {
+    fun serialize(headers: List<Pair<String, String>>): String
+    fun deserialize(headers: String): List<Pair<String, String>>
+}
+

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/MessageHeaderSerializerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/MessageHeaderSerializerImpl.kt
@@ -1,0 +1,18 @@
+package net.corda.messagebus.db.serialization
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+class MessageHeaderSerializerImpl : MessageHeaderSerializer {
+    private val objectMapper = ObjectMapper()
+
+    override fun serialize(headers: List<Pair<String, String>>): String {
+        return objectMapper.writeValueAsString(Headers(headers.map { Header(it.first, it.second) }))
+    }
+
+    override fun deserialize(headers: String): List<Pair<String, String>> {
+        return objectMapper.readValue(headers, Headers::class.java).items!!.map { Pair(it.key!!, it.value!!) }
+    }
+
+    private class Header(var key: String? = null, var value: String? = null)
+    private class Headers(var items: List<Header>? = listOf())
+}

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/producer/CordaAtomicDBProducerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/producer/CordaAtomicDBProducerImplTest.kt
@@ -33,7 +33,7 @@ internal class CordaAtomicDBProducerImplTest {
     @Test
     fun `atomic producer inserts atomic transaction record on initialization`() {
         val dbAccess: DBAccess = mock()
-        CordaAtomicDBProducerImpl(mock(), dbAccess, mock())
+        CordaAtomicDBProducerImpl(mock(), dbAccess, mock(), mock())
         verify(dbAccess).writeAtomicTransactionRecord()
     }
 
@@ -43,7 +43,7 @@ internal class CordaAtomicDBProducerImplTest {
         whenever(dbAccess.writeTransactionRecord(any())).thenAnswer {
             throw RollbackException("I already have this!")
         }
-        CordaAtomicDBProducerImpl(mock(), dbAccess, mock())
+        CordaAtomicDBProducerImpl(mock(), dbAccess, mock(), mock())
     }
 
     @Test
@@ -63,7 +63,8 @@ internal class CordaAtomicDBProducerImplTest {
         val producer = CordaAtomicDBProducerImpl(
             serializer,
             dbAccess,
-            writeOffsets
+            writeOffsets,
+            mock()
         )
         val cordaRecord = CordaProducerRecord(topic, key, value)
 
@@ -95,7 +96,8 @@ internal class CordaAtomicDBProducerImplTest {
         val producer = CordaAtomicDBProducerImpl(
             serializer,
             dbAccess,
-            writeOffsets
+            writeOffsets,
+            mock()
         )
         val cordaRecord = CordaProducerRecord(topic, key, value)
 
@@ -117,7 +119,7 @@ internal class CordaAtomicDBProducerImplTest {
     fun `atomic producer does not allow transactional calls`() {
         val dbAccess: DBAccess = mock()
 
-        val producer = CordaAtomicDBProducerImpl(mock(), dbAccess, mock())
+        val producer = CordaAtomicDBProducerImpl(mock(), dbAccess, mock(), mock())
 
         assertThatExceptionOfType(CordaMessageAPIFatalException::class.java).isThrownBy {
             producer.beginTransaction()
@@ -141,7 +143,7 @@ internal class CordaAtomicDBProducerImplTest {
     @Test
     fun `producer correctly closes down dbAccess when closed`() {
         val dbAccess: DBAccess = mock()
-        val producer = CordaAtomicDBProducerImpl(mock(), dbAccess, mock())
+        val producer = CordaAtomicDBProducerImpl(mock(), dbAccess, mock(), mock())
         producer.close()
         verify(dbAccess).close()
     }

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/producer/CordaTransactionalDBProducerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/producer/CordaTransactionalDBProducerImplTest.kt
@@ -37,6 +37,7 @@ internal class CordaTransactionalDBProducerImplTest {
         val producer = CordaTransactionalDBProducerImpl(
             mock(),
             dbAccess,
+            mock(),
             mock()
         ) as CordaProducer
 
@@ -77,7 +78,7 @@ internal class CordaTransactionalDBProducerImplTest {
         whenever(serializer.serialize(eq(value))).thenReturn(serializedValue)
         val callback: CordaProducer.Callback = mock()
 
-        val producer = CordaTransactionalDBProducerImpl(serializer, dbAccess, mock())
+        val producer = CordaTransactionalDBProducerImpl(serializer, dbAccess, mock(), mock())
         val cordaRecord = CordaProducerRecord(topic, key, value)
 
         producer.beginTransaction()
@@ -106,7 +107,7 @@ internal class CordaTransactionalDBProducerImplTest {
         whenever(serializer.serialize(eq(value))).thenReturn(serializedValue)
         val callback: CordaProducer.Callback = mock()
 
-        val producer = CordaTransactionalDBProducerImpl(serializer, dbAccess, writeOffsets)
+        val producer = CordaTransactionalDBProducerImpl(serializer, dbAccess, writeOffsets, mock())
         val cordaRecord = CordaProducerRecord(topic, key, value)
 
         producer.beginTransaction()
@@ -140,7 +141,7 @@ internal class CordaTransactionalDBProducerImplTest {
     @Test
     fun `producer correctly closes down dbAccess when closed`() {
         val dbAccess: DBAccess = mock()
-        val producer = CordaTransactionalDBProducerImpl(mock(), dbAccess, mock())
+        val producer = CordaTransactionalDBProducerImpl(mock(), dbAccess, mock(), mock())
         producer.close()
         verify(dbAccess).close()
     }

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/serialization/MessageHeaderSerializationTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/serialization/MessageHeaderSerializationTest.kt
@@ -1,0 +1,58 @@
+package net.corda.messagebus.db.serialization
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MessageHeaderSerializationTest {
+
+    @Test
+    fun `Serialize headers`() {
+        val headers = listOf("item1" to "value1a")
+        val result = MessageHeaderSerializerImpl().serialize(headers).trimIndent()
+        assertThat(result).isEqualTo("{\"items\":[{\"key\":\"item1\",\"value\":\"value1a\"}]}")
+    }
+
+    @Test
+    fun `Serialize empty length headers`() {
+        val result = MessageHeaderSerializerImpl().serialize(listOf()).trimIndent()
+        assertThat(result).isEqualTo("{\"items\":[]}")
+    }
+
+    @Test
+    fun `deserialize headers`() {
+        val json = """{
+            "items":[
+             {
+                 "key":"item1",
+                 "value":"value1a"
+             },
+             {
+                 "key":"item1",
+                 "value":"value1b"
+             },
+             {
+                 "key":"item2",
+                 "value":"value2a"
+             }
+        ]
+}""".trimMargin()
+
+        val result = MessageHeaderSerializerImpl().deserialize(json)
+
+        assertThat(result[0].first).isEqualTo("item1")
+        assertThat(result[0].second).isEqualTo("value1a")
+        assertThat(result[1].first).isEqualTo("item1")
+        assertThat(result[1].second).isEqualTo("value1b")
+        assertThat(result[2].first).isEqualTo("item2")
+        assertThat(result[2].second).isEqualTo("value2a")
+    }
+
+    @Test
+    fun `deserialize empty`() {
+        val json = "{}"
+
+        val result = MessageHeaderSerializerImpl().deserialize(json)
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/CordaKafkaProducerImpl.kt
@@ -6,6 +6,7 @@ import net.corda.messagebus.api.producer.CordaProducer
 import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messagebus.kafka.config.ResolvedProducerConfig
 import net.corda.messagebus.kafka.consumer.CordaKafkaConsumerImpl
+import net.corda.messagebus.kafka.utils.toKafkaRecord
 import net.corda.messagebus.kafka.utils.toKafkaRecords
 import net.corda.messaging.api.chunking.ChunkSerializerService
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
@@ -15,7 +16,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.Callback
 import org.apache.kafka.clients.producer.Producer
-import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.AuthorizationException
@@ -98,7 +98,7 @@ class CordaKafkaProducerImpl(
         if (chunkedRecords.isNotEmpty()) {
             sendChunks(chunkedRecords, callback, partition)
         } else {
-            producer.send(ProducerRecord(topicPrefix + record.topic, partition, record.key, record.value), callback?.toKafkaCallback())
+            producer.send(record.toKafkaRecord(topicPrefix , partition), callback?.toKafkaCallback())
         }
     }
 
@@ -126,7 +126,7 @@ class CordaKafkaProducerImpl(
         }
         cordaProducerRecords.forEach {
             //note callback is only applicable to async calls which are not allowed
-            producer.send(ProducerRecord(topicPrefix + it.topic, partition, it.key, it.value))
+            producer.send(it.toKafkaRecord(topicPrefix,partition))
         }
     }
 

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaConversions.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaConversions.kt
@@ -1,16 +1,58 @@
 package net.corda.messagebus.kafka.utils
 
-import net.corda.messagebus.api.CordaOffsetAndMetadata
 import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
+import net.corda.messagebus.api.producer.CordaProducerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.header.internals.RecordHeader
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+
+private val stringDeserializer = StringDeserializer()
+private val stringSerializer = StringSerializer()
 
 fun CordaOffsetResetStrategy.toKafka() = OffsetResetStrategy.valueOf(this.name)
-fun CordaOffsetAndMetadata.toKafka() = OffsetAndMetadata(this.offset, this.metadata)
+
+fun <K : Any, V : Any> CordaProducerRecord<K, V>.toKafkaRecord(
+    topicPrefix: String,
+    partition: Int? = null
+): ProducerRecord<Any, Any> {
+    return ProducerRecord(
+        topicPrefix + this.topic,
+        partition,
+        this.key,
+        this.value,
+        this.headers.map {
+            RecordHeader(it.first, stringSerializer.serialize(null, it.second))
+        })
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <K : Any, V : Any> ConsumerRecord<Any, Any>.toCordaConsumerRecord(
+    topicPrefix: String
+): CordaConsumerRecord<K, V> {
+    return this.toCordaConsumerRecord(topicPrefix, this.key() as K,this.value() as V)
+}
+
+fun <K : Any, V : Any> ConsumerRecord<Any, Any>.toCordaConsumerRecord(
+    topicPrefix: String,
+    key:K,
+    value:V?
+): CordaConsumerRecord<K, V> {
+    return CordaConsumerRecord(
+        this.topic().removePrefix(topicPrefix),
+        this.partition(),
+        this.offset(),
+        key,
+        value,
+        this.timestamp(),
+        this.headers().map { it.key() to stringDeserializer.deserialize(null, it.value()) }
+    )
+}
 
 fun List<CordaConsumerRecord<*, *>>.toKafkaRecords():
         List<ConsumerRecord<*, *>> {
@@ -40,5 +82,8 @@ fun TopicPartition.toCordaTopicPartition(topicPrefix: String): CordaTopicPartiti
     return CordaTopicPartition(topic().removePrefix(topicPrefix), partition())
 }
 
-fun Collection<CordaTopicPartition>.toTopicPartitions(topicPrefix: String) = this.map { it.toTopicPartition(topicPrefix) }
-fun Collection<TopicPartition>.toCordaTopicPartitions(topicPrefix: String ) = this.map { it.toCordaTopicPartition(topicPrefix) }
+fun Collection<CordaTopicPartition>.toTopicPartitions(topicPrefix: String) =
+    this.map { it.toTopicPartition(topicPrefix) }
+
+fun Collection<TopicPartition>.toCordaTopicPartitions(topicPrefix: String) =
+    this.map { it.toCordaTopicPartition(topicPrefix) }

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaConversions.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/utils/KafkaConversions.kt
@@ -35,7 +35,7 @@ fun <K : Any, V : Any> CordaProducerRecord<K, V>.toKafkaRecord(
 fun <K : Any, V : Any> ConsumerRecord<Any, Any>.toCordaConsumerRecord(
     topicPrefix: String
 ): CordaConsumerRecord<K, V> {
-    return this.toCordaConsumerRecord(topicPrefix, this.key() as K,this.value() as V)
+    return this.toCordaConsumerRecord(topicPrefix, this.key() as K,this.value() as V?)
 }
 
 fun <K : Any, V : Any> ConsumerRecord<Any, Any>.toCordaConsumerRecord(

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
@@ -114,7 +114,7 @@ internal class KafkaConversionsTest {
 
         kafkaConsumerRecord.headers().add("h1", headerData)
 
-        val result = kafkaConsumerRecord.toCordaConsumerRecord<String, Int>("prefix1_","key1",null)
+        val result = kafkaConsumerRecord.toCordaConsumerRecord<String, Int>("prefix1_", "key1", null)
 
         assertThat(result.topic).isEqualTo("topic1")
         assertThat(result.partition).isEqualTo(1)
@@ -122,8 +122,6 @@ internal class KafkaConversionsTest {
         assertThat(result.key).isEqualTo("key1")
         assertThat(result.value).isNull()
         assertThat(result.headers).containsExactly("h1" to "h_value")
-
-
     }
 
     @Test

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
@@ -1,8 +1,8 @@
-package net.corda.messaging.kafka.subscription.net.corda.messagebus.kafka.utils
+package net.corda.messagebus.kafka.utils
 
 import net.corda.messagebus.api.CordaTopicPartition
-import net.corda.messagebus.kafka.utils.toCordaTopicPartition
-import net.corda.messagebus.kafka.utils.toTopicPartition
+import net.corda.messagebus.api.producer.CordaProducerRecord
+import org.apache.avro.util.Utf8
 import org.apache.kafka.common.TopicPartition
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -11,6 +11,24 @@ internal class KafkaConversionsTest {
     private val partition = 100
     private val topicName = "topic1"
     private val testTopicPrefix = "test-"
+
+    @Test
+    fun toKafkaRecordAddsPrefixAndHeaders() {
+        val prefix = "p_"
+        val topic = "topic1"
+        val headers = listOf("a" to "a_value", "b" to "b_value")
+        val record = CordaProducerRecord(topic, "key", "value", headers)
+
+        val result = record.toKafkaRecord(prefix)
+
+        val expectedHeaderAValue = Utf8.getBytesFor("a_value")
+        val expectedHeaderBValue = Utf8.getBytesFor("b_value")
+        assertThat(result.topic()).isEqualTo("p_topic1")
+        assertThat(result.key()).isEqualTo("key")
+        assertThat(result.value()).isEqualTo("value")
+        assertThat(result.headers().headers("a").single().value()).isEqualTo(expectedHeaderAValue)
+        assertThat(result.headers().headers("b").single().value()).isEqualTo(expectedHeaderBValue)
+    }
 
     @Test
     fun toTopicPartitionAddsPrefixToTopic() {

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/utils/KafkaConversionsTest.kt
@@ -3,9 +3,11 @@ package net.corda.messagebus.kafka.utils
 import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.producer.CordaProducerRecord
 import org.apache.avro.util.Utf8
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
 
 internal class KafkaConversionsTest {
     private val partition = 100
@@ -28,6 +30,100 @@ internal class KafkaConversionsTest {
         assertThat(result.value()).isEqualTo("value")
         assertThat(result.headers().headers("a").single().value()).isEqualTo(expectedHeaderAValue)
         assertThat(result.headers().headers("b").single().value()).isEqualTo(expectedHeaderBValue)
+    }
+
+    @Test
+    fun toCordaConsumerRecord() {
+        val headerData = "h_value".toByteArray(StandardCharsets.UTF_8)
+        val kafkaConsumerRecord = ConsumerRecord<Any, Any>(
+            "prefix1_topic1",
+            1,
+            2,
+            "key1",
+            10
+        )
+
+        kafkaConsumerRecord.headers().add("h1", headerData)
+
+        val result = kafkaConsumerRecord.toCordaConsumerRecord<String, Int>("prefix1_")
+
+        assertThat(result.topic).isEqualTo("topic1")
+        assertThat(result.partition).isEqualTo(1)
+        assertThat(result.offset).isEqualTo(2)
+        assertThat(result.key).isEqualTo("key1")
+        assertThat(result.value).isEqualTo(10)
+        assertThat(result.headers).containsExactly("h1" to "h_value")
+    }
+
+    @Test
+    fun `toCordaConsumerRecord null record value`() {
+        val headerData = "h_value".toByteArray(StandardCharsets.UTF_8)
+        val kafkaConsumerRecord = ConsumerRecord<Any, Any>(
+            "prefix1_topic1",
+            1,
+            2,
+            "key1",
+            null
+        )
+
+        kafkaConsumerRecord.headers().add("h1", headerData)
+
+        val result = kafkaConsumerRecord.toCordaConsumerRecord<String, Int>("prefix1_")
+
+        assertThat(result.topic).isEqualTo("topic1")
+        assertThat(result.partition).isEqualTo(1)
+        assertThat(result.offset).isEqualTo(2)
+        assertThat(result.key).isEqualTo("key1")
+        assertThat(result.value).isNull()
+        assertThat(result.headers).containsExactly("h1" to "h_value")
+    }
+
+    @Test
+    fun `toCordaConsumerRecord with key and value`() {
+        val headerData = "h_value".toByteArray(StandardCharsets.UTF_8)
+        val kafkaConsumerRecord = ConsumerRecord<Any, Any>(
+            "prefix1_topic1",
+            1,
+            2,
+            "",
+            0
+        )
+
+        kafkaConsumerRecord.headers().add("h1", headerData)
+
+        val result = kafkaConsumerRecord.toCordaConsumerRecord<String, Int>("prefix1_", "key1", 10)
+
+        assertThat(result.topic).isEqualTo("topic1")
+        assertThat(result.partition).isEqualTo(1)
+        assertThat(result.offset).isEqualTo(2)
+        assertThat(result.key).isEqualTo("key1")
+        assertThat(result.value).isEqualTo(10)
+        assertThat(result.headers).containsExactly("h1" to "h_value")
+    }
+
+    @Test
+    fun `toCordaConsumerRecord with key and null value`() {
+        val headerData = "h_value".toByteArray(StandardCharsets.UTF_8)
+        val kafkaConsumerRecord = ConsumerRecord<Any, Any>(
+            "prefix1_topic1",
+            1,
+            2,
+            "",
+            0
+        )
+
+        kafkaConsumerRecord.headers().add("h1", headerData)
+
+        val result = kafkaConsumerRecord.toCordaConsumerRecord<String, Int>("prefix1_","key1",null)
+
+        assertThat(result.topic).isEqualTo("topic1")
+        assertThat(result.partition).isEqualTo(1)
+        assertThat(result.offset).isEqualTo(2)
+        assertThat(result.key).isEqualTo("key1")
+        assertThat(result.value).isNull()
+        assertThat(result.headers).containsExactly("h1" to "h_value")
+
+
     }
 
     @Test

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumerRecord.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumerRecord.kt
@@ -1,4 +1,4 @@
-package net.corda.messagebus.api.consumer;
+package net.corda.messagebus.api.consumer
 
 /**
  * A key/value pair to be received from the message bus. This also consists of a topic name and
@@ -36,4 +36,9 @@ data class CordaConsumerRecord<K, V>(
      * The timestamp of this record.
      */
     val timestamp: Long,
+
+    /**
+     * The optional headers carried on the message.
+     */
+    val headers: List<Pair<String, String>> = listOf()
 )

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/producer/CordaProducerRecord.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/producer/CordaProducerRecord.kt
@@ -5,5 +5,11 @@ package net.corda.messagebus.api.producer
  * @property topic defined the id of the topic the record is stored on.
  * @property key is the unique per topic key for a record
  * @property value the value of the record
+ * @property headers Optional list of headers to added to the message.
  */
-data class CordaProducerRecord<K : Any, V : Any>(val topic: String, val key: K, val value: V?)
+data class CordaProducerRecord<K : Any, V : Any>(
+    val topic: String,
+    val key: K,
+    val value: V?,
+    val headers: List<Pair<String, String>> = listOf()
+)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/RecordExtensions.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/RecordExtensions.kt
@@ -14,7 +14,7 @@ fun <K : Any, V : Any> CordaConsumerRecord<K, V>.toEventLogRecord(): EventLogRec
 }
 
 fun Record<*, *>.toCordaProducerRecord(): CordaProducerRecord<*, *> {
-    return CordaProducerRecord(this.topic, this.key, this.value)
+    return CordaProducerRecord(this.topic, this.key, this.value, this.headers)
 }
 
 fun List<Record<*, *>>.toCordaProducerRecords(): List<CordaProducerRecord<*, *>> {

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/RecordExtensionsTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/RecordExtensionsTest.kt
@@ -1,0 +1,19 @@
+package net.corda.messaging.utils
+
+import net.corda.messaging.api.records.Record
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RecordExtensionsTest {
+
+    @Test
+    fun `toCordaProducerRecord maps all fields`(){
+        val record = Record("topic","key","value", listOf("a" to "b"))
+        val result = record.toCordaProducerRecord()
+
+        assertThat(result.topic).isEqualTo(record.topic)
+        assertThat(result.key).isEqualTo(record.key)
+        assertThat(result.value).isEqualTo(record.value)
+        assertThat(result.headers).isEqualTo(record.headers)
+    }
+}

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/records/Record.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/records/Record.kt
@@ -2,8 +2,14 @@ package net.corda.messaging.api.records
 
 /**
  * Object to encapsulate the events stored on topics
- * @property topic defined the id of the topic the record is stored on.
- * @property key is the unique per topic key for a record
- * @property value the value of the record
+ * @property topic Defines the id of the topic the record is stored on.
+ * @property key Is the unique per topic key for a record
+ * @property value The value of the record
+ * @property headers Optional list of headers to added to the message.
  */
-data class Record<K : Any, V : Any>(val topic: String, val key: K, val value: V?)
+data class Record<K : Any, V : Any>(
+    val topic: String,
+    val key: K,
+    val value: V?,
+    val headers: List<Pair<String, String>> = listOf()
+)


### PR DESCRIPTION
To support messaging to external applications we need to add support for message headers in the messaging libs. This change only covers publishing (required for phase 1 of external messaging) and durable subscribers (required for testing).