### PR TITLE
CORE-11255: Fail a flow when the current platform version is different than the initial one.

### DIFF
--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:metrics")
     implementation project(":libs:messaging:messaging")
+    implementation project(':libs:platform-info')
     implementation project(":libs:sandbox")
     implementation project(':libs:serialization:serialization-amqp')
     implementation project(":libs:serialization:serialization-checkpoint-api")

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
@@ -12,6 +12,7 @@ import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.fiber.FlowLogicAndArgs
 import net.corda.flow.fiber.factory.FlowFiberFactory
 import net.corda.flow.pipeline.events.FlowEventContext
+import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.factory.FlowFactory
 import net.corda.flow.pipeline.factory.FlowFiberExecutionContextFactory
 import net.corda.flow.pipeline.runner.FlowRunner
@@ -46,6 +47,12 @@ class FlowRunnerImpl @Activate constructor(
         context: FlowEventContext<Any>,
         flowContinuation: FlowContinuation
     ): FiberFuture {
+        if (context.checkpoint.initialPlatformVersion != platformInfoProvider.localWorkerPlatformVersion) {
+            throw FlowFatalException("Platform has been modified from version " +
+                    "${context.checkpoint.initialPlatformVersion} to version " +
+                    "${platformInfoProvider.localWorkerPlatformVersion}.  The flow must be restarted.")
+        }
+
         return when (val receivedEvent = context.inputEvent.payload) {
             is StartFlow -> startFlow(context, receivedEvent)
             is SessionEvent -> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/CheckpointInitializerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/CheckpointInitializerImpl.kt
@@ -20,7 +20,6 @@ class CheckpointInitializerImpl @Activate constructor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
     private val cpiInfoReadService: CpiInfoReadService
-
 ) : CheckpointInitializer {
     override fun initialize(
         checkpoint: FlowCheckpoint,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointFactoryImpl.kt
@@ -1,23 +1,29 @@
 package net.corda.flow.state.impl
 
+import java.time.Instant
 import net.corda.data.crypto.SecureHash
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.flow.state.checkpoint.PipelineState
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.schema.configuration.FlowConfig
+import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import java.time.Instant
+import org.osgi.service.component.annotations.Reference
 
 @Suppress("Unused")
 @Component(service = [FlowCheckpointFactory::class])
-class FlowCheckpointFactoryImpl : FlowCheckpointFactory {
+class FlowCheckpointFactoryImpl @Activate constructor(
+    @Reference(service = PlatformInfoProvider::class)
+    private val platformInfoProvider: PlatformInfoProvider,
+) : FlowCheckpointFactory {
     override fun create(flowId: String, checkpoint: Checkpoint?, config: SmartConfig): FlowCheckpoint {
         val checkpointToUse = checkpoint ?: newCheckpoint(flowId, config)
         return FlowCheckpointImpl(checkpointToUse, config) { Instant.now() }
     }
 
-    private fun newCheckpoint(newFlowId: String, config: SmartConfig) : Checkpoint {
+    private fun newCheckpoint(newFlowId: String, config: SmartConfig): Checkpoint {
         val newPipelineState = PipelineState.newBuilder().apply {
             retryState = null
             maxFlowSleepDuration = config.getInt(FlowConfig.PROCESSING_MAX_FLOW_SLEEP_DURATION)
@@ -27,6 +33,7 @@ class FlowCheckpointFactoryImpl : FlowCheckpointFactory {
         return Checkpoint.newBuilder().apply {
             flowId = newFlowId
             pipelineState = newPipelineState
+            initialPlatformVersion = platformInfoProvider.localWorkerPlatformVersion
             flowState = null
         }.build()
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -1,5 +1,7 @@
 package net.corda.flow.state.impl
 
+import java.nio.ByteBuffer
+import java.time.Instant
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
@@ -16,8 +18,6 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
-import java.nio.ByteBuffer
-import java.time.Instant
 
 @Suppress("TooManyFunctions")
 class FlowCheckpointImpl(
@@ -124,6 +124,9 @@ class FlowCheckpointImpl(
 
     override val maxMessageSize: Long
         get() = config.getLong(MAX_ALLOWED_MSG_SIZE)
+
+    override val initialPlatformVersion: Int
+        get() = checkpoint.initialPlatformVersion
 
     override fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>) {
         if (flowStateManager != null) {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
@@ -16,12 +16,13 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.BOB_X500_HOLDING_IDENTITY
 import net.corda.flow.FLOW_ID_1
 import net.corda.flow.SESSION_ID_1
+import net.corda.flow.fiber.ClientStartedFlow
 import net.corda.flow.fiber.FiberFuture
 import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.fiber.InitiatedFlow
-import net.corda.flow.fiber.ClientStartedFlow
 import net.corda.flow.fiber.factory.FlowFiberFactory
+import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.factory.FlowFactory
 import net.corda.flow.pipeline.factory.FlowFiberExecutionContextFactory
 import net.corda.flow.pipeline.runner.impl.FlowRunnerImpl
@@ -45,9 +46,11 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -64,8 +67,8 @@ class FlowRunnerImplTest {
     private val cpiInfoReadService = mock<CpiInfoReadService>()
     private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService>()
     private val sandboxDependencyInjector = mock<SandboxDependencyInjector>()
-    private val platformInfoProvider = mock<PlatformInfoProvider>()
     private val fiberFuture = mock<FiberFuture>()
+    private val platformInfoProvider = mock<PlatformInfoProvider> { on { localWorkerPlatformVersion} doReturn 50000 }
     private var flowFiberExecutionContext: FlowFiberExecutionContext
     private var flowStackItem = FlowStackItem().apply { sessions = mutableListOf() }
     private var clientFlow = mock<ClientStartableFlow>()
@@ -101,8 +104,8 @@ class FlowRunnerImplTest {
         )
         whenever(virtualNodeInfoReadService.get(any())).thenReturn(getMockVNodeInfo())
         whenever(cpiInfoReadService.get(any())).thenReturn(getMockCpiMetaData())
-        whenever(platformInfoProvider.localWorkerPlatformVersion).thenReturn(1)
-        whenever(platformInfoProvider.localWorkerSoftwareVersion).thenReturn("1")
+        whenever(flowCheckpoint.initialPlatformVersion).thenReturn(50000)
+        whenever(platformInfoProvider.localWorkerSoftwareVersion).thenReturn("50000")
     }
 
     @BeforeEach
@@ -223,6 +226,18 @@ class FlowRunnerImplTest {
         val result = flowRunner.runFlow(context, flowContinuation)
 
         assertThat(result).isSameAs(fiberFuture)
+    }
+
+    @Test
+    fun `resuming a flow fails when the platform version is different`() {
+        val flowContinuation = FlowContinuation.Run()
+        val context = buildFlowEventContext<Any>(flowCheckpoint, Wakeup())
+
+        whenever(flowCheckpoint.initialPlatformVersion).thenReturn(500100)
+
+        assertThatExceptionOfType(FlowFatalException::class.java).isThrownBy {
+            flowRunner.runFlow(context, flowContinuation)
+        }
     }
 
     private fun getMockVNodeInfo(): VirtualNodeInfo {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
@@ -2,6 +2,8 @@ package net.corda.flow.state
 
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
+import java.nio.ByteBuffer
+import java.time.Instant
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
@@ -33,8 +35,6 @@ import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.nio.ByteBuffer
-import java.time.Instant
 
 class FlowCheckpointImplTest {
     private val flowConfig = ConfigFactory.empty()
@@ -110,6 +110,7 @@ class FlowCheckpointImplTest {
             flowId = "F1"
             flowState = newFlowState
             pipelineState = newPipelineState
+            initialPlatformVersion = 50000
         }
     }
 
@@ -169,6 +170,13 @@ class FlowCheckpointImplTest {
         val checkpoint = setupAvroCheckpoint()
 
         assertThat(createFlowCheckpoint(checkpoint).flowId).isEqualTo("F1")
+    }
+
+    @Test
+    fun `existing checkpoint - sets initial platform version`() {
+        val checkpoint = setupAvroCheckpoint()
+
+        assertThat(createFlowCheckpoint(checkpoint).initialPlatformVersion).isEqualTo(50000)
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.741-alpha-1680255469452
+cordaApiVersion=5.0.0.741-alpha-1680255890340
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
@@ -1,5 +1,6 @@
 package net.corda.flow.state
 
+import java.nio.ByteBuffer
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
@@ -11,7 +12,6 @@ import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
-import java.nio.ByteBuffer
 
 /**
  * The FlowCheckpoint provides an API for managing the checkpoint during the processing of a flow.
@@ -52,6 +52,8 @@ interface FlowCheckpoint : NonSerializable {
     val flowContext: FlowContext
 
     val maxMessageSize: Long
+
+    val initialPlatformVersion: Int
 
     fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>)
 

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -12,7 +12,7 @@ class PlatformInfoProviderTest {
     lateinit var platformInfoProvider: PlatformInfoProvider
 
     private companion object {
-        const val EXPECTED_STUB_PLATFORM_VERSION = 5000
+        const val EXPECTED_STUB_PLATFORM_VERSION = 50000
     }
 
     @Test

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -12,9 +12,9 @@ class PlatformInfoProviderImpl @Activate constructor(
 ) : PlatformInfoProvider {
 
     internal companion object {
-        const val STUB_PLATFORM_VERSION = 5000
+        const val STUB_PLATFORM_VERSION = 50000
 
-        private const val DEFAULT_PLATFORM_VERSION = 5000
+        private const val DEFAULT_PLATFORM_VERSION = 50000
         private const val PLATFORM_VERSION_KEY = "net.corda.platform.version"
     }
 


### PR DESCRIPTION
In order to avoid any issues with underlying changes during a platform upgrade we'll fail any outstanding flows, for now, when we detect a platform version change.  These flow can then be run again on the new platform version