### PR TITLE
CORE-9662: Make SignatureSpec an interface on public API

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
+import net.corda.crypto.core.CryptoConsts.Categories.LEDGER
 import net.corda.e2etest.utilities.FlowStatus
 import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.RPC_FLOW_STATUS_FAILED
@@ -14,6 +15,7 @@ import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
 import net.corda.e2etest.utilities.awaitRpcFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.configWithDefaultsNode
+import net.corda.e2etest.utilities.createKeyFor
 import net.corda.e2etest.utilities.getConfig
 import net.corda.e2etest.utilities.getFlowClasses
 import net.corda.e2etest.utilities.getHoldingIdShortHash
@@ -39,6 +41,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.TestMethodOrder
 import java.util.UUID
 import net.corda.v5.application.flows.FlowContextPropertyKeys
+import net.corda.v5.crypto.KeySchemeCodes.RSA_CODE_NAME
 import kotlin.text.Typography.quote
 
 @Suppress("Unused", "FunctionName")

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -3,6 +3,7 @@ package net.corda.crypto.client.impl
 import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.crypto.component.impl.exceptionFactories
@@ -55,7 +56,6 @@ import net.corda.test.util.eventually
 import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -753,7 +753,7 @@ class CryptoOpsClientComponentTests {
             schemeMetadata.encodeAsByteArray(keyPair.public)
         )
         val data = ByteBuffer.wrap(UUID.randomUUID().toString().toByteArray())
-        val signature = signData(schemeMetadata, SignatureSpec.ECDSA_SHA256, keyPair, data.array())
+        val signature = signData(schemeMetadata, SignatureSpecs.ECDSA_SHA256, keyPair, data.array())
         val spec = CryptoSignatureSpec(
             "NONEwithECDSA",
             DigestAlgorithmName.SHA2_256.name,
@@ -805,7 +805,7 @@ class CryptoOpsClientComponentTests {
         }
         val keyPair = generateKeyPair(schemeMetadata, ECDSA_SECP256R1_CODE_NAME)
         val data = UUID.randomUUID().toString().toByteArray()
-        val signature = signData(schemeMetadata, SignatureSpec.ECDSA_SHA256, keyPair, data)
+        val signature = signData(schemeMetadata, SignatureSpecs.ECDSA_SHA256, keyPair, data)
         setupCompletedResponse {
             CryptoSignatureWithKey(
                 ByteBuffer.wrap(schemeMetadata.encodeAsByteArray(keyPair.public)),
@@ -820,7 +820,7 @@ class CryptoOpsClientComponentTests {
         assertArrayEquals(signature, result.value.bytes)
         val command = assertOperationType<SignRpcCommand>()
         assertNotNull(command)
-        assertEquals(SignatureSpec.ECDSA_SHA256.signatureName, command.signatureSpec.signatureName)
+        assertEquals(SignatureSpecs.ECDSA_SHA256.signatureName, command.signatureSpec.signatureName)
         assertNull(command.signatureSpec.customDigestName)
         assertNull(command.signatureSpec.params)
         assertArrayEquals(schemeMetadata.encodeAsByteArray(keyPair.public), command.publicKey.array())
@@ -837,7 +837,7 @@ class CryptoOpsClientComponentTests {
         }
         val keyPair = generateKeyPair(schemeMetadata, ECDSA_SECP256R1_CODE_NAME)
         val data = UUID.randomUUID().toString().toByteArray()
-        val signature = signData(schemeMetadata, SignatureSpec.ECDSA_SHA256, keyPair, data)
+        val signature = signData(schemeMetadata, SignatureSpecs.ECDSA_SHA256, keyPair, data)
         val spec = CustomSignatureSpec(
             signatureName = "NONEwithECDSA",
             customDigestName = DigestAlgorithmName.SHA2_256

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoOperationsTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoOperationsTests.kt
@@ -1,10 +1,8 @@
 package net.corda.crypto.service.impl
 
-import java.security.KeyPair
-import java.security.PublicKey
-import java.util.UUID
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.SignatureVerificationService
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
@@ -48,6 +46,9 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import java.security.KeyPair
+import java.security.PublicKey
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -314,7 +315,7 @@ class CryptoOperationsTests {
     fun `Should generate RSA key pair and be able sign and verify using RSASSA-PSS signature`() {
         val testData = UUID.randomUUID().toString().toByteArray()
         val scheme = schemeMetadata.findKeyScheme(RSA_CODE_NAME)
-        val rsaPss = SignatureSpec.RSASSA_PSS_SHA256
+        val rsaPss = SignatureSpecs.RSASSA_PSS_SHA256
         val info = signingAliasedKeys.getValue(scheme)
         assertEquals(info.publicKey.algorithm, "RSA")
         val customSignature1 = info.signingService.sign(
@@ -331,7 +332,7 @@ class CryptoOperationsTests {
     fun `Should generate fresh RSA key pair and be able sign and verify using RSASSA-PSS signature`() {
         val testData = UUID.randomUUID().toString().toByteArray()
         val scheme = schemeMetadata.findKeyScheme(RSA_CODE_NAME)
-        val rsaPss = SignatureSpec.RSASSA_PSS_SHA256
+        val rsaPss = SignatureSpecs.RSASSA_PSS_SHA256
         val info = signingFreshKeys.getValue(scheme)
         assertNotNull(info.publicKey)
         assertEquals(info.publicKey.algorithm, "RSA")

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -1,12 +1,10 @@
 package net.corda.crypto.service.impl
 
 import com.github.benmanes.caffeine.cache.Cache
-import java.security.PublicKey
-import java.time.Instant
-import java.util.UUID
 import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.GeneratedPublicKey
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256R1_TEMPLATE
 import net.corda.crypto.component.test.utils.generateKeyPair
 import net.corda.crypto.core.CryptoConsts
@@ -30,7 +28,6 @@ import net.corda.crypto.softhsm.SigningRepository
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -48,6 +45,9 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import java.security.PublicKey
+import java.time.Instant
+import java.util.UUID
 
 class SigningServiceGeneralTests {
     companion object {
@@ -82,7 +82,7 @@ class SigningServiceGeneralTests {
                 publicKey = mock {
                     on { encoded } doReturn UUID.randomUUID().toString().toByteArray()
                 },
-                signatureSpec = SignatureSpec("NONE"),
+                signatureSpec = SignatureSpecImpl("NONE"),
                 data = ByteArray(2),
                 context = emptyMap()
             )
@@ -109,7 +109,7 @@ class SigningServiceGeneralTests {
                 publicKey = mock {
                     on { encoded } doReturn UUID.randomUUID().toString().toByteArray()
                 },
-                signatureSpec = SignatureSpec("NONE"),
+                signatureSpec = SignatureSpecImpl("NONE"),
                 data = ByteArray(2),
                 context = emptyMap()
             )

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessorTests.kt
@@ -2,6 +2,7 @@ package net.corda.crypto.service.impl.bus
 
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.crypto.client.CryptoOpsProxyClient
 import net.corda.crypto.config.impl.createDefaultCryptoConfig
@@ -36,7 +37,6 @@ import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SignatureSpec
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -332,7 +332,7 @@ class CryptoFlowOpsBusProcessorTests {
                             UUID.randomUUID().toString(),
                             tenantId,
                             publicKey.encoded,
-                            SignatureSpec.EDDSA_ED25519,
+                            SignatureSpecs.EDDSA_ED25519,
                             data,
                             operationContext,
                             flowExternalEventContext
@@ -351,7 +351,7 @@ class CryptoFlowOpsBusProcessorTests {
         assertEquals(tenantId, passedTenantId)
         assertArrayEquals(keyEncodingService.encodeAsByteArray(publicKey), passedPublicKey.array())
         assertArrayEquals(data, passedData.array())
-        assertEquals(SignatureSpec.EDDSA_ED25519.signatureName, passedSignatureSpec.signatureName)
+        assertEquals(SignatureSpecs.EDDSA_ED25519.signatureName, passedSignatureSpec.signatureName)
         val transformed = transformer.transform(flowOpsResponseArgumentCaptor.firstValue)
         assertInstanceOf(DigitalSignatureWithKey::class.java, transformed)
         val transformedSignature = transformed as DigitalSignatureWithKey

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SupportedSchemes.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SupportedSchemes.kt
@@ -1,6 +1,7 @@
 package net.corda.crypto.softhsm
 
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import net.corda.crypto.cipher.suite.schemes.KeySchemeCapability
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256K1_CODE_NAME
@@ -15,31 +16,31 @@ import net.corda.v5.crypto.SignatureSpec
 
 private val SUPPORTED_SCHEMES: Map<String, List<SignatureSpec>> = mapOf(
     RSA_CODE_NAME to listOf(
-        SignatureSpec.RSA_SHA256,
-        SignatureSpec.RSA_SHA384,
-        SignatureSpec.RSA_SHA512,
-        SignatureSpec.RSASSA_PSS_SHA256,
-        SignatureSpec.RSASSA_PSS_SHA384,
-        SignatureSpec.RSASSA_PSS_SHA512,
-        SignatureSpec.RSA_SHA256_WITH_MGF1,
-        SignatureSpec.RSA_SHA384_WITH_MGF1,
-        SignatureSpec.RSA_SHA512_WITH_MGF1
+        SignatureSpecs.RSA_SHA256,
+        SignatureSpecs.RSA_SHA384,
+        SignatureSpecs.RSA_SHA512,
+        SignatureSpecs.RSASSA_PSS_SHA256,
+        SignatureSpecs.RSASSA_PSS_SHA384,
+        SignatureSpecs.RSASSA_PSS_SHA512,
+        SignatureSpecs.RSA_SHA256_WITH_MGF1,
+        SignatureSpecs.RSA_SHA384_WITH_MGF1,
+        SignatureSpecs.RSA_SHA512_WITH_MGF1
     ),
     ECDSA_SECP256K1_CODE_NAME to listOf(
-        SignatureSpec.ECDSA_SHA256,
-        SignatureSpec.ECDSA_SHA384,
-        SignatureSpec.ECDSA_SHA512
+        SignatureSpecs.ECDSA_SHA256,
+        SignatureSpecs.ECDSA_SHA384,
+        SignatureSpecs.ECDSA_SHA512
     ),
     ECDSA_SECP256R1_CODE_NAME to listOf(
-        SignatureSpec.ECDSA_SHA256,
-        SignatureSpec.ECDSA_SHA384,
-        SignatureSpec.ECDSA_SHA512
+        SignatureSpecs.ECDSA_SHA256,
+        SignatureSpecs.ECDSA_SHA384,
+        SignatureSpecs.ECDSA_SHA512
     ),
-    EDDSA_ED25519_CODE_NAME to listOf(SignatureSpec.EDDSA_ED25519),
+    EDDSA_ED25519_CODE_NAME to listOf(SignatureSpecs.EDDSA_ED25519),
     X25519_CODE_NAME to emptyList(),
-    SPHINCS256_CODE_NAME to listOf(SignatureSpec.SPHINCS256_SHA512),
-    SM2_CODE_NAME to listOf(SignatureSpec.SM2_SM3),
-    GOST3410_GOST3411_CODE_NAME to listOf(SignatureSpec.GOST3410_GOST3411)
+    SPHINCS256_CODE_NAME to listOf(SignatureSpecs.SPHINCS256_SHA512),
+    SM2_CODE_NAME to listOf(SignatureSpecs.SM2_SM3),
+    GOST3410_GOST3411_CODE_NAME to listOf(SignatureSpecs.GOST3410_GOST3411)
 )
 
 fun deriveSupportedSchemes(schemeMetadata: CipherSchemeMetadata): Map<KeyScheme, List<SignatureSpec>> =

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
@@ -7,6 +7,7 @@ import net.corda.crypto.cipher.suite.CryptoServiceExtensions
 import net.corda.crypto.cipher.suite.KeyGenerationSpec
 import net.corda.crypto.cipher.suite.KeyMaterialSpec
 import net.corda.crypto.cipher.suite.SharedSecretWrappedSpec
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.SigningWrappedSpec
 import net.corda.crypto.component.test.utils.generateKeyPair
 import net.corda.crypto.core.CryptoConsts
@@ -18,12 +19,10 @@ import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256K1_CODE_NAME
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.KeySchemeCodes.EDDSA_ED25519_CODE_NAME
 import net.corda.v5.crypto.KeySchemeCodes.X25519_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
-import org.assertj.core.api.Assertions.assertThat
-
 import java.util.UUID
 import kotlin.test.assertTrue
 
@@ -93,7 +92,7 @@ class SoftCryptoServiceGeneralTests {
                         encodingVersion = PRIVATE_KEY_ENCODING_VERSION
                     ),
                     keyScheme = service.supportedSchemes.keys.first { it.codeName == ECDSA_SECP256R1_CODE_NAME },
-                    signatureSpec = SignatureSpec.ECDSA_SHA256
+                    signatureSpec = SignatureSpecs.ECDSA_SHA256
                 ),
                 ByteArray(0),
                 defaultContext
@@ -113,7 +112,7 @@ class SoftCryptoServiceGeneralTests {
                         encodingVersion = PRIVATE_KEY_ENCODING_VERSION
                     ),
                     keyScheme = UNSUPPORTED_SIGNATURE_SCHEME,
-                    signatureSpec = SignatureSpec.ECDSA_SHA256
+                    signatureSpec = SignatureSpecs.ECDSA_SHA256
                 ),
                 ByteArray(0),
                 defaultContext
@@ -133,7 +132,7 @@ class SoftCryptoServiceGeneralTests {
                         encodingVersion = PRIVATE_KEY_ENCODING_VERSION
                     ),
                     keyScheme = service.supportedSchemes.keys.first { it.codeName == X25519_CODE_NAME },
-                    signatureSpec = SignatureSpec.EDDSA_ED25519
+                    signatureSpec = SignatureSpecs.EDDSA_ED25519
                 ),
                 ByteArray(0),
                 defaultContext

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/DigitalSignatureVerificationServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/DigitalSignatureVerificationServiceImplTest.kt
@@ -26,4 +26,9 @@ class DigitalSignatureVerificationServiceImplTest {
         whenever(signatureService.verify(any(), any(), any(), any<SignatureSpec>())).thenThrow(CryptoSignatureException("oops!"))
         assertThrows<CryptoSignatureException> { signingService.verify(byteArrayOf(), byteArrayOf(), mock(), mock()) }
     }
+
+    @Test
+    fun `fails when verifying against a different signature spec`() {
+
+    }
 }

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestCryptoOpsClient.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestCryptoOpsClient.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.gateway
 
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.crypto.core.ShortHash
@@ -13,7 +14,6 @@ import net.corda.lifecycle.createCoordinator
 import net.corda.p2p.gateway.messaging.http.KeyStoreWithPassword
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.SignatureSpec
 import org.bouncycastle.openssl.PEMKeyPair

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualFinalityFlowV1Test.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.consensual.flow.impl.flows.finality.v1
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -20,7 +21,6 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
@@ -322,7 +322,7 @@ class ConsensualFinalityFlowV1Test {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
-            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), emptyMap())
         )
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/flows/finality/v1/ConsensualReceiveFinalityFlowV1Test.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.consensual.flow.impl.flows.finality.v1
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -18,7 +19,6 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionSignatureException
@@ -239,7 +239,7 @@ class ConsensualReceiveFinalityFlowV1Test {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
-            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), emptyMap())
         )
     }
 }

--- a/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-consensual-flow/src/test/kotlin/net/corda/ledger/consensual/flow/impl/transaction/serializer/kryo/ConsensualSignedTransactionKryoSerializerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.consensual.flow.impl.transaction.serializer.kryo
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.kryoserialization.testkit.createCheckpointSerializer
 import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
@@ -8,7 +9,6 @@ import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransac
 import net.corda.ledger.consensual.test.ConsensualLedgerTest
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.crypto.DigitalSignature
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class ConsensualSignedTransactionKryoSerializerTest: ConsensualLedgerTest() {
                 emptyMap<String, String>()::class.java,
                 DigitalSignature.WithKeyId::class.java,
                 DigitalSignatureWithKeyId::class.java,
-                SignatureSpec::class.java,
+                SignatureSpecImpl::class.java,
                 mapOf("" to "")::class.java
             )
         )

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality.v1
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -29,7 +30,6 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
@@ -949,7 +949,7 @@ class UtxoFinalityFlowV1Test {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
-            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), emptyMap())
         )
     }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality.v1
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -25,7 +26,6 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionSignatureException
@@ -441,7 +441,7 @@ class UtxoReceiveFinalityFlowV1Test {
     private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
         return DigitalSignatureAndMetadata(
             DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
-            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), emptyMap())
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction.serializer.kryo
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.kryoserialization.testkit.createCheckpointSerializer
 import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
@@ -8,7 +9,6 @@ import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.test.UtxoLedgerTest
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.crypto.DigitalSignature
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -30,7 +30,7 @@ class UtxoSignedTransactionKryoSerializerTest: UtxoLedgerTest() {
                 emptyList<String>()::class.java,
                 DigitalSignature.WithKeyId::class.java,
                 DigitalSignatureWithKeyId::class.java,
-                SignatureSpec::class.java,
+                SignatureSpecImpl::class.java,
                 mapOf("" to "")::class.java
             )
         )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/PublicKeyReader.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/PublicKeyReader.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.linkmanager.common
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.p2p.crypto.protocol.api.KeyAlgorithm
 import net.corda.v5.crypto.SignatureSpec
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
@@ -19,8 +20,8 @@ internal class PublicKeyReader {
 
         internal fun KeyAlgorithm.getSignatureSpec(): SignatureSpec {
             return when (this) {
-                KeyAlgorithm.RSA -> SignatureSpec.RSA_SHA256
-                KeyAlgorithm.ECDSA -> SignatureSpec.ECDSA_SHA256
+                KeyAlgorithm.RSA -> SignatureSpecs.RSA_SHA256
+                KeyAlgorithm.ECDSA -> SignatureSpecs.ECDSA_SHA256
             }
         }
     }

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -4,27 +4,13 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigValueFactory
-import java.io.StringWriter
-import java.net.URL
-import java.nio.ByteBuffer
-import java.security.Key
-import java.security.KeyFactory
-import java.security.KeyPairGenerator
-import java.security.KeyStore
-import java.security.PublicKey
-import java.security.Signature
-import java.security.spec.PKCS8EncodedKeySpec
-import java.time.Duration
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArrayList
 import net.corda.configuration.read.impl.ConfigurationReadServiceImpl
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
+import net.corda.crypto.cipher.suite.PublicKeyHash
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256R1_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.KeySchemeTemplate
 import net.corda.crypto.cipher.suite.schemes.RSA_TEMPLATE
 import net.corda.crypto.client.CryptoOpsClient
