### PR TITLE
CORE-12066: Add support for Kubenetes Ingress to Corda REST worker

### DIFF
--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1338,6 +1338,60 @@
                                         }
                                     ]
                                 },
+                                "ingress": {
+                                    "type": "object",
+                                    "default": {},
+                                    "title": "REST worker ingress configuration",
+                                    "required": [
+                                        "annotations",
+                                        "hosts"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "annotations": {
+                                            "type": "object",
+                                            "default": {},
+                                            "title": "the annotations for REST worker ingress",
+                                            "required": [],
+                                            "properties": {},
+                                            "examples": [
+                                                {
+                                                    "cert-manager.io/cluster-issuer": "production",
+                                                    "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+                                                }
+                                            ]
+                                        },
+                                        "className": {
+                                            "type": "string",
+                                            "default": "",
+                                            "title": "the className for the REST worker ingress",
+                                            "examples": [
+                                                "nginx"
+                                            ]
+                                        },
+                                        "hosts": {
+                                            "type": "array",
+                                            "default": [],
+                                            "title": "the hosts for REST worker ingress",
+                                            "items": {},
+                                            "examples": [
+                                                ["rest-worker-1234.dev.corda.cloud"]
+                                            ]
+                                        }
+                                    },
+                                    "examples": [
+                                        {
+                                            "annotations": {
+                                                "cert-manager.io/cluster-issuer": "production",
+                                                "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+                                            },
+                                            "className": "nginx",
+                                            "hosts": [
+                                                "rest-worker-1234.dev.corda.cloud"
+                                            ]
+                                        }
+                                    ]
+                                },
                                 "tls": {
                                     "type": "object",
                                     "title": "REST Worker TLS configuration",
@@ -1429,6 +1483,16 @@
                                         "externalTrafficPolicy": "",
                                         "loadBalancerSourceRanges": [],
                                         "annotations": {}
+                                    },
+                                    "ingress": {
+                                        "annotations": {
+                                            "cert-manager.io/cluster-issuer": "production",
+                                            "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+                                        },
+                                        "className": "nginx",
+                                        "hosts": [
+                                            "rest-worker-1234.dev.corda.cloud"
+                                        ]
                                     }
                                 }
                             ]
@@ -1708,6 +1772,16 @@
                         "externalTrafficPolicy": "",
                         "loadBalancerSourceRanges": [],
                         "annotations": {}
+                    },
+                    "ingress": {
+                        "annotations": {
+                            "cert-manager.io/cluster-issuer": "production",
+                            "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+                        },
+                        "className": "nginx",
+                        "hosts": [
+                            "rest-worker-1234.dev.corda.cloud"
+                        ]
                     }
                 },
                 "p2pLinkManager": {

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -715,6 +715,14 @@ workers:
       loadBalancerSourceRanges: []
       # -- the annotations for REST worker service
       annotations: {}
+    # REST worker ingress configuration
+    ingress:
+      # -- the annotations for the REST worker ingress
+      annotations: {}
+      # -- the className for the REST worker ingress
+      className: ""
+      # -- the hosts for the REST worker ingress
+      hosts: []
     # REST worker Kafka configuration
     kafka:
       # if kafka.sasl.enabled, the credentials to connect to Kafka with for the REST worker


### PR DESCRIPTION
# Introduction
Adding support for Kubernetes Ingress to the Corda REST worker. It is disabled by default and enabled by setting `.Values.worker.rest.ingress.hosts`, a `[]string`.

# Reason
To provide the Corda REST worker with HTTP load balancing and optionally integration with [External DNS](https://github.com/kubernetes-sigs/external-dns) and [Cert Manager](https://cert-manager.io/docs/).

# Testing
```shell
helm install andrewv-test-rest-worker-ingress charts/corda \
  --namespace test-ingress \
  --set "workers.rest.ingress.annotations.cert-manager\.io\/cluster-issuer=production" \
  --set "workers.rest.ingress.annotations.nginx\.ingress\.kubernetes\.io\/backend-protocol=HTTPS" \
  --set "workers.rest.ingress.className=nginx" \
  --set "workers.rest.ingress.hosts[0]=rest.poc-eks-cluster.corda.cloud" \
  --values ./values-prereqs.yaml
```

Running on `corda-eks-cluster`: https://rest.poc-eks-cluster.corda.cloud

# Additional Details
As the Corda REST worker uses HTTPS, the annotation `nginx.ingress.kubernetes.io/backend-protocol` must be set for the Nginx Ingress controller to function as a reverse proxy.

To work in clusters built with EaaS (with External DNS and Cert Manager installed), you must also set the annotation `cert-manager.io/cluster-issuer`.