### PR TITLE
CORE-11804 - Exclude DB Connection Manager from Quasar instrumentation

### DIFF
--- a/components/db/db-connection-manager/build.gradle
+++ b/components/db/db-connection-manager/build.gradle
@@ -7,6 +7,7 @@ description "DB Connection Manager"
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'

--- a/components/db/db-connection-manager/src/main/java/net/corda/db/connection/manager/package-info.java
+++ b/components/db/db-connection-manager/src/main/java/net/corda/db/connection/manager/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.db.connection.manager;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Prevent net.corda.db.connection.manager packages of being instrumented by Quasar.