### PR TITLE
CORE-12098: Remove superfluous "immediate=true" from referenced components.

### DIFF
--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
@@ -42,7 +42,7 @@ import java.time.Duration
 import java.time.Instant
 import kotlin.random.Random
 
-@Component(immediate = true)
+@Component
 class AppSimulator @Activate constructor(
     @Reference(service = Shutdown::class)
     private val shutDownService: Shutdown,

--- a/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/Application.kt
+++ b/applications/tools/p2p-test/dump-topic/src/main/kotlin/net/corda/p2p/app/topic/dump/Application.kt
@@ -10,7 +10,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import picocli.CommandLine
 
-@Component(immediate = true)
+@Component
 internal class Application @Activate constructor(
     @Reference(service = Shutdown::class)
     private val shutDownService: Shutdown,

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/FlowMapperService.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/FlowMapperService.kt
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
 import java.util.concurrent.Executors
 
-@Component(service = [FlowMapperService::class], immediate = true)
+@Component(service = [FlowMapperService::class])
 class FlowMapperService @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val coordinatorFactory: LifecycleCoordinatorFactory,

--- a/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterService.kt
+++ b/components/flow/flow-p2p-filter-service/src/main/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterService.kt
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
 
-@Component(service = [FlowP2PFilterService::class], immediate = true)
+@Component(service = [FlowP2PFilterService::class])
 class FlowP2PFilterService @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val coordinatorFactory: LifecycleCoordinatorFactory,

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/FlowRestResourceServiceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/FlowRestResourceServiceImpl.kt
@@ -26,7 +26,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /** An implementation of [FlowRestResourceService]. */
-@Component(immediate = true, service = [FlowRestResourceService::class])
+@Component(service = [FlowRestResourceService::class])
 internal class FlowRestResourceServiceImpl @Activate constructor(
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/FlowStatusCacheServiceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/FlowStatusCacheServiceImpl.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReadWriteLock
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.withLock
 
-@Component(immediate = true, service = [FlowStatusCacheService::class])
+@Component(service = [FlowStatusCacheService::class])
 class FlowStatusCacheServiceImpl @Activate constructor(
     @Reference(service = SubscriptionFactory::class)
     private val subscriptionFactory: SubscriptionFactory,

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/factory/MessageFactoryImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/factory/MessageFactoryImpl.kt
@@ -16,7 +16,7 @@ import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Component
 import java.time.Instant
 
-@Component(immediate = true, service = [MessageFactory::class])
+@Component(service = [MessageFactory::class])
 class MessageFactoryImpl : MessageFactory {
 
     override fun createStartFlowEvent(

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-@Component(service = [FlowClassRestResource::class, PluggableRestResource::class], immediate = true)
+@Component(service = [FlowClassRestResource::class, PluggableRestResource::class])
 class FlowClassRestResourceImpl @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
-@Component(service = [FlowRestResource::class, PluggableRestResource::class], immediate = true)
+@Component(service = [FlowRestResource::class, PluggableRestResource::class])
 class FlowRestResourceImpl @Activate constructor(
     @Reference(service = VirtualNodeInfoReadService::class)
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,

--- a/components/kafka-topic-admin/src/main/kotlin/net/corda/comp/kafka/topic/admin/KafkaTopicAdmin.kt
+++ b/components/kafka-topic-admin/src/main/kotlin/net/corda/comp/kafka/topic/admin/KafkaTopicAdmin.kt
@@ -6,9 +6,9 @@ import net.corda.libs.messaging.topic.utils.factory.TopicUtilsFactory
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.*
+import java.util.Properties
 
-@Component(immediate = true, service = [KafkaTopicAdmin::class])
+@Component(service = [KafkaTopicAdmin::class])
 class KafkaTopicAdmin @Activate constructor(
     @Reference(service = TopicUtilsFactory::class)
     private val topicUtilsFactory: TopicUtilsFactory

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/status/VirtualNodeStatusCacheServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/status/VirtualNodeStatusCacheServiceImpl.kt
@@ -1,6 +1,6 @@
 package net.corda.virtualnode.rest.impl.status
 
-import net.corda.data.virtualnode.VirtualNodeOperationStatus
+import net.corda.data.virtualnode.VirtualNodeOperationStatus as AvroVirtualNodeOperationStatus
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -24,10 +24,9 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
-import net.corda.data.virtualnode.VirtualNodeOperationStatus as AvroVirtualNodeOperationStatus
 
 @Suppress("Unused")
-@Component(immediate = true, service = [VirtualNodeStatusCacheService::class])
+@Component(service = [VirtualNodeStatusCacheService::class])
 class VirtualNodeStatusCacheServiceImpl @Activate constructor(
     @Reference(service = SubscriptionFactory::class)
     private val subscriptionFactory: SubscriptionFactory,
@@ -38,7 +37,7 @@ class VirtualNodeStatusCacheServiceImpl @Activate constructor(
 ) : VirtualNodeStatusCacheService, CompactedProcessor<String, AvroVirtualNodeOperationStatus> {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var vNodeStatusSubscription: CompactedSubscription<String, AvroVirtualNodeOperationStatus>? = null
@@ -85,7 +84,7 @@ class VirtualNodeStatusCacheServiceImpl @Activate constructor(
         return cache[requestId]
     }
 
-    override fun setStatus(requestId: String, newStatus: VirtualNodeOperationStatus) {
+    override fun setStatus(requestId: String, newStatus: AvroVirtualNodeOperationStatus) {
 
         cache[requestId] = newStatus
         val record = Record(

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -9,6 +9,7 @@ import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeManagementRequest
 import net.corda.data.virtualnode.VirtualNodeManagementResponse
 import net.corda.data.virtualnode.VirtualNodeManagementResponseFailure
+import net.corda.data.virtualnode.VirtualNodeOperationStatus
 import net.corda.data.virtualnode.VirtualNodeOperationStatusRequest
 import net.corda.data.virtualnode.VirtualNodeOperationStatusResponse
 import net.corda.data.virtualnode.VirtualNodeOperationalState
@@ -23,6 +24,7 @@ import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundE
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity as HoldingIdentityEndpointType
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
 import net.corda.lifecycle.CustomEvent
@@ -75,8 +77,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
-import net.corda.data.virtualnode.VirtualNodeOperationStatus as AvroVirtualNodeOperationStatus
-import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity as HoldingIdentityEndpointType
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @Component(service = [PluggableRestResource::class])
@@ -484,9 +484,9 @@ internal class VirtualNodeRestResourceImpl(
     override fun start() = lifecycleCoordinator.start()
     override fun stop() = lifecycleCoordinator.stop()
 
-    private fun createVirtualNodeOperationStatus(requestId: String): AvroVirtualNodeOperationStatus {
+    private fun createVirtualNodeOperationStatus(requestId: String): VirtualNodeOperationStatus {
         val now = Instant.now()
-        return AvroVirtualNodeOperationStatus.newBuilder()
+        return VirtualNodeOperationStatus.newBuilder()
             .setRequestId(requestId)
             .setRequestData("{}")
             .setRequestTimestamp(now)

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/factory/RestServerFactoryImpl.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/factory/RestServerFactoryImpl.kt
@@ -11,7 +11,7 @@ import org.osgi.service.component.annotations.Component
 import java.nio.file.Path
 import java.util.function.Supplier
 
-@Component(immediate = true, service = [RestServerFactory::class])
+@Component(service = [RestServerFactory::class])
 @Suppress("Unused")
 class RestServerFactoryImpl : RestServerFactory {
 


### PR DESCRIPTION
By default, an OSGi component is declared as `immediate = false`, which means that the OSGi framework will not instantiate it until something - most likely another component - asks for an instance. We would prefer this to be when our OSGi bootstrapper requests the `Application` service instance, as all bundles will have been safely activated by this time.

Conversely, if an OSGi component is declared as `immediate = true` then the OSGi framework will try to instantiate it as soon as all of its (known) requirements have been satisfied. This could be _before_ the rest of the application's bundles have been activated, if the framework believes it can activate a component without them.

The Quasar instrumentor injects dynamic references to the `co.paralleluniverse.fibers.suspend.SuspendExecution` class into the classes that it instruments, along with a `DynamicImport-Package` reference to the `co.paralleluniverse.fibers.suspend` package. However, this requires that the `quasar-core-osgi` bundle is already active to _export_ this package, and there's no way to guarantee that. And not least because `quasar-core-osgi` has a few bundle dependencies of its own which need to be installed first too.

Reset as many components as possible back to using `immediate = false` to prevent the `combined-worker` from failing to start because it cannot find the `SuspendExecution` class.