### PR TITLE
NOTICK Change Helm version scheme in order not to collide with main/beta builds.

### DIFF
--- a/charts/corda-lib/Chart.yaml
+++ b/charts/corda-lib/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 5.0.0-Interop
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/corda/Chart.yaml
+++ b/charts/corda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 5.0.0-Interop
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "unstable"
 
 dependencies:
   - name: corda-lib
-    version: 0.1.0
+    version: 5.0.0-Interop
     repository: file://../corda-lib


### PR DESCRIPTION
Change Helm version to 5.0.0-Interop so it doesn't clash with builds with main branch /beta.