### PR TITLE
CORE-12069 - change confusing use function on EntityManagerFactory

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -111,7 +111,7 @@ import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
 import java.time.Instant
-import java.util.UUID
+import java.util.*
 import java.util.UUID.randomUUID
 import javax.persistence.EntityManagerFactory
 
@@ -525,7 +525,7 @@ class MembershipPersistenceTest {
 
         assertThat(result).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(RegistrationRequestEntity::class.java, registrationId)
         }
         assertThat(persistedEntity).isNotNull
@@ -554,13 +554,13 @@ class MembershipPersistenceTest {
         val persisted2 = membershipPersistenceClientWrapper.persistGroupPolicy(viewOwningHoldingIdentity, groupPolicy2, 2)
         assertThat(persisted2).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(GroupPolicyEntity::class.java, 1L)
         }
         assertThat(cordaAvroDeserializer.deserialize(persistedEntity.properties)!!.toMap()).isEqualTo(
             groupPolicy1.entries.associate { it.key to it.value }
         )
-        val secondPersistedEntity = vnodeEmf.use {
+        val secondPersistedEntity = vnodeEmf.createEntityManager().use {
             it.find(GroupPolicyEntity::class.java, 2L)
         }
         assertThat(cordaAvroDeserializer.deserialize(secondPersistedEntity.properties)!!.toMap()).isEqualTo(
@@ -576,7 +576,7 @@ class MembershipPersistenceTest {
         val persisted = membershipPersistenceClientWrapper.persistGroupParametersInitialSnapshot(viewOwningHoldingIdentity)
         assertThat(persisted).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 GroupParametersEntity::class.java,
                 1
@@ -616,7 +616,7 @@ class MembershipPersistenceTest {
         val persisted = membershipPersistenceClientWrapper.persistGroupParameters(viewOwningHoldingIdentity, groupParameters)
         assertThat(persisted).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 GroupParametersEntity::class.java,
                 2
@@ -696,7 +696,7 @@ class MembershipPersistenceTest {
             assertThat(containsAll(expectedGroupParameters))
         }
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 GroupParametersEntity::class.java,
                 51
@@ -778,7 +778,7 @@ class MembershipPersistenceTest {
             assertThat(containsAll(expectedGroupParameters))
         }
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 GroupParametersEntity::class.java,
                 101
@@ -866,7 +866,7 @@ class MembershipPersistenceTest {
             assertThat(containsAll(expectedGroupParameters))
         }
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 GroupParametersEntity::class.java,
                 151
@@ -915,7 +915,7 @@ class MembershipPersistenceTest {
 
         assertThat(result).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 MemberInfoEntity::class.java,
                 MemberInfoEntityPrimaryKey(
@@ -950,7 +950,7 @@ class MembershipPersistenceTest {
         val memberPersistentResult = persistMember(registeringX500Name, MEMBER_STATUS_PENDING)
 
         assertThat(memberPersistentResult).isInstanceOf(MembershipPersistenceResult.Success::class.java)
-        val memberEntity = vnodeEmf.use {
+        val memberEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 MemberInfoEntity::class.java,
                 MemberInfoEntityPrimaryKey(
@@ -966,7 +966,7 @@ class MembershipPersistenceTest {
 
         assertThat(requestPersistentResult).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val requestEntity = vnodeEmf.use {
+        val requestEntity = vnodeEmf.createEntityManager().use {
             it.find(RegistrationRequestEntity::class.java, registrationId)
         }
         assertThat(requestEntity.status).isEqualTo(RegistrationStatus.SENT_TO_MGM.toString())
@@ -980,7 +980,7 @@ class MembershipPersistenceTest {
         assertThat(approveResult.status).isEqualTo(MEMBER_STATUS_ACTIVE)
         assertThat(approveResult.groupId).isEqualTo(groupId)
         assertThat(approveResult.name).isEqualTo(registeringHoldingIdentity.x500Name)
-        val newMemberEntity = vnodeEmf.use {
+        val newMemberEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 MemberInfoEntity::class.java,
                 MemberInfoEntityPrimaryKey(
@@ -989,7 +989,7 @@ class MembershipPersistenceTest {
             )
         }
         assertThat(newMemberEntity.status).isEqualTo(MEMBER_STATUS_ACTIVE)
-        val newRequestEntity = vnodeEmf.use {
+        val newRequestEntity = vnodeEmf.createEntityManager().use {
             it.find(RegistrationRequestEntity::class.java, registrationId)
         }
         assertThat(newRequestEntity.status).isEqualTo(RegistrationStatus.APPROVED.toString())
@@ -1093,7 +1093,7 @@ class MembershipPersistenceTest {
 
         assertThat(persistRegRequestResult).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val persistedEntity = vnodeEmf.use {
+        val persistedEntity = vnodeEmf.createEntityManager().use {
             it.find(RegistrationRequestEntity::class.java, registrationId)
         }
         assertThat(persistedEntity).isNotNull
@@ -1109,7 +1109,7 @@ class MembershipPersistenceTest {
 
         assertThat(updateRegRequestStatusResult).isInstanceOf(MembershipPersistenceResult.Success::class.java)
 
-        val updatedEntity = vnodeEmf.use {
+        val updatedEntity = vnodeEmf.createEntityManager().use {
             it.find(RegistrationRequestEntity::class.java, registrationId)
         }
         assertThat(updatedEntity).isNotNull
@@ -1128,7 +1128,7 @@ class MembershipPersistenceTest {
             ApprovalRuleParams(RULE_REGEX, ApprovalRuleType.STANDARD, RULE_LABEL)
         ).getOrThrow()
 
-        val approvalRuleEntity = vnodeEmf.use {
+        val approvalRuleEntity = vnodeEmf.createEntityManager().use {
             it.find(
                 ApprovalRulesEntity::class.java,
                 ApprovalRulesEntityPrimaryKey(
@@ -1158,7 +1158,7 @@ class MembershipPersistenceTest {
             viewOwningHoldingIdentity, RULE_ID, ApprovalRuleType.STANDARD
         ).getOrThrow()
 
-        vnodeEmf.use {
+        vnodeEmf.createEntityManager().use {
             assertThat(
                 it.find(
                     ApprovalRulesEntity::class.java,
@@ -1309,7 +1309,7 @@ class MembershipPersistenceTest {
             viewOwningHoldingIdentity, member1, 1L, "test-reason"
         ).getOrThrow()
 
-        val persistedEntity1 = vnodeEmf.use {
+        val persistedEntity1 = vnodeEmf.createEntityManager().use {
             it.find(
                 MemberInfoEntity::class.java,
                 MemberInfoEntityPrimaryKey(viewOwningHoldingIdentity.groupId, member1.toString(), false)
@@ -1332,7 +1332,7 @@ class MembershipPersistenceTest {
             viewOwningHoldingIdentity, member2, null, "test-reason"
         ).getOrThrow()
 
-        val persistedEntity2 = vnodeEmf.use {
+        val persistedEntity2 = vnodeEmf.createEntityManager().use {
             it.find(
                 MemberInfoEntity::class.java,
                 MemberInfoEntityPrimaryKey(viewOwningHoldingIdentity.groupId, member2.toString(), false)
@@ -1357,7 +1357,7 @@ class MembershipPersistenceTest {
             viewOwningHoldingIdentity, member1, 1L, "test-reason"
         ).getOrThrow()
 
-        val persistedEntity1 = vnodeEmf.use {
+        val persistedEntity1 = vnodeEmf.createEntityManager().use {
             it.find(
                 MemberInfoEntity::class.java,
                 MemberInfoEntityPrimaryKey(viewOwningHoldingIdentity.groupId, member1.toString(), false)
@@ -1380,7 +1380,7 @@ class MembershipPersistenceTest {
             viewOwningHoldingIdentity, member2, 1L, "test-reason"
         ).getOrThrow()
 
-        val persistedEntity2 = vnodeEmf.use {
+        val persistedEntity2 = vnodeEmf.createEntityManager().use {
             it.find(
                 MemberInfoEntity::class.java,
                 MemberInfoEntityPrimaryKey(viewOwningHoldingIdentity.groupId, member2.toString(), false)

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -111,7 +111,7 @@ import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.UUID.randomUUID
 import javax.persistence.EntityManagerFactory
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeEntityRepository.kt
@@ -53,7 +53,7 @@ internal class VirtualNodeEntityRepository(
 
     /** Reads CPI metadata from the database. */
     override fun getCPIMetadataByNameAndVersion(name: String, version: String): CpiMetadataLite? {
-        val cpiMetadataEntity = entityManagerFactory.use {
+        val cpiMetadataEntity = entityManagerFactory.createEntityManager().use {
             it.transaction {
                 it.createQuery(
                     "SELECT cpi FROM CpiMetadataEntity cpi " +

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
@@ -29,7 +29,7 @@ import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDb
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbConnections
 import org.slf4j.LoggerFactory
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import javax.persistence.EntityManager
@@ -73,7 +73,7 @@ internal class CreateVirtualNodeServiceImpl(
     override fun ensureHoldingIdentityIsUnique(request: VirtualNodeCreateRequest) {
         val emf = dbConnectionManager.getClusterEntityManagerFactory()
         val holdingIdShortHash = request.holdingId.toCorda().shortHash
-        emf.use { em ->
+        emf.createEntityManager().use { em ->
             if (virtualNodeRepository.find(em, holdingIdShortHash) != null) {
                 throw VirtualNodeAlreadyExistsException(
                     "Virtual node for CPI with file checksum ${request.cpiFileChecksum} and x500Name " +

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
@@ -29,7 +29,7 @@ import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDb
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbConnections
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import javax.persistence.EntityManager

--- a/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/EntityManagerUtilsTest.kt
+++ b/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/EntityManagerUtilsTest.kt
@@ -95,19 +95,20 @@ class EntityManagerUtilsTest {
     @Test
     fun `can load JPA entities using EntityManagerFactory#transaction`() {
 
-        val emf = createEntityManagerFactory()
+        createEntityManagerFactory().use { emf ->
 
-        val owner = Owner(UUID.randomUUID(), "Fred", 25)
-        val cat = Cat(UUID.randomUUID(), "Tom", "Black & White", owner)
+            val owner = Owner(UUID.randomUUID(), "Fred", 25)
+            val cat = Cat(UUID.randomUUID(), "Tom", "Black & White", owner)
 
-        emf.transaction {
-            it.persist(owner)
-            it.persist(cat)
-        }
+            emf.transaction {
+                it.persist(owner)
+                it.persist(cat)
+            }
 
-        emf.createEntityManager().transaction {
-            val loadedCats = it.createQuery("from Cat", Cat::class.java)
-            Assertions.assertThat(loadedCats.resultList).contains(cat)
+            emf.createEntityManager().transaction {
+                val loadedCats = it.createQuery("from Cat", Cat::class.java)
+                Assertions.assertThat(loadedCats.resultList).contains(cat)
+            }
         }
     }
 
@@ -135,22 +136,23 @@ class EntityManagerUtilsTest {
     @Test
     fun `can load JPA entities using EntityManager#transaction`() {
 
-        val emf = createEntityManagerFactory()
+        createEntityManagerFactory().use { emf ->
 
-        val owner = Owner(UUID.randomUUID(), "Fred", 25)
-        val cat = Cat(UUID.randomUUID(), "Tom", "Black & White", owner)
+            val owner = Owner(UUID.randomUUID(), "Fred", 25)
+            val cat = Cat(UUID.randomUUID(), "Tom", "Black & White", owner)
 
-        val em = emf.createEntityManager()
-        em.use {
-            it.transaction.begin()
-            it.persist(owner)
-            it.persist(cat)
-            it.transaction.commit()
-        }
+            val em = emf.createEntityManager()
+            em.use {
+                it.transaction.begin()
+                it.persist(owner)
+                it.persist(cat)
+                it.transaction.commit()
+            }
 
-        emf.transaction {
-            val loadedCats = it.createQuery("from Cat", Cat::class.java)
-            Assertions.assertThat(loadedCats.resultList).contains(cat)
+            emf.transaction {
+                val loadedCats = it.createQuery("from Cat", Cat::class.java)
+                Assertions.assertThat(loadedCats.resultList).contains(cat)
+            }
         }
     }
 

--- a/libs/db/db-orm/src/main/kotlin/net/corda/orm/utils/EntityManagerUtils.kt
+++ b/libs/db/db-orm/src/main/kotlin/net/corda/orm/utils/EntityManagerUtils.kt
@@ -15,8 +15,12 @@ import javax.persistence.EntityManagerFactory
  *
  * @see transaction
  */
-inline fun <R> EntityManagerFactory.use(block: (EntityManager) -> R): R {
-    return createEntityManager().use(block)
+inline fun <R> EntityManagerFactory.use(block: (EntityManagerFactory) -> R): R {
+    return try {
+        block(this)
+    } finally {
+        close()
+    }
 }
 
 

--- a/libs/db/db-orm/src/main/kotlin/net/corda/orm/utils/EntityManagerUtils.kt
+++ b/libs/db/db-orm/src/main/kotlin/net/corda/orm/utils/EntityManagerUtils.kt
@@ -4,9 +4,9 @@ import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
 /**
- * Creates an [EntityManager], executes the [block] and closes the [EntityManager].
+ * Executes the [block] and then closes the [EntityManagerFactory].
  *
- * Starting and committing the [EntityManager]'s transaction is up to the [block].
+ * NOTE: because EntityManagerFactory does not implement [AutoCloseable] it doesn't support 'use' natively.
  *
  * @param block The code to execute using the [EntityManager].
  * @param R The type returned by [block].

--- a/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RbacEntitiesTest.kt
+++ b/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RbacEntitiesTest.kt
@@ -23,7 +23,7 @@ import org.osgi.test.junit5.service.ServiceExtension
 import org.slf4j.LoggerFactory
 import java.io.StringWriter
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import javax.persistence.EntityManagerFactory
 
 @ExtendWith(ServiceExtension::class)

--- a/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RbacEntitiesTest.kt
+++ b/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RbacEntitiesTest.kt
@@ -23,7 +23,7 @@ import org.osgi.test.junit5.service.ServiceExtension
 import org.slf4j.LoggerFactory
 import java.io.StringWriter
 import java.time.Instant
-import java.util.UUID
+import java.util.*
 import javax.persistence.EntityManagerFactory
 
 @ExtendWith(ServiceExtension::class)
@@ -97,7 +97,7 @@ class RbacEntitiesTest {
             null
         )
         emf.transaction { em -> em.persist(user) }
-        emf.use { em ->
+        emf.createEntityManager().use { em ->
             val retrievedUser = em.createQuery("from User where id = '$id'", user.javaClass).singleResult
             Assertions.assertThat(retrievedUser).isEqualTo(user)
         }

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpkFileRepositoryTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpkFileRepositoryTest.kt
@@ -11,30 +11,24 @@ import net.corda.libs.cpi.datamodel.repository.CpkFileRepositoryImpl
 import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
-import net.corda.orm.utils.use
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.*
-import javax.persistence.EntityManager
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CpkFileRepositoryTest {
 
     private val dbConfig: EntityManagerConfiguration = DbUtils.getEntityManagerConfiguration("cpk_file_db")
-
-    private val cpkFileRepository = CpkFileRepositoryImpl()
-    private fun transaction(callback: EntityManager.() -> Unit): Unit = EntityManagerFactoryFactoryImpl().create(
+    private val emf = EntityManagerFactoryFactoryImpl().create(
         "test_unit",
         CpiEntities.classes.toList(),
         dbConfig
-    ).use { em ->
-        em.transaction {
-            it.callback()
-        }
-    }
+    )
+
+    private val cpkFileRepository = CpkFileRepositoryImpl()
 
     init {
         val dbChange = ClassloaderChangeLog(
@@ -55,19 +49,19 @@ class CpkFileRepositoryTest {
     fun clearCpkFileTable(){
         // This is required because when the tests run using Jenkins a real database is used and the data
         // is not wiped out. The tests in this class require a clean CpkFileEntity table.
-        transaction {
-            createQuery("DELETE FROM ${CpkFileEntity::class.simpleName}").executeUpdate()
+        emf.transaction {
+            it.createQuery("DELETE FROM ${CpkFileEntity::class.simpleName}").executeUpdate()
         }
     }
 
     @AfterAll
     fun cleanUp() {
-        dbConfig.close()
+        emf.close()
     }
 
     @Test
     fun `can persist cpk files and query with given cpk checksum`() {
-        transaction {
+        emf.transaction {
             //Create CPK files
             val cpkFile1 = TestObject.genRandomCpkFile()
             val cpkFile2 = TestObject.genRandomCpkFile()
@@ -96,21 +90,21 @@ class CpkFileRepositoryTest {
             )
 
             // Update database
-            persist(cpkMetadataEntity1)
-            persist(cpkMetadataEntity2)
-            persist(cpkMetadataEntity3)
-            cpkFileRepository.put(this, cpkFile1)
-            cpkFileRepository.put(this, cpkFile2)
-            cpkFileRepository.put(this, cpkFile3)
+            it.persist(cpkMetadataEntity1)
+            it.persist(cpkMetadataEntity2)
+            it.persist(cpkMetadataEntity3)
+            cpkFileRepository.put(it, cpkFile1)
+            cpkFileRepository.put(it, cpkFile2)
+            cpkFileRepository.put(it, cpkFile3)
 
             // Query database
-            val queriedCpkFile = cpkFileRepository.findById(this, cpkFile1.fileChecksum)
+            val queriedCpkFile = cpkFileRepository.findById(it, cpkFile1.fileChecksum)
             assertThat(queriedCpkFile).isEqualTo(cpkFile1)
 
-            val queriedCpkFile2 = cpkFileRepository.findById(this, cpkFile2.fileChecksum)
+            val queriedCpkFile2 = cpkFileRepository.findById(it, cpkFile2.fileChecksum)
             assertThat(queriedCpkFile2).isEqualTo(cpkFile2)
 
-            val queriedCpkFile3 = cpkFileRepository.findById(this, listOf(cpkFile1.fileChecksum, cpkFile3.fileChecksum))
+            val queriedCpkFile3 = cpkFileRepository.findById(it, listOf(cpkFile1.fileChecksum, cpkFile3.fileChecksum))
             assertThat(queriedCpkFile3.size).isEqualTo(2)
             assertThat(queriedCpkFile3).containsAll(listOf(cpkFile1, cpkFile3))
         }
@@ -118,7 +112,7 @@ class CpkFileRepositoryTest {
 
     @Test
     fun `can persist cpk files and check if a cpk file exists`() {
-        transaction {
+        emf.transaction {
             //Create CPK files
             val cpkFile1 = TestObject.genRandomCpkFile()
 
@@ -131,19 +125,19 @@ class CpkFileRepositoryTest {
             )
 
             // Update database
-            persist(cpkMetadataEntity1)
-            cpkFileRepository.put(this, cpkFile1)
+            it.persist(cpkMetadataEntity1)
+            cpkFileRepository.put(it, cpkFile1)
 
             // Query database
-            assertThat(cpkFileRepository.exists(this, cpkFile1.fileChecksum)).isTrue
-            assertThat(cpkFileRepository.exists(this, SecureHashImpl("SHA-256", "DUMMY".toByteArray()))).isFalse
+            assertThat(cpkFileRepository.exists(it, cpkFile1.fileChecksum)).isTrue
+            assertThat(cpkFileRepository.exists(it, SecureHashImpl("SHA-256", "DUMMY".toByteArray()))).isFalse
         }
     }
 
     @Test
     fun `can persist cpk files and retrive all cpk files`() {
-        transaction {
-            this.createQuery("delete from ${CpkFileEntity::class.simpleName}").executeUpdate()
+        emf.transaction {
+            it.createQuery("delete from ${CpkFileEntity::class.simpleName}").executeUpdate()
             //Create CPK files
             val cpkFile1 = TestObject.genRandomCpkFile()
             val cpkFile2 = TestObject.genRandomCpkFile()
@@ -164,13 +158,13 @@ class CpkFileRepositoryTest {
             )
 
             // Update database
-            persist(cpkMetadataEntity1)
-            persist(cpkMetadataEntity2)
-            cpkFileRepository.put(this, cpkFile1)
-            cpkFileRepository.put(this, cpkFile2)
+            it.persist(cpkMetadataEntity1)
+            it.persist(cpkMetadataEntity2)
+            cpkFileRepository.put(it, cpkFile1)
+            cpkFileRepository.put(it, cpkFile2)
 
             // Query database
-            val queriedCpkFiles = cpkFileRepository.findAll(this)
+            val queriedCpkFiles = cpkFileRepository.findAll(it)
             assertThat(queriedCpkFiles.size).isEqualTo(2)
             assertThat(queriedCpkFiles).containsAll(listOf(cpkFile1, cpkFile2))
         }
@@ -178,7 +172,7 @@ class CpkFileRepositoryTest {
 
     @Test
     fun `all cpk files are retrieved excepted the filtered ones`() {
-        transaction {
+        emf.transaction {
             //Create CPK files
             val cpkFile1 = TestObject.genRandomCpkFile()
             val cpkFile2 = TestObject.genRandomCpkFile()
@@ -207,38 +201,38 @@ class CpkFileRepositoryTest {
             )
 
             // Update database
-            persist(cpkMetadataEntity1)
-            persist(cpkMetadataEntity2)
-            persist(cpkMetadataEntity3)
-            cpkFileRepository.put(this, cpkFile1)
-            cpkFileRepository.put(this, cpkFile2)
-            cpkFileRepository.put(this, cpkFile3)
+            it.persist(cpkMetadataEntity1)
+            it.persist(cpkMetadataEntity2)
+            it.persist(cpkMetadataEntity3)
+            cpkFileRepository.put(it, cpkFile1)
+            cpkFileRepository.put(it, cpkFile2)
+            cpkFileRepository.put(it, cpkFile3)
 
             // Query database
             //  All cpk files were excluded
             val queriedCpkFiles1 = cpkFileRepository.findAll(
-                this,
+                it,
                 listOf(cpkFile1.fileChecksum, cpkFile2.fileChecksum, cpkFile3.fileChecksum)
             )
             assertThat(queriedCpkFiles1.size).isEqualTo(0)
 
             val queriedCpkFiles2 =
                 cpkFileRepository.findAll(
-                    this,
+                    it,
                     fileChecksumsToExclude = listOf(cpkFile1.fileChecksum, cpkFile3.fileChecksum)
                 )
             assertThat(queriedCpkFiles2.size).isEqualTo(1)
             assertThat(queriedCpkFiles2).contains(cpkFile2)
 
             val queriedCpkFiles3 =
-                cpkFileRepository.findAll(this, fileChecksumsToExclude = listOf(cpkFile1.fileChecksum))
+                cpkFileRepository.findAll(it, fileChecksumsToExclude = listOf(cpkFile1.fileChecksum))
             assertThat(queriedCpkFiles3.size).isEqualTo(2)
             assertThat(queriedCpkFiles3).containsAll(listOf(cpkFile2, cpkFile3))
 
             // Order should not matter
             val queriedCpkFiles4 =
                 cpkFileRepository.findAll(
-                    this,
+                    it,
                     fileChecksumsToExclude = listOf(cpkFile3.fileChecksum, cpkFile1.fileChecksum)
                 )
             assertThat(queriedCpkFiles4.size).isEqualTo(1)


### PR DESCRIPTION
Fix up the `use` extension method on `EntityManagerFactory` as its current usage is confusing as it doesn't close the `EntityManagerFactory`, only the `EntityManager` it creates.

This makes the usages slightly more verbose, but more explicit and will hopefully lead to fixing some failures to close connection pools in the integration tests.