### PR TITLE
CORE-11922 - Fix issue with MemberListCache

### DIFF
--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
@@ -40,11 +40,10 @@ interface MemberListCache : MemberDataListCache<MemberInfo> {
             cache.compute(holdingIdentity) { _, value ->
                 (value ?: ReplaceableList())
                     .addOrReplace(data) { old, new ->
-                        if(new.status == MEMBER_STATUS_ACTIVE || new.status == MEMBER_STATUS_SUSPENDED) {
-                            old.name == new.name &&
-                                    (old.status == MEMBER_STATUS_ACTIVE|| old.status == MEMBER_STATUS_SUSPENDED)
+                        if (new.status == MEMBER_STATUS_PENDING) {
+                            old.status == MEMBER_STATUS_PENDING && old.name == new.name
                         } else {
-                            old.name == new.name && old.status == MEMBER_STATUS_PENDING
+                            old.status != MEMBER_STATUS_PENDING && old.name == new.name
                         }
                     }
             }

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
@@ -1,5 +1,9 @@
 package net.corda.membership.impl.read.cache
 
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import org.slf4j.LoggerFactory
@@ -36,7 +40,12 @@ interface MemberListCache : MemberDataListCache<MemberInfo> {
             cache.compute(holdingIdentity) { _, value ->
                 (value ?: ReplaceableList())
                     .addOrReplace(data) { old, new ->
-                        old.name == new.name
+                        if(new.status == MEMBER_STATUS_ACTIVE || new.status == MEMBER_STATUS_SUSPENDED) {
+                            old.name == new.name &&
+                                    (old.status == MEMBER_STATUS_ACTIVE|| old.status == MEMBER_STATUS_SUSPENDED)
+                        } else {
+                            old.name == new.name && old.status == MEMBER_STATUS_PENDING
+                        }
                     }
             }
         }

--- a/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
+++ b/components/membership/membership-group-read-impl/src/main/kotlin/net/corda/membership/impl/read/cache/MemberListCache.kt
@@ -1,8 +1,6 @@
 package net.corda.membership.impl.read.cache
 
-import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
-import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
@@ -5,6 +5,11 @@ import net.corda.membership.impl.read.TestProperties.Companion.GROUP_ID_2
 import net.corda.membership.impl.read.TestProperties.Companion.aliceName
 import net.corda.membership.impl.read.TestProperties.Companion.bobName
 import net.corda.membership.impl.read.TestProperties.Companion.charlieName
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
+import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import org.assertj.core.api.Assertions.assertThat
@@ -13,8 +18,8 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 
 class MemberListCacheImplTest {
     private lateinit var memberListCache: MemberListCache
@@ -27,11 +32,23 @@ class MemberListCacheImplTest {
     private val bobIdGroup1 = HoldingIdentity(bob, GROUP_ID_1)
     private val aliceIdGroup2 = HoldingIdentity(alice, GROUP_ID_2)
 
-    private val memberInfo1 = mock<MemberInfo>().apply {
-        whenever(name).thenReturn(bob)
+    private val pendingContext = mock<MGMContext> {
+        on { parse(STATUS, String::class.java) } doReturn MEMBER_STATUS_PENDING
     }
-    private val memberInfo2 = mock<MemberInfo>().apply {
-        whenever(name).thenReturn(charlie)
+    private val activeContext = mock<MGMContext> {
+        on { parse(STATUS, String::class.java) } doReturn MEMBER_STATUS_ACTIVE
+    }
+    private val suspendedContext = mock<MGMContext> {
+        on { parse(STATUS, String::class.java) } doReturn MEMBER_STATUS_SUSPENDED
+    }
+
+    private val bobInfo = mock<MemberInfo> {
+        on { mgmProvidedContext } doReturn activeContext
+        on { name } doReturn bob
+    }
+    private val aliceInfo = mock<MemberInfo> {
+        on { mgmProvidedContext } doReturn activeContext
+        on { name } doReturn alice
     }
 
     @BeforeEach
@@ -46,14 +63,14 @@ class MemberListCacheImplTest {
 
     @Test
     fun `Add member list to cache then read same member from cache`() {
-        memberListCache.put(aliceIdGroup1, listOf(memberInfo1))
-        assertMemberList(lookupWithDefaults(), memberInfo1)
+        memberListCache.put(aliceIdGroup1, listOf(bobInfo))
+        assertMemberList(lookupWithDefaults(), bobInfo)
     }
 
     @Test
     fun `Add single member to cache then read same member from cache`() {
         addToCacheWithDefaults()
-        assertMemberList(lookupWithDefaults(), memberInfo1)
+        assertMemberList(lookupWithDefaults(), bobInfo)
     }
 
     @Test
@@ -71,30 +88,30 @@ class MemberListCacheImplTest {
     @Test
     fun `Cache and lookup for a multiple groups`() {
         addToCacheWithDefaults()
-        addToCacheWithDefaults(aliceIdGroup2, memberInfo = memberInfo2)
+        addToCacheWithDefaults(aliceIdGroup2, memberInfo = aliceInfo)
 
-        assertMemberList(lookupWithDefaults(), memberInfo1)
-        assertMemberList(lookupWithDefaults(aliceIdGroup2), memberInfo2)
+        assertMemberList(lookupWithDefaults(), bobInfo)
+        assertMemberList(lookupWithDefaults(aliceIdGroup2), aliceInfo)
     }
 
     @Test
     fun `get all returns all information from cache`() {
         addToCacheWithDefaults()
-        addToCacheWithDefaults(aliceIdGroup2, memberInfo = memberInfo2)
+        addToCacheWithDefaults(aliceIdGroup2, memberInfo = aliceInfo)
 
         val cache = memberListCache.getAll()
         assertThat(cache.size).isEqualTo(2)
-        assertMemberList(cache.get(aliceIdGroup1), memberInfo1)
-        assertMemberList(cache.get(aliceIdGroup2), memberInfo2)
+        assertMemberList(cache.get(aliceIdGroup1), bobInfo)
+        assertMemberList(cache.get(aliceIdGroup2), aliceInfo)
     }
 
     @Test
     fun `Cache and lookup for multiple members in the same group`() {
         addToCacheWithDefaults()
-        addToCacheWithDefaults(bobIdGroup1, memberInfo = memberInfo2)
+        addToCacheWithDefaults(bobIdGroup1, memberInfo = aliceInfo)
 
-        assertMemberList(lookupWithDefaults(), memberInfo1)
-        assertMemberList(lookupWithDefaults(bobIdGroup1), memberInfo2)
+        assertMemberList(lookupWithDefaults(), bobInfo)
+        assertMemberList(lookupWithDefaults(bobIdGroup1), aliceInfo)
     }
 
     @Test
@@ -106,6 +123,77 @@ class MemberListCacheImplTest {
         }
     }
 
+    @Test
+    fun `Member info discarded if status is the same - active`() {
+        val originalInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn activeContext
+            on { name } doReturn charlie
+
+        }
+        val updatedInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn activeContext
+            on { name } doReturn charlie
+        }
+
+        addToCacheWithDefaults(memberInfo = originalInfo)
+        addToCacheWithDefaults(memberInfo = updatedInfo)
+        assertMemberList(lookupWithDefaults(), updatedInfo)
+    }
+
+    @Test
+    fun `Member info discarded if status is the same - pending`() {
+        val originalInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn pendingContext
+            on { name } doReturn charlie
+        }
+        val updatedInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn pendingContext
+            on { name } doReturn charlie
+        }
+
+        addToCacheWithDefaults(memberInfo = originalInfo)
+        addToCacheWithDefaults(memberInfo = updatedInfo)
+        assertMemberList(lookupWithDefaults(), updatedInfo)
+    }
+
+    @Test
+    fun `Member info discarded if status is active or suspended`() {
+        val activeInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn activeContext
+            on { name } doReturn charlie
+        }
+        val suspendedInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn suspendedContext
+            on { name } doReturn charlie
+        }
+
+        addToCacheWithDefaults(memberInfo = activeInfo)
+        // suspend member
+        addToCacheWithDefaults(memberInfo = suspendedInfo)
+        assertMemberList(lookupWithDefaults(), suspendedInfo)
+        // activate member
+        addToCacheWithDefaults(memberInfo = activeInfo)
+        assertMemberList(lookupWithDefaults(), activeInfo)
+    }
+
+    @Test
+    fun `Member info not discarded if status is pending and then active`() {
+        val originalInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn pendingContext
+            on { name } doReturn charlie
+        }
+        val updatedInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn activeContext
+            on { name } doReturn charlie
+        }
+
+        addToCacheWithDefaults(memberInfo = originalInfo)
+        addToCacheWithDefaults(memberInfo = updatedInfo)
+        // add extra member
+        addToCacheWithDefaults(memberInfo = bobInfo)
+        assertThat(lookupWithDefaults()).containsExactlyInAnyOrder(bobInfo, originalInfo, updatedInfo)
+    }
+
     private fun lookupWithDefaults(
         holdingIdentity: HoldingIdentity = aliceIdGroup1
     ): List<MemberInfo>? {
@@ -114,7 +202,7 @@ class MemberListCacheImplTest {
 
     private fun addToCacheWithDefaults(
         holdingIdentity: HoldingIdentity = aliceIdGroup1,
-        memberInfo: MemberInfo = memberInfo1
+        memberInfo: MemberInfo = bobInfo
     ) {
         memberListCache.put(holdingIdentity, memberInfo)
     }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
@@ -141,6 +141,23 @@ class MemberListCacheImplTest {
     }
 
     @Test
+    fun `Member info discarded if status is the same - suspended`() {
+        val originalInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn suspendedContext
+            on { name } doReturn charlie
+
+        }
+        val updatedInfo = mock<MemberInfo> {
+            on { mgmProvidedContext } doReturn suspendedContext
+            on { name } doReturn charlie
+        }
+
+        addToCacheWithDefaults(memberInfo = originalInfo)
+        addToCacheWithDefaults(memberInfo = updatedInfo)
+        assertMemberList(lookupWithDefaults(), updatedInfo)
+    }
+
+    @Test
     fun `Member info discarded if status is the same - pending`() {
         val originalInfo = mock<MemberInfo> {
             on { mgmProvidedContext } doReturn pendingContext

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
@@ -32,6 +32,7 @@ import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -167,6 +168,11 @@ class MemberListProcessorTest {
             charlieIdentity = HoldingIdentity(charlie.name, charlie.groupId)
             memberListFromTopic = convertToTestTopicData(listOf(alice, bob, charlie))
         }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        membershipGroupReadCache.clear()
     }
 
     @Test

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
@@ -31,6 +31,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -200,7 +201,7 @@ class MemberListProcessorTest {
     @Test
     fun `Member list cache is successfully updated with changed record`() {
         memberListProcessor.onSnapshot(memberListFromTopic)
-        val updatedAlice = createTestMemberInfo("O=Alice,L=London,C=GB", MEMBER_STATUS_ACTIVE)
+        val updatedAlice = createTestMemberInfo(aliceIdentity.x500Name.toString(), MEMBER_STATUS_PENDING)
         val topicData = convertToTestTopicData(listOf(updatedAlice), true).entries.first()
         val newRecord = Record("dummy-topic", topicData.key, topicData.value)
         val oldValue = PersistentMemberInfo(
@@ -209,8 +210,26 @@ class MemberListProcessorTest {
             alice.mgmProvidedContext.toAvro()
         )
         memberListProcessor.onNext(newRecord, oldValue, memberListFromTopic)
+        assertThat(membershipGroupReadCache.memberListCache.get(aliceIdentity))
+            .containsExactlyInAnyOrder(bob, charlie, updatedAlice)
+    }
+
+    @Test
+    fun `Member list cache is successfully replaced with changed record`() {
+        val oldAlice = createTestMemberInfo(aliceIdentity.x500Name.toString(), MEMBER_STATUS_ACTIVE)
+        val memberList = convertToTestTopicData(listOf(oldAlice), true)
+        memberListProcessor.onSnapshot(memberList)
+        val updatedAlice = createTestMemberInfo(aliceIdentity.x500Name.toString(), MEMBER_STATUS_ACTIVE)
+        val topicData = convertToTestTopicData(listOf(updatedAlice), true).entries.first()
+        val newRecord = Record("dummy-topic", topicData.key, topicData.value)
+        val oldValue = PersistentMemberInfo(
+            aliceIdentity.toAvro(),
+            oldAlice.memberProvidedContext.toAvro(),
+            oldAlice.mgmProvidedContext.toAvro()
+        )
+        memberListProcessor.onNext(newRecord, oldValue, memberList)
         assertEquals(
-            listOf(bob, charlie, updatedAlice),
+            listOf(updatedAlice),
             membershipGroupReadCache.memberListCache.get(aliceIdentity)
         )
     }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
@@ -228,9 +228,7 @@ class MemberListProcessorTest {
             oldAlice.mgmProvidedContext.toAvro()
         )
         memberListProcessor.onNext(newRecord, oldValue, memberList)
-        assertEquals(
-            listOf(updatedAlice),
-            membershipGroupReadCache.memberListCache.get(aliceIdentity)
-        )
+        assertThat(membershipGroupReadCache.memberListCache.get(aliceIdentity))
+            .containsExactly(updatedAlice)
     }
 }


### PR DESCRIPTION
**Description of the issue:**
MemberListCache replaces entries based on name check. This means that we are not able to store penguin and non-pending information in it at the same time.

**Fix:**
Do a status check: 
- if new entry has status active or suspended, then replace old entry with same name having non-pending status
- if new entry has pending status, then replace old entry with same name and status

**Testing:**
To test these changes I had to modify the lookup API to return not just the active/suspended, but pending information too.

Registered MGM and two members, Alice and Bob.

**MGM calling the lookup API:**

_**Picture:**_
![mgm-lookup](https://user-images.githubusercontent.com/61757742/227631718-3ef9e8e3-afee-43b8-896b-929b975e91fc.png)

_**Result as string:**_
`
{"members":[
{"memberContext":{"corda.cpi.name":"cpi name","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.ecdh.key":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBu+OEejHWDl3jKpMEc1AXnqUoncy\noTUJi/5QFnewLmGoJzWox+hk6nGWLGmXjGLlr7s3SOqGxP7Vjk0gc0R5cQ==\n-----END PUBLIC KEY-----\n","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.name":"O=MGM, L=London, C=GB","corda.platformVersion":"5000","corda.session.keys.0.hash":"1CACF6945553AE3688F1B838E543551625ACE9E55A4ECACFD7474C112B7299A7","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5380Y0mskY/JD8FHeXhgP79BgcPW\nmuriM7ZI04dQyeHWIioQlsK14Fp6CAD0DVcTlZTnqiTFhXJHYNkCO/0aFQ==\n-----END PUBLIC KEY-----\n","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T19:56:49.320938Z","corda.mgm":"true","corda.modifiedTime":"2023-03-24T19:56:49.320938Z","corda.serial":"1","corda.status":"ACTIVE"}},
{"memberContext":{"corda.cpi.name":"cpi name2","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.ledger.keys.0.hash":"001B3BB61212859F8F5A1932488FBCE35ED8726A36EE4B4EFE9176B0F6312063","corda.ledger.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYJcEj4CqetHLCiPRdiZa45s8WzwS\n1CSO2/fz+45Ky/jocQI76VgZqgzQZQZ4breVGNwjyW4nKyRnio0J+rGCpA==\n-----END PUBLIC KEY-----\n","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.name":"O=Alice, L=London, C=GB","corda.platformVersion":"5000","corda.registration.id":"d8761dd6-a837-47f2-a4c6-9c0ec20178c4","corda.session.keys.0.hash":"653944F0B62D1F469C59993B6CB227BCBFDADFE592BFEB3B8E28A5CFAF8B5C3A","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED8vm/FAhqU1goI0rSUyWl+vlMf/n\nIhUXCeBIYDoNguEg3jDMzKte522gZeUfrD+EalJL4j+KhfnLM5Jn5iN6kw==\n-----END PUBLIC KEY-----\n","corda.session.keys.0.signature.spec":"SHA256withECDSA","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T20:02:22.037630Z","corda.modifiedTime":"2023-03-24T20:02:22.037630Z","corda.serial":"1","corda.status":"ACTIVE"}},
{"memberContext":{"corda.cpi.name":"cpi name2","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.ledger.keys.0.hash":"B0E95B9E844AD21866CDF55E0E5D0465C4CB71E366D3D6934033DDACA8B6A003","corda.ledger.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU+gsCyxHsezWhb+OsSIqbrehak9a\njk/VnO6Md4Q2OcdZtwfO7pNCwU0D67uwPs6NHj+VumlRSavjSoziaOAHHA==\n-----END PUBLIC KEY-----\n","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.name":"O=Bob, L=London, C=GB","corda.platformVersion":"5000","corda.registration.id":"7664b919-e23e-44ac-b667-3a074a4d9816","corda.session.keys.0.hash":"DBD18FDF5CB5F2C86676D267CF41B7069DF05341B02766000867128EA3F688C0","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJuYma5Gjh8Mi2GStY7e0w14YQzaF\n6dknTls2aUoyZEXFoc9hbIzngfn3Ps4ZfqcfCub0tsBkr0iSEUOpGDeFSA==\n-----END PUBLIC KEY-----\n","corda.session.keys.0.signature.spec":"SHA256withECDSA","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T20:04:21.879139Z","corda.modifiedTime":"2023-03-24T20:04:21.879139Z","corda.serial":"1","corda.status":"ACTIVE"}},
{"memberContext":{"corda.cpi.name":"cpi name2","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.ledger.keys.0.hash":"001B3BB61212859F8F5A1932488FBCE35ED8726A36EE4B4EFE9176B0F6312063","corda.ledger.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYJcEj4CqetHLCiPRdiZa45s8WzwS\n1CSO2/fz+45Ky/jocQI76VgZqgzQZQZ4breVGNwjyW4nKyRnio0J+rGCpA==\n-----END PUBLIC KEY-----\n","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.name":"O=Alice, L=London, C=GB","corda.platformVersion":"5000","corda.registration.id":"d8761dd6-a837-47f2-a4c6-9c0ec20178c4","corda.session.keys.0.hash":"653944F0B62D1F469C59993B6CB227BCBFDADFE592BFEB3B8E28A5CFAF8B5C3A","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED8vm/FAhqU1goI0rSUyWl+vlMf/n\nIhUXCeBIYDoNguEg3jDMzKte522gZeUfrD+EalJL4j+KhfnLM5Jn5iN6kw==\n-----END PUBLIC KEY-----\n","corda.session.keys.0.signature.spec":"SHA256withECDSA","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T20:02:22.037630Z","corda.modifiedTime":"2023-03-24T20:02:22.037630Z","corda.serial":"1","corda.status":"PENDING"}},
{"memberContext":{"corda.cpi.name":"cpi name2","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.ledger.keys.0.hash":"B0E95B9E844AD21866CDF55E0E5D0465C4CB71E366D3D6934033DDACA8B6A003","corda.ledger.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU+gsCyxHsezWhb+OsSIqbrehak9a\njk/VnO6Md4Q2OcdZtwfO7pNCwU0D67uwPs6NHj+VumlRSavjSoziaOAHHA==\n-----END PUBLIC KEY-----\n","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.name":"O=Bob, L=London, C=GB","corda.platformVersion":"5000","corda.registration.id":"7664b919-e23e-44ac-b667-3a074a4d9816","corda.session.keys.0.hash":"DBD18FDF5CB5F2C86676D267CF41B7069DF05341B02766000867128EA3F688C0","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJuYma5Gjh8Mi2GStY7e0w14YQzaF\n6dknTls2aUoyZEXFoc9hbIzngfn3Ps4ZfqcfCub0tsBkr0iSEUOpGDeFSA==\n-----END PUBLIC KEY-----\n","corda.session.keys.0.signature.spec":"SHA256withECDSA","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T20:04:21.879139Z","corda.modifiedTime":"2023-03-24T20:04:21.879139Z","corda.serial":"1","corda.status":"PENDING"}}
]}%  
`

**Bob calling the lookup API:**

_**Picture:**_
![bob-lookup](https://user-images.githubusercontent.com/61757742/227632165-da31cfe7-bf18-4759-949e-25f5c5e719e9.png)

_**Result as string:**_
`
{"members":[
{"memberContext":{"corda.cpi.name":"cpi name","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.ecdh.key":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBu+OEejHWDl3jKpMEc1AXnqUoncy\noTUJi/5QFnewLmGoJzWox+hk6nGWLGmXjGLlr7s3SOqGxP7Vjk0gc0R5cQ==\n-----END PUBLIC KEY-----\n","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.name":"O=MGM, L=London, C=GB","corda.platformVersion":"5000","corda.session.keys.0.hash":"1CACF6945553AE3688F1B838E543551625ACE9E55A4ECACFD7474C112B7299A7","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5380Y0mskY/JD8FHeXhgP79BgcPW\nmuriM7ZI04dQyeHWIioQlsK14Fp6CAD0DVcTlZTnqiTFhXJHYNkCO/0aFQ==\n-----END PUBLIC KEY-----\n","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T20:02:53.580752Z","corda.mgm":"true","corda.modifiedTime":"2023-03-24T20:02:53.580752Z","corda.serial":"1","corda.status":"ACTIVE"}},
{"memberContext":{"corda.cpi.name":"cpi name2","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.ledger.keys.0.hash":"B0E95B9E844AD21866CDF55E0E5D0465C4CB71E366D3D6934033DDACA8B6A003","corda.ledger.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU+gsCyxHsezWhb+OsSIqbrehak9a\njk/VnO6Md4Q2OcdZtwfO7pNCwU0D67uwPs6NHj+VumlRSavjSoziaOAHHA==\n-----END PUBLIC KEY-----\n","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.name":"O=Bob, L=London, C=GB","corda.platformVersion":"5000","corda.registration.id":"7664b919-e23e-44ac-b667-3a074a4d9816","corda.session.keys.0.hash":"DBD18FDF5CB5F2C86676D267CF41B7069DF05341B02766000867128EA3F688C0","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJuYma5Gjh8Mi2GStY7e0w14YQzaF\n6dknTls2aUoyZEXFoc9hbIzngfn3Ps4ZfqcfCub0tsBkr0iSEUOpGDeFSA==\n-----END PUBLIC KEY-----\n","corda.session.keys.0.signature.spec":"SHA256withECDSA","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T20:04:21.879139Z","corda.modifiedTime":"2023-03-24T20:04:21.879139Z","corda.serial":"1","corda.status":"ACTIVE"}},
{"memberContext":{"corda.cpi.name":"cpi name2","corda.cpi.signer.summary.hash":"SHA-256:367DDC08BB0BFBC8B338E2B8DC17EB1715A542386E6FE2376A9FB9EBC80A3DEC","corda.cpi.version":"1.0.0.0-SNAPSHOT","corda.endpoints.0.connectionURL":"https://corda-p2p-gateway-worker.corda-cluster-a:8080","corda.endpoints.0.protocolVersion":"1","corda.groupId":"da0966f1-de87-411a-8444-2d1259df0181","corda.ledger.keys.0.hash":"001B3BB61212859F8F5A1932488FBCE35ED8726A36EE4B4EFE9176B0F6312063","corda.ledger.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYJcEj4CqetHLCiPRdiZa45s8WzwS\n1CSO2/fz+45Ky/jocQI76VgZqgzQZQZ4breVGNwjyW4nKyRnio0J+rGCpA==\n-----END PUBLIC KEY-----\n","corda.ledger.keys.0.signature.spec":"SHA256withECDSA","corda.name":"O=Alice, L=London, C=GB","corda.platformVersion":"5000","corda.registration.id":"d8761dd6-a837-47f2-a4c6-9c0ec20178c4","corda.session.keys.0.hash":"653944F0B62D1F469C59993B6CB227BCBFDADFE592BFEB3B8E28A5CFAF8B5C3A","corda.session.keys.0.pem":"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAED8vm/FAhqU1goI0rSUyWl+vlMf/n\nIhUXCeBIYDoNguEg3jDMzKte522gZeUfrD+EalJL4j+KhfnLM5Jn5iN6kw==\n-----END PUBLIC KEY-----\n","corda.session.keys.0.signature.spec":"SHA256withECDSA","corda.softwareVersion":"5.0.0.0-SNAPSHOT"},"mgmContext":{"corda.creationTime":"2023-03-24T20:02:22.037630Z","corda.modifiedTime":"2023-03-24T20:02:22.037630Z","corda.serial":"1","corda.status":"ACTIVE"}}
]}%  
`