### PR TITLE
CORE-12083 - Replaced the constructor call VirtualNodeInfoAvro with the builder.

### DIFF
--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -60,24 +60,24 @@ typealias VirtualNodeInfoAvro = net.corda.data.virtualnode.VirtualNodeInfo
 
 fun VirtualNodeInfo.toAvro(): VirtualNodeInfoAvro =
     with (holdingIdentity) {
-        VirtualNodeInfoAvro(
-            toAvro(),
-            cpiIdentifier.toAvro(),
-            vaultDdlConnectionId?.let{ vaultDdlConnectionId.toString() },
-            vaultDmlConnectionId.toString(),
-            cryptoDdlConnectionId?.let{ cryptoDdlConnectionId.toString() },
-            cryptoDmlConnectionId.toString(),
-            uniquenessDdlConnectionId?.let{ uniquenessDdlConnectionId.toString() },
-            uniquenessDmlConnectionId.toString(),
-            hsmConnectionId?.let { hsmConnectionId.toString() },
-            flowP2pOperationalStatus.toAvro(),
-            flowStartOperationalStatus.toAvro(),
-            flowOperationalStatus.toAvro(),
-            vaultDbOperationalStatus.toAvro(),
-            operationInProgress,
-            version,
-            timestamp
-        )
+        VirtualNodeInfoAvro.newBuilder()
+            .setHoldingIdentity(toAvro())
+            .setCpiIdentifier(cpiIdentifier.toAvro())
+            .setVaultDdlConnectionId(vaultDdlConnectionId?.let{ vaultDdlConnectionId.toString() })
+            .setVaultDmlConnectionId(vaultDmlConnectionId.toString())
+            .setCryptoDdlConnectionId(cryptoDdlConnectionId?.let{ cryptoDdlConnectionId.toString() })
+            .setCryptoDmlConnectionId(cryptoDmlConnectionId.toString())
+            .setUniquenessDdlConnectionId(uniquenessDdlConnectionId?.let{ uniquenessDdlConnectionId.toString() })
+            .setUniquenessDmlConnectionId(uniquenessDmlConnectionId.toString())
+            .setHsmConnectionId(hsmConnectionId?.let { hsmConnectionId.toString() })
+            .setFlowP2pOperationalStatus(flowP2pOperationalStatus.toAvro())
+            .setFlowStartOperationalStatus(flowStartOperationalStatus.toAvro())
+            .setFlowOperationalStatus(flowOperationalStatus.toAvro())
+            .setVaultDbOperationalStatus(vaultDbOperationalStatus.toAvro())
+            .setOperationInProgress(operationInProgress)
+            .setVersion(version)
+            .setTimestamp(timestamp)
+            .build()
     }
 
 fun VirtualNodeInfoAvro.toCorda(): VirtualNodeInfo {


### PR DESCRIPTION
Replaced the constructor call `VirtualNodeInfoAvro` with the builder. This change is required to prevent breaking changes when a new field with a default value is added to the `VirtualNodeInfo` schema.