### PR TITLE
CORE-11648 Added message bus admin list topic feature

### DIFF
--- a/libs/messaging/db-message-bus-impl/build.gradle
+++ b/libs/messaging/db-message-bus-impl/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
+    testRuntimeOnly 'org.osgi:osgi.core'
+
     integrationTestImplementation project(":libs:db:db-admin-impl")
     integrationTestImplementation project(":libs:db:db-orm-impl")
     integrationTestImplementation project(":libs:utilities")

--- a/libs/messaging/db-message-bus-impl/src/integrationTest/kotlin/net/corda/messagebus/db/persistence/DBAccessIntegrationTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/integrationTest/kotlin/net/corda/messagebus/db/persistence/DBAccessIntegrationTest.kt
@@ -95,6 +95,23 @@ class DBAccessIntegrationTest {
     }
 
     @Test
+    fun `Can read a list of topics`() {
+        val dbAccess = DBAccess(emf)
+
+        val topic1 = randomId()
+        val topic2 = randomId()
+        val topic3 = randomId()
+
+        dbAccess.createTopic(topic1, 2)
+        dbAccess.createTopic(topic2, 2)
+        dbAccess.createTopic(topic3, 2)
+
+        val topics = dbAccess.getAllTopics()
+
+        assertThat(topics).contains(topic1, topic2, topic3)
+    }
+
+    @Test
     fun `DBWriter writes topic records`() {
         val timestamp = Instant.parse("2022-01-01T00:00:00.00Z")
         val topic = randomId()
@@ -216,7 +233,10 @@ class DBAccessIntegrationTest {
         dbAccess.writeOffsets(offsets)
 
         val results =
-            query(CommittedPositionEntry::class.java, "from topic_consumer_offset where topic='$topic' order by partition, record_offset")
+            query(
+                CommittedPositionEntry::class.java,
+                "from topic_consumer_offset where topic='$topic' order by partition, record_offset"
+            )
         assertThat(results).size().isEqualTo(offsets.size)
         results.forEachIndexed { index, topicRecordEntry ->
             assertThat(topicRecordEntry).usingRecursiveComparison().isEqualTo(offsets[index])

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/admin/DbMessagingAdmin.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/admin/DbMessagingAdmin.kt
@@ -1,0 +1,13 @@
+package net.corda.messagebus.db.admin
+
+import net.corda.messagebus.api.admin.Admin
+import net.corda.messagebus.db.persistence.DBAccess
+
+class DbMessagingAdmin(
+    private val dbAccess: DBAccess
+) : Admin {
+
+    override fun getTopics(): Set<String> {
+        return dbAccess.getAllTopics()
+    }
+}

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/admin/builder/DbMessagingAdminBuilder.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/admin/builder/DbMessagingAdminBuilder.kt
@@ -1,0 +1,33 @@
+package net.corda.messagebus.db.admin.builder
+
+import net.corda.libs.configuration.SmartConfig
+import net.corda.messagebus.api.admin.Admin
+import net.corda.messagebus.api.admin.builder.AdminBuilder
+import net.corda.messagebus.api.configuration.AdminConfig
+import net.corda.messagebus.db.admin.DbMessagingAdmin
+import net.corda.messagebus.db.configuration.MessageBusConfigResolver
+import net.corda.messagebus.db.persistence.DBAccess
+import net.corda.messagebus.db.persistence.EntityManagerFactoryHolder
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+@Suppress("Unused")
+@Component(service = [AdminBuilder::class])
+class DbMessagingAdminBuilder @Activate constructor(
+    @Reference(service = EntityManagerFactoryHolder::class)
+    private val entityManagerFactoryHolder: EntityManagerFactoryHolder,
+) : AdminBuilder {
+    override fun createAdmin(adminConfig: AdminConfig, messageBusConfig: SmartConfig): Admin {
+        val resolver = MessageBusConfigResolver(messageBusConfig.factory)
+        val resolvedConfig = resolver.resolve(messageBusConfig, adminConfig)
+
+        val emf = entityManagerFactoryHolder.getEmf(
+            resolvedConfig.jdbcUrl,
+            resolvedConfig.jdbcUser,
+            resolvedConfig.jdbcPass
+        )
+
+        return DbMessagingAdmin(DBAccess(emf))
+    }
+}

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/ResolvedAdminConfig.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/ResolvedAdminConfig.kt
@@ -1,0 +1,7 @@
+package net.corda.messagebus.db.configuration
+
+data class ResolvedAdminConfig (
+    val jdbcUrl: String?,
+    val jdbcUser: String,
+    val jdbcPass: String,
+)

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
@@ -107,7 +107,7 @@ class DBAccess(
         }
     }
 
-    fun getAllTopics():Set<String>{
+    fun getAllTopics(): Set<String> {
         return executeWithErrorHandling("retrieve all the topics") { entityManager ->
             val builder = entityManager.criteriaBuilder
             val query = builder.createQuery(TopicEntry::class.java)

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/persistence/DBAccess.kt
@@ -107,6 +107,16 @@ class DBAccess(
         }
     }
 
+    fun getAllTopics():Set<String>{
+        return executeWithErrorHandling("retrieve all the topics") { entityManager ->
+            val builder = entityManager.criteriaBuilder
+            val query = builder.createQuery(TopicEntry::class.java)
+            query.select(query.from(TopicEntry::class.java))
+            val results = entityManager.createQuery(query).resultList
+            results.map { it.topic }.toSet()
+        }
+    }
+
     /**
      * If auto topic creation is enabled then will create the topic
      */

--- a/libs/messaging/db-message-bus-impl/src/main/resources/messaging-enforced.conf
+++ b/libs/messaging/db-message-bus-impl/src/main/resources/messaging-enforced.conf
@@ -25,6 +25,9 @@ producer = ${common} {
 # Roles that particular consumers or producers could be taking. By tying consumers and producers to the roles they are
 # performing in the patterns, each can be configured properly to reflect the job they are supposed to do.
 roles {
+   admin {
+       admin = ${common}
+   }
     pubsub {
         consumer = ${consumer} {
             # Pubsub consumers can ignore old messages so choose to start at the end of the stream.

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/configuration/MessageBusConfigResolverTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/configuration/MessageBusConfigResolverTest.kt
@@ -1,0 +1,36 @@
+package net.corda.messagebus.db.configuration
+
+import com.typesafe.config.ConfigFactory
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.messagebus.api.configuration.AdminConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MessageBusConfigResolverTest {
+    companion object {
+        private const val TEST_CONFIG = "test.conf"
+    }
+
+    private val smartConfigFactory = SmartConfigFactory.createWithoutSecurityServices()
+
+    @Test
+    fun `DB admin config can be resolved`(){
+        val target = MessageBusConfigResolver(smartConfigFactory)
+        val testConfig = loadTestConfig(TEST_CONFIG)
+        val results = target.resolve(testConfig, AdminConfig("client1"))
+
+        assertThat(results.jdbcUrl).isEqualTo("connectionUrl")
+        assertThat(results.jdbcUser).isEqualTo("user1")
+        assertThat(results.jdbcPass).isEqualTo("pass1")
+    }
+
+    private fun loadTestConfig(resource: String): SmartConfig {
+        val url = this::class.java.classLoader.getResource(resource)
+            ?: throw IllegalArgumentException("Failed to find $resource")
+        val configString = url.openStream().bufferedReader().use {
+            it.readText()
+        }
+        return smartConfigFactory.create(ConfigFactory.parseString(configString))
+    }
+}

--- a/libs/messaging/db-message-bus-impl/src/test/resources/test.conf
+++ b/libs/messaging/db-message-bus-impl/src/test/resources/test.conf
@@ -1,0 +1,14 @@
+# A more fleshed out configuration for test. Aims to override enforced properties, as well as specify some things with
+# defaults and some things that are unspecified.
+bus {
+    busType = "DATABASE"
+    dbProperties {
+        jdbcUrl = "connectionUrl"
+        user = "user1"
+        pass = "pass1"
+    }
+}
+topicPrefix = "test"
+instanceId = 1
+maxAllowedMessageSize = 10000000
+

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/KafkaAdmin.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/KafkaAdmin.kt
@@ -1,0 +1,10 @@
+package net.corda.messagebus.kafka.admin
+
+import net.corda.messagebus.api.admin.Admin
+import org.apache.kafka.clients.admin.AdminClient
+
+class KafkaAdmin(private val adminClient: AdminClient) : Admin {
+    override fun getTopics(): Set<String> {
+        return adminClient.listTopics().names().get()
+    }
+}

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/builder/KafkaAdminBuilder.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/builder/KafkaAdminBuilder.kt
@@ -4,9 +4,10 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.messagebus.api.admin.Admin
 import net.corda.messagebus.api.admin.builder.AdminBuilder
 import net.corda.messagebus.api.configuration.AdminConfig
-import net.corda.messagebus.kafka.config.MessageBusConfigResolver
 import net.corda.messagebus.kafka.admin.KafkaAdmin
+import net.corda.messagebus.kafka.config.MessageBusConfigResolver
 import net.corda.utilities.classload.OsgiDelegatedClassLoader
+import net.corda.utilities.classload.executeWithThreadContextClassLoader
 import org.apache.kafka.clients.admin.AdminClient
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.annotations.Component
@@ -18,15 +19,11 @@ class KafkaAdminBuilder : AdminBuilder {
         val configResolver = MessageBusConfigResolver(messageBusConfig.factory)
         val kafkaProperties = configResolver.resolve(messageBusConfig, adminConfig)
 
-        val contextClassLoader = Thread.currentThread().contextClassLoader
         val currentBundle = FrameworkUtil.getBundle(AdminClient::class.java)
 
         return if (currentBundle != null) {
-            try {
-                Thread.currentThread().contextClassLoader = OsgiDelegatedClassLoader(currentBundle)
+            executeWithThreadContextClassLoader(OsgiDelegatedClassLoader(currentBundle)) {
                 KafkaAdmin(AdminClient.create(kafkaProperties))
-            } finally {
-                Thread.currentThread().contextClassLoader = contextClassLoader
             }
         } else {
             KafkaAdmin(AdminClient.create(kafkaProperties))

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/builder/KafkaAdminBuilder.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/builder/KafkaAdminBuilder.kt
@@ -1,0 +1,35 @@
+package net.corda.messagebus.kafka.admin.builder
+
+import net.corda.libs.configuration.SmartConfig
+import net.corda.messagebus.api.admin.Admin
+import net.corda.messagebus.api.admin.builder.AdminBuilder
+import net.corda.messagebus.api.configuration.AdminConfig
+import net.corda.messagebus.kafka.config.MessageBusConfigResolver
+import net.corda.messagebus.kafka.admin.KafkaAdmin
+import net.corda.utilities.classload.OsgiDelegatedClassLoader
+import org.apache.kafka.clients.admin.AdminClient
+import org.osgi.framework.FrameworkUtil
+import org.osgi.service.component.annotations.Component
+
+@Suppress("Unused")
+@Component(service = [AdminBuilder::class])
+class KafkaAdminBuilder : AdminBuilder {
+    override fun createAdmin(adminConfig: AdminConfig, messageBusConfig: SmartConfig): Admin {
+        val configResolver = MessageBusConfigResolver(messageBusConfig.factory)
+        val kafkaProperties = configResolver.resolve(messageBusConfig, adminConfig)
+
+        val contextClassLoader = Thread.currentThread().contextClassLoader
+        val currentBundle = FrameworkUtil.getBundle(AdminClient::class.java)
+
+        return if (currentBundle != null) {
+            try {
+                Thread.currentThread().contextClassLoader = OsgiDelegatedClassLoader(currentBundle)
+                KafkaAdmin(AdminClient.create(kafkaProperties))
+            } finally {
+                Thread.currentThread().contextClassLoader = contextClassLoader
+            }
+        } else {
+            KafkaAdmin(AdminClient.create(kafkaProperties))
+        }
+    }
+}

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolver.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolver.kt
@@ -5,6 +5,7 @@ import java.util.Properties
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.messagebus.api.configuration.ConsumerConfig
+import net.corda.messagebus.api.configuration.AdminConfig
 import net.corda.messagebus.api.configuration.ProducerConfig
 import net.corda.messagebus.kafka.producer.KafkaProducerPartitioner
 import net.corda.messaging.api.exception.CordaMessageAPIConfigException
@@ -71,6 +72,19 @@ internal class MessageBusConfigResolver(private val smartConfigFactory: SmartCon
 
         logger.debug {"Kafka properties for role $rolePath: $properties" }
         return properties
+    }
+
+    /**
+     * Resolve the provided configuration and return a valid set of Kafka properties suitable for the given role
+     * as well as a concrete class containing user configurable admin values.
+     *
+     * @param messageBusConfig The supplied message bus configuration. Must match the schema used in the defaults and enforced
+     *               config files included with this library.
+     * @param adminConfig User configurable values.
+     * @return Resolved kafka properties
+     */
+    fun resolve(messageBusConfig: SmartConfig, adminConfig: AdminConfig): Properties {
+        return  resolve(messageBusConfig, "admin.admin", adminConfig.toSmartConfig())
     }
 
     /**
@@ -163,6 +177,18 @@ internal class MessageBusConfigResolver(private val smartConfigFactory: SmartCon
                     CLIENT_ID_PATH to clientId,
                     GROUP_PATH to "<undefined>",
                     TRANSACTIONAL_ID_PATH to transactionalId
+                )
+            )
+        )
+    }
+
+    private fun AdminConfig.toSmartConfig(): SmartConfig {
+        return smartConfigFactory.create(
+            ConfigFactory.parseMap(
+                mapOf(
+                    CLIENT_ID_PATH to clientId,
+                    GROUP_PATH to "<undefined>",
+                    TRANSACTIONAL_ID_PATH to "<undefined>"
                 )
             )
         )

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -42,6 +42,9 @@ producer = ${common} {
 # Roles that particular consumers or producers could be taking. By tying consumers and producers to the roles they are
 # performing in the patterns, each can be configured properly to reflect the job they are supposed to do.
 roles {
+    admin {
+        admin = ${common}
+    }
     pubsub {
         consumer = ${consumer} {
             # Pubsub consumers can ignore old messages so choose to start at the end of the stream.

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
@@ -43,6 +43,11 @@ producer = ${common} {
 # Roles that particular consumers or producers could be taking. By tying consumers and producers to the roles they are
 # performing in the patterns, each can be configured properly to reflect the job they are supposed to do.
 roles {
+    admin {
+        admin = ${common} {
+          client.id = admin-${clientId}
+        }
+    }
     pubsub {
         consumer = ${consumer} {
             # Pubsub consumers can ignore old messages so choose to start at the end of the stream.

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
@@ -1,0 +1,30 @@
+package net.corda.messagebus.kafka.admin
+
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.ListTopicsResult
+import org.apache.kafka.common.KafkaFuture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class KafkaAdminTest {
+
+    private var adminClient = mock<AdminClient>()
+
+    @Test
+    fun `When list topics then return all none internal topics from kafka`() {
+        val kafkaFuture = mock<KafkaFuture<Set<String>>>().apply {
+            whenever(get()).thenReturn(setOf("topic1"))
+        }
+        val result = mock<ListTopicsResult>().apply {
+            whenever(names()).thenReturn(kafkaFuture)
+        }
+
+        whenever(adminClient.listTopics()).thenReturn(result)
+
+        val target = KafkaAdmin(adminClient)
+
+        assertThat(target.getTopics()).containsOnly("topic1")
+    }
+}

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
@@ -5,6 +5,7 @@ import java.util.Properties
 import java.util.stream.Stream
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.messagebus.api.configuration.AdminConfig
 import net.corda.messagebus.api.configuration.ConsumerConfig
 import net.corda.messagebus.api.configuration.ProducerConfig
 import net.corda.messagebus.api.constants.ConsumerRoles
@@ -266,6 +267,22 @@ class MessageBusConfigResolverTest {
         }
     }
 
+    @Test
+    fun `resolve config for admin`(){
+        val messageBusConfig = loadTestConfig(TEST_CONFIG)
+        val resolver = MessageBusConfigResolver(smartConfigFactory)
+        val  properties = resolver.resolve(messageBusConfig, AdminConfig(CLIENT_ID))
+
+        val expectedProperties = getExpectedProducerProperties(
+            mapOf(
+                CLIENT_ID_PROP to "admin-test-client-id",
+                BOOTSTRAP_SERVERS_PROP to "kafka:1001",
+            )
+        )
+
+        assertAdminProperties(expectedProperties, properties)
+    }
+
     private fun loadTestConfig(resource: String): SmartConfig {
         val url = this::class.java.classLoader.getResource(resource)
             ?: throw IllegalArgumentException("Failed to find $resource")
@@ -300,5 +317,10 @@ class MessageBusConfigResolverTest {
         assertEquals(expected[ACKS_PROP], actual[ACKS_PROP])
         assertEquals(expected[BOOTSTRAP_SERVERS_PROP], actual[BOOTSTRAP_SERVERS_PROP])
         assertEquals(expected[SSL_KEYSTORE_PROP], actual[SSL_KEYSTORE_PROP])
+    }
+
+    private fun assertAdminProperties(expected: Properties, actual: Properties) {
+        assertEquals(expected[CLIENT_ID_PROP], actual[CLIENT_ID_PROP])
+        assertEquals(expected[BOOTSTRAP_SERVERS_PROP], actual[BOOTSTRAP_SERVERS_PROP])
     }
 }

--- a/libs/messaging/message-bus/src/main/java/net/corda/messagebus/api/admin/builder/package-info.java
+++ b/libs/messaging/message-bus/src/main/java/net/corda/messagebus/api/admin/builder/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.messagebus.api.admin.builder;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/messaging/message-bus/src/main/java/net/corda/messagebus/api/admin/package-info.java
+++ b/libs/messaging/message-bus/src/main/java/net/corda/messagebus/api/admin/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.messagebus.api.admin;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/admin/Admin.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/admin/Admin.kt
@@ -1,0 +1,12 @@
+package net.corda.messagebus.api.admin
+
+/**
+ * [Admin] provides an API for admin operations on the message bus
+ */
+interface Admin {
+
+    /**
+     * Returns a list of all topics supported by the message bus.
+     */
+    fun getTopics():Set<String>
+}

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/admin/builder/AdminBuilder.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/admin/builder/AdminBuilder.kt
@@ -1,0 +1,23 @@
+package net.corda.messagebus.api.admin.builder
+
+import net.corda.libs.configuration.SmartConfig
+import net.corda.messagebus.api.configuration.AdminConfig
+import net.corda.messagebus.api.admin.Admin
+
+/**
+ * Builder Interface for creating instances of [Admin].
+ */
+interface AdminBuilder {
+
+    /**
+     * Generate kafka producer with given properties.
+     * @param adminConfig The mandatory config for setting up admin
+     * @param messageBusConfig Configuration for connecting to the message bus and controlling its behaviour.
+     * @return A new instance of [Admin] for the underlying bus implementation .
+     * @throws CordaMessageAPIFatalException thrown if an instance of [Admin] cannot be created.
+     */
+    fun createAdmin(
+        adminConfig: AdminConfig,
+        messageBusConfig: SmartConfig
+    ): Admin
+}

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/admin/builder/AdminBuilder.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/admin/builder/AdminBuilder.kt
@@ -1,8 +1,8 @@
 package net.corda.messagebus.api.admin.builder
 
 import net.corda.libs.configuration.SmartConfig
-import net.corda.messagebus.api.configuration.AdminConfig
 import net.corda.messagebus.api.admin.Admin
+import net.corda.messagebus.api.configuration.AdminConfig
 
 /**
  * Builder Interface for creating instances of [Admin].
@@ -10,7 +10,7 @@ import net.corda.messagebus.api.admin.Admin
 interface AdminBuilder {
 
     /**
-     * Generate kafka producer with given properties.
+     * Generate a message bus admin with given properties.
      * @param adminConfig The mandatory config for setting up admin
      * @param messageBusConfig Configuration for connecting to the message bus and controlling its behaviour.
      * @return A new instance of [Admin] for the underlying bus implementation .

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/configuration/AdminConfig.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/configuration/AdminConfig.kt
@@ -1,0 +1,3 @@
+package net.corda.messagebus.api.configuration
+
+data class AdminConfig(val clientId: String)


### PR DESCRIPTION
Add an admin function to the message bus to support listing available topics. This is required for the external app messaging changes. We need to check topics exist before trying to send external messages.