### PR TITLE
CORE-3819: Update Gradle API usage for configurations.

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda.common-library.gradle
@@ -19,10 +19,10 @@ configurations {
     integrationTestCompileOnly.extendsFrom testCompileOnly
     integrationTestImplementation.extendsFrom testImplementation
 
-    all {
+    configureEach {
         resolutionStrategy {
             dependencySubstitution {
-                substitute module('de.javakaffee:kryo-serializers') with project(':libs:serialization:kryo-serializers')
+                substitute module('de.javakaffee:kryo-serializers') using project(':libs:serialization:kryo-serializers')
             }
         }
     }


### PR DESCRIPTION
`with` has been deprecated, and replaced by `using`.

Also prefer `configureEach` over `all`.