### PR TITLE
CORE-12034 Make `DigitalSignature` an interface on public API

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/SigningServiceImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.application.crypto
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.flow.application.crypto.external.events.CreateSignatureExternalEventFactory
 import net.corda.flow.application.crypto.external.events.FilterMyKeysExternalEventFactory
@@ -42,7 +43,7 @@ class SigningServiceImpl @Activate constructor(
             SignParameters(bytes, keyEncodingService.encodeAsByteArray(publicKey), signatureSpec)
         )
 
-        return DigitalSignature.WithKeyId(
+        return DigitalSignatureWithKeyId(
             // TODO the following static conversion to key id needs to be replaced with fetching the key id from crypto worker DB
             //  as recorded in https://r3-cev.atlassian.net/browse/CORE-12033
             digitalSignatureWithKey.by.fullIdHash(),

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/SigningServiceImplTest.kt
@@ -2,13 +2,13 @@ package net.corda.flow.application.crypto
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.core.DigitalSignatureWithKey
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.flow.application.crypto.external.events.CreateSignatureExternalEventFactory
 import net.corda.flow.application.crypto.external.events.FilterMyKeysExternalEventFactory
 import net.corda.flow.application.crypto.external.events.SignParameters
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.v5.crypto.CompositeKey
-import net.corda.v5.crypto.DigitalSignature
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
@@ -35,7 +35,7 @@ class SigningServiceImplTest {
         whenever(keyEncodingService.encodeAsByteArray(publicKey)).thenReturn(encodedPublicKeyBytes)
         whenever(externalEventExecutor.execute(eq(CreateSignatureExternalEventFactory::class.java), captor.capture()))
             .thenReturn(signature)
-        val signatureWithKeyId = DigitalSignature.WithKeyId(signature.by.fullIdHash(), signature.bytes)
+        val signatureWithKeyId = DigitalSignatureWithKeyId(signature.by.fullIdHash(), signature.bytes)
         assertEquals(signatureWithKeyId, signingService.sign(byteArrayOf(1), publicKey, mock()))
         assertEquals(encodedPublicKeyBytes, captor.firstValue.encodedPublicKeyBytes)
     }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualFinalityFlowV1Test.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.consensual.flow.impl.flows.finality.v1
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -19,7 +20,6 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
@@ -321,7 +321,7 @@ class ConsensualFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKeyId(publicKey.fullIdHash(), byteArray),
+            DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualReceiveFinalityFlowV1Test.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.consensual.flow.impl.flows.finality.v1
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -17,7 +18,6 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
@@ -238,7 +238,7 @@ class ConsensualReceiveFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKeyId(publicKey.fullIdHash(), byteArray),
+            DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.consensual.flow.impl.transaction.serializer.kryo
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.kryoserialization.testkit.createCheckpointSerializer
 import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
@@ -27,6 +28,7 @@ class ConsensualSignedTransactionKryoSerializerTest: ConsensualLedgerTest() {
                 consensualSignedTransactionExample.signatures[0].by::class.java,
                 emptyMap<String, String>()::class.java,
                 DigitalSignature.WithKeyId::class.java,
+                DigitalSignatureWithKeyId::class.java,
                 SignatureSpec::class.java,
                 mapOf("" to "")::class.java
             )

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality.v1
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -27,7 +28,6 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
@@ -948,7 +948,7 @@ class UtxoFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKeyId(publicKey.fullIdHash(), byteArray),
+            DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality.v1
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -24,7 +25,6 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
@@ -440,7 +440,7 @@ class UtxoReceiveFinalityFlowV1Test {
 
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
-            DigitalSignature.WithKeyId(publicKey.fullIdHash(), byteArray),
+            DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
             DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
         )
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.transaction.serializer.kryo
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.kryoserialization.testkit.createCheckpointSerializer
 import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
@@ -28,6 +29,7 @@ class UtxoSignedTransactionKryoSerializerTest: UtxoLedgerTest() {
                 emptyMap<String, String>()::class.java,
                 emptyList<String>()::class.java,
                 DigitalSignature.WithKeyId::class.java,
+                DigitalSignatureWithKeyId::class.java,
                 SignatureSpec::class.java,
                 mapOf("" to "")::class.java
             )

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.736-beta+
+cordaApiVersion=5.0.0.737-alpha-1680020407825
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.737-alpha-1680020407825
+cordaApiVersion=5.0.0.737-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigitalSignatureWithKey.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigitalSignatureWithKey.kt
@@ -1,9 +1,10 @@
 package net.corda.crypto.core
 
+import net.corda.v5.base.types.OpaqueBytes
 import net.corda.v5.crypto.DigitalSignature
 import java.security.PublicKey
 
 class DigitalSignatureWithKey(
     val by: PublicKey,
     bytes: ByteArray
-) : DigitalSignature(bytes)
+) : DigitalSignature, OpaqueBytes(bytes)

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigitalSignatureWithKeyId.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigitalSignatureWithKeyId.kt
@@ -8,6 +8,5 @@ class DigitalSignatureWithKeyId(
     private val by: SecureHash,
     bytes: ByteArray
     ) : DigitalSignature.WithKeyId, OpaqueBytes(bytes) {
-    // TODO Not sure why Kotlin generated getter cannot override?
     override fun getBy() = by
 }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigitalSignatureWithKeyId.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigitalSignatureWithKeyId.kt
@@ -1,0 +1,13 @@
+package net.corda.crypto.core
+
+import net.corda.v5.base.types.OpaqueBytes
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SecureHash
+
+class DigitalSignatureWithKeyId(
+    private val by: SecureHash,
+    bytes: ByteArray
+    ) : DigitalSignature.WithKeyId, OpaqueBytes(bytes) {
+    // TODO Not sure why Kotlin generated getter cannot override?
+    override fun getBy() = by
+}

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation "org.apache.qpid:proton-j:$protonjVersion"
     implementation 'org.slf4j:slf4j-api'
 
+    testImplementation project(':libs:crypto:cipher-suite')
+    testImplementation project(':libs:crypto:cipher-suite-impl')
+    testImplementation project(':libs:crypto:crypto-core')
+    testImplementation project(':libs:crypto:crypto-serialization-impl')
     testImplementation project(':testing:test-serialization')
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DigitalSignatureTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/DigitalSignatureTests.kt
@@ -1,0 +1,41 @@
+package net.corda.internal.serialization.amqp
+
+import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
+import net.corda.crypto.core.DigitalSignatureWithKey
+import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.impl.serialization.PublicKeySerializer
+import net.corda.internal.serialization.amqp.testutils.testDefaultFactory
+import org.junit.jupiter.api.Test
+import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
+
+class DigitalSignatureTests {
+    private val kpg: KeyPairGenerator =
+        KeyPairGenerator.getInstance("EC").apply { initialize(ECGenParameterSpec("secp256r1")) }
+
+    private val keyEncodingService = CipherSchemeMetadataImpl()
+    private val publicKeySerializer = PublicKeySerializer(keyEncodingService)
+
+    @Test
+    fun `DigitalSignatureWithKey is serializable`() {
+        val publicKey = kpg.generateKeyPair().public
+        val digitalSignatureWithKey = DigitalSignatureWithKey(
+            publicKey,
+            byteArrayOf(0x01, 0x02, 0x03)
+        )
+        val factory = testDefaultFactory()
+        factory.register(publicKeySerializer, factory)
+        ReusableSerialiseDeserializeAssert.serializeDeserializeAssert(digitalSignatureWithKey, factory)
+    }
+
+    @Test
+    fun `DigitalSignatureWithKeyId is serializable`() {
+        val digitalSignatureWithKeyId = DigitalSignatureWithKeyId(
+            SecureHashImpl("ALGO", byteArrayOf(0x01, 0x02)),
+            byteArrayOf(0x01, 0x02, 0x03)
+        )
+
+        ReusableSerialiseDeserializeAssert.serializeDeserializeAssert(digitalSignatureWithKeyId)
+    }
+}

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -6,6 +6,7 @@ import com.r3.corda.notary.plugin.common.NotaryExceptionGeneral
 import com.r3.corda.notary.plugin.common.NotaryExceptionReferenceStateUnknown
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarizationPayload
 import net.corda.crypto.cipher.suite.sha256Bytes
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.testkit.SecureHashUtils.randomSecureHash
@@ -25,7 +26,6 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
@@ -415,7 +415,7 @@ class NonValidatingNotaryServerFlowImplTest {
             on { receive(NonValidatingNotarizationPayload::class.java) } doReturn NonValidatingNotarizationPayload(
                 filteredTx,
                 NotarizationRequestSignature(
-                    DigitalSignature.WithKeyId(
+                    DigitalSignatureWithKeyId(
                         charlieKeyId,
                         "ABC".toByteArray()
                     ),

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningService.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.signing
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.simulator.runtime.serialization.SimpleJsonMarshallingService
 import net.corda.v5.application.crypto.SigningService
@@ -47,7 +48,7 @@ class SimWithJsonSigningService(private val keyStore: SimKeyStore) : SigningServ
                 keyParameters
             )
         ).toByteArray()
-        return DigitalSignature.WithKeyId(publicKey.fullIdHash(), opaqueBytes)
+        return DigitalSignatureWithKeyId(publicKey.fullIdHash(), opaqueBytes)
     }
 
     /**

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBaseTest.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.ledger.consensual
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.simulator.factories.SimulatorConfigurationBuilder
 import net.corda.simulator.runtime.serialization.BaseSerializationService
@@ -8,7 +9,6 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.base.annotations.CordaSerializable
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
@@ -154,7 +154,7 @@ class ConsensualSignedTransactionBaseTest {
     }
 
     private fun toSignatureWithMetadata(key: PublicKey, timestamp: Instant = now()) = DigitalSignatureAndMetadata(
-        DigitalSignature.WithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
+        DigitalSignatureWithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
         DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
     )
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualTransactionBuilderBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualTransactionBuilderBaseTest.kt
@@ -1,11 +1,11 @@
 package net.corda.simulator.runtime.ledger.consensual
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.simulator.factories.SimulatorConfigurationBuilder
 import net.corda.simulator.runtime.testutils.generateKeys
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.membership.MemberLookup
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
@@ -35,7 +35,7 @@ class ConsensualTransactionBuilderBaseTest {
     fun `set up signing service mock`() {
         publicKeys.map {
             whenever(signingService.sign(any(), eq(it), any()))
-                .thenReturn(DigitalSignature.WithKeyId(it.fullIdHash(), "some bytes".toByteArray()))
+                .thenReturn(DigitalSignatureWithKeyId(it.fullIdHash(), "some bytes".toByteArray()))
         }
         whenever(myMemberInfo.ledgerKeys).thenReturn(listOf(myLedgerKey))
         whenever(memberLookup.myInfo()).thenReturn(myMemberInfo)
@@ -58,7 +58,7 @@ class ConsensualTransactionBuilderBaseTest {
     fun `should be able to build a consensual transaction and sign with a key`() {
         // Given a key has been generated on the node, so the SigningService can sign with it
         whenever(signingService.sign(any(), eq(publicKeys[0]), eq(SignatureSpec.ECDSA_SHA256)))
-            .thenReturn(DigitalSignature.WithKeyId(publicKeys[0].fullIdHash(), "My fake signed things".toByteArray()))
+            .thenReturn(DigitalSignatureWithKeyId(publicKeys[0].fullIdHash(), "My fake signed things".toByteArray()))
 
         // And our configuration has a special clock
         val clock = mock<Clock>()

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/SimConsensualLedgerServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/SimConsensualLedgerServiceTest.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.ledger.consensual
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.entities.ConsensualTransactionEntity
@@ -13,7 +14,6 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
@@ -223,7 +223,7 @@ class SimConsensualLedgerServiceTest {
     }
 
     private fun toSignature(key: PublicKey) = DigitalSignatureAndMetadata(
-        DigitalSignature.WithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
+        DigitalSignatureWithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
         DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
     )
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTestUtils.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTestUtils.kt
@@ -1,9 +1,9 @@
 package net.corda.simulator.runtime.ledger.utxo
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.utxo.BelongsToContract
 import net.corda.v5.ledger.utxo.Command
@@ -14,7 +14,7 @@ import java.security.PublicKey
 import java.time.Instant
 
 fun toSignatureWithMetadata(key: PublicKey, timestamp: Instant = Instant.now()) = DigitalSignatureAndMetadata(
-    DigitalSignature.WithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
+    DigitalSignatureWithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
     DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
 )
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionBuilderBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionBuilderBaseTest.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.ledger.utxo
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.core.parseSecureHash
 import net.corda.simulator.entities.UtxoTransactionOutputEntity
@@ -12,7 +13,6 @@ import net.corda.simulator.runtime.testutils.generateKeys
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.utxo.StateRef
@@ -39,7 +39,7 @@ class UtxoTransactionBuilderBaseTest {
         // Given a key has been generated on the node, so the SigningService can sign with it
         val signingService = mock<SigningService>()
         whenever(signingService.sign(any(), eq(publicKeys[0]), eq(SignatureSpec.ECDSA_SHA256)))
-            .thenReturn(DigitalSignature.WithKeyId(publicKeys[0].fullIdHash(), "My fake signed things".toByteArray()))
+            .thenReturn(DigitalSignatureWithKeyId(publicKeys[0].fullIdHash(), "My fake signed things".toByteArray()))
         whenever(signingService.findMySigningKeys(any())).thenReturn(mapOf(publicKeys[0] to publicKeys[0]))
 
         val notaryLookup = mock<NotaryLookup>()

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
@@ -1,15 +1,15 @@
 package net.corda.ledger.common.testkit
 
+import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import java.security.PublicKey
 import java.time.Instant
 
 fun getSignatureWithMetadataExample(publicKey: PublicKey = publicKeyExample, createdTs: Instant = Instant.now()) =
     DigitalSignatureAndMetadata(
-        DigitalSignature.WithKeyId(publicKey.fullIdHash(), "signature".toByteArray()),
+        DigitalSignatureWithKeyId(publicKey.fullIdHash(), "signature".toByteArray()),
         DigitalSignatureMetadata(createdTs, SignatureSpec("dummySignatureName"), mapOf("propertyKey1" to "propertyValue1"))
     )


### PR DESCRIPTION
- adds `DigitalSignature.WithKeyId` implementation and updates use sites
- adds tests asserting AMQP serializability for types `DigitalSignatureWithKey` and `DigitalSignatureWithKeyId`


api PR: [#1011](https://github.com/corda/corda-api/pull/1011)