-import net.corda.crypto.cipher.suite.PublicKeyHash
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.data.config.Configuration
 import net.corda.data.config.ConfigurationSchemaVersion
@@ -97,7 +83,6 @@ import net.corda.test.util.eventually
 import net.corda.testing.p2p.certificates.Certificates
 import net.corda.utilities.seconds
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.EndpointInfo
 import net.corda.v5.membership.MemberContext
@@ -118,6 +103,21 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.slf4j.LoggerFactory
+import java.io.StringWriter
+import java.net.URL
+import java.nio.ByteBuffer
+import java.security.Key
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PublicKey
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 class P2PLayerEndToEndTest {
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -1,7 +1,8 @@
 package net.corda.p2p.linkmanager.sessions
 
-import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.cipher.suite.PublicKeyHash
+import net.corda.crypto.cipher.suite.SignatureSpecs
+import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.data.p2p.DataMessagePayload
@@ -835,7 +836,7 @@ class SessionManagerTest {
             protocolResponder.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage,
                 PEER_MEMBER_INFO.holdingIdentity.x500Name,
-                listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256)
+                listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256)
             )
         ).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         val responderHandshakeMsg = mock<ResponderHandshakeMessage>()
@@ -879,7 +880,7 @@ class SessionManagerTest {
             protocolResponder.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage,
                 PEER_MEMBER_INFO.holdingIdentity.x500Name,
-                listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+                listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
             )
         ).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         val responderHandshakeMsg = mock<ResponderHandshakeMessage>()
@@ -915,7 +916,7 @@ class SessionManagerTest {
             protocolResponder.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage,
                 PEER_MEMBER_INFO.holdingIdentity.x500Name,
-                listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+                listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
             )
         ).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         val responderHandshakeMsg = mock<ResponderHandshakeMessage>()
