### PR TITLE
CORE-11878 Add additional members to test to prevent regression when onboarding multiple members across clusters

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
@@ -31,12 +31,12 @@ class MultiClusterDynamicNetworkTest {
 
     private val clusterA = E2eClusterFactory.getE2eCluster(E2eClusterAConfig).apply {
         addMember(createTestMember("Alice"))
-        // Blocked by CORE-11878
-        // addMember(createTestMember("Notary", E2eClusterMemberRole.NOTARY))
+        addMember(createTestMember("Notary", E2eClusterMemberRole.NOTARY))
     }
 
     private val clusterB = E2eClusterFactory.getE2eCluster(E2eClusterBConfig).apply {
         addMember(createTestMember("Bob"))
+        addMember(createTestMember("Charlie"))
     }
 
     private val clusterC = E2eClusterFactory.getE2eCluster(E2eClusterCConfig).apply {


### PR DESCRIPTION
[CORE-11878](https://r3-cev.atlassian.net/browse/CORE-11878) has already been resolved by [CORE-11922](https://github.com/corda/corda-runtime-os/commit/2b28abddc192b8cc384796a1407bac23811fc30f). No additional fix is required. This PR updates an e2e test to add additional members in the multi cluster scenario to attempt to prevent regression in this area again since updating this test was blocked originally by this bug. 

Note: this test should be ported over to the e2e test repo but that will be covered as part of [CORE-10087](https://r3-cev.atlassian.net/browse/CORE-10087) and is not in scope for this PR.

[CORE-11878]: https://r3-cev.atlassian.net/browse/CORE-11878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-11922]: https://r3-cev.atlassian.net/browse/CORE-11922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-10087]: https://r3-cev.atlassian.net/browse/CORE-10087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