### PR TITLE
CORE-11278: Fix e2e tests

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -293,7 +293,10 @@ class ClusterBuilder {
                 {
                     "p2pTlsCertificateChainAlias": "$CERT_ALIAS_P2P",
                     "useClusterLevelTlsCertificateAndKey": true,
-                    "sessionKeyId": "$sessionKeyId"
+                    "sessionKeysAndCertificates": [
+                      "preferred": true,
+                      "sessionKeyId": "$sessionKeyId"
+                    ]
                 }
             """.trimIndent()
         )


### PR DESCRIPTION
The `net.corda.e2etest.membership.RegistrationApprovalTest` tests fail (for example - [here](https://ci02.dev.r3.com/job/Corda5/job/corda5-e2e-tests/view/change-requests/job/PR-47/4/)). This is because the network setup API had changed as part of the session key ID rotation.