@@ -1033,7 +1034,7 @@ class SessionManagerTest {
         whenever(protocolResponder.validatePeerHandshakeMessage(
             initiatorHandshake,
             PEER_MEMBER_INFO.holdingIdentity.x500Name,
-            listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenThrow(WrongPublicKeyHashException(initiatorPublicKeyHash.reversedArray(), listOf(initiatorPublicKeyHash)))
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
 
@@ -1059,7 +1060,7 @@ class SessionManagerTest {
         whenever(protocolResponder.validatePeerHandshakeMessage(
             initiatorHandshake,
             PEER_MEMBER_INFO.holdingIdentity.x500Name,
-            listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenThrow(InvalidHandshakeMessageException())
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
 
@@ -1085,7 +1086,7 @@ class SessionManagerTest {
         whenever(protocolResponder.validatePeerHandshakeMessage(
             initiatorHandshake,
             PEER_MEMBER_INFO.holdingIdentity.x500Name,
-            listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenThrow(InvalidPeerCertificate("Invalid peer certificate"))
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
 
@@ -1112,7 +1113,7 @@ class SessionManagerTest {
         whenever(protocolResponder.validatePeerHandshakeMessage(
             initiatorHandshake,
             PEER_MEMBER_INFO.holdingIdentity.x500Name,
-            listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         whenever(linkManagerHostingMap.getInfo(responderPublicKeyHash, GROUP_ID)).thenReturn(null)
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
@@ -1142,7 +1143,7 @@ class SessionManagerTest {
         whenever(protocolResponder.validatePeerHandshakeMessage(
             initiatorHandshake,
             PEER_MEMBER_INFO.holdingIdentity.x500Name,
-            listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
@@ -1172,7 +1173,7 @@ class SessionManagerTest {
         whenever(protocolResponder.validatePeerHandshakeMessage(
             initiatorHandshake,
             PEER_MEMBER_INFO.holdingIdentity.x500Name,
-            listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         whenever(protocolResponder.generateOurHandshakeMessage(eq(OUR_KEY.public), eq(null), any()))
             .thenThrow(CordaRuntimeException("Nop"))
@@ -1202,7 +1203,7 @@ class SessionManagerTest {
         whenever(protocolResponder.validatePeerHandshakeMessage(
             initiatorHandshake,
             PEER_MEMBER_INFO.holdingIdentity.x500Name,
-            listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
 
@@ -1282,7 +1283,7 @@ class SessionManagerTest {
             protocolInitiator.validatePeerHandshakeMessage(
                 responderHandshakeMessage,
                 PEER_MEMBER_INFO.holdingIdentity.x500Name,
-                listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+                listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
             )
         ).thenThrow(InvalidHandshakeResponderKeyHash())
         assertThat(sessionManager.processSessionMessage(LinkInMessage(responderHandshakeMessage))).isNull()
@@ -1303,7 +1304,7 @@ class SessionManagerTest {
             protocolInitiator.validatePeerHandshakeMessage(
                 responderHandshakeMessage,
                 PEER_MEMBER_INFO.holdingIdentity.x500Name,
-                listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+                listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
 
             )
         ).thenThrow(InvalidPeerCertificate("Bad Cert"))
@@ -1325,7 +1326,7 @@ class SessionManagerTest {
             protocolInitiator.validatePeerHandshakeMessage(
                 responderHandshakeMessage,
                 PEER_MEMBER_INFO.holdingIdentity.x500Name,
-                listOf(PEER_KEY.public to SignatureSpec.ECDSA_SHA256),
+                listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
             )
         ).thenThrow(InvalidHandshakeMessageException())
         assertThat(sessionManager.processSessionMessage(LinkInMessage(responderHandshakeMessage))).isNull()

--- a/components/membership/group-params-writer-service-impl/src/test/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceTest.kt
+++ b/components/membership/group-params-writer-service-impl/src/test/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceTest.kt
@@ -5,6 +5,7 @@ import jdk.jshell.spi.ExecutionControl.NotImplementedException
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.data.membership.PersistentGroupParameters
 import net.corda.libs.configuration.SmartConfigFactory
@@ -27,7 +28,6 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.GROUP_PARAMETERS_TOPIC
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
@@ -102,7 +102,7 @@ class GroupParametersWriterServiceTest {
         publicKey,
         sigBytes
     )
-    private val signatureSpec = SignatureSpec.ECDSA_SHA256
+    private val signatureSpec = SignatureSpecs.ECDSA_SHA256
 
     private val writerService = GroupParametersWriterServiceImpl(
         coordinatorFactory,

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.p2p.helpers
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.ShortHash
@@ -24,33 +25,33 @@ class KeySpecExtractor(
             get() = defaultCodeNameToSpec[schemeCodeName]
 
         private val defaultCodeNameToSpec = mapOf(
-            ECDSA_SECP256K1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
-            ECDSA_SECP256R1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
-            EDDSA_ED25519_CODE_NAME to SignatureSpec.EDDSA_ED25519,
-            GOST3410_GOST3411_CODE_NAME to SignatureSpec.GOST3410_GOST3411,
-            RSA_CODE_NAME to SignatureSpec.RSA_SHA512,
-            SM2_CODE_NAME to SignatureSpec.SM2_SM3,
-            SPHINCS256_CODE_NAME to SignatureSpec.SPHINCS256_SHA512,
+            ECDSA_SECP256K1_CODE_NAME to SignatureSpecs.ECDSA_SHA256,
+            ECDSA_SECP256R1_CODE_NAME to SignatureSpecs.ECDSA_SHA256,
+            EDDSA_ED25519_CODE_NAME to SignatureSpecs.EDDSA_ED25519,
+            GOST3410_GOST3411_CODE_NAME to SignatureSpecs.GOST3410_GOST3411,
+            RSA_CODE_NAME to SignatureSpecs.RSA_SHA512,
+            SM2_CODE_NAME to SignatureSpecs.SM2_SM3,
+            SPHINCS256_CODE_NAME to SignatureSpecs.SPHINCS256_SHA512,
         )
         private val validSpecsNames = mapOf(
             ECDSA_SECP256K1_CODE_NAME to listOf(
-                SignatureSpec.ECDSA_SHA256,
-                SignatureSpec.ECDSA_SHA384,
-                SignatureSpec.ECDSA_SHA512,
+                SignatureSpecs.ECDSA_SHA256,
+                SignatureSpecs.ECDSA_SHA384,
+                SignatureSpecs.ECDSA_SHA512,
             )
                 .map { it.signatureName },
             ECDSA_SECP256R1_CODE_NAME to listOf(
-                SignatureSpec.ECDSA_SHA256,
-                SignatureSpec.ECDSA_SHA384,
-                SignatureSpec.ECDSA_SHA512,
+                SignatureSpecs.ECDSA_SHA256,
+                SignatureSpecs.ECDSA_SHA384,
+                SignatureSpecs.ECDSA_SHA512,
             )
                 .map { it.signatureName },
-            EDDSA_ED25519_CODE_NAME to listOf(SignatureSpec.EDDSA_ED25519.signatureName),
-            GOST3410_GOST3411_CODE_NAME to listOf(SignatureSpec.GOST3410_GOST3411.signatureName),
-            RSA_CODE_NAME to listOf(SignatureSpec.RSA_SHA256, SignatureSpec.RSA_SHA384, SignatureSpec.RSA_SHA512)
+            EDDSA_ED25519_CODE_NAME to listOf(SignatureSpecs.EDDSA_ED25519.signatureName),
+            GOST3410_GOST3411_CODE_NAME to listOf(SignatureSpecs.GOST3410_GOST3411.signatureName),
+            RSA_CODE_NAME to listOf(SignatureSpecs.RSA_SHA256, SignatureSpecs.RSA_SHA384, SignatureSpecs.RSA_SHA512)
                 .map { it.signatureName },
-            SM2_CODE_NAME to listOf(SignatureSpec.SM2_SM3.signatureName),
-            SPHINCS256_CODE_NAME to listOf(SignatureSpec.SPHINCS256_SHA512.signatureName),
+            SM2_CODE_NAME to listOf(SignatureSpecs.SM2_SM3.signatureName),
+            SPHINCS256_CODE_NAME to listOf(SignatureSpecs.SPHINCS256_SHA512.signatureName),
         )
 
         fun CryptoSigningKey.validateSpecName(specName: String) {

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/Verifier.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/Verifier.kt
@@ -1,11 +1,11 @@
 package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.cipher.suite.SignatureVerificationService
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.crypto.SignatureSpec
 import java.security.PublicKey
 
 class Verifier(
@@ -34,7 +34,7 @@ class Verifier(
         data: ByteArray
     ) {
         val signatureSpec = signatureSpecAvro.signatureName?.let {
-            SignatureSpec(it)
+            SignatureSpecImpl(it)
         } ?: throw CordaRuntimeException("Can not find signature spec")
         signatureVerificationService.verify(
             data,

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractorTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractorTest.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.p2p.helpers
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.ShortHash
@@ -7,7 +8,6 @@ import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.membership.p2p.helpers.KeySpecExtractor.Companion.validateSpecName
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -36,7 +36,7 @@ class KeySpecExtractorTest {
 
     @Test
     fun `valid key returns the correct spec`() {
-        assertThat(extractor.getSpec(publicKeyOne)).isEqualTo(SignatureSpec.ECDSA_SHA256)
+        assertThat(extractor.getSpec(publicKeyOne)).isEqualTo(SignatureSpecs.ECDSA_SHA256)
     }
 
     @Test
@@ -54,7 +54,7 @@ class KeySpecExtractorTest {
         }
 
         val exception = assertThrows<IllegalArgumentException> {
-            key.validateSpecName(SignatureSpec.ECDSA_SHA256.signatureName)
+            key.validateSpecName(SignatureSpecs.ECDSA_SHA256.signatureName)
         }
         assertThat(exception).hasMessageContaining("Could not identify spec for key scheme nop")
     }
@@ -62,15 +62,15 @@ class KeySpecExtractorTest {
     @Test
     fun `validateSpecName throw exception for invalid spec name`() {
         val exception = assertThrows<IllegalArgumentException> {
-            signingKey.validateSpecName(SignatureSpec.RSA_SHA512.signatureName)
+            signingKey.validateSpecName(SignatureSpecs.RSA_SHA512.signatureName)
         }
-        assertThat(exception).hasMessageContaining("Invalid key spec ${SignatureSpec.RSA_SHA512.signatureName}")
+        assertThat(exception).hasMessageContaining("Invalid key spec ${SignatureSpecs.RSA_SHA512.signatureName}")
     }
 
     @Test
     fun `validateSpecName pass with valid names`() {
         assertDoesNotThrow {
-            signingKey.validateSpecName(SignatureSpec.ECDSA_SHA256.signatureName)
+            signingKey.validateSpecName(SignatureSpecs.ECDSA_SHA256.signatureName)
         }
     }
 }

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/MembershipPackageFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.p2p.helpers
 
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.bytes
 import net.corda.crypto.core.DigitalSignatureWithKey
@@ -19,7 +20,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.merkle.MerkleTree
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
@@ -66,7 +66,7 @@ class MembershipPackageFactoryTest {
     private val merkleTreeGenerator = mock<MerkleTreeGenerator>()
     private val mgmSigner = mock<Signer> {
         on { sign(eq(groupParametersBytes)) } doReturn signedGroupParameters
-        on { this.signatureSpec } doReturn SignatureSpec("dummy")
+        on { this.signatureSpec } doReturn SignatureSpecImpl("dummy")
     }
     private val membersCount = 4
     private val members = (1..membersCount).map {

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/SignerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.p2p.helpers
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.DigitalSignatureWithKey
@@ -7,7 +8,6 @@ import net.corda.crypto.core.ShortHash
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.KeySchemeCodes.RSA_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -38,7 +38,7 @@ class SignerTest {
                 tenantId = tenantId,
                 publicKey = publicKey,
                 data = data,
-                signatureSpec = SignatureSpec.RSA_SHA512
+                signatureSpec = SignatureSpecs.RSA_SHA512
             )
         ).doReturn(signature)
 

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
@@ -57,8 +58,8 @@ import net.corda.lifecycle.StopEvent
 import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.SignedGroupParameters
-import net.corda.membership.lib.approval.ApprovalRuleParams
 import net.corda.membership.lib.SignedMemberInfo
+import net.corda.membership.lib.approval.ApprovalRuleParams
 import net.corda.membership.lib.registration.RegistrationRequest
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
@@ -71,7 +72,6 @@ import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
@@ -175,7 +175,7 @@ class MembershipPersistenceClientImplTest {
         publicKey,
         signatureBytes
     )
-    private val mockSignatureSpec = SignatureSpec.ECDSA_SHA256
+    private val mockSignatureSpec = SignatureSpecs.ECDSA_SHA256
     private val keyEncodingService = mock<KeyEncodingService> {
         on { encodeAsByteArray(publicKey) } doReturn publicKeyBytes
     }

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -3,6 +3,7 @@ package net.corda.membership.impl.persistence.service
 import com.typesafe.config.ConfigFactory
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs.RSA_SHA256
 import net.corda.crypto.cipher.suite.calculateHash
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.data.CordaAvroDeserializer
@@ -111,7 +112,6 @@ import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.SignatureSpec
-import net.corda.v5.crypto.SignatureSpec.RSA_SHA256
 import net.corda.v5.membership.MemberInfo
 import net.corda.v5.membership.NotaryInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -119,10 +119,13 @@ import net.corda.virtualnode.VirtualNodeInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.persistence.service.handler
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
@@ -34,7 +35,6 @@ import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
@@ -112,7 +112,7 @@ class AddNotaryToGroupParametersHandlerTest {
             parameters = previousGroupParameters,
             signaturePublicKey = byteArrayOf(0),
             signatureContent = byteArrayOf(1),
-            signatureSpec = SignatureSpec.ECDSA_SHA256.signatureName
+            signatureSpec = SignatureSpecs.ECDSA_SHA256.signatureName
         )
     }
     private val groupParametersQuery: TypedQuery<GroupParametersEntity> = mock {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.impl.persistence.service.handler
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
@@ -19,7 +20,6 @@ import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
 import net.corda.test.util.time.TestClock
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -66,7 +66,7 @@ class PersistGroupParametersHandlerTest {
         ByteBuffer.wrap(sigContent)
     )
     private val signatureSpec = CryptoSignatureSpec(
-        SignatureSpec.ECDSA_SHA256.signatureName, null, null
+        SignatureSpecs.ECDSA_SHA256.signatureName, null, null
     )
 
     private val newSignedParams = SignedGroupParameters(

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.persistence.service.handler
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.data.CordaAvroDeserializer
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.CordaAvroSerializer
@@ -18,7 +19,6 @@ import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
 import net.corda.test.util.time.TestClock
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
@@ -147,7 +147,7 @@ class PersistGroupParametersInitialSnapshotHandlerTest {
                 parameters = content,
                 signaturePublicKey = byteArrayOf(0),
                 signatureContent = byteArrayOf(1),
-                signatureSpec = SignatureSpec.ECDSA_SHA256.signatureName
+                signatureSpec = SignatureSpecs.ECDSA_SHA256.signatureName
             )
         )
 
@@ -182,7 +182,7 @@ class PersistGroupParametersInitialSnapshotHandlerTest {
                 parameters = content,
                 signaturePublicKey = byteArrayOf(0),
                 signatureContent = byteArrayOf(1),
-                signatureSpec = SignatureSpec.ECDSA_SHA256.signatureName
+                signatureSpec = SignatureSpecs.ECDSA_SHA256.signatureName
             )
         )
 

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -1,6 +1,8 @@
 package net.corda.membership.impl.rest.v1
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.schemes.EDDSA_ED25519_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.GOST3410_GOST3411_TEMPLATE
 import net.corda.crypto.client.CryptoOpsClient
@@ -82,13 +84,13 @@ class CertificatesRestResourceImpl @Activate constructor(
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val defaultCodeNameToSpec = mapOf(
-            ECDSA_SECP256K1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
-            ECDSA_SECP256R1_CODE_NAME to SignatureSpec.ECDSA_SHA256,
-            EDDSA_ED25519_TEMPLATE to SignatureSpec.EDDSA_ED25519,
-            GOST3410_GOST3411_TEMPLATE to SignatureSpec.GOST3410_GOST3411,
-            RSA_CODE_NAME to SignatureSpec.RSA_SHA512,
-            SM2_CODE_NAME to SignatureSpec.SM2_SM3,
-            SPHINCS256_CODE_NAME to SignatureSpec.SPHINCS256_SHA512,
+            ECDSA_SECP256K1_CODE_NAME to SignatureSpecs.ECDSA_SHA256,
+            ECDSA_SECP256R1_CODE_NAME to SignatureSpecs.ECDSA_SHA256,
+            EDDSA_ED25519_TEMPLATE to SignatureSpecs.EDDSA_ED25519,
+            GOST3410_GOST3411_TEMPLATE to SignatureSpecs.GOST3410_GOST3411,
+            RSA_CODE_NAME to SignatureSpecs.RSA_SHA512,
+            SM2_CODE_NAME to SignatureSpecs.SM2_SM3,
+            SPHINCS256_CODE_NAME to SignatureSpecs.SPHINCS256_SHA512,
         )
 
         fun getSignatureSpec(
@@ -96,7 +98,7 @@ class CertificatesRestResourceImpl @Activate constructor(
             defaultSpec: String?
         ): SignatureSpec {
             if (defaultSpec != null) {
-                return SignatureSpec(defaultSpec)
+                return SignatureSpecImpl(defaultSpec)
             }
 
             return defaultCodeNameToSpec[key.schemeCodeName]

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.rest.v1
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts
 import net.corda.crypto.core.CryptoTenants.P2P
@@ -27,7 +28,6 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
-import net.corda.v5.crypto.SignatureSpec.ECDSA_SHA256
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -157,7 +157,7 @@ class CertificatesRestResourceImplTest {
                     cryptoOpsClient.sign(
                         eq(tenantId),
                         eq(publicKey),
-                        argThat<SignatureSpec> { this.signatureName == ECDSA_SHA256.signatureName },
+                        argThat<SignatureSpec> { this.signatureName == SignatureSpecs.ECDSA_SHA256.signatureName },
                         any(),
                         eq(emptyMap())
                     )
@@ -216,7 +216,7 @@ class CertificatesRestResourceImplTest {
             verify(cryptoOpsClient).sign(
                 eq(holdingIdentityShortHash),
                 eq(publicKey),
-                argThat<SignatureSpec> { this.signatureName == ECDSA_SHA256.signatureName },
+                argThat<SignatureSpec> { this.signatureName == SignatureSpecs.ECDSA_SHA256.signatureName },
                 any(),
                 eq(emptyMap())
             )
@@ -235,7 +235,7 @@ class CertificatesRestResourceImplTest {
             verify(cryptoOpsClient).sign(
                 eq(P2P),
                 eq(publicKey),
-                argThat<SignatureSpec> { this.signatureName == ECDSA_SHA256.signatureName },
+                argThat<SignatureSpec> { this.signatureName == SignatureSpecs.ECDSA_SHA256.signatureName },
                 any(),
                 eq(emptyMap())
             )

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -3,6 +3,7 @@ package net.corda.membership.impl.registration
 import com.typesafe.config.ConfigFactory
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts
@@ -46,8 +47,8 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
-import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.locally.hosted.identities.LocallyHostedIdentitiesService
@@ -69,7 +70,6 @@ import net.corda.utilities.concurrent.getOrThrow
 import net.corda.utilities.seconds
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
@@ -404,11 +404,11 @@ class MemberRegistrationIntegrationTest {
                 .publicKeyId()
         return mapOf(
             "corda.session.keys.0.id" to sessionKeyId,
-            "corda.session.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+            "corda.session.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
             URL_KEY to URL_VALUE,
             PROTOCOL_KEY to PROTOCOL_VALUE,
             "corda.ledger.keys.0.id" to ledgerKeyId,
-            "corda.ledger.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+            "corda.ledger.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
             CUSTOM_KEY to CUSTOM_VALUE
         )
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -4,6 +4,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationGetService
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.cipher.suite.calculateHash
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts.Categories.LEDGER
@@ -60,10 +61,10 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS_SIGNATURE_SPEC
-import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.TLS_CERTIFICATE_SUBJECT
 import net.corda.membership.lib.MemberInfoExtension.Companion.ecdhKey
@@ -300,7 +301,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                 val memberSignature = cryptoOpsClient.sign(
                     member.shortHash.value,
                     publicKey,
-                    SignatureSpec(signatureSpec),
+                    SignatureSpecImpl(signatureSpec),
                     serializedMemberContext
                 ).let {
                     CryptoSignatureWithKey(
@@ -508,7 +509,7 @@ class DynamicMemberRegistrationService @Activate constructor(
         private fun getSignatureSpec(key: CryptoSigningKey, specFromContext: String?): SignatureSpec {
             if (specFromContext != null) {
                 key.validateSpecName(specFromContext)
-                return SignatureSpec(specFromContext)
+                return SignatureSpecImpl(specFromContext)
             }
             logger.info(
                 "Signature spec for key with ID: ${key.id} was not specified. Applying default signature spec " +

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/KeysFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.registration
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.calculateHash
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.client.CryptoOpsClient
@@ -10,7 +11,6 @@ import net.corda.crypto.core.KeyAlreadyExistsException
 import net.corda.crypto.core.ShortHash
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -152,6 +152,6 @@ class KeysFactoryTest {
             keysFactory
                 .getOrGenerateKeyPair(noExistingKeyCategory)
                 .spec
-        ).isEqualTo(SignatureSpec.ECDSA_SHA256)
+        ).isEqualTo(SignatureSpecs.ECDSA_SHA256)
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.registration
 
 import net.corda.crypto.cipher.suite.PublicKeyHash
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.membership.impl.registration.MemberRole.Companion.extractRolesFromContext
 import net.corda.membership.impl.registration.MemberRole.Companion.toMemberInfo
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_HASH
@@ -11,7 +12,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PRO
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
 import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -155,13 +155,13 @@ class MemberRoleTest {
         val key1 = mock<KeyDetails> {
             on { pem } doReturn "pem1"
             on { hash } doReturn key1Hash
-            on { spec } doReturn SignatureSpec.RSA_SHA256
+            on { spec } doReturn SignatureSpecs.RSA_SHA256
         }
         val key2Hash = PublicKeyHash.calculate("test2".toByteArray())
         val key2 = mock<KeyDetails> {
             on { pem } doReturn "pem2"
             on { hash } doReturn key2Hash
-            on { spec } doReturn SignatureSpec.ECDSA_SHA512
+            on { spec } doReturn SignatureSpecs.ECDSA_SHA512
         }
         val roles = extractRolesFromContext(
             mapOf(

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -5,6 +5,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationGetService
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts.Categories.LEDGER
 import net.corda.crypto.core.CryptoConsts.Categories.NOTARY
@@ -21,9 +22,9 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.platform.PlatformInfoProvider
@@ -59,10 +60,10 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
+import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS_SIGNATURE_SPEC
-import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
-import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.SOFTWARE_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.TLS_CERTIFICATE_SUBJECT
 import net.corda.membership.lib.MemberInfoExtension.Companion.URL_KEY
@@ -340,11 +341,11 @@ class DynamicMemberRegistrationServiceTest {
 
     private val context = mapOf(
         "corda.session.keys.0.id" to SESSION_KEY_ID,
-        "corda.session.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+        "corda.session.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
         "corda.endpoints.0.connectionURL" to "https://localhost:1080",
         "corda.endpoints.0.protocolVersion" to "1",
         "corda.ledger.keys.0.id" to LEDGER_KEY_ID,
-        "corda.ledger.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+        "corda.ledger.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
     )
 
     @AfterEach
@@ -444,11 +445,11 @@ class DynamicMemberRegistrationServiceTest {
             registrationService.start()
             val context = mapOf(
                 "corda.session.keys.0.id" to SESSION_KEY_ID,
-                "corda.session.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+                "corda.session.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
                 "corda.endpoints.0.connectionURL" to "https://localhost:1080",
                 "corda.endpoints.0.protocolVersion" to "1",
                 "corda.ledger.keys.0.id" to LEDGER_KEY_ID,
-                "corda.ledger.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+                "corda.ledger.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
                 "corda.serial" to "12"
             )
             val capturedRequest = argumentCaptor<MembershipRegistrationRequest>()
@@ -471,7 +472,7 @@ class DynamicMemberRegistrationServiceTest {
                 )
             )
             assertThat(capturedRequest.firstValue.signatureSpec.signatureName)
-                .isEqualTo(SignatureSpec.ECDSA_SHA512.signatureName)
+                .isEqualTo(SignatureSpecs.ECDSA_SHA512.signatureName)
         }
 
         @Test
@@ -596,11 +597,11 @@ class DynamicMemberRegistrationServiceTest {
                 "corda.endpoints.0.connectionURL" to "https://localhost:1080",
                 "corda.endpoints.0.protocolVersion" to "1",
                 "corda.ledger.keys.0.id" to LEDGER_KEY_ID,
-                "corda.ledger.keys.0.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName,
+                "corda.ledger.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
             ) +
                 keys.map { "corda.session.keys.${it.index}.id" to it.keyId.value } +
                 keys.map {
-                    "corda.session.keys.${it.index}.signature.spec" to SignatureSpec.ECDSA_SHA512.signatureName
+                    "corda.session.keys.${it.index}.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName
                 }
 
             registrationService.register(registrationResultId, member, context)
@@ -931,7 +932,7 @@ class DynamicMemberRegistrationServiceTest {
                 .containsEntry("corda.notary.keys.0.id", NOTARY_KEY_ID)
                 .containsEntry(String.format(NOTARY_KEY_PEM, 0), "1234")
                 .containsKey(String.format(NOTARY_KEY_HASH, 0))
-                .containsEntry(String.format(NOTARY_KEY_SPEC, 0), SignatureSpec.ECDSA_SHA256.signatureName)
+                .containsEntry(String.format(NOTARY_KEY_SPEC, 0), SignatureSpecs.ECDSA_SHA256.signatureName)
         }
 
         @Test
@@ -945,7 +946,7 @@ class DynamicMemberRegistrationServiceTest {
             registrationService.register(registrationResultId, member, registrationContext)
 
             assertThat(memberContext.firstValue.toMap())
-                .containsEntry("corda.session.keys.0.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
+                .containsEntry("corda.session.keys.0.signature.spec", SignatureSpecs.ECDSA_SHA256.signatureName)
         }
 
         @Test
@@ -959,7 +960,7 @@ class DynamicMemberRegistrationServiceTest {
             registrationService.register(registrationResultId, member, registrationContext)
 
             assertThat(memberContext.firstValue.toMap())
-                .containsEntry("corda.ledger.keys.0.signature.spec", SignatureSpec.ECDSA_SHA256.signatureName)
+                .containsEntry("corda.ledger.keys.0.signature.spec", SignatureSpecs.ECDSA_SHA256.signatureName)
         }
 
         @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -4,6 +4,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.cipher.suite.PublicKeyHash
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.calculateHash
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.client.hsm.HSMRegistrationClient
@@ -100,7 +101,6 @@ import net.corda.schema.membership.MembershipSchema
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.KeySchemeCodes.RSA_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -807,7 +807,7 @@ class StaticMemberRegistrationServiceTest {
                         it.publicKeyHash == PublicKeyHash.calculate(defaultKey)
                     }
                     .allMatch {
-                        it.spec.signatureName == SignatureSpec.RSA_SHA512.signatureName
+                        it.spec.signatureName == SignatureSpecs.RSA_SHA512.signatureName
                     }
             }
         }

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/SynchronisationIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigValueFactory
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.bytes
@@ -94,7 +95,6 @@ import net.corda.utilities.seconds
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
@@ -492,7 +492,7 @@ class SynchronisationIntegrationTest {
         val members: List<MemberInfo> = mutableListOf(participantInfo)
         val signedMembers = members.map {
             val memberInfo = keyValueSerializer.serialize(it.memberProvidedContext.toAvro())
-            val memberSignatureSpec = SignatureSpec.ECDSA_SHA256
+            val memberSignatureSpec = SignatureSpecs.ECDSA_SHA256
             val memberSignature = cryptoOpsClient.sign(
                 participant.toCorda().shortHash.value,
                 participantSessionKey,
@@ -504,7 +504,7 @@ class SynchronisationIntegrationTest {
                     ByteBuffer.wrap(withKey.bytes)
                 )
             }
-            val mgmSignatureSpec = SignatureSpec.ECDSA_SHA256
+            val mgmSignatureSpec = SignatureSpecs.ECDSA_SHA256
             val mgmSignature = cryptoOpsClient.sign(
                 mgm.toCorda().shortHash.value,
                 mgmSessionKey,
@@ -545,7 +545,7 @@ class SynchronisationIntegrationTest {
         val mgmSignatureGroupParameters = cryptoOpsClient.sign(
             mgm.toCorda().shortHash.value,
             mgmSessionKey,
-            SignatureSpec.ECDSA_SHA256,
+            SignatureSpecs.ECDSA_SHA256,
             serializedGroupParameters
         ).let { withKey ->
             CryptoSignatureWithKey(
@@ -556,7 +556,7 @@ class SynchronisationIntegrationTest {
         val signedGroupParameters = SignedGroupParameters(
             ByteBuffer.wrap(serializedGroupParameters),
             mgmSignatureGroupParameters,
-            CryptoSignatureSpec(SignatureSpec.ECDSA_SHA256.signatureName, null, null)
+            CryptoSignatureSpec(SignatureSpecs.ECDSA_SHA256.signatureName, null, null)
         )
 
         val membershipPackage = MembershipPackage.newBuilder()

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.742-alpha-1680268768271
+cordaApiVersion=5.0.0.742-alpha-1680272890229
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/LocalCertificatesAuthority.kt
+++ b/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/LocalCertificatesAuthority.kt
@@ -1,7 +1,7 @@
 package net.corda.crypto.test.certificates.generation
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.test.certificates.generation.CertificateAuthority.Companion.PASSWORD
-import net.corda.v5.crypto.SignatureSpec
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.BasicConstraints
@@ -84,8 +84,8 @@ internal open class LocalCertificatesAuthority(
         )
 
         val signatureAlgorithm = when (keysFactoryDefinitions.algorithm) {
-            Algorithm.RSA -> SignatureSpec.RSA_SHA256
-            Algorithm.EC -> SignatureSpec.ECDSA_SHA256
+            Algorithm.RSA -> SignatureSpecs.RSA_SHA256
+            Algorithm.EC -> SignatureSpecs.ECDSA_SHA256
         }.signatureName
         val signer = JcaContentSignerBuilder(signatureAlgorithm).build(caKeyPair.private)
 
@@ -130,8 +130,8 @@ internal open class LocalCertificatesAuthority(
     override fun generateCertificate(hosts: Collection<String>, publicKey: PublicKey): Certificate {
         val signatureAlgorithm =
             when (privateKeyAndCertificate.privateKey.algorithm) {
-                "RSA" -> SignatureSpec.RSA_SHA256.signatureName
-                "EC" -> SignatureSpec.ECDSA_SHA256.signatureName
+                "RSA" -> SignatureSpecs.RSA_SHA256.signatureName
+                "EC" -> SignatureSpecs.ECDSA_SHA256.signatureName
                 else -> throw InvalidParameterException("Unsupported Algorithm")
             }
         val sigAlgId = DefaultSignatureAlgorithmIdentifierFinder().find(signatureAlgorithm)
@@ -169,8 +169,8 @@ internal open class LocalCertificatesAuthority(
 
         val signatureAlgorithm =
             when (privateKeyAndCertificate.privateKey.algorithm) {
-                "RSA" -> SignatureSpec.RSA_SHA256.signatureName
-                "EC" -> SignatureSpec.ECDSA_SHA256.signatureName
+                "RSA" -> SignatureSpecs.RSA_SHA256.signatureName
+                "EC" -> SignatureSpecs.ECDSA_SHA256.signatureName
                 else -> throw InvalidParameterException("Unsupported Algorithm")
             }
         val sigAlgId = DefaultSignatureAlgorithmIdentifierFinder().find(signatureAlgorithm)

--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/SignatureVerificationServiceGeneralTests.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/SignatureVerificationServiceGeneralTests.kt
@@ -1,9 +1,9 @@
 package net.corda.cipher.suite.impl
 
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256R1_TEMPLATE
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SignatureSpec
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -54,7 +54,7 @@ class SignatureVerificationServiceGeneralTests {
                 originalData = UUID.randomUUID().toString().toByteArray(),
                 signatureData = UUID.randomUUID().toString().toByteArray(),
                 publicKey = publicKey,
-                signatureSpec = SignatureSpec.ECDSA_SHA256
+                signatureSpec = SignatureSpecs.ECDSA_SHA256
             )
         }
     }
@@ -74,7 +74,7 @@ class SignatureVerificationServiceGeneralTests {
                 originalData = UUID.randomUUID().toString().toByteArray(),
                 signatureData = ByteArray(0),
                 publicKey = publicKey,
-                signatureSpec = SignatureSpec.ECDSA_SHA256
+                signatureSpec = SignatureSpecs.ECDSA_SHA256
             )
         }
     }
@@ -94,7 +94,7 @@ class SignatureVerificationServiceGeneralTests {
                 originalData = ByteArray(0),
                 signatureData = UUID.randomUUID().toString().toByteArray(),
                 publicKey = publicKey,
-                signatureSpec = SignatureSpec.ECDSA_SHA256
+                signatureSpec = SignatureSpecs.ECDSA_SHA256
             )
         }
     }
@@ -133,7 +133,7 @@ class SignatureVerificationServiceGeneralTests {
                 originalData = UUID.randomUUID().toString().toByteArray(),
                 signatureData = UUID.randomUUID().toString().toByteArray(),
                 publicKey = publicKey,
-                signatureSpec = SignatureSpec.ECDSA_SHA256
+                signatureSpec = SignatureSpecs.ECDSA_SHA256
             )
         }
     }
@@ -153,7 +153,7 @@ class SignatureVerificationServiceGeneralTests {
                 originalData = UUID.randomUUID().toString().toByteArray(),
                 signatureData = ByteArray(0),
                 publicKey = publicKey,
-                signatureSpec = SignatureSpec.ECDSA_SHA256
+                signatureSpec = SignatureSpecs.ECDSA_SHA256
             )
         }
     }
@@ -173,7 +173,7 @@ class SignatureVerificationServiceGeneralTests {
                 originalData = ByteArray(0),
                 signatureData = UUID.randomUUID().toString().toByteArray(),
                 publicKey = publicKey,
-                signatureSpec = SignatureSpec.ECDSA_SHA256
+                signatureSpec = SignatureSpecs.ECDSA_SHA256
             )
         }
     }

--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/infra/TestUtils.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/infra/TestUtils.kt
@@ -1,6 +1,7 @@
 package net.corda.cipher.suite.impl.infra
 
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.getParamsSafely
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256K1_CODE_NAME
@@ -54,12 +55,12 @@ fun CipherSchemeMetadata.inferSignatureSpecOrCreateDefault(publicKey: PublicKey,
         return inferred
     }
     return when(val codeName = findKeyScheme(publicKey).codeName) {
-        RSA_CODE_NAME -> SignatureSpec.RSA_SHA256
-        ECDSA_SECP256R1_CODE_NAME, ECDSA_SECP256K1_CODE_NAME -> SignatureSpec.ECDSA_SHA256
-        EDDSA_ED25519_CODE_NAME -> SignatureSpec.EDDSA_ED25519
-        SM2_CODE_NAME -> SignatureSpec.SM2_SM3
-        GOST3410_GOST3411_CODE_NAME -> SignatureSpec.GOST3410_GOST3411
-        SPHINCS256_CODE_NAME -> SignatureSpec.SPHINCS256_SHA512
+        RSA_CODE_NAME -> SignatureSpecs.RSA_SHA256
+        ECDSA_SECP256R1_CODE_NAME, ECDSA_SECP256K1_CODE_NAME -> SignatureSpecs.ECDSA_SHA256
+        EDDSA_ED25519_CODE_NAME -> SignatureSpecs.EDDSA_ED25519
+        SM2_CODE_NAME -> SignatureSpecs.SM2_SM3
+        GOST3410_GOST3411_CODE_NAME -> SignatureSpecs.GOST3410_GOST3411
+        SPHINCS256_CODE_NAME -> SignatureSpecs.SPHINCS256_SHA512
         else -> throw IllegalArgumentException("Cannot get default signature spec for $codeName")
     }
 }

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CustomSignatureSpec.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CustomSignatureSpec.kt
@@ -22,7 +22,7 @@ import java.security.spec.AlgorithmParameterSpec
  * and the decryption using the public key.
  */
 class CustomSignatureSpec(
-    signatureName: String,
+    private val signatureName: String,
     /**
      * Digest algorithm name.
      */
@@ -31,7 +31,7 @@ class CustomSignatureSpec(
      * Signature parameters.
      */
     val params: AlgorithmParameterSpec?
-) : SignatureSpec(signatureName) {
+) : SignatureSpec {
 
     /**
      * Creates an instance of the [CustomSignatureSpec] with specified signature name and the digest name,
@@ -42,14 +42,25 @@ class CustomSignatureSpec(
      * @param customDigestName digest algorithm name (e.g. "SHA512")
      */
     constructor(signatureName: String, customDigestName: DigestAlgorithmName)
-        : this(signatureName, customDigestName, null)
+            : this(signatureName, customDigestName, null) {
+        require(signatureName.isNotBlank()) { "The signatureName must not be blank." }
+    }
 
-    /**
-     * Converts a [CustomSignatureSpec] object to a string representation.
-     */
-    override fun toString(): String = if(params != null) {
+    override fun toString(): String = if (params != null) {
         "$signatureName:$customDigestName:${params::class.java.simpleName}"
     } else {
         "$signatureName:$customDigestName"
+    }
+
+    override fun getSignatureName(): String {
+        return this.signatureName
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return this === other || other != null && other is CustomSignatureSpec && other.signatureName == this.signatureName
+    }
+
+    override fun hashCode(): Int {
+        return this.signatureName.hashCode()
     }
 }

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/ParameterizedSignatureSpec.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/ParameterizedSignatureSpec.kt
@@ -1,0 +1,39 @@
+package net.corda.crypto.cipher.suite
+
+import net.corda.v5.crypto.SignatureSpec
+import java.security.spec.AlgorithmParameterSpec
+
+/**
+ * This class is used to define a digital signature scheme which has the additional algorithm parameters,
+ * such as `RSASSA-PSS`.  Construct a parameterized signature spec.
+
+ * @param signatureName A signature-scheme name as required to create [java.security.Signature]
+ *                      objects (for example, `SHA256withECDSA`).
+ * @param params        Signature parameters. For example, if using `RSASSA-PSS`, to avoid
+ *                      using the default SHA1, you must specify the signature parameters explicitly.
+ *
+ *                      When used for signing, the `signatureName` must match the corresponding key scheme,
+ *                      for example, you cannot use `SHA256withECDSA` with `RSA` keys.
+`` */
+class ParameterizedSignatureSpec(private val signatureName: String, val params: AlgorithmParameterSpec) : SignatureSpec {
+
+    init {
+        require(signatureName.isNotBlank()) { "The signatureName must not be blank." }
+    }
+
+    override fun toString(): String {
+        return this.signatureName + ':' + params.javaClass.simpleName
+    }
+
+    override fun getSignatureName(): String {
+        return this.signatureName
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return this === other || other != null && other is ParameterizedSignatureSpec && other.signatureName == this.signatureName
+    }
+
+    override fun hashCode(): Int {
+        return this.signatureName.hashCode()
+    }
+}

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecEquality.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecEquality.kt
@@ -2,7 +2,6 @@
 
 package net.corda.crypto.cipher.suite
 
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import java.security.spec.MGF1ParameterSpec
 import java.security.spec.PSSParameterSpec

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecImpl.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecImpl.kt
@@ -1,0 +1,43 @@
+package net.corda.crypto.cipher.suite
+
+import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.crypto.SignatureSpec
+
+/**
+ * This class is used to define a digital signature scheme.
+ */
+@CordaSerializable
+class SignatureSpecImpl(
+    private val signatureName: String
+) : SignatureSpec  {
+    /**
+     * The signature-scheme name as required to create [java.security.Signature] objects
+     * (for example, `SHA256withECDSA`). Construct a signature spec.
+
+     * @param signatureName The signature-scheme name as required to create {@link java.security.Signature}
+     *                      objects (for example, `SHA256withECDSA`).
+     *                      <p>
+     *                      When used for signing, the [signatureName] must match the corresponding key scheme, for example,
+     *                      you cannot use `SHA256withECDSA` with `RSA` keys.
+     */
+
+    init {
+        require(signatureName.isNotBlank()) { "The signatureName must not be blank." }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return this === other || other != null && other is SignatureSpecImpl && other.signatureName == this.signatureName
+    }
+
+    override fun toString(): String {
+        return this.signatureName
+    }
+
+    override fun getSignatureName(): String {
+        return this.signatureName
+    }
+
+    override fun hashCode(): Int {
+        return this.signatureName.hashCode()
+    }
+}

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecUtils.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecUtils.kt
@@ -2,7 +2,6 @@
 
 package net.corda.crypto.cipher.suite
 
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import java.security.spec.AlgorithmParameterSpec
 

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecs.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SignatureSpecs.kt
@@ -1,0 +1,123 @@
+package net.corda.crypto.cipher.suite
+
+import net.corda.v5.crypto.SignatureSpec
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.PSSParameterSpec
+
+/**
+ * This class holds supported [SignatureSpec]s which defines a digital signature scheme.
+ */
+object SignatureSpecs {
+
+    /**
+     * SHA256withRSA [SignatureSpec].
+     */
+    val RSA_SHA256 = SignatureSpecImpl("SHA256withRSA")
+
+    /**
+     * SHA384withRSA [SignatureSpec].
+     */
+    val RSA_SHA384 = SignatureSpecImpl("SHA384withRSA")
+
+    /**
+     * SHA512withRSA [SignatureSpec].
+     */
+    val RSA_SHA512 = SignatureSpecImpl("SHA512withRSA")
+
+    /**
+     * RSASSA-PSS with SHA256 [SignatureSpec].
+     */
+    val RSASSA_PSS_SHA256 = ParameterizedSignatureSpec(
+        "RSASSA-PSS",
+        PSSParameterSpec(
+            "SHA-256",
+            "MGF1",
+            MGF1ParameterSpec.SHA256,
+            32,
+            1
+        )
+    )
+
+    /**
+     * RSASSA-PSS with SHA384 [SignatureSpec].
+     */
+    val RSASSA_PSS_SHA384 = ParameterizedSignatureSpec(
+        "RSASSA-PSS",
+        PSSParameterSpec(
+            "SHA-384",
+            "MGF1",
+            MGF1ParameterSpec.SHA384,
+            48,
+            1
+        )
+    )
+
+    /**
+     * RSASSA-PSS with SHA512 [SignatureSpec].
+     */
+    val RSASSA_PSS_SHA512 = ParameterizedSignatureSpec(
+        "RSASSA-PSS",
+        PSSParameterSpec(
+            "SHA-512",
+            "MGF1",
+            MGF1ParameterSpec.SHA512,
+            64,
+            1
+        )
+    )
+
+    /**
+     * RSASSA-PSS with SHA256 and MGF1 [SignatureSpec].
+     */
+    val RSA_SHA256_WITH_MGF1 = SignatureSpecImpl("SHA256withRSAandMGF1")
+
+    /**
+     * RSASSA-PSS with SHA384 and MGF1 [SignatureSpec].
+     */
+    val RSA_SHA384_WITH_MGF1 = SignatureSpecImpl("SHA384withRSAandMGF1")
+
+    /**
+     * RSASSA-PSS with SHA512 and MGF1 [SignatureSpec].
+     */
+    val RSA_SHA512_WITH_MGF1 = SignatureSpecImpl("SHA512withRSAandMGF1")
+
+    /**
+     * SHA256withECDSA [SignatureSpec].
+     */
+    val ECDSA_SHA256 = SignatureSpecImpl("SHA256withECDSA")
+
+    /**
+     * SHA384withECDSA [SignatureSpec].
+     */
+    val ECDSA_SHA384 = SignatureSpecImpl("SHA384withECDSA")
+
+    /**
+     * SHA512withECDSA [SignatureSpec].
+     */
+    val ECDSA_SHA512 = SignatureSpecImpl("SHA512withECDSA")
+
+    /**
+     * EdDSA [SignatureSpec].
+     */
+    val EDDSA_ED25519 = SignatureSpecImpl("EdDSA")
+
+    /**
+     * SHA512withSPHINCS256 [SignatureSpec].
+     */
+    val SPHINCS256_SHA512 = SignatureSpecImpl("SHA512withSPHINCS256")
+
+    /**
+     * SM3withSM2 [SignatureSpec].
+     */
+    val SM2_SM3 = SignatureSpecImpl("SM3withSM2")
+
+    /**
+     * SHA256withSM2 [SignatureSpec].
+     */
+    val SM2_SHA256 = SignatureSpecImpl("SHA256withSM2")
+
+    /**
+     * GOST3411withGOST3410 [SignatureSpec].
+     */
+    val GOST3410_GOST3411 = SignatureSpecImpl("GOST3411withGOST3410")
+}

--- a/libs/crypto/cipher-suite/src/test/java/net/corda/crypto/cipher/suite/SignatureSpecEqualityJavaApiTest.java
+++ b/libs/crypto/cipher-suite/src/test/java/net/corda/crypto/cipher/suite/SignatureSpecEqualityJavaApiTest.java
@@ -1,6 +1,5 @@
 package net.corda.crypto.cipher.suite;
 
-import net.corda.v5.crypto.SignatureSpec;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SignatureSpecEqualityJavaApiTest {
     @Test
     public void apiShouldLookNiceInJava() {
-        var spec = new SignatureSpec("SHA256withRSA");
+        var spec = new SignatureSpecImpl("SHA256withRSA");
         assertTrue(SignatureSpecEquality.equal(spec, spec));
     }
 }

--- a/libs/crypto/cipher-suite/src/test/java/net/corda/crypto/cipher/suite/SignatureSpecUtilsJavaApiTest.java
+++ b/libs/crypto/cipher-suite/src/test/java/net/corda/crypto/cipher/suite/SignatureSpecUtilsJavaApiTest.java
@@ -1,13 +1,12 @@
 package net.corda.crypto.cipher.suite;
 
-import net.corda.v5.crypto.SignatureSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SignatureSpecUtilsJavaApiTest {
     @Test
     public void shouldCallGetParamsSafely() {
-        var spec = new SignatureSpec("SHA256withECDSA");
+        var spec = new SignatureSpecImpl("SHA256withECDSA");
         Assertions.assertNull(SignatureSpecUtils.getParamsSafely(spec));
     }
 }

--- a/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/ParameterizedSignatureSpecTests.kt
+++ b/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/ParameterizedSignatureSpecTests.kt
@@ -1,0 +1,24 @@
+package net.corda.crypto.cipher.suite
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.PSSParameterSpec
+
+class ParameterizedSignatureSpecTests {
+    @Test
+    fun `Should throw IllegalArgumentException when initializing with blank signature name`() {
+        assertThrows<IllegalArgumentException> {
+            ParameterizedSignatureSpec(
+                "  ",
+                PSSParameterSpec(
+                    "SHA-256",
+                    "MGF1",
+                    MGF1ParameterSpec.SHA256,
+                    32,
+                    1
+                )
+            )
+        }
+    }
+ }

--- a/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/SignatureSpecEqualityTests.kt
+++ b/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/SignatureSpecEqualityTests.kt
@@ -1,7 +1,6 @@
 package net.corda.crypto.cipher.suite
 
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -12,10 +11,10 @@ import kotlin.test.assertTrue
 
 class SignatureSpecEqualityTests {
     companion object {
-        private val SIGNATURE_SPEC_1 = SignatureSpec("SHA256withRSA")
-        private val SIGNATURE_SPEC_10 = SignatureSpec("SHA256withRSA")
-        private val SIGNATURE_SPEC_100 = SignatureSpec("sha256WITHrsa")
-        private val SIGNATURE_SPEC_2 = SignatureSpec("SHA384withRSA")
+        private val SIGNATURE_SPEC_1 = SignatureSpecImpl("SHA256withRSA")
+        private val SIGNATURE_SPEC_10 = SignatureSpecImpl("SHA256withRSA")
+        private val SIGNATURE_SPEC_100 = SignatureSpecImpl("sha256WITHrsa")
+        private val SIGNATURE_SPEC_2 = SignatureSpecImpl("SHA384withRSA")
         private val PARAMETERIZED_SIGNATURE_SPEC_1 = ParameterizedSignatureSpec(
             "RSASSA-PSS",
             PSSParameterSpec(

--- a/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/SignatureSpecTests.kt
+++ b/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/SignatureSpecTests.kt
@@ -1,0 +1,12 @@
+package net.corda.crypto.cipher.suite
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SignatureSpecTests {
+    @Test
+    fun `Should throw IllegalArgumentException when initializing with blank signature name`() {
+        assertThrows<IllegalArgumentException> {
+            SignatureSpecImpl(" ")
+        }
+    }
+}

--- a/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/SignatureSpecUtilsTests.kt
+++ b/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/SignatureSpecUtilsTests.kt
@@ -1,8 +1,6 @@
 package net.corda.crypto.cipher.suite
 
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.ParameterizedSignatureSpec
-import net.corda.v5.crypto.SignatureSpec
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
@@ -12,7 +10,7 @@ import java.security.spec.PSSParameterSpec
 class SignatureSpecUtilsTests {
     @Test
     fun `getParamsSafely should return null for SignatureSpec`() {
-        val spec = SignatureSpec("SHA256withECDSA")
+        val spec = SignatureSpecImpl("SHA256withECDSA")
         assertNull(spec.getParamsSafely())
     }
 

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DefaultSignatureOIDMap.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DefaultSignatureOIDMap.kt
@@ -1,6 +1,7 @@
 package net.corda.crypto.core
 
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.equal
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256K1_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256R1_TEMPLATE
@@ -11,7 +12,6 @@ import net.corda.crypto.cipher.suite.schemes.RSA_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.SHA512_256
 import net.corda.crypto.cipher.suite.schemes.SM2_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.SPHINCS256_TEMPLATE
-
 import net.corda.v5.crypto.SignatureSpec
 import org.bouncycastle.asn1.ASN1Integer
 import org.bouncycastle.asn1.DERNull
@@ -112,60 +112,60 @@ object DefaultSignatureOIDMap {
         } ?: return null
         val algorithm = normaliseAlgorithmIdentifier(keyInfo.algorithm)
         return if (EDDSA_ED25519_TEMPLATE.algorithmOIDs.contains(algorithm)) {
-            if (signatureSpec.equal(SignatureSpec.EDDSA_ED25519)) {
+            if (signatureSpec.equal(SignatureSpecs.EDDSA_ED25519)) {
                 EDDSA_ED25519
             } else {
                 null
             }
         } else if (SPHINCS256_TEMPLATE.algorithmOIDs.contains(algorithm)) {
-            if (signatureSpec.equal(SignatureSpec.SPHINCS256_SHA512)) {
+            if (signatureSpec.equal(SignatureSpecs.SPHINCS256_SHA512)) {
                 SPHINCS256_SHA512
             } else {
                 null
             }
         } else if (SM2_TEMPLATE.algorithmOIDs.contains(algorithm)) {
             when {
-                signatureSpec.equal(SignatureSpec.SM2_SM3) -> SM3_SM2
-                signatureSpec.equal(SignatureSpec.SM2_SHA256) -> SM3_SHA256
+                signatureSpec.equal(SignatureSpecs.SM2_SM3) -> SM3_SM2
+                signatureSpec.equal(SignatureSpecs.SM2_SHA256) -> SM3_SHA256
                 else -> null
             }
         } else if (GOST3410_GOST3411_TEMPLATE.algorithmOIDs.contains(algorithm)) {
-            if (signatureSpec.equal(SignatureSpec.GOST3410_GOST3411)) {
+            if (signatureSpec.equal(SignatureSpecs.GOST3410_GOST3411)) {
                 GOST3410_GOST3411
             } else {
                 null
             }
         } else if (ECDSA_SECP256R1_TEMPLATE.algorithmOIDs.contains(algorithm)) {
             when {
-                signatureSpec.equal(SignatureSpec.ECDSA_SHA256) -> SHA256_ECDSA_R1
-                signatureSpec.equal(SignatureSpec.ECDSA_SHA384) -> SHA384_ECDSA_R1
-                signatureSpec.equal(SignatureSpec.ECDSA_SHA512) -> SHA512_ECDSA_R1
+                signatureSpec.equal(SignatureSpecs.ECDSA_SHA256) -> SHA256_ECDSA_R1
+                signatureSpec.equal(SignatureSpecs.ECDSA_SHA384) -> SHA384_ECDSA_R1
+                signatureSpec.equal(SignatureSpecs.ECDSA_SHA512) -> SHA512_ECDSA_R1
                 else -> null
             }
         } else if (ECDSA_SECP256K1_TEMPLATE.algorithmOIDs.contains(algorithm)) {
             when {
-                signatureSpec.equal(SignatureSpec.ECDSA_SHA256) -> SHA256_ECDSA_K1
-                signatureSpec.equal(SignatureSpec.ECDSA_SHA384) -> SHA384_ECDSA_K1
-                signatureSpec.equal(SignatureSpec.ECDSA_SHA512) -> SHA512_ECDSA_K1
+                signatureSpec.equal(SignatureSpecs.ECDSA_SHA256) -> SHA256_ECDSA_K1
+                signatureSpec.equal(SignatureSpecs.ECDSA_SHA384) -> SHA384_ECDSA_K1
+                signatureSpec.equal(SignatureSpecs.ECDSA_SHA512) -> SHA512_ECDSA_K1
                 else -> null
             }
         } else if (RSA_TEMPLATE.algorithmOIDs.contains(algorithm)) {
-            if (signatureSpec.equal(SignatureSpec.RSA_SHA256)) {
+            if (signatureSpec.equal(SignatureSpecs.RSA_SHA256)) {
                 SHA256_RSA
-            } else if (signatureSpec.equal(SignatureSpec.RSA_SHA384)) {
+            } else if (signatureSpec.equal(SignatureSpecs.RSA_SHA384)) {
                 SHA384_RSA
-            } else if (signatureSpec.equal(SignatureSpec.RSA_SHA512)) {
+            } else if (signatureSpec.equal(SignatureSpecs.RSA_SHA512)) {
                 SHA512_RSA
-            } else if (signatureSpec.equal(SignatureSpec.RSASSA_PSS_SHA256) ||
-                signatureSpec.equal(SignatureSpec.RSA_SHA256_WITH_MGF1)
+            } else if (signatureSpec.equal(SignatureSpecs.RSASSA_PSS_SHA256) ||
+                signatureSpec.equal(SignatureSpecs.RSA_SHA256_WITH_MGF1)
             ) {
                 SHA256_RSASSA_PSS
-            } else if (signatureSpec.equal(SignatureSpec.RSASSA_PSS_SHA384) ||
-                signatureSpec.equal(SignatureSpec.RSA_SHA384_WITH_MGF1)
+            } else if (signatureSpec.equal(SignatureSpecs.RSASSA_PSS_SHA384) ||
+                signatureSpec.equal(SignatureSpecs.RSA_SHA384_WITH_MGF1)
             ) {
                 SHA384_RSASSA_PSS
-            } else if (signatureSpec.equal(SignatureSpec.RSASSA_PSS_SHA512) ||
-                signatureSpec.equal(SignatureSpec.RSA_SHA512_WITH_MGF1)
+            } else if (signatureSpec.equal(SignatureSpecs.RSASSA_PSS_SHA512) ||
+                signatureSpec.equal(SignatureSpecs.RSA_SHA512_WITH_MGF1)
             ) {
                 SHA512_RSASSA_PSS
             } else {

--- a/libs/crypto/crypto-core/src/test/kotlin/net/corda/crypto/core/DefaultSignatureOIDMapTests.kt
+++ b/libs/crypto/crypto-core/src/test/kotlin/net/corda/crypto/core/DefaultSignatureOIDMapTests.kt
@@ -1,6 +1,8 @@
 package net.corda.crypto.core
 
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256K1_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256R1_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.EDDSA_ED25519_TEMPLATE
@@ -10,7 +12,6 @@ import net.corda.crypto.cipher.suite.schemes.RSA_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.SM2_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.SPHINCS256_TEMPLATE
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -55,20 +56,20 @@ class DefaultSignatureOIDMapTests {
             ecdsak1 = generateKeyPair(ECDSA_SECP256K1_TEMPLATE, defaultProvider)
             ecdsar1 = generateKeyPair(ECDSA_SECP256R1_TEMPLATE, defaultProvider)
             generatedTestData = listOf(
-                Arguments.of(eddsa, SignatureSpec.EDDSA_ED25519, DefaultSignatureOIDMap.EDDSA_ED25519),
-                Arguments.of(sphincs, SignatureSpec.SPHINCS256_SHA512, DefaultSignatureOIDMap.SPHINCS256_SHA512),
-                Arguments.of(sm2, SignatureSpec.SM2_SM3, DefaultSignatureOIDMap.SM3_SM2),
-                Arguments.of(sm2, SignatureSpec.SM2_SHA256, DefaultSignatureOIDMap.SM3_SHA256),
-                Arguments.of(gost, SignatureSpec.GOST3410_GOST3411, DefaultSignatureOIDMap.GOST3410_GOST3411),
-                Arguments.of(rsa, SignatureSpec.RSA_SHA256, DefaultSignatureOIDMap.SHA256_RSA),
-                Arguments.of(rsa, SignatureSpec.RSA_SHA384, DefaultSignatureOIDMap.SHA384_RSA),
-                Arguments.of(rsa, SignatureSpec.RSA_SHA512, DefaultSignatureOIDMap.SHA512_RSA),
-                Arguments.of(rsa, SignatureSpec.RSA_SHA256_WITH_MGF1, DefaultSignatureOIDMap.SHA256_RSASSA_PSS),
-                Arguments.of(rsa, SignatureSpec.RSA_SHA384_WITH_MGF1, DefaultSignatureOIDMap.SHA384_RSASSA_PSS),
-                Arguments.of(rsa, SignatureSpec.RSA_SHA512_WITH_MGF1, DefaultSignatureOIDMap.SHA512_RSASSA_PSS),
-                Arguments.of(rsa, SignatureSpec.RSASSA_PSS_SHA256, DefaultSignatureOIDMap.SHA256_RSASSA_PSS),
-                Arguments.of(rsa, SignatureSpec.RSASSA_PSS_SHA384, DefaultSignatureOIDMap.SHA384_RSASSA_PSS),
-                Arguments.of(rsa, SignatureSpec.RSASSA_PSS_SHA512, DefaultSignatureOIDMap.SHA512_RSASSA_PSS),
+                Arguments.of(eddsa, SignatureSpecs.EDDSA_ED25519, DefaultSignatureOIDMap.EDDSA_ED25519),
+                Arguments.of(sphincs, SignatureSpecs.SPHINCS256_SHA512, DefaultSignatureOIDMap.SPHINCS256_SHA512),
+                Arguments.of(sm2, SignatureSpecs.SM2_SM3, DefaultSignatureOIDMap.SM3_SM2),
+                Arguments.of(sm2, SignatureSpecs.SM2_SHA256, DefaultSignatureOIDMap.SM3_SHA256),
+                Arguments.of(gost, SignatureSpecs.GOST3410_GOST3411, DefaultSignatureOIDMap.GOST3410_GOST3411),
+                Arguments.of(rsa, SignatureSpecs.RSA_SHA256, DefaultSignatureOIDMap.SHA256_RSA),
+                Arguments.of(rsa, SignatureSpecs.RSA_SHA384, DefaultSignatureOIDMap.SHA384_RSA),
+                Arguments.of(rsa, SignatureSpecs.RSA_SHA512, DefaultSignatureOIDMap.SHA512_RSA),
+                Arguments.of(rsa, SignatureSpecs.RSA_SHA256_WITH_MGF1, DefaultSignatureOIDMap.SHA256_RSASSA_PSS),
+                Arguments.of(rsa, SignatureSpecs.RSA_SHA384_WITH_MGF1, DefaultSignatureOIDMap.SHA384_RSASSA_PSS),
+                Arguments.of(rsa, SignatureSpecs.RSA_SHA512_WITH_MGF1, DefaultSignatureOIDMap.SHA512_RSASSA_PSS),
+                Arguments.of(rsa, SignatureSpecs.RSASSA_PSS_SHA256, DefaultSignatureOIDMap.SHA256_RSASSA_PSS),
+                Arguments.of(rsa, SignatureSpecs.RSASSA_PSS_SHA384, DefaultSignatureOIDMap.SHA384_RSASSA_PSS),
+                Arguments.of(rsa, SignatureSpecs.RSASSA_PSS_SHA512, DefaultSignatureOIDMap.SHA512_RSASSA_PSS),
                 Arguments.of(
                     rsa,
                     ParameterizedSignatureSpec(
@@ -111,12 +112,12 @@ class DefaultSignatureOIDMapTests {
                     ),
                     null
                 ),
-                Arguments.of(ecdsak1, SignatureSpec.ECDSA_SHA256, DefaultSignatureOIDMap.SHA256_ECDSA_K1),
-                Arguments.of(ecdsak1, SignatureSpec.ECDSA_SHA384, DefaultSignatureOIDMap.SHA384_ECDSA_K1),
-                Arguments.of(ecdsak1, SignatureSpec.ECDSA_SHA512, DefaultSignatureOIDMap.SHA512_ECDSA_K1),
-                Arguments.of(ecdsar1, SignatureSpec.ECDSA_SHA256, DefaultSignatureOIDMap.SHA256_ECDSA_R1),
-                Arguments.of(ecdsar1, SignatureSpec.ECDSA_SHA384, DefaultSignatureOIDMap.SHA384_ECDSA_R1),
-                Arguments.of(ecdsar1, SignatureSpec.ECDSA_SHA512, DefaultSignatureOIDMap.SHA512_ECDSA_R1)
+                Arguments.of(ecdsak1, SignatureSpecs.ECDSA_SHA256, DefaultSignatureOIDMap.SHA256_ECDSA_K1),
+                Arguments.of(ecdsak1, SignatureSpecs.ECDSA_SHA384, DefaultSignatureOIDMap.SHA384_ECDSA_K1),
+                Arguments.of(ecdsak1, SignatureSpecs.ECDSA_SHA512, DefaultSignatureOIDMap.SHA512_ECDSA_K1),
+                Arguments.of(ecdsar1, SignatureSpecs.ECDSA_SHA256, DefaultSignatureOIDMap.SHA256_ECDSA_R1),
+                Arguments.of(ecdsar1, SignatureSpecs.ECDSA_SHA384, DefaultSignatureOIDMap.SHA384_ECDSA_R1),
+                Arguments.of(ecdsar1, SignatureSpecs.ECDSA_SHA512, DefaultSignatureOIDMap.SHA512_ECDSA_R1)
             )
         }
 

--- a/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
+++ b/libs/crypto/crypto-flow/src/test/kotlin/net/corda/crypto/flow/impl/CryptoFlowOpsTransformerImplTests.kt
@@ -1,6 +1,7 @@
 package net.corda.crypto.flow.impl
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.crypto.core.SecureHashImpl
@@ -28,7 +29,6 @@ import net.corda.data.crypto.wire.ops.flow.queries.ByIdsFlowQuery
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -254,7 +254,7 @@ class CryptoFlowOpsTransformerImplTests {
                 UUID.randomUUID().toString(),
                 knownTenantId,
                 publicKey.encoded,
-                SignatureSpec.EDDSA_ED25519,
+                SignatureSpecs.EDDSA_ED25519,
                 data,
                 knownOperationContext,
                 flowExternalEventContext
@@ -266,7 +266,7 @@ class CryptoFlowOpsTransformerImplTests {
         val command = result.value.request as SignFlowCommand
         assertArrayEquals(keyEncodingService.encodeAsByteArray(publicKey), command.publicKey.array())
         assertArrayEquals(data, command.bytes.array())
-        assertEquals(SignatureSpec.EDDSA_ED25519.signatureName, command.signatureSpec.signatureName)
+        assertEquals(SignatureSpecs.EDDSA_ED25519.signatureName, command.signatureSpec.signatureName)
         assertRequestContext<SignFlowCommand>(result)
         assertOperationContext(knownOperationContext, command.context)
     }
@@ -280,7 +280,7 @@ class CryptoFlowOpsTransformerImplTests {
                 UUID.randomUUID().toString(),
                 knownTenantId,
                 publicKey.encoded,
-                SignatureSpec.EDDSA_ED25519,
+                SignatureSpecs.EDDSA_ED25519,
                 data,
                 emptyMap(),
                 flowExternalEventContext
@@ -292,7 +292,7 @@ class CryptoFlowOpsTransformerImplTests {
         val command = result.value.request as SignFlowCommand
         assertArrayEquals(keyEncodingService.encodeAsByteArray(publicKey), command.publicKey.array())
         assertArrayEquals(data, command.bytes.array())
-        assertEquals(SignatureSpec.EDDSA_ED25519.signatureName, command.signatureSpec.signatureName)
+        assertEquals(SignatureSpecs.EDDSA_ED25519.signatureName, command.signatureSpec.signatureName)
         assertRequestContext<SignFlowCommand>(result)
         assertOperationContext(emptyMap(), command.context)
     }

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/KeySchemeInfo.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/KeySchemeInfo.kt
@@ -1,5 +1,6 @@
 package net.corda.crypto.impl
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256K1_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.ECDSA_SECP256R1_TEMPLATE
 import net.corda.crypto.cipher.suite.schemes.EDDSA_ED25519_TEMPLATE
@@ -40,22 +41,22 @@ class RSAKeySchemeInfo(
     provider: Provider
 ) : KeySchemeInfo(
     provider, RSA_TEMPLATE, mapOf(
-        DigestAlgorithmName.SHA2_256 to SignatureSpec.RSA_SHA256,
-        DigestAlgorithmName.SHA2_384 to SignatureSpec.RSA_SHA384,
-        DigestAlgorithmName.SHA2_512 to SignatureSpec.RSA_SHA512
+        DigestAlgorithmName.SHA2_256 to SignatureSpecs.RSA_SHA256,
+        DigestAlgorithmName.SHA2_384 to SignatureSpecs.RSA_SHA384,
+        DigestAlgorithmName.SHA2_512 to SignatureSpecs.RSA_SHA512
     ),
-    SignatureSpec.RSA_SHA256
+    SignatureSpecs.RSA_SHA256
 )
 
 abstract class ECDSAKeySchemeInfo(
     provider: Provider, template: KeySchemeTemplate
 ) : KeySchemeInfo(
     provider, template, mapOf(
-        DigestAlgorithmName.SHA2_256 to SignatureSpec.ECDSA_SHA256,
-        DigestAlgorithmName.SHA2_384 to SignatureSpec.ECDSA_SHA384,
-        DigestAlgorithmName.SHA2_512 to SignatureSpec.ECDSA_SHA512
+        DigestAlgorithmName.SHA2_256 to SignatureSpecs.ECDSA_SHA256,
+        DigestAlgorithmName.SHA2_384 to SignatureSpecs.ECDSA_SHA384,
+        DigestAlgorithmName.SHA2_512 to SignatureSpecs.ECDSA_SHA512
     ),
-    SignatureSpec.ECDSA_SHA256
+    SignatureSpecs.ECDSA_SHA256
 )
 
 class ECDSAR1KeySchemeInfo(
@@ -70,9 +71,9 @@ class EDDSAKeySchemeInfo(
     provider: Provider
 ) : KeySchemeInfo(
     provider, EDDSA_ED25519_TEMPLATE, mapOf(
-        DigestAlgorithmName("NONE") to SignatureSpec.EDDSA_ED25519
+        DigestAlgorithmName("NONE") to SignatureSpecs.EDDSA_ED25519
     ),
-    SignatureSpec.EDDSA_ED25519
+    SignatureSpecs.EDDSA_ED25519
 )
 
 class X25519KeySchemeInfo(
@@ -84,26 +85,26 @@ class SM2KeySchemeInfo(
     provider: Provider
 ) : KeySchemeInfo(
     provider, SM2_TEMPLATE, mapOf(
-        DigestAlgorithmName("SM3") to SignatureSpec.SM2_SM3,
-        DigestAlgorithmName.SHA2_256 to SignatureSpec.SM2_SHA256
+        DigestAlgorithmName("SM3") to SignatureSpecs.SM2_SM3,
+        DigestAlgorithmName.SHA2_256 to SignatureSpecs.SM2_SHA256
     ),
-    SignatureSpec.SM2_SM3
+    SignatureSpecs.SM2_SM3
 )
 
 class GOST3410GOST3411KeySchemeInfo(
     provider: Provider
 ) : KeySchemeInfo(
     provider, GOST3410_GOST3411_TEMPLATE, mapOf(
-        DigestAlgorithmName("GOST3411") to SignatureSpec.GOST3410_GOST3411
+        DigestAlgorithmName("GOST3411") to SignatureSpecs.GOST3410_GOST3411
     ),
-    SignatureSpec.GOST3410_GOST3411
+    SignatureSpecs.GOST3410_GOST3411
 )
 
 class SPHINCS256KeySchemeInfo(
     provider: Provider
 ) : KeySchemeInfo(
     provider, SPHINCS256_TEMPLATE, mapOf(
-        DigestAlgorithmName.SHA2_512 to SignatureSpec.SPHINCS256_SHA512
+        DigestAlgorithmName.SHA2_512 to SignatureSpecs.SPHINCS256_SHA512
     ),
-    SignatureSpec.SPHINCS256_SHA512
+    SignatureSpecs.SPHINCS256_SHA512
 )

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/WireUtils.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/WireUtils.kt
@@ -4,6 +4,8 @@ package net.corda.crypto.impl
 
 import net.corda.crypto.cipher.suite.AlgorithmParameterSpecEncodingService
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.cipher.suite.schemes.SerializedAlgorithmParameterSpec
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
@@ -11,7 +13,6 @@ import net.corda.data.crypto.wire.CryptoRequestContext
 import net.corda.data.crypto.wire.CryptoSignatureParameterSpec
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import java.nio.ByteBuffer
 import java.security.spec.AlgorithmParameterSpec
@@ -75,7 +76,7 @@ fun CryptoSignatureSpec.toSignatureSpec(serializer: AlgorithmParameterSpecEncodi
             CustomSignatureSpec(signatureName, DigestAlgorithmName(customDigestName), algorithmParams)
         }
         algorithmParams != null -> ParameterizedSignatureSpec(signatureName, algorithmParams)
-        else -> SignatureSpec(signatureName)
+        else -> SignatureSpecImpl(signatureName)
     }
 }
 

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/SignatureSpecUtilsTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/SignatureSpecUtilsTests.kt
@@ -1,12 +1,12 @@
 package net.corda.crypto.impl
 
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
 import net.corda.crypto.cipher.suite.PlatformDigestService
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec.ECDSA_SHA256
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -53,7 +53,7 @@ class SignatureSpecUtilsTests {
 
     @Test
     fun `getSigningData should return original byte array for SignatureSpec`() {
-        val spec = ECDSA_SHA256
+        val spec = SignatureSpecs.ECDSA_SHA256
         val data = UUID.randomUUID().toString().toByteArray()
         assertArrayEquals(data, spec.getSigningData(digestService, data))
     }

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/WireUtilsTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/WireUtilsTests.kt
@@ -2,6 +2,8 @@ package net.corda.crypto.impl
 
 import net.corda.crypto.cipher.suite.AlgorithmParameterSpecEncodingService
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.cipher.suite.schemes.SerializedAlgorithmParameterSpec
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.data.KeyValuePair
@@ -10,8 +12,6 @@ import net.corda.data.crypto.wire.CryptoSignatureParameterSpec
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.v5.base.util.EncodingUtils.toHex
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.ParameterizedSignatureSpec
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Test
@@ -159,7 +159,7 @@ class WireUtilsTests {
     }
 
     @Test
-    fun `Should convert CryptoSignatureSpec to SignatureSpec`() {
+    fun `Should convert CryptoSignatureSpec to SignatureSpecImpl`() {
         val serializer = mock<AlgorithmParameterSpecEncodingService>()
         val origin = CryptoSignatureSpec(
             "name1",
@@ -167,7 +167,7 @@ class WireUtilsTests {
             null
         )
         val result = origin.toSignatureSpec(serializer)
-        assertEquals(SignatureSpec::class.java, result::class.java)
+        assertEquals(SignatureSpecImpl::class.java, result::class.java)
         assertEquals("name1", result.signatureName)
         Mockito.verify(serializer, never()).deserialize(any())
     }
@@ -212,7 +212,7 @@ class WireUtilsTests {
     @Test
     fun `Should convert SignatureSpec to wire without spec params and without custom digest`() {
         val serializer = mock<AlgorithmParameterSpecEncodingService>()
-        val origin = SignatureSpec("name1")
+        val origin = SignatureSpecImpl("name1")
         val result = origin.toWire(serializer)
         assertEquals("name1", result.signatureName)
         assertNull(result.customDigestName)

--- a/libs/crypto/delegated-signing/build.gradle
+++ b/libs/crypto/delegated-signing/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
+    implementation project(':libs:crypto:cipher-suite')
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'

--- a/libs/crypto/delegated-signing/src/main/kotlin/net/corda/crypto/delegated/signing/DelegatedSignature.kt
+++ b/libs/crypto/delegated-signing/src/main/kotlin/net/corda/crypto/delegated/signing/DelegatedSignature.kt
@@ -1,7 +1,7 @@
 package net.corda.crypto.delegated.signing
 
-import net.corda.v5.crypto.ParameterizedSignatureSpec
-import net.corda.v5.crypto.SignatureSpec
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import java.io.ByteArrayOutputStream
 import java.security.AlgorithmParameters
 import java.security.PrivateKey
@@ -34,7 +34,7 @@ internal class DelegatedSignature(
         val spec = if (parameterSpec != null) {
             ParameterizedSignatureSpec(signatureName, parameterSpec!!)
         } else {
-            SignatureSpec(signatureName)
+            SignatureSpecImpl(signatureName)
         }
         return try {
             val key = signingKey ?: throw SecurityException(

--- a/libs/crypto/delegated-signing/src/test/kotlin/net/corda/crypto/delegated/signing/DelegatedSignatureTest.kt
+++ b/libs/crypto/delegated-signing/src/test/kotlin/net/corda/crypto/delegated/signing/DelegatedSignatureTest.kt
@@ -1,6 +1,6 @@
 package net.corda.crypto.delegated.signing
 
-import net.corda.v5.crypto.ParameterizedSignatureSpec
+import net.corda.crypto.cipher.suite.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -20,7 +20,6 @@ import java.security.PublicKey
 import java.security.Security
 import java.security.Signature
 import java.security.spec.AlgorithmParameterSpec
-import kotlin.math.sign
 
 class DelegatedSignatureTest {
     companion object {

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/GroupParametersFactoryImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/GroupParametersFactoryImpl.kt
@@ -2,6 +2,7 @@ package net.corda.membership.lib.impl
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.core.DigitalSignatureWithKey
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.data.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
@@ -14,7 +15,6 @@ import net.corda.membership.lib.exceptions.FailedGroupParametersDeserialization
 import net.corda.membership.lib.exceptions.FailedGroupParametersSerialization
 import net.corda.membership.lib.toMap
 import net.corda.v5.base.types.LayeredPropertyMap
-import net.corda.v5.crypto.SignatureSpec
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -76,7 +76,7 @@ class GroupParametersFactoryImpl @Activate constructor(
         bytes.array()
     )
 
-    private fun CryptoSignatureSpec.toCorda() = SignatureSpec(signatureName)
+    private fun CryptoSignatureSpec.toCorda() = SignatureSpecImpl(signatureName)
 
     private fun deserializeLayeredPropertyMap(params: ByteArray): LayeredPropertyMap = avroDeserializer
         .deserialize(params)

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
@@ -2,13 +2,13 @@ package net.corda.membership.lib.impl.converter
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.cipher.suite.PublicKeyHash
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.layeredpropertymap.ConversionContext
 import net.corda.layeredpropertymap.CustomPropertyConverter
 import net.corda.membership.lib.notary.MemberNotaryDetails
 import net.corda.membership.lib.notary.MemberNotaryKey
 import net.corda.v5.base.exceptions.ValueNotFoundException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -58,7 +58,7 @@ class MemberNotaryDetailsConverter @Activate constructor(
                 MemberNotaryKey(
                     publicKey = keyEncodingService.decodePublicKey(pem),
                     publicKeyHash = PublicKeyHash.parse(hash),
-                    spec = SignatureSpec(signatureName)
+                    spec = SignatureSpecImpl(signatureName)
                 )
             } else {
                 null

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverterTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverterTest.kt
@@ -2,10 +2,10 @@ package net.corda.membership.lib.impl.converter
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.cipher.suite.PublicKeyHash
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.layeredpropertymap.ConversionContext
 import net.corda.v5.base.exceptions.ValueNotFoundException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
@@ -41,10 +41,10 @@ class MemberNotaryDetailsConverterTest {
         on { value("$PROTOCOL_VERSIONS_PREFIX.1") } doReturn "2"
         on { value("keys.0.hash") } doReturn hashOne
         on { value("keys.0.pem") } doReturn "PEM1"
-        on { value("keys.0.signature.spec") } doReturn SignatureSpec.ECDSA_SHA512.signatureName
+        on { value("keys.0.signature.spec") } doReturn SignatureSpecs.ECDSA_SHA512.signatureName
         on { value("keys.1.hash") } doReturn hashTwo
         on { value("keys.1.pem") } doReturn "PEM2"
-        on { value("keys.1.signature.spec") } doReturn SignatureSpec.RSA_SHA512.signatureName
+        on { value("keys.1.signature.spec") } doReturn SignatureSpecs.RSA_SHA512.signatureName
     }
 
     private val converter = MemberNotaryDetailsConverter(keyEncodingService)
@@ -72,10 +72,10 @@ class MemberNotaryDetailsConverterTest {
                     assertThat(it.publicKeyHash.value).isEqualTo(hashTwo)
                 }
                 .anySatisfy {
-                    assertThat(it.spec.signatureName).isEqualTo(SignatureSpec.ECDSA_SHA512.signatureName)
+                    assertThat(it.spec.signatureName).isEqualTo(SignatureSpecs.ECDSA_SHA512.signatureName)
                 }
                 .anySatisfy {
-                    assertThat(it.spec.signatureName).isEqualTo(SignatureSpec.RSA_SHA512.signatureName)
+                    assertThat(it.spec.signatureName).isEqualTo(SignatureSpecs.RSA_SHA512.signatureName)
                 }
         }
     }

--- a/libs/membership/network-info/src/main/kotlin/net/corda/membership/network/writer/staticnetwork/StaticNetworkUtils.kt
+++ b/libs/membership/network-info/src/main/kotlin/net/corda/membership/network/writer/staticnetwork/StaticNetworkUtils.kt
@@ -1,6 +1,6 @@
 package net.corda.membership.network.writer.staticnetwork
 
-import net.corda.v5.crypto.SignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 object StaticNetworkUtils {
@@ -9,7 +9,7 @@ object StaticNetworkUtils {
         get() = "RSA"
 
     val mgmSignatureSpec
-        get() = SignatureSpec.RSA_SHA256
+        get() = SignatureSpecs.RSA_SHA256
 
     val mgmSigningKeyProvider
         get() = BouncyCastleProvider()

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
@@ -1,10 +1,10 @@
 package net.corda.p2p.crypto.protocol.api
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.data.p2p.crypto.AuthenticatedDataMessage
 import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -18,7 +18,7 @@ class AuthenticatedEncryptionSessionTest {
 
     private val provider = BouncyCastleProvider()
     private val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
-    private val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+    private val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
 
     private val sessionId = UUID.randomUUID().toString()
     private val groupId = "some-group-id"
@@ -75,7 +75,7 @@ class AuthenticatedEncryptionSessionTest {
             initiatorHandshakeMessage,
             aliceX500Name,
             listOf(
-                partyASessionKey.public to SignatureSpec.ECDSA_SHA256,
+                partyASessionKey.public to SignatureSpecs.ECDSA_SHA256,
             ),
         )
 
@@ -94,7 +94,7 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
             aliceX500Name,
-            listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256,),
+            listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256,),
         )
 
         // Both sides generate session secrets
@@ -163,7 +163,7 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -181,7 +181,7 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
             aliceX500Name,
-            listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256)
+            listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256)
         )
 
         // Both sides generate session secrets
@@ -256,7 +256,7 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -274,7 +274,7 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
             aliceX500Name,
-            listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Both sides generate session secrets

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
@@ -1,11 +1,11 @@
 package net.corda.p2p.crypto.protocol.api
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.data.p2p.crypto.AuthenticatedDataMessage
 import net.corda.data.p2p.crypto.CommonHeader
 import net.corda.data.p2p.crypto.MessageType
 import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class AuthenticatedSessionTest {
 
     private val provider = BouncyCastleProvider()
     private val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
-    private val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+    private val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
 
     private val sessionId = UUID.randomUUID().toString()
     private val groupId = "some-group-id"
@@ -73,7 +73,7 @@ class AuthenticatedSessionTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256)
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -91,7 +91,7 @@ class AuthenticatedSessionTest {
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
             aliceX500Name,
-            listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256)
+            listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256)
         )
 
         // Both sides generate session secrets
@@ -153,7 +153,7 @@ class AuthenticatedSessionTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -171,7 +171,7 @@ class AuthenticatedSessionTest {
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
             aliceX500Name,
-            listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256)
+            listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256)
         )
 
         // Both sides generate session secrets
@@ -224,7 +224,7 @@ class AuthenticatedSessionTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -242,7 +242,7 @@ class AuthenticatedSessionTest {
         authenticationProtocolA.validatePeerHandshakeMessage(
             responderHandshakeMessage,
             aliceX500Name,
-            listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256)
+            listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256)
         )
 
         // Both sides generate session secrets

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
@@ -1,9 +1,9 @@
 package net.corda.p2p.crypto.protocol.api
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.data.p2p.crypto.InitiatorHandshakeMessage
 import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.AfterEach
@@ -25,7 +25,7 @@ class AuthenticationProtocolFailureTest {
 
     private val provider = BouncyCastleProvider()
     private val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
-    private val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+    private val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
     private val aliceX500Name = MemberX500Name.parse("CN=alice, OU=MyUnit, O=MyOrg, L=London, S=London, C=GB")
 
     private val sessionId = UUID.randomUUID().toString()
@@ -90,7 +90,7 @@ class AuthenticationProtocolFailureTest {
         )
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                modifiedInitiatorHandshakeMessage, aliceX500Name, listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256)
+                modifiedInitiatorHandshakeMessage, aliceX500Name, listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -124,7 +124,7 @@ class AuthenticationProtocolFailureTest {
 
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage, aliceX500Name, listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256)
+                initiatorHandshakeMessage, aliceX500Name, listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -159,7 +159,7 @@ class AuthenticationProtocolFailureTest {
         )
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage, aliceX500Name, listOf(wrongPublicKey to SignatureSpec.ECDSA_SHA256)
+                initiatorHandshakeMessage, aliceX500Name, listOf(wrongPublicKey to SignatureSpecs.ECDSA_SHA256)
             )
         }
             .isInstanceOf(WrongPublicKeyHashException::class.java)
@@ -194,7 +194,7 @@ class AuthenticationProtocolFailureTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Step 4: responder creating different signature than the one expected.
@@ -211,7 +211,7 @@ class AuthenticationProtocolFailureTest {
 
         assertThatThrownBy {
             authenticationProtocolA.validatePeerHandshakeMessage(
-                responderHandshakeMessage, aliceX500Name, listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256)
+                responderHandshakeMessage, aliceX500Name, listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -287,7 +287,7 @@ class AuthenticationProtocolFailureTest {
         assertThrows<InvalidPeerCertificate> { authenticationProtocolB.validatePeerHandshakeMessage(
                 initiatorHandshakeMessage,
                 aliceX500Name,
-                listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256)
+                listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
     }
@@ -338,7 +338,7 @@ class AuthenticationProtocolFailureTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -355,7 +355,7 @@ class AuthenticationProtocolFailureTest {
 
         assertThrows<InvalidPeerCertificate> {
             authenticationProtocolA.validatePeerHandshakeMessage(
-                responderHandshakeMessage, aliceX500Name, listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256)
+                responderHandshakeMessage, aliceX500Name, listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
 
@@ -404,7 +404,7 @@ class AuthenticationProtocolFailureTest {
         assertThrows<InvalidPeerCertificate> { authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
         }
     }
@@ -453,7 +453,7 @@ class AuthenticationProtocolFailureTest {
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
             aliceX500Name,
-            listOf(partyASessionKey.public to SignatureSpec.ECDSA_SHA256),
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -470,7 +470,7 @@ class AuthenticationProtocolFailureTest {
 
         assertThrows<InvalidPeerCertificate> {
             authenticationProtocolA.validatePeerHandshakeMessage(
-                responderHandshakeMessage, aliceX500Name, listOf(partyBSessionKey.public to SignatureSpec.ECDSA_SHA256)
+                responderHandshakeMessage, aliceX500Name, listOf(partyBSessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
 

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.crypto.protocol.api
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.utils.PemCertificate
 import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.p2p.crypto.protocol.ProtocolConstants.Companion.MIN_PACKET_SIZE
@@ -31,37 +32,37 @@ class AuthenticationProtocolTest {
 
     @Test
     fun `no handshake message crosses the minimum value allowed for max message size`() {
-        val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+        val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
         val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
         val partyASessionKey = keyPairGenerator.generateKeyPair()
         val partyBSessionKey = keyPairGenerator.generateKeyPair()
 
-        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpec.ECDSA_SHA256)
+        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpecs.ECDSA_SHA256)
     }
 
     @Test
     fun `authentication protocol works successfully with ECDSA key algorithm`() {
-        val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+        val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
         val keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", provider)
         val partyASessionKey = keyPairGenerator.generateKeyPair()
         val partyBSessionKey = keyPairGenerator.generateKeyPair()
 
-        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpec.ECDSA_SHA256)
+        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpecs.ECDSA_SHA256)
     }
 
     @Test
     fun `authentication protocol works successfully with RSA signatures`() {
-        val signature = Signature.getInstance(SignatureSpec.RSA_SHA256.signatureName, provider)
+        val signature = Signature.getInstance(SignatureSpecs.RSA_SHA256.signatureName, provider)
         val keyPairGenerator = KeyPairGenerator.getInstance("RSA", provider)
         val partyASessionKey = keyPairGenerator.generateKeyPair()
         val partyBSessionKey = keyPairGenerator.generateKeyPair()
 
-        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpec.RSA_SHA256)
+        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpecs.RSA_SHA256)
     }
 
     @Test
     fun `authentication protocol verifies cert if CertificateCheckMode is CheckCertificate`() {
-        val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+        val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
         val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
         val partyASessionKey = keyPairGenerator.generateKeyPair()
         val partyBSessionKey = keyPairGenerator.generateKeyPair()
@@ -70,7 +71,7 @@ class AuthenticationProtocolTest {
         val certificateValidator = Mockito.mockConstruction(CertificateValidator::class.java)
 
         executeProtocol(
-            partyASessionKey, partyBSessionKey, signature, SignatureSpec.ECDSA_SHA256,
+            partyASessionKey, partyBSessionKey, signature, SignatureSpecs.ECDSA_SHA256,
             certificateCheckMode = certificateCheckMode, partyACertificate = ourCertificate, partyBCertificate = ourCertificate
         )
         //One validator for AuthenticationProtocolInitiator and one for AuthenticationProtocolResponder
@@ -83,12 +84,12 @@ class AuthenticationProtocolTest {
 
     @Test
     fun `authentication protocol methods are idempotent`() {
-        val signature = Signature.getInstance(SignatureSpec.ECDSA_SHA256.signatureName, provider)
+        val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
         val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
         val partyASessionKey = keyPairGenerator.generateKeyPair()
         val partyBSessionKey = keyPairGenerator.generateKeyPair()
 
-        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpec.ECDSA_SHA256, duplicateInvocations = true)
+        executeProtocol(partyASessionKey, partyBSessionKey, signature, SignatureSpecs.ECDSA_SHA256, duplicateInvocations = true)
     }
 
     @Suppress("LongParameterList")

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation project(':libs:crypto:crypto-core')
     testImplementation project(':libs:crypto:crypto-serialization-impl')
     testImplementation project(':testing:test-serialization')
+    testImplementation project(':libs:crypto:cipher-suite')
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ParameterizedSignatureSpecTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/ParameterizedSignatureSpecTest.kt
@@ -1,13 +1,13 @@
 package net.corda.internal.serialization.amqp.custom
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert
-import net.corda.v5.crypto.SignatureSpec
 import org.junit.jupiter.api.Test
 
 class ParameterizedSignatureSpecTest {
     @Test
     fun `ParameterizedSignatureSpec taking PSSParameterSpec as AlgorithmParameterSpec is serializable`() {
-        val parameterizedSignatureSpec = SignatureSpec.RSASSA_PSS_SHA256
+        val parameterizedSignatureSpec = SignatureSpecs.RSASSA_PSS_SHA256
         ReusableSerialiseDeserializeAssert.serializeDeserializeAssert(parameterizedSignatureSpec)
     }
 }

--- a/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/NotarizationRequestSignature.kt
+++ b/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/NotarizationRequestSignature.kt
@@ -2,6 +2,7 @@ package com.r3.corda.notary.plugin.common
 
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 
 /**
  * A wrapper around a digital signature used for notarization requests.
@@ -12,5 +13,6 @@ import net.corda.v5.crypto.DigitalSignature
 @CordaSerializable
 data class NotarizationRequestSignature(
     val digitalSignature: DigitalSignature.WithKeyId,
+    val signatureSpec: SignatureSpec,
     val platformVersion: Int
 )

--- a/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
+++ b/notary-plugins/notary-plugin-common/src/main/kotlin/com/r3/corda/notary/plugin/common/PluggableNotaryFlowHelpers.kt
@@ -5,6 +5,7 @@ package com.r3.corda.notary.plugin.common
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
+import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.application.uniqueness.model.UniquenessCheckError
@@ -21,7 +22,6 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResultSuccess
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.notary.plugin.core.NotaryException
 import net.corda.v5.membership.MemberInfo
 import java.security.PublicKey
@@ -37,10 +37,10 @@ fun validateRequestSignature(notarizationRequest: NotarizationRequest,
                              requestingPartyKey: PublicKey,
                              serializationService: SerializationService,
                              signatureVerifier: DigitalSignatureVerificationService,
-                             signature: NotarizationRequestSignature,
+                             signatureAndSpec: NotarizationRequestSignature,
                              digestService: DigestService
 ) {
-    val digitalSignature = signature.digitalSignature
+    val digitalSignature = signatureAndSpec.digitalSignature
     val digestAlgorithmOfSignatureKeyId = digitalSignature.by.algorithm
     val requestingPartyKeyId =
         requestingPartyKey.fullIdHash(digestService, digestAlgorithmOfSignatureKeyId)
@@ -58,7 +58,7 @@ fun validateRequestSignature(notarizationRequest: NotarizationRequest,
             expectedSignedBytes,
             digitalSignature.bytes,
             requestingPartyKey,
-            SignatureSpec.ECDSA_SHA256 // TODO This shouldn't be hardcoded?
+            signatureAndSpec.signatureSpec
         )
     } catch (e: Exception) {
         throw IllegalStateException("Error while verifying request signature.", e)
@@ -70,16 +70,21 @@ fun validateRequestSignature(notarizationRequest: NotarizationRequest,
 fun generateRequestSignature(notarizationRequest: NotarizationRequest,
                              memberInfo: MemberInfo,
                              serializationService: SerializationService,
-                             signingService: SigningService
+                             signingService: SigningService,
+                             signatureSpecService: SignatureSpecService
 ): NotarizationRequestSignature {
     val serializedRequest = serializationService.serialize(notarizationRequest).bytes
     val myLegalIdentity = memberInfo.ledgerKeys.first()
-    val signature = signingService.sign(
-        serializedRequest,
-        myLegalIdentity,
-        SignatureSpec.ECDSA_SHA256 // TODO This shouldn't be hardcoded?
-    )
-    return NotarizationRequestSignature(signature, memberInfo.platformVersion)
+    val signatureSpec =
+        signatureSpecService.defaultSignatureSpec(myLegalIdentity)
+            ?: throw IllegalStateException("Default signature spec not found for key")
+    val signature =
+        signingService.sign(
+            serializedRequest,
+            myLegalIdentity,
+            signatureSpec
+        )
+    return NotarizationRequestSignature(signature, signatureSpec, memberInfo.platformVersion)
 }
 
 /**

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/build.gradle
@@ -37,5 +37,6 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
     testImplementation project(':libs:serialization:serialization-amqp')
+    testImplementation project(':libs:crypto:cipher-suite')
     testImplementation project(":testing:crypto-testkit")
 }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
@@ -5,6 +5,7 @@ import com.r3.corda.notary.plugin.common.NotarizationResponse
 import com.r3.corda.notary.plugin.common.generateRequestSignature
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarizationPayload
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatingFlow
@@ -48,6 +49,9 @@ class NonValidatingNotaryClientFlowImpl(
     @CordaInject
     private lateinit var utxoLedgerService: UtxoLedgerService
 
+    @CordaInject
+    private lateinit var signatureSpecService: SignatureSpecService
+
     /**
      * Constructor used for testing to initialize the necessary services
      */
@@ -60,13 +64,15 @@ class NonValidatingNotaryClientFlowImpl(
         memberLookupService: MemberLookup,
         serializationService: SerializationService,
         signingService: SigningService,
-        utxoLedgerService: UtxoLedgerService
+        utxoLedgerService: UtxoLedgerService,
+        signatureSpecService: SignatureSpecService
     ): this(stx, notary) {
         this.flowMessaging = flowMessaging
         this.serializationService = serializationService
         this.memberLookupService = memberLookupService
         this.signingService = signingService
         this.utxoLedgerService = utxoLedgerService
+        this.signatureSpecService = signatureSpecService
     }
 
     /**
@@ -138,7 +144,8 @@ class NonValidatingNotaryClientFlowImpl(
             notarizationRequest,
             memberLookupService.myInfo(),
             serializationService,
-            signingService
+            signingService,
+            signatureSpecService
         )
 
         return NonValidatingNotarizationPayload(

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImplTest.kt
@@ -2,15 +2,17 @@ package com.r3.corda.notary.plugin.nonvalidating.client
 
 import com.r3.corda.notary.plugin.common.NotarizationResponse
 import com.r3.corda.notary.plugin.common.NotaryExceptionReferenceStateUnknown
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.testkit.SecureHashUtils
 import net.corda.internal.serialization.SerializedBytesImpl
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
+import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigitalSignature
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
@@ -41,7 +43,7 @@ class NonValidatingNotaryClientFlowImplTest {
         val mockRequestSignature = mock<DigitalSignature.WithKeyId>()
         val dummyUniquenessSignature = DigitalSignatureAndMetadata(
             mock(),
-            DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), emptyMap())
+            DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), emptyMap())
         )
 
         /* State Refs */
@@ -63,6 +65,9 @@ class NonValidatingNotaryClientFlowImplTest {
             on { id } doReturn txId
             on { notaryName } doReturn MemberX500Name.parse("O=MyNotaryService, L=London, C=GB")
             on { notaryKey } doReturn mock<PublicKey>()
+        }
+        val mockSignatureSpecService = mock<SignatureSpecService> {
+            on { defaultSignatureSpec(any()) } doReturn SignatureSpecs.ECDSA_SHA256
         }
     }
 
@@ -150,7 +155,8 @@ class NonValidatingNotaryClientFlowImplTest {
             },
             mock {
                 on { filterSignedTransaction(any()) } doReturn mockBuilder
-            }
+            },
+            mockSignatureSpecService
         )
     }
 }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -8,6 +8,7 @@ import com.r3.corda.notary.plugin.common.validateRequestSignature
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarizationPayload
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
+import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.ResponderFlow
@@ -56,6 +57,9 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
     @CordaInject
     private lateinit var digestService: DigestService
 
+    @CordaInject
+    private lateinit var signatureSpecService: SignatureSpecService
+
     /**
      * Constructor used for testing to initialize the necessary services
      */
@@ -67,7 +71,8 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
         signatureVerifier: DigitalSignatureVerificationService,
         memberLookup: MemberLookup,
         transactionSignatureService: TransactionSignatureService,
-        digestService: DigestService
+        digestService: DigestService,
+        signatureSpecService: SignatureSpecService
     ) : this() {
         this.clientService = clientService
         this.serializationService = serializationService
@@ -75,6 +80,7 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
         this.memberLookup = memberLookup
         this.transactionSignatureService = transactionSignatureService
         this.digestService = digestService
+        this.signatureSpecService = signatureSpecService
     }
 
     /**

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -5,6 +5,7 @@ import com.r3.corda.notary.plugin.common.NotarizationResponse
 import com.r3.corda.notary.plugin.common.NotaryExceptionGeneral
 import com.r3.corda.notary.plugin.common.NotaryExceptionReferenceStateUnknown
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarizationPayload
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.SecureHashImpl
@@ -18,6 +19,7 @@ import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultFailureImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultSuccessImpl
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
+import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.serialization.SerializationService
@@ -89,6 +91,8 @@ class NonValidatingNotaryServerFlowImplTest {
         }
 
         val mockTransactionSignatureService = mock<TransactionSignatureService>()
+
+        val mockSignatureSpecService = mock<SignatureSpecService>()
     }
 
     @BeforeEach
@@ -418,6 +422,7 @@ class NonValidatingNotaryServerFlowImplTest {
                         charlieKeyId,
                         "ABC".toByteArray()
                     ),
+                    SignatureSpecs.RSA_SHA256,
                     DUMMY_PLATFORM_VERSION
                 ),
                 notaryServiceKey
@@ -459,7 +464,8 @@ class NonValidatingNotaryServerFlowImplTest {
             sigVerifier,
             mockMemberLookup,
             mockTransactionSignatureService,
-            mockDigestService
+            mockDigestService,
+            mockSignatureSpecService
         )
 
         server.call(paramOrDefaultSession)

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -2,6 +2,8 @@ package net.corda.processors.crypto.tests
 
 import com.typesafe.config.ConfigRenderOptions
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.SignatureVerificationService
 import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.crypto.cipher.suite.sha256Bytes
@@ -69,11 +71,9 @@ import net.corda.test.util.TestRandom
 import net.corda.test.util.eventually
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
 import net.corda.v5.crypto.KeySchemeCodes.X25519_CODE_NAME
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.bouncycastle.jcajce.provider.util.DigestFactory
@@ -723,8 +723,8 @@ class CryptoProcessorTests {
     ) {
         val data = randomDataByteArray()
         val signatureSpec = when (publicKey.algorithm) {
-            "EC" -> SignatureSpec("SHA512withECDSA")
-            "RSA" -> SignatureSpec.RSASSA_PSS_SHA256
+            "EC" -> SignatureSpecImpl("SHA512withECDSA")
+            "RSA" -> SignatureSpecs.RSASSA_PSS_SHA256
             else -> throw IllegalArgumentException("Test supports only RSA or ECDSA")
         }
         val signature = opsClient.sign(

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.processors.db.internal.reconcile.db
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.db.connection.manager.DbConnectionManager
@@ -18,7 +19,6 @@ import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.ReconcilerWriter
 import net.corda.test.util.TestRandom
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -60,7 +60,7 @@ class GroupParametersReconcilerTest {
 
     private val signatureKey = byteArrayOf(1, 2, 3)
     private val signatureContent = byteArrayOf(4, 5, 6)
-    private val signatureSpec = SignatureSpec.ECDSA_SHA256.signatureName
+    private val signatureSpec = SignatureSpecs.ECDSA_SHA256.signatureName
 
     private val signedGroupParametersEntity = GroupParametersEntity(
         epoch = 9,

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
@@ -13,7 +13,6 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import org.slf4j.LoggerFactory
 import java.security.PublicKey
 import java.util.UUID
@@ -62,11 +61,12 @@ class TruancyResponderFlow : ResponderFlow {
             return
         }
 
+        val signatureSpec = record.signatureSpec
         verificationService.verify(
             serializationService.serialize(record.absentees).bytes,
             record.signature.bytes,
             keyOfSignature,
-            SignatureSpec.ECDSA_SHA256
+            signatureSpec
         )
         log.info("Records verified; persisting records")
 

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/TruancySubFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/TruancySubFlowTest.kt
@@ -27,6 +27,7 @@ class TruancySubFlowTest {
         val simulator = Simulator()
         val truancyRecord = TruancyRecord(
             listOf(bob),
+            mock(),
             mock()
         )
 

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SigningTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SigningTest.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.simulator.crypto.HsmCategory
 import net.corda.simulator.runtime.testflows.HelloFlow
 import net.corda.simulator.runtime.testutils.createMember
@@ -11,7 +12,6 @@ import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -34,7 +34,7 @@ class SigningTest {
                 val keyHolder = requestBody.getRequestBodyAs(jsonMarshallingService, MemberX500Name::class.java)
                 val publicKey = memberLookup.lookup(keyHolder)?.ledgerKeys?.get(0)
                 checkNotNull(publicKey)
-                signingService.sign("Hello!".toByteArray(), publicKey, SignatureSpec.ECDSA_SHA256)
+                signingService.sign("Hello!".toByteArray(), publicKey, SignatureSpecs.ECDSA_SHA256)
                 return "Signed"
             }
         }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBase.kt
@@ -1,5 +1,7 @@
 package net.corda.simulator.runtime.ledger.consensual
 
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.entities.ConsensualTransactionEntity
@@ -11,7 +13,6 @@ import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
@@ -126,10 +127,10 @@ class ConsensualSignedTransactionBase(
     override fun toLedgerTransaction(): ConsensualLedgerTransaction = ledgerTransaction
 
     private fun signWithMetadata(key: PublicKey, timestamp: Instant): DigitalSignatureAndMetadata {
-        val signature = signingService.sign(ledgerTransaction.bytes, key, SignatureSpec.ECDSA_SHA256)
+        val signature = signingService.sign(ledgerTransaction.bytes, key, SignatureSpecs.ECDSA_SHA256)
         return DigitalSignatureAndMetadata(
             signature,
-            DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
+            DigitalSignatureMetadata(timestamp, SignatureSpecImpl("dummySignatureName"), mapOf())
         )
     }
 

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/consensual/SimConsensualLedgerService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/consensual/SimConsensualLedgerService.kt
@@ -1,5 +1,7 @@
 package net.corda.simulator.runtime.ledger.consensual
 
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.bytes
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.entities.ConsensualTransactionEntity
@@ -11,7 +13,6 @@ import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
@@ -92,10 +93,10 @@ class SimConsensualLedgerService(
         val serializer = SimpleJsonMarshallingService()
         val bytesToSign = serializer.format(signedTransaction.toLedgerTransaction().states).toByteArray()
         val signatures = publicKeys.map {
-            val signature = signingService.sign(bytesToSign, it, SignatureSpec.ECDSA_SHA256)
+            val signature = signingService.sign(bytesToSign, it, SignatureSpecs.ECDSA_SHA256)
             DigitalSignatureAndMetadata(
                 signature,
-                DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
+                DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), mapOf())
             )
         }
         return signatures

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoSignedTransactionBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoSignedTransactionBase.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.ledger.utxo
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.bytes
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.entities.UtxoTransactionEntity
@@ -16,14 +17,13 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.utxo.Command
-import net.corda.v5.ledger.utxo.StateRef
-import net.corda.v5.ledger.utxo.TimeWindow
-import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.EncumbranceGroup
+import net.corda.v5.ledger.utxo.StateAndRef
+import net.corda.v5.ledger.utxo.StateRef
+import net.corda.v5.ledger.utxo.TimeWindow
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.membership.NotaryInfo
@@ -230,9 +230,9 @@ class UtxoSignedTransactionBase(
     }
 
     private fun signWithMetadata(key: PublicKey, timestamp: Instant) : DigitalSignatureAndMetadata {
-        val signature = signingService.sign(ledgerTransaction.bytes, key, SignatureSpec.ECDSA_SHA256)
+        val signature = signingService.sign(ledgerTransaction.bytes, key, SignatureSpecs.ECDSA_SHA256)
         return DigitalSignatureAndMetadata(signature,
-            DigitalSignatureMetadata(timestamp, SignatureSpec.ECDSA_SHA256, mapOf()))
+            DigitalSignatureMetadata(timestamp, SignatureSpecs.ECDSA_SHA256, mapOf()))
     }
 
     override fun equals(other: Any?): Boolean {

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionFinalityHandler.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionFinalityHandler.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.ledger.utxo
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.bytes
 import net.corda.simulator.entities.UtxoTransactionOutputEntity
 import net.corda.simulator.entities.UtxoTransactionOutputEntityId
@@ -13,7 +14,6 @@ import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
@@ -170,9 +170,9 @@ class UtxoTransactionFinalityHandler(
         val serializer = SimpleJsonMarshallingService()
         val bytesToSign = serializer.format(signedTransaction.toLedgerTransaction()).toByteArray()
         val signatures = publicKeys.map {
-            val signature = signingService.sign(bytesToSign, it, SignatureSpec.ECDSA_SHA256)
+            val signature = signingService.sign(bytesToSign, it, SignatureSpecs.ECDSA_SHA256)
             DigitalSignatureAndMetadata(signature, DigitalSignatureMetadata(
-                Instant.now(), SignatureSpec.ECDSA_SHA256, mapOf()))
+                Instant.now(), SignatureSpecs.ECDSA_SHA256, mapOf()))
         }
         return signatures
     }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/OnlyOneSignatureSpecService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/signing/OnlyOneSignatureSpecService.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.signing
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SignatureSpec
@@ -7,22 +8,22 @@ import java.security.PublicKey
 
 class OnlyOneSignatureSpecService : SignatureSpecService {
     override fun compatibleSignatureSpecs(publicKey: PublicKey): List<SignatureSpec> {
-        return listOf(SignatureSpec.ECDSA_SHA256)
+        return listOf(SignatureSpecs.ECDSA_SHA256)
     }
 
     override fun compatibleSignatureSpecs(
         publicKey: PublicKey,
         digestAlgorithmName: DigestAlgorithmName
     ): List<SignatureSpec> {
-        return listOf(SignatureSpec.ECDSA_SHA256)
+        return listOf(SignatureSpecs.ECDSA_SHA256)
     }
 
     override fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec? {
-        return SignatureSpec.ECDSA_SHA256
+        return SignatureSpecs.ECDSA_SHA256
     }
 
     override fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): SignatureSpec? {
-        return SignatureSpec.ECDSA_SHA256
+        return SignatureSpecs.ECDSA_SHA256
     }
 
 }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBaseTest.kt
@@ -1,6 +1,7 @@
 package net.corda.simulator.runtime.ledger.consensual
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.fullIdHash
 import net.corda.simulator.factories.SimulatorConfigurationBuilder
 import net.corda.simulator.runtime.serialization.BaseSerializationService
@@ -9,7 +10,6 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.base.annotations.CordaSerializable
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import org.hamcrest.MatcherAssert.assertThat
@@ -155,7 +155,7 @@ class ConsensualSignedTransactionBaseTest {
 
     private fun toSignatureWithMetadata(key: PublicKey, timestamp: Instant = now()) = DigitalSignatureAndMetadata(
         DigitalSignatureWithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
-        DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
+        DigitalSignatureMetadata(timestamp, SignatureSpecImpl("dummySignatureName"), mapOf())
     )
 
     @CordaSerializable

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualTransactionBuilderBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualTransactionBuilderBaseTest.kt
@@ -1,12 +1,12 @@
 package net.corda.simulator.runtime.ledger.consensual
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.simulator.factories.SimulatorConfigurationBuilder
 import net.corda.simulator.runtime.testutils.generateKeys
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.membership.MemberLookup
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import net.corda.v5.membership.MemberInfo
@@ -57,7 +57,7 @@ class ConsensualTransactionBuilderBaseTest {
     @Test
     fun `should be able to build a consensual transaction and sign with a key`() {
         // Given a key has been generated on the node, so the SigningService can sign with it
-        whenever(signingService.sign(any(), eq(publicKeys[0]), eq(SignatureSpec.ECDSA_SHA256)))
+        whenever(signingService.sign(any(), eq(publicKeys[0]), eq(SignatureSpecs.ECDSA_SHA256)))
             .thenReturn(DigitalSignatureWithKeyId(publicKeys[0].fullIdHash(), "My fake signed things".toByteArray()))
 
         // And our configuration has a special clock

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/SimConsensualLedgerServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/consensual/SimConsensualLedgerServiceTest.kt
@@ -2,6 +2,7 @@ package net.corda.simulator.runtime.ledger.consensual
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.entities.ConsensualTransactionEntity
 import net.corda.simulator.factories.SimulatorConfigurationBuilder
@@ -14,7 +15,6 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
@@ -100,7 +100,7 @@ class SimConsensualLedgerServiceTest {
         val sessions = publicKeys.minus(publicKeys[0]).map {
             val signature = DigitalSignatureAndMetadata(
                 toSignature(it).signature,
-                DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
+                DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), mapOf())
             )
             val flowSession = mock<FlowSession>()
             whenever(flowSession.receive<Any>(any())).thenReturn(listOf(signature), Unit)
@@ -224,7 +224,7 @@ class SimConsensualLedgerServiceTest {
 
     private fun toSignature(key: PublicKey) = DigitalSignatureAndMetadata(
         DigitalSignatureWithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
-        DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
+        DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), mapOf())
     )
 
     data class NameConsensualState(val name: String, private val participants: List<PublicKey>) : ConsensualState {

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTestUtils.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTestUtils.kt
@@ -2,9 +2,9 @@ package net.corda.simulator.runtime.ledger.utxo
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.utxo.BelongsToContract
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.Contract
@@ -15,7 +15,7 @@ import java.time.Instant
 
 fun toSignatureWithMetadata(key: PublicKey, timestamp: Instant = Instant.now()) = DigitalSignatureAndMetadata(
     DigitalSignatureWithKeyId(key.fullIdHash(), "some bytes".toByteArray()),
-    DigitalSignatureMetadata(timestamp, SignatureSpec("dummySignatureName"), mapOf())
+    DigitalSignatureMetadata(timestamp, SignatureSpecImpl("dummySignatureName"), mapOf())
 )
 
 @BelongsToContract(TestUtxoContract::class)

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionBuilderBaseTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionBuilderBaseTest.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.ledger.utxo
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.core.parseSecureHash
@@ -13,7 +14,6 @@ import net.corda.simulator.runtime.testutils.generateKeys
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.utxo.StateRef
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -38,7 +38,7 @@ class UtxoTransactionBuilderBaseTest {
     fun `should be able to build a utxo transaction and sign it with a key`() {
         // Given a key has been generated on the node, so the SigningService can sign with it
         val signingService = mock<SigningService>()
-        whenever(signingService.sign(any(), eq(publicKeys[0]), eq(SignatureSpec.ECDSA_SHA256)))
+        whenever(signingService.sign(any(), eq(publicKeys[0]), eq(SignatureSpecs.ECDSA_SHA256)))
             .thenReturn(DigitalSignatureWithKeyId(publicKeys[0].fullIdHash(), "My fake signed things".toByteArray()))
         whenever(signingService.findMySigningKeys(any())).thenReturn(mapOf(publicKeys[0] to publicKeys[0]))
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionFinalityHandlerTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionFinalityHandlerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.simulator.runtime.ledger.utxo
 
 import net.corda.crypto.core.fullIdHash
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.parseSecureHash
 import net.corda.simulator.factories.SimulatorConfigurationBuilder
 import net.corda.simulator.runtime.messaging.BaseMemberInfo
@@ -16,7 +17,6 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
@@ -25,12 +25,12 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Instant
 import kotlin.time.Duration.Companion.days
 
@@ -71,7 +71,7 @@ class UtxoTransactionFinalityHandlerTest {
         val sessions = publicKeys.minus(publicKeys[0]).map {
             val signature = DigitalSignatureAndMetadata(
                 toSignatureWithMetadata(it).signature,
-                DigitalSignatureMetadata(Instant.now(), SignatureSpec("dummySignatureName"), mapOf())
+                DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), mapOf())
             )
             val flowSession = mock<FlowSession>()
             whenever(flowSession.receive<Any>(any())).thenReturn(listOf(signature))

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/OnlyOneSignatureSpecServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/OnlyOneSignatureSpecServiceTest.kt
@@ -1,8 +1,8 @@
 package net.corda.simulator.runtime.signing
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.simulator.runtime.testutils.generateKey
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SignatureSpec
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
@@ -13,7 +13,7 @@ class OnlyOneSignatureSpecServiceTest {
     fun `should always return a never-actually-used ECDSA SHA256 spec`() {
         val service = OnlyOneSignatureSpecService()
         val key = generateKey()
-        val expected = SignatureSpec.ECDSA_SHA256
+        val expected = SignatureSpecs.ECDSA_SHA256
 
         assertThat(service.compatibleSignatureSpecs(key), `is`(listOf(expected)))
         assertThat(service.compatibleSignatureSpecs(key, DigestAlgorithmName.SHA2_384), `is`(listOf(expected)))

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSignAndVerifyTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSignAndVerifyTest.kt
@@ -1,7 +1,7 @@
 package net.corda.simulator.runtime.signing
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.simulator.crypto.HsmCategory
-import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -15,14 +15,14 @@ class SimWithJsonSignAndVerifyTest {
     @Test
     fun `should be able to sign and verify some bytes`() {
         val signed = SimWithJsonSigningService(keyStore)
-            .sign("Hello!".toByteArray(), key, SignatureSpec.ECDSA_SHA256)
+            .sign("Hello!".toByteArray(), key, SignatureSpecs.ECDSA_SHA256)
 
         assertDoesNotThrow {
             SimWithJsonSignatureVerificationService().verify(
                 "Hello!".toByteArray(),
                 signed.bytes,
                 key,
-                SignatureSpec.ECDSA_SHA256
+                SignatureSpecs.ECDSA_SHA256
             )
         }
     }
@@ -31,14 +31,14 @@ class SimWithJsonSignAndVerifyTest {
     fun `should fail to verify if the key is not the same key`() {
         val newKey = keyStore.generateKey("another-alias", HsmCategory.LEDGER, "any scheme will do")
         val signed = SimWithJsonSigningService(keyStore)
-            .sign("Hello!".toByteArray(), key, SignatureSpec.ECDSA_SHA256)
+            .sign("Hello!".toByteArray(), key, SignatureSpecs.ECDSA_SHA256)
 
         assertThrows<CryptoSignatureException> {
             SimWithJsonSignatureVerificationService().verify(
                 "Hello!".toByteArray(),
                 signed.bytes,
                 newKey,
-                SignatureSpec.ECDSA_SHA256
+                SignatureSpecs.ECDSA_SHA256
             )
         }
     }
@@ -46,14 +46,14 @@ class SimWithJsonSignAndVerifyTest {
     @Test
     fun `should fail to verify if the signature spec does not match`() {
         val signed = SimWithJsonSigningService(keyStore)
-            .sign("Hello!".toByteArray(), key, SignatureSpec.ECDSA_SHA256)
+            .sign("Hello!".toByteArray(), key, SignatureSpecs.ECDSA_SHA256)
 
         assertThrows<CryptoSignatureException> {
             SimWithJsonSignatureVerificationService().verify(
                 "Hello!".toByteArray(),
                 signed.bytes,
                 key,
-                SignatureSpec.ECDSA_SHA384
+                SignatureSpecs.ECDSA_SHA384
             )
         }
     }
@@ -61,14 +61,14 @@ class SimWithJsonSignAndVerifyTest {
     @Test
     fun `should fail to verify if original data does not match`() {
         val signed = SimWithJsonSigningService(keyStore)
-            .sign("Hello!".toByteArray(), key, SignatureSpec.ECDSA_SHA256)
+            .sign("Hello!".toByteArray(), key, SignatureSpecs.ECDSA_SHA256)
 
         assertThrows<CryptoSignatureException> {
             SimWithJsonSignatureVerificationService().verify(
                 "Goodbye!".toByteArray(),
                 signed.bytes,
                 key,
-                SignatureSpec.ECDSA_SHA256
+                SignatureSpecs.ECDSA_SHA256
             )
         }
     }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/signing/SimWithJsonSigningServiceTest.kt
@@ -1,8 +1,8 @@
 package net.corda.simulator.runtime.signing
 
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.simulator.crypto.HsmCategory
 import net.corda.simulator.runtime.serialization.SimpleJsonMarshallingService
-import net.corda.v5.crypto.SignatureSpec
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
@@ -20,14 +20,14 @@ class SimWithJsonSigningServiceTest {
 
         // When we add a key to the keystore and sign using the service
         val publicKey = keyStore.generateKey("my-alias", HsmCategory.LEDGER, "anyscheme")
-        val signed = service.sign("Hello!".toByteArray(), publicKey, SignatureSpec.ECDSA_SHA256)
+        val signed = service.sign("Hello!".toByteArray(), publicKey, SignatureSpecs.ECDSA_SHA256)
 
         // Then we should be able to see what we signed them with
         val result = jsonMarshallingService.parse(signed.bytes.decodeToString(), SimJsonSignedWrapper::class.java)
         val expected = SimJsonSignedWrapper(
             "Hello!".toByteArray(),
             pemEncode(publicKey),
-            SignatureSpec.ECDSA_SHA256.signatureName,
+            SignatureSpecs.ECDSA_SHA256.signatureName,
             KeyParameters("my-alias", HsmCategory.LEDGER, "anyscheme"),
         )
         assertThat(result, `is`(expected))

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/SignatureWithMetadaExample.kt
@@ -2,14 +2,14 @@ package net.corda.ledger.common.testkit
 
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
-import net.corda.v5.crypto.SignatureSpec
 import java.security.PublicKey
 import java.time.Instant
 
 fun getSignatureWithMetadataExample(publicKey: PublicKey = publicKeyExample, createdTs: Instant = Instant.now()) =
     DigitalSignatureAndMetadata(
         DigitalSignatureWithKeyId(publicKey.fullIdHash(), "signature".toByteArray()),
-        DigitalSignatureMetadata(createdTs, SignatureSpec("dummySignatureName"), mapOf("propertyKey1" to "propertyValue1"))
+        DigitalSignatureMetadata(createdTs, SignatureSpecImpl("dummySignatureName"), mapOf("propertyKey1" to "propertyValue1"))
     )

--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/BaseOnboard.kt
@@ -6,11 +6,11 @@ import kong.unirest.Unirest
 import net.corda.cli.plugins.mgm.Helpers.restPasswordFromClusterName
 import net.corda.cli.plugins.mgm.Helpers.urlFromClusterName
 import net.corda.cli.plugins.packaging.signing.SigningOptions
+import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.schemes.RSA_TEMPLATE
 import net.corda.crypto.test.certificates.generation.CertificateAuthorityFactory
 import net.corda.crypto.test.certificates.generation.toFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
-import net.corda.v5.crypto.SignatureSpec
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
@@ -41,7 +41,7 @@ abstract class BaseOnboard : Runnable {
         fun createKeyStoreFile(keyStoreFile: File) {
             val keyPair = KeyPairGenerator.getInstance("RSA").genKeyPair()
             val sigAlgId = DefaultSignatureAlgorithmIdentifierFinder().find(
-                SignatureSpec.RSA_SHA256.signatureName
+                SignatureSpecs.RSA_SHA256.signatureName
             )
             val digAlgId = DefaultDigestAlgorithmIdentifierFinder().find(sigAlgId)
             val parameter = PrivateKeyFactory.createKey(keyPair.private.encoded)


### PR DESCRIPTION
* adds `SignatureSpec` implementation and updates use sites
* adds `ParameterizedSignatureSpec` (moved from api repo)

API PR: [#1003](https://github.com/corda/corda-api/pull/1003)