### PR TITLE
CORE-9775 Support extendable finalization result

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/FinalizationResultImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/FinalizationResultImpl.kt
@@ -3,7 +3,7 @@ package net.corda.ledger.utxo.flow.impl
 import net.corda.v5.ledger.utxo.FinalizationResult
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 
-class FinalizationResultImpl(private val utxoSignedTransaction:UtxoSignedTransaction):FinalizationResult {
+class FinalizationResultImpl(private val utxoSignedTransaction: UtxoSignedTransaction) : FinalizationResult {
     override fun getTransaction(): UtxoSignedTransaction {
         return utxoSignedTransaction
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/FinalizationResultImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/FinalizationResultImpl.kt
@@ -1,0 +1,10 @@
+package net.corda.ledger.utxo.flow.impl
+
+import net.corda.v5.ledger.utxo.FinalizationResult
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+
+class FinalizationResultImpl(private val utxoSignedTransaction:UtxoSignedTransaction):FinalizationResult {
+    override fun getTransaction(): UtxoSignedTransaction {
+        return utxoSignedTransaction
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -28,6 +28,7 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
 import net.corda.v5.ledger.utxo.ContractState
+import net.corda.v5.ledger.utxo.FinalizationResult
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.UtxoLedgerService
@@ -99,7 +100,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
     override fun finalize(
         signedTransaction: UtxoSignedTransaction,
         sessions: List<FlowSession>
-    ): UtxoSignedTransaction {
+    ): FinalizationResult {
         /*
         Need [doPrivileged] due to [contextLogger] being used in the flow's constructor.
         Creating the executing the SubFlow must be independent otherwise the security manager causes issues with Quasar.
@@ -115,13 +116,13 @@ class UtxoLedgerServiceImpl @Activate constructor(
         } catch (e: PrivilegedActionException) {
             throw e.exception
         }
-        return flowEngine.subFlow(utxoFinalityFlow)
+        return FinalizationResultImpl(flowEngine.subFlow(utxoFinalityFlow))
     }
 
     @Suspendable
     override fun receiveFinality(
         session: FlowSession, validator: UtxoTransactionValidator
-    ): UtxoSignedTransaction {
+    ): FinalizationResult {
         val utxoReceiveFinalityFlow = try {
             AccessController.doPrivileged(PrivilegedExceptionAction {
                 UtxoReceiveFinalityFlow(session, validator)
@@ -129,7 +130,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
         } catch (e: PrivilegedActionException) {
             throw e.exception
         }
-        return flowEngine.subFlow(utxoReceiveFinalityFlow)
+        return FinalizationResultImpl(flowEngine.subFlow(utxoReceiveFinalityFlow))
     }
 
     // Retrieve notary client plugin class for specified notary service identity. This is done in

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.729-beta+
+cordaApiVersion=5.0.0.732-alpha-1679590837091
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.732-alpha-1679590837091
+cordaApiVersion=5.0.0.730-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/landregistry/flows/IssueLandTitleFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/landregistry/flows/IssueLandTitleFlow.kt
@@ -1,13 +1,11 @@
 package net.cordacon.example.landregistry.flows
 
 import net.corda.v5.application.flows.ClientRequestBody
-import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
-import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.flows.InitiatedBy
-import net.cordacon.example.landregistry.states.LandTitleContract
-import net.cordacon.example.landregistry.states.LandTitleState
+import net.corda.v5.application.flows.InitiatingFlow
+import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
@@ -17,6 +15,8 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.utxo.UtxoLedgerService
+import net.cordacon.example.landregistry.states.LandTitleContract
+import net.cordacon.example.landregistry.states.LandTitleState
 import java.time.Instant
 import java.time.LocalDateTime
 import kotlin.time.Duration.Companion.days
@@ -81,10 +81,10 @@ class IssueLandTitleFlow: ClientStartableFlow {
 
         val signedTransaction = transaction.toSignedTransaction()
         val flowSession = flowMessaging.initiateFlow(owner.name)
-        val finalizedSignedTransaction = utxoLedgerService.finalize(
+        val finalizationResult = utxoLedgerService.finalize(
             signedTransaction, listOf(flowSession)
         )
-        return finalizedSignedTransaction.id.toString()
+        return finalizationResult.transaction.id.toString()
     }
 }
 

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/landregistry/flows/TransferLandTitleFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/landregistry/flows/TransferLandTitleFlow.kt
@@ -1,13 +1,11 @@
 package net.cordacon.example.landregistry.flows
 
 import net.corda.v5.application.flows.ClientRequestBody
-import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
 import net.corda.v5.application.flows.ResponderFlow
-import net.cordacon.example.landregistry.states.LandTitleContract
-import net.cordacon.example.landregistry.states.LandTitleState
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
@@ -16,6 +14,8 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.ledger.utxo.UtxoLedgerService
+import net.cordacon.example.landregistry.states.LandTitleContract
+import net.cordacon.example.landregistry.states.LandTitleState
 import java.time.Instant
 import java.time.LocalDateTime
 import kotlin.time.Duration.Companion.days
@@ -81,12 +81,12 @@ class TransferLandTitleFlow : ClientStartableFlow {
         val ownerSession = flowMessaging.initiateFlow(request.newOwner)
 
         // CP Signing automatically handled by finalize()
-        val finalizedSignedTransaction = utxoLedgerService.finalize(
+        val finalizationResult = utxoLedgerService.finalize(
             partiallySignedTransaction,
             listOf(issuerSession, ownerSession)
         )
 
-        return finalizedSignedTransaction.id.toString()
+        return finalizationResult.transaction.id.toString()
 
     }
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimFinalizationResultImpl.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimFinalizationResultImpl.kt
@@ -1,0 +1,10 @@
+package net.corda.simulator.runtime.ledger.utxo
+
+import net.corda.v5.ledger.utxo.FinalizationResult
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+
+class SimFinalizationResultImpl(private val utxoSignedTransaction:UtxoSignedTransaction):FinalizationResult {
+    override fun getTransaction(): UtxoSignedTransaction {
+        return utxoSignedTransaction
+    }
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
@@ -12,11 +12,12 @@ import net.corda.simulator.runtime.serialization.BaseSerializationService
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.EncumbranceGroup
+import net.corda.v5.ledger.utxo.FinalizationResult
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
+import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
@@ -54,12 +55,12 @@ class SimUtxoLedgerService(
     override fun finalize(
         signedTransaction: UtxoSignedTransaction,
         sessions: List<FlowSession>
-    ): UtxoSignedTransaction {
-        return finalityHandler.finalizeTransaction(signedTransaction, sessions)
+    ): FinalizationResult {
+        return SimFinalizationResultImpl(finalityHandler.finalizeTransaction(signedTransaction, sessions))
     }
 
-    override fun receiveFinality(session: FlowSession, validator: UtxoTransactionValidator): UtxoSignedTransaction {
-        return finalityHandler.receiveFinality(session, validator)
+    override fun receiveFinality(session: FlowSession, validator: UtxoTransactionValidator): FinalizationResult {
+        return SimFinalizationResultImpl(finalityHandler.receiveFinality(session, validator))
     }
 
     override fun sendAndReceiveTransactionBuilder(

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
@@ -88,12 +88,12 @@ class UtxoDemoEvolveFlow : ClientStartableFlow {
 
             val sessions = members.map { flowMessaging.initiateFlow(it.name) }
 
-            val finalizedSignedTransaction = utxoLedgerService.finalize(
+            val finalizationResult = utxoLedgerService.finalize(
                     signedTransaction,
                     sessions
                 )
 
-            val transactionId = finalizedSignedTransaction.id.toString()
+            val transactionId = finalizationResult.transaction.id.toString()
             EvolveResponse(transactionId, null).also {
                 log.info("Success! Response: $it")
             }
@@ -118,7 +118,7 @@ class UtxoEvolveResponderFlow : ResponderFlow {
     @Suspendable
     override fun call(session: FlowSession) {
         try {
-            val finalizedSignedTransaction = utxoLedgerService.receiveFinality(session) { ledgerTransaction ->
+            val finalizationResult = utxoLedgerService.receiveFinality(session) { ledgerTransaction ->
                 val state = ledgerTransaction.outputContractStates.first() as TestUtxoState
                 if (state.testField == "fail") {
                     log.info("Failed to verify the transaction - ${ledgerTransaction.id}")
@@ -126,7 +126,7 @@ class UtxoEvolveResponderFlow : ResponderFlow {
                 }
                 log.info("Verified the transaction- ${ledgerTransaction.id}")
             }
-            log.info("Finished responder flow - ${finalizedSignedTransaction.id}")
+            log.info("Finished responder flow - ${finalizationResult.transaction.id}")
         } catch (e: Exception) {
             log.warn("Exceptionally finished responder flow", e)
         }

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
@@ -80,11 +80,11 @@ class UtxoDemoFlow : ClientStartableFlow {
             val sessions = members.map { flowMessaging.initiateFlow(it.name) }
 
             return try {
-                val finalizedSignedTransaction = utxoLedgerService.finalize(
+                val finalizationResult = utxoLedgerService.finalize(
                     signedTransaction,
                     sessions
                 )
-                finalizedSignedTransaction.id.toString().also {
+                finalizationResult.transaction.id.toString().also {
                     log.info("Success! Response: $it")
                 }
 
@@ -112,7 +112,7 @@ class UtxoResponderFlow : ResponderFlow {
     @Suspendable
     override fun call(session: FlowSession) {
         try {
-            val finalizedSignedTransaction = utxoLedgerService.receiveFinality(session) { ledgerTransaction ->
+            val finalizationResult = utxoLedgerService.receiveFinality(session) { ledgerTransaction ->
                 val state = ledgerTransaction.outputContractStates.first() as TestUtxoState
                 if (state.testField == "fail") {
                     log.info("Failed to verify the transaction - ${ledgerTransaction.id}")
@@ -120,7 +120,7 @@ class UtxoResponderFlow : ResponderFlow {
                 }
                 log.info("Verified the transaction- ${ledgerTransaction.id}")
             }
-            log.info("Finished responder flow - ${finalizedSignedTransaction.id}")
+            log.info("Finished responder flow - ${finalizationResult.transaction.id}")
         } catch (e: Exception) {
             log.warn("Exceptionally finished responder flow", e)
         }


### PR DESCRIPTION
UTXO finalization methods have been changed to return a new FinalizationResult interface, this allows additional results (such as automatic token locking) to be returned in future versions of the API without a breaking change.