### PR TITLE
CORE-11838: Remove sessionInitiationKeys from Member Info

### DIFF
--- a/components/ledger/notary-worker-selection-impl/src/test/kotlin/net/corda/ledger/notary/worker/selection/impl/NotaryVirtualNodeSelectorServiceImplTest.kt
+++ b/components/ledger/notary-worker-selection-impl/src/test/kotlin/net/corda/ledger/notary/worker/selection/impl/NotaryVirtualNodeSelectorServiceImplTest.kt
@@ -47,8 +47,7 @@ class NotaryVirtualNodeSelectorServiceImplTest {
             }
             return mock {
                 on { name } doReturn MemberX500Name.parse(memberName)
-                // CORE-11837: Use notary key instead
-                on { sessionInitiationKeys } doReturn listOf(mock())
+                on { ledgerKeys } doReturn listOf(mock())
                 on { memberProvidedContext } doReturn mockMemberContext
             }
         }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -37,6 +37,7 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.metrics.CordaMetrics
 import net.corda.data.p2p.app.MembershipStatusFilter
+import net.corda.membership.lib.MemberInfoExtension.Companion.sessionInitiationKeys
 import net.corda.p2p.crypto.protocol.api.AuthenticationProtocolInitiator
 import net.corda.p2p.crypto.protocol.api.AuthenticationProtocolResponder
 import net.corda.p2p.crypto.protocol.api.CertificateCheckMode

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -60,6 +60,7 @@ import net.corda.lifecycle.impl.registry.LifecycleRegistryImpl
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants
 import net.corda.membership.read.MembershipGroupReader
@@ -460,12 +461,11 @@ class P2PLayerEndToEndTest {
             val context = mock<MemberContext> {
                 on { parseList(ENDPOINTS, EndpointInfo::class.java) } doReturn listOf(endpointInfo)
                 on { parse(MemberInfoExtension.GROUP_ID, String::class.java) } doReturn identity.groupId
+                on { parseList(SESSION_KEYS, PublicKey::class.java) } doReturn listOf(keyPair.public)
             }
             return mock {
                 on { name } doReturn identity.name
                 on { memberProvidedContext } doReturn context
-                on { sessionInitiationKeys } doReturn listOf(keyPair.public)
-
             }
         }
     }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/utilities/MockMembersAndGroups.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/utilities/MockMembersAndGroups.kt
@@ -4,6 +4,8 @@ import net.corda.crypto.cipher.suite.PublicKeyHash
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
+import net.corda.membership.lib.MemberInfoExtension.Companion.sessionInitiationKeys
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants
 import net.corda.membership.read.MembershipGroupReader
@@ -42,11 +44,11 @@ fun mockMemberInfo(
     val context = mock<MemberContext> {
         on { parse(GROUP_ID, String::class.java) } doReturn holdingIdentity.groupId
         on { parseList(ENDPOINTS, EndpointInfo::class.java) } doReturn listOf(endpoints)
+        on { parseList(SESSION_KEYS, PublicKey::class.java) } doReturn listOf(publicKey)
     }
     return mock {
         on { memberProvidedContext } doReturn context
         on { name } doReturn holdingIdentity.x500Name
-        on { sessionInitiationKeys } doReturn listOf(publicKey)
         on { serial } doReturn serialNumber
     }
 }

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/reader/MembershipGroupReaderImplTest.kt
@@ -11,6 +11,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.SignedGroupParameters
@@ -62,11 +63,11 @@ class MembershipGroupReaderImplTest {
     }
     private val mockedSuspendedMgmProvidedContext = mock<MGMContext> {
         on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_SUSPENDED
+        on { parseList(SESSION_KEYS, PublicKey::class.java) } doReturn listOf(mockSessionKey)
     }
     private val aliceSuspendedMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
         on { ledgerKeys } doReturn listOf(mockLedgerKey)
-        on { sessionInitiationKeys } doReturn listOf(mockSessionKey)
         on { memberProvidedContext } doReturn mockedSuspendedMemberProvidedContext
         on { mgmProvidedContext } doReturn mockedSuspendedMgmProvidedContext
         on { isActive } doReturn false
@@ -74,7 +75,6 @@ class MembershipGroupReaderImplTest {
     private val bobSuspendedMemberInfo: MemberInfo = mock {
         on { name } doReturn bobName
         on { ledgerKeys } doReturn listOf(mockLedgerKey)
-        on { sessionInitiationKeys } doReturn listOf(mockSessionKey)
         on { memberProvidedContext } doReturn mockedSuspendedMemberProvidedContext
         on { mgmProvidedContext } doReturn mockedSuspendedMgmProvidedContext
         on { isActive } doReturn false
@@ -84,6 +84,7 @@ class MembershipGroupReaderImplTest {
         on { parseSet(eq(LEDGER_KEY_HASHES), eq(PublicKeyHash::class.java)) } doReturn setOf(mockLedgerKeyHash)
         on { parseSet(eq(SESSION_KEYS_HASH), eq(PublicKeyHash::class.java)) } doReturn setOf(mockSessionKeyHash)
         on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_ACTIVE
+        on { parseList(SESSION_KEYS, PublicKey::class.java) } doReturn listOf(mockSessionKey)
     }
     private val mockedActiveMgmProvidedContext = mock<MGMContext> {
         on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_ACTIVE
@@ -91,7 +92,6 @@ class MembershipGroupReaderImplTest {
     private val aliceActiveMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceName
         on { ledgerKeys } doReturn listOf(mockLedgerKey)
-        on { sessionInitiationKeys } doReturn listOf(mockSessionKey)
         on { memberProvidedContext } doReturn mockedActiveMemberProvidedContext
         on { mgmProvidedContext } doReturn mockedActiveMgmProvidedContext
         on { isActive } doReturn true
@@ -99,7 +99,6 @@ class MembershipGroupReaderImplTest {
     private val bobActiveMemberInfo: MemberInfo = mock {
         on { name } doReturn bobName
         on { ledgerKeys } doReturn listOf(mockLedgerKey)
-        on { sessionInitiationKeys } doReturn listOf(mockSessionKey)
         on { memberProvidedContext } doReturn mockedActiveMemberProvidedContext
         on { mgmProvidedContext } doReturn mockedActiveMgmProvidedContext
         on { isActive } doReturn true

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/SignerFactory.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/SignerFactory.kt
@@ -2,6 +2,7 @@ package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.membership.lib.MemberInfoExtension.Companion.id
+import net.corda.membership.lib.MemberInfoExtension.Companion.sessionInitiationKeys
 import net.corda.v5.membership.MemberInfo
 
 class SignerFactory(

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerFactoryTest.kt
@@ -2,6 +2,7 @@ package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.membership.lib.MemberInfoExtension
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
@@ -21,11 +22,11 @@ class SignerFactoryTest {
         val publicKey = mock<PublicKey>()
         val memberContext = mock<MemberContext> {
             on { parse(eq(MemberInfoExtension.GROUP_ID), any<Class<String>>()) } doReturn "GroupId"
+            on { parseList(SESSION_KEYS, PublicKey::class.java) } doReturn listOf(publicKey)
         }
         val mgm = mock<MemberInfo> {
             on { memberProvidedContext } doReturn memberContext
             on { name } doReturn MemberX500Name.parse("C=GB,L=London,O=mgm")
-            on { sessionInitiationKeys } doReturn listOf(publicKey)
         }
 
         val signer = factory.createSigner(mgm)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -64,6 +64,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.ledgerKeyHashes
 import net.corda.membership.lib.MemberInfoExtension.Companion.modifiedTime
 import net.corda.membership.lib.MemberInfoExtension.Companion.notaryDetails
+import net.corda.membership.lib.MemberInfoExtension.Companion.sessionInitiationKeys
 import net.corda.membership.lib.MemberInfoExtension.Companion.softwareVersion
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -35,6 +35,7 @@ import net.corda.membership.groupparams.writer.service.GroupParametersWriterServ
 import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoExtension.Companion.id
 import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
+import net.corda.membership.lib.MemberInfoExtension.Companion.sessionInitiationKeys
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.toSortedMap
 import net.corda.membership.lib.toWire

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
@@ -39,6 +39,7 @@ import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.id
 import net.corda.membership.lib.MemberInfoFactory
@@ -88,6 +89,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
+import java.security.PublicKey
 import java.time.Instant
 import java.util.SortedMap
 import java.util.concurrent.CompletableFuture
@@ -253,9 +255,9 @@ class MemberSynchronisationServiceImplTest {
     }
     private val mgmMemberContext = mock<MemberContext> {
         on { parse(GROUP_ID, String::class.java) } doReturn GROUP_NAME
+        on { parseList(SESSION_KEYS, PublicKey::class.java) } doReturn listOf(mock())
     }
     private val mgmInfo = mock<MemberInfo> {
-        on { sessionInitiationKeys } doReturn listOf(mock())
         on { name } doReturn MemberX500Name.parse("O=MGM, L=London, C=GB")
         on { mgmProvidedContext } doReturn mgmMgmContext
         on { memberProvidedContext } doReturn mgmMemberContext

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -196,6 +196,13 @@ class MemberInfoExtension {
             get() = memberProvidedContext.parseSet(LEDGER_KEY_HASHES)
 
         /**
+         * The member session initiation keys
+         */
+        @JvmStatic
+        val MemberInfo.sessionInitiationKeys: Collection<PublicKey>
+            get() = memberProvidedContext.parseList(SESSION_KEYS)
+
+        /**
          * [PublicKeyHash] for the session initiation key.
          * The hash value should be stored in the member context, but as a fallback it is calculated if not available.
          * It is preferable to always store this in the member context to avoid the repeated calculation.

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/MemberInfoImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/MemberInfoImpl.kt
@@ -5,7 +5,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTI
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
-import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.softwareVersion
@@ -31,7 +30,6 @@ class MemberInfoImpl(
     override fun getMemberProvidedContext() = memberProvidedContext
     override fun getMgmProvidedContext() = mgmProvidedContext
     override fun getName(): MemberX500Name = memberProvidedContext.parse(PARTY_NAME)
-    override fun getSessionInitiationKeys(): List<PublicKey> = memberProvidedContext.parseList(SESSION_KEYS)
     override fun getLedgerKeys(): List<PublicKey> = memberProvidedContext.parseList(LEDGER_KEYS)
     override fun getPlatformVersion(): Int = memberProvidedContext.parse(PLATFORM_VERSION)
     override fun getSerial(): Long = mgmProvidedContext.parse(SERIAL)

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/MemberInfoTest.kt
@@ -234,7 +234,6 @@ class MemberInfoTest {
         assertEquals(memberInfo, recreatedMemberInfo)
         assertEquals(memberInfo?.ledgerKeys, recreatedMemberInfo?.ledgerKeys)
         assertEquals(memberInfo?.name, recreatedMemberInfo?.name)
-        assertEquals(memberInfo?.sessionInitiationKeys, recreatedMemberInfo?.sessionInitiationKeys)
         assertEquals(memberInfo?.endpoints, recreatedMemberInfo?.endpoints)
         assertEquals(memberInfo?.modifiedTime, recreatedMemberInfo?.modifiedTime)
         assertEquals(memberInfo?.isActive, recreatedMemberInfo?.isActive)

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImplTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/grouppolicy/GroupPolicyParserImplTest.kt
@@ -189,7 +189,6 @@ class GroupPolicyParserImplTest {
         assertSoftly {
             it.assertThat(mgmInfo.name.toString())
                 .isEqualTo("CN=Corda Network MGM, OU=MGM, O=Corda Network, L=London, C=GB")
-            it.assertThat(mgmInfo.sessionInitiationKeys).isNotEmpty
             it.assertThat(mgmInfo.ledgerKeys.size).isEqualTo(0)
             it.assertThat(mgmInfo.ledgerKeyHashes.size).isEqualTo(0)
             it.assertThat(mgmInfo.endpoints.size).isEqualTo(2)

--- a/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
+++ b/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
@@ -73,8 +73,7 @@ fun generateRequestSignature(notarizationRequest: NotarizationRequest,
                              signingService: SigningService
 ): NotarizationRequestSignature {
     val serializedRequest = serializationService.serialize(notarizationRequest).bytes
-    // CORE-11837: Use notary key instead
-    val myLegalIdentity = memberInfo.sessionInitiationKeys.first()
+    val myLegalIdentity = memberInfo.ledgerKeys.first()
     val signature = signingService.sign(
         serializedRequest,
         myLegalIdentity,

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
@@ -123,8 +123,7 @@ class NonValidatingNotaryClientFlowImplTest {
     private fun createClient(flowMessaging: FlowMessaging): NonValidatingNotaryClientFlowImpl {
         val mockMemberInfo = mock<MemberInfo> {
             on { platformVersion } doReturn DUMMY_PLATFORM_VERSION
-            // CORE-11837: Use ledger key
-            on { sessionInitiationKeys } doReturn listOf(mock())
+            on { ledgerKeys } doReturn listOf(mock())
         }
 
         val mockBuilder = mock<UtxoFilteredTransactionBuilder> {

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -105,8 +105,7 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
             val otherMemberInfo = memberLookup.lookup(session.counterparty)
                 ?: throw IllegalStateException("Could not find counterparty on the network: ${session.counterparty}")
 
-            // CORE-11837: Use ledger key
-            val otherPartySessionKey = otherMemberInfo.sessionInitiationKeys.first()
+            val otherPartySessionKey = otherMemberInfo.ledgerKeys.first()
 
             validateRequestSignature(
                 request,

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -79,8 +79,7 @@ class NonValidatingNotaryServerFlowImplTest {
 
         val memberCharlieMemberInfo = mock<MemberInfo> {
             on { name } doReturn memberCharlieName
-            // CORE-11837: Use ledger key
-            on { sessionInitiationKeys } doReturn listOf(memberCharlieKey)
+            on { ledgerKeys } doReturn listOf(memberCharlieKey)
         }
 
         // Default signature verifier, no verification

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/MemberProcessorTestUtils.kt
@@ -17,6 +17,7 @@ import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.lifecycle.Lifecycle
 import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.lib.MemberInfoExtension.Companion.sessionInitiationKeys
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.registration.RegistrationProxy
@@ -233,7 +234,6 @@ class MemberProcessorTestUtils {
 
         fun lookUpBySessionKey(groupReader: MembershipGroupReader, member: MemberInfo?) = eventually {
             val result = member?.let {
-                // CORE-11837: Use ledger key
                 groupReader.lookupBySessionKey(it.sessionInitiationKeys.first().calculateHash())
             }
             assertNotNull(result)

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseMemberInfo.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BaseMemberInfo.kt
@@ -32,10 +32,6 @@ data class BaseMemberInfo(
 
     override fun getName(): MemberX500Name = name
 
-    override fun getSessionInitiationKeys(): List<PublicKey> {
-        TODO("Not yet implemented")
-    }
-
     override fun getLedgerKeys(): MutableList<PublicKey> = ledgerKeys.toMutableList()
 
     override fun getPlatformVersion(): Int {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -218,8 +218,7 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
         referenceStateRefs: List<String>,
         timeWindowBounds: Pair<Long?, Long>
     ): UtxoSignedTransaction {
-        // CORE-11837: Use notary key instead
-        val myKey = memberLookup.myInfo().sessionInitiationKeys.first()
+        val myKey = memberLookup.myInfo().ledgerKeys.first()
         return utxoLedgerService.getTransactionBuilder()
                 .setNotary(notaryServerName)
                 .addCommand(TestCommand())


### PR DESCRIPTION
API pull request is in https://github.com/corda/corda-api/pull/974
E2E pull request in https://github.com/corda/corda-e2e-tests/pull/52

Remove the `sessionInitiationKeys` from the public member info API. Change the places that it is used by non network components to use the `ledgerKeys`.