### PR TITLE
CORE-11035 - additional-db-pool-configuration 

### DIFF
--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -47,7 +47,12 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
         )
 
     DbConfig.log.debug("Creating DB connection for: $driver, $jdbcUrl, $username, $maxPoolSize")
-    return this.create(driver, jdbcUrl, username, password, false, maxPoolSize)
+    return this.create(
+        driverClass = driver,
+        jdbcUrl = jdbcUrl,
+        username = username,
+        password = password,
+        maximumPoolSize = maxPoolSize)
 }
 
 @Suppress("LongParameterList")

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -63,12 +63,11 @@ class DbConfigTest {
         dataSourceFactory.createFromConfig(fullSmartConfig)
 
         verify(dataSourceFactory).create(
-            driver,
-            url,
-            user,
-            pass,
-            false,
-            poolsize)
+            driverClass = driver,
+            jdbcUrl = url,
+            username = user,
+            password = pass,
+            maximumPoolSize = poolsize)
     }
 
     @Test
@@ -80,8 +79,7 @@ class DbConfigTest {
             DEFAULT_JDBC_URL,
             user,
             pass,
-            false,
-            DB_POOL_MAX_SIZE)
+            maximumPoolSize = DB_POOL_MAX_SIZE)
     }
 
     @Test

--- a/libs/db/db-core/build.gradle
+++ b/libs/db/db-core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     integrationTestRuntimeOnly 'org.osgi:osgi.core'
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
+    integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }
 

--- a/libs/db/db-core/src/integrationTest/kotlin/net/corda/db/core/HikariDataSourceFactoryTest.kt
+++ b/libs/db/db-core/src/integrationTest/kotlin/net/corda/db/core/HikariDataSourceFactoryTest.kt
@@ -1,0 +1,119 @@
+package net.corda.db.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import kotlin.time.toJavaDuration
+
+class HikariDataSourceFactoryTest {
+    private val dbName = "cordacluster"
+    private val connectionsSQL = "SELECT " +
+            "query, " +
+            "state " +
+            "backend_start, " +
+            "query_start, " +
+            "application_name, " +
+            "client_addr " +
+            "FROM pg_stat_activity WHERE datname = '$dbName'"
+
+    private val monitorPoolDelegate = lazy {
+        HikariDataSourceFactory().create(
+            driverClass = "org.postgresql.Driver",
+            jdbcUrl = "jdbc:postgresql://localhost:5432/$dbName",
+            username = "postgres",
+            password = "password",
+            maximumPoolSize = 1,
+        )
+    }
+    private val monitorPool by monitorPoolDelegate
+
+    @AfterEach
+    fun tearDown() {
+        if(monitorPoolDelegate.isInitialized())
+            monitorPool.close()
+    }
+
+    @Disabled("This test should not be run in the pipeline. It is useful for observing Hikari behaviour for particular" +
+            " configuration settings, but it isn't a useful test for corda and will always be time bound.")
+    @Test
+    fun `observe hikari remove idle connections`() {
+        val maxConnections = 5
+        val minConnections = 0
+        val idleTimeout = 10.toDuration(DurationUnit.SECONDS).toJavaDuration()
+        HikariDataSourceFactory().create(
+            driverClass = "org.postgresql.Driver",
+            jdbcUrl = "jdbc:postgresql://localhost:5432/$dbName",
+            username = "postgres",
+            password = "password",
+            maximumPoolSize = maxConnections,
+            minimumPoolSize = minConnections,
+            idleTimeout = idleTimeout
+        ).use { hf ->
+            val connections1 = checkConnections()
+            println("Pool has $connections1 connections.")
+            assertThat(connections1).isEqualTo(0)
+
+            (1..20).toList().parallelStream().forEach {
+                hf.connection.use {
+                    it.prepareStatement("SELECT NOW();").execute()
+                    Thread.sleep(20)
+                }
+            }
+
+            val connections2 = checkConnections()
+            println("Pool has $connections2 connections.")
+            assertThat(connections2).isEqualTo(maxConnections)
+
+            val start = Instant.now()
+            println("Wait for the connections to go to $minConnections")
+            Thread.sleep(idleTimeout.toMillis()) // wait at least as long as idle timeout
+            while(
+                checkConnections(false) > minConnections
+                && start.plusMillis(idleTimeout.toMillis()).plusSeconds(30) > Instant.now()
+            ) {
+                println("Still ${checkConnections(false)} connections remaining after " +
+                        "${Duration.between(start, Instant.now()).seconds}s.")
+                Thread.sleep(1000)
+            }
+
+            val connections3 = checkConnections()
+            println("Pool has $connections3 connections.")
+            assertThat(connections3).isEqualTo(minConnections)
+
+            println("Execute another query so we can check we can scale back up from zero")
+            hf.connection.use {
+                it.prepareStatement("SELECT NOW();").execute()
+            }
+            val connections4 = checkConnections()
+            println("Pool has $connections4 connections.")
+            assertThat(connections4).isGreaterThan(minConnections)
+        }
+    }
+
+    private fun checkConnections(print: Boolean = true): Int {
+        monitorPool.connection.use {
+            val results = it.prepareStatement(connectionsSQL).executeQuery()
+            val meta = results.metaData
+            var connections = 0
+            while (results.next()) {
+                if(results.getString(1) == connectionsSQL)
+                    continue
+
+                connections++
+
+                if(print) {
+                    val row = (1..meta.columnCount).fold("") { s, i ->
+                        "$s|${meta.getColumnName(i)}=${results.getObject(i)}"
+                    }
+                    println(row)
+                }
+            }
+            return connections
+        }
+    }
+}

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
@@ -1,6 +1,37 @@
 package net.corda.db.core
 
+import java.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import kotlin.time.toJavaDuration
+
 interface DataSourceFactory {
+    /**
+     * Create a new [CloseableDataSource] with the given configuration
+     *
+     * @param driverClass type of JDBC driver to use.
+     * @param jdbcUrl
+     * @param username
+     * @param password
+     * @param isAutoCommit default auto-commit behaviour.
+     * @param isReadOnly when set, and supported by the database, the pool will return read-only connections. Default - false.
+     * @param maximumPoolSize the maximum number of connection in the pool. Default - 10
+     * @param minimumPoolSize the minimum number of connections in the pool.
+     *      Defaults - the same as the maximum number of connections configured ([maximumPoolSize])
+     * @param idleTimeout the maximum amount of time a connection is allowed to be idle before being removed from the pool.
+     *      If [minimumPoolSize] is equal to [maximumPoolSize], then connections will never be removed.
+     *      Default - 2 minutes.
+     * @param maxLifetime the maximum lifetime of a connection in the pool.
+     *      An in-use connection will never be retired, only when it is closed will it then be removed.
+     *      This should be set several seconds shorter than any database or infrastructure imposed connection time limit.
+     *      Default - 30 minutes.
+     * @param keepaliveTime This property controls how frequently the pool will attempt to keep a connection alive,
+     *      in order to prevent it from being timed out by the database or network infrastructure.
+     *      This value must be less than the [maxLifetime] value.
+     *      A value in the range of minutes is most desirable.
+     *      Default - 0 (disabled).
+     * @param validationTimeout maximum amount of time that a connection will be tested for aliveness. Default - 5 seconds.
+     */
     @Suppress("LongParameterList")
     fun create(
         driverClass: String,
@@ -8,6 +39,12 @@ interface DataSourceFactory {
         username: String,
         password: String,
         isAutoCommit: Boolean = false,
-        maximumPoolSize: Int = 10
+        isReadOnly: Boolean = false,
+        maximumPoolSize: Int = 10,
+        minimumPoolSize: Int = maximumPoolSize,
+        idleTimeout: Duration = 2.toDuration(DurationUnit.MINUTES).toJavaDuration(),
+        maxLifetime: Duration = 30.toDuration(DurationUnit.MINUTES).toJavaDuration(),
+        keepaliveTime: Duration = Duration.ZERO,
+        validationTimeout: Duration = 5.toDuration(DurationUnit.SECONDS).toJavaDuration(),
     ): CloseableDataSource
 }

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
@@ -1,9 +1,6 @@
 package net.corda.db.core
 
 import java.time.Duration
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
-import kotlin.time.toJavaDuration
 
 interface DataSourceFactory {
     /**
@@ -42,9 +39,9 @@ interface DataSourceFactory {
         isReadOnly: Boolean = false,
         maximumPoolSize: Int = 10,
         minimumPoolSize: Int = maximumPoolSize,
-        idleTimeout: Duration = 2.toDuration(DurationUnit.MINUTES).toJavaDuration(),
-        maxLifetime: Duration = 30.toDuration(DurationUnit.MINUTES).toJavaDuration(),
+        idleTimeout: Duration = Duration.ofMinutes(2),
+        maxLifetime: Duration = Duration.ofMinutes(30),
         keepaliveTime: Duration = Duration.ZERO,
-        validationTimeout: Duration = 5.toDuration(DurationUnit.SECONDS).toJavaDuration(),
+        validationTimeout: Duration = Duration.ofSeconds(5),
     ): CloseableDataSource
 }

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/HikariDataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/HikariDataSourceFactory.kt
@@ -3,6 +3,7 @@ package net.corda.db.core
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import java.io.Closeable
+import java.time.Duration
 import javax.sql.DataSource
 
 /**
@@ -35,7 +36,13 @@ class HikariDataSourceFactory(
         username: String,
         password: String,
         isAutoCommit: Boolean,
-        maximumPoolSize: Int
+        isReadOnly: Boolean,
+        maximumPoolSize: Int,
+        minimumPoolSize: Int,
+        idleTimeout: Duration,
+        maxLifetime: Duration,
+        keepaliveTime: Duration,
+        validationTimeout: Duration
     ): CloseableDataSource {
         val conf = HikariConfig()
 
@@ -57,7 +64,14 @@ class HikariDataSourceFactory(
         }
 
         conf.isAutoCommit = isAutoCommit
+        conf.isReadOnly = isReadOnly
         conf.maximumPoolSize = maximumPoolSize
+        conf.minimumIdle = minimumPoolSize
+        conf.idleTimeout = idleTimeout.toMillis()
+        conf.maxLifetime = maxLifetime.toMillis()
+        if(Duration.ZERO != keepaliveTime)
+            conf.keepaliveTime = keepaliveTime.toMillis()
+        conf.validationTimeout = validationTimeout.toMillis()
 
         return hikariDataSourceFactory(conf)
     }

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/PostgresDataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/PostgresDataSourceFactory.kt
@@ -7,14 +7,15 @@ class PostgresDataSourceFactory(
         jdbcUrl: String,
         username: String,
         password: String,
-        maximumPoolSize: Int = 3
+        maximumPoolSize: Int = 5
     ): CloseableDataSource {
         return datasourceFactory.create(
             driverClass = "org.postgresql.Driver",
             jdbcUrl = jdbcUrl,
             username = username,
             password = password,
-            maximumPoolSize = maximumPoolSize
+            minimumPoolSize = 1,
+            maximumPoolSize = maximumPoolSize,
         )
     }
 }

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/PostgresDataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/PostgresDataSourceFactory.kt
@@ -7,16 +7,14 @@ class PostgresDataSourceFactory(
         jdbcUrl: String,
         username: String,
         password: String,
-        isAutoCommit: Boolean = false,
-        maximumPoolSize: Int = 10
+        maximumPoolSize: Int = 3
     ): CloseableDataSource {
         return datasourceFactory.create(
-            "org.postgresql.Driver",
-            jdbcUrl,
-            username,
-            password,
-            isAutoCommit,
-            maximumPoolSize
+            driverClass = "org.postgresql.Driver",
+            jdbcUrl = jdbcUrl,
+            username = username,
+            password = password,
+            maximumPoolSize = maximumPoolSize
         )
     }
 }

--- a/libs/db/db-core/src/test/kotlin/PostgresEntityManagerConfigurationTest.kt
+++ b/libs/db/db-core/src/test/kotlin/PostgresEntityManagerConfigurationTest.kt
@@ -11,15 +11,13 @@ class PostgresEntityManagerConfigurationTest {
     @Test
     fun `set default config values`() {
         val dataSourceFactory = mock<DataSourceFactory>() {
-            on { create(any(), any(), any(), any(), any(), any()) } doReturn (mock())
+            on { create(any(), any(), any(), any(), any(), any(),any(), any(), any(), any(), any(), any()) } doReturn (mock())
         }
 
         PostgresDataSourceFactory(dataSourceFactory).create(
             "jdbcUrl",
             "user",
             "pass",
-            true,
-            20
         )
 
         verify(dataSourceFactory).create(
@@ -27,8 +25,14 @@ class PostgresEntityManagerConfigurationTest {
             eq("jdbcUrl"),
             eq("user"),
             eq("pass"),
-            eq(true),
-            eq(20)
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
         )
     }
 }

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/DbUtils.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/DbUtils.kt
@@ -102,7 +102,7 @@ object DbUtils {
         }
         logger.info("Using Postgres URL $jdbcUrl".emphasise())
         // reduce poolsize when testing
-        return factory.create(jdbcUrl, user, password, maximumPoolSize = 5)
+        return factory.create(jdbcUrl, user, password)
     }
 
     fun createConfig(

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
@@ -17,6 +17,7 @@ import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.propertytypes.ServiceRanking
 import org.slf4j.LoggerFactory
+import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import javax.persistence.EntityManager
@@ -153,7 +154,13 @@ class DbConnectionManagerImpl @Activate constructor(
         username: String,
         password: String,
         isAutoCommit: Boolean,
-        maximumPoolSize: Int
+        isReadOnly: Boolean,
+        maximumPoolSize: Int,
+        minimumPoolSize: Int,
+        idleTimeout: Duration,
+        maxLifetime: Duration,
+        keepaliveTime: Duration,
+        validationTimeout: Duration
     ): CloseableDataSource {
         TODO("Not yet implemented")
     }

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -13,6 +13,7 @@ import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.orm.JpaEntitiesSet
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import org.slf4j.LoggerFactory
+import java.time.Duration
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
@@ -146,7 +147,13 @@ class FakeDbConnectionManager(
         username: String,
         password: String,
         isAutoCommit: Boolean,
-        maximumPoolSize: Int
+        isReadOnly: Boolean,
+        maximumPoolSize: Int,
+        minimumPoolSize: Int,
+        idleTimeout: Duration,
+        maxLifetime: Duration,
+        keepaliveTime: Duration,
+        validationTimeout: Duration
     ): CloseableDataSource {
         TODO("Not yet implemented")
     }


### PR DESCRIPTION
Expose additional DB Pool configuration to the Pool Factory API.
These configuration settings broadly line up with Hikari's configuration and will allow us to tune the pool.

A follow-up PR will expose this configuration to workers and the vnode DB configuration.

The test that as added is not meant to be run as part of the PR gate. It's not really a useful test for CI, but it is useful for observing/verifying Hikari's behaviour. The reason for me doing this was to verify the pool can even scale down to zero connections when they are idle, which may be useful for vnode DB connections as the pool in that case is cached along with the Sandbox